### PR TITLE
refactor (graphql-server): Optimize Hasura Queries with Session Variables

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -9,7 +9,7 @@ import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.Permissions
-import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
 trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -237,6 +237,15 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
         )
 
         outGW.send(BbbCommonEnvCoreMsg(envelope, LockSettingsInMeetingChangedEvtMsg(header, body)))
+
+        for {
+          user <- Users2x.findAll(liveMeeting.users2x)
+          if user.locked
+          if user.role == Roles.VIEWER_ROLE
+          regUser <- RegisteredUsers.findWithUserId(user.intId, liveMeeting.registeredUsers)
+        } yield {
+          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "lockSettings_changed", outGW)
+        }
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -238,6 +238,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
 
         outGW.send(BbbCommonEnvCoreMsg(envelope, LockSettingsInMeetingChangedEvtMsg(header, body)))
 
+        //Refresh graphql session for all locked viewers
         for {
           user <- Users2x.findAll(liveMeeting.users2x)
           if user.locked

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
@@ -78,6 +78,7 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
 
             broadcastEvent(meetingId, msg.body.setBy, value)
 
+            //Refresh graphql session for all locked viewers
             for {
               user <- Users2x.findAll(liveMeeting.users2x)
               if user.locked

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
@@ -4,8 +4,9 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.db.MeetingUsersPoliciesDAO
+import org.bigbluebutton.core.models.{ RegisteredUsers, Roles, Users2x }
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
 trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
   this: WebcamApp2x =>
@@ -76,6 +77,15 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
             }
 
             broadcastEvent(meetingId, msg.body.setBy, value)
+
+            for {
+              user <- Users2x.findAll(liveMeeting.users2x)
+              if user.locked
+              if user.role == Roles.VIEWER_ROLE
+              regUser <- RegisteredUsers.findWithUserId(user.intId, liveMeeting.registeredUsers)
+            } yield {
+              Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "webcamOnlyForMod_changed", bus.outGW)
+            }
           }
           case _ =>
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -32,6 +32,10 @@ object RegisteredUsers {
     )
   }
 
+  def getAll(users: RegisteredUsers): Vector[RegisteredUser] = {
+    users.toVector
+  }
+
   def findWithToken(token: String, users: RegisteredUsers): Option[RegisteredUser] = {
     users.toVector.find(u => u.authToken == token)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -32,10 +32,6 @@ object RegisteredUsers {
     )
   }
 
-  def getAll(users: RegisteredUsers): Vector[RegisteredUser] = {
-    users.toVector
-  }
-
   def findWithToken(token: String, users: RegisteredUsers): Option[RegisteredUser] = {
     users.toVector.find(u => u.authToken == token)
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -1184,6 +1184,10 @@ public class MeetingService implements MessageListener {
           processGuestStatusChangedEventMsg((GuestStatusChangedEventMsg) message);
         } else if (message instanceof GuestPolicyChanged) {
           processGuestPolicyChanged((GuestPolicyChanged) message);
+        } else if (message instanceof LockSettingsChanged) {
+          processLockSettingsChanged((LockSettingsChanged) message);
+        } else if (message instanceof WebcamsOnlyForModeratorChanged) {
+          processWebcamsOnlyForModeratorChanged((WebcamsOnlyForModeratorChanged) message);
         } else if (message instanceof GuestLobbyMessageChanged) {
           processGuestLobbyMessageChanged((GuestLobbyMessageChanged) message);
         } else if (message instanceof PrivateGuestLobbyMessageChanged) {
@@ -1207,6 +1211,32 @@ public class MeetingService implements MessageListener {
     Meeting m = getMeeting(msg.meetingId);
     if (m != null) {
       m.setGuestPolicy(msg.policy);
+    }
+  }
+
+  public void processLockSettingsChanged(LockSettingsChanged msg) {
+    Meeting m = getMeeting(msg.meetingId);
+    if (m != null) {
+      m.setLockSettings(
+              new LockSettingsParams(
+                msg.disableCam,
+                msg.disableMic,
+                msg.disablePrivateChat,
+                msg.disablePublicChat,
+                msg.disableNotes,
+                msg.hideUserList,
+                msg.lockOnJoin,
+                msg.lockOnJoinConfigurable,
+                msg.hideViewersCursor,
+                msg.hideViewersAnnotation)
+      );
+    }
+  }
+
+  public void processWebcamsOnlyForModeratorChanged(WebcamsOnlyForModeratorChanged msg) {
+    Meeting m = getMeeting(msg.meetingId);
+    if (m != null) {
+      m.setWebcamsOnlyForModerator(msg.webcamsOnlyForModerator);
     }
   }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -110,7 +110,7 @@ public class Meeting {
     private Integer endWhenNoModeratorDelayInMinutes = 1;
 
 	public final BreakoutRoomsParams breakoutRoomsParams;
-	public final LockSettingsParams lockSettingsParams;
+	public LockSettingsParams lockSettingsParams;
 
 	public final Integer maxUserConcurrentAccesses;
 
@@ -472,7 +472,15 @@ public class Meeting {
 	}
 
 	public String getGuestPolicy() {
-    	return guestPolicy;
+		return guestPolicy;
+	}
+
+	public void setLockSettings(LockSettingsParams lockSettingsParams) {
+		this.lockSettingsParams = lockSettingsParams;
+	}
+
+	public void setWebcamsOnlyForModerator(Boolean webcamsOnlyForModerator) {
+		this.webcamsOnlyForModerator = webcamsOnlyForModerator;
 	}
 
 	public void setGuestLobbyMessage(String message) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/User.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/User.java
@@ -137,6 +137,10 @@ public class User {
 	public boolean isModerator() {
 		return "MODERATOR".equalsIgnoreCase(this.role);
 	}
+
+	public boolean isLocked() {
+		return this.locked;
+	}
 	
 	public void setStatus(String key, String value){
 		this.status.put(key, value);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/LockSettingsChanged.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/LockSettingsChanged.java
@@ -1,0 +1,40 @@
+package org.bigbluebutton.api.messaging.messages;
+
+public class LockSettingsChanged implements IMessage {
+
+    public final String meetingId;
+    public final Boolean disableCam;
+    public final Boolean disableMic;
+    public final Boolean disablePrivateChat;
+    public final Boolean disablePublicChat;
+    public final Boolean disableNotes;
+    public final Boolean hideUserList;
+    public final Boolean lockOnJoin;
+    public final Boolean lockOnJoinConfigurable;
+    public final Boolean hideViewersCursor;
+    public final Boolean hideViewersAnnotation;
+
+    public LockSettingsChanged(String meetingId,
+                               Boolean disableCam,
+                               Boolean disableMic,
+                               Boolean disablePrivateChat,
+                               Boolean disablePublicChat,
+                               Boolean disableNotes,
+                               Boolean hideUserList,
+                               Boolean lockOnJoin,
+                               Boolean lockOnJoinConfigurable,
+                               Boolean hideViewersCursor,
+                               Boolean hideViewersAnnotation) {
+        this.meetingId = meetingId;
+        this.disableCam = disableCam;
+        this.disableMic = disableMic;
+        this.disablePrivateChat = disablePrivateChat;
+        this.disablePublicChat = disablePublicChat;
+        this.disableNotes = disableNotes;
+        this.hideUserList = hideUserList;
+        this.lockOnJoin = lockOnJoin;
+        this.lockOnJoinConfigurable = lockOnJoinConfigurable;
+        this.hideViewersCursor = hideViewersCursor;
+        this.hideViewersAnnotation = hideViewersAnnotation;
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/WebcamsOnlyForModeratorChanged.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/WebcamsOnlyForModeratorChanged.java
@@ -1,0 +1,11 @@
+package org.bigbluebutton.api.messaging.messages;
+
+public class WebcamsOnlyForModeratorChanged implements IMessage {
+    public final String meetingId;
+    public final Boolean webcamsOnlyForModerator;
+
+    public WebcamsOnlyForModeratorChanged(String meetingId, Boolean webcamsOnlyForModerator) {
+        this.meetingId = meetingId;
+        this.webcamsOnlyForModerator = webcamsOnlyForModerator;
+    }
+}

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/bus/ReceivedJsonMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/bus/ReceivedJsonMsgHdlrActor.scala
@@ -100,6 +100,10 @@ class ReceivedJsonMsgHdlrActor(val msgFromAkkaAppsEventBus: MsgFromAkkaAppsEvent
         route[PosInWaitingQueueUpdatedRespMsg](envelope, jsonNode)
       case GuestPolicyChangedEvtMsg.NAME =>
         route[GuestPolicyChangedEvtMsg](envelope, jsonNode)
+      case LockSettingsInMeetingChangedEvtMsg.NAME =>
+        route[LockSettingsInMeetingChangedEvtMsg](envelope, jsonNode)
+      case WebcamsOnlyForModeratorChangedEvtMsg.NAME =>
+        route[WebcamsOnlyForModeratorChangedEvtMsg](envelope, jsonNode)
       case GuestLobbyMessageChangedEvtMsg.NAME =>
         route[GuestLobbyMessageChangedEvtMsg](envelope, jsonNode)
       case PrivateGuestLobbyMsgChangedEvtMsg.NAME =>

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -1,8 +1,7 @@
 package org.bigbluebutton.api2.meeting
 
 import java.util
-
-import org.apache.pekko.actor.{ Actor, ActorLogging, Props }
+import org.apache.pekko.actor.{Actor, ActorLogging, Props}
 import org.bigbluebutton.api.messaging.messages._
 import org.bigbluebutton.api2.bus.OldMessageReceivedGW
 import org.bigbluebutton.common2.msgs._
@@ -41,6 +40,8 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       case m: GuestsWaitingApprovedEvtMsg       => handleGuestsWaitingApprovedEvtMsg(m)
       case m: PosInWaitingQueueUpdatedRespMsg   => handlePosInWaitingQueueUpdatedRespMsg(m)
       case m: GuestPolicyChangedEvtMsg          => handleGuestPolicyChangedEvtMsg(m)
+      case m: LockSettingsInMeetingChangedEvtMsg => handleLockSettingsInMeetingChangedEvtMsg(m)
+      case m: WebcamsOnlyForModeratorChangedEvtMsg => handleWebcamsOnlyForModeratorChangedEvtMsg(m)
       case m: GuestLobbyMessageChangedEvtMsg    => handleGuestLobbyMessageChangedEvtMsg(m)
       case m: PrivateGuestLobbyMsgChangedEvtMsg => handlePrivateGuestLobbyMsgChangedEvtMsg(m)
       case m: RecordingChapterBreakSysMsg       => handleRecordingChapterBreakSysMsg(m)
@@ -53,6 +54,25 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
 
   def handleGuestPolicyChangedEvtMsg(msg: GuestPolicyChangedEvtMsg): Unit = {
     olgMsgGW.handle(new GuestPolicyChanged(msg.header.meetingId, msg.body.policy))
+  }
+
+  def handleLockSettingsInMeetingChangedEvtMsg(msg: LockSettingsInMeetingChangedEvtMsg): Unit = {
+    olgMsgGW.handle(new LockSettingsChanged(msg.header.meetingId,
+                                            msg.body.disableCam,
+                                            msg.body.disableMic,
+                                            msg.body.disablePrivChat,
+                                            msg.body.disablePubChat,
+                                            msg.body.disableNotes,
+                                            msg.body.hideUserList,
+                                            msg.body.lockOnJoin,
+                                            msg.body.lockOnJoinConfigurable,
+                                            msg.body.hideViewersCursor,
+                                            msg.body.hideViewersAnnotation,
+    ))
+  }
+
+  def handleWebcamsOnlyForModeratorChangedEvtMsg(msg: WebcamsOnlyForModeratorChangedEvtMsg): Unit = {
+    olgMsgGW.handle(new WebcamsOnlyForModeratorChanged(msg.header.meetingId, msg.body.webcamsOnlyForModerator))
   }
 
   def handleGuestLobbyMessageChangedEvtMsg(msg: GuestLobbyMessageChangedEvtMsg): Unit = {

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -138,6 +138,7 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
+        - createdAt
         - createdTime
         - disabledFeatures
         - durationInSeconds

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_showUserlist.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_showUserlist.yaml
@@ -1,3 +1,0 @@
-table:
-  name: v_meeting_showUserlist
-  schema: public

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_annotation_curr.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_annotation_curr.yaml
@@ -32,22 +32,10 @@ select_permissions:
           - meetingId:
               _eq: X-Hasura-MeetingId
           - _or:
-              - meetingId:
-                  _eq: X-Hasura-ModeratorInMeeting
-              - userId:
-                  _eq: X-Hasura-LockedUserId
-              - meetingId:
-                  _neq: X-Hasura-LockedInMeeting
-              - _exists:
-                  _table:
-                    name: v_meeting_lockSettings
-                    schema: public
-                  _where:
-                    _and:
-                      - meetingId:
-                          _eq: X-Hasura-MeetingId
-                      - hideViewersAnnotation:
-                          _eq: false
               - user:
                   isModerator:
                     _eq: true
+              - meetingId:
+                  _eq: X-Hasura-AnnotationsNotLockedInMeeting
+              - userId:
+                  _eq: X-Hasura-AnnotationsLockedUserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_annotation_history_curr.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_annotation_history_curr.yaml
@@ -31,22 +31,10 @@ select_permissions:
           - meetingId:
               _eq: X-Hasura-MeetingId
           - _or:
-              - meetingId:
-                  _eq: X-Hasura-ModeratorInMeeting
-              - userId:
-                  _eq: X-Hasura-LockedUserId
-              - meetingId:
-                  _neq: X-Hasura-LockedInMeeting
-              - _exists:
-                  _table:
-                    name: v_meeting_lockSettings
-                    schema: public
-                  _where:
-                    _and:
-                      - meetingId:
-                          _eq: X-Hasura-MeetingId
-                      - hideViewersAnnotation:
-                          _eq: false
               - user:
                   isModerator:
                     _eq: true
+              - meetingId:
+                  _eq: X-Hasura-AnnotationsNotLockedInMeeting
+              - userId:
+                  _eq: X-Hasura-AnnotationsLockedUserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_cursor.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_cursor.yaml
@@ -36,18 +36,6 @@ select_permissions:
                   isModerator:
                     _eq: true
               - meetingId:
-                  _eq: X-Hasura-ModeratorInMeeting
-              - meetingId:
-                  _neq: X-Hasura-LockedInMeeting
+                  _eq: X-Hasura-CursorNotLockedInMeeting
               - userId:
-                  _eq: X-Hasura-LockedUserId
-              - _exists:
-                  _table:
-                    name: v_meeting_lockSettings
-                    schema: public
-                  _where:
-                    _and:
-                      - meetingId:
-                          _eq: X-Hasura-MeetingId
-                      - hideViewersCursor:
-                          _eq: false
+                  _eq: X-Hasura-CursorLockedUserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -114,17 +114,8 @@ select_permissions:
           - meetingId:
               _eq: X-Hasura-MeetingId
           - _or:
-              - meetingId:
-                  _eq: X-Hasura-ModeratorInMeeting
               - isModerator:
-                  _eq: true
+                    _eq: true
               - meetingId:
-                  _neq: X-Hasura-LockedInMeeting
-              - _exists:
-                  _table:
-                    name: v_meeting_showUserlist
-                    schema: public
-                  _where:
-                    meetingId:
-                      _eq: X-Hasura-MeetingId
+                  _eq: X-Hasura-UserListNotLockedInMeeting
       allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -115,7 +115,7 @@ select_permissions:
               _eq: X-Hasura-MeetingId
           - _or:
               - isModerator:
-                    _eq: true
+                  _eq: true
               - meetingId:
                   _eq: X-Hasura-UserListNotLockedInMeeting
       allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -32,4 +32,6 @@ select_permissions:
                     _eq: true
               - meetingId:
                   _eq: X-Hasura-WebcamsNotLockedInMeeting
+              - userId:
+                  _eq: X-Hasura-WebcamsLockedUserId
       allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -23,6 +23,13 @@ select_permissions:
         - streamId
         - userId
       filter:
-        meetingId:
-          _eq: X-Hasura-MeetingId
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - _or:
+              - user:
+                  isModerator:
+                    _eq: true
+              - meetingId:
+                  _eq: X-Hasura-WebcamsNotLockedInMeeting
       allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_typing_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_typing_public.yaml
@@ -31,7 +31,7 @@ select_permissions:
               _eq: X-Hasura-MeetingId
           - _or:
               - user:
-                    isModerator:
-                      _eq: true
+                  isModerator:
+                    _eq: true
               - meetingId:
                   _eq: X-Hasura-UserListNotLockedInMeeting

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_typing_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_typing_public.yaml
@@ -30,17 +30,8 @@ select_permissions:
           - meetingId:
               _eq: X-Hasura-MeetingId
           - _or:
-              - meetingId:
-                  _eq: X-Hasura-ModeratorInMeeting
               - user:
-                  isModerator:
-                    _eq: true
+                    isModerator:
+                      _eq: true
               - meetingId:
-                  _neq: X-Hasura-LockedInMeeting
-              - _exists:
-                  _table:
-                    name: v_meeting_showUserlist
-                    schema: public
-                  _where:
-                    meetingId:
-                      _eq: X-Hasura-MeetingId
+                  _eq: X-Hasura-UserListNotLockedInMeeting

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -19,7 +19,6 @@
 - "!include public_v_meeting_lockSettings.yaml"
 - "!include public_v_meeting_recording.yaml"
 - "!include public_v_meeting_recordingPolicies.yaml"
-- "!include public_v_meeting_showUserlist.yaml"
 - "!include public_v_meeting_usersPolicies.yaml"
 - "!include public_v_meeting_voiceSettings.yaml"
 - "!include public_v_pluginDataChannelMessage.yaml"

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -106,6 +106,7 @@ class ConnectionController {
               "X-Hasura-AnnotationsLockedUserId" annotationsLocked ? userSession.internalUserId : ""
               "X-Hasura-UserListNotLockedInMeeting" userListLocked ? "" : userSession.meetingID
               "X-Hasura-WebcamsNotLockedInMeeting" webcamOnlyForMod ? "" : userSession.meetingID
+              "X-Hasura-WebcamsLockedUserId" webcamOnlyForMod ? userSession.internalUserId : ""
             }
             render(contentType: "application/json", text: builder.toPrettyString())
           }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -20,6 +20,7 @@ package org.bigbluebutton.web.controllers
 
 import groovy.json.JsonBuilder
 import org.bigbluebutton.api.MeetingService
+import org.bigbluebutton.api.domain.Meeting
 import org.bigbluebutton.api.domain.UserSession
 import org.bigbluebutton.api.domain.User
 import org.bigbluebutton.api.util.ParamsUtil
@@ -64,7 +65,7 @@ class ConnectionController {
         throw new Exception("Invalid User Agent")
       }
 
-      def sessionToken = request.getHeader("x-session-token")
+      String sessionToken = request.getHeader("x-session-token")
 
       UserSession userSession = meetingService.getUserSessionWithAuthToken(sessionToken)
       Boolean allowRequestsWithoutSession = meetingService.getAllowRequestsWithoutSession(sessionToken)
@@ -73,7 +74,20 @@ class ConnectionController {
       response.addHeader("Cache-Control", "no-cache")
 
       if (userSession != null && !isSessionTokenInvalid) {
-        User u = meetingService.getMeeting(userSession.meetingID).getUserById(userSession.internalUserId)
+        Meeting m = meetingService.getMeeting(userSession.meetingID)
+        User u = m.getUserById(userSession.internalUserId)
+
+
+        Boolean cursorLocked = false
+        Boolean annotationsLocked = false
+        Boolean userListLocked = false
+        Boolean webcamOnlyForMod = false
+        if(u && u.isLocked() && !u.isModerator()) {
+          cursorLocked = m.lockSettingsParams.hideViewersCursor
+          annotationsLocked = m.lockSettingsParams.hideViewersAnnotation
+          userListLocked = m.lockSettingsParams.hideUserList
+          webcamOnlyForMod = m.getWebcamsOnlyForModerator()
+        }
 
         response.setStatus(200)
         withFormat {
@@ -82,13 +96,16 @@ class ConnectionController {
             builder {
               "response" "authorized"
               "X-Hasura-Role" u ? "bbb_client" : "pre_join_bbb_client"
-              "X-Hasura-Locked" u && u.locked ? "true" : "false"
-              "X-Hasura-LockedInMeeting" u && u.locked ? userSession.meetingID : ""
-              "X-Hasura-LockedUserId" u && u.locked ? userSession.internalUserId : ""
               "X-Hasura-ModeratorInMeeting" u && u.isModerator() ? userSession.meetingID : ""
               "X-Hasura-PresenterInMeeting" u && u.isPresenter() ? userSession.meetingID : ""
               "X-Hasura-UserId" userSession.internalUserId
               "X-Hasura-MeetingId" userSession.meetingID
+              "X-Hasura-CursorNotLockedInMeeting" cursorLocked ? "" : userSession.meetingID
+              "X-Hasura-CursorLockedUserId" cursorLocked ? userSession.internalUserId : ""
+              "X-Hasura-AnnotationsNotLockedInMeeting" annotationsLocked ? "" : userSession.meetingID
+              "X-Hasura-AnnotationsLockedUserId" annotationsLocked ? userSession.internalUserId : ""
+              "X-Hasura-UserListNotLockedInMeeting" userListLocked ? "" : userSession.meetingID
+              "X-Hasura-WebcamsNotLockedInMeeting" webcamOnlyForMod ? "" : userSession.meetingID
             }
             render(contentType: "application/json", text: builder.toPrettyString())
           }


### PR DESCRIPTION
### Optimize Hasura Queries with Session Variables

This update introduces Hasura session variables to enhance query performance, particularly for validations involving `lockSettings`. Previously, queries frequently checked `lockSettings` and `userId` to determine user access to specific data, such as cursor visibility. This approach hindered query multiplexing efficiency. Now, `lockSettings` are fetched only once when the Graphql connection is established, using session variables. This reduces reliance on repetitive, resource-intensive checks. Key areas benefiting from this include:
- Userlist visibility (`lockSettings.hideUserList`)
- Cursor visibility for other viewers (`lockSettings.hideViewersCursor`)
- Annotation visibility (`lockSettings.hideViewersAnnotation`)
- Webcam access control (`webcamsOnlyForModerator`)

### Other than that
- Add `meeting.createdAt` (the idea is to standardize dates using `timestamp` type and ending name with `At`)
- BBB-WEB will update `lockSettings` and `webcamsOnlyForModerator` in real-time (to make the new Hasura session variables possible)

### Tests
[Screencast from 2023-12-15 18-50-36.webm](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/d31156c0-f9a2-4e9f-9bce-2431cf4911f2)

