### PR TITLE
fix: Graphql-action to write annotations should expect type json instead of string

### DIFF
--- a/bbb-graphql-actions/src/actions/presAnnotationSubmit.ts
+++ b/bbb-graphql-actions/src/actions/presAnnotationSubmit.ts
@@ -17,6 +17,10 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     userId: routing.userId
   };
 
+  if(typeof input.annotations !== 'object' || !Array.isArray(input.annotations)) {
+    throw new ValidationError('Field `annotations` contains an invalid Json Array.', 400);
+  }
+
   const body = {
     whiteboardId: input.pageId,
     annotations: input.annotations,

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -276,7 +276,7 @@ type Mutation {
 type Mutation {
   presAnnotationSubmit(
     pageId: String!
-    annotations: [String]!
+    annotations: json!
   ): Boolean
 }
 


### PR DESCRIPTION
Graphql-action `presAnnotationSubmit` expects input `annotations` with type `string`.
This PR fix it to require type `json (array)` instead.

The input will expect json array of objects containing any props, for instance:

```gql
mutation {
  presAnnotationSubmit(
    pageId: "378197720ae01998e297287eff2bca274b79512c-1706052526592/1"
    annotations: [
    {
        id: "shape:Ji4QiPLuDj98XJIJ0A5h1",
        annotationInfo: {
            x: 401.9972451790634,
            y: 269.90358126721765,
            rotation: 0,
            isLocked: false,
            opacity: 1,
            meta: {
                updatedBy: "w_rjq2wjba5ccy",
                createdBy: undefined,
            },
            id: "shape:Ji4QiPLuDj98XJIJ0A5h1",
            type: "draw",
            props: {
                segments: [
                    {
                        type: "free",
                        points: [
                            {
                                x: 0,
                                y: 0,
                                z: 0.5
                            },
                            {
                                x: 33.06,
                                y: 37.47,
                                z: 0.5
                            },
                            {
                                x: 39.67,
                                y: 50.69,
                                z: 0.5
                            },
                            {
                                x: 57.3,
                                y: 70.52,
                                z: 0.5
                            },
                            {
                                x: 85.95,
                                y: 101.38,
                                z: 0.5
                            },
                            {
                                x: 110.19,
                                y: 130.03,
                                z: 0.5
                            }
                        ]
                    }
                ],
                color: "black",
                fill: "none",
                dash: "draw",
                size: "m",
                isComplete: false,
                isClosed: false,
                isPen: false
            },
            parentId: "page:1",
            index: "a1",
            typeName: "shape",
            isModerator: true
        },
        wbId: "378197720ae01998e297287eff2bca274b79512c-1706052526592/1",
        userId: "w_rjq2wjba5ccy"
    }
]
  )
}
```