### PR TITLE
build(sec): upgrade FreeSWITCH to 1.10.11 +sofia-sip +libks

### DIFF
--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -31,7 +31,7 @@ if [ ! -d sofia-sip ]; then
   git clone https://github.com/freeswitch/sofia-sip.git
 fi
 cd sofia-sip/
-git checkout v1.13.15
+git checkout v1.13.17
 ./bootstrap.sh
 ./configure
 
@@ -62,7 +62,7 @@ if [ ! -d libks ]; then
   git clone https://github.com/signalwire/libks.git
 fi
 cd libks/
-git checkout v1.8.2
+git checkout v2.0.3
 
 cmake .
 make

--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -2,5 +2,5 @@ mkdir freeswitch
 cd freeswitch
 git init
 git remote add origin https://github.com/signalwire/freeswitch.git
-git fetch --depth 1 origin v1.10.10
+git fetch --depth 1 origin v1.10.11
 git checkout FETCH_HEAD


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Upgrades FreeSWITCH to the latest patch release to address a security advisory.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
https://github.com/signalwire/freeswitch/security/advisories/GHSA-39gv-hq72-j6m6 security advisory
<!-- What inspired you to submit this pull request? -->

### More
* sofia-sip had to be upgraded to v1.13.17 (latest) too
* libks seemed happy to also be upgraded to v2.0.3 (latest)
* spandsp could not be set to 7b0b8cf3d42b725405bcc63145de5e280265ce4e - could not build
* libwebsockets could not be set to 4.3.3 - could not build
