### PR TITLE
Refactor (graphql): Add permission to aggregate Poll users/responses

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1239,7 +1239,8 @@ CREATE TABLE "poll" (
 "multipleResponses" boolean,
 "ended" boolean,
 "published" boolean,
-"publishedAt" timestamp with time zone
+"publishedAt" timestamp with time zone,
+"createdAt" timestamp with time zone not null default current_timestamp
 );
 CREATE INDEX "idx_poll_meetingId" ON "poll"("meetingId");
 CREATE INDEX "idx_poll_meetingId_active" ON "poll"("meetingId") where ended is false;

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll.yaml
@@ -38,6 +38,7 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
+        - createdAt
         - ended
         - multipleResponses
         - ownerId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_option.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_option.yaml
@@ -16,3 +16,4 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
+      allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_response.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_response.yaml
@@ -26,3 +26,4 @@ select_permissions:
                   _eq: true
               - pollOwnerId:
                   _eq: X-Hasura-UserId
+      allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_user.yaml
@@ -33,3 +33,4 @@ select_permissions:
               _eq: X-Hasura-UserId
           - userId:
               _eq: X-Hasura-UserId
+      allow_aggregations: true


### PR DESCRIPTION
- Add permission for `poll.users_aggregate`
- Add permission for `poll.responses_aggregate`
- Add permission for `poll.options_aggregate`
- Add field `createdAt` that can be used for `order_by`

```gql
subscription {
  poll(order_by: {createdAt: asc}, limit: 1) {
    pollId
    users_aggregate {
      aggregate {
        count
      }
    }
    responses_aggregate {
      aggregate {
        count
      }
    }
  }
}

```