### PR TITLE
build: Bump Etherpad to 1.9.6; use default npm

### DIFF
--- a/bbb-etherpad.placeholder.sh
+++ b/bbb-etherpad.placeholder.sh
@@ -1,2 +1,2 @@
-git clone --branch 1.9.4 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
+git clone --branch 1.9.6 --depth 1 https://github.com/ether/etherpad-lite bbb-etherpad
 

--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -18,13 +18,6 @@ rm -rf staging
 
 set +e
 
-# as of March 12, 2022, circa BigBlueButton 2.5-alpha4, we set npm by default to 8.5.0
-# however, it seems bbb-etherpad has troubles building with npm as high.
-# Setting npm to 6.14.11 which was used successfully for building in BigBlueButton 2.4.x
-npm -v
-npm i -g npm@6.14.11
-npm -v
-
 ls -l node_modules/
 ls -l node_modules/ep_etherpad-lite
 ls -l src/


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
- Upgrades Etherpad (1.9.5, 1.9.6)
- Remove workaround in bbb-etherpad build process where we had to use an old npm version
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
No longer having to use old npm to install dependencies
<!-- What inspired you to submit this pull request? -->

### More
https://github.com/ether/etherpad-lite/releases/tag/v1.9.5
https://github.com/ether/etherpad-lite/releases/tag/v1.9.6

