### PR TITLE
graphql-actions: BreakoutRoom actions

### DIFF
--- a/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomCreate.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomCreate.ts
@@ -1,0 +1,39 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'CreateBreakoutRoomsCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    meetingId: routing.meetingId,
+    record: input.record,
+    captureNotes: input.captureNotes,
+    captureSlides: input.captureSlides,
+    durationInMinutes: input.durationInMinutes,
+    sendInviteToModerators: input.sendInviteToModerators,
+    rooms: input.rooms,
+  };
+
+  // TODO check if akka-apps apply this validation
+  // const BREAKOUT_LIM = Meteor.settings.public.app.breakouts.breakoutRoomLimit;
+  // const MIN_BREAKOUT_ROOMS = 2;
+  // const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
+  // if (rooms.length > MAX_BREAKOUT_ROOMS) {
+  //   Logger.info(`Attempt to create breakout rooms with invalid number of rooms in meeting id=${meetingId}`);
+  //   return;
+  // }
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomEndAll.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomEndAll.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'EndAllBreakoutRoomsMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    meetingId: routing.meetingId
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomMoveUser.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomMoveUser.ts
@@ -1,0 +1,27 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'ChangeUserBreakoutReqMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    meetingId: routing.meetingId,
+    userId: input.userId,
+    fromBreakoutId: input.fromBreakoutRoomId,
+    toBreakoutId: input.toBreakoutRoomId,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomRequestJoinUrl.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomRequestJoinUrl.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  const eventName = 'RequestBreakoutJoinURLReqMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    meetingId: routing.meetingId,
+    userId: routing.userId,
+    breakoutId: input.breakoutRoomId,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomSendMessageToAll.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomSendMessageToAll.ts
@@ -1,0 +1,25 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'SendMessageToAllBreakoutRoomsReqMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    meetingId: routing.meetingId,
+    msg: input.message,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomSetTime.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/breakoutRoomSetTime.ts
@@ -1,0 +1,25 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'UpdateBreakoutRoomsTimeReqMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    meetingId: routing.meetingId,
+    timeInMinutes: input.timeInMinutes
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/userTransferVoiceToMeeting.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/userTransferVoiceToMeeting.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  const eventName = 'TransferUserToMeetingRequestMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    userId: routing.userId,
+    fromMeetingId: input.fromMeetingId,
+    toMeetingId: input.toMeetingId
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -7,6 +7,47 @@ type Mutation {
 }
 
 type Mutation {
+  breakoutRoomCreate(
+    record: Boolean!
+    captureNotes: Boolean!
+    captureSlides: Boolean!
+    durationInMinutes: Int!
+    sendInviteToModerators: Boolean!
+    rooms: [BreakoutRoom]!
+  ): Boolean
+}
+
+type Mutation {
+  breakoutRoomEndAll: Boolean
+}
+
+type Mutation {
+  breakoutRoomMoveUser(
+    userId: String!
+    fromBreakoutRoomId: String!
+    toBreakoutRoomId: String!
+  ): Boolean
+}
+
+type Mutation {
+  breakoutRoomRequestJoinUrl(
+    breakoutRoomId: String!
+  ): Boolean
+}
+
+type Mutation {
+  breakoutRoomSendMessageToAll(
+    msg: String!
+  ): Boolean
+}
+
+type Mutation {
+  breakoutRoomSetTime(
+    timeInMinutes: Int!
+  ): Boolean
+}
+
+type Mutation {
   chatCreateWithUser(
     userId: String!
   ): Boolean
@@ -277,5 +318,23 @@ type Mutation {
     locale: String!
     provider: String!
   ): Boolean
+}
+
+type Mutation {
+  userTransferVoiceToMeeting(
+    fromMeetingId: String!
+    toMeetingId: String!
+  ): Boolean
+}
+
+input BreakoutRoom {
+  captureNotesFilename: String!
+  captureSlidesFilename: String!
+  freeJoin: Boolean!
+  isDefaultName: Boolean!
+  name: String!
+  sequence: Int!
+  shortName: String!
+  users: [String]!
 }
 

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -11,6 +11,42 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: breakoutRoomCreate
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: breakoutRoomEndAll
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: breakoutRoomMoveUser
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: breakoutRoomRequestJoinUrl
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: breakoutRoomSendMessageToAll
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: breakoutRoomSetTime
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: chatCreateWithUser
     definition:
       kind: synchronous
@@ -270,8 +306,15 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: userTransferVoiceToMeeting
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
 custom_types:
   enums: []
-  input_objects: []
+  input_objects:
+    - name: BreakoutRoom
   objects: []
   scalars: []


### PR DESCRIPTION
```gql
mutation {
  breakoutRoomCreate(
      record: false,
      captureNotes: false,
      captureSlides: false,
      durationInMinutes: 60,
      sendInviteToModerators: false,
      rooms: [
          {
          captureNotesFilename: "Test",
          captureSlidesFilename: "Test",
          freeJoin: true,
          isDefaultName: true,
          name: "Test Room",
          sequence: 1,
          shortName: "Test",
          users: []
          },
          {
          captureNotesFilename: "Test 2",
          captureSlidesFilename: "Test 2",
          freeJoin: true,
          isDefaultName: true,
          name: "Test 2 Room",
          sequence: 2,
          shortName: "Test2 ",
          users: []
          }
      ]
  )
}

mutation {
  breakoutRoomMoveUser(
    userId: "w_cvdvgxunsesv",
    fromBreakoutRoomId: "1f8ab3ec086e1997e48c3fdfbe9f80f0c9ae9f1b-1701800217595",
    toBreakoutRoomId: "6effbe4052402ab775c1c06670ef4754401b0147-1701800217592"
  )
}

mutation {
  breakoutRoomSendMessageToAll(
    message: "Heello!!!"
  )
}

mutation {
  breakoutRoomSetTime(
    timeInMinutes: 50
  )
}

mutation {
  breakoutRoomEndAll
}

mutation {
  userTransferVoiceToMeeting(
    fromMeetingId: "1f8ab3ec086e1997e48c3fdfbe9f80f0c9ae9f1b-1701800217595",
    toMeetingId: "6effbe4052402ab775c1c06670ef4754401b0147-1701800217592"
  )
}

mutation {
  breakoutRoomRequestJoinUrl(
    breakoutRoomId: "1f8ab3ec086e1997e48c3fdfbe9f80f0c9ae9f1b-1701800217595"
  )
}
```