### PR TITLE
feat: join param for default animations setting value

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -36,6 +36,7 @@ const currentParameters = [
   'bbb_skip_check_audio_on_first_join',
   'bbb_fullaudio_bridge',
   'bbb_transparent_listen_only',
+  'bbb_show_animations_default',
   // BRANDING
   'bbb_display_branding_area',
   // SHORTCUTS

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -9,6 +9,7 @@ import VideoService from '/imports/ui/components/video-provider/service';
 import WakeLockService from '/imports/ui/components/wake-lock/service';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import Settings from '/imports/ui/services/settings';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const MIN_FONTSIZE = 0;
 const SHOW_AUDIO_FILTERS = (Meteor.settings.public.app
@@ -436,6 +437,10 @@ class ApplicationMenu extends BaseMenu {
 
     const showSelect = allLocales && allLocales.length > 0;
 
+    const showAnimationsDefault = getFromUserSettings(
+      'bbb_show_animations_default',
+      settings.animations,
+    );
     return (
       <div>
         <div>
@@ -455,12 +460,12 @@ class ApplicationMenu extends BaseMenu {
             </Styled.Col>
             <Styled.Col>
               <Styled.FormElementRight>
-                {displaySettingsStatus(settings.animations)}
+                {displaySettingsStatus(showAnimationsDefault)}
                 <Toggle
                   icons={false}
-                  defaultChecked={settings.animations}
+                  defaultChecked={showAnimationsDefault}
                   onChange={() => this.handleToggle('animations')}
-                  ariaLabel={`${intl.formatMessage(intlMessages.animationsLabel)} - ${displaySettingsStatus(settings.animations, true)}`}
+                  ariaLabel={`${intl.formatMessage(intlMessages.animationsLabel)} - ${displaySettingsStatus(showAnimationsDefault, true)}`}
                   showToggleLabel={showToggleLabel}
                 />
               </Styled.FormElementRight>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds a join parameter to allow for a finer control on who sees the animations -- people who explicitly enable them
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
Some users complaining about too much noise when using emoji rain. However, others still like that noise, i.e. can't just disable for all via settings.yml
<!-- What inspired you to submit this pull request? -->

### More
Pass on join `userdata-bbb_show_animations_default=false` and you should not be seeing animations (most specifically emoji rain i.e. Reactions)

