### PR TITLE
Refactor: Makes Graphql provide authToken (makes /api/enter unnecessary)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -14,6 +14,7 @@ case class UserDbModel(
     avatar:                 String = "",
     color:                  String = "",
     sessionToken:           String = "",
+    authToken:              String = "",
     authed:                 Boolean = false,
     joined:                 Boolean = false,
     joinErrorMessage:       Option[String],
@@ -31,7 +32,7 @@ case class UserDbModel(
 
 class UserDbTableDef(tag: Tag) extends Table[UserDbModel](tag, None, "user") {
   override def * = (
-    userId,extId,meetingId,name,role,avatar,color, sessionToken, authed,joined,joinErrorCode, joinErrorMessage, banned,loggedOut,guest,guestStatus,registeredOn,excludeFromDashboard, enforceLayout) <> (UserDbModel.tupled, UserDbModel.unapply)
+    userId,extId,meetingId,name,role,avatar,color, sessionToken, authToken, authed,joined,joinErrorCode, joinErrorMessage, banned,loggedOut,guest,guestStatus,registeredOn,excludeFromDashboard, enforceLayout) <> (UserDbModel.tupled, UserDbModel.unapply)
   val userId = column[String]("userId", O.PrimaryKey)
   val extId = column[String]("extId")
   val meetingId = column[String]("meetingId")
@@ -40,6 +41,7 @@ class UserDbTableDef(tag: Tag) extends Table[UserDbModel](tag, None, "user") {
   val avatar = column[String]("avatar")
   val color = column[String]("color")
   val sessionToken = column[String]("sessionToken")
+  val authToken = column[String]("authToken")
   val authed = column[Boolean]("authed")
   val joined = column[Boolean]("joined")
   val joinErrorCode = column[Option[String]]("joinErrorCode")
@@ -60,6 +62,7 @@ object UserDAO {
         UserDbModel(
           userId = regUser.id,
           extId = regUser.externId,
+          authToken = regUser.authToken,
           meetingId = meetingId,
           name = regUser.name,
           role = regUser.role,

--- a/bbb-graphql-client-test/src/App.js
+++ b/bbb-graphql-client-test/src/App.js
@@ -1,29 +1,9 @@
-import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
+import {ApolloClient, ApolloProvider, gql, InMemoryCache, useQuery, useSubscription} from '@apollo/client';
  import { WebSocketLink } from "@apollo/client/link/ws";
  import React, {useEffect, useState} from "react";
 import './App.css';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
-import UserList from './UserList';
-import MeetingInfo from './MeetingInfo';
-import TotalOfUsers from './TotalOfUsers';
-import TotalOfModerators from './TotalOfModerators';
-import TotalOfViewers from './TotalOfViewers';
-import TotalOfUsersTalking from './TotalOfUsersTalking';
-import TotalOfUniqueNames from './TotalOfUniqueNames';
-import ChatMessages from "./ChatMessages";
-import ChatsInfo from "./ChatsInfo";
-import ChatPublicMessages from "./ChatPublicMessages";
-import PluginDataChannel from "./PluginDataChannel";
-import Annotations from "./Annotations";
-import AnnotationsHistory from "./AnnotationsHistory";
-import CursorsStream from "./CursorsStream";
-import CursorsAll from "./CursorsAll";
-import TalkingStream from "./TalkingStream";
-import MyInfo from "./MyInfo";
-import UserClientSettings from "./UserClientSettings";
-import UserConnectionStatus from "./UserConnectionStatus";
-import UserConnectionStatusReport from "./UserConnectionStatusReport";
-import PresPresentationUploadToken from "./PresPresentationUploadToken";
+import Auth from "./Auth";
 
 
 function App() {
@@ -33,121 +13,110 @@ function App() {
   const [userAuthToken, setUserAuthToken] = useState(null);
   const [graphqlClient, setGraphqlClient] = useState(null);
   const [enterApiResponse, setEnterApiResponse] = useState('');
+  const [graphqlConnected, setGraphqlConnected] = useState(false);
+  const [graphqlError, setGraphqlError] = useState('');
 
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
 
-  async function callApiEnter(sessionToken) {
-    // get url from input text box
-    fetch('/bigbluebutton/api/enter/?sessionToken=' + sessionToken, { credentials: 'include' })
-        .then((response) => response.json())
-        .then((json) => {
-          console.log(json.response);
-          setEnterApiResponse(json.response.returncode);
-          if(json?.response?.internalUserID) {
-            setUserId(json.response.internalUserID);
-            setUserName(json.response.fullname);
-            setUserAuthToken(json.response.authToken);
-          }
-        });
-  }
+
+    const findSessionToken = async () => {
+        if (urlParams.has('sessionToken')) {
+            const sessionTokenFromUrl = urlParams.get('sessionToken');
+
+            if (sessionTokenFromUrl !== null &&
+                sessionTokenFromUrl !== '' &&
+                sessionToken !== sessionTokenFromUrl) {
+                setSessionToken(sessionTokenFromUrl);
+            }
+        }
+    };
 
     useEffect(() => {
-        const fetchApiData = async () => {
-            if (urlParams.has('sessionToken')) {
-                const sessionTokenFromUrl = urlParams.get('sessionToken');
-
-                if (sessionTokenFromUrl !== null) {
-                    await callApiEnter(sessionTokenFromUrl);
-                    setSessionToken(sessionTokenFromUrl);
-                }
-            }
-        };
-        fetchApiData();
+        findSessionToken();
     },[]);
 
   async function connectGraphqlServer(sessionToken) {
-    // setSessionToken(sessionToken);
-    const wsLink = new WebSocketLink(
-      new SubscriptionClient(`wss://${window.location.hostname}/v1/graphql`, {
-        reconnect: true,
-        timeout: 30000,
-        connectionParams: {
-          headers: {
-            'X-Session-Token': sessionToken,
-            'json-patch-supported': 'true'
+      if(sessionToken == null) return;
+      console.log('connectGraphqlServer');
+
+      const subscriptionClient = new SubscriptionClient(`wss://${window.location.hostname}/v1/graphql`, {
+          reconnect: true,
+          timeout: 30000,
+          connectionParams: {
+              headers: {
+                  'X-Session-Token': sessionToken,
+                  'json-patch-supported': 'true'
+              }
+          },
+          connectionCallback: (error) => {
+              console.log('connectionCallback');
+              console.log(error);
+              if (error) {
+                  // Check if the error is the specific authentication error
+                  const errorMessage = error.message;
+                  if (typeof errorMessage === 'string' && errorMessage.includes('Authentication hook unauthorized this request')) {
+                      console.error('Authentication Error:', errorMessage);
+                      setGraphqlError('Authentication Error:' + errorMessage);
+                      // Handle the authentication error here
+                  } else {
+                      console.error('WebSocket Connection Error:', error);
+                      setGraphqlError('WebSocket Connection Error:' + error);
+                  }
+              } else {
+                  console.log('WebSocket Connected');
+              }
           }
-        }
-      })
-    );
+      });
+
+      // Listening for successful connection
+      subscriptionClient.onConnected(() => {
+          console.log('WebSocket Connected');
+
+          setGraphqlConnected(true);
+
+          // Perform actions after successful connection if needed
+      });
+
+      // Listening for errors
+      subscriptionClient.onError((error) => {
+          console.error('WebSocket Error', error);
+          setGraphqlError('WebSocket Error', error);
+      });
+
+      // Listening for disconnection
+      subscriptionClient.onDisconnected(() => {
+          console.log('WebSocket Disconnected');
+          // Handle disconnection scenario
+      });
+
+
+    // setSessionToken(sessionToken);
+    const wsLink = new WebSocketLink(subscriptionClient);
 
     setGraphqlClient(new ApolloClient({link: wsLink, cache: new InMemoryCache()}));
   }
 
     useEffect(() => {
-        if(enterApiResponse === 'SUCCESS' && !graphqlClient) {
-            console.log(`Creating graphql socket with token ${sessionToken}`);
-            const fetchData = async () => {
-                await connectGraphqlServer(sessionToken);
-            }
-            fetchData();
-        } else if(enterApiResponse === 'FAILED') {
-            console.log('Error on enter API call: ' + enterApiResponse.message);
-            console.log(enterApiResponse);
-        }
-    },[sessionToken, enterApiResponse]);
+        connectGraphqlServer(sessionToken);
+
+    },[sessionToken]);
 
 
   return (
     <div className="App">
-        {graphqlClient ? (
+        {graphqlClient && graphqlConnected ? (
           <div
             style={{
               height: '100vh',
             }}
           >
           <ApolloProvider client={graphqlClient}>
-            Who am I? {userName} ({userId})
-            <MeetingInfo />
-            <br />
-            <PluginDataChannel userId={userId} />
-            <br />
-            <MyInfo userAuthToken={userAuthToken} />
-            <br />
-            <PresPresentationUploadToken />
-            <br />
-            <UserConnectionStatus />
-            <br />
-            <UserConnectionStatusReport />
-            <br />
-            <UserClientSettings userId={userId} />
-            <br />
-            <UserList userId={userId} />
-            <br />
-            <ChatsInfo />
-            <br />
-            <ChatMessages userId={userId} />
-            <br />
-            <ChatPublicMessages userId={userId} />
-            <br />
-            <CursorsAll />
-            <br />
-            <TalkingStream />
-            <br />
-            <CursorsStream />
-            <br />
-            <Annotations />
-            <br />
-            <AnnotationsHistory />
-            <br />
-            <TotalOfUsers />
-            <TotalOfModerators />
-            <TotalOfViewers />
-            <TotalOfUsersTalking />
-            <TotalOfUniqueNames />
+            {/*Who am I? {userName} ({userId})*/}
+            <Auth />
         </ApolloProvider>
         </div>
-         ) : sessionToken == null ? 'Param sessionToken missing' : 'Loading...'}
+         ) : sessionToken == null ? 'Param sessionToken missing' : (graphqlError === '' ? 'Loading...' : graphqlError)}
     </div>
   );
 }

--- a/bbb-graphql-client-test/src/Auth.js
+++ b/bbb-graphql-client-test/src/Auth.js
@@ -1,0 +1,215 @@
+import {gql, useMutation, useSubscription} from '@apollo/client';
+import React from "react";
+import UserList from './UserList';
+import MeetingInfo from './MeetingInfo';
+import TotalOfUsers from './TotalOfUsers';
+import TotalOfModerators from './TotalOfModerators';
+import TotalOfViewers from './TotalOfViewers';
+import TotalOfUsersTalking from './TotalOfUsersTalking';
+import TotalOfUniqueNames from './TotalOfUniqueNames';
+import ChatMessages from "./ChatMessages";
+import ChatsInfo from "./ChatsInfo";
+import ChatPublicMessages from "./ChatPublicMessages";
+import PluginDataChannel from "./PluginDataChannel";
+import Annotations from "./Annotations";
+import AnnotationsHistory from "./AnnotationsHistory";
+import CursorsStream from "./CursorsStream";
+import CursorsAll from "./CursorsAll";
+import TalkingStream from "./TalkingStream";
+import MyInfo from "./MyInfo";
+import UserClientSettings from "./UserClientSettings";
+import UserConnectionStatus from "./UserConnectionStatus";
+import UserConnectionStatusReport from "./UserConnectionStatusReport";
+import PresPresentationUploadToken from "./PresPresentationUploadToken";
+
+export default function Auth() {
+
+    //where is not necessary once user can update only its own status
+    //Hasura accepts "now()" as value to timestamp fields
+    const [updateUserClientEchoTestRunningAtMeAsNow] = useMutation(gql`
+      mutation UpdateUserClientEchoTestRunningAt {
+        update_user_current(
+            where: {}
+            _set: { echoTestRunningAt: "now()" }
+          ) {
+            affected_rows
+          }
+      }
+    `);
+
+    const handleUpdateUserEchoTestRunningAt = () => {
+        updateUserClientEchoTestRunningAtMeAsNow();
+    };
+
+    const [dispatchUserJoin] = useMutation(gql`
+      mutation UserJoin($authToken: String!, $clientType: String!) {
+        userJoinMeeting(
+          authToken: $authToken,
+          clientType: $clientType,
+        )
+      }
+    `);
+
+    const handleDispatchUserJoin = (authToken) => {
+        dispatchUserJoin({
+            variables: {
+                authToken: authToken,
+                clientType: 'HTML5',
+            },
+        });
+    };
+
+    const [dispatchUserLeave] = useMutation(gql`
+      mutation UserLeaveMeeting {
+        userLeaveMeeting
+      }
+    `);
+    const handleDispatchUserLeave = (authToken) => {
+        dispatchUserLeave();
+    };
+
+
+  const { loading, error, data } = useSubscription(
+    gql`subscription {
+      user_current {
+        userId
+        authToken
+        name
+        loggedOut
+        ejected
+        isOnline
+        joined
+        joinErrorCode
+        joinErrorMessage
+        guestStatus
+        guestStatusDetails {
+          guestLobbyMessage
+          positionInWaitingQueue
+        }
+        meeting {
+            name
+        }
+      }
+    }`
+  );
+
+  console.log("data");
+  console.log(data);
+  console.log("error");
+  console.log(error);
+  console.log(loading);
+
+  if(!loading && !error) {
+
+      if(!data.hasOwnProperty('user_current') ||
+          data.user_current.length == 0
+      ) {
+          return <div><br />Error: User not found</div>;
+      }
+
+    return (<div>
+        <br />
+        {data.user_current.map((curr) => {
+            console.log('user_current', curr);
+
+            if(curr.loggedOut) {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    You left the meeting.</div>
+            } else if(curr.ejected) {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    You were ejected from the meeting.</div>
+            } else if(curr.guestStatus !== 'ALLOW') {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    <span>You are waiting for approval.</span>
+                    <span>{curr.guestStatusDetails.guestLobbyMessage}</span>
+                    <span>Your position is: {curr.guestStatusDetails.positionInWaitingQueue}</span>
+                </div>
+            } else if(!curr.joined) {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    <span>You didn't join yet.</span>
+                    <button onClick={() => handleDispatchUserJoin(curr.authToken)}>Join Now!</button>
+                </div>
+            } else if(curr.isOnline) {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    <span>You are online, welcome {curr.name} ({curr.userId})</span>
+                    <button onClick={() => handleDispatchUserLeave()}>Leave Now!</button>
+
+                    {/*<MyInfo userAuthToken={curr.authToken} />*/}
+                    {/*<br />*/}
+
+                    {/*<MeetingInfo />*/}
+                    {/*<br />*/}
+
+                    <TotalOfUsers />
+                    <TotalOfModerators />
+                    <TotalOfViewers />
+                    <TotalOfUsersTalking />
+                    <TotalOfUniqueNames />
+                    <br />
+
+                    <UserList user={curr} />
+                    <br />
+
+                    <UserConnectionStatus />
+                    <br />
+                    <UserConnectionStatusReport />
+                    <br />
+                    <UserClientSettings userId={curr.userId} />
+                    <br />
+                    <ChatsInfo />
+                    <br />
+                    <ChatMessages userId={curr.userId} />
+                    <br />
+                    <ChatPublicMessages userId={curr.userId} />
+                    <br />
+                    <CursorsAll />
+                    <br />
+                    <TalkingStream />
+                    <br />
+                    <CursorsStream />
+                    <br />
+                    <Annotations />
+                    <br />
+                    <AnnotationsHistory />
+                    <br />
+
+                    <PluginDataChannel userId={curr.userId} />
+                    <br />
+
+                    <PresPresentationUploadToken />
+                    <br />
+
+                </div>
+
+                // return (
+                //     <tr key={curr.userId}>
+                //         <td>{curr.userId}</td>
+                //         <td>{curr.name}</td>
+                //         <td>{curr.joined && !curr.loggedOut && !curr.ejected ? 'joined' : ''}
+                //             {curr.loggedOut ? 'loggedOut' : ''}
+                //             {curr.ejected ? 'ejected' : ''}
+                //             {!curr.joined && !curr.loggedOut ? <button onClick={() => handleDispatchUserJoin(userAuthToken)}>Join Now!</button> : ''}
+                //             {curr.joined && !curr.loggedOut && !curr.ejected ? <button onClick={() => handleDispatchUserLeave()}>Leave Now!</button> : ''}
+                //         </td>
+                //         <td>{curr.joinErrorCode}</td>
+                //         <td>{curr.joinErrorMessage}</td>
+                //     </tr>
+                // );
+            }
+
+
+        })}
+    </div>)
+  }
+}
+

--- a/bbb-graphql-client-test/src/ChatMessages.js
+++ b/bbb-graphql-client-test/src/ChatMessages.js
@@ -25,12 +25,11 @@ export default function ChatMessages({userId}) {
 
   const { loading, error, data } = usePatchedSubscription(
     gql`subscription {
-      chat_message_private(limit: 20, order_by: [{createdTime: desc}, {senderName: asc}]) {
+      chat_message_private(limit: 20, order_by: [{createdAt: desc}, {senderName: asc}]) {
         chatEmphasizedText
         chatId
         correlationId
-        createdTime
-        createdTimeAsDate
+        createdAt
         message
         messageId
         senderId
@@ -63,7 +62,7 @@ export default function ChatMessages({userId}) {
                   <td>{curr.chatId}</td>
                   <td>{curr.senderName}</td>
                   <td>{curr.message}</td>
-                  <td>{curr.createdTimeAsDate} ({curr.createdTime})</td>
+                  <td>{curr.createdAt}</td>
                   <td>
                       {
                           curr.senderId !== userId ?

--- a/bbb-graphql-client-test/src/CursorsAll.js
+++ b/bbb-graphql-client-test/src/CursorsAll.js
@@ -24,7 +24,7 @@ export default function CursorsAll() {
     (<table border="1">
       <thead>
         <tr>
-            <th colSpan="4">Private Chat Messages</th>
+            <th colSpan="4">Cursor</th>
         </tr>
         <tr>
             <th>userId</th>

--- a/bbb-graphql-client-test/src/MeetingInfo.js
+++ b/bbb-graphql-client-test/src/MeetingInfo.js
@@ -7,7 +7,7 @@ export default function MeetingInfo() {
         meetingId
         createdTime
         disabledFeatures
-        duration
+        durationInSeconds
         extId
         html5InstanceId
         isBreakout
@@ -31,7 +31,7 @@ export default function MeetingInfo() {
             {/*<th>Id</th>*/}
             <th>Name</th>
             <th>extId</th>
-            <th>duration</th>
+            <th>durationInSeconds</th>
         </tr>
       </thead>
       <tbody>
@@ -42,7 +42,7 @@ export default function MeetingInfo() {
                   {/*<td>{user.userId}</td>*/}
                   <td>{curr.name}</td>
                   <td>{curr.extId}</td>
-                  <td>{curr.duration}</td>
+                  <td>{curr.durationInSeconds}</td>
               </tr>
           );
         })}

--- a/bbb-graphql-client-test/src/MyInfo.js
+++ b/bbb-graphql-client-test/src/MyInfo.js
@@ -22,12 +22,13 @@ export default function MyInfo({userAuthToken}) {
 
     const [dispatchUserJoin] = useMutation(gql`
       mutation UserJoin($authToken: String!, $clientType: String!) {
-        userJoin(
+        userJoinMeeting(
           authToken: $authToken,
           clientType: $clientType,
         )
       }
     `);
+
     const handleDispatchUserJoin = (authToken) => {
         dispatchUserJoin({
             variables: {
@@ -37,12 +38,23 @@ export default function MyInfo({userAuthToken}) {
         });
     };
 
+    const [dispatchUserLeave] = useMutation(gql`
+      mutation UserLeaveMeeting {
+        userLeaveMeeting
+      }
+    `);
+    const handleDispatchUserLeave = (authToken) => {
+        dispatchUserLeave();
+    };
+
 
   const { loading, error, data } = useSubscription(
     gql`subscription {
       user_current {
         userId
         name
+        loggedOut
+        ejected
         joined
         joinErrorCode
         joinErrorMessage
@@ -60,7 +72,7 @@ export default function MyInfo({userAuthToken}) {
             {/*<th>Id</th>*/}
             <th>userId</th>
             <th>name</th>
-            <th>joined</th>
+            <th>Status</th>
             <th>joinErrorCode</th>
             <th>joinErrorMessage</th>
         </tr>
@@ -72,8 +84,11 @@ export default function MyInfo({userAuthToken}) {
               <tr key={curr.userId}>
                   <td>{curr.userId}</td>
                   <td>{curr.name}</td>
-                  <td>{curr.joined ? 'Yes' : 'No'}
-                      {curr.joined ? '' : <button onClick={() => handleDispatchUserJoin(userAuthToken)}>Join Now!</button>}
+                  <td>{curr.joined && !curr.loggedOut && !curr.ejected ? 'joined' : ''}
+                      {curr.loggedOut ? 'loggedOut' : ''}
+                      {curr.ejected ? 'ejected' : ''}
+                      {!curr.joined && !curr.loggedOut ? <button onClick={() => handleDispatchUserJoin(userAuthToken)}>Join Now!</button> : ''}
+                      {curr.joined && !curr.loggedOut && !curr.ejected ? <button onClick={() => handleDispatchUserLeave()}>Leave Now!</button> : ''}
                   </td>
                   <td>{curr.joinErrorCode}</td>
                   <td>{curr.joinErrorMessage}</td>

--- a/bbb-graphql-client-test/src/UserConnectionStatus.js
+++ b/bbb-graphql-client-test/src/UserConnectionStatus.js
@@ -52,7 +52,7 @@ export default function UserConnectionStatus() {
 
         setTimeout(() => {
             handleUpdateConnectionAliveAt();
-        }, 5000);
+        }, 25000);
     };
 
     useEffect(() => {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -233,6 +233,7 @@ CREATE TABLE "user" (
 	"avatar" varchar(500),
 	"color" varchar(7),
     "sessionToken" varchar(16),
+    "authToken" varchar(16),
     "authed" bool,
     "joined" bool,
     "joinErrorCode" varchar(50),
@@ -384,6 +385,7 @@ CREATE INDEX "idx_v_user_meetingId_orderByColumns" ON "user"("meetingId","role",
 CREATE OR REPLACE VIEW "v_user_current"
 AS SELECT "user"."userId",
     "user"."extId",
+    "user"."authToken",
     "user"."meetingId",
     "user"."name",
     "user"."nameSortable",
@@ -419,7 +421,8 @@ AS SELECT "user"."userId",
     "user"."hasDrawPermissionOnCurrentPage",
     "user"."echoTestRunningAt",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
-    CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator"
+    CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
+    CASE WHEN "user"."joined" IS true AND "user"."expired" IS false AND "user"."loggedOut" IS false AND "user"."ejected" IS NOT TRUE THEN true ELSE false END "isOnline"
    FROM "user";
 
 CREATE OR REPLACE VIEW "v_user_guest" AS

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -130,6 +130,7 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
+        - authToken
         - authed
         - avatar
         - away
@@ -150,6 +151,7 @@ select_permissions:
         - hasDrawPermissionOnCurrentPage
         - isDialIn
         - isModerator
+        - isOnline
         - isRunningEchoTest
         - joinErrorCode
         - joinErrorMessage
@@ -173,6 +175,7 @@ select_permissions:
   - role: pre_join_bbb_client
     permission:
       columns:
+        - authToken
         - authed
         - banned
         - color
@@ -181,6 +184,8 @@ select_permissions:
         - ejectReasonCode
         - ejected
         - expired
+        - isOnline
+        - isModerator
         - extId
         - guest
         - guestStatus

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -95,7 +95,7 @@ class ConnectionController {
             def builder = new JsonBuilder()
             builder {
               "response" "authorized"
-              "X-Hasura-Role" u ? "bbb_client" : "pre_join_bbb_client"
+              "X-Hasura-Role" u && !u.hasLeft() ? "bbb_client" : "pre_join_bbb_client"
               "X-Hasura-ModeratorInMeeting" u && u.isModerator() ? userSession.meetingID : ""
               "X-Hasura-PresenterInMeeting" u && u.isPresenter() ? userSession.meetingID : ""
               "X-Hasura-UserId" userSession.internalUserId


### PR DESCRIPTION
This PR will:

- Makes graphql provide `authToken` (necessary for joining process)
- Add an example how to handle error `Authentication hook unauthorized this request`
- Add an example of validations to redirect the user to components `guest-room`, `pre-join`, `end-meeting`, `meeting`
- fix a problem where the user received wrong Hasura-Role after leaving the meeting

This is a test using the Client-Test to perform some meeting actions:

[Screencast from 2024-01-18 10-30-25.webm](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/1cf8aea8-635b-4e89-9229-726128026729)
