### PR TITLE
Refactor: Use state from akka-apps for bbb-web API requests

### DIFF
--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -6,6 +6,7 @@ import com.typesafe.sbt.SbtNativePackager.autoImport._
 enablePlugins(JavaServerAppPackaging)
 enablePlugins(UniversalPlugin)
 enablePlugins(DebianPlugin)
+enablePlugins(PekkoGrpcPlugin)
 
 version := "0.0.4"
 
@@ -36,6 +37,7 @@ retrieveManaged := true
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0"
+libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.22-SNAPSHOT" % "protobuf-src" intransitive()
 
 testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", "junitxml")
 

--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -37,7 +37,7 @@ retrieveManaged := true
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0"
-libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.27-SNAPSHOT" % "protobuf-src" intransitive()
+libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.28-SNAPSHOT" % "protobuf-src" intransitive()
 
 testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", "junitxml")
 

--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -37,7 +37,7 @@ retrieveManaged := true
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0"
-libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.23-SNAPSHOT" % "protobuf-src" intransitive()
+libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.27-SNAPSHOT" % "protobuf-src" intransitive()
 
 testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", "junitxml")
 

--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -37,7 +37,7 @@ retrieveManaged := true
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0"
-libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.29-SNAPSHOT" % "protobuf-src" intransitive()
+libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.30-SNAPSHOT" % "protobuf-src" intransitive()
 
 testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", "junitxml")
 

--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -37,7 +37,7 @@ retrieveManaged := true
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0"
-libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.22-SNAPSHOT" % "protobuf-src" intransitive()
+libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.23-SNAPSHOT" % "protobuf-src" intransitive()
 
 testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", "junitxml")
 

--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -37,7 +37,7 @@ retrieveManaged := true
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0"
-libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.28-SNAPSHOT" % "protobuf-src" intransitive()
+libraryDependencies += "org.bigbluebutton" % "bbb-common-message_2.13" % "0.0.29-SNAPSHOT" % "protobuf-src" intransitive()
 
 testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", "junitxml")
 

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val codec = "1.15"
 
     // BigBlueButton
-    val bbbCommons = "0.0.27-SNAPSHOT"
+    val bbbCommons = "0.0.28-SNAPSHOT"
 
     // Database
     val slick = "3.4.1"

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val codec = "1.15"
 
     // BigBlueButton
-    val bbbCommons = "0.0.23-SNAPSHOT"
+    val bbbCommons = "0.0.27-SNAPSHOT"
 
     // Database
     val slick = "3.4.1"

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val codec = "1.15"
 
     // BigBlueButton
-    val bbbCommons = "0.0.28-SNAPSHOT"
+    val bbbCommons = "0.0.29-SNAPSHOT"
 
     // Database
     val slick = "3.4.1"

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val codec = "1.15"
 
     // BigBlueButton
-    val bbbCommons = "0.0.29-SNAPSHOT"
+    val bbbCommons = "0.0.30-SNAPSHOT"
 
     // Database
     val slick = "3.4.1"

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     val codec = "1.15"
 
     // BigBlueButton
-    val bbbCommons = "0.0.22-SNAPSHOT"
+    val bbbCommons = "0.0.23-SNAPSHOT"
 
     // Database
     val slick = "3.4.1"

--- a/akka-bbb-apps/project/plugins.sbt
+++ b/akka-bbb-apps/project/plugins.sbt
@@ -9,3 +9,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.15")
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "0.2.9")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.1")
+
+ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
@@ -120,17 +120,17 @@ object Boot extends App with SystemConfiguration {
 
   val bindingFuture = Http().bindAndHandle(apiService.routes, httpHost, httpPort)
 
-  new GrpcServer(system, bbbActor).run()
+  new GrpcServer(system, bbbActor, grpcHost, grpcPort).run()
 }
 
