### PR TITLE
graphql-server: Add field positionInWaitingQueue to GuestUser

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -279,7 +279,15 @@ ALTER TABLE "user" ADD COLUMN "isWaiting" boolean GENERATED ALWAYS AS ("guestSta
 ALTER TABLE "user" ADD COLUMN "isAllowed" boolean GENERATED ALWAYS AS ("guestStatus" = 'ALLOW') STORED;
 ALTER TABLE "user" ADD COLUMN "isDenied" boolean GENERATED ALWAYS AS ("guestStatus" = 'DENY') STORED;
 
-ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp(("registeredOn" + 6000) / 1000)) STORED;
+--ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (
+--    TIMESTAMP WITH TIME ZONE 'epoch' +
+--    (u."registeredOn" / 1000) * INTERVAL '1 second' +
+--    (u."registeredOn" % 1000) * INTERVAL '1 millisecond'
+--) STORED;
+
+
+ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("registeredOn"::double precision / 1000)) STORED;
+
 
 --Used to sort the Userlist
 ALTER TABLE "user" ADD COLUMN "nameSortable" varchar(255) GENERATED ALWAYS AS (immutable_lower_unaccent("name")) STORED;
@@ -421,11 +429,16 @@ CREATE OR REPLACE VIEW "v_user_guest" AS
 SELECT u."meetingId", u."userId",
 u."guestStatus",
 u."isWaiting",
+rank() OVER (
+    PARTITION BY u."meetingId"
+    ORDER BY u."registeredOn" ASC, u."userId" ASC
+) as "positionInWaitingQueue",
 u."isAllowed",
 u."isDenied",
 COALESCE(u."guestLobbyMessage",mup."guestLobbyMessage") AS "guestLobbyMessage"
 FROM "user" u
-JOIN "meeting_usersPolicies" mup using("meetingId");
+JOIN "meeting_usersPolicies" mup using("meetingId")
+where u."guestStatus" != 'ALLOW';
 
 --v_user_ref will be used only as foreign key (not possible to fetch this table directly through graphql)
 --it is necessary because v_user has some conditions like "lockSettings-hideUserList"
@@ -508,7 +521,7 @@ CREATE TABLE "user_voice" (
 );
 --CREATE INDEX "idx_user_voice_userId" ON "user_voice"("userId");
 ALTER TABLE "user_voice" ADD COLUMN "hideTalkingIndicatorAt" timestamp with time zone
-GENERATED ALWAYS AS (to_timestamp((COALESCE("endTime","startTime") + 6000) / 1000)) STORED;
+GENERATED ALWAYS AS (to_timestamp(COALESCE("endTime","startTime")::double precision / 1000)) STORED;
 
 CREATE INDEX "idx_user_voice_userId_talking" ON "user_voice"("userId","talking");
 CREATE INDEX "idx_user_voice_userId_hideTalkingIndicatorAt" ON "user_voice"("userId","hideTalkingIndicatorAt");

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -514,7 +514,7 @@ CREATE TABLE "user_voice" (
 );
 --CREATE INDEX "idx_user_voice_userId" ON "user_voice"("userId");
 ALTER TABLE "user_voice" ADD COLUMN "hideTalkingIndicatorAt" timestamp with time zone
-GENERATED ALWAYS AS (to_timestamp(COALESCE("endTime","startTime")::double precision / 1000)) STORED;
+GENERATED ALWAYS AS (to_timestamp((COALESCE("endTime","startTime") + 6000) / 1000)) STORED;
 
 CREATE INDEX "idx_user_voice_userId_talking" ON "user_voice"("userId","talking");
 CREATE INDEX "idx_user_voice_userId_hideTalkingIndicatorAt" ON "user_voice"("userId","hideTalkingIndicatorAt");

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -279,13 +279,6 @@ ALTER TABLE "user" ADD COLUMN "isWaiting" boolean GENERATED ALWAYS AS ("guestSta
 ALTER TABLE "user" ADD COLUMN "isAllowed" boolean GENERATED ALWAYS AS ("guestStatus" = 'ALLOW') STORED;
 ALTER TABLE "user" ADD COLUMN "isDenied" boolean GENERATED ALWAYS AS ("guestStatus" = 'DENY') STORED;
 
---ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (
---    TIMESTAMP WITH TIME ZONE 'epoch' +
---    (u."registeredOn" / 1000) * INTERVAL '1 second' +
---    (u."registeredOn" % 1000) * INTERVAL '1 millisecond'
---) STORED;
-
-
 ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("registeredOn"::double precision / 1000)) STORED;
 
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_guest.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_guest.yaml
@@ -25,6 +25,7 @@ select_permissions:
         - isAllowed
         - isDenied
         - isWaiting
+        - positionInWaitingQueue
         - userId
       filter:
         _or:


### PR DESCRIPTION
In favor of #19240

- Moderator get users position
```gql
{
  user_guest(order_by: {positionInWaitingQueue: asc}) {
    positionInWaitingQueue
    user {
      name
    }
  }
}
```

- User get his position while waiting
```gql
{
  user_current {
    guestStatus {
      positionInWaitingQueue
    }
  }
}
```