### PR TITLE
Refactor (Timer): Shift Accumulated Time Calculation to Backend

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
@@ -45,6 +45,14 @@ object TimerModel {
   }
 
   def setRunning(model: TimerModel, running: Boolean): Unit = {
+
+    //If it is running and will stop, calculate new Accumulated
+    if(getRunning(model) && !running) {
+      val now = System.currentTimeMillis()
+      val accumulated = getAccumulated(model) + Math.abs(now - getStartedAt(model)).toInt
+      this.setAccumulated(model, accumulated)
+    }
+
     model.running = running
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/DeactivateTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/DeactivateTimerReqMsgHdlr.scala
@@ -30,7 +30,10 @@ trait DeactivateTimerReqMsgHdlr extends RightsManagementTrait {
       val reason = "You need to be the presenter or moderator to deactivate timer"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      TimerModel.setIsActive(liveMeeting.timerModel, false)
+      TimerModel.setRunning(liveMeeting.timerModel, running = false)
+      TimerModel.setIsActive(liveMeeting.timerModel, active = false)
+      TimerModel.setStopwatch(liveMeeting.timerModel, stopwatch = true)
+      TimerModel.reset(liveMeeting.timerModel)
       TimerDAO.update(liveMeeting.props.meetingProp.intId, liveMeeting.timerModel)
       broadcastEvent()
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StartTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StartTimerReqMsgHdlr.scala
@@ -31,7 +31,7 @@ trait StartTimerReqMsgHdlr extends RightsManagementTrait {
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
       TimerModel.setStartedAt(liveMeeting.timerModel, System.currentTimeMillis())
-      TimerModel.setRunning(liveMeeting.timerModel, true)
+      TimerModel.setRunning(liveMeeting.timerModel, running = true)
       TimerDAO.update(liveMeeting.props.meetingProp.intId, liveMeeting.timerModel)
       broadcastEvent()
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StopTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StopTimerReqMsgHdlr.scala
@@ -33,10 +33,9 @@ trait StopTimerReqMsgHdlr extends RightsManagementTrait {
       val reason = "You need to be the presenter or moderator to stop timer"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      TimerModel.setAccumulated(liveMeeting.timerModel, msg.body.accumulated)
-      TimerModel.setRunning(liveMeeting.timerModel, false)
+      TimerModel.setRunning(liveMeeting.timerModel, running = false)
       TimerDAO.update(liveMeeting.props.meetingProp.intId, liveMeeting.timerModel)
-      broadcastEvent(msg.body.accumulated)
+      broadcastEvent(TimerModel.getAccumulated(liveMeeting.timerModel))
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/SwitchTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/SwitchTimerReqMsgHdlr.scala
@@ -34,6 +34,7 @@ trait SwitchTimerReqMsgHdlr extends RightsManagementTrait {
     } else {
       if (TimerModel.getStopwatch(liveMeeting.timerModel) != msg.body.stopwatch) {
         TimerModel.setStopwatch(liveMeeting.timerModel, msg.body.stopwatch)
+        TimerModel.setRunning(liveMeeting.timerModel, running = false)
         TimerModel.reset(liveMeeting.timerModel) //Reset on switch Stopwatch/Timer
         if (msg.body.stopwatch) {
           TimerModel.setTrack(liveMeeting.timerModel, "noTrack")

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/TimerMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/TimerMsgs.scala
@@ -19,7 +19,7 @@ case class StartTimerReqMsgBody()
 
 object StopTimerReqMsg { val NAME = "StopTimerReqMsg" }
 case class StopTimerReqMsg(header: BbbClientMsgHeader, body: StopTimerReqMsgBody) extends StandardMsg
-case class StopTimerReqMsgBody(accumulated: Int)
+case class StopTimerReqMsgBody()
 
 object SwitchTimerReqMsg { val NAME = "SwitchTimerReqMsg" }
 case class SwitchTimerReqMsg(header: BbbClientMsgHeader, body: SwitchTimerReqMsgBody) extends StandardMsg

--- a/bbb-graphql-actions/src/actions/timerStop.ts
+++ b/bbb-graphql-actions/src/actions/timerStop.ts
@@ -16,11 +16,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     userId: routing.userId
   };
 
-  const body = {
-    accumulated: input.accumulated
-  };
-
-  //TODO calculate accumulated on the backend
+  const body = {};
 
   return { eventName, routing, header, body };
 }

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -391,9 +391,7 @@ type Mutation {
 }
 
 type Mutation {
-  timerStop(
-    accumulated: Float!
-  ): Boolean
+  timerStop: Boolean
 }
 
 type Mutation {

--- a/bigbluebutton-html5/imports/ui/components/timer/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/component.jsx
@@ -121,19 +121,11 @@ class Timer extends Component {
 
   handleControlClick() {
     const {
-      timer, startTimer, stopTimer, timeOffset,
+      timer, startTimer, stopTimer,
     } = this.props;
 
-    const {
-      running,
-      accumulated,
-      timestamp,
-    } = timer;
-
     if (timer.running) {
-      const elapsedTime = Service.getElapsedTime(running, timestamp, timeOffset, accumulated);
-
-      stopTimer(elapsedTime);
+      stopTimer();
     } else {
       startTimer();
     }
@@ -173,7 +165,7 @@ class Timer extends Component {
     const { timer, stopTimer, switchTimer } = this.props;
 
     if (!timer.stopwatch) {
-      stopTimer(this.getTime());
+      stopTimer();
       switchTimer(true);
     }
   }
@@ -182,7 +174,7 @@ class Timer extends Component {
     const { timer, stopTimer, switchTimer } = this.props;
 
     if (timer.stopwatch) {
-      stopTimer(this.getTime());
+      stopTimer();
       switchTimer(false);
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/timer/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/container.jsx
@@ -35,8 +35,8 @@ const TimerContainer = ({ children, ...props }) => {
     timerStart();
   };
 
-  const stopTimer = (accumulated) => {
-    timerStop({ variables: { accumulated } });
+  const stopTimer = () => {
+    timerStop();
   };
 
   const switchTimer = (stopwatch) => {

--- a/bigbluebutton-html5/imports/ui/components/timer/mutations.jsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/mutations.jsx
@@ -29,8 +29,8 @@ export const TIMER_START = gql`
 `;
 
 export const TIMER_STOP = gql`
-  mutation timerStop($accumulated: Float!) {
-    timerStop(accumulated: $accumulated)
+  mutation timerStop {
+    timerStop
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/component.tsx
@@ -53,13 +53,7 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
   };
 
   const stopTimer = () => {
-    stopTimerMutation(
-      {
-        variables: {
-          accumulated: time,
-        },
-      },
-    );
+    stopTimerMutation();
   };
 
   useEffect(() => {


### PR DESCRIPTION
- The accumulated prop will now be calculated on the backend, and the client will access this information via Graphql.
- Fixed an error where the timer/stopwatch continued running and did not reset upon deactivation.
- Fixed an error where the system did not reset to Stopwatch mode upon deactivation.
- Fixed an error where, when switching between Timer and Stopwatch, the timer did not stop running.

Related: #19451 #19242