### PR TITLE
Update GraphQL WebSocket URL Configuration for Cluster Setup

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -70,6 +70,8 @@ public class ParamsProcessorUtil {
     private String defaultServerUrl;
     private int defaultNumDigitsForTelVoice;
     private String defaultHTML5ClientUrl;
+
+    private String graphqlWebsocketUrl;
     private String defaultGuestWaitURL;
     private Boolean allowRequestsWithoutSession = false;
     private Integer defaultHttpSessionTimeout = 14400;
@@ -864,6 +866,10 @@ public class ParamsProcessorUtil {
 		return defaultHTML5ClientUrl;
 	}
 
+    public String getGraphqlWebsocketUrl() {
+        return graphqlWebsocketUrl;
+    }
+
 	public String getDefaultGuestWaitURL() {
 		return defaultGuestWaitURL;
         }
@@ -1216,6 +1222,10 @@ public class ParamsProcessorUtil {
 	public void setDefaultHTML5ClientUrl(String defaultHTML5ClientUrl) {
 		this.defaultHTML5ClientUrl = defaultHTML5ClientUrl;
 	}
+
+    public void setGraphqlWebsocketUrl(String graphqlWebsocketUrl) {
+        this.graphqlWebsocketUrl = graphqlWebsocketUrl.replace("https://","wss://");
+    }
 
 	public void setDefaultGuestWaitURL(String url) {
 		this.defaultGuestWaitURL = url;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
@@ -52,7 +52,7 @@ public class ResponseBuilder {
         return new Date(timestamp).toString();
     }
 
-    public String buildMeetingVersion(String apiVersion, String bbbVersion, String returnCode) {
+    public String buildMeetingVersion(String apiVersion, String bbbVersion, String graphqlWebsocketUrl, String returnCode) {
         StringWriter xmlText = new StringWriter();
 
         Map<String, Object> data = new HashMap<String, Object>();
@@ -60,6 +60,7 @@ public class ResponseBuilder {
         data.put("version", apiVersion);
         data.put("apiVersion", apiVersion);
         data.put("bbbVersion", bbbVersion);
+        data.put("graphqlWebsocketUrl", graphqlWebsocketUrl);
 
         processData(getTemplate("api-version.ftlx"), data, xmlText);
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -286,7 +286,7 @@ waitingGuestUsersTimeout=30000
 enteredUsersTimeout=45000
 
 #----------------------------------------------------
-# This URL is where the BBB client is accessible. When a user sucessfully
+# This URL is where the BBB client is accessible. When a user successfully
 # enters a name and password, she is redirected here to load the client.
 # Do not commit changes to this field.
 bigbluebutton.web.serverURL=http://bigbluebutton.example.com
@@ -299,6 +299,10 @@ bigbluebutton.web.logoutURL=default
 # The url of the BigBlueButton HTML5 client. Users will be redirected here when
 # successfully joining the meeting.
 defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join
+
+# Graphql websocket url (it's necessary to change for cluster setup)
+# Using `serverURL` as default, so `https` will be automatically replaced by `wss`
+graphqlWebsocketUrl=${bigbluebutton.web.serverURL}/v1/graphql
 
 useDefaultLogo=false
 defaultLogoURL=${bigbluebutton.web.serverURL}/images/logo.png

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -145,6 +145,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultServerUrl" value="${bigbluebutton.web.serverURL}"/>
         <property name="defaultNumDigitsForTelVoice" value="${defaultNumDigitsForTelVoice}"/>
         <property name="defaultHTML5ClientUrl" value="${defaultHTML5ClientUrl}"/>
+        <property name="graphqlWebsocketUrl" value="${graphqlWebsocketUrl}"/>
         <property name="useDefaultLogo" value="${useDefaultLogo}"/>
         <property name="defaultLogoURL" value="${defaultLogoURL}"/>
         <property name="defaultGuestWaitURL" value="${defaultGuestWaitURL}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -85,9 +85,32 @@ class ApiController {
     log.debug CONTROLLER_NAME + "#index"
     response.addHeader("Cache-Control", "no-cache")
 
-    withFormat {
-      xml {
-        render(text: responseBuilder.buildMeetingVersion(paramsProcessorUtil.getApiVersion(), paramsProcessorUtil.getBbbVersion(), RESP_CODE_SUCCESS), contentType: "text/xml")
+    def contentType = request.getHeader("content-type")
+
+    if(contentType == 'application/json') {
+      withFormat {
+        json {
+          def builder = new JsonBuilder()
+          builder.response {
+            returncode RESP_CODE_SUCCESS
+            version paramsProcessorUtil.getApiVersion()
+            apiVersion paramsProcessorUtil.getApiVersion()
+            bbbVersion paramsProcessorUtil.getBbbVersion()
+            graphqlWebsocketUrl paramsProcessorUtil.getGraphqlWebsocketUrl()
+          }
+          render(contentType: "application/json", text: builder.toPrettyString())
+        }
+      }
+    } else {
+      withFormat {
+        xml {
+          render(text: responseBuilder.buildMeetingVersion(
+                  paramsProcessorUtil.getApiVersion(),
+                  paramsProcessorUtil.getBbbVersion(),
+                  paramsProcessorUtil.getGraphqlWebsocketUrl(),
+                  RESP_CODE_SUCCESS),
+                  contentType: "text/xml")
+        }
       }
     }
   }

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/api-version.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/api-version.ftlx
@@ -6,5 +6,6 @@
     <version>${apiVersion}</version>
     <apiVersion>${apiVersion}</apiVersion>
     <bbbVersion>${bbbVersion}</bbbVersion>
+    <graphqlWebsocketUrl>${graphqlWebsocketUrl}</graphqlWebsocketUrl>
 </response>
 </#compress>

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -98,6 +98,7 @@ defaultHTML5ClientUrl=https://bbb-proxy.example.com/bbb-01/html5client/join
 presentationBaseURL=https://bbb-01.example.com/bigbluebutton/presentation
 accessControlAllowOrigin=https://bbb-proxy.example.com
 defaultGuestWaitURL=https://bbb-01.example.com/bbb-01/html5client/guestWait
+graphqlWebsocketUrl=wss://bbb-01.example.com/v1/graphql
 ```
 
 Add the following options to `/etc/bigbluebutton/bbb-html5.yml`:
@@ -108,7 +109,6 @@ public:
     basename: '/bbb-01/html5client'
     bbbWebBase: 'https://bbb-01.example.com/bigbluebutton'
     learningDashboardBase: 'https://bbb-01.example.com/learning-dashboard'
-    graphqlUrl: wss://bbb-01.example.com/v1/graphql
   media:
     stunTurnServersFetchAddress: 'https://bbb-01.example.com/bigbluebutton/api/stuns'
     sip_ws_host: 'bbb-01.example.com'


### PR DESCRIPTION
As highlighted by @schrd in PR #19207, there's a need to modify the way we set the GraphQL WebSocket (WS) URL, especially for cluster environments.

**Initial Approach:**
- We initially planned to set the GraphQL WS URL in the `bbb-html5.yml` file. 

**Issue Identified:**
- However, the client settings will start to be fetched via GraphQL. Consequently, the client wouldn't have the correct GraphQL URL for connection, as it's supposed to retrieve this information through GraphQL itself.

**Proposed Solution:**
- To address this, we are moving the configuration of the GraphQL URL to the `bbb-web.properties` file.
- This change allows the GraphQL URL to be accessible via the API endpoint: `https://bbb30.bbb.imdt.dev/bigbluebutton/api/`.

This update ensures proper access to the GraphQL WS URL in clustered setups, resolving the connectivity issue identified.


<table><tr><td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/8de89a09-5a2a-484d-885a-bcac81dfa7af)

</td></tr></table>

Once it's easier to handle `json` in Javascript (BBB Client), an alternative content-type is now available:

```bash
curl --request GET \
  --url https://bbb30.bbb.imdt.dev/bigbluebutton/api \
  --header 'Content-Type: application/json' \
  --cookie JSESSIONID=12345
```

```json
{
	"response": {
		"returncode": "SUCCESS",
		"version": "2.0",
		"apiVersion": "2.0",
		"bbbVersion": "",
		"graphqlWebsocketUrl": "wss://bbb30.bbb.imdt.dev/v1/graphql"
	}
}
```


----

A subsequent PR will be sent to make the BBB Client make use of this new config.
And removing the code that try to fetch the old config (https://github.com/bigbluebutton/bigbluebutton/blob/20fd9581952a61adfcf61eba085136425c559023/bigbluebutton-html5/imports/ui/components/graphql-provider/component.tsx#L20) .
