### PR TITLE
Plugins: Add actions to Delete/Reset dataChannel messages

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDispatchMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDispatchMessageMsgHdlr.scala
@@ -1,0 +1,54 @@
+package org.bigbluebutton.core.apps.plugin
+
+import org.bigbluebutton.ClientSettings
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.db.{ PluginDataChannelMessageDAO }
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.{ Roles, Users2x }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+
+trait PluginDataChannelDispatchMessageMsgHdlr extends HandlerHelpers {
+
+  def handle(msg: PluginDataChannelDispatchMessageMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
+    val pluginsDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("plugins")
+    val meetingId = liveMeeting.props.meetingProp.intId
+
+    for {
+      _ <- if (!pluginsDisabled) Some(()) else None
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
+    } yield {
+      val pluginsConfig = ClientSettings.getPluginsFromConfig(ClientSettings.clientSettingsFromFile)
+
+      if (!pluginsConfig.contains(msg.body.pluginName)) {
+        println(s"Plugin '${msg.body.pluginName}' not found.")
+      } else if (!pluginsConfig(msg.body.pluginName).dataChannels.contains(msg.body.dataChannel)) {
+        println(s"Data channel '${msg.body.dataChannel}' not found in plugin '${msg.body.pluginName}'.")
+      } else {
+        val hasPermission = for {
+          writePermission <- pluginsConfig(msg.body.pluginName).dataChannels(msg.body.dataChannel).writePermission
+        } yield {
+          writePermission.toLowerCase match {
+            case "all"       => true
+            case "moderator" => user.role == Roles.MODERATOR_ROLE
+            case "presenter" => user.presenter
+            case _           => false
+          }
+        }
+
+        if (!hasPermission.contains(true)) {
+          println(s"No permission to write in plugin: '${msg.body.pluginName}', data channel: '${msg.body.dataChannel}'.")
+        } else {
+          PluginDataChannelMessageDAO.insert(
+            meetingId,
+            msg.body.pluginName,
+            msg.body.dataChannel,
+            msg.header.userId,
+            msg.body.payloadJson,
+            msg.body.toRoles,
+            msg.body.toUserIds
+          )
+        }
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelResetMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelResetMsgHdlr.scala
@@ -1,0 +1,50 @@
+package org.bigbluebutton.core.apps.plugin
+
+import org.bigbluebutton.ClientSettings
+import org.bigbluebutton.common2.msgs.PluginDataChannelResetMsg
+import org.bigbluebutton.core.db.PluginDataChannelMessageDAO
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.{ Roles, Users2x }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+
+trait PluginDataChannelResetMsgHdlr extends HandlerHelpers {
+
+  def handle(msg: PluginDataChannelResetMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
+    val pluginsDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("plugins")
+    val meetingId = liveMeeting.props.meetingProp.intId
+
+    for {
+      _ <- if (!pluginsDisabled) Some(()) else None
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
+    } yield {
+      val pluginsConfig = ClientSettings.getPluginsFromConfig(ClientSettings.clientSettingsFromFile)
+
+      if (!pluginsConfig.contains(msg.body.pluginName)) {
+        println(s"Plugin '${msg.body.pluginName}' not found.")
+      } else if (!pluginsConfig(msg.body.pluginName).dataChannels.contains(msg.body.dataChannel)) {
+        println(s"Data channel '${msg.body.dataChannel}' not found in plugin '${msg.body.pluginName}'.")
+      } else {
+        val hasPermission = for {
+          deletePermission <- pluginsConfig(msg.body.pluginName).dataChannels(msg.body.dataChannel).deletePermission
+        } yield {
+          deletePermission.toLowerCase match {
+            case "all"       => true
+            case "moderator" => user.role == Roles.MODERATOR_ROLE
+            case "presenter" => user.presenter
+            case _           => false
+          }
+        }
+
+        if (!hasPermission.contains(true)) {
+          println(s"No permission to delete (reset) in plugin: '${msg.body.pluginName}', data channel: '${msg.body.dataChannel}'.")
+        } else {
+          PluginDataChannelMessageDAO.reset(
+            meetingId,
+            msg.body.pluginName,
+            msg.body.dataChannel
+          )
+        }
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginHdlrs.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginHdlrs.scala
@@ -4,7 +4,9 @@ import org.apache.pekko.actor.ActorContext
 import org.apache.pekko.event.Logging
 
 class PluginHdlrs(implicit val context: ActorContext)
-  extends DispatchPluginDataChannelMessageMsgHdlr {
+  extends PluginDataChannelDispatchMessageMsgHdlr
+  with PluginDataChannelDeleteMessageMsgHdlr
+  with PluginDataChannelResetMsgHdlr {
 
   val log = Logging(context.system, getClass)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -416,8 +416,14 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[CreateGroupChatReqMsg](envelope, jsonNode)
 
       //Plugin
-      case DispatchPluginDataChannelMessageMsg.NAME =>
-        routeGenericMsg[DispatchPluginDataChannelMessageMsg](envelope, jsonNode)
+      case PluginDataChannelDispatchMessageMsg.NAME =>
+        routeGenericMsg[PluginDataChannelDispatchMessageMsg](envelope, jsonNode)
+
+      case PluginDataChannelDeleteMessageMsg.NAME =>
+        routeGenericMsg[PluginDataChannelDeleteMessageMsg](envelope, jsonNode)
+
+      case PluginDataChannelResetMsg.NAME =>
+        routeGenericMsg[PluginDataChannelResetMsg](envelope, jsonNode)
 
       // ExternalVideo
       case StartExternalVideoPubMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -594,7 +594,9 @@ class MeetingActor(
         updateUserLastActivity(m.body.msg.sender.id)
 
       // Plugin
-      case m: DispatchPluginDataChannelMessageMsg => pluginHdlrs.handle(m, state, liveMeeting)
+      case m: PluginDataChannelDispatchMessageMsg => pluginHdlrs.handle(m, state, liveMeeting)
+      case m: PluginDataChannelDeleteMessageMsg   => pluginHdlrs.handle(m, state, liveMeeting)
+      case m: PluginDataChannelResetMsg           => pluginHdlrs.handle(m, state, liveMeeting)
 
       // Webcams
       case m: UserBroadcastCamStartMsg            => webcamApp2x.handle(m, liveMeeting, msgBus)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PluginMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PluginMsgs.scala
@@ -5,12 +5,28 @@ package org.bigbluebutton.common2.msgs
 /**
  * Sent from graphql-actions to bbb-akka
  */
-object DispatchPluginDataChannelMessageMsg { val NAME = "DispatchPluginDataChannelMessageMsg" }
-case class DispatchPluginDataChannelMessageMsg(header: BbbClientMsgHeader, body: DispatchPluginDataChannelMessageMsgBody) extends StandardMsg
-case class DispatchPluginDataChannelMessageMsgBody(
+object PluginDataChannelDispatchMessageMsg { val NAME = "PluginDataChannelDispatchMessageMsg" }
+case class PluginDataChannelDispatchMessageMsg(header: BbbClientMsgHeader, body: PluginDataChannelDispatchMessageMsgBody) extends StandardMsg
+case class PluginDataChannelDispatchMessageMsgBody(
                                               pluginName: String,
                                               dataChannel: String,
                                               payloadJson: String,
                                               toRoles: List[String],
                                               toUserIds: List[String],
                                             )
+
+object PluginDataChannelDeleteMessageMsg { val NAME = "PluginDataChannelDeleteMessageMsg" }
+case class PluginDataChannelDeleteMessageMsg(header: BbbClientMsgHeader, body: PluginDataChannelDeleteMessageMsgBody) extends StandardMsg
+case class PluginDataChannelDeleteMessageMsgBody(
+                                                    pluginName: String,
+                                                    dataChannel: String,
+                                                    messageId: String
+                                                  )
+
+
+object PluginDataChannelResetMsg { val NAME = "PluginDataChannelResetMsg" }
+case class PluginDataChannelResetMsg(header: BbbClientMsgHeader, body: PluginDataChannelResetMsgBody) extends StandardMsg
+case class PluginDataChannelResetMsgBody(
+                                                    pluginName: String,
+                                                    dataChannel: String
+                                                  )

--- a/bbb-graphql-actions/src/actions/pluginDataChannelDeleteMessage.ts
+++ b/bbb-graphql-actions/src/actions/pluginDataChannelDeleteMessage.ts
@@ -1,0 +1,25 @@
+import { RedisMessage } from '../types';
+import { ValidationError } from '../types/ValidationError';
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  const eventName = `PluginDataChannelDeleteMessageMsg`;
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    pluginName: input.pluginName,
+    dataChannel: input.dataChannel,
+    messageId: input.messageId
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions/src/actions/pluginDataChannelDispatchMessage.ts
+++ b/bbb-graphql-actions/src/actions/pluginDataChannelDispatchMessage.ts
@@ -2,7 +2,7 @@ import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
-  const eventName = `DispatchPluginDataChannelMessageMsg`;
+  const eventName = `PluginDataChannelDispatchMessageMsg`;
 
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,

--- a/bbb-graphql-actions/src/actions/pluginDataChannelReset.ts
+++ b/bbb-graphql-actions/src/actions/pluginDataChannelReset.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+import { ValidationError } from '../types/ValidationError';
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  const eventName = `PluginDataChannelResetMsg`;
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    pluginName: input.pluginName,
+    dataChannel: input.dataChannel
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-client-test/src/PluginDataChannel.js
+++ b/bbb-graphql-client-test/src/PluginDataChannel.js
@@ -5,9 +5,9 @@ import {useState} from "react";
 export default function PluginDataChannel({userId}) {
     const [textAreaValue, setTextAreaValue] = useState(``);
 
-    const [dispatchPluginDataChannelMessage] = useMutation(gql`
-      mutation DispatchPluginDataChannelMessageMsg($pluginName: String!, $dataChannel: String!, $payloadJson: String!, $toRoles: [String]!,$toUserIds: [String]!) {
-        dispatchPluginDataChannelMessageMsg(
+    const [pluginDataChannelDispatchMessage] = useMutation(gql`
+      mutation PluginDataChannelDispatchMessage($pluginName: String!, $dataChannel: String!, $payloadJson: String!, $toRoles: [String]!,$toUserIds: [String]!) {
+        pluginDataChannelDispatchMessage(
           pluginName: $pluginName,
           dataChannel: $dataChannel,
           payloadJson: $payloadJson,
@@ -16,18 +16,54 @@ export default function PluginDataChannel({userId}) {
         )
       }
     `);
-    const handleDispatchPluginDataChannelMessage = (roles, userIds) => {
+    const handlePluginDataChannelDispatchMessage = (roles, userIds) => {
         if (textAreaValue.trim() !== '') {
-            dispatchPluginDataChannelMessage({
+            pluginDataChannelDispatchMessage({
                 variables: {
-                    pluginName: 'SamplePresentationToolbarPlugin',
-                    dataChannel: 'public-channel',
+                    pluginName: 'SelectRandomUserPlugin',
+                    dataChannel: 'pickRandomUser',
                     payloadJson: textAreaValue,
                     toRoles: roles,
                     toUserIds: userIds,
                 },
             });
         }
+    };
+
+    const [pluginDataChannelReset] = useMutation(gql`
+      mutation PluginDataChannelReset($pluginName: String!, $dataChannel: String!) {
+        pluginDataChannelReset(
+          pluginName: $pluginName,
+          dataChannel: $dataChannel
+        )
+      }
+    `);
+    const handlePluginDataChannelReset = () => {
+        pluginDataChannelReset({
+            variables: {
+                pluginName: 'SelectRandomUserPlugin',
+                dataChannel: 'pickRandomUser'
+            },
+        });
+    };
+
+    const [pluginDataChannelDeleteMessage] = useMutation(gql`
+      mutation PluginDataChannelDeleteMessage($pluginName: String!, $dataChannel: String!, $messageId: String!) {
+        pluginDataChannelDeleteMessage(
+          pluginName: $pluginName,
+          dataChannel: $dataChannel,
+          messageId: $messageId
+        )
+      }
+    `);
+    const handlePluginDataChannelDeleteMessage = (messageId) => {
+        pluginDataChannelDeleteMessage({
+            variables: {
+                pluginName: 'SelectRandomUserPlugin',
+                dataChannel: 'pickRandomUser',
+                messageId: messageId
+            },
+        });
     };
 
     const { loading, error, data } = usePatchedSubscription(
@@ -74,6 +110,9 @@ export default function PluginDataChannel({userId}) {
                         <td>{JSON.stringify(curr.payloadJson)}</td>
                         <td>{JSON.stringify(curr.toRoles)}</td>
                         <td>{curr.createdAt}</td>
+                        <td>
+                            <button onClick={() => handlePluginDataChannelDeleteMessage(curr.messageId)}>Delete!</button>
+                        </td>
                     </tr>
                 );
             })}
@@ -86,12 +125,13 @@ export default function PluginDataChannel({userId}) {
                               value={textAreaValue}
                               onChange={(e) => setTextAreaValue(e.target.value)}
                     ></textarea>
-                    <button onClick={() => handleDispatchPluginDataChannelMessage([],[])}>Dispatch to All!</button>
-                    <button onClick={() => handleDispatchPluginDataChannelMessage(['moderator'], [])}>Dispatch to Moderators!</button>
-                    <button onClick={() => handleDispatchPluginDataChannelMessage(['viewer'], [])}>Dispatch to Viewers!</button>
-                    <button onClick={() => handleDispatchPluginDataChannelMessage(['moderator','viewer'], [])}>Dispatch to Moderators and Viewers!</button>
-                    <button onClick={() => handleDispatchPluginDataChannelMessage(['presenter'], [])}>Dispatch to Presenter!</button>
-                    <button onClick={() => handleDispatchPluginDataChannelMessage([], [userId, 'user-xxx'])}>Dispatch to Me!</button>
+                    <button onClick={() => handlePluginDataChannelDispatchMessage([],[])}>Dispatch to All!</button>
+                    <button onClick={() => handlePluginDataChannelDispatchMessage(['moderator'], [])}>Dispatch to Moderators!</button>
+                    <button onClick={() => handlePluginDataChannelDispatchMessage(['viewer'], [])}>Dispatch to Viewers!</button>
+                    <button onClick={() => handlePluginDataChannelDispatchMessage(['moderator','viewer'], [])}>Dispatch to Moderators and Viewers!</button>
+                    <button onClick={() => handlePluginDataChannelDispatchMessage(['presenter'], [])}>Dispatch to Presenter!</button>
+                    <button onClick={() => handlePluginDataChannelDispatchMessage([], [userId, 'user-xxx'])}>Dispatch to Me!</button>
+                    <button onClick={() => handlePluginDataChannelReset()}>Reset!</button>
                 </td>
             </tr>
             </tfoot>

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1501,7 +1501,7 @@ create table "sharedNotes_rev" (
 --create view "v_sharedNotes_rev" as select * from "sharedNotes_rev";
 
 create view "v_sharedNotes_diff" as
-select "meetingId", "sharedNotesExtId", "userId", "start", "end", "diff"
+select "meetingId", "sharedNotesExtId", "userId", "start", "end", "diff", "rev"
 from "sharedNotes_rev"
 where "diff" is not null;
 
@@ -1585,12 +1585,13 @@ CREATE TABLE "pluginDataChannelMessage" (
 	"fromUserId" varchar(50) REFERENCES "user"("userId") ON DELETE CASCADE,
 	"toRoles" varchar[], --MODERATOR, VIEWER, PRESENTER
 	"toUserIds" varchar[],
-	"createdAt" timestamp with time ZONE DEFAULT current_timestamp,
+	"createdAt" timestamp with time zone DEFAULT current_timestamp,
+	"deletedAt" timestamp with time zone,
 	CONSTRAINT "pluginDataChannel_pkey" PRIMARY KEY ("meetingId","pluginName","dataChannel","messageId")
 );
 
-create index "idx_pluginDataChannelMessage_dataChannel" on "pluginDataChannelMessage"("meetingId", "pluginName", "dataChannel", "toRoles", "toUserIds", "createdAt");
-create index "idx_pluginDataChannelMessage_roles" on "pluginDataChannelMessage"("meetingId", "toRoles", "toUserIds", "createdAt");
+create index "idx_pluginDataChannelMessage_dataChannel" on "pluginDataChannelMessage"("meetingId", "pluginName", "dataChannel", "toRoles", "toUserIds", "createdAt") where "deletedAt" is null;
+create index "idx_pluginDataChannelMessage_roles" on "pluginDataChannelMessage"("meetingId", "toRoles", "toUserIds", "createdAt") where "deletedAt" is null;
 
 CREATE OR REPLACE VIEW "v_pluginDataChannelMessage" AS
 SELECT u."meetingId", u."userId", m."pluginName", m."dataChannel", m."messageId", m."payloadJson", m."fromUserId", m."toRoles", m."createdAt"
@@ -1601,6 +1602,7 @@ JOIN "pluginDataChannelMessage" m ON m."meetingId" = u."meetingId"
 				OR u."role" = ANY(m."toRoles")
 				OR (u."presenter" AND 'PRESENTER' = ANY(m."toRoles"))
 				)
+WHERE "deletedAt" is null
 ORDER BY m."createdAt";
 
 ------------------------

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -101,16 +101,6 @@ type Mutation {
 }
 
 type Mutation {
-  dispatchPluginDataChannelMessageMsg(
-    pluginName: String!
-    dataChannel: String!
-    payloadJson: String!
-    toRoles: [String]!
-    toUserIds: [String]!
-  ): Boolean
-}
-
-type Mutation {
   externalVideoStart(
     externalVideoUrl: String!
   ): Boolean
@@ -207,6 +197,31 @@ type Mutation {
 type Mutation {
   meetingSetWebcamOnlyForModerator(
     webcamsOnlyForModerator: Boolean!
+  ): Boolean
+}
+
+type Mutation {
+  pluginDataChannelDeleteMessage(
+    pluginName: String!
+    dataChannel: String!
+    messageId: String!
+  ): Boolean
+}
+
+type Mutation {
+  pluginDataChannelDispatchMessage(
+    pluginName: String!
+    dataChannel: String!
+    payloadJson: String!
+    toRoles: [String]!
+    toUserIds: [String]!
+  ): Boolean
+}
+
+type Mutation {
+  pluginDataChannelReset(
+    pluginName: String!
+    dataChannel: String!
   ): Boolean
 }
 

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -95,12 +95,6 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
-  - name: dispatchPluginDataChannelMessageMsg
-    definition:
-      kind: synchronous
-      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
-    permissions:
-      - role: bbb_client
   - name: externalVideoStart
     definition:
       kind: synchronous
@@ -180,6 +174,24 @@ actions:
     permissions:
       - role: bbb_client
   - name: meetingSetWebcamOnlyForModerator
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: pluginDataChannelDeleteMessage
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: pluginDataChannelDispatchMessage
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: pluginDataChannelReset
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'


### PR DESCRIPTION
This PR will:

- Renames action `dispatchPluginDataChannelMessage` to `pluginDataChannelDispatchMessage`
- Adds action `pluginDataChannelReset`
```gql
mutation PluginDataChannelReset($pluginName: String!, $dataChannel: String!) {
        pluginDataChannelReset(
          pluginName: $pluginName,
          dataChannel: $dataChannel
        )
      }
```
- Adds action `pluginDataChannelDeleteMessage`
```gql
mutation PluginDataChannelDeleteMessage($pluginName: String!, $dataChannel: String!, $messageId: String!) {
        pluginDataChannelDeleteMessage(
          pluginName: $pluginName,
          dataChannel: $dataChannel,
          messageId: $messageId
        )
      }
```
- Adds config `public.plugins.$plugin.dataChannels.deletePermission` (optional)
    - Options are `moderator, presenter, all, sender`
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/962a6d0d-b5f7-4405-abea-e5ee7117051a)

- Adds examples on how to use it on `bbb-graphql-client-test/src/PluginDataChannel.js`

Related: #18999