### PR TITLE
refactor (akka-apps): Validate number of breakout rooms in the backend

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core.apps.breakout
 
+import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPath
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{BreakoutModel, PermissionCheck, RightsManagementTrait}
 import org.bigbluebutton.core.db.BreakoutRoomDAO
@@ -16,6 +17,16 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
 
   def handleCreateBreakoutRoomsCmdMsg(msg: CreateBreakoutRoomsCmdMsg, state: MeetingState2x): MeetingState2x = {
 
+
+    val minOfRooms = 2
+    val maxOfRooms =
+      getConfigPropertyValueByPath(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomLimit") match {
+        case Some(breakoutRoomLimit: Int) => breakoutRoomLimit max minOfRooms
+        case _ =>
+          log.debug("Config `public.app.breakouts.breakoutRoomLimit` not found.")
+          16
+      }
+
     if (liveMeeting.props.meetingProp.disabledFeatures.contains("breakoutRooms")) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "Breakout rooms is disabled for this meeting."
@@ -26,6 +37,15 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       val reason = "No permission to create breakout room for meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId,
         reason, outGW, liveMeeting)
+      state
+    } else if(msg.body.rooms.length > maxOfRooms || msg.body.rooms.length < minOfRooms) {
+      log.warning(
+        "Attempt to create breakout rooms with invalid number of rooms (rooms: {}, max: {}, min: {}) in meeting {}",
+        msg.body.rooms.size,
+        maxOfRooms,
+        minOfRooms,
+        liveMeeting.props.meetingProp.intId
+      )
       state
     } else {
       state.breakout match {
@@ -54,8 +74,8 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       val voiceConf = BreakoutRoomsUtil.createVoiceConfId(liveMeeting.props.voiceProp.voiceConf, i)
 
       val breakout = BreakoutModel.create(parentId, internalId, externalId, room.name, room.sequence, room.shortName,
-                                          room.isDefaultName, room.freeJoin, voiceConf, room.users, msg.body.captureNotes,
-                                          msg.body.captureSlides, room.captureNotesFilename, room.captureSlidesFilename)
+        room.isDefaultName, room.freeJoin, voiceConf, room.users, msg.body.captureNotes,
+        msg.body.captureSlides, room.captureNotesFilename, room.captureSlidesFilename)
 
       rooms = rooms + (breakout.id -> breakout)
     }

--- a/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
@@ -26,14 +26,5 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     rooms: input.rooms,
   };
 
-  // TODO check if akka-apps apply this validation
-  // const BREAKOUT_LIM = Meteor.settings.public.app.breakouts.breakoutRoomLimit;
-  // const MIN_BREAKOUT_ROOMS = 2;
-  // const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
-  // if (rooms.length > MAX_BREAKOUT_ROOMS) {
-  //   Logger.info(`Attempt to create breakout rooms with invalid number of rooms in meeting id=${meetingId}`);
-  //   return;
-  // }
-
   return { eventName, routing, header, body };
 }


### PR DESCRIPTION
It used to be validated in the `Meteor.call('createBreakoutRoom')`, which was replaced by graphql actions.
So this validation will now be performed in Akka-apps since now it knows the client configs.