### PR TITLE
[2.7] build(bbb-webrtc-recorder): v0.6.0

### DIFF
--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v0.5.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder
+git clone --branch v0.6.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder


### PR DESCRIPTION
### What does this PR do?

* [build(bbb-webrtc-recorder): v0.6.0](https://github.com/bigbluebutton/bigbluebutton/commit/9ba037397bd450ee3db12a40dfbc922fb44cad8f)
  * feat: recorder.writeToDevNull option to write files to /dev/null (testing)
  * fix: crash due to negative seqnums in sequence unwrapper
  
### Closes Issue(s)

n/a