### PR TITLE
Graphql: Implementing Read-Only Database Access for Frontend (temporarily)

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -428,6 +428,13 @@ AS SELECT "user"."userId",
     CASE WHEN "user"."joined" IS true AND "user"."expired" IS false AND "user"."loggedOut" IS false AND "user"."ejected" IS NOT TRUE THEN true ELSE false END "isOnline"
    FROM "user";
 
+--This view will be used by Meteor to validate if the provided authToken is valid
+--It is temporary while Meteor is not removed
+create view "v_user_connection_auth" as
+select "meetingId", "userId", "authToken"
+from "v_user_current"
+where "isOnline" is true;
+
 CREATE OR REPLACE VIEW "v_user_guest" AS
 SELECT u."meetingId", u."userId",
 u."guestStatus",

--- a/bbb-graphql-server/install-hasura.sh
+++ b/bbb-graphql-server/install-hasura.sh
@@ -18,6 +18,21 @@ sudo -u postgres psql -U postgres -d bbb_graphql -a -f bbb_schema.sql --set ON_E
 sudo -u postgres psql -c "drop database if exists hasura_app with (force)"
 sudo -u postgres psql -c "create database hasura_app"
 
+echo "Creating frontend in bbb_graphql"
+DATABASE_FRONTEND_USER="bbb_frontend"
+FRONT_USER_EXISTS=$(sudo -u postgres psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '$DATABASE_FRONTEND_USER'")
+if [ "$FRONT_USER_EXISTS" = '1' ]
+then
+    echo "User $DATABASE_FRONTEND_USER already exists"
+else
+    sudo -u postgres psql -q -c "CREATE USER $DATABASE_FRONTEND_USER WITH PASSWORD '$DATABASE_FRONTEND_USER'"
+    sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
+    sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
+    sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
+    sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
+    echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
+fi
+
 echo "Postgresql installed!"
 
 

--- a/bbb-graphql-server/update_graphql_data.sh
+++ b/bbb-graphql-server/update_graphql_data.sh
@@ -24,6 +24,22 @@ sudo -u postgres psql -c "alter database bbb_graphql set timezone to 'UTC'"
 echo "Creating tables in bbb_graphql"
 sudo -u postgres psql -U postgres -d bbb_graphql -q -f bbb_schema.sql --set ON_ERROR_STOP=on
 
+echo "Creating frontend in bbb_graphql"
+DATABASE_FRONTEND_USER="bbb_frontend"
+FRONT_USER_EXISTS=$(sudo -u postgres psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '$DATABASE_FRONTEND_USER'")
+if [ "$FRONT_USER_EXISTS" = '1' ]
+then
+    echo "User $DATABASE_FRONTEND_USER already exists"
+else
+    sudo -u postgres psql -q -c "CREATE USER $DATABASE_FRONTEND_USER WITH PASSWORD '$DATABASE_FRONTEND_USER'"
+    sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
+    sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
+    sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
+    sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
+    echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
+fi
+
+
 if [ "$hasura_status" = "active" ]; then
   echo "Starting Hasura"
   sudo systemctl start bbb-graphql-server

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -21,6 +21,22 @@ case "$1" in
       echo "Database $DATABASE_NAME created"
   fi
 
+  # Create a readonly user that will be used by Meteor to check authToken (while Meteor not removed from the project)
+  DATABASE_FRONTEND_USER="bbb_frontend"
+  FRONT_USER_EXISTS=$(sudo -u postgres psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '$DATABASE_FRONTEND_USER'")
+  if [ "$FRONT_USER_EXISTS" = '1' ]
+  then
+      echo "User $DATABASE_FRONTEND_USER already exists"
+  else
+      sudo -u postgres psql -q -c "CREATE USER $DATABASE_FRONTEND_USER WITH PASSWORD '$DATABASE_FRONTEND_USER'"
+      sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
+      sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
+      sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
+      sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
+      echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
+  fi
+
+
   echo "Postgresql configured"
 
   if [ ! -f /.dockerenv ]; then


### PR DESCRIPTION
Following #19104 and #19454, the system is transitioning away from using `ValidateAuthTokenReqMsg` for user authentication. In the new approach, Graphql will handle the authentication process. However, until the complete phase-out of the Meteor framework, there is a need for an interim solution to validate user authTokens. The proposed idea is to enable Meteor to query the Graphql database directly. This will allow Meteor to verify whether a user's token is valid during the transition period.

Database: `bbb_graphql`
User (read-only): `bbb_frontend`
Password: `bbb_frontend`

Allowed query:
```sql
select "meetingId", "userId" 
from v_user_connection_auth 
where "authToken" = 'yc14toemfvcx'
```