### PR TITLE
build(bbb-webhooks): v3.0.0-beta.3

### DIFF
--- a/bbb-webhooks.placeholder.sh
+++ b/bbb-webhooks.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.6.1 --depth 1 https://github.com/bigbluebutton/bbb-webhooks bbb-webhooks
+git clone --branch v3.0.0-beta.3 --depth 1 https://github.com/bigbluebutton/bbb-webhooks bbb-webhooks

--- a/build/packages-template/bbb-webhooks/after-install.sh
+++ b/build/packages-template/bbb-webhooks/after-install.sh
@@ -10,13 +10,13 @@ case "$1" in
     chown bigbluebutton:bigbluebutton $TARGET
 
     BBB_HOST=$(bbb-conf --secret | grep -F URL: | sed 's#^.*://##; s#/.*##')
-    BBB_SECRET=$(bbb-conf --secret | grep -F Secret: | sed 's/.*Secret: //')    
+    BBB_SECRET=$(bbb-conf --secret | grep -F Secret: | sed 's/.*Secret: //')
 
     yq e -i  ".bbb.sharedSecret  = \"$BBB_SECRET\"" $TARGET
     yq e -i  ".bbb.serverDomain = \"$BBB_HOST\"" $TARGET
     yq e -i  '.bbb.auth2_0 = true' $TARGET
-    yq e -i  '.server.port = 3005' $TARGET
-    yq e -i  '.hooks.getRaw = false' $TARGET
+    yq e -i  '.modules."../out/webhooks/index.js".config.getRaw = false' $TARGET
+    yq e -i  '.log.filename = "/var/log/bbb-webhooks/bbb-webhooks.log"' $TARGET
 
     mkdir -p /var/log/bbb-webhooks/
     touch /var/log/bbb-webhooks/bbb-webhooks.log

--- a/build/packages-template/bbb-webhooks/build.sh
+++ b/build/packages-template/bbb-webhooks/build.sh
@@ -22,11 +22,11 @@ done
 
 mkdir -p staging/usr/local/bigbluebutton/bbb-webhooks
 
-find -maxdepth 1 ! -path . ! -name staging $(printf "! -name %s " $(cat .build-files)) -exec cp -r {} staging/usr/local/bigbluebutton/bbb-webhooks/ \;
+find -maxdepth 1 ! -path . ! -name staging ! -name .git $(printf "! -name %s " $(cat .build-files)) -exec cp -r {} staging/usr/local/bigbluebutton/bbb-webhooks/ \;
 
 pushd .
 cd staging/usr/local/bigbluebutton/bbb-webhooks/
-npm install --unsafe-perm --production
+npm ci --omit=dev
 popd
 
 cp webhooks.nginx staging/usr/share/bigbluebutton/nginx/webhooks.nginx


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webhooks): v3.0.0-beta.3](https://github.com/bigbluebutton/bigbluebutton/commit/0368a677a6b18504bad89b0a4cb765f29fc46a12) 
  - Bump bbb-webhooks to v3.0.0-beta.3. The full v3.0.x changelog can be
    found at: https://github.com/bigbluebutton/bbb-webhooks/blob/v3.0.0-beta.3/CHANGELOG.md#changelog
  - Transition from `npm install` to `npm ci`
  - Adjust configs that changed paths (`hooks.getRaw`, `log.filename`)
  - Omit `.git` directory from the final package
- [docs: adjust docs to be compatible with bbb-webhooks@v3.0.x](https://github.com/bigbluebutton/bigbluebutton/commit/8ec9b7f68f6e92303cf3a8e92356b03e3d2db73f) 
  - These are minor changes to make the current bbb-webhooks documentation
page compatible with the newer bbb-webhooks@v3.0.x versions.
  - It'll be further detailed with some of the new features (e.g.: xAPI
support) down the road. A cleanup should also be done later on.


### Closes Issue(s)

None

### More

```
  # CHANGELOG

  All notable changes to this project will be documented in this file.

  ### v3.0.0-beta.3

  * build: bullmq@4.17.0, bump transitive deps

  ### v3.0.0-beta.2

  * fix(webhooks): re-implement includeEvents/excludeEvents

  ### v3.0.0-beta.1

  * fix(xapi): ensure the correct lrs_endpoint is used
  * feat(xapi): add suport for meta_xapi-create-end-actor-name

  ### v3.0.0-beta.0

  * feat(test): add support for modular test suites
  * feat(test): add xAPI test suite
  * refactor(test): remove nock as a dependency
  * fix(test): restore remaining out/webhooks tests
  * fix(xapi): set chat message statements timestamp to ISO format
  * fix: add Redis disconnection handling

  ### v3.0.0-alpha.1

  * !refactor: application rewritten to use a modular input/processing/ouput system
  * !refactor: modernize codebase (ES6 imports, Node.js >= 18 etc.)
  * !refactor(webhooks): the webhooks functionality was rewritten into an output module
  * !refactor(webhooks): hook IDs are now UUIDs instead of integers
  * !refactor: new logging system (using Pino)
  * !refactor: migrate node-redis from v3 to v4
  * !refactor: new queue system (using Bullmq)
  * refactor(webhooks): replace request with node-fetch
  * refactor: replace sha1 dependency with native code
  * feat: new xAPI output module with support for multitenancy
      - Implements https://github.com/gaia-x-dases/xapi-virtual-classroom
      - For more information: (README.md)[src/out/xapi/README.md]
  * feat(events): add support for poll events
  * feat(events): add support for raise-hand events
  * feat(events): add support for emoji events
  * feat(events): add user info to screenshare events
  * feat(events): add support for audio muted/unmuted events
  * feat: add Prometheus instrumentation
  * feat: add JSDoc annotations to most of the codebase
  * feat: log to file
  * feat: add support for multiple checksum algorithms (SHA1,...,SHA512)
  * fix(events): user-left events are now emitted for trailing users on meeting-ended events
  * build: add docker-compose and updated Dockerfile examples
```