### PR TITLE
fix: Bump spring-boot-starter-validation to 2.7.17 to match bbb-web (port from 2.7)

### DIFF
--- a/bbb-common-web/build.sbt
+++ b/bbb-common-web/build.sbt
@@ -103,7 +103,7 @@ homepage := Some(url("http://www.bigbluebutton.org"))
 
 libraryDependencies ++= Seq(
   "javax.validation" % "validation-api" % "2.0.1.Final",
-  "org.springframework.boot" % "spring-boot-starter-validation" % "2.7.12",
+  "org.springframework.boot" % "spring-boot-starter-validation" % "2.7.17",
   "org.springframework.data" % "spring-data-commons" % "2.7.6",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",
   "org.postgresql" % "postgresql" % "42.4.3",


### PR DESCRIPTION
Ports https://github.com/bigbluebutton/bigbluebutton/pull/19385 to BBB 3.0