### PR TITLE
Fix: Multi-User Drawing Issue When Presenter Switches Pages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -33,7 +33,11 @@ const PresentationContainer = (props) => {
   const currentPresentationPage = presentationPageArray && presentationPageArray[0];
   const slideSvgUrl = currentPresentationPage && currentPresentationPage.svgUrl;
 
-  const { data: whiteboardWritersData } = useSubscription(CURRENT_PAGE_WRITERS_SUBSCRIPTION);
+  const { data: whiteboardWritersData } = useSubscription(CURRENT_PAGE_WRITERS_SUBSCRIPTION, {
+    variables: { pageId: currentPresentationPage?.pageId },
+    skip: !currentPresentationPage?.pageId,
+  });
+
   const whiteboardWriters = whiteboardWritersData?.pres_page_writers || [];
 
   const [presentationSetZoom] = useMutation(PRESENTATION_SET_ZOOM);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -59,7 +59,10 @@ const WhiteboardContainer = (props) => {
   const curPageId = currentPresentationPage?.num;
   const presentationId = currentPresentationPage?.presentationId;
 
-  const { data: whiteboardWritersData } = useSubscription(CURRENT_PAGE_WRITERS_SUBSCRIPTION);
+  const { data: whiteboardWritersData } = useSubscription(CURRENT_PAGE_WRITERS_SUBSCRIPTION, {
+    variables: { pageId: currentPresentationPage?.pageId },
+    skip: !currentPresentationPage?.pageId,
+  });
   const whiteboardWriters = whiteboardWritersData?.pres_page_writers || [];
   const hasWBAccess = whiteboardWriters?.some((writer) => writer.userId === Auth.userID);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.jsx
@@ -97,11 +97,13 @@ export const CURRENT_PAGE_ANNOTATIONS_STREAM = gql`subscription annotationsStrea
   }
 }`;
 
-export const CURRENT_PAGE_WRITERS_SUBSCRIPTION = gql`subscription currentPageWritersSubscription {
-  pres_page_writers {
-    userId
+export const CURRENT_PAGE_WRITERS_SUBSCRIPTION = gql`
+  subscription currentPageWritersSubscription($pageId: String!) {
+    pres_page_writers(where: { pageId: { _eq: $pageId } }) {
+      userId
+    }
   }
-}`;
+`;
 
 export const CURRENT_PAGE_WRITERS_QUERY = gql`query currentPageWritersQuery {
   pres_page_writers {


### PR DESCRIPTION
### What does this PR do?
This PR addresses an issue in the multi-user drawing feature related to page-switching behavior. The fix ensures that when multi-user drawing is enabled and the presenter switches to a different page, they can still see the drawings made by other users and retain control over the multi-user drawing feature.


### Motivation
The issue was observed when multi-user drawing was enabled: if the presenter switched to a different page, they would lose the ability to view drawings made by other users, and the controls for the multi-user feature would stop working. This meant the presenter could not toggle multi-user off until returning to the original page where multi-user was enabled.