-class GrpcServer(system: ActorSystem, bbbActor: ActorRef) {
+class GrpcServer(system: ActorSystem, bbbActor: ActorRef, host: String, port: Int) {
   def run(): Future[Http.ServerBinding] = {
     implicit val sys: ActorSystem = system
     implicit val ec: ExecutionContext = sys.dispatcher
     implicit val bbb: ActorRef = bbbActor
 
     val service: HttpRequest => Future[HttpResponse] = MeetingServiceHandler(new MeetingServiceImpl())
-    val binding = Http().newServerAt("127.0.0.1", 8081).bind(service)
+    val binding = Http().newServerAt(host, port).bind(service)
     binding.foreach { binding => println(s"gRPC server bound to ${binding.localAddress}")}
     binding
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -91,4 +91,7 @@ trait SystemConfiguration {
   val httpHost = config.getString("http.interface")
   // Grab the "port" parameter from the http config
   val httpPort = config.getInt("http.port")
+
+  val grpcHost = config.getString("grpc.interface")
+  val grpcPort = config.getInt("grpc.port")
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -205,7 +205,7 @@ class BigBlueButtonActor(
   private def handleIsMeetingRunning(sender: ActorRef, msg: IsMeetingRunning): Unit = {
     RunningMeetings.findWithId(meetings, msg.meetingId) match {
       case Some(_) => sender ! true
-      case None          => sender ! false
+      case None    => sender ! false
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -66,11 +66,12 @@ class BigBlueButtonActor(
   def receive = {
     // Internal messages
     case msg: DestroyMeetingInternalMsg => handleDestroyMeeting(msg)
-    case msg: IsMeetingRunning => handleIsMeetingRunning(sender(), msg)
+    case msg: IsMeetingRunning          => handleIsMeetingRunning(sender(), msg)
+    case msg: GetMeeting                => handleGetMeeting(sender(), msg)
 
     // 2x messages
-    case msg: BbbCommonEnvCoreMsg => handleBbbCommonEnvCoreMsg(msg)
-    case _                        => // do nothing
+    case msg: BbbCommonEnvCoreMsg       => handleBbbCommonEnvCoreMsg(msg)
+    case _                              => // do nothing
   }
 
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
@@ -205,6 +206,10 @@ class BigBlueButtonActor(
       case Some(meeting) => sender ! true
       case None          => sender ! false
     }
+  }
+
+  private def handleGetMeeting(sender: ActorRef, msg: GetMeeting): Unit = {
+    sender ! RunningMeetings.findWithId(meetings, msg.meetingId)
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -66,10 +66,11 @@ class BigBlueButtonActor(
   def receive = {
     // Internal messages
     case msg: DestroyMeetingInternalMsg => handleDestroyMeeting(msg)
+    case msg: IsMeetingRunning => handleIsMeetingRunning(sender(), msg)
 
     // 2x messages
-    case msg: BbbCommonEnvCoreMsg       => handleBbbCommonEnvCoreMsg(msg)
-    case _                              => // do nothing
+    case msg: BbbCommonEnvCoreMsg => handleBbbCommonEnvCoreMsg(msg)
+    case _                        => // do nothing
   }
 
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
@@ -196,6 +197,13 @@ class BigBlueButtonActor(
 
       //Remove ColorPicker idx of the meeting
       ColorPicker.reset(m.props.meetingProp.intId)
+    }
+  }
+
+  private def handleIsMeetingRunning(sender: ActorRef, msg: IsMeetingRunning): Unit = {
+    RunningMeetings.findWithId(meetings, msg.meetingId) match {
+      case Some(meeting) => sender ! true
+      case None          => sender ! false
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -68,13 +68,11 @@ class BigBlueButtonActor(
     case msg: DestroyMeetingInternalMsg => handleDestroyMeeting(msg)
     case msg: IsMeetingRunning          => handleIsMeetingRunning(sender(), msg)
     case msg: GetMeeting                => handleGetMeeting(sender(), msg)
-    case msg: GetMeetings =>
-      println("***** Received GetMeetings message")
-      handleGetMeetings(sender(), msg)
+    case msg: GetMeetings               => handleGetMeetings(sender(), msg)
 
     // 2x messages
-    case msg: BbbCommonEnvCoreMsg => handleBbbCommonEnvCoreMsg(msg)
-    case _                        => // do nothing
+    case msg: BbbCommonEnvCoreMsg       => handleBbbCommonEnvCoreMsg(msg)
+    case _                              => // do nothing
   }
 
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
@@ -206,7 +204,7 @@ class BigBlueButtonActor(
 
   private def handleIsMeetingRunning(sender: ActorRef, msg: IsMeetingRunning): Unit = {
     RunningMeetings.findWithId(meetings, msg.meetingId) match {
-      case Some(meeting) => sender ! true
+      case Some(_) => sender ! true
       case None          => sender ! false
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -68,10 +68,13 @@ class BigBlueButtonActor(
     case msg: DestroyMeetingInternalMsg => handleDestroyMeeting(msg)
     case msg: IsMeetingRunning          => handleIsMeetingRunning(sender(), msg)
     case msg: GetMeeting                => handleGetMeeting(sender(), msg)
+    case msg: GetMeetings =>
+      println("***** Received GetMeetings message")
+      handleGetMeetings(sender(), msg)
 
     // 2x messages
-    case msg: BbbCommonEnvCoreMsg       => handleBbbCommonEnvCoreMsg(msg)
-    case _                              => // do nothing
+    case msg: BbbCommonEnvCoreMsg => handleBbbCommonEnvCoreMsg(msg)
+    case _                        => // do nothing
   }
 
   private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
@@ -210,6 +213,10 @@ class BigBlueButtonActor(
 
   private def handleGetMeeting(sender: ActorRef, msg: GetMeeting): Unit = {
     sender ! RunningMeetings.findWithId(meetings, msg.meetingId)
+  }
+
+  private def handleGetMeetings(sender: ActorRef, msg: GetMeetings): Unit = {
+    sender ! RunningMeetings.meetings(meetings)
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -228,7 +228,7 @@ class BigBlueButtonActor(
   }
 
   private def handleGetMeetings(sender: ActorRef, msg: GetMeetings): Unit = {
-    sender ! RunningMeetings.meetings(meetings)
+    sender ! RunningMeetings.meetingsMap(meetings)
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -132,3 +132,6 @@ case class DeskShareStoppedRequest(conferenceName: String, callerId: String, cal
 case class DeskShareRTMPBroadcastStartedRequest(conferenceName: String, streamname: String, videoWidth: Int, videoHeight: Int, timestamp: String) extends InMessage
 case class DeskShareRTMPBroadcastStoppedRequest(conferenceName: String, streamname: String, videoWidth: Int, videoHeight: Int, timestamp: String) extends InMessage
 case class DeskShareGetDeskShareInfoRequest(conferenceName: String, requesterID: String, replyTo: String) extends InMessage
+
+// gRPC messages
+case class IsMeetingRunning(meetingId: String) extends InMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -136,4 +136,5 @@ case class DeskShareGetDeskShareInfoRequest(conferenceName: String, requesterID:
 // gRPC messages
 case class IsMeetingRunning(meetingId: String) extends InMessage
 case class GetMeeting(meetingId: String) extends InMessage
+case class GetMeetings() extends InMessage
 case class GetMeetingInfo() extends InMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/api/InMessages.scala
@@ -135,3 +135,5 @@ case class DeskShareGetDeskShareInfoRequest(conferenceName: String, requesterID:
 
 // gRPC messages
 case class IsMeetingRunning(meetingId: String) extends InMessage
+case class GetMeeting(meetingId: String) extends InMessage
+case class GetMeetingInfo() extends InMessage

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -675,7 +675,6 @@ class MeetingActor(
   }
 
   private def handleGetMeetingInfo(): MeetingInfo = {
-    println(s"***** Getting meeting info for meeting with ID ${liveMeeting.props.meetingProp.intId}")
     val attendees = for {
       u <- Users2x.findAll(liveMeeting.users2x)
     } yield {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -695,8 +695,8 @@ class MeetingActor(
       createTime = liveMeeting.props.durationProps.createdTime,
       createdOn = liveMeeting.props.durationProps.createdDate,
       duration = liveMeeting.props.durationProps.duration,
-      startTime = 1000000L,
-      endTime = 1000000L,
+      startTime = 0L,
+      endTime = 0L,
       isRunning = MeetingStatus2x.hasMeetingEnded(liveMeeting.status),
       hasBeenForciblyEnded = false
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -670,69 +670,6 @@ class MeetingActor(
     )
   }
 
-  //  private def handleGetMeetingInfo(): MeetingInfo = {
-  //    val users = for {
-  //      u <- Users2x.findAll(liveMeeting.users2x)
-  //    } yield {
-  //      User(
-  //        userId = u.intId,
-  //        fullName = u.name,
-  //        role = u.role,
-  //        isPresenter = u.presenter,
-  //        isListeningOnly = findAllListenOnlyVoiceUsers(liveMeeting.voiceUsers).exists(v => v.intId == u.intId),
-  //        hasJoinedVoice = VoiceUsers.findAllNonListenOnlyVoiceUsers(liveMeeting.voiceUsers).exists(v => v.intId == u.intId),
-  //        hasVideo = findAll(liveMeeting.webcams).exists(w => w.userId == u.intId),
-  //        clientType = u.clientType,
-  //        customData = Map()
-  //      )
-  //    }
-  //
-  //    val durationInfo = DurationInfo(
-  //      createTime = liveMeeting.props.durationProps.createdTime,
-  //      createdOn = liveMeeting.props.durationProps.createdDate,
-  //      duration = liveMeeting.props.durationProps.duration,
-  //      startTime = 0L,
-  //      endTime = 0L,
-  //      isRunning = MeetingStatus2x.hasMeetingEnded(liveMeeting.status),
-  //      hasBeenForciblyEnded = false
-  //    )
-  //
-  //    val lc = findAllListenOnlyVoiceUsers(liveMeeting.voiceUsers).length
-  //    val participantInfo = ParticipantInfo(
-  //      hasUserJoined = hasAuthedUserJoined(liveMeeting.status),
-  //      participantCount = Users2x.findAll(liveMeeting.users2x).length,
-  //      listenerCount = lc,
-  //      voiceParticipantCount = VoiceUsers.findAll(liveMeeting.voiceUsers).length - lc,
-  //      videoCount = findAll(liveMeeting.webcams).length,
-  //      maxUsers = liveMeeting.props.usersProp.maxUsers,
-  //      moderatorCount = Users2x.findAll(liveMeeting.users2x).count(u => u.role.equalsIgnoreCase("moderator"))
-  //    )
-  //
-  //    val breakoutInfo = BreakoutInfo(
-  //      isBreakout = liveMeeting.props.meetingProp.isBreakout,
-  //      parentMeetingId = liveMeeting.props.breakoutProps.parentId,
-  //      sequence = liveMeeting.props.breakoutProps.sequence,
-  //      freeJoin = liveMeeting.props.breakoutProps.freeJoin
-  //    )
-  //
-  //    MeetingInfo(
-  //      meetingName = liveMeeting.props.meetingProp.name,
-  //      meetingExtId = liveMeeting.props.meetingProp.extId,
-  //      meetingIntId = liveMeeting.props.meetingProp.intId,
-  //      voiceBridge = liveMeeting.props.voiceProp.voiceConf,
-  //      dialNumber = liveMeeting.props.voiceProp.dialNumber,
-  //      attendeePw = liveMeeting.props.password.viewerPass,
-  //      moderatorPw = liveMeeting.props.password.moderatorPass,
-  //      recording = liveMeeting.props.recordProp.record,
-  //      users = users,
-  //      metadata = Map(),
-  //      breakoutRooms = if (state.breakout.isDefined) state.breakout.get.getRooms().map(_.name).toList else List(),
-  //      durationInfo = Some(durationInfo),
-  //      participantInfo = Some(participantInfo),
-  //      breakoutInfo = Some(breakoutInfo)
-  //    )
-  //  }
-
   private def resolveUserName(userId: String): String = {
     val userName: String = Users2x.findWithIntId(liveMeeting.users2x, userId).map(_.name).getOrElse("")
     if (userName.isEmpty) log.error(s"Failed to map username for id $userId")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -675,9 +675,6 @@ class MeetingActor(
   }
 
   private def handleGetMeetingInfo(): MeetingInfo = {
-
-    VoiceUsers.findAll(liveMeeting.voiceUsers).foreach(v => println(s"VoiceUser with intId ${v.intId} and voiceUserId ${v.voiceUserId}"))
-
     val attendees = for {
       u <- Users2x.findAll(liveMeeting.users2x)
     } yield {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -46,7 +46,7 @@ import org.bigbluebutton.core.models.VoiceUsers.{ findAllFreeswitchCallers, find
 import org.bigbluebutton.core.models.Webcams.findAll
 import org.bigbluebutton.core2.MeetingStatus2x.{ authUserHadJoined, hasAuthedUserJoined }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
-import org.bigbluebutton.protos.{ Attendee, BreakoutInfo, DurationInfo, MeetingInfo, ParticipantInfo }
+import org.bigbluebutton.protos.{ User, BreakoutInfo, DurationInfo, MeetingInfo, ParticipantInfo }
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -657,7 +657,7 @@ class MeetingActor(
     val isMeetingRecorded = MeetingStatus2x.isRecording(liveMeeting.status)
 
     // TODO: Placeholder values as required values not available
-    val screenshareStream: ScreenshareStream = ScreenshareStream(new User("", ""), List())
+    val screenshareStream: ScreenshareStream = ScreenshareStream(new org.bigbluebutton.common2.msgs.User("", ""), List())
     val screenshare: Screenshare = Screenshare(screenshareStream)
 
     val listOfUsers: List[UserState] = Users2x.findAll(liveMeeting.users2x).toList
@@ -675,10 +675,10 @@ class MeetingActor(
   }
 
   private def handleGetMeetingInfo(): MeetingInfo = {
-    val attendees = for {
+    val users = for {
       u <- Users2x.findAll(liveMeeting.users2x)
     } yield {
-      Attendee(
+      User(
         userId = u.intId,
         fullName = u.name,
         role = u.role,
@@ -728,7 +728,7 @@ class MeetingActor(
       attendeePw = liveMeeting.props.password.viewerPass,
       moderatorPw = liveMeeting.props.password.moderatorPass,
       recording = liveMeeting.props.recordProp.record,
-      attendees = attendees,
+      users = users,
       metadata = Map(),
       breakoutRooms = if (state.breakout.isDefined) state.breakout.get.getRooms().map(_.name).toList else List(),
       durationInfo = Some(durationInfo),
@@ -748,7 +748,7 @@ class MeetingActor(
     val numOfLiveWebcams: Int = liveWebcams.length
     val broadcasts: List[Broadcast] = liveWebcams.map(webcam => Broadcast(
       webcam.streamId,
-      User(webcam.userId, resolveUserName(webcam.userId)), 0L
+      org.bigbluebutton.common2.msgs.User(webcam.userId, resolveUserName(webcam.userId)), 0L
     )).toList
     val subscribers: Set[String] = liveWebcams.flatMap(_.subscribers).toSet
     val webcamStream: msgs.WebcamStream = msgs.WebcamStream(broadcasts, subscribers)
@@ -763,14 +763,14 @@ class MeetingActor(
     val numOfListenOnlyUsers: Int = listenOnlyUsers.length
     val listenOnlyAudio = ListenOnlyAudio(
       numOfListenOnlyUsers,
-      listenOnlyUsers.map(voiceUserState => User(voiceUserState.voiceUserId, resolveUserName(voiceUserState.intId))).toList
+      listenOnlyUsers.map(voiceUserState => org.bigbluebutton.common2.msgs.User(voiceUserState.voiceUserId, resolveUserName(voiceUserState.intId))).toList
     )
 
     val freeswitchUsers: Vector[VoiceUserState] = findAllFreeswitchCallers(liveMeeting.voiceUsers)
     val numOfFreeswitchUsers: Int = freeswitchUsers.length
     val twoWayAudio = TwoWayAudio(
       numOfFreeswitchUsers,
-      freeswitchUsers.map(voiceUserState => User(voiceUserState.voiceUserId, resolveUserName(voiceUserState.intId))).toList
+      freeswitchUsers.map(voiceUserState => org.bigbluebutton.common2.msgs.User(voiceUserState.voiceUserId, resolveUserName(voiceUserState.intId))).toList
     )
 
     // TODO: Placeholder values

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/RunningMeetings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/RunningMeetings.scala
@@ -3,6 +3,8 @@ package org.bigbluebutton.core2
 import org.bigbluebutton.core.db.MeetingDAO
 import org.bigbluebutton.core.running.RunningMeeting
 
+import scala.collection.immutable.VectorMap
+
 object RunningMeetings {
   def findWithId(meetings: RunningMeetings, id: String): Option[RunningMeeting] = {
     meetings.toVector.find(m => m.props.meetingProp.intId == id)
@@ -30,6 +32,10 @@ object RunningMeetings {
     meetings.toVector
   }
 
+  def meetingsMap(meetings: RunningMeetings): VectorMap[String, RunningMeeting] = {
+    meetings.getMeetings
+  }
+
   def findMeetingWithVoiceConfId(meetings: RunningMeetings, voiceConfId: String): Option[RunningMeeting] = {
     meetings.toVector.find(m => { m.props.voiceProp.voiceConf == voiceConfId })
   }
@@ -37,9 +43,11 @@ object RunningMeetings {
 }
 
 class RunningMeetings {
-  private var meetings = new collection.immutable.HashMap[String, RunningMeeting]
+  private var meetings: VectorMap[String, RunningMeeting] = VectorMap.empty
 
   private def toVector: Vector[RunningMeeting] = meetings.values.toVector
+
+  private def getMeetings: VectorMap[String, RunningMeeting] = meetings
 
   private def save(meeting: RunningMeeting): RunningMeeting = {
     meetings += meeting.props.meetingProp.intId -> meeting

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/RunningMeetings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/RunningMeetings.scala
@@ -8,6 +8,10 @@ object RunningMeetings {
     meetings.toVector.find(m => m.props.meetingProp.intId == id)
   }
 
+  def findWithExtId(meetings: RunningMeetings, id: String): Option[RunningMeeting] = {
+    meetings.toVector.find(m => m.props.meetingProp.extId == id)
+  }
+
   def add(meetings: RunningMeetings, meeting: RunningMeeting): RunningMeeting = {
     meetings.save(meeting)
     MeetingDAO.insert(meeting.props, meeting.clientSettings)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/GetMeetingInfoMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/GetMeetingInfoMsgHdlr.scala
@@ -1,0 +1,76 @@
+package org.bigbluebutton.core2.message.handlers
+
+import org.bigbluebutton.core.models.{ Users2x, VoiceUsers }
+import org.bigbluebutton.core.models.VoiceUsers.findAllListenOnlyVoiceUsers
+import org.bigbluebutton.core.models.Webcams.findAll
+import org.bigbluebutton.core.running.MeetingActor
+import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core2.MeetingStatus2x.hasAuthedUserJoined
+import org.bigbluebutton.protos.{ BreakoutInfo, DurationInfo, MeetingInfo, ParticipantInfo, User }
+
+trait GetMeetingInfoMsgHdlr {
+  this: MeetingActor =>
+
+  def handleGetMeetingInfo(): MeetingInfo = {
+    val users = for {
+      u <- Users2x.findAll(liveMeeting.users2x)
+    } yield {
+      User(
+        userId = u.intId,
+        fullName = u.name,
+        role = u.role,
+        isPresenter = u.presenter,
+        isListeningOnly = findAllListenOnlyVoiceUsers(liveMeeting.voiceUsers).exists(v => v.intId == u.intId),
+        hasJoinedVoice = VoiceUsers.findAllNonListenOnlyVoiceUsers(liveMeeting.voiceUsers).exists(v => v.intId == u.intId),
+        hasVideo = findAll(liveMeeting.webcams).exists(w => w.userId == u.intId),
+        clientType = u.clientType,
+        customData = Map()
+      )
+    }
+
+    val durationInfo = DurationInfo(
+      createTime = liveMeeting.props.durationProps.createdTime,
+      createdOn = liveMeeting.props.durationProps.createdDate,
+      duration = liveMeeting.props.durationProps.duration,
+      startTime = 0L,
+      endTime = 0L,
+      isRunning = MeetingStatus2x.hasMeetingEnded(liveMeeting.status),
+      hasBeenForciblyEnded = false
+    )
+
+    val lc = findAllListenOnlyVoiceUsers(liveMeeting.voiceUsers).length
+    val participantInfo = ParticipantInfo(
+      hasUserJoined = hasAuthedUserJoined(liveMeeting.status),
+      participantCount = Users2x.findAll(liveMeeting.users2x).length,
+      listenerCount = lc,
+      voiceParticipantCount = VoiceUsers.findAll(liveMeeting.voiceUsers).length - lc,
+      videoCount = findAll(liveMeeting.webcams).length,
+      maxUsers = liveMeeting.props.usersProp.maxUsers,
+      moderatorCount = Users2x.findAll(liveMeeting.users2x).count(u => u.role.equalsIgnoreCase("moderator"))
+    )
+
+    val breakoutInfo = BreakoutInfo(
+      isBreakout = liveMeeting.props.meetingProp.isBreakout,
+      parentMeetingId = liveMeeting.props.breakoutProps.parentId,
+      sequence = liveMeeting.props.breakoutProps.sequence,
+      freeJoin = liveMeeting.props.breakoutProps.freeJoin
+    )
+
+    MeetingInfo(
+      meetingName = liveMeeting.props.meetingProp.name,
+      meetingExtId = liveMeeting.props.meetingProp.extId,
+      meetingIntId = liveMeeting.props.meetingProp.intId,
+      voiceBridge = liveMeeting.props.voiceProp.voiceConf,
+      dialNumber = liveMeeting.props.voiceProp.dialNumber,
+      attendeePw = liveMeeting.props.password.viewerPass,
+      moderatorPw = liveMeeting.props.password.moderatorPass,
+      recording = liveMeeting.props.recordProp.record,
+      users = users,
+      metadata = Map(),
+      breakoutRooms = if (state.breakout.isDefined) state.breakout.get.getRooms().map(_.name).toList else List(),
+      durationInfo = Some(durationInfo),
+      participantInfo = Some(participantInfo),
+      breakoutInfo = Some(breakoutInfo)
+    )
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
@@ -4,8 +4,9 @@ import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.pattern.ask
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.util.Timeout
-import org.bigbluebutton.core.api.IsMeetingRunning
-import org.bigbluebutton.protos.{ MeetingInfoReq, MeetingInfoResp, MeetingRunningReq, MeetingRunningResp, MeetingService, MeetingsReq, MeetingsResp }
+import org.bigbluebutton.core.api._
+import org.bigbluebutton.core.running.RunningMeeting
+import org.bigbluebutton.protos.{ MeetingInfo, MeetingInfoReq, MeetingInfoResp, MeetingRunningReq, MeetingRunningResp, MeetingService, MeetingsReq, MeetingsResp }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -18,7 +19,13 @@ class MeetingServiceImpl(implicit materializer: Materializer, bbbActor: ActorRef
     (bbbActor ? IsMeetingRunning(in.meetingId)).mapTo[Boolean].map(msg => MeetingRunningResp(msg))
   }
 
-  override def getMeetingInfo(in: MeetingInfoReq): Future[MeetingInfoResp] = ???
+  override def getMeetingInfo(in: MeetingInfoReq): Future[MeetingInfoResp] = {
+    implicit val timeout: Timeout = 3.seconds
+    (bbbActor ? GetMeeting(in.meetingId)).mapTo[Option[RunningMeeting]].flatMap {
+      case Some(runningMeeting) => (runningMeeting.actorRef ? GetMeetingInfo()).mapTo[MeetingInfo].map(msg => MeetingInfoResp(Some(msg)))
+      case None                 => Future.successful(MeetingInfoResp(None))
+    }
+  }
 
   override def getMeetings(in: MeetingsReq): Future[MeetingsResp] = ???
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
@@ -1,13 +1,18 @@
 package org.bigbluebutton.service
 
+import com.google.rpc.Code
+import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.grpc.GrpcServiceException
 import org.apache.pekko.pattern.ask
 import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.Timeout
 import org.bigbluebutton.core.api._
 import org.bigbluebutton.core.running.RunningMeeting
-import org.bigbluebutton.protos.{ MeetingInfo, MeetingInfoReq, MeetingInfoResp, MeetingRunningReq, MeetingRunningResp, MeetingService, MeetingsReq, MeetingsResp }
+import org.bigbluebutton.protos._
 
+import scala.collection.immutable.VectorMap
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
@@ -23,15 +28,68 @@ class MeetingServiceImpl(implicit materializer: Materializer, bbbActor: ActorRef
     implicit val timeout: Timeout = 3.seconds
     (bbbActor ? GetMeeting(in.meetingId)).mapTo[Option[RunningMeeting]].flatMap {
       case Some(runningMeeting) => (runningMeeting.actorRef ? GetMeetingInfo()).mapTo[MeetingInfo].map(msg => MeetingInfoResp(Some(msg)))
-      case None                 => Future.successful(MeetingInfoResp(None))
+      case None                 => Future.failed(GrpcServiceException(Code.NOT_FOUND, "notFound", Seq(new ErrorResp("notFound", "A meeting with that ID does not exist"))))
     }
   }
 
-  override def getMeetings(in: MeetingsReq): Future[MeetingsResp] = {
+  override def listMeetings(in: ListMeetingsReq): Future[ListMeetingsResp] = {
     implicit val timeout: Timeout = 3.seconds
-    (bbbActor ? GetMeetings()).mapTo[Vector[RunningMeeting]].flatMap { runningMeetings =>
-      val meetingInfoFutures = runningMeetings.map(m => (m.actorRef ? GetMeetingInfo()).mapTo[MeetingInfo])
-      Future.sequence(meetingInfoFutures).map(meetings => MeetingsResp(meetings))
+
+    def getPageStartingFromToken(meetings: VectorMap[String, RunningMeeting], token: String, size: Int): Either[GrpcServiceException, VectorMap[String, RunningMeeting]] = {
+      meetings.keys.indexOf(token) match {
+        case -1    => Left(GrpcServiceException(Code.INVALID_ARGUMENT, "invalidPageToken", Seq(new ErrorResp("invalidPageToken", "The provided page token is not valid"))))
+        case index => Right(meetings.slice(index, index + size))
+      }
+    }
+
+    def constructListMeetingsResponse(meetings: VectorMap[String, RunningMeeting], nextPageToken: Option[String]): Future[ListMeetingsResp] = {
+      val meetingInfoFutures = meetings.map { case (_, runningMeeting) =>
+        (runningMeeting.actorRef ? GetMeetingInfo()).mapTo[MeetingInfo]
+      }
+      Future.sequence(meetingInfoFutures.toVector).map(meetings => ListMeetingsResp(meetings, nextPageToken.getOrElse("")))
+    }
+
+    if (in.pageSize < 0) Future.failed(GrpcServiceException(Code.INVALID_ARGUMENT, "invalidPageSize", Seq(new ErrorResp("invalidPageSize", "The page size cannot be negative"))))
+    else {
+      val pageSize = math.min(in.pageSize, 50)
+
+      (bbbActor ? GetMeetings()).mapTo[VectorMap[String, RunningMeeting]].flatMap { runningMeetings =>
+        val nextPageIndex = if (Option(in.pageToken).forall(_.isBlank)) pageSize else runningMeetings.keys.toSeq.indexOf(in.pageToken) + pageSize
+        val meetingsToReturn = if (Option(in.pageToken).forall(_.isBlank)) runningMeetings.take(pageSize) else getPageStartingFromToken(runningMeetings, in.pageToken, pageSize)
+        meetingsToReturn match {
+          case Left(error: GrpcServiceException) => Future.failed(error)
+          case Right(meetings: VectorMap[String, RunningMeeting]) =>
+            val nextPageToken = meetings.drop(nextPageIndex).headOption.map(_._1)
+            constructListMeetingsResponse(meetings, nextPageToken)
+        }
+      }
+    }
+  }
+
+  override def streamMeetings(in: StreamMeetingsReq): Source[MeetingInfoResp, NotUsed] = {
+    implicit val timeout: Timeout = 3.seconds
+
+    val runningMeetingFutures: Future[VectorMap[String, RunningMeeting]] = (bbbActor ? GetMeetings()).mapTo[VectorMap[String, RunningMeeting]]
+
+    Source.future(runningMeetingFutures).flatMapConcat { runningMeetings: VectorMap[String, RunningMeeting] =>
+      val meetingsToReturn = if (Option(in.meetingId).forall(_.isBlank)) runningMeetings else {
+        val startIndex = runningMeetings.keys.indexOf(in.meetingId)
+        startIndex match {
+          case -1    => VectorMap.empty
+          case index => runningMeetings.slice(index, runningMeetings.size)
+        }
+      }
+
+      if (meetingsToReturn.isEmpty) Source.failed(GrpcServiceException(Code.INVALID_ARGUMENT, "invalidMeetingID", Seq(new ErrorResp("invalidMeetingID", "No meeting with the provided meetingID exists"))))
+      else {
+        Source(meetingsToReturn.toList).mapAsync(parallelism = 4) { case (_, runningMeeting) =>
+          (runningMeeting.actorRef ? GetMeetingInfo()).mapTo[MeetingInfo].map(meetingInfo => MeetingInfoResp(Option(meetingInfo))).recover {
+            case ex: Throwable   => MeetingInfoResp(None)
+          }
+        }
+      }
+    }.recoverWith {
+      case ex: Throwable => Source.single(MeetingInfoResp(None))
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
@@ -27,5 +27,11 @@ class MeetingServiceImpl(implicit materializer: Materializer, bbbActor: ActorRef
     }
   }
 
-  override def getMeetings(in: MeetingsReq): Future[MeetingsResp] = ???
+  override def getMeetings(in: MeetingsReq): Future[MeetingsResp] = {
+    implicit val timeout: Timeout = 3.seconds
+    (bbbActor ? GetMeetings()).mapTo[Vector[RunningMeeting]].flatMap { runningMeetings =>
+      val meetingInfoFutures = runningMeetings.map(m => (m.actorRef ? GetMeetingInfo()).mapTo[MeetingInfo])
+      Future.sequence(meetingInfoFutures).map(meetings => MeetingsResp(meetings))
+    }
+  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
@@ -1,0 +1,16 @@
+package org.bigbluebutton.service
+
+import org.apache.pekko.stream.Materializer
+import org.bigbluebutton.protos.{ MeetingService, TestRequest, TestResponse }
+
+import scala.concurrent.Future
+
+class MeetingServiceImpl(implicit materializer: Materializer) extends MeetingService {
+
+  import materializer.executionContext
+
+  override def test(in: TestRequest): Future[TestResponse] = {
+    println(s"Received test request with message ${in.msg}")
+    Future.successful(TestResponse(s"Request successful"))
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
@@ -65,7 +65,7 @@ class MeetingServiceImpl(implicit materializer: Materializer, bbbActor: ActorRef
     }
   }
 
-  override def streamMeetings(in: StreamMeetingsReq): Source[MeetingInfoResp, NotUsed] = {
+  override def getMeetingsStream(in: GetMeetingsStreamReq): Source[MeetingInfoResp, NotUsed] = {
     implicit val timeout: Timeout = 3.seconds
 
     val runningMeetingFutures: Future[VectorMap[String, RunningMeeting]] = (bbbActor ? GetMeetings()).mapTo[VectorMap[String, RunningMeeting]]

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/MeetingServiceImpl.scala
@@ -1,16 +1,24 @@
 package org.bigbluebutton.service
 
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.pattern.ask
 import org.apache.pekko.stream.Materializer
-import org.bigbluebutton.protos.{ MeetingService, TestRequest, TestResponse }
+import org.apache.pekko.util.Timeout
+import org.bigbluebutton.core.api.IsMeetingRunning
+import org.bigbluebutton.protos.{ MeetingInfoReq, MeetingInfoResp, MeetingRunningReq, MeetingRunningResp, MeetingService, MeetingsReq, MeetingsResp }
 
 import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
 
-class MeetingServiceImpl(implicit materializer: Materializer) extends MeetingService {
+class MeetingServiceImpl(implicit materializer: Materializer, bbbActor: ActorRef) extends MeetingService {
 
   import materializer.executionContext
-
-  override def test(in: TestRequest): Future[TestResponse] = {
-    println(s"Received test request with message ${in.msg}")
-    Future.successful(TestResponse(s"Request successful"))
+  override def isMeetingRunning(in: MeetingRunningReq): Future[MeetingRunningResp] = {
+    implicit val timeout: Timeout = 3.seconds
+    (bbbActor ? IsMeetingRunning(in.meetingId)).mapTo[Boolean].map(msg => MeetingRunningResp(msg))
   }
+
+  override def getMeetingInfo(in: MeetingInfoReq): Future[MeetingInfoResp] = ???
+
+  override def getMeetings(in: MeetingsReq): Future[MeetingsResp] = ???
 }

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -25,6 +25,14 @@ pekko {
       # Set to 1 for as fair as possible.
       throughput = 512
     }
+
+  http {
+    server {
+        preview {
+            enable-http2 = "on"
+        }
+    }
+  }
 }
 
 client {

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -88,6 +88,11 @@ http {
   port = ${?PORT}
 }
 
+grpc {
+  interface = "127.0.0.1"
+  port = 8081
+}
+
 services {
   telizeHost = "www.telize.com"
   telizePort = 80

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -1,7 +1,7 @@
 import org.bigbluebutton.build._
 
 
-version := "0.0.28-SNAPSHOT"
+version := "0.0.29-SNAPSHOT"
 
 val compileSettings = Seq(
   organization := "org.bigbluebutton",

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -34,7 +34,7 @@ testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/sc
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 
 Seq(Revolver.settings: _*)
-lazy val commonMessage = (project in file(".")).settings(name := "bbb-common-message", libraryDependencies ++= Dependencies.runtime).settings(compileSettings)
+lazy val commonMessage = (project in file(".")).settings(name := "bbb-common-message", libraryDependencies ++= Dependencies.runtime).settings(compileSettings, unmanagedResourceDirectories in Compile += baseDirectory.value / "src/main/protobuf")
 
 // See https://github.com/scala-ide/scalariform
 // Config file is in ./.scalariform.conf

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -1,7 +1,7 @@
 import org.bigbluebutton.build._
 
 
-version := "0.0.29-SNAPSHOT"
+version := "0.0.30-SNAPSHOT"
 
 val compileSettings = Seq(
   organization := "org.bigbluebutton",

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -1,7 +1,7 @@
 import org.bigbluebutton.build._
 
 
-version := "0.0.27-SNAPSHOT"
+version := "0.0.28-SNAPSHOT"
 
 val compileSettings = Seq(
   organization := "org.bigbluebutton",

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -1,7 +1,7 @@
 import org.bigbluebutton.build._
 
 
-version := "0.0.22-SNAPSHOT"
+version := "0.0.23-SNAPSHOT"
 
 val compileSettings = Seq(
   organization := "org.bigbluebutton",

--- a/bbb-common-message/build.sbt
+++ b/bbb-common-message/build.sbt
@@ -1,7 +1,7 @@
 import org.bigbluebutton.build._
 
 
-version := "0.0.23-SNAPSHOT"
+version := "0.0.27-SNAPSHOT"
 
 val compileSettings = Seq(
   organization := "org.bigbluebutton",

--- a/bbb-common-message/src/main/protobuf/common.proto
+++ b/bbb-common-message/src/main/protobuf/common.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package org.bigbluebutton.protos;
+
+message ErrorResp {
+  string key = 1;
+  string message = 2;
+}

--- a/bbb-common-message/src/main/protobuf/meeting-service.proto
+++ b/bbb-common-message/src/main/protobuf/meeting-service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package org.bigbluebutton.protos;
+
+message TestRequest {
+  string msg = 1;
+}
+
+message TestResponse {
+  string msg = 1;
+}
+
+service MeetingService {
+  rpc test(TestRequest) returns (TestResponse);
+}

--- a/bbb-common-message/src/main/protobuf/meeting-service.proto
+++ b/bbb-common-message/src/main/protobuf/meeting-service.proto
@@ -10,7 +10,7 @@ message MeetingRunningResp {
   bool is_running = 1;
 }
 
-message Attendee {
+message User {
   string user_id = 1;
   string full_name = 2;
   string role = 3;
@@ -58,7 +58,7 @@ message MeetingInfo {
   string attendee_pw = 8;
   string moderator_pw = 9;
   bool recording = 10;
-  repeated Attendee attendees = 11;
+  repeated User users = 11;
   map<string, string> metadata = 12;
   repeated string breakout_rooms = 13;
   DurationInfo duration_info = 14;

--- a/bbb-common-message/src/main/protobuf/meeting-service.proto
+++ b/bbb-common-message/src/main/protobuf/meeting-service.proto
@@ -2,14 +2,32 @@ syntax = "proto3";
 
 package org.bigbluebutton.protos;
 
-message TestRequest {
-  string msg = 1;
+message MeetingRunningReq {
+  string meetingId = 1;
 }
 
-message TestResponse {
-  string msg = 1;
+message MeetingRunningResp {
+  bool isRunning = 1;
+}
+
+message MeetingInfoReq {
+  string meetingId = 1;
+}
+
+message MeetingInfoResp {
+
+}
+
+message MeetingsReq {
+
+}
+
+message MeetingsResp {
+
 }
 
 service MeetingService {
-  rpc test(TestRequest) returns (TestResponse);
+  rpc isMeetingRunning(MeetingRunningReq) returns (MeetingRunningResp);
+  rpc getMeetingInfo(MeetingInfoReq) returns (MeetingInfoResp);
+  rpc getMeetings(MeetingsReq) returns (MeetingsResp);
 }

--- a/bbb-common-message/src/main/protobuf/meeting-service.proto
+++ b/bbb-common-message/src/main/protobuf/meeting-service.proto
@@ -84,7 +84,7 @@ message ListMeetingsResp {
   string next_page_token = 2;
 }
 
-message StreamMeetingsReq {
+message GetMeetingsStreamReq {
   string meeting_id = 1;
 }
 
@@ -92,5 +92,5 @@ service MeetingService {
   rpc isMeetingRunning(MeetingRunningReq) returns (MeetingRunningResp);
   rpc getMeetingInfo(MeetingInfoReq) returns (MeetingInfoResp);
   rpc listMeetings(ListMeetingsReq) returns (ListMeetingsResp);
-  rpc streamMeetings(StreamMeetingsReq) returns (stream MeetingInfoResp);
+  rpc getMeetingsStream(GetMeetingsStreamReq) returns (stream MeetingInfoResp);
 }

--- a/bbb-common-message/src/main/protobuf/meeting-service.proto
+++ b/bbb-common-message/src/main/protobuf/meeting-service.proto
@@ -3,19 +3,75 @@ syntax = "proto3";
 package org.bigbluebutton.protos;
 
 message MeetingRunningReq {
-  string meetingId = 1;
+  string meeting_id = 1;
 }
 
 message MeetingRunningResp {
-  bool isRunning = 1;
+  bool is_running = 1;
+}
+
+message Attendee {
+  string user_id = 1;
+  string full_name = 2;
+  string role = 3;
+  bool is_presenter = 4;
+  bool is_listening_only = 5;
+  bool has_joined_voice = 6;
+  bool has_video = 7;
+  string clientType = 8;
+  map<string, string> custom_data = 9;
+}
+
+message DurationInfo {
+  int64 create_time = 1;
+  string created_on = 2;
+  int32 duration = 3;
+  int64 start_time = 4;
+  int64 end_time = 5;
+  bool is_running = 6;
+  bool has_been_forcibly_ended = 7;
+}
+
+message ParticipantInfo {
+  bool has_user_joined = 1;
+  int32 participant_count = 2;
+  int32 listener_count = 3;
+  int32 voice_participant_count = 4;
+  int32 video_count = 5;
+  int32 max_users = 6;
+  int32 moderator_count = 7;
+}
+
+message BreakoutInfo {
+  bool is_breakout = 1;
+  string parent_meeting_id = 2;
+  int32 sequence = 3;
+  bool free_join = 4;
+}
+
+message MeetingInfo {
+  string meeting_name = 1;
+  string meeting_ext_id = 2;
+  string meeting_int_id = 3;
+  string voice_bridge = 6;
+  string dial_number = 7;
+  string attendee_pw = 8;
+  string moderator_pw = 9;
+  bool recording = 10;
+  repeated Attendee attendees = 11;
+  map<string, string> metadata = 12;
+  repeated string breakout_rooms = 13;
+  DurationInfo duration_info = 14;
+  ParticipantInfo participant_info = 15;
+  BreakoutInfo breakout_info = 16;
 }
 
 message MeetingInfoReq {
-  string meetingId = 1;
+  string meeting_id = 1;
 }
 
 message MeetingInfoResp {
-
+  MeetingInfo  meeting_info = 1;
 }
 
 message MeetingsReq {
@@ -23,7 +79,7 @@ message MeetingsReq {
 }
 
 message MeetingsResp {
-
+  repeated MeetingInfo meetings = 1;
 }
 
 service MeetingService {

--- a/bbb-common-message/src/main/protobuf/meeting-service.proto
+++ b/bbb-common-message/src/main/protobuf/meeting-service.proto
@@ -74,16 +74,23 @@ message MeetingInfoResp {
   MeetingInfo  meeting_info = 1;
 }
 
-message MeetingsReq {
-
+message ListMeetingsReq {
+  int32 page_size = 1;
+  string page_token = 2;
 }
 
-message MeetingsResp {
+message ListMeetingsResp {
   repeated MeetingInfo meetings = 1;
+  string next_page_token = 2;
+}
+
+message StreamMeetingsReq {
+  string meeting_id = 1;
 }
 
 service MeetingService {
   rpc isMeetingRunning(MeetingRunningReq) returns (MeetingRunningResp);
   rpc getMeetingInfo(MeetingInfoReq) returns (MeetingInfoResp);
-  rpc getMeetings(MeetingsReq) returns (MeetingsResp);
+  rpc listMeetings(ListMeetingsReq) returns (ListMeetingsResp);
+  rpc streamMeetings(StreamMeetingsReq) returns (stream MeetingInfoResp);
 }

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val text = "1.10.0"
 
     // BigBlueButton
-    val bbbCommons = "0.0.29-SNAPSHOT"
+    val bbbCommons = "0.0.30-SNAPSHOT"
 
     // Test
     val scalaTest = "3.2.11"

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val text = "1.10.0"
 
     // BigBlueButton
-    val bbbCommons = "0.0.22-SNAPSHOT"
+    val bbbCommons = "0.0.23-SNAPSHOT"
 
     // Test
     val scalaTest = "3.2.11"

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val text = "1.10.0"
 
     // BigBlueButton
-    val bbbCommons = "0.0.28-SNAPSHOT"
+    val bbbCommons = "0.0.29-SNAPSHOT"
 
     // Test
     val scalaTest = "3.2.11"

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val text = "1.10.0"
 
     // BigBlueButton
-    val bbbCommons = "0.0.27-SNAPSHOT"
+    val bbbCommons = "0.0.28-SNAPSHOT"
 
     // Test
     val scalaTest = "3.2.11"

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val text = "1.10.0"
 
     // BigBlueButton
-    val bbbCommons = "0.0.23-SNAPSHOT"
+    val bbbCommons = "0.0.27-SNAPSHOT"
 
     // Test
     val scalaTest = "3.2.11"

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -120,6 +120,13 @@ public class Meeting {
 
 	private String overrideClientSettings = "";
 
+	private boolean isRunning;
+	private int numUsersOnline;
+	private int numListenOnlyUsers;
+	private int numVoiceUsers;
+	private int numVideoUsers;
+	private int numMods;
+
     public Meeting(Meeting.Builder builder) {
         name = builder.name;
         extMeetingId = builder.externalId;
@@ -477,6 +484,62 @@ public class Meeting {
 
 	public void setGuestLobbyMessage(String message) {
 		guestLobbyMessage = message;
+	}
+
+	public void setIsRunning(boolean isRunning) {
+		this.isRunning = isRunning;
+	}
+
+	public boolean getIsRunning() {
+		return isRunning;
+	}
+
+	public void setUserHasJoined(boolean userHasJoined) {
+		this.userHasJoined = userHasJoined;
+	}
+
+	public void setIsForciblyEnded(boolean forciblyEnded) {
+		this.forciblyEnded = forciblyEnded;
+	}
+
+	public void setNumUsersOnline(int numUsersOnline) {
+		this.numUsersOnline = numUsersOnline;
+	}
+
+	public int getNumOnlineUsers() {
+		return numUsersOnline;
+	}
+
+	public void setNumListenOnlyUsers(int numListenOnlyUsers) {
+		this.numListenOnlyUsers = numListenOnlyUsers;
+	}
+
+	public int getNumListenOnlyUsers() {
+		return numListenOnlyUsers;
+	}
+
+	public void setNumVoiceUsers(int numVoiceUsers) {
+		this.numVoiceUsers = numVoiceUsers;
+	}
+
+	public int getNumVoiceUsers() {
+		return this.numVoiceUsers;
+	}
+
+	public void setNumVideoUsers(int numVideoUsers) {
+		this.numVideoUsers = numVideoUsers;
+	}
+
+	public int getNumVideoUsers() {
+		return numVideoUsers;
+	}
+
+	public void setNumMods(int numMods) {
+		this.numMods = numMods;
+	}
+
+	public int getNumMods() {
+		return numMods;
 	}
 
 	public String getGuestLobbyMessage(String guestId) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/User.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/User.java
@@ -40,6 +40,8 @@ public class User {
 	private String clientType;
 	private List<String> streams;
 	private Long leftOn = null;
+	private Boolean isPresenter;
+	private Boolean hasVideo;
 
 	public User(String internalUserId,
 							String externalUserId,
@@ -194,4 +196,19 @@ public class User {
 		return this.clientType;
 	}
 
+	public void setIsPresenter(Boolean isPresenter) {
+		this.isPresenter = isPresenter;
+	}
+
+	public boolean getIsPresenter() {
+		return isPresenter;
+	}
+
+	public void setHasVideo(Boolean hasVideo) {
+		this.hasVideo = hasVideo;
+	}
+
+	public boolean getHasVideo() {
+		return hasVideo;
+	}
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/MeetingInfo.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/MeetingInfo.java
@@ -19,7 +19,6 @@ public class MeetingInfo extends RequestWithChecksum<MeetingInfo.Params> {
     }
 
     @MeetingIDConstraint
-    @MeetingExistsConstraint
     private String meetingID;
 
     public MeetingInfo(Checksum checksum) {

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -93,8 +93,8 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${tomcatEmbedVersion}"
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
-  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT"
-  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT"
+  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.28-SNAPSHOT"
+  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.28-SNAPSHOT"
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -16,6 +16,10 @@ buildscript {
   }
 }
 
+plugins {
+  id "com.google.protobuf" version "0.9.4"
+}
+
 version "0.10.0"
 group "org.bigbluebutton.web"
 
@@ -90,6 +94,7 @@ dependencies {
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
   implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.22-SNAPSHOT"
+  protobuf 'org.bigbluebutton:bbb-common-message_2.13:0.0.22-SNAPSHOT'
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"
@@ -105,6 +110,11 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-validation:${springVersion}"
   implementation 'org.postgresql:postgresql:42.4.3'
   implementation 'org.hibernate:hibernate-core:5.6.1.Final'
+
+
+  implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
+  implementation "io.grpc:grpc-protobuf:${grpcVersion}"
+  implementation "io.grpc:grpc-stub:${grpcVersion}"
 
   //--- BigBlueButton Dependencies End
   console "org.grails:grails-console:5.2.0"

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -146,15 +146,6 @@ protobuf {
   }
 }
 
-//sourceSets {
-//  main {
-//    java {
-//      srcDirs 'generated/source/proto/main/grpc'
-//      srcDirs 'generated/source/proto/main/java'
-//    }
-//  }
-//}
-
 tasks.named('bootWarMainClassName') {
     it.mustRunAfter(tasks.named('compileGsonViews'))
 }

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -93,8 +93,8 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${tomcatEmbedVersion}"
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
-  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.28-SNAPSHOT"
-  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.28-SNAPSHOT"
+  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.29-SNAPSHOT"
+  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.29-SNAPSHOT"
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -93,8 +93,8 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${tomcatEmbedVersion}"
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
-  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.29-SNAPSHOT"
-  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.29-SNAPSHOT"
+  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.30-SNAPSHOT"
+  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.30-SNAPSHOT"
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -94,7 +94,7 @@ dependencies {
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
   implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT"
-  protobuf 'org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT'
+  protobuf "org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT"
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -93,8 +93,8 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${tomcatEmbedVersion}"
   implementation "org.apache.tomcat:tomcat-annotations-api:${tomcatEmbedVersion}"
   //--- BigBlueButton Dependencies Start - Transitive dependencies have to be re-defined below
-  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.22-SNAPSHOT"
-  protobuf 'org.bigbluebutton:bbb-common-message_2.13:0.0.22-SNAPSHOT'
+  implementation "org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT"
+  protobuf 'org.bigbluebutton:bbb-common-message_2.13:0.0.27-SNAPSHOT'
   implementation "org.bigbluebutton:bbb-common-web:0.0.3-SNAPSHOT"
   implementation "io.lettuce:lettuce-core:6.1.9.RELEASE"
   implementation "org.reactivestreams:reactive-streams:1.0.3"
@@ -115,6 +115,7 @@ dependencies {
   implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
   implementation "io.grpc:grpc-protobuf:${grpcVersion}"
   implementation "io.grpc:grpc-stub:${grpcVersion}"
+  implementation 'com.google.protobuf:protobuf-java:3.25.1'
 
   //--- BigBlueButton Dependencies End
   console "org.grails:grails-console:5.2.0"
@@ -128,6 +129,31 @@ dependencies {
   testRuntimeOnly "net.sourceforge.htmlunit:htmlunit:2.63.0"
   testImplementation "com.github.javafaker:javafaker:0.12"
 }
+
+protobuf {
+  protoc {
+    artifact = 'com.google.protobuf:protoc:3.25.1'
+  }
+  plugins {
+    grpc {
+      artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+    }
+  }
+  generateProtoTasks {
+    all()*.plugins {
+      grpc {}
+    }
+  }
+}
+
+//sourceSets {
+//  main {
+//    java {
+//      srcDirs 'generated/source/proto/main/grpc'
+//      srcDirs 'generated/source/proto/main/java'
+//    }
+//  }
+//}
 
 tasks.named('bootWarMainClassName') {
     it.mustRunAfter(tasks.named('compileGsonViews'))

--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -5,3 +5,4 @@ grailsGradlePluginVersion=5.0.0
 groovyVersion=3.0.19
 tomcatEmbedVersion=9.0.82
 springVersion=2.7.17
+grpcVersion=1.59.0

--- a/bigbluebutton-web/grails-app/conf/application.yml
+++ b/bigbluebutton-web/grails-app/conf/application.yml
@@ -106,3 +106,7 @@ hibernate:
         queries: false
         use_second_level_cache: false
         use_query_cache: false
+
+grpc:
+    host: 127.0.0.1
+    port: 8081

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -2119,13 +2119,13 @@ class ApiController {
     meeting.setNumVideoUsers(meetingInfo.getParticipantInfo().getVideoCount())
     meeting.setNumMods(meetingInfo.getParticipantInfo().getModeratorCount())
 
-    for(MeetingServiceOuterClass.Attendee attendee: meetingInfo.getAttendeesList()) {
-      User user = new User(attendee.getUserId(), attendee.getFullName(), attendee.getFullName(), attendee.getRole(), false, "", false, "", attendee.getClientType())
-      user.setIsPresenter(attendee.getIsPresenter())
-      user.setListeningOnly(attendee.getIsListeningOnly())
-      user.setVoiceJoined(attendee.getHasJoinedVoice())
-      user.setHasVideo(attendee.getHasVideo())
-      meeting.addUserCustomData(attendee.getUserId(), m.getUserCustomData(attendee.getUserId()))
+    for(MeetingServiceOuterClass.User u: meetingInfo.getUsersList()) {
+      User user = new User(u.getUserId(), u.getFullName(), u.getFullName(), u.getRole(), false, "", false, "", u.getClientType())
+      user.setIsPresenter(u.getIsPresenter())
+      user.setListeningOnly(u.getIsListeningOnly())
+      user.setVoiceJoined(u.getHasJoinedVoice())
+      user.setHasVideo(u.getHasVideo())
+      meeting.addUserCustomData(u.getUserId(), m.getUserCustomData(u.getUserId()))
       meeting.userJoined(user)
     }
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -707,9 +707,9 @@ class ApiController {
     }
 
     List<Meeting> meetings = new ArrayList<>()
-    MeetingServiceOuterClass.StreamMeetingsReq request = MeetingServiceOuterClass.StreamMeetingsReq.newBuilder().build()
+    MeetingServiceOuterClass.GetMeetingsStreamReq request = MeetingServiceOuterClass.GetMeetingsStreamReq.newBuilder().build()
     try {
-      Iterator<MeetingServiceOuterClass.MeetingInfoResp> responseItr = blockingStub.streamMeetings(request)
+      Iterator<MeetingServiceOuterClass.MeetingInfoResp> responseItr = blockingStub.getMeetingsStream(request)
       while (responseItr.hasNext()) {
         MeetingServiceOuterClass.MeetingInfoResp response = responseItr.next()
         MeetingInfo meetingInfo = response.getMeetingInfo()

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -702,9 +702,12 @@ class ApiController {
     List<Meeting> meetings = new ArrayList<>()
     MeetingServiceOuterClass.StreamMeetingsReq request = MeetingServiceOuterClass.StreamMeetingsReq.newBuilder().build()
     try {
-      Iterator<MeetingServiceOuterClass.MeetingInfoResp> response = blockingStub.streamMeetings(request)
-      while (response.hasNext()) {
-        meetings.add(meetingInfoToMeeting(response.next().getMeetingInfo()))
+      Iterator<MeetingServiceOuterClass.MeetingInfoResp> responseItr = blockingStub.streamMeetings(request)
+      while (responseItr.hasNext()) {
+        MeetingServiceOuterClass.MeetingInfoResp response = responseItr.next()
+        MeetingInfo meetingInfo = response.getMeetingInfo()
+        if (meetingInfo.getMeetingIntId() == null || meetingInfo.getMeetingIntId().isBlank()) continue
+        meetings.add(meetingInfoToMeeting(meetingInfo))
       }
     } catch (StatusRuntimeException e) {
       log.error("RPC getMeetings request failed")

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -560,15 +560,17 @@ class ApiController {
       return
     }
 
-    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
-    boolean isRunning = meeting != null && meeting.isRunning();
+//    Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
+//    boolean isRunning = meeting != null && meeting.isRunning();
 
-    MeetingServiceOuterClass.TestRequest request = MeetingServiceOuterClass.TestRequest.newBuilder().setMsg("Sending test request").build()
+    boolean isRunning = false
+    MeetingServiceOuterClass.MeetingRunningReq request = MeetingServiceOuterClass.MeetingRunningReq.newBuilder().setMeetingId(params.meetingID).build()
     try {
-      MeetingServiceOuterClass.TestResponse response = blockingStub.test(request)
-      log.info("Got response from test request {}", response.msg)
+      MeetingServiceOuterClass.MeetingRunningResp response = blockingStub.isMeetingRunning(request)
+      log.info("isMeetingRunning request was successful. Returned {}", response.getIsRunning())
+      isRunning = response.getIsRunning()
     } catch (StatusRuntimeException e) {
-      log.error("RPC test request failed")
+      log.error("RPC isMeetingRunning request failed")
       log.error("Status code {}", e.getStatus())
       log.error("{}", e.getMessage())
     }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -691,8 +691,6 @@ class ApiController {
       return
     }
 
-//    Collection<Meeting> mtgs = meetingService.getMeetings();
-
     List<Meeting> meetings = new ArrayList<>()
     MeetingServiceOuterClass.MeetingsReq request = MeetingServiceOuterClass.MeetingsReq.newBuilder().build()
 

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meeting-info.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meeting-info.ftlx
@@ -16,29 +16,29 @@
   <#if meeting.getModeratorPassword()?? && meeting.getModeratorPassword()!="">
           <moderatorPW>${meeting.getModeratorPassword()}</moderatorPW>
   </#if>
-  <running>${meeting.isRunning()?c}</running>
+  <running>${meeting.getIsRunning()?c}</running>
   <duration>${meeting.getDuration()?c}</duration>
   <hasUserJoined>${meeting.hasUserJoined()?c}</hasUserJoined>
   <recording>${meeting.isRecord()?c}</recording>
   <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
   <startTime>${meeting.getStartTime()?c}</startTime>
   <endTime>${meeting.getEndTime()?c}</endTime>
-  <participantCount>${meeting.getNumUsersOnline()?c}</participantCount>
+  <participantCount>${meeting.getNumOnlineUsers()?c}</participantCount>
   <listenerCount>${meeting.getNumListenOnly()?c}</listenerCount>
-  <voiceParticipantCount>${meeting.getNumVoiceJoined()?c}</voiceParticipantCount>
-  <videoCount>${meeting.getNumVideos()?c}</videoCount>
+  <voiceParticipantCount>${meeting.getNumVoiceUsers()?c}</voiceParticipantCount>
+  <videoCount>${meeting.getNumVideoUsers()?c}</videoCount>
   <maxUsers>${meeting.getMaxUsers()?c}</maxUsers>
-  <moderatorCount>${meeting.getNumModerators()?c}</moderatorCount>
+  <moderatorCount>${meeting.getNumMods()?c}</moderatorCount>
   <attendees>
   <#list meeting.getOnlineUsers() as att>
     <attendee>
         <userID>${att.getExternalUserId()}</userID>
         <fullName>${att.getFullname()}</fullName>
         <role>${att.getRole()}</role>
-        <isPresenter>${att.isPresenter()?c}</isPresenter>
+        <isPresenter>${att.getIsPresenter()?c}</isPresenter>
         <isListeningOnly>${att.isListeningOnly()?c}</isListeningOnly>
         <hasJoinedVoice>${att.isVoiceJoined()?c}</hasJoinedVoice>
-        <hasVideo>${att.hasVideo()?c}</hasVideo>
+        <hasVideo>${att.getHasVideo()?c}</hasVideo>
         <clientType>${att.getClientType()}</clientType>
         <#if meeting.getUserCustomData(att.getExternalUserId())??>
             <#assign ucd = meeting.getUserCustomData(att.getExternalUserId())>

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
@@ -21,29 +21,29 @@
         <#if meeting.getModeratorPassword()?? && meeting.getModeratorPassword()!="">
                 <moderatorPW>${meeting.getModeratorPassword()}</moderatorPW>
         </#if>
-        <running>${meeting.isRunning()?c}</running>
+        <running>${meeting.getIsRunning()?c}</running>
         <duration>${meeting.getDuration()?c}</duration>
         <hasUserJoined>${meeting.hasUserJoined()?c}</hasUserJoined>
         <recording>${meeting.isRecord()?c}</recording>
         <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
         <startTime>${meeting.getStartTime()?c}</startTime>
         <endTime>${meeting.getEndTime()?c}</endTime>
-        <participantCount>${meeting.getNumUsersOnline()}</participantCount>
+        <participantCount>${meeting.getNumOnlineUsers()}</participantCount>
         <listenerCount>${meeting.getNumListenOnly()}</listenerCount>
-        <voiceParticipantCount>${meeting.getNumVoiceJoined()}</voiceParticipantCount>
-        <videoCount>${meeting.getNumVideos()}</videoCount>
+        <voiceParticipantCount>${meeting.getNumVoiceUsers()}</voiceParticipantCount>
+        <videoCount>${meeting.getNumVideoUsers()}</videoCount>
         <maxUsers>${meeting.getMaxUsers()?c}</maxUsers>
-        <moderatorCount>${meeting.getNumModerators()}</moderatorCount>
+        <moderatorCount>${meeting.getNumMods()}</moderatorCount>
         <attendees>
         <#list meetingDetail.meeting.getUsers() as att>
           <attendee>
               <userID>${att.getExternalUserId()}</userID>
               <fullName>${att.getFullname()}</fullName>
               <role>${att.getRole()}</role>
-              <isPresenter>${att.isPresenter()?c}</isPresenter>
+              <isPresenter>${att.getIsPresenter()?c}</isPresenter>
               <isListeningOnly>${att.isListeningOnly()?c}</isListeningOnly>
               <hasJoinedVoice>${att.isVoiceJoined()?c}</hasJoinedVoice>
-              <hasVideo>${att.hasVideo()?c}</hasVideo>
+              <hasVideo>${att.getHasVideo()?c}</hasVideo>
               <clientType>${att.getClientType()}</clientType>
               <#if meeting.getUserCustomData(att.getExternalUserId())??>
                   <#assign ucd = meetingDetail.meeting.getUserCustomData(att.getExternalUserId())>


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that meeting state from `akka-apps` is used rather than the state from `bbb-web` to construct responses for `isMeetingRunning`, `getMeetingInfo`, and `getMeetings` API requests. gRPC has been used to facilitate communication between `bbb-web` and `akka-apps`.

The classes used for communication through gRPC are defined in the `meeting-service.proto` file found in `bbb-common-message`. Both `bbb-web` and `akka-apps` extract this definition from `bbb-common-message` and then generate the required Java and Scala class files. The class files are generated for `bbb-web` when `run-dev.sh` is run, but it is also possible to generate the files without running the application by running the `gradlew` file with the `build` task. For `akka-apps` the files are generated by `sbt` using the `compile` task.


### Motivation

Removal of application state from `bbb-web` is part of the ongoing process to consolidate application state in `akka-apps`. Currently when responding to API requests for meeting information `bbb-web` gets the information from its own internal state when it should rely on `akka-apps` for this information.

This is the first step in the process of totally removing application state from `bbb-web`. The next step is to redesign the other APIs such as `create` and `join` to not store any state in `bbb-web`.
