### PR TITLE
Graphql: Provide shared notes fullContent (for readOnly users)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadContentSysMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadContentSysMsgHdlr.scala
@@ -29,7 +29,8 @@ trait PadContentSysMsgHdlr {
           msg.body.rev.toInt,
           msg.body.start,
           msg.body.end,
-          msg.body.text
+          msg.body.text,
+          msg.body.html
         )
         broadcastEvent(group.externalId, msg.body.padId, msg.body.rev, msg.body.start, msg.body.end, msg.body.text)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
@@ -14,6 +14,7 @@ case class SharedNotesRevDbModel(
     start:            Option[Int],
     end:              Option[Int],
     diff:             Option[String],
+    fullContentHtml:  Option[String],
     createdAt:        java.sql.Timestamp
 )
 
@@ -26,8 +27,9 @@ class SharedNotesRevDbTableDef(tag: Tag) extends Table[SharedNotesRevDbModel](ta
   val start = column[Option[Int]]("start")
   val end = column[Option[Int]]("end")
   val diff = column[Option[String]]("diff")
+  val fullContentHtml = column[Option[String]]("fullContentHtml")
   val createdAt = column[java.sql.Timestamp]("createdAt")
-  val * = (meetingId, sharedNotesExtId, rev, userId, changeset, start, end, diff, createdAt) <> (SharedNotesRevDbModel.tupled, SharedNotesRevDbModel.unapply)
+  val * = (meetingId, sharedNotesExtId, rev, userId, changeset, start, end, diff, fullContentHtml, createdAt) <> (SharedNotesRevDbModel.tupled, SharedNotesRevDbModel.unapply)
 }
 
 object SharedNotesRevDAO {
@@ -43,6 +45,7 @@ object SharedNotesRevDAO {
           start = None,
           end = None,
           diff = None,
+          fullContentHtml = None,
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
@@ -52,14 +55,14 @@ object SharedNotesRevDAO {
       }
   }
 
-  def update(meetingId: String, sharedNotesExtId: String, revId: Int, start: Int, end: Int, text: String) = {
+  def update(meetingId: String, sharedNotesExtId: String, revId: Int, start: Int, end: Int, diffText: String, fullContentHtml: String) = {
     DatabaseConnection.db.run(
       TableQuery[SharedNotesRevDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.sharedNotesExtId === sharedNotesExtId)
         .filter(_.rev === revId)
-        .map(n => (n.start, n.end, n.diff))
-        .update((Some(start), Some(end), Some(text)))
+        .map(n => (n.start, n.end, n.diff, n.fullContentHtml))
+        .update((Some(start), Some(end), Some(diffText), Some(fullContentHtml)))
     ).onComplete {
         case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated Rev on SharedNotes table!")
         case Failure(e)            => DatabaseConnection.logger.error(s"Error updating Rev SharedNotes: $e")

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PadsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PadsMsgs.scala
@@ -87,7 +87,7 @@ case class PadUpdatedEvtMsgBody(externalId: String, padId: String, userId: Strin
 // pads -> apps
 object PadContentSysMsg { val NAME = "PadContentSysMsg" }
 case class PadContentSysMsg(header: BbbCoreHeaderWithMeetingId, body: PadContentSysMsgBody) extends PadStandardMsg
-case class PadContentSysMsgBody(groupId: String, padId: String, rev: String, start: Int, end: Int, text: String)
+case class PadContentSysMsgBody(groupId: String, padId: String, rev: String, html: String, start: Int, end: Int, text: String)
 
 // apps -> client
 object PadContentEvtMsg { val NAME = "PadContentEvtMsg" }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1491,6 +1491,7 @@ create table "sharedNotes_rev" (
 	"start" integer,
 	"end" integer,
 	"diff" TEXT,
+	"fullContentHtml" TEXT,
 	"createdAt" timestamp with time zone,
 	constraint "pk_sharedNotes_rev" primary key ("meetingId", "sharedNotesExtId", "rev")
 );
@@ -1506,10 +1507,12 @@ create table "sharedNotes_session" (
 create index "sharedNotes_session_userId" on "sharedNotes_session"("userId");
 
 create view "v_sharedNotes" as
-SELECT sn.*, max(snr.rev) "lastRev"
+SELECT sn.*, max(snr.rev) "lastRev",
+(array_remove(array_agg(snr."fullContentHtml" ORDER BY snr.rev DESC),NULL))[1] as "fullContentHtml"
 FROM "sharedNotes" sn
 LEFT JOIN "sharedNotes_rev" snr ON snr."meetingId" = sn."meetingId" AND snr."sharedNotesExtId" = sn."sharedNotesExtId"
 GROUP BY sn."meetingId", sn."sharedNotesExtId";
+
 
 create view "v_sharedNotes_session" as
 SELECT sns.*, sn."padId"

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes.yaml
@@ -11,6 +11,7 @@ select_permissions:
     permission:
       columns:
         - lastRev
+        - fullContentHtml
         - model
         - name
         - padId


### PR DESCRIPTION
Provide `sharedNotes.fullContentHtml` that will be used to refactor the shared-notes component for Read-Only users.

```gql
query {
  sharedNotes {
    sharedNotesExtId
    fullContentHtml
    lastRev
  }
}
```

Depends on https://github.com/bigbluebutton/bbb-pads/pull/42