### PR TITLE
Graphql provide SharedNotes diff

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1500,6 +1500,11 @@ create table "sharedNotes_rev" (
 );
 --create view "v_sharedNotes_rev" as select * from "sharedNotes_rev";
 
+create view "v_sharedNotes_diff" as
+select "meetingId", "sharedNotesExtId", "userId", "start", "end", "diff"
+from "sharedNotes_rev"
+where "diff" is not null;
+
 create table "sharedNotes_session" (
     "meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "sharedNotesExtId" varchar(25),

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes_diff.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_sharedNotes_diff.yaml
@@ -1,0 +1,22 @@
+table:
+  name: v_sharedNotes_diff
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: sharedNotes_diff
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - diff
+        - end
+        - rev
+        - sharedNotesExtId
+        - start
+        - userId
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -36,6 +36,7 @@
 - "!include public_v_pres_presentation_uploadToken.yaml"
 - "!include public_v_screenshare.yaml"
 - "!include public_v_sharedNotes.yaml"
+- "!include public_v_sharedNotes_diff.yaml"
 - "!include public_v_sharedNotes_session.yaml"
 - "!include public_v_timer.yaml"
 - "!include public_v_user.yaml"


### PR DESCRIPTION
Now it's possible to fetch sharedNotes patch using graphql stream:

```gql
subscription MySubscription {
  sharedNotes_diff_stream(batch_size: 10, cursor: {initial_value: {rev: 0}}, where: {sharedNotesExtId: {_eq: "notes"}}) {
    start
    end
    diff
    rev
  }
}
```