### PR TITLE
Graphql: New flag to inform if current user responded to a Poll (useful for Anonymous Polls)

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1310,6 +1310,13 @@ FROM poll_option o
 JOIN poll using("pollId")
 WHERE poll."type" != 'R-';
 
+create view "v_poll_user_current" as
+select "user"."userId", "poll"."pollId", case when count(pr.*) > 0 then true else false end as responded
+from "user"
+join "poll" on "poll"."meetingId" = "user"."meetingId"
+left join "poll_response" pr on pr."userId" = "user"."userId" and pr."pollId" = "poll"."pollId"
+group by "user"."userId", "poll"."pollId";
+
 --------------------------------
 ----External video
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll.yaml
@@ -6,6 +6,16 @@ configuration:
   custom_column_names: {}
   custom_name: poll
   custom_root_fields: {}
+object_relationships:
+  - name: userCurrent
+    using:
+      manual_configuration:
+        column_mapping:
+          pollId: pollId
+        insertion_order: null
+        remote_table:
+          name: v_poll_user_current
+          schema: public
 array_relationships:
   - name: options
     using:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_poll_user_current.yaml
@@ -1,0 +1,17 @@
+table:
+  name: v_poll_user_current
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: pollUserCurrent
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - responded
+      filter:
+        userId:
+          _eq: X-Hasura-UserId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -26,6 +26,7 @@
 - "!include public_v_poll_option.yaml"
 - "!include public_v_poll_response.yaml"
 - "!include public_v_poll_user.yaml"
+- "!include public_v_poll_user_current.yaml"
 - "!include public_v_pres_annotation_curr.yaml"
 - "!include public_v_pres_annotation_history_curr.yaml"
 - "!include public_v_pres_page.yaml"


### PR DESCRIPTION
Currently it's impossible to know if the current user responded to an Anonymous Poll. Once Graphql doesn't provide this information. 
This PR introduces a new flag to obtain this information:

```gql
subscription {
  poll {
    pollId
    userCurrent {
      responded
    }
  }
}
```

Result:
```json
{
  "data": {
    "poll": [
      {
        "pollId": "62a08f9862fe4b25f54a2d181ba38c5cca23c2d8",
        "userCurrent": {
          "responded": false
        }
      }
    ]
  }
}
```