### PR TITLE
fix: add transitions to cursors for smoothing (port from 2.7)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/cursor/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/cursors/cursor/component.jsx
@@ -25,19 +25,22 @@ const Cursor = (props) => {
     _y = (y + tldrawCamera?.point[1]) * tldrawCamera?.zoom;
   }
 
+  const transitionStyle = owner ? { transition: 'left 0.3s ease-out, top 0.3s ease-out' } : {};
+
   return (
     <>
       <div
         style={{
           zIndex: z,
           position: 'absolute',
-          left: (_x || x) - pointerDiameter/2,
-          top: (_y || y) - pointerDiameter/2,
+          left: (_x || x) - pointerDiameter / 2,
+          top: (_y || y) - pointerDiameter / 2,
           width: pointerDiameter,
           height: pointerDiameter,
           borderRadius: '50%',
           background: `${color}`,
           pointerEvents: 'none',
+          ...transitionStyle,
         }}
       />
 
@@ -57,6 +60,7 @@ const Cursor = (props) => {
             color: '#FFF',
             backgroundColor: color,
             border: `1px solid ${color}`,
+            ...transitionStyle,
           }}
           data-test="whiteboardCursorIndicator"
         >


### PR DESCRIPTION
Ports https://github.com/bigbluebutton/bigbluebutton/pull/19127 to BBB 3.0