### PR TITLE
Graphql: Introduce meeting.componentsFlags

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -226,53 +226,6 @@ create table "meeting_group" (
 create index "idx_meeting_group_meetingId" on "meeting_group"("meetingId");
 create view "v_meeting_group" as select * from meeting_group;
 
-
-create view "v_meeting_componentsFlags" as
-select "meeting"."meetingId",
-        exists (
-            select 1
-            from "breakoutRoom"
-            where "breakoutRoom"."parentMeetingId" = "meeting"."meetingId"
-            and "endedAt" is null
-        ) as "hasBreakoutRoom",
-        exists (
-            select 1
-            from "poll"
-            where "poll"."meetingId" = "meeting"."meetingId"
-            and "ended" is false
-            and "published" is false
-        ) as "hasPoll",
-        exists (
-            select 1
-            from "timer"
-            where "timer"."meetingId" = "meeting"."meetingId"
-            and "active" is true
-        ) as "hasTimer",
-        exists (
-            select 1
-            from "v_screenshare"
-            where "v_screenshare"."meetingId" = "meeting"."meetingId"
-        ) as "hasScreenshare",
-        exists (
-            select 1
-            from "v_externalVideo"
-            where "v_externalVideo"."meetingId" = "meeting"."meetingId"
-        ) as "hasExternalVideo",
-        (
-            select array_agg(distinct "speechLocale")
-            from "user"
-            where "user"."meetingId" = "meeting"."meetingId"
-            and NULLIF("speechLocale",'') is not null
-        ) as "audioTranscriptionCaption",
-        (
-            select array_agg(distinct "name")
-            from "sharedNotes"
-            where "sharedNotes"."meetingId" = "meeting"."meetingId"
-            and "model" = 'captions'
-        ) as "typedCaption"
-from "meeting";
-
-
 -- ========== User tables
 
 CREATE TABLE "user" (
@@ -1638,3 +1591,51 @@ JOIN "pluginDataChannelMessage" m ON m."meetingId" = u."meetingId"
 				OR (u."presenter" AND 'PRESENTER' = ANY(m."toRoles"))
 				)
 ORDER BY m."createdAt";
+
+------------------------
+
+
+create view "v_meeting_componentsFlags" as
+select "meeting"."meetingId",
+        exists (
+            select 1
+            from "breakoutRoom"
+            where "breakoutRoom"."parentMeetingId" = "meeting"."meetingId"
+            and "endedAt" is null
+        ) as "hasBreakoutRoom",
+        exists (
+            select 1
+            from "poll"
+            where "poll"."meetingId" = "meeting"."meetingId"
+            and "ended" is false
+            and "published" is false
+        ) as "hasPoll",
+        exists (
+            select 1
+            from "timer"
+            where "timer"."meetingId" = "meeting"."meetingId"
+            and "active" is true
+        ) as "hasTimer",
+        exists (
+            select 1
+            from "v_screenshare"
+            where "v_screenshare"."meetingId" = "meeting"."meetingId"
+        ) as "hasScreenshare",
+        exists (
+            select 1
+            from "v_externalVideo"
+            where "v_externalVideo"."meetingId" = "meeting"."meetingId"
+        ) as "hasExternalVideo",
+        (
+            select array_agg(distinct "speechLocale")
+            from "user"
+            where "user"."meetingId" = "meeting"."meetingId"
+            and NULLIF("speechLocale",'') is not null
+        ) as "audioTranscriptionCaption",
+        (
+            select array_agg(distinct "name")
+            from "sharedNotes"
+            where "sharedNotes"."meetingId" = "meeting"."meetingId"
+            and "model" = 'captions'
+        ) as "typedCaption"
+from "meeting";

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -25,6 +25,15 @@ object_relationships:
         remote_table:
           name: v_meeting_clientSettings
           schema: public
+  - name: componentsFlags
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+        insertion_order: null
+        remote_table:
+          name: v_meeting_componentsFlags
+          schema: public
   - name: externalVideo
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
@@ -1,0 +1,23 @@
+table:
+  name: v_meeting_componentsFlags
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: meeting_componentFlags
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - audioTranscriptionCaption
+        - hasBreakoutRoom
+        - hasExternalVideo
+        - hasPoll
+        - hasScreenshare
+        - hasTimer
+        - typedCaption
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -14,6 +14,7 @@
 - "!include public_v_meeting_breakoutPolicies.yaml"
 - "!include public_v_meeting_clientPluginSettings.yaml"
 - "!include public_v_meeting_clientSettings.yaml"
+- "!include public_v_meeting_componentsFlags.yaml"
 - "!include public_v_meeting_group.yaml"
 - "!include public_v_meeting_lockSettings.yaml"
 - "!include public_v_meeting_recording.yaml"


### PR DESCRIPTION
In order to improve Client efficiency, this PR introduce a few flags that will inform to the Client whether it is necessary to render certain components or not.

Adds a prop `componentsFlags` to Type `meeting`

#### Subscription
```gql
subscription {
  meeting {
    meetingId
    componentsFlags {
      hasBreakoutRoom
      hasExternalVideo
      hasPoll
      hasScreenshare
      hasTimer
      audioTranscriptionCaption
      typedCaption
    }
  }
}
```

#### Result
```json
{
    "meetingId": "6fd958cd0c1f967f2eceda95b91b69edc9876690-1702058871500",
    "componentsFlags": {
      "hasBreakoutRoom": true,
      "hasExternalVideo": false,
      "hasPoll": false,
      "hasScreenshare": false,
      "hasTimer": false,
      "audioTranscriptionCaption": ["fr-FR","pt-BR"],
      "typedCaption": ["en"]
    }
}
```

It is also possible to query the flags directly (not through `meeting.componentsFlags`)
```gql
query {
  meeting_componentFlags {
    hasBreakoutRoom
    hasExternalVideo
    hasPoll
    hasScreenshare
    hasTimer
    meetingId
  }
}
```