### PR TITLE
build: Bump bbb-pads to 1.5.2 (port from 2.7) #19070

### DIFF
--- a/bbb-pads.placeholder.sh
+++ b/bbb-pads.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v1.5.1 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads
+git clone --branch v1.5.2 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads


### PR DESCRIPTION
Porting https://github.com/bigbluebutton/bigbluebutton/pull/19070 to v3.0.x-release