### PR TITLE
refactor (graphql-middlware): Maintain Hasura Connection During Active Mutations

### DIFF
--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -18,15 +18,15 @@ const (
 )
 
 type GraphQlSubscription struct {
-	Id                        string
-	Message                   map[string]interface{}
-	Type                      QueryType
-	OperationName             string
-	StreamCursorField         string
-	StreamCursorVariableName  string
-	StreamCursorCurrValue     interface{}
-	JsonPatchSupported        bool   // indicate if client support Json Patch for this subscription
-	LastSeenOnHasuraConnetion string // id of the hasura connection that this query was active
+	Id                         string
+	Message                    map[string]interface{}
+	Type                       QueryType
+	OperationName              string
+	StreamCursorField          string
+	StreamCursorVariableName   string
+	StreamCursorCurrValue      interface{}
+	JsonPatchSupported         bool   // indicate if client support Json Patch for this subscription
+	LastSeenOnHasuraConnection string // id of the hasura connection that this query was active
 }
 
 type BrowserConnection struct {

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -98,15 +98,15 @@ RangeLoop:
 
 					browserConnection.ActiveSubscriptionsMutex.Lock()
 					browserConnection.ActiveSubscriptions[queryId] = common.GraphQlSubscription{
-						Id:                        queryId,
-						Message:                   fromBrowserMessageAsMap,
-						OperationName:             operationName,
-						StreamCursorField:         streamCursorField,
-						StreamCursorVariableName:  streamCursorVariableName,
-						StreamCursorCurrValue:     streamCursorInitialValue,
-						LastSeenOnHasuraConnetion: hc.Id,
-						JsonPatchSupported:        jsonPatchSupported,
-						Type:                      messageType,
+						Id:                         queryId,
+						Message:                    fromBrowserMessageAsMap,
+						OperationName:              operationName,
+						StreamCursorField:          streamCursorField,
+						StreamCursorVariableName:   streamCursorVariableName,
+						StreamCursorCurrValue:      streamCursorInitialValue,
+						LastSeenOnHasuraConnection: hc.Id,
+						JsonPatchSupported:         jsonPatchSupported,
+						Type:                       messageType,
 					}
 					// log.Tracef("Current queries: %v", browserConnection.ActiveSubscriptions)
 					browserConnection.ActiveSubscriptionsMutex.Unlock()

--- a/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
@@ -11,6 +11,11 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowse
 	hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 	for _, subscription := range hc.Browserconn.ActiveSubscriptions {
 
+		//Not retransmitting Mutations
+		if subscription.Type == common.Mutation {
+			continue
+		}
+
 		if subscription.LastSeenOnHasuraConnection != hc.Id {
 
 			log.Tracef("retransmiting subscription start: %v", subscription.Message)

--- a/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hascli/retransmiter/retransmiter.go
@@ -10,7 +10,8 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowse
 
 	hc.Browserconn.ActiveSubscriptionsMutex.RLock()
 	for _, subscription := range hc.Browserconn.ActiveSubscriptions {
-		if subscription.LastSeenOnHasuraConnetion != hc.Id {
+
+		if subscription.LastSeenOnHasuraConnection != hc.Id {
 
 			log.Tracef("retransmiting subscription start: %v", subscription.Message)
 


### PR DESCRIPTION
When a user's role is modified, the connection between the graphql-middleware and the graphql-server (Hasura) is reset for that user. However, if a request (mutation) is sent to Hasura and no confirmation response is received, this request remains active in the Middleware. As a result, when the connection is re-established, the same request is sent again. This can lead to unexpected issues, such as the same chat message being sent twice.

To solve this, the proposed change (PR) will ensure that the connection to Hasura is not closed while awaiting a response to any pending request. Additionally, it will modify the re-transmitter, activated upon establishing a new connection, to prevent it from resending requests of the type 'Mutation'.

----

It's really hard to reproduce, I could do it by creating this code in the client:
<img src="https://github.com/bigbluebutton/bigbluebutton/assets/5660191/334c65c7-e2b6-4baa-a195-82e29db21000" width="450">