### PR TITLE
Introducing Session Persistence Post-Meeting

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -189,9 +189,10 @@ class BigBlueButtonActor(
         context.stop(m.actorRef)
       }
 
-      MeetingDAO.delete(msg.meetingId)
+      //      MeetingDAO.delete(msg.meetingId)
+      MeetingDAO.setMeetingEnded(msg.meetingId)
       //      Removing the meeting is enough, all other tables has "ON DELETE CASCADE"
-      //      UserDAO.deleteAllFromMeeting(msg.meetingId)
+      //      UserDAO.softDeleteAllFromMeeting(msg.meetingId)
       //      MeetingRecordingDAO.updateStopped(msg.meetingId, "")
 
       //Remove ColorPicker idx of the meeting

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
@@ -30,7 +30,7 @@ trait EjectUserFromBreakoutInternalMsgHdlr {
       )
 
       //TODO inform reason
-      UserDAO.delete(registeredUser.id)
+      UserDAO.softDelete(registeredUser.id)
 
       // send a system message to force disconnection
       Sender.sendDisconnectClientSysMsg(msg.breakoutId, registeredUser.id, msg.ejectedBy, msg.reasonCode, outGW)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
@@ -40,7 +40,7 @@ trait UserLeftVoiceConfEvtMsgHdlr {
         UsersApp.guestWaitingLeft(liveMeeting, user.intId, outGW)
       }
       Users2x.remove(liveMeeting.users2x, user.intId)
-      UserDAO.delete(user.intId)
+      UserDAO.softDelete(user.intId)
       VoiceApp.removeUserFromVoiceConf(liveMeeting, outGW, msg.body.voiceUserId)
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -135,7 +135,7 @@ object UserDAO {
   }
 
 
-  def delete(intId: String) = {
+  def softDelete(intId: String) = {
     DatabaseConnection.db.run(
       TableQuery[UserDbTableDef]
         .filter(_.userId === intId)
@@ -147,7 +147,19 @@ object UserDAO {
     }
   }
 
-  def deleteAllFromMeeting(meetingId: String) = {
+  def softDeleteAllFromMeeting(meetingId: String) = {
+    DatabaseConnection.db.run(
+      TableQuery[UserDbTableDef]
+        .filter(_.meetingId === meetingId)
+        .map(u => (u.loggedOut))
+        .update((true))
+    ).onComplete {
+      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated loggedOut=true on user table!")
+      case Failure(e) => DatabaseConnection.logger.error(s"Error updating loggedOut=true user: $e")
+    }
+  }
+
+  def permanentlyDeleteAllFromMeeting(meetingId: String) = {
     DatabaseConnection.db.run(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === meetingId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -122,7 +122,7 @@ object RegisteredUsers {
       u
     } else {
       users.delete(ejectedUser.id)
-//      UserDAO.delete(ejectedUser) it's being removed in User2x already
+//      UserDAO.softDelete(ejectedUser) it's being removed in User2x already
       ejectedUser
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -27,7 +27,7 @@ object Users2x {
   }
 
   def remove(users: Users2x, intId: String): Option[UserState] = {
-    //UserDAO.delete(intId)
+    //UserDAO.softDelete(intId)
     users.remove(intId)
   }
 
@@ -125,7 +125,7 @@ object Users2x {
       _ <- users.remove(intId)
       ejectedUser <- users.removeFromCache(intId)
     } yield {
-      //      UserDAO.delete(intId)  --it will keep the user on Db
+      //      UserDAO.softDelete(intId)  --it will keep the user on Db
       ejectedUser
     }
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSessionBasicData.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSessionBasicData.java
@@ -1,0 +1,30 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+* 
+* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+* 
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+package org.bigbluebutton.api.domain;
+
+public class UserSessionBasicData {
+  public String sessionToken = null;
+  public String userId = null;
+  public String meetingId = null;
+
+  public String toString() {
+    return meetingId + " " + userId + " " + sessionToken;
+  }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GuestPolicyValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/GuestPolicyValidator.java
@@ -22,7 +22,7 @@ public class GuestPolicyValidator implements ConstraintValidator<GuestPolicyCons
         }
 
         MeetingService meetingService = ServiceUtils.getMeetingService();
-        UserSession userSession = meetingService.getUserSessionWithAuthToken(sessionToken);
+        UserSession userSession = meetingService.getUserSessionWithSessionToken(sessionToken);
 
         if(userSession == null || !userSession.guestStatus.equals(GuestPolicy.ALLOW)) {
             return false;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/UserSessionValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/UserSessionValidator.java
@@ -19,7 +19,7 @@ public class UserSessionValidator implements ConstraintValidator<UserSessionCons
             return false;
         }
 
-        UserSession userSession = ServiceUtils.getMeetingService().getUserSessionWithAuthToken(sessionToken);
+        UserSession userSession = ServiceUtils.getMeetingService().getUserSessionWithSessionToken(sessionToken);
 
         if(userSession == null) {
             return false;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/SessionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/SessionService.java
@@ -22,7 +22,7 @@ public class SessionService {
 
     private void getUserSessionWithToken() {
         if(sessionToken != null) {
-            userSession = meetingService.getUserSessionWithAuthToken(sessionToken);
+            userSession = meetingService.getUserSessionWithSessionToken(sessionToken);
         }
     }
 

--- a/bbb-graphql-client-test/src/Auth.js
+++ b/bbb-graphql-client-test/src/Auth.js
@@ -89,6 +89,7 @@ export default function Auth() {
         }
         meeting {
             name
+            ended
         }
       }
     }`
@@ -107,7 +108,12 @@ export default function Auth() {
         {data.user_current.map((curr) => {
             console.log('user_current', curr);
 
-            if(curr.loggedOut) {
+            if(curr.meeting.ended) {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    Meeting has ended.</div>
+            } else if(curr.ejected) {
                 return <div>
                     {curr.meeting.name}
                     <br/><br/>

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -25,9 +25,11 @@ create table "meeting" (
 	"bannerText" text,
 	"bannerColor" varchar(50),
 	"createdTime" bigint,
-	"durationInSeconds" integer
+	"durationInSeconds" integer,
+	"endedAt" timestamp with time zone
 );
 ALTER TABLE "meeting" ADD COLUMN "createdAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("createdTime"::double precision / 1000)) STORED;
+ALTER TABLE "meeting" ADD COLUMN "ended" boolean GENERATED ALWAYS AS ("endedAt" is not null) STORED;
 
 create index "idx_meeting_extId" on "meeting"("extId");
 

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -382,7 +382,7 @@ actions:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
-      - role: pre_join_bbb_client
+      - role: not_joined_bbb_client
       - role: bbb_client
   - name: userLeaveMeeting
     definition:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -149,6 +149,7 @@ select_permissions:
         - html5InstanceId
         - isBreakout
         - logoutUrl
+        - ended
         - maxPinnedCameras
         - meetingCameraCap
         - meetingId
@@ -159,13 +160,14 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
-  - role: pre_join_bbb_client
+  - role: not_joined_bbb_client
     permission:
       columns:
         - bannerColor
         - bannerText
         - customLogoUrl
         - logoutUrl
+        - ended
         - meetingId
         - name
       filter:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -172,7 +172,7 @@ select_permissions:
       filter:
         userId:
           _eq: X-Hasura-UserId
-  - role: pre_join_bbb_client
+  - role: not_joined_bbb_client
     permission:
       columns:
         - authToken

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_guest.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_guest.yaml
@@ -34,7 +34,7 @@ select_permissions:
           - meetingId:
               _eq: X-Hasura-ModeratorInMeeting
       allow_aggregations: true
-  - role: pre_join_bbb_client
+  - role: not_joined_bbb_client
     permission:
       columns:
         - guestLobbyMessage

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -307,7 +307,7 @@ graphqlWebsocketUrl=${bigbluebutton.web.serverURL}/v1/graphql
 # This parameter defines the duration (in minutes) to wait before removing user sessions after a meeting has ended.
 # During this delay, users can still access information indicating that the "Meeting has ended".
 # Setting this value to 0 will result in the sessions being kept alive indefinitely (permanent availability).
-sessionsCleanupDelayInMinutes=1
+sessionsCleanupDelayInMinutes=60
 
 useDefaultLogo=false
 defaultLogoURL=${bigbluebutton.web.serverURL}/images/logo.png

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -304,6 +304,11 @@ defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join
 # Using `serverURL` as default, so `https` will be automatically replaced by `wss`
 graphqlWebsocketUrl=${bigbluebutton.web.serverURL}/v1/graphql
 
+# This parameter defines the duration (in minutes) to wait before removing user sessions after a meeting has ended.
+# During this delay, users can still access information indicating that the "Meeting has ended".
+# Setting this value to 0 will result in the sessions being kept alive indefinitely (permanent availability).
+sessionsCleanupDelayInMinutes=1
+
 useDefaultLogo=false
 defaultLogoURL=${bigbluebutton.web.serverURL}/images/logo.png
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -53,6 +53,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="stunTurnService" ref="stunTurnService"/>
         <property name="waitingGuestCleanupTimerTask" ref="waitingGuestCleanupTimerTask"/>
         <property name="userCleanupTimerTask" ref="userCleanupTimerTask"/>
+        <property name="sessionsCleanupDelayInMinutes" value="${sessionsCleanupDelayInMinutes}"/>
         <property name="enteredUserCleanupTimerTask" ref="enteredUserCleanupTimerTask"/>
         <property name="gw" ref="bbbWebApiGWApp"/>
         <property name="callbackUrlService" ref="callbackUrlService"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1112,7 +1112,7 @@ class ApiController {
 
     if(validationResponse == null) {
       String sessionToken = sanitizeSessionToken(params.sessionToken)
-      UserSession us = meetingService.removeUserSessionWithAuthToken(sessionToken)
+      UserSession us = meetingService.removeUserSessionWithSessionToken(sessionToken)
       Map<String, Object> logData = new HashMap<String, Object>();
       logData.put("meetingid", us.meetingID);
       logData.put("extMeetingid", us.externMeetingID);
@@ -1803,7 +1803,7 @@ class ApiController {
       return null
     }
 
-    UserSession us = meetingService.getUserSessionWithAuthToken(token)
+    UserSession us = meetingService.getUserSessionWithSessionToken(token)
     if (us == null) {
       log.info("Cannot find UserSession for token ${token}")
     }


### PR DESCRIPTION
This Pull Request addresses an issue where user sessions are immediately removed after a meeting ends. This creates a problem for users who refresh their browser and seek information about the meeting they were part of, as there's no retained information about the ended meeting or the user's involvement.

- With this PR, user sessions will now remain active for a specified duration after a meeting concludes. This allows users to access important information about their participation, including whether the meeting has ended, if they were ejected, or if they logged out.
- To avoid side effects, we introduce a new `Map` structure for storing sessions of removed users. This Map will be exclusively accessed by the Graphql AuthHook, ensuring no impact on other service authentication behaviors.
- A new configuration parameter, `sessionsCleanupDelayInMinutes`, is introduced. Administrators can set a custom delay time for session cleanup or opt to keep sessions alive indefinitely. The default value is set to 60 minutes (1 hour).
- The Hasura role `pre_join_bbb_client` has been renamed to `not_joined_bbb_client`. This change reflects the role's applicability both before and after joining a meeting.
- It introduces a new field `ended` to graphql Type `meeting`, it can be fetched even when user left the meeting by `user_current`:
```gql
query {
  user_current {
    meeting {
      ended
    }
  }
}
``` 
- As an interim measure, the database will store information about all meetings indefinitely. This approach will be revised in a subsequent PR for optimal data management.