### PR TITLE
Refactor Poll flow for typed answer (reducing steps)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -52,6 +52,33 @@ object ClientSettings extends SystemConfiguration {
     } else clientSettingsFromFile
   }
 
+  def getConfigPropertyValueByPathAsIntOrElse(map: Map[String, Any], path: String, alternativeValue: Int): Int = {
+    getConfigPropertyValueByPath(map, path) match {
+      case Some(configValue: Int) => configValue
+      case _ =>
+        logger.debug("Config `{}` not found.", path)
+        alternativeValue
+    }
+  }
+
+  def getConfigPropertyValueByPathAsStringOrElse(map: Map[String, Any], path: String, alternativeValue: String): String = {
+    getConfigPropertyValueByPath(map, path) match {
+      case Some(configValue: String) => configValue
+      case _ =>
+        logger.debug("Config `{}` not found.", path)
+        alternativeValue
+    }
+  }
+
+  def getConfigPropertyValueByPathAsBooleanOrElse(map: Map[String, Any], path: String, alternativeValue: Boolean): Boolean = {
+    getConfigPropertyValueByPath(map, path) match {
+      case Some(configValue: Boolean) => configValue
+      case _ =>
+        logger.debug("Config `{}` not found.", path)
+        alternativeValue
+    }
+  }
+
   def getConfigPropertyValueByPath(map: Map[String, Any], path: String): Option[Any] = {
     val keys = path.split("\\.")
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton.core.apps.breakout
 
-import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPath
+import org.bigbluebutton.ClientSettings.{getConfigPropertyValueByPath, getConfigPropertyValueByPathAsIntOrElse}
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{BreakoutModel, PermissionCheck, RightsManagementTrait}
 import org.bigbluebutton.core.db.BreakoutRoomDAO
@@ -19,13 +19,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
 
 
     val minOfRooms = 2
-    val maxOfRooms =
-      getConfigPropertyValueByPath(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomLimit") match {
-        case Some(breakoutRoomLimit: Int) => breakoutRoomLimit max minOfRooms
-        case _ =>
-          log.debug("Config `public.app.breakouts.breakoutRoomLimit` not found.")
-          16
-      }
+    val maxOfRooms = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomLimit", 16)
 
     if (liveMeeting.props.meetingProp.disabledFeatures.contains("breakoutRooms")) {
       val meetingId = liveMeeting.props.meetingProp.intId

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton.core.apps.groupchats
 
-import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPath
+import org.bigbluebutton.ClientSettings.{ getConfigPropertyValueByPath, getConfigPropertyValueByPathAsBooleanOrElse }
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
@@ -49,13 +49,11 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
         val userIsAParticipant = chat.users.filter(u => u.id == sender.id).length > 0;
 
         if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-          val moderatorChatEmphasizedEnabled =
-            getConfigPropertyValueByPath(liveMeeting.clientSettings, "public.chat.moderatorChatEmphasized") match {
-              case Some(moderatorChatEmphasized: Boolean) => moderatorChatEmphasized
-              case _ =>
-                log.debug("Config `public.chat.moderatorChatEmphasized` not found.")
-                true
-            }
+          val moderatorChatEmphasizedEnabled = getConfigPropertyValueByPathAsBooleanOrElse(
+            liveMeeting.clientSettings,
+            "public.chat.moderatorChatEmphasized",
+            alternativeValue = true
+          )
 
           val emphasizedText = moderatorChatEmphasizedEnabled &&
             !chatIsPrivate &&

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/PollHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/PollHdlrHelpers.scala
@@ -1,0 +1,56 @@
+package org.bigbluebutton.core.apps.polls
+
+import org.bigbluebutton.common2.domain.SimplePollResultOutVO
+import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, MessageTypes, PollUpdatedEvtMsg, PollUpdatedEvtMsgBody, Routing, UserRespondedToPollRecordMsg, UserRespondedToPollRecordMsgBody, UserRespondedToPollRespMsg, UserRespondedToPollRespMsgBody, UserRespondedToTypedPollRespMsg, UserRespondedToTypedPollRespMsgBody }
+import org.bigbluebutton.core.running.OutMsgRouter
+
+object PollHdlrHelpers {
+
+  def broadcastPollUpdatedEvent(outGW: OutMsgRouter, meetingId: String, userId: String, pollId: String, poll: SimplePollResultOutVO): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+    val envelope = BbbCoreEnvelope(PollUpdatedEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(PollUpdatedEvtMsg.NAME, meetingId, userId)
+
+    val body = PollUpdatedEvtMsgBody(pollId, poll)
+    val event = PollUpdatedEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    outGW.send(msgEvent)
+  }
+
+  def broadcastUserRespondedToTypedPollRespMsg(outGW: OutMsgRouter, meetingId: String, userId: String,
+                                               pollId: String, answer: String, sendToId: String): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, sendToId)
+    val envelope = BbbCoreEnvelope(UserRespondedToTypedPollRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(UserRespondedToTypedPollRespMsg.NAME, meetingId, sendToId)
+
+    val body = UserRespondedToTypedPollRespMsgBody(pollId, userId, answer)
+    val event = UserRespondedToTypedPollRespMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    outGW.send(msgEvent)
+  }
+
+  def broadcastUserRespondedToPollRecordMsg(outGW: OutMsgRouter, meetingId: String, userId: String,
+                                            pollId: String, answerId: Int, answer: String, isSecret: Boolean): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+    val envelope = BbbCoreEnvelope(UserRespondedToPollRecordMsg.NAME, routing)
+    val header = BbbClientMsgHeader(UserRespondedToPollRecordMsg.NAME, meetingId, userId)
+
+    val body = UserRespondedToPollRecordMsgBody(pollId, answerId, answer, isSecret)
+    val event = UserRespondedToPollRecordMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    outGW.send(msgEvent)
+  }
+
+  def broadcastUserRespondedToPollRespMsg(outGW: OutMsgRouter, meetingId: String, userId: String,
+                                          pollId: String, answerIds: Seq[Int], sendToId: String): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, sendToId)
+    val envelope = BbbCoreEnvelope(UserRespondedToPollRespMsg.NAME, routing)
+    val header = BbbClientMsgHeader(UserRespondedToPollRespMsg.NAME, meetingId, sendToId)
+
+    val body = UserRespondedToPollRespMsgBody(pollId, userId, answerIds)
+    val event = UserRespondedToPollRespMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    outGW.send(msgEvent)
+  }
+
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToPollReqMsgHdlr.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.common2.domain.SimplePollResultOutVO
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.models.Polls
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.models.Users2x
 
 trait RespondToPollReqMsgHdlr {
@@ -12,45 +12,12 @@ trait RespondToPollReqMsgHdlr {
 
   def handle(msg: RespondToPollReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
-    def broadcastPollUpdatedEvent(msg: RespondToPollReqMsg, pollId: String, poll: SimplePollResultOutVO): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
-      val envelope = BbbCoreEnvelope(PollUpdatedEvtMsg.NAME, routing)
-      val header = BbbClientMsgHeader(PollUpdatedEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
-
-      val body = PollUpdatedEvtMsgBody(pollId, poll)
-      val event = PollUpdatedEvtMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      bus.outGW.send(msgEvent)
-    }
-
-    def broadcastUserRespondedToPollRecordMsg(msg: RespondToPollReqMsg, pollId: String, answerId: Int, answer: String, isSecret: Boolean): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
-      val envelope = BbbCoreEnvelope(UserRespondedToPollRecordMsg.NAME, routing)
-      val header = BbbClientMsgHeader(UserRespondedToPollRecordMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
-
-      val body = UserRespondedToPollRecordMsgBody(pollId, answerId, answer, isSecret)
-      val event = UserRespondedToPollRecordMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      bus.outGW.send(msgEvent)
-    }
-
-    def broadcastUserRespondedToPollRespMsg(msg: RespondToPollReqMsg, pollId: String, answerIds: Seq[Int], sendToId: String): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, sendToId)
-      val envelope = BbbCoreEnvelope(UserRespondedToPollRespMsg.NAME, routing)
-      val header = BbbClientMsgHeader(UserRespondedToPollRespMsg.NAME, liveMeeting.props.meetingProp.intId, sendToId)
-
-      val body = UserRespondedToPollRespMsgBody(pollId, msg.header.userId, answerIds)
-      val event = UserRespondedToPollRespMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      bus.outGW.send(msgEvent)
-    }
-
-    if (Polls.checkUserResponded(msg.body.pollId, msg.header.userId, liveMeeting.polls) == false) {
+    if (!Polls.hasUserAlreadyResponded(msg.body.pollId, msg.header.userId, liveMeeting.polls)) {
       for {
         (pollId: String, updatedPoll: SimplePollResultOutVO) <- Polls.handleRespondToPollReqMsg(msg.header.userId, msg.body.pollId,
           msg.body.questionId, msg.body.answerIds, liveMeeting)
       } yield {
-        broadcastPollUpdatedEvent(msg, pollId, updatedPoll)
+        PollHdlrHelpers.broadcastPollUpdatedEvent(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, updatedPoll)
         for {
           poll <- Polls.getPoll(pollId, liveMeeting.polls)
         } yield {
@@ -58,14 +25,14 @@ trait RespondToPollReqMsgHdlr {
             answerId <- msg.body.answerIds
           } yield {
             val answerText = poll.questions(0).answers.get(answerId).key
-            broadcastUserRespondedToPollRecordMsg(msg, pollId, answerId, answerText, poll.isSecret)
+            PollHdlrHelpers.broadcastUserRespondedToPollRecordMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, answerId, answerText, poll.isSecret)
           }
         }
 
         for {
           presenter <- Users2x.findPresenter(liveMeeting.users2x)
         } yield {
-          broadcastUserRespondedToPollRespMsg(msg, pollId, msg.body.answerIds, presenter.intId)
+          PollHdlrHelpers.broadcastUserRespondedToPollRespMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, msg.body.answerIds, presenter.intId)
         }
       }
     } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToTypedPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToTypedPollReqMsgHdlr.scala
@@ -64,7 +64,7 @@ trait RespondToTypedPollReqMsgHdlr {
             }
           }
         }
-        case None => log.error("Error while trying to answer the poll {} in meeting {}: Answer not found.", msg.body.pollId, msg.header.meetingId)
+        case None => log.error("Error while trying to answer the poll {} in meeting {}: Answer not found or something went wrong while trying to create the answer.", msg.body.pollId, msg.header.meetingId)
       }
 
     } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToTypedPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToTypedPollReqMsgHdlr.scala
@@ -1,10 +1,11 @@
 package org.bigbluebutton.core.apps.polls
 
+import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPathAsIntOrElse
 import org.bigbluebutton.common2.domain.SimplePollResultOutVO
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.models.Polls
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.models.Users2x
 
 trait RespondToTypedPollReqMsgHdlr {
@@ -12,43 +13,60 @@ trait RespondToTypedPollReqMsgHdlr {
 
   def handle(msg: RespondToTypedPollReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
-    def broadcastPollUpdatedEvent(msg: RespondToTypedPollReqMsg, pollId: String, poll: SimplePollResultOutVO): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
-      val envelope = BbbCoreEnvelope(PollUpdatedEvtMsg.NAME, routing)
-      val header = BbbClientMsgHeader(PollUpdatedEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
-
-      val body = PollUpdatedEvtMsgBody(pollId, poll)
-      val event = PollUpdatedEvtMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      bus.outGW.send(msgEvent)
-    }
-
-    def broadcastUserRespondedToTypedPollRespMsg(msg: RespondToTypedPollReqMsg, pollId: String, answer: String, sendToId: String): Unit = {
-      val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, liveMeeting.props.meetingProp.intId, sendToId)
-      val envelope = BbbCoreEnvelope(UserRespondedToTypedPollRespMsg.NAME, routing)
-      val header = BbbClientMsgHeader(UserRespondedToTypedPollRespMsg.NAME, liveMeeting.props.meetingProp.intId, sendToId)
-
-      val body = UserRespondedToTypedPollRespMsgBody(pollId, msg.header.userId, answer)
-      val event = UserRespondedToTypedPollRespMsg(header, body)
-      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-      bus.outGW.send(msgEvent)
-    }
-
     if (Polls.isResponsePollType(msg.body.pollId, liveMeeting.polls) &&
-      Polls.checkUserResponded(msg.body.pollId, msg.header.userId, liveMeeting.polls) == false &&
-      Polls.checkUserAddedQuestion(msg.body.pollId, msg.header.userId, liveMeeting.polls) == false) {
-      for {
-        (pollId: String, updatedPoll: SimplePollResultOutVO) <- Polls.handleRespondToTypedPollReqMsg(msg.header.userId, msg.body.pollId,
-          msg.body.questionId, msg.body.answer, liveMeeting)
-      } yield {
-        broadcastPollUpdatedEvent(msg, pollId, updatedPoll)
+      !Polls.hasUserAlreadyResponded(msg.body.pollId, msg.header.userId, liveMeeting.polls) &&
+      !Polls.hasUserAlreadyAddedTypedAnswer(msg.body.pollId, msg.header.userId, liveMeeting.polls)) {
 
-        for {
-          presenter <- Users2x.findPresenter(liveMeeting.users2x)
-        } yield {
-          broadcastUserRespondedToTypedPollRespMsg(msg, pollId, msg.body.answer, presenter.intId)
+      //Truncate answer case it is longer than `maxTypedAnswerLength`
+      val maxTypedAnswerLength = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.poll.maxTypedAnswerLength", 45)
+      val answer = msg.body.answer.substring(0, Math.min(msg.body.answer.length, maxTypedAnswerLength))
+
+      val answerExists = Polls.findAnswerWithText(msg.body.pollId, msg.body.questionId, answer, liveMeeting.polls)
+
+      //Create answer if it doesn't exist
+      answerExists match {
+        case None => {
+          for {
+            (pollId: String, updatedPoll: SimplePollResultOutVO) <- Polls.handleRespondToTypedPollReqMsg(msg.header.userId, msg.body.pollId,
+              msg.body.questionId, answer, liveMeeting)
+          } yield {
+            PollHdlrHelpers.broadcastPollUpdatedEvent(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, updatedPoll)
+
+            for {
+              presenter <- Users2x.findPresenter(liveMeeting.users2x)
+            } yield {
+              PollHdlrHelpers.broadcastUserRespondedToTypedPollRespMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, answer, presenter.intId)
+            }
+          }
         }
+        case _ => //Do nothing, answer with same text exists already
       }
+
+      //Submit the answer
+      Polls.findAnswerWithText(msg.body.pollId, msg.body.questionId, answer, liveMeeting.polls) match {
+        case Some(answerId) => {
+          for {
+            (pollId: String, updatedPoll: SimplePollResultOutVO) <- Polls.handleRespondToPollReqMsg(msg.header.userId, msg.body.pollId,
+              msg.body.questionId, Seq(answerId), liveMeeting)
+          } yield {
+            PollHdlrHelpers.broadcastPollUpdatedEvent(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, updatedPoll)
+            for {
+              poll <- Polls.getPoll(pollId, liveMeeting.polls)
+            } yield {
+              val answerText = poll.questions(0).answers.get(answerId).key
+              PollHdlrHelpers.broadcastUserRespondedToPollRecordMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, answerId, answerText, poll.isSecret)
+            }
+
+            for {
+              presenter <- Users2x.findPresenter(liveMeeting.users2x)
+            } yield {
+              PollHdlrHelpers.broadcastUserRespondedToPollRespMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, Seq(answerId), presenter.intId)
+            }
+          }
+        }
+        case None => log.error("Error while trying to answer the poll {} in meeting {}: Answer not found.", msg.body.pollId, msg.header.meetingId)
+      }
+
     } else {
       log.info("Ignoring typed answer from user {} once user already added an answer to this poll {} in meeting {}", msg.header.userId, msg.body.pollId, msg.header.meetingId)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserReactionEmojiReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserReactionEmojiReqMsgHdlr.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton.core.apps.users
 
-import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPath
+import org.bigbluebutton.ClientSettings.{ getConfigPropertyValueByPath, getConfigPropertyValueByPathAsIntOrElse }
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.RightsManagementTrait
 import org.bigbluebutton.core.models.{ UserState, Users2x }
@@ -31,13 +31,7 @@ trait ChangeUserReactionEmojiReqMsgHdlr extends RightsManagementTrait {
     }
 
     //Get durationInSeconds from Client config
-    val userReactionExpire =
-      getConfigPropertyValueByPath(liveMeeting.clientSettings, "public.userReaction.expire") match {
-        case Some(durationInSeconds: Int) => durationInSeconds
-        case _ =>
-          log.debug("Config `public.userReaction.expire` not found.")
-          30
-      }
+    val userReactionExpire = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.userReaction.expire", 30)
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
       newUserState <- Users2x.setReactionEmoji(liveMeeting.users2x, user.intId, msg.body.reactionEmoji, userReactionExpire)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -243,7 +243,6 @@ object Polls {
 
   private def handleRespondToTypedPoll(poll: SimplePollResultOutVO, requesterId: String, pollId: String, questionId: Int,
                                        answer: String, lm: LiveMeeting): Option[SimplePollResultOutVO] = {
-
     addQuestionResponse(poll.id, questionId, answer, requesterId, lm.polls)
     for {
       updatedPoll <- getSimplePollResult(poll.id, lm.polls)
@@ -362,10 +361,10 @@ object Polls {
     pvo
   }
 
-  def checkUserResponded(pollId: String, userId: String, polls: Polls): Boolean = {
+  def hasUserAlreadyResponded(pollId: String, userId: String, polls: Polls): Boolean = {
     polls.polls.get(pollId) match {
       case Some(p) => {
-        if (p.getResponders().filter(p => p.userId == userId).length > 0) {
+        if (p.getResponders().exists(p => p.userId == userId)) {
           true
         } else {
           false
@@ -375,10 +374,10 @@ object Polls {
     }
   }
 
-  def checkUserAddedQuestion(pollId: String, userId: String, polls: Polls): Boolean = {
+  def hasUserAlreadyAddedTypedAnswer(pollId: String, userId: String, polls: Polls): Boolean = {
     polls.polls.get(pollId) match {
       case Some(p) => {
-        if (p.getTypedPollResponders().filter(responderId => responderId == userId).length > 0) {
+        if (p.getTypedPollResponders().contains(userId)) {
           true
         } else {
           false
@@ -398,6 +397,17 @@ object Polls {
         }
       }
       case None => false
+    }
+  }
+
+  def findAnswerWithText(pollId: String, questionId: Int, answerText: String, polls: Polls): Option[Int] = {
+    for {
+      poll <- Polls.getPoll(pollId, polls)
+      question <- poll.questions.find(q => q.id == questionId)
+      answers <- question.answers
+      equalAnswer <- answers.find(ans => ans.text.getOrElse("") == answerText)
+    } yield {
+      equalAnswer.id
     }
   }
 

--- a/bbb-graphql-actions/src/actions/pollSubmitUserTypedVote.ts
+++ b/bbb-graphql-actions/src/actions/pollSubmitUserTypedVote.ts
@@ -21,8 +21,5 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     answer: input.answer
   };
 
-  //TODO Validate answer length in the Backend (Meteor.settings.public.poll.maxTypedAnswerLength)
-  //TODO Check if answer exists and use the same ID (backend)
-
   return { eventName, routing, header, body };
 }


### PR DESCRIPTION
- Add `public.poll.maxTypedAnswerLength` validation to Backend (akka-apps)
- Akka-apps automatically check if there is a similar answer and pick its id and submit user answer

This new approach simplify the flow. Previously Meter would send one message to add the answer and another to submit the vote. Now graphql will send only one message and Akka-apps will add the answer and submit user vote.

Before:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/ed492508-4265-4f0f-9994-5c142188ad21)


After:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/421c603f-5f36-486b-b81d-71ea39ab47f9)
