### PR TITLE
refactor: Graphql middleware enhancements

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -75,15 +75,15 @@ class BigBlueButtonActor(
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
     msg.core match {
 
-      case m: CreateMeetingReqMsg                   => handleCreateMeetingReqMsg(m)
-      case m: RegisterUserReqMsg                    => handleRegisterUserReqMsg(m)
-      case m: GetAllMeetingsReqMsg                  => handleGetAllMeetingsReqMsg(m)
-      case m: GetRunningMeetingsReqMsg              => handleGetRunningMeetingsReqMsg(m)
-      case m: CheckAlivePingSysMsg                  => handleCheckAlivePingSysMsg(m)
-      case m: ValidateConnAuthTokenSysMsg           => handleValidateConnAuthTokenSysMsg(m)
-      case _: UserGraphqlConnectionStablishedSysMsg => //Ignore
-      case _: UserGraphqlConnectionClosedSysMsg     => //Ignore
-      case _                                        => log.warning("Cannot handle " + msg.envelope.name)
+      case m: CreateMeetingReqMsg                    => handleCreateMeetingReqMsg(m)
+      case m: RegisterUserReqMsg                     => handleRegisterUserReqMsg(m)
+      case m: GetAllMeetingsReqMsg                   => handleGetAllMeetingsReqMsg(m)
+      case m: GetRunningMeetingsReqMsg               => handleGetRunningMeetingsReqMsg(m)
+      case m: CheckAlivePingSysMsg                   => handleCheckAlivePingSysMsg(m)
+      case m: ValidateConnAuthTokenSysMsg            => handleValidateConnAuthTokenSysMsg(m)
+      case _: UserGraphqlConnectionEstablishedSysMsg => //Ignore
+      case _: UserGraphqlConnectionClosedSysMsg      => //Ignore
+      case _                                         => log.warning("Cannot handle " + msg.envelope.name)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -95,7 +95,7 @@ object PermissionCheck extends SystemConfiguration {
       for {
         regUser <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
       } yield {
-        Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, reason, outGW)
+        Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, reason, outGW)
       }
     } else {
       // TODO: get this object a context so it can use the akka logging system

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
@@ -36,7 +36,7 @@ trait EjectUserFromBreakoutInternalMsgHdlr {
       Sender.sendDisconnectClientSysMsg(msg.breakoutId, registeredUser.id, msg.ejectedBy, msg.reasonCode, outGW)
 
       // Force reconnection with graphql to refresh permissions
-      Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, msg.reasonCode, outGW)
+      Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, msg.reasonCode, outGW)
 
       //send users update to parent meeting
       BreakoutHdlrHelpers.updateParentMeetingWithUsers(liveMeeting, eventBus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -85,7 +85,7 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
           for {
             u <- RegisteredUsers.findWithUserId(oldPres.intId, liveMeeting.registeredUsers)
           } yield {
-            Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, oldPres.intId, u.sessionToken, "role_changed", outGW)
+            Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, oldPres.intId, u.sessionToken, "role_changed", outGW)
           }
         }
       }
@@ -100,7 +100,7 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
         for {
           u <- RegisteredUsers.findWithUserId(newPres.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, newPres.intId, u.sessionToken, "role_changed", outGW)
+          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, newPres.intId, u.sessionToken, "role_changed", outGW)
         }
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -73,7 +73,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
         for {
           u <- RegisteredUsers.findWithUserId(uvo.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, uvo.intId, u.sessionToken, "role_changed", outGW)
+          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, uvo.intId, u.sessionToken, "role_changed", outGW)
         }
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -74,7 +74,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
             Sender.sendDisconnectClientSysMsg(meetingId, ru.id, ejectedBy, EjectReasonCode.EJECT_USER, outGW)
 
             // Force reconnection with graphql to refresh permissions
-            Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, EjectReasonCode.EJECT_USER, outGW)
+            Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, EjectReasonCode.EJECT_USER, outGW)
           }
         } else {
           // User is ejecting self, so just eject this userid not all sessions if joined using multiple
@@ -93,7 +93,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
           Sender.sendDisconnectClientSysMsg(meetingId, userId, ejectedBy, EjectReasonCode.EJECT_USER, outGW)
 
           // Force reconnection with graphql to refresh permissions
-          Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, EjectReasonCode.EJECT_USER, outGW)
+          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, EjectReasonCode.EJECT_USER, outGW)
         }
 
       }
