### PR TITLE
feature (graphql-middlware): Enhancing GraphQL Stream Subscriptions: Efficient Handling of Connection Resets and Cursor Management

### DIFF
--- a/bbb-graphql-middleware/internal/common/StreamCursorUtils.go
+++ b/bbb-graphql-middleware/internal/common/StreamCursorUtils.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func GetStreamCursorPropsFromQuery(payload map[string]interface{}, query string) (string, string, interface{}) {
+	streamCursorKey := ""
+	streamCursorVariable := ""
+	var streamCursorInitialValue interface{}
+
+	regexPattern := `cursor:\s*\{\s*initial_value\s*:\s*\{\s*([^\:]+):\s*([^}]+)\s*\}\s*\}`
+	re := regexp.MustCompile(regexPattern)
+	matches := re.FindStringSubmatch(query)
+	if matches != nil {
+		streamCursorKey = matches[1]
+		if strings.HasPrefix(matches[2], "$") {
+			//Variable
+			streamCursorVariable, _ = strings.CutPrefix(matches[2], "$")
+			variables, ok := payload["variables"].(map[string]interface{})
+			if ok {
+				for varKey, varValue := range variables {
+					if varKey == streamCursorVariable {
+						streamCursorInitialValue = varValue
+					}
+				}
+			}
+		} else {
+			streamCursorInitialValue = matches[2]
+		}
+	}
+
+	return streamCursorKey, streamCursorVariable, streamCursorInitialValue
+}
+
+func GetLastStreamCursorValueFromReceivedMessage(messageAsMap map[string]interface{}, streamCursorKey string) interface{} {
+	var lastStreamCursorValue interface{}
+
+	if payload, okPayload := messageAsMap["payload"].(map[string]interface{}); okPayload {
+		if data, okData := payload["data"].(map[string]interface{}); okData {
+			//Data will have only one prop, `range` because its name is unknown
+			for _, dataItem := range data {
+				currentDataProp, okCurrentDataProp := dataItem.([]interface{})
+				if okCurrentDataProp && len(currentDataProp) > 0 {
+					// Get the last item directly (once it will contain the last cursor value)
+					lastItemOfMessage := currentDataProp[len(currentDataProp)-1]
+					if lastItemOfMessageAsMap, currDataOk := lastItemOfMessage.(map[string]interface{}); currDataOk {
+						if lastItemValue, okLastItemValue := lastItemOfMessageAsMap[streamCursorKey]; okLastItemValue {
+							lastStreamCursorValue = lastItemValue
+							//fmt.Println("Descobriu ultimo valor: " + lastStreamCursorValue.(string))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return lastStreamCursorValue
+}
+
+func ReplaceMessageWithLastCursorValue(subscription GraphQlSubscription) interface{} {
+	var message = subscription.Message.(map[string]interface{})
+	payload, okPayload := message["payload"].(map[string]interface{})
+
+	if okPayload {
+		if subscription.StreamCursorVariable != "" {
+			/**** This stream has its cursor value set through variables ****/
+			if variables, okVariables := payload["variables"].(map[string]interface{}); okVariables {
+				if variables[subscription.StreamCursorVariable] != subscription.StreamCursorCurrValue {
+					variables[subscription.StreamCursorVariable] = subscription.StreamCursorCurrValue
+					payload["variables"] = variables
+					message["payload"] = payload
+				}
+			}
+		} else {
+			/**** This stream has its cursor value set through inline value (not variables) ****/
+			query, okQuery := payload["query"].(string)
+			if okQuery {
+				pattern := `cursor:\s*\{\s*initial_value\s*:\s*\{\s*([^\:]+:\s*[^}]+)\s*\}\s*\}`
+				re := regexp.MustCompile(pattern)
+
+				newValue := ""
+
+				replaceInitialValueFunc := func(match string) string {
+					switch v := subscription.StreamCursorCurrValue.(type) {
+					case string:
+						newValue = v
+
+						//Append quotes if it is missing
+						if !strings.HasPrefix(v, "\"") {
+							newValue = "\"" + newValue
+						}
+						if !strings.HasSuffix(v, "\"") {
+							newValue = newValue + "\""
+						}
+					case int:
+						newValue = strconv.Itoa(v)
+					case float32:
+						myFloat64 := float64(v)
+						newValue = strconv.FormatFloat(myFloat64, 'f', -1, 32)
+					case float64:
+						newValue = strconv.FormatFloat(v, 'f', -1, 64)
+					default:
+						newValue = ""
+					}
+
+					if newValue != "" {
+						replacement := subscription.StreamCursorKey + ": " + newValue
+						return fmt.Sprintf("cursor: {initial_value: {%s}}", replacement)
+					} else {
+						return match
+					}
+				}
+
+				newQuery := re.ReplaceAllStringFunc(query, replaceInitialValueFunc)
+				if query != newQuery {
+					payload["query"] = newQuery
+					message["payload"] = payload
+				}
+			}
+		}
+	}
+
+	return message
+}

--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -21,6 +21,10 @@ type GraphQlSubscription struct {
 	Id                        string
 	Message                   interface{}
 	Type                      QueryType
+	OperationName             string
+	StreamCursorKey           string
+	StreamCursorVariable      string
+	StreamCursorCurrValue     interface{}
 	JsonPatchSupported        bool   // indicate if client support Json Patch for this subscription
 	LastSeenOnHasuraConnetion string // id of the hasura connection that this query was active
 }

--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -19,11 +19,11 @@ const (
 
 type GraphQlSubscription struct {
 	Id                        string
-	Message                   interface{}
+	Message                   map[string]interface{}
 	Type                      QueryType
 	OperationName             string
-	StreamCursorKey           string
-	StreamCursorVariable      string
+	StreamCursorField         string
+	StreamCursorVariableName  string
 	StreamCursorCurrValue     interface{}
 	JsonPatchSupported        bool   // indicate if client support Json Patch for this subscription
 	LastSeenOnHasuraConnetion string // id of the hasura connection that this query was active
@@ -35,7 +35,7 @@ type BrowserConnection struct {
 	Context                  context.Context                // browser connection context
 	ActiveSubscriptions      map[string]GraphQlSubscription // active subscriptions of this connection (start, but no stop)
 	ActiveSubscriptionsMutex sync.RWMutex                   // mutex to control the map usage
-	ConnectionInitMessage    interface{}                    // init message received in this connection (to be used on hasura reconnect)
+	ConnectionInitMessage    map[string]interface{}         // init message received in this connection (to be used on hasura reconnect)
 	HasuraConnection         *HasuraConnection              // associated hasura connection
 	Disconnected             bool                           // indicate if the connection is gone
 }

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -68,7 +68,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 
 				//Set last cursor value for stream
 				if subscription.Type == common.Streaming {
-					lastCursor := common.GetLastStreamCursorValueFromReceivedMessage(messageAsMap, subscription.StreamCursorKey)
+					lastCursor := common.GetLastStreamCursorValueFromReceivedMessage(messageAsMap, subscription.StreamCursorField)
 					if lastCursor != nil && subscription.StreamCursorCurrValue != lastCursor {
 						subscription.StreamCursorCurrValue = lastCursor
 

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -66,6 +66,18 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 					msgpatch.PatchMessage(&messageAsMap, hc.Browserconn)
 				}
 
+				//Set last cursor value for stream
+				if subscription.Type == common.Streaming {
+					lastCursor := common.GetLastStreamCursorValueFromReceivedMessage(messageAsMap, subscription.StreamCursorKey)
+					if lastCursor != nil && subscription.StreamCursorCurrValue != lastCursor {
+						subscription.StreamCursorCurrValue = lastCursor
+
+						hc.Browserconn.ActiveSubscriptionsMutex.Lock()
+						hc.Browserconn.ActiveSubscriptions[queryId] = subscription
+						hc.Browserconn.ActiveSubscriptionsMutex.Unlock()
+					}
+
+				}
 			}
 
 			// Write the message to browser

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -41,7 +41,11 @@ RangeLoop:
 
 					//Identify type based on query string
 					messageType := common.Query
+					streamCursorKey := ""
+					streamCursorVariable := ""
+					var streamCursorInitialValue interface{}
 					payload := fromBrowserMessageAsMap["payload"].(map[string]interface{})
+
 					query, ok := payload["query"].(string)
 					if ok {
 						if strings.HasPrefix(query, "subscription") {
@@ -49,6 +53,7 @@ RangeLoop:
 
 							if strings.Contains(query, "_stream(") && strings.Contains(query, "cursor: {") {
 								messageType = common.Streaming
+								streamCursorKey, streamCursorVariable, streamCursorInitialValue = common.GetStreamCursorPropsFromQuery(payload, query)
 							}
 
 							if strings.Contains(query, "_aggregate") && strings.Contains(query, "aggregate {") {
@@ -73,6 +78,10 @@ RangeLoop:
 					browserConnection.ActiveSubscriptions[queryId] = common.GraphQlSubscription{
 						Id:                        queryId,
 						Message:                   fromBrowserMessage,
+						OperationName:             operationName,
+						StreamCursorKey:           streamCursorKey,
+						StreamCursorVariable:      streamCursorVariable,
+						StreamCursorCurrValue:     streamCursorInitialValue,
 						LastSeenOnHasuraConnetion: hc.Id,
 						JsonPatchSupported:        jsonPatchSupported,
 						Type:                      messageType,

--- a/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
@@ -11,8 +11,14 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowse
 	hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 	for _, subscription := range hc.Browserconn.ActiveSubscriptions {
 		if subscription.LastSeenOnHasuraConnetion != hc.Id {
+
 			log.Tracef("retransmiting subscription start: %v", subscription.Message)
-			fromBrowserToHasuraChannel.Send(subscription.Message)
+
+			if subscription.Type == common.Streaming && subscription.StreamCursorCurrValue != nil {
+				fromBrowserToHasuraChannel.Send(common.ReplaceMessageWithLastCursorValue(subscription))
+			} else {
+				fromBrowserToHasuraChannel.Send(subscription.Message)
+			}
 		}
 	}
 	hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()

--- a/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
@@ -15,7 +15,7 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowse
 			log.Tracef("retransmiting subscription start: %v", subscription.Message)
 
 			if subscription.Type == common.Streaming && subscription.StreamCursorCurrValue != nil {
-				fromBrowserToHasuraChannel.Send(common.ReplaceMessageWithLastCursorValue(subscription))
+				fromBrowserToHasuraChannel.Send(common.PatchQuerySettingLastCursorValue(subscription))
 			} else {
 				fromBrowserToHasuraChannel.Send(subscription.Message)
 			}


### PR DESCRIPTION
This pull request enhances the functionality of GraphQL's subscription feature, specifically for stream-type subscriptions. In this mode, clients initiate the connection by specifying an initial cursor. GraphQL then streams data that is new or updated beyond this cursor point (https://hasura.io/docs/latest/subscriptions/postgres/streaming/index/). 
However, there's an issue when a user's role changes (e.g., gaining Presenter status). This change necessitates reestablishing their GraphQL connection to update their role, which inadvertently triggers a resend of all active subscriptions. Consequently, stream subscriptions retransmit the initial cursor, leading to the redundant transmission of previously received data.

To address this, we've implemented a middleware solution. `bbb-graphql-middleware` will monitor and stores the cursor value of the last received record for each subscription. If a connection is reestablished (such as when a user's role changes), the middleware modifies the subscription query. It sets the stored cursor value as the new initial cursor. This adjustment signals to GraphQL (specifically Hasura, in our implementation) that it's unnecessary to resend all the data. As a result, clients will only receive new and relevant data, avoiding the retransmission of old data. This improvement significantly enhances the efficiency and performance of our GraphQL streaming subscriptions.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>

<tr>
<td>

[subscription_stream_before.webm](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/8a73db2b-d30b-4915-9bf3-7c1755aa506a)

</td>
<td>

[subscription_stream_after.webm](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/348c1034-6b89-47cd-98fd-fa7e3ab2e231)

</td>
</tr>

</table>
