### PR TITLE
feat: join param for default animations setting value

### DIFF
--- a/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
+++ b/bigbluebutton-html5/imports/api/users-settings/server/methods/addUserSettings.js
@@ -36,6 +36,7 @@ const currentParameters = [
   'bbb_skip_check_audio_on_first_join',
   'bbb_fullaudio_bridge',
   'bbb_transparent_listen_only',
+  'bbb_show_animations_default',
   // BRANDING
   'bbb_display_branding_area',
   // SHORTCUTS

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -177,6 +177,14 @@ class Base extends Component {
 
     if (Session.equals('layoutReady', true) && (sidebarContentPanel === PANELS.NONE || Session.equals('subscriptionsReady', true))) {
       if (!checkedUserSettings) {
+        const showAnimationsDefault = getFromUserSettings(
+          'bbb_show_animations_default',
+          Meteor.settings.public.app.defaultSettings.application.animations
+        );
+
+        Settings.application.animations = showAnimationsDefault;
+        Settings.save();
+
         if (getFromUserSettings('bbb_show_participants_on_login', Meteor.settings.public.layout.showParticipantsOnLogin) && !deviceInfo.isPhone) {
           if (isChatEnabled() && getFromUserSettings('bbb_show_public_chat_on_login', !Meteor.settings.public.chat.startClosed)) {
             layoutContextDispatch({

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1433,6 +1433,7 @@ Useful tools for development:
 | `userdata-bbb_override_default_locale=`        | (Introduced in BigBlueButton 2.3) If set to `de`, the user's browser preference will be ignored - the client will be shown in 'de' (i.e. German) regardless of the otherwise preferred locale 'en' (or other)                                                                                                                   | `null`        |
 | `userdata-bbb_hide_presentation_on_join`        | (Introduced in BigBlueButton 2.6) If set to `true` it will make the user enter the meeting with presentation minimized (Only for non-presenters), not peremanent.                                                                                                                   | `false`        |
 | `userdata-bbb_direct_leave_button`        | (Introduced in BigBlueButton 2.7) If set to `true` it will make a button to leave the meeting appear to the left of the Options menu.                                                                                                                   | `false`        |
+| `userdata-bbb_show_animations_default` | (Introduced in BigBlueButton 2.7.4) If set to `false` the default value for the Animations toggle in Settings will be 'off' | `true` |
 
 #### Branding parameters
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds a join parameter to allow for a finer control on who sees the animations -- people who explicitly enable them
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
Some users complaining about too much noise when using emoji rain. However, others still like that noise, i.e. can't just disable for all via settings.yml
<!-- What inspired you to submit this pull request? -->

### More
Pass on join `userdata-bbb_show_animations_default=false` and you should not be seeing animations (most specifically emoji rain i.e. Reactions)