@@ -129,7 +129,7 @@ trait EjectUserFromMeetingSysMsgHdlr {
     for {
       regUser <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
     } yield {
-      Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, EjectReasonCode.SYSTEM_EJECT_USER, outGW)
+      Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, EjectReasonCode.SYSTEM_EJECT_USER, outGW)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
@@ -44,7 +44,7 @@ trait LockUserInMeetingCmdMsgHdlr extends RightsManagementTrait {
         for {
           u <- RegisteredUsers.findWithUserId(uvo.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, uvo.intId, u.sessionToken, "lock_user_changed", outGW)
+          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, uvo.intId, u.sessionToken, "lock_user_changed", outGW)
         }
 
         log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -49,7 +49,7 @@ trait RegisterUserReqMsgHdlr {
                 Sender.sendDisconnectClientSysMsg(meetingId, userToRemove.id, SystemUser.ID, EjectReasonCode.DUPLICATE_USER, outGW)
 
                 // Force reconnection with graphql to refresh permissions
-                Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, userToRemove.id, userToRemove.sessionToken, EjectReasonCode.DUPLICATE_USER, outGW)
+                Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, userToRemove.id, userToRemove.sessionToken, EjectReasonCode.DUPLICATE_USER, outGW)
               }
           }
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -51,7 +51,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
     notifyPreviousUsersWithSameExtId(regUser)
     clearCachedVoiceUser(regUser)
     clearExpiredUserState(regUser)
-    invalidateUserGraphqlConnection(regUser)
+    ForceUserGraphqlReconnection(regUser)
 
     newState
   }
@@ -146,7 +146,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
   private def clearExpiredUserState(regUser: RegisteredUser) =
     UserStateDAO.updateExpired(regUser.id, false)
 
-  private def invalidateUserGraphqlConnection(regUser: RegisteredUser) =
-    Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "user_joined", outGW)
+  private def ForceUserGraphqlReconnection(regUser: RegisteredUser) =
+    Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "user_joined", outGW)
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -31,7 +31,7 @@ trait UserLeaveReqMsgHdlr extends HandlerHelpers {
             ru <- RegisteredUsers.findWithUserId(msg.body.userId, liveMeeting.registeredUsers)
           } yield {
             RegisteredUsers.setUserLoggedOutFlag(liveMeeting.registeredUsers, ru)
-            Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, ru.id, ru.sessionToken, "user_loggedout", outGW)
+            Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, ru.id, ru.sessionToken, "user_loggedout", outGW)
           }
         }
         state

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -450,8 +450,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[TimerEndedPubMsg](envelope, jsonNode)
 
       // Messages from Graphql Middleware
-      case UserGraphqlConnectionStablishedSysMsg.NAME =>
-        route[UserGraphqlConnectionStablishedSysMsg](meetingManagerChannel, envelope, jsonNode)
+      case UserGraphqlConnectionEstablishedSysMsg.NAME =>
+        route[UserGraphqlConnectionEstablishedSysMsg](meetingManagerChannel, envelope, jsonNode)
 
       case UserGraphqlConnectionClosedSysMsg.NAME =>
         route[UserGraphqlConnectionClosedSysMsg](meetingManagerChannel, envelope, jsonNode)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -1005,7 +1005,7 @@ class MeetingActor(
         for {
           regUser <- RegisteredUsers.findWithUserId(u.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendInvalidateUserGraphqlConnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, EjectReasonCode.USER_INACTIVITY, outGW)
+          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, EjectReasonCode.USER_INACTIVITY, outGW)
         }
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -246,12 +246,12 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildInvalidateUserGraphqlConnectionSysMsg(meetingId: String, userId: String, sessionToken: String, reason: String): BbbCommonEnvCoreMsg = {
+  def buildForceUserGraphqlReconnectionSysMsg(meetingId: String, userId: String, sessionToken: String, reason: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.SYSTEM, meetingId, userId)
-    val envelope = BbbCoreEnvelope(InvalidateUserGraphqlConnectionSysMsg.NAME, routing)
-    val header = BbbCoreHeaderWithMeetingId(InvalidateUserGraphqlConnectionSysMsg.NAME, meetingId)
-    val body = InvalidateUserGraphqlConnectionSysMsgBody(meetingId, userId, sessionToken, reason)
-    val event = InvalidateUserGraphqlConnectionSysMsg(header, body)
+    val envelope = BbbCoreEnvelope(ForceUserGraphqlReconnectionSysMsg.NAME, routing)
+    val header = BbbCoreHeaderWithMeetingId(ForceUserGraphqlReconnectionSysMsg.NAME, meetingId)
+    val body = ForceUserGraphqlReconnectionSysMsgBody(meetingId, userId, sessionToken, reason)
+    val event = ForceUserGraphqlReconnectionSysMsg(header, body)
 
     BbbCommonEnvCoreMsg(envelope, event)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/Sender.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/Sender.scala
@@ -10,9 +10,9 @@ object Sender {
     outGW.send(ejectFromMeetingSystemEvent)
   }
 
-  def sendInvalidateUserGraphqlConnectionSysMsg(meetingId: String, userId: String, sessionToken: String, reason: String, outGW: OutMsgRouter): Unit = {
-    val invalidateUserGraphqlConnectionSysMsg = MsgBuilder.buildInvalidateUserGraphqlConnectionSysMsg(meetingId, userId, sessionToken, reason)
-    outGW.send(invalidateUserGraphqlConnectionSysMsg)
+  def sendForceUserGraphqlReconnectionSysMsg(meetingId: String, userId: String, sessionToken: String, reason: String, outGW: OutMsgRouter): Unit = {
+    val ForceUserGraphqlReconnectionSysMsg = MsgBuilder.buildForceUserGraphqlReconnectionSysMsg(meetingId, userId, sessionToken, reason)
+    outGW.send(ForceUserGraphqlReconnectionSysMsg)
   }
 
   def sendUserInactivityInspectMsg(meetingId: String, userId: String, responseDelay: Long, outGW: OutMsgRouter): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/GraphqlActionsSubscriberActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/GraphqlActionsSubscriberActor.scala
@@ -26,13 +26,13 @@ class GraphqlActionsActor(
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
     msg.core match {
       // Messages from bbb-graphql-middleware
-      case m: UserGraphqlConnectionStablishedSysMsg       => handleUserGraphqlConnectionStablishedSysMsg(m)
+      case m: UserGraphqlConnectionEstablishedSysMsg       => handleUserGraphqlConnectionEstablishedSysMsg(m)
       case m: UserGraphqlConnectionClosedSysMsg       => handleUserGraphqlConnectionClosedSysMsg(m)
       case _                          => // message not to be handled.
     }
   }
 
-  private def handleUserGraphqlConnectionStablishedSysMsg(msg: UserGraphqlConnectionStablishedSysMsg) {
+  private def handleUserGraphqlConnectionEstablishedSysMsg(msg: UserGraphqlConnectionEstablishedSysMsg) {
     UserGraphqlConnectionDAO.insert(msg.body.sessionToken, msg.body.browserConnectionId)
   }
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -235,30 +235,30 @@ case class DeletedRecordingSysMsgBody(recordId: String)
 /**
  * Sent from akka-apps to graphql-middleware
  */
-object InvalidateUserGraphqlConnectionSysMsg { val NAME = "InvalidateUserGraphqlConnectionSysMsg" }
-case class InvalidateUserGraphqlConnectionSysMsg(
+object ForceUserGraphqlReconnectionSysMsg { val NAME = "ForceUserGraphqlReconnectionSysMsg" }
+case class ForceUserGraphqlReconnectionSysMsg(
     header: BbbCoreHeaderWithMeetingId,
-    body:   InvalidateUserGraphqlConnectionSysMsgBody
+    body:   ForceUserGraphqlReconnectionSysMsgBody
 ) extends BbbCoreMsg
-case class InvalidateUserGraphqlConnectionSysMsgBody(meetingId: String, userId: String, sessionToken: String, reason: String)
+case class ForceUserGraphqlReconnectionSysMsgBody(meetingId: String, userId: String, sessionToken: String, reason: String)
 
 /**
  * Sent from graphql-middleware to akka-apps
  */
 
-object UserGraphqlConnectionInvalidatedEvtMsg { val NAME = "UserGraphqlConnectionInvalidatedEvtMsg" }
-case class UserGraphqlConnectionInvalidatedEvtMsg(
+object UserGraphqlReconnectionForcedEvtMsg { val NAME = "UserGraphqlReconnectionForcedEvtMsg" }
+case class UserGraphqlReconnectionForcedEvtMsg(
     header: BbbCoreBaseHeader,
-    body:   UserGraphqlConnectionInvalidatedEvtMsgBody
+    body:   UserGraphqlReconnectionForcedEvtMsgBody
 ) extends BbbCoreMsg
-case class UserGraphqlConnectionInvalidatedEvtMsgBody(sessionToken: String, browserConnectionId: String)
+case class UserGraphqlReconnectionForcedEvtMsgBody(sessionToken: String, browserConnectionId: String)
 
-object UserGraphqlConnectionStablishedSysMsg { val NAME = "UserGraphqlConnectionStablishedSysMsg" }
-case class UserGraphqlConnectionStablishedSysMsg(
+object UserGraphqlConnectionEstablishedSysMsg { val NAME = "UserGraphqlConnectionEstablishedSysMsg" }
+case class UserGraphqlConnectionEstablishedSysMsg(
     header: BbbCoreBaseHeader,
-    body:   UserGraphqlConnectionStablishedSysMsgBody
+    body:   UserGraphqlConnectionEstablishedSysMsgBody
 ) extends BbbCoreMsg
-case class UserGraphqlConnectionStablishedSysMsgBody(sessionToken: String, browserConnectionId: String)
+case class UserGraphqlConnectionEstablishedSysMsgBody(sessionToken: String, browserConnectionId: String)
 
 object UserGraphqlConnectionClosedSysMsg { val NAME = "UserGraphqlConnectionClosedSysMsg" }
 case class UserGraphqlConnectionClosedSysMsg(

--- a/bbb-graphql-middleware/internal/common/SafeChannel.go
+++ b/bbb-graphql-middleware/internal/common/SafeChannel.go
@@ -32,6 +32,10 @@ func (s *SafeChannel) Receive() (interface{}, bool) {
 	return val, ok
 }
 
+func (s *SafeChannel) ReceiveChannel() <-chan interface{} {
+	return s.ch
+}
+
 func (s *SafeChannel) Close() {
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/bbb-graphql-middleware/internal/hascli/client.go
+++ b/bbb-graphql-middleware/internal/hascli/client.go
@@ -22,7 +22,7 @@ var lastHasuraConnectionId int
 var hasuraEndpoint = os.Getenv("BBB_GRAPHQL_MIDDLEWARE_HASURA_WS")
 
 // Hasura client connection
-func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.Cookie, fromBrowserChannel chan interface{}, toBrowserChannel chan interface{}) error {
+func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.Cookie, fromBrowserChannel *common.SafeChannel, toBrowserChannel *common.SafeChannel) error {
 	log := log.WithField("_routine", "HasuraClient").WithField("browserConnectionId", browserConnection.Id)
 
 	// Obtain id for this connection
@@ -97,7 +97,7 @@ func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.C
 
 	// if it's a reconnect, inject authentication
 	if !browserConnection.Disconnected && browserConnection.ConnectionInitMessage != nil {
-		fromBrowserChannel <- browserConnection.ConnectionInitMessage
+		fromBrowserChannel.Send(browserConnection.ConnectionInitMessage)
 	}
 
 	// Wait

--- a/bbb-graphql-middleware/internal/hascli/client.go
+++ b/bbb-graphql-middleware/internal/hascli/client.go
@@ -22,7 +22,7 @@ var lastHasuraConnectionId int
 var hasuraEndpoint = os.Getenv("BBB_GRAPHQL_MIDDLEWARE_HASURA_WS")
 
 // Hasura client connection
-func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.Cookie, fromBrowserChannel *common.SafeChannel, toBrowserChannel *common.SafeChannel) error {
+func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.Cookie, fromBrowserToHasuraChannel *common.SafeChannel, fromHasuraToBrowserChannel *common.SafeChannel) error {
 	log := log.WithField("_routine", "HasuraClient").WithField("browserConnectionId", browserConnection.Id)
 
 	// Obtain id for this connection
@@ -90,14 +90,14 @@ func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.C
 	// Start routines
 
 	// reads from browser, writes to hasura
-	go writer.HasuraConnectionWriter(&thisConnection, fromBrowserChannel, &wg)
+	go writer.HasuraConnectionWriter(&thisConnection, fromBrowserToHasuraChannel, &wg)
 
 	// reads from hasura, writes to browser
-	go reader.HasuraConnectionReader(&thisConnection, toBrowserChannel, fromBrowserChannel, &wg)
+	go reader.HasuraConnectionReader(&thisConnection, fromHasuraToBrowserChannel, fromBrowserToHasuraChannel, &wg)
 
 	// if it's a reconnect, inject authentication
 	if !browserConnection.Disconnected && browserConnection.ConnectionInitMessage != nil {
-		fromBrowserChannel.Send(browserConnection.ConnectionInitMessage)
+		fromBrowserToHasuraChannel.Send(browserConnection.ConnectionInitMessage)
 	}
 
 	// Wait

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -10,7 +10,7 @@ import (
 )
 
 // HasuraConnectionReader consumes messages from Hasura connection and add send to the browser channel
-func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChannel chan interface{}, fromBrowserToHasuraChannel chan interface{}, wg *sync.WaitGroup) {
+func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChannel *common.SafeChannel, fromBrowserToHasuraChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "HasuraConnectionReader").WithField("browserConnectionId", hc.Browserconn.Id).WithField("hasuraConnectionId", hc.Id)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
@@ -62,7 +62,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 			}
 
 			// Write the message to browser
-			fromHasuraToBrowserChannel <- messageAsMap
+			fromHasuraToBrowserChannel.Send(messageAsMap)
 
 			// Replay the subscription start commands when hasura confirms the connection
 			// this is useful in case of a connection invalidation

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -2,7 +2,7 @@ package reader
 
 import (
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
-	"github.com/iMDT/bbb-graphql-middleware/internal/hascli/replayer"
+	"github.com/iMDT/bbb-graphql-middleware/internal/hascli/retransmiter"
 	"github.com/iMDT/bbb-graphql-middleware/internal/msgpatch"
 	log "github.com/sirupsen/logrus"
 	"nhooyr.io/websocket/wsjson"
@@ -64,10 +64,10 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 			// Write the message to browser
 			fromHasuraToBrowserChannel.Send(messageAsMap)
 
-			// Replay the subscription start commands when hasura confirms the connection
+			// Retransmit the subscription start commands when hasura confirms the connection
 			// this is useful in case of a connection invalidation
 			if messageType == "connection_ack" {
-				go replayer.ReplaySubscriptionStartMessages(hc, fromBrowserToHasuraChannel)
+				go retransmiter.RetransmitSubscriptionStartMessages(hc, fromBrowserToHasuraChannel)
 			}
 		}
 	}

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -12,7 +12,7 @@ import (
 
 // HasuraConnectionWriter
 // process messages (middleware to hasura)
-func HasuraConnectionWriter(hc *common.HasuraConnection, fromBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
+func HasuraConnectionWriter(hc *common.HasuraConnection, fromBrowserToHasuraChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "HasuraConnectionWriter")
 
 	browserConnection := hc.Browserconn
@@ -28,7 +28,7 @@ RangeLoop:
 		select {
 		case <-hc.Context.Done():
 			break RangeLoop
-		case fromBrowserMessage := <-fromBrowserChannel.ReceiveChannel():
+		case fromBrowserMessage := <-fromBrowserToHasuraChannel.ReceiveChannel():
 			{
 				if fromBrowserMessage == nil {
 					continue

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -12,7 +12,7 @@ import (
 
 // HasuraConnectionWriter
 // process messages (middleware to hasura)
-func HasuraConnectionWriter(hc *common.HasuraConnection, fromBrowserChannel chan interface{}, wg *sync.WaitGroup) {
+func HasuraConnectionWriter(hc *common.HasuraConnection, fromBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "HasuraConnectionWriter")
 
 	browserConnection := hc.Browserconn
@@ -28,7 +28,7 @@ RangeLoop:
 		select {
 		case <-hc.Context.Done():
 			break RangeLoop
-		case fromBrowserMessage := <-fromBrowserChannel:
+		case fromBrowserMessage := <-fromBrowserChannel.ReceiveChannel():
 			{
 				if fromBrowserMessage == nil {
 					continue

--- a/bbb-graphql-middleware/internal/hascli/replayer/replayer.go
+++ b/bbb-graphql-middleware/internal/hascli/replayer/replayer.go
@@ -5,14 +5,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func ReplaySubscriptionStartMessages(hc *common.HasuraConnection, fromBrowserChannel chan interface{}) {
+func ReplaySubscriptionStartMessages(hc *common.HasuraConnection, fromBrowserToHasuraChannel *common.SafeChannel) {
 	log := log.WithField("_routine", "ReplaySubscriptionStartMessages").WithField("browserConnectionId", hc.Browserconn.Id).WithField("hasuraConnectionId", hc.Id)
 
 	hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 	for _, subscription := range hc.Browserconn.ActiveSubscriptions {
 		if subscription.LastSeenOnHasuraConnetion != hc.Id {
 			log.Tracef("replaying subscription start: %v", subscription.Message)
-			fromBrowserChannel <- subscription.Message
+			fromBrowserToHasuraChannel.Send(subscription.Message)
 		}
 	}
 	hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()

--- a/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
@@ -1,17 +1,17 @@
-package replayer
+package retransmiter
 
 import (
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
 	log "github.com/sirupsen/logrus"
 )
 
-func ReplaySubscriptionStartMessages(hc *common.HasuraConnection, fromBrowserToHasuraChannel *common.SafeChannel) {
-	log := log.WithField("_routine", "ReplaySubscriptionStartMessages").WithField("browserConnectionId", hc.Browserconn.Id).WithField("hasuraConnectionId", hc.Id)
+func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowserToHasuraChannel *common.SafeChannel) {
+	log := log.WithField("_routine", "RetransmitSubscriptionStartMessages").WithField("browserConnectionId", hc.Browserconn.Id).WithField("hasuraConnectionId", hc.Id)
 
 	hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 	for _, subscription := range hc.Browserconn.ActiveSubscriptions {
 		if subscription.LastSeenOnHasuraConnetion != hc.Id {
-			log.Tracef("replaying subscription start: %v", subscription.Message)
+			log.Tracef("retransmiting subscription start: %v", subscription.Message)
 			fromBrowserToHasuraChannel.Send(subscription.Message)
 		}
 	}

--- a/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
+++ b/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
@@ -70,7 +70,7 @@ func ClearAllCaches() {
 	if err == nil && info.IsDir() {
 		filepath.Walk(cacheDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				log.Errorf("prevent panic by handling failure accessing a path %q: %v\n", path, err)
+				log.Debugf("Cache dir was removed previously (probably user disconnected): %q: %v\n", path, err)
 				return err
 			}
 

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -139,7 +139,7 @@ func InvalidateSessionTokenConnections(sessionTokenToInvalidate string) {
 				browserConnection.HasuraConnection.ContextCancelFunc()
 				log.Debugf("Processed invalidate request for sessionToken %v (hasura connection %v)", sessionTokenToInvalidate, browserConnection.HasuraConnection.Id)
 
-				go SendUserGraphqlConnectionInvalidatedEvtMsg(browserConnection.SessionToken)
+				go SendUserGraphqlReconnectionForcedEvtMsg(browserConnection.SessionToken)
 			}
 		}
 	}

--- a/bbb-graphql-middleware/internal/websrv/conninithandler.go
+++ b/bbb-graphql-middleware/internal/websrv/conninithandler.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-func ConnectionInitHandler(browserConnectionId string, browserConnectionContext context.Context, fromBrowser *common.SafeChannel, wg *sync.WaitGroup) {
+func ConnectionInitHandler(browserConnectionId string, browserConnectionContext context.Context, fromBrowserToHasuraConnectionEstablishingChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "ConnectionInitHandler").WithField("browserConnectionId", browserConnectionId)
 
 	log.Debugf("starting")
@@ -21,7 +21,7 @@ func ConnectionInitHandler(browserConnectionId string, browserConnectionContext 
 
 	// Intercept the fromBrowserMessage channel to get the sessionToken
 	for {
-		fromBrowserMessage, ok := fromBrowser.Receive()
+		fromBrowserMessage, ok := fromBrowserToHasuraConnectionEstablishingChannel.Receive()
 		if !ok {
 			//Received all messages. Channel is closed
 			return
@@ -40,8 +40,8 @@ func ConnectionInitHandler(browserConnectionId string, browserConnectionContext 
 					browserConnection.SessionToken = sessionToken
 					BrowserConnectionsMutex.Unlock()
 
-					go SendUserGraphqlConnectionStablishedSysMsg(sessionToken, browserConnectionId)
-					fromBrowser.Close()
+					go SendUserGraphqlConnectionEstablishedSysMsg(sessionToken, browserConnectionId)
+					fromBrowserToHasuraConnectionEstablishingChannel.Close()
 					break
 				}
 			}

--- a/bbb-graphql-middleware/internal/websrv/conninithandler.go
+++ b/bbb-graphql-middleware/internal/websrv/conninithandler.go
@@ -35,7 +35,7 @@ func ConnectionInitHandler(browserConnectionId string, browserConnectionContext 
 				var sessionToken = headersAsMap["X-Session-Token"]
 				if sessionToken != nil {
 					sessionToken := headersAsMap["X-Session-Token"].(string)
-					log.Infof("[SessionTokenReader] intercepted session token %v", sessionToken)
+					log.Debugf("[SessionTokenReader] intercepted session token %v", sessionToken)
 					BrowserConnectionsMutex.Lock()
 					browserConnection.SessionToken = sessionToken
 					BrowserConnectionsMutex.Unlock()

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -10,14 +10,14 @@ import (
 	"time"
 )
 
-func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromBrowserChannel1 chan interface{}, fromBrowserChannel2 *common.SafeChannel, waitGroups []*sync.WaitGroup) {
+func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromBrowserToHasuraChannel1 *common.SafeChannel, fromBrowserToHasuraChannel2 *common.SafeChannel, waitGroups []*sync.WaitGroup) {
 	log := log.WithField("_routine", "BrowserConnectionReader").WithField("browserConnectionId", browserConnectionId)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
 
 	defer func() {
-		close(fromBrowserChannel1)
-		fromBrowserChannel2.Close()
+		fromBrowserToHasuraChannel1.Close()
+		fromBrowserToHasuraChannel2.Close()
 	}()
 
 	defer func() {
@@ -32,21 +32,23 @@ func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	fromBrowserChannel2Alive := true
-
 	for {
 		var v interface{}
 		err := wsjson.Read(ctx, c, &v)
 		if err != nil {
-			log.Errorf("error on read (browser is disconnected): %v", err)
+			log.Debugf("Browser is disconnected, skiping reading of ws message: %v", err)
+
+			//Dec 13 15:00:51 bbb30.bbb.imdt.dev bbb-graphql-middleware[20317]: {"_routine":"BrowserConnectionReader","browserConnectionId":"BC0000000007","level":"error","msg":"error on read (browser is disconnected):
+			//failed to read JSON message: failed to get reader: received close frame: status = StatusGoingAway and reason = \"\"","time":"2023-12-13T15:00:51-03:00"}
+			//Dec 13 15:00:51 bbb30.bbb.imdt.dev bbb-graphql-middleware[20317]: {"_routine":"BrowserConnectionWriter","browserConnectionId":"BC0000000007","level":"error","msg":"error on write (browser is disconnected):
+			//failed to write JSON message: failed to marshal JSON: failed to write msg: use of closed network connection","time":"2023-12-13T15:00:51-03:00"}
+
 			return
 		}
 
 		log.Tracef("received from browser: %v", v)
 
-		fromBrowserChannel1 <- v
-		if fromBrowserChannel2Alive {
-			fromBrowserChannel2Alive = fromBrowserChannel2.Send(v)
-		}
+		fromBrowserToHasuraChannel1.Send(v)
+		fromBrowserToHasuraChannel2.Send(v)
 	}
 }

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -37,12 +37,6 @@ func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c 
 		err := wsjson.Read(ctx, c, &v)
 		if err != nil {
 			log.Debugf("Browser is disconnected, skiping reading of ws message: %v", err)
-
-			//Dec 13 15:00:51 bbb30.bbb.imdt.dev bbb-graphql-middleware[20317]: {"_routine":"BrowserConnectionReader","browserConnectionId":"BC0000000007","level":"error","msg":"error on read (browser is disconnected):
-			//failed to read JSON message: failed to get reader: received close frame: status = StatusGoingAway and reason = \"\"","time":"2023-12-13T15:00:51-03:00"}
-			//Dec 13 15:00:51 bbb30.bbb.imdt.dev bbb-graphql-middleware[20317]: {"_routine":"BrowserConnectionWriter","browserConnectionId":"BC0000000007","level":"error","msg":"error on write (browser is disconnected):
-			//failed to write JSON message: failed to marshal JSON: failed to write msg: use of closed network connection","time":"2023-12-13T15:00:51-03:00"}
-
 			return
 		}
 

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -3,7 +3,6 @@ package websrv
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 	"os"
@@ -89,17 +88,17 @@ func sendBbbCoreMsgToRedis(name string, body map[string]interface{}) {
 
 	messageJSON, err := json.Marshal(message)
 	if err != nil {
-		fmt.Printf("Error while marshaling message to json: %v\n", err)
+		log.Tracef("Error while marshaling message to json: %v\n", err)
 		return
 	}
 
 	err = GetRedisConn().Publish(context.Background(), channelName, messageJSON).Err()
 	if err != nil {
-		fmt.Printf("Error while sending msg to redis channel: %v\n", err)
+		log.Tracef("Error while sending msg to redis channel: %v\n", err)
 		return
 	}
 
-	fmt.Printf("JSON message sent to channel %s:\n%s\n", channelName, messageJSON)
+	log.Tracef("JSON message sent to channel %s:\n%s\n", channelName, messageJSON)
 }
 
 func SendUserGraphqlConnectionInvalidatedEvtMsg(sessionToken string) {

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -34,7 +34,7 @@ func StartRedisListener() {
 		}
 
 		// Skip parsing unnecessary messages
-		if !strings.Contains(msg.Payload, "InvalidateUserGraphqlConnectionSysMsg") {
+		if !strings.Contains(msg.Payload, "ForceUserGraphqlReconnectionSysMsg") {
 			continue
 		}
 
@@ -49,7 +49,7 @@ func StartRedisListener() {
 
 		messageType := messageEnvelopeAsMap["name"]
 
-		if messageType == "InvalidateUserGraphqlConnectionSysMsg" {
+		if messageType == "ForceUserGraphqlReconnectionSysMsg" {
 			messageCoreAsMap := messageAsMap["core"].(map[string]interface{})
 			messageBodyAsMap := messageCoreAsMap["body"].(map[string]interface{})
 			sessionTokenToInvalidate := messageBodyAsMap["sessionToken"]
@@ -101,21 +101,21 @@ func sendBbbCoreMsgToRedis(name string, body map[string]interface{}) {
 	log.Tracef("JSON message sent to channel %s:\n%s\n", channelName, messageJSON)
 }
 
-func SendUserGraphqlConnectionInvalidatedEvtMsg(sessionToken string) {
+func SendUserGraphqlReconnectionForcedEvtMsg(sessionToken string) {
 	var body = map[string]interface{}{
 		"sessionToken": sessionToken,
 	}
 
-	sendBbbCoreMsgToRedis("UserGraphqlConnectionInvalidatedEvtMsg", body)
+	sendBbbCoreMsgToRedis("UserGraphqlReconnectionForcedEvtMsg", body)
 }
 
-func SendUserGraphqlConnectionStablishedSysMsg(sessionToken string, browserConnectionId string) {
+func SendUserGraphqlConnectionEstablishedSysMsg(sessionToken string, browserConnectionId string) {
 	var body = map[string]interface{}{
 		"sessionToken":        sessionToken,
 		"browserConnectionId": browserConnectionId,
 	}
 
-	sendBbbCoreMsgToRedis("UserGraphqlConnectionStablishedSysMsg", body)
+	sendBbbCoreMsgToRedis("UserGraphqlConnectionEstablishedSysMsg", body)
 }
 
 func SendUserGraphqlConnectionClosedSysMsg(sessionToken string, browserConnectionId string) {

--- a/bbb-graphql-middleware/internal/websrv/writer/writer.go
+++ b/bbb-graphql-middleware/internal/websrv/writer/writer.go
@@ -10,7 +10,7 @@ import (
 	"nhooyr.io/websocket/wsjson"
 )
 
-func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, toBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
+func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromHasuratoBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "BrowserConnectionWriter").WithField("browserConnectionId", browserConnectionId)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
@@ -21,7 +21,7 @@ RangeLoop:
 		select {
 		case <-ctx.Done():
 			break RangeLoop
-		case toBrowserMessage := <-toBrowserChannel.ReceiveChannel():
+		case toBrowserMessage := <-fromHasuratoBrowserChannel.ReceiveChannel():
 			{
 				var toBrowserMessageAsMap = toBrowserMessage.(map[string]interface{})
 

--- a/bbb-graphql-middleware/internal/websrv/writer/writer.go
+++ b/bbb-graphql-middleware/internal/websrv/writer/writer.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+	"github.com/iMDT/bbb-graphql-middleware/internal/common"
 	log "github.com/sirupsen/logrus"
 	"sync"
 
@@ -9,7 +10,7 @@ import (
 	"nhooyr.io/websocket/wsjson"
 )
 
-func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, toBrowserChannel chan interface{}, wg *sync.WaitGroup) {
+func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, toBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "BrowserConnectionWriter").WithField("browserConnectionId", browserConnectionId)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
@@ -20,14 +21,14 @@ RangeLoop:
 		select {
 		case <-ctx.Done():
 			break RangeLoop
-		case toBrowserMessage := <-toBrowserChannel:
+		case toBrowserMessage := <-toBrowserChannel.ReceiveChannel():
 			{
 				var toBrowserMessageAsMap = toBrowserMessage.(map[string]interface{})
 
 				log.Tracef("sending to browser: %v", toBrowserMessage)
 				err := wsjson.Write(ctx, c, toBrowserMessage)
 				if err != nil {
-					log.Errorf("error on write (browser is disconnected): %v", err)
+					log.Debugf("Browser is disconnected, skiping writing of ws message: %v", err)
 					return
 				}
 


### PR DESCRIPTION
- Change some log messages and levels in order to avoid thinking it's a system error when actually it's a normal situation.
- Rename channel names and set the same name in all places to avoid confusion (`fromBrowserToHasuraConnectionEstablishingChannel`,  `fromBrowserToHasuraChannel`,  `fromHasuraToBrowserChannel`).
- Rename `InvalidateUserGraphqlConnectionSysMsg` to `ForceUserGraphqlReconnectionSysMsg` to make it clearer that the user will not be removed but just reconnected to refresh roles.
- Rename `replayer` to `retransmiter` to make it clearer.
- Convert all go `chan interface{}` to `SafeChannel` introduced in #18895 to avoid the error bellow:
```
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]: {"_routine":"BrowserConnectionReader","browserConnectionId":"BC0000000001","level":"error","msg":"error on read (browser is disconnected): failed to read JSON message: failed to get reader: received close frame: status = StatusNoStatusRcvd and reason = \"\"","time":"2023-11-30T18:44:35Z"}
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]: panic: send on closed channel
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]: goroutine 46 [running]:
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]: github.com/iMDT/bbb-graphql-middleware/internal/hascli/replayer.ReplaySubscriptionStartMessages(0xc000114cc0, 0x0?)
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]:         /var/tmp/bbb-graphql-middleware_3.0_jammy_m30f/internal/hascli/replayer/replayer.go:15 +0x357
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]: created by github.com/iMDT/bbb-graphql-middleware/internal/hascli/conn/reader.HasuraConnectionReader
Nov 30 18:44:35 bbb30-load-test bbb-graphql-middleware[155748]:         /var/tmp/bbb-graphql-middleware_3.0_jammy_m30f/internal/hascli/conn/reader/reader.go:70 +0x832
Nov 30 18:44:35 bbb30-load-test systemd[1]: bbb-graphql-middleware.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Nov 30 18:44:35 bbb30-load-test systemd[1]: bbb-graphql-middleware.service: Failed with result 'exit-code'.
Nov 30 18:45:35 bbb30-load-test systemd[1]: bbb-graphql-middleware.service: Scheduled restart job, restart counter is at 3.
Nov 30 18:45:35 bbb30-load-test systemd[1]: Stopped BigBlueButton GraphQL Middleware.
Nov 30 18:45:35 bbb30-load-test systemd[1]: Started BigBlueButton GraphQL Middleware.
```