### PR TITLE
fix (graphql-server): Type user_breakoutRoom showing old rooms

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1458,9 +1458,15 @@ WHERE "currentRoomIsOnline" IS TRUE;
 --JOIN "breakoutRoom" br ON br."parentMeetingId" = vmbp."parentId" AND br."externalId" = m."extId";
 
 --User to update "inviteDismissedAt" via Mutation
-CREATE VIEW "v_breakoutRoom_user" AS
-SELECT *
-FROM "breakoutRoom_user";
+CREATE OR REPLACE VIEW "v_breakoutRoom_user" AS
+SELECT bu.*
+FROM "breakoutRoom_user" bu
+where bu."breakoutRoomId" in (
+    select b."breakoutRoomId"
+    from "user" u
+    join "breakoutRoom" b on b."parentMeetingId" = u."meetingId" and b."endedAt" is null
+    where u."userId" = bu."userId"
+);
 
 ------------------------------------
 ----sharedNotes

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -7,15 +7,6 @@ configuration:
   custom_name: user_current
   custom_root_fields: {}
 object_relationships:
-  - name: breakoutRooms
-    using:
-      manual_configuration:
-        column_mapping:
-          meetingId: parentMeetingId
-        insertion_order: null
-        remote_table:
-          name: v_breakoutRoom
-          schema: public
   - name: connectionStatus
     using:
       manual_configuration:
@@ -98,6 +89,15 @@ object_relationships:
           name: v_user_voice
           schema: public
 array_relationships:
+  - name: breakoutRooms
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: parentMeetingId
+        insertion_order: null
+        remote_table:
+          name: v_breakoutRoom
+          schema: public
   - name: cameras
     using:
       manual_configuration:


### PR DESCRIPTION
- Fix type `user_breakoutRoom` showing old rooms
- Makes it possible to aggregate available breakoutRooms through `user_current`

```gql
subscription {
  user_current {
    name
    breakoutRooms_aggregate(where: {showInvitation: {_eq: true}}) {
      roomsToShowInvitation: aggregate {
        count
      }
    }
  }
}
```