### PR TITLE
graphql-actions: Moderators actions 

### DIFF
--- a/bbb-graphql-actions-adapter-server/src/actions/meetingEnd.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingEnd.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'LogoutAndEndMeetingCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    userId: routing.userId
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingLayoutSetProps.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingLayoutSetProps.ts
@@ -1,0 +1,30 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'BroadcastLayoutMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    layout: input.layout,
+    pushLayout: input.syncWithPresenterLayout,
+    presentationIsOpen: input.presentationIsOpen,
+    isResizing: input.isResizing,
+    cameraPosition: input.cameraPosition || "",
+    focusedCamera: input.focusedCamera,
+    presentationVideoRate: input.presentationVideoRate
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingLayoutSetSyncWithPresenterLayout.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingLayoutSetSyncWithPresenterLayout.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'BroadcastPushLayoutMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    pushLayout: input.syncWithPresenterLayout
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingLockSettingsSetProps.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingLockSettingsSetProps.ts
@@ -1,0 +1,34 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'ChangeLockSettingsInMeetingCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    setBy: routing.userId,
+    disableCam: input.disableCam,
+    disableMic: input.disableMic,
+    disablePrivChat: input.disablePrivChat,
+    disablePubChat: input.disablePubChat,
+    disableNotes: input.disableNotes,
+    hideUserList: input.hideUserList,
+    lockOnJoin: input.lockOnJoin,
+    lockOnJoinConfigurable: input.lockOnJoinConfigurable,
+    hideViewersCursor: input.hideViewersCursor,
+    hideViewersAnnotation: input.hideViewersAnnotation,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingRecordingSetStatus.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingRecordingSetStatus.ts
@@ -1,0 +1,42 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'SetRecordingStatusCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    setBy: routing.userId,
+    recording: input.recording
+  };
+
+  //TODO check if backend velidate it
+
+  // const recordObject = await RecordMeetings.findOneAsync({ meetingId });
+  //
+  // if (recordObject != null) {
+  //   const {
+  //     allowStartStopRecording,
+  //     recording,
+  //     record,
+  //   } = recordObject;
+  //
+  //   meetingRecorded = recording;
+  //   allowedToRecord = record && allowStartStopRecording; // TODO-- remove some day
+  // }
+  //
+  // if (allowedToRecord) {}
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingSetMuted.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingSetMuted.ts
@@ -1,0 +1,28 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName =
+      (input.exceptPresenter || false) ?
+      'MuteAllExceptPresentersCmdMsg' :
+      'MuteMeetingCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    mutedBy: routing.userId,
+    mute: input.muted
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingSetWebcamOnlyForModerator.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingSetWebcamOnlyForModerator.ts
@@ -1,0 +1,42 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'UpdateWebcamsOnlyForModeratorCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    setBy: routing.userId,
+    webcamsOnlyForModerator: input.webcamsOnlyForModerator
+  };
+
+  //TODO check if backend velidate it
+
+  // const recordObject = await RecordMeetings.findOneAsync({ meetingId });
+  //
+  // if (recordObject != null) {
+  //   const {
+  //     allowStartStopRecording,
+  //     recording,
+  //     record,
+  //   } = recordObject;
+  //
+  //   meetingRecorded = recording;
+  //   allowedToRecord = record && allowStartStopRecording; // TODO-- remove some day
+  // }
+  //
+  // if (allowedToRecord) {}
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/meetingSetWebcamOnlyForModerator.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/meetingSetWebcamOnlyForModerator.ts
@@ -21,22 +21,5 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     webcamsOnlyForModerator: input.webcamsOnlyForModerator
   };
 
-  //TODO check if backend velidate it
-
-  // const recordObject = await RecordMeetings.findOneAsync({ meetingId });
-  //
-  // if (recordObject != null) {
-  //   const {
-  //     allowStartStopRecording,
-  //     recording,
-  //     record,
-  //   } = recordObject;
-  //
-  //   meetingRecorded = recording;
-  //   allowedToRecord = record && allowStartStopRecording; // TODO-- remove some day
-  // }
-  //
-  // if (allowedToRecord) {}
-
   return { eventName, routing, header, body };
 }

--- a/bbb-graphql-actions-adapter-server/src/actions/userEjectCameras.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/userEjectCameras.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'EjectUserCamerasCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    userId: input.userId
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions-adapter-server/src/actions/userEjectFromVoice.ts
+++ b/bbb-graphql-actions-adapter-server/src/actions/userEjectFromVoice.ts
@@ -1,0 +1,26 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  const eventName = 'EjectUserFromVoiceCmdMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    ejectedBy: routing.userId,
+    userId: input.userId,
+    banUser: input.banUser || false
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -112,6 +112,62 @@ type Mutation {
 }
 
 type Mutation {
+  meetingEnd: Boolean
+}
+
+type Mutation {
+  meetingLayoutSetProps(
+    layout: String!
+    syncWithPresenterLayout: Boolean!
+    presentationIsOpen: Boolean!
+    isResizing: Boolean!
+    cameraPosition: String
+    focusedCamera: String!
+    presentationVideoRate: Float!
+  ): Boolean
+}
+
+type Mutation {
+  meetingLayoutSetSyncWithPresenterLayout(
+    syncWithPresenterLayout: Boolean!
+  ): Boolean
+}
+
+type Mutation {
+  meetingLockSettingsSetProps(
+    disableCam: Boolean!
+    disableMic: Boolean!
+    disablePrivChat: Boolean!
+    disablePubChat: Boolean!
+    disableNotes: Boolean!
+    hideUserList: Boolean!
+    lockOnJoin: Boolean!
+    lockOnJoinConfigurable: Boolean!
+    hideViewersCursor: Boolean!
+    hideViewersAnnotation: Boolean!
+  ): Boolean
+}
+
+type Mutation {
+  meetingRecordingSetStatus(
+    recording: Boolean!
+  ): Boolean
+}
+
+type Mutation {
+  meetingSetMuted(
+    muted: Boolean!
+    exceptPresenter: Boolean
+  ): Boolean
+}
+
+type Mutation {
+  meetingSetWebcamOnlyForModerator(
+    webcamsOnlyForModerator: Boolean!
+  ): Boolean
+}
+
+type Mutation {
   pickRandomViewer: Boolean
 }
 
@@ -257,9 +313,22 @@ type Mutation {
 }
 
 type Mutation {
+  userEjectCameras(
+    userId: String!
+  ): Boolean
+}
+
+type Mutation {
   userEjectFromMeeting(
     userId: String!
     banUser: Boolean!
+  ): Boolean
+}
+
+type Mutation {
+  userEjectFromVoice(
+    userId: String!
+    banUser: Boolean
   ): Boolean
 }
 

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -107,6 +107,48 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: meetingEnd
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: meetingLayoutSetProps
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: meetingLayoutSetSyncWithPresenterLayout
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: meetingLockSettingsSetProps
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: meetingRecordingSetStatus
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: meetingSetMuted
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: meetingSetWebcamOnlyForModerator
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: pickRandomViewer
     definition:
       kind: synchronous
@@ -245,7 +287,19 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: userEjectCameras
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: userEjectFromMeeting
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: userEjectFromVoice
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'


### PR DESCRIPTION
```gql
mutation {
  meetingEnd
}

#Depends on `allowModsToEjectCameras=true`
mutation {
  userEjectCameras(
    userId: "w_5ukvmnxbg5lo"
  )
}

mutation {
  userEjectFromVoice(
    userId: "w_5ukvmnxbg5lo",
    banUser: false
  )
}

mutation {
  meetingSetMuted(
    muted: true
    exceptPresenter: true
  )
}

mutation {
  meetingLayoutSetProps(
    layout: "videoFocus",
    syncWithPresenterLayout: true,
    presentationIsOpen: true,
    isResizing: false,
    cameraPosition: "contentTop",
    focusedCamera: "none",
    presentationVideoRate: 0
  )
}

mutation {
  meetingLayoutSetSyncWithPresenterLayout(
    syncWithPresenterLayout: true
  )
}

mutation {
  meetingLockSettingsSetProps(
    disableCam: true,
    disableMic: true,
    disablePrivChat: false,
    disablePubChat: false,
    disableNotes: false,
    hideUserList: false,
    lockOnJoin: true,
    lockOnJoinConfigurable: false,
    hideViewersCursor: false,
    hideViewersAnnotation: false,
  )
}

mutation {
  meetingRecordingSetStatus(
    recording: true
  )
}

mutation {
  meetingSetWebcamOnlyForModerator(
    webcamsOnlyForModerator: true
  )
}
```