### PR TITLE
fix away and raiseHands 'reactions' being hidden by avatar image

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -151,7 +151,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
 
   const reactionsEnabled = isReactionsEnabled();
 
-  const userAvatarFiltered = (user.raiseHand === true || user.away === true || ( user.reaction && user.reaction.reactionEmoji !== 'none')) ? '' : user.avatar;
+  const userAvatarFiltered = (user.raiseHand === true || user.away === true || (user.reaction && user.reaction.reactionEmoji !== 'none')) ? '' : user.avatar;
 
   const emojiIcons = [
     {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -151,7 +151,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
 
   const reactionsEnabled = isReactionsEnabled();
 
-  const userAvatarFiltered = user.avatar;
+  const userAvatarFiltered = (user.raiseHand === true || user.away === true || ( user.reaction && user.reaction.reactionEmoji !== 'none')) ? '' : user.avatar;
 
   const emojiIcons = [
     {


### PR DESCRIPTION
Ports https://github.com/bigbluebutton/bigbluebutton/pull/19266 to BBB 3.0

Note: the file name/path had changed and so had the content. I had to tweak the change. I tested after the tweaks and it seemed to work fine.

I used this file in GLv3 as avatar:
![Screenshot from 2024-01-25 14-49-09](https://github.com/bigbluebutton/bigbluebutton/assets/6312397/38190bc4-9965-484d-ac3a-6a93dd83cb74)


Before:

![Screenshot from 2024-01-25 14-39-36](https://github.com/bigbluebutton/bigbluebutton/assets/6312397/9d69dbec-1525-42aa-a680-07f91856d95a)


After:

![Screenshot from 2024-01-25 14-59-18](https://github.com/bigbluebutton/bigbluebutton/assets/6312397/bcc3fde6-338f-44b1-952d-f647d4e5ef5f)



