### PR TITLE
Fix and Refactor moderatorChatEmphasize

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToBreakoutRoomInternalMsgHdlr.scala
@@ -18,8 +18,8 @@ trait SendMessageToBreakoutRoomInternalMsgHdlr {
       sender <- GroupChatApp.findGroupChatUser(SystemUser.ID, liveMeeting.users2x)
       chat <- state.groupChats.find(GroupChatApp.MAIN_PUBLIC_CHAT)
     } yield {
-      val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.senderName), true, msg.msg)
-      val gcm = GroupChatApp.toGroupChatMessage(sender.copy(name = msg.senderName), groupChatMsgFromUser)
+      val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.senderName), msg.msg)
+      val gcm = GroupChatApp.toGroupChatMessage(sender.copy(name = msg.senderName), groupChatMsgFromUser, emphasizedText = true)
       val gcs = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm, GroupChatMessageType.BREAKOUTROOM_MOD_MSG)
 
       val event = buildGroupChatMessageBroadcastEvtMsg(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -59,7 +59,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
           val newState = for {
             createdBy <- GroupChatApp.findGroupChatUser(msg.header.userId, liveMeeting.users2x)
           } yield {
-            val msgs = msg.body.msg.map(m => GroupChatApp.toGroupChatMessage(createdBy, m))
+            val msgs = msg.body.msg.map(m => GroupChatApp.toGroupChatMessage(createdBy, m, emphasizedText = false))
             val users = {
               if (msg.body.access == GroupChatAccess.PRIVATE) {
                 val cu = msg.body.users.toSet + msg.header.userId

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -20,10 +20,10 @@ object GroupChatApp {
     GroupChatFactory.create(gcId, access, createBy, users, msgs)
   }
 
-  def toGroupChatMessage(sender: GroupChatUser, msg: GroupChatMsgFromUser): GroupChatMessage = {
+  def toGroupChatMessage(sender: GroupChatUser, msg: GroupChatMsgFromUser, emphasizedText: Boolean): GroupChatMessage = {
     val now = System.currentTimeMillis()
     val id = GroupChatFactory.genId()
-    GroupChatMessage(id, now, msg.correlationId, now, now, sender, msg.chatEmphasizedText, msg.message)
+    GroupChatMessage(id, now, msg.correlationId, now, now, sender, emphasizedText, msg.message)
   }
 
   def toMessageToUser(msg: GroupChatMessage): GroupChatMsgToUser = {
@@ -80,8 +80,8 @@ object GroupChatApp {
         sender <- GroupChatApp.findGroupChatUser(userId, liveMeeting.users2x)
         chat <- state.groupChats.find(chatId)
       } yield {
-
-        val gcm1 = GroupChatApp.toGroupChatMessage(sender, msg)
+        val emphasizedText = sender.role == Roles.MODERATOR_ROLE
+        val gcm1 = GroupChatApp.toGroupChatMessage(sender, msg, emphasizedText)
         val gcs1 = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm1)
         state.update(gcs1)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core.apps.groupchats
 
+import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPath
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
@@ -48,7 +49,19 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
         val userIsAParticipant = chat.users.filter(u => u.id == sender.id).length > 0;
 
         if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-          val gcm = GroupChatApp.toGroupChatMessage(sender, msg.body.msg)
+          val moderatorChatEmphasizedEnabled =
+            getConfigPropertyValueByPath(liveMeeting.clientSettings, "public.chat.moderatorChatEmphasized") match {
+              case Some(moderatorChatEmphasized: Boolean) => moderatorChatEmphasized
+              case _ =>
+                log.debug("Config `public.chat.moderatorChatEmphasized` not found.")
+                true
+            }
+
+          val emphasizedText = moderatorChatEmphasizedEnabled &&
+            !chatIsPrivate &&
+            sender.role == Roles.MODERATOR_ROLE
+
+          val gcm = GroupChatApp.toGroupChatMessage(sender, msg.body.msg, emphasizedText)
           val gcs = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm)
 
           val event = buildGroupChatMessageBroadcastEvtMsg(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -15,7 +15,7 @@ object GroupChatMessageType {
 }
 
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")
-case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
+case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, message: String)
 case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
 case class GroupChatInfo(id: String, access: String, createdBy: GroupChatUser, users: Vector[GroupChatUser])
 

--- a/bbb-graphql-actions/src/actions/chatSendMessage.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessage.ts
@@ -14,13 +14,9 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     userId: routing.userId
   };
 
-  // TODO - move this property to akka and make it read the setting chat.moderatorChatEmphasized also
-  const chatEmphasizedText = (sessionVariables['x-hasura-moderatorinmeeting'] as string).length>0;
-
-  const body = { 
+  const body = {
     msg: {
       correlationId: `${routing.userId}-${Date.now()}`,
-      chatEmphasizedText,
       message: input.chatMessageInMarkdownFormat,
       sender: {
         id: routing.userId,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
@@ -22,6 +22,7 @@ query getChatMessageHistory {
     message
     messageId
     messageType
+    chatEmphasizedText
     createdAt
     user {
       userId

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -168,7 +168,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
           isSystemSender: ChatMessageType.BREAKOUT_ROOM,
           component: (
             <ChatMessageTextContent
-              emphasizedMessage={message?.user?.isModerator}
+              emphasizedMessage={message.chatEmphasizedText}
               text={message.message}
             />
           ),

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
@@ -13,6 +13,7 @@ export const CHAT_MESSAGE_PUBLIC_SUBSCRIPTION = gql`
         color
       }
       messageType
+      chatEmphasizedText
       chatId
       message
       messageId
@@ -43,6 +44,7 @@ export const CHAT_MESSAGE_PRIVATE_SUBSCRIPTION = gql`
       chatId
       message
       messageType
+      chatEmphasizedText
       messageId
       createdAt
       messageMetadata

--- a/bigbluebutton-html5/imports/ui/components/chat/service.js
+++ b/bigbluebutton-html5/imports/ui/components/chat/service.js
@@ -12,7 +12,6 @@ import PollService from '/imports/ui/components/poll/service';
 const APP = Meteor.settings.public.app;
 const CHAT_CONFIG = Meteor.settings.public.chat;
 const GROUPING_MESSAGES_WINDOW = CHAT_CONFIG.grouping_messages_window;
-const CHAT_EMPHASIZE_TEXT = CHAT_CONFIG.moderatorChatEmphasized;
 
 const SYSTEM_CHAT_TYPE = CHAT_CONFIG.type_system;
 
@@ -79,7 +78,7 @@ const mapGroupMessage = (message) => {
     time: message.timestamp || message.time,
     sender: null,
     key: message.key,
-    chatId: message.chatId
+    chatId: message.chatId,
   };
 
   if (message.sender && message.sender !== SYSTEM_CHAT_TYPE) {
@@ -169,7 +168,7 @@ const isChatLocked = (receiverID) => {
 
 const isChatClosed = (chatId) => {
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY) || [];
-  return !!currentClosedChats.find(closedChat => closedChat.chatId === chatId);
+  return !!currentClosedChats.find((closedChat) => closedChat.chatId === chatId);
 };
 
 const lastReadMessageTime = (receiverID) => {
@@ -215,8 +214,8 @@ const removeFromClosedChatsSession = (idChatOpen) => {
   const currentClosedChats = Storage.getItem(CLOSED_CHAT_LIST_KEY);
 
   if (isChatClosed(chatID)) {
-    const closedChats = currentClosedChats.filter(closedChat => closedChat.chatId !== chatID);
-    Storage.setItem(CLOSED_CHAT_LIST_KEY,closedChats);
+    const closedChats = currentClosedChats.filter((closedChat) => closedChat.chatId !== chatID);
+    Storage.setItem(CLOSED_CHAT_LIST_KEY, closedChats);
   }
 };
 
@@ -234,7 +233,8 @@ const exportChat = (timeWindowList, intl) => {
       const min = date.getMinutes().toString().padStart(2, 0);
       const hourMin = `[${hour}:${min}]`;
 
-      // Skip the reduce aggregation for the sync messages because they aren't localized, causing an error in line 268
+      // Skip the reduce aggregation for the sync messages because they aren't localized
+      // (causing an error in line 268)
       // Also they're temporary (preliminary) messages, so it doesn't make sense export them
       if (['SYSTEM_MESSAGE-sync-msg', 'synced'].includes(message.id)) return acc;
 


### PR DESCRIPTION
This PR will:

- Fix: Moderators have `chatEmphasizedText = true` in private chat
- Fix: Messages is considering the current user role to set `chatEmphasizedText` (it should consider the role of the moment the msg was sent)
- Consider config `public.chat.moderatorChatEmphasized` to emphasize or not
- Make akka-apps populate `chatEmphasizedText` (instead of graphql-actions)