### PR TITLE
Allow to select voice props along with userCamera in Graphql

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -16,6 +16,15 @@ object_relationships:
         remote_table:
           name: v_user_ref
           schema: public
+  - name: voice
+    using:
+      manual_configuration:
+        column_mapping:
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_voice
+          schema: public
 select_permissions:
   - role: bbb_client
     permission:


### PR DESCRIPTION
Considering scenarios where viewers can't see other viewers in the userlist, it will not be possible to use the Type `user` in Graphql to obtain viewers's cameras and voice.
But the endpoint `user_camera` will works fine in this case. So to be able to select all relevant informations for the `video-list` component in one single query, this PR will add the `voice` information as child of the `user_camera` Type.

```gql
subscription {
  user_camera {
    streamId
    user {
      name
      color
    }
    voice {
      muted
      talking
    }
  }
}
```

<table><tr><td>

![lockSettings-other-users-in-userlist](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/07767ad8-2eec-40c8-be72-ebe693ca0287)

</td></tr></table>

