### PR TITLE
[3.0a] quicker zoom by wheel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -89,8 +89,8 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef }, {
 
         const MAX_ZOOM = 4;
         const MIN_ZOOM = .2;
-        const ZOOM_IN_FACTOR = 0.025; // Finer zoom control
-        const ZOOM_OUT_FACTOR = 0.025;
+        const ZOOM_IN_FACTOR = 0.100; // Finer zoom control
+        const ZOOM_OUT_FACTOR = 0.100;
 
         const { x: cx, y: cy, z: cz } = tlEditorRef.current.camera;
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation

Current zoom rate by wheel is too slow compared to the previous versions. It's important to be able to quickly navigate the slide in a real life lecture.

### More

I guess the core developers will fine-tune the parameters including this one. So this PR is like my humble proposal/request.
