### PR TITLE
recording: Bump bbb_version to 3.0 in bigbluebutton.yml

### DIFF
--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '2.6.1'
+bbb_version: '3.0'
 raw_audio_src: /var/freeswitch/meetings
 mediasoup_video_src: /var/mediasoup/recordings
 mediasoup_screenshare_src: /var/mediasoup/screenshare

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '3.0'
+bbb_version: '3.0.0'
 raw_audio_src: /var/freeswitch/meetings
 mediasoup_video_src: /var/mediasoup/recordings
 mediasoup_screenshare_src: /var/mediasoup/screenshare


### PR DESCRIPTION
### What does this PR do?
Sets `bbb_version` in `bigbluebutton.yml` to `3.0`, as the whiteboard shapes stored in `tldraw.json` are incompatible with earlier versions like 2.6 and 2.7 due to Tldraw having been upgraded to a newer version.

This version string will be used by other components (e.g., `bbb-playback`) to determine which Tldraw version to display.