### PR TITLE
Revert "docs: Force trailingSlash"

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -13,7 +13,6 @@ const config = {
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',
-    trailingSlash: true,
 
     // GitHub pages deployment config.
     // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#19522 There are are consequences for the docs deploy that did not show locally. Digging deeper