### PR TITLE
fix: Graphql with hard-coded reaction expire time

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserReactionEmojiReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserReactionEmojiReqMsgHdlr.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core.apps.users
 
+import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPath
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.RightsManagementTrait
 import org.bigbluebutton.core.models.{ UserState, Users2x }
@@ -29,9 +30,17 @@ trait ChangeUserReactionEmojiReqMsgHdlr extends RightsManagementTrait {
       outGW.send(msgEventChange)
     }
 
+    //Get durationInSeconds from Client config
+    val userReactionExpire =
+      getConfigPropertyValueByPath(liveMeeting.clientSettings, "public.userReaction.expire") match {
+        case Some(durationInSeconds: Int) => durationInSeconds
+        case _ =>
+          log.debug("Config `public.userReaction.expire` not found.")
+          30
+      }
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
-      newUserState <- Users2x.setReactionEmoji(liveMeeting.users2x, user.intId, msg.body.reactionEmoji)
+      newUserState <- Users2x.setReactionEmoji(liveMeeting.users2x, user.intId, msg.body.reactionEmoji, userReactionExpire)
     } yield {
       if (user.reactionEmoji != msg.body.reactionEmoji) {
         broadcast(newUserState, msg.body.reactionEmoji)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ClearAllUsersReactionCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ClearAllUsersReactionCmdMsgHdlr.scala
@@ -24,7 +24,7 @@ trait ClearAllUsersReactionCmdMsgHdlr extends RightsManagementTrait {
         user <- Users2x.findAll(liveMeeting.users2x)
       } yield {
         //Don't clear away and RaiseHand
-        Users2x.setReactionEmoji(liveMeeting.users2x, user.intId, "none")
+        Users2x.setReactionEmoji(liveMeeting.users2x, user.intId, "none", 0)
       }
       sendClearedAllUsersReactionEvtMsg(outGW, liveMeeting.props.meetingProp.intId, msg.header.userId)
     } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserReactionTimeExpiredCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserReactionTimeExpiredCmdMsgHdlr.scala
@@ -13,7 +13,7 @@ trait UserReactionTimeExpiredCmdMsgHdlr extends RightsManagementTrait {
   def handleUserReactionTimeExpiredCmdMsg(msg: UserReactionTimeExpiredCmdMsg) {
     val isNodeUser = msg.header.userId.equals("nodeJSapp")
     if (isNodeUser) {
-      Users2x.setReactionEmoji(liveMeeting.users2x, msg.body.userId, "none")
+      Users2x.setReactionEmoji(liveMeeting.users2x, msg.body.userId, "none", 0)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserReactionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserReactionDAO.scala
@@ -23,13 +23,13 @@ class UserReactionDbTableDef(tag: Tag) extends Table[UserReactionDbModel](tag, "
 }
 
 object UserReactionDAO {
-  def insert(userId: String, reactionEmoji: String) = {
+  def insert(userId: String, reactionEmoji: String, durationInSeconds: Int) = {
     DatabaseConnection.db.run(
       TableQuery[UserReactionDbTableDef].forceInsert(
         UserReactionDbModel(
           userId = userId,
           reactionEmoji = reactionEmoji,
-          durationInSeconds = 60,
+          durationInSeconds = durationInSeconds,
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -195,7 +195,7 @@ object Users2x {
       newUser
     }
   }
-  def setReactionEmoji(users: Users2x, intId: String, reactionEmoji: String): Option[UserState] = {
+  def setReactionEmoji(users: Users2x, intId: String, reactionEmoji: String, durationInSeconds: Int): Option[UserState] = {
     for {
       u <- findWithIntId(users, intId)
     } yield {
@@ -203,7 +203,7 @@ object Users2x {
         .modify(_.reactionChangedOn).setTo(System.currentTimeMillis())
 
       users.save(newUser)
-      UserReactionDAO.insert(intId, reactionEmoji)
+      UserReactionDAO.insert(intId, reactionEmoji, durationInSeconds)
       newUser
     }
   }


### PR DESCRIPTION
Graphql was not respecting the time set on `public.userReaction.expire` for Reactions.
Required by: #19333

_Alert for development: This config should be set in `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml` once Akka-apps doesn´t read the config from `bigbluebutton-html5` project._