### PR TITLE
graphql-server: Provide new Type meeting_clientPluginSettings

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -205,6 +205,16 @@ create table "meeting_clientSettings" (
 
 CREATE VIEW "v_meeting_clientSettings" AS SELECT * FROM "meeting_clientSettings";
 
+create view "v_meeting_clientPluginSettings" as
+select "meetingId",
+       plugin->>'name' as "name",
+       plugin->>'url' as "url",
+       (plugin->>'settings')::jsonb as "settings",
+       (plugin->>'dataChannels')::jsonb as "dataChannels"
+from (
+    select "meetingId", jsonb_array_elements("clientSettingsJson"->'public'->'plugins') AS plugin
+    from "meeting_clientSettings"
+) settings;
 
 create table "meeting_group" (
 	"meetingId"  varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientPluginSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientPluginSettings.yaml
@@ -1,0 +1,20 @@
+table:
+  name: v_meeting_clientPluginSettings
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: meeting_clientPluginSettings
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - dataChannels
+        - name
+        - settings
+        - url
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -12,6 +12,7 @@
 - "!include public_v_layout.yaml"
 - "!include public_v_meeting.yaml"
 - "!include public_v_meeting_breakoutPolicies.yaml"
+- "!include public_v_meeting_clientPluginSettings.yaml"
 - "!include public_v_meeting_clientSettings.yaml"
 - "!include public_v_meeting_group.yaml"
 - "!include public_v_meeting_lockSettings.yaml"


### PR DESCRIPTION
Introduce a new graphql Type `meeting_clientPluginSettings`.
It makes it possible to filter by a plugin name and get all its properties.

#### Confg
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/6f1eed4b-dea0-4718-945f-aac34c68a224)

#### Query
```gql
query {
  meeting_clientPluginSettings(where: {name: {_eq: "SelectRandomUserPlugin"}}) {
    name
    url
    dataChannels
    settings
  }
}
```

#### Result
```json
{
  "data": {
    "meeting_clientPluginSettings": [
      {
        "name": "SelectRandomUserPlugin",
        "url": "https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/SelectRandomUserPlugin.js"
        "settings": {
          "outraConf": 1234,
          "teste": "abc"
        },
        "dataChannels": [
          {
            "name": "pickRandomUser",
            "writePermission": [
              "moderator",
              "presenter"
            ]
          },
          {
            "name": "lastResetTime",
            "writePermission": [
              "moderator",
              "presenter"
            ]
          }
        ],
      }
    ]
  }
}
```

#### Example querying only a given setting
```gql
{
  meeting_clientPluginSettings(where: {name: {_eq: "SelectRandomUserPlugin"}}) {
    serverUrl: settings(path: "serverUrl")
  }
}
```