### PR TITLE
refactor (graphql-middleware): Queue Messages During Hasura Disconnection

### DIFF
--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -42,9 +42,10 @@ type BrowserConnection struct {
 }
 
 type HasuraConnection struct {
-	Id                string             // hasura connection id
-	Browserconn       *BrowserConnection // browser connection that originated this hasura connection
-	Websocket         *websocket.Conn    // websocket used to connect to hasura
-	Context           context.Context    // hasura connection context (child of browser connection context)
-	ContextCancelFunc context.CancelFunc // function to cancel the hasura context (and so, the hasura connection)
+	Id                     string             // hasura connection id
+	Browserconn            *BrowserConnection // browser connection that originated this hasura connection
+	Websocket              *websocket.Conn    // websocket used to connect to hasura
+	Context                context.Context    // hasura connection context (child of browser connection context)
+	ContextCancelFunc      context.CancelFunc // function to cancel the hasura context (and so, the hasura connection)
+	MsgReceivingActiveChan chan struct{}      // indicate that it's waiting for the return of mutations before closing connection
 }

--- a/bbb-graphql-middleware/internal/hascli/client.go
+++ b/bbb-graphql-middleware/internal/hascli/client.go
@@ -60,10 +60,11 @@ func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.C
 	defer hasuraConnectionContextCancel()
 
 	var thisConnection = common.HasuraConnection{
-		Id:                hasuraConnectionId,
-		Browserconn:       browserConnection,
-		Context:           hasuraConnectionContext,
-		ContextCancelFunc: hasuraConnectionContextCancel,
+		Id:                     hasuraConnectionId,
+		Browserconn:            browserConnection,
+		Context:                hasuraConnectionContext,
+		ContextCancelFunc:      hasuraConnectionContextCancel,
+		MsgReceivingActiveChan: make(chan struct{}),
 	}
 
 	browserConnection.HasuraConnection = &thisConnection

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -1,13 +1,13 @@
 package writer
 
 import (
-	"github.com/iMDT/bbb-graphql-middleware/internal/msgpatch"
-	"strings"
-	"sync"
-
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
+	"github.com/iMDT/bbb-graphql-middleware/internal/msgpatch"
 	log "github.com/sirupsen/logrus"
 	"nhooyr.io/websocket/wsjson"
+	"strings"
+	"sync"
+	"time"
 )
 
 // HasuraConnectionWriter
@@ -39,6 +39,10 @@ RangeLoop:
 		select {
 		case <-hc.Context.Done():
 			break RangeLoop
+		case <-hc.MsgReceivingActiveChan:
+			//Freeze channel once it's about to close Hasura connection
+			fromBrowserToHasuraChannel.FreezeChannel()
+			time.Sleep(1000 * time.Millisecond)
 		case fromBrowserMessage := <-fromBrowserToHasuraChannel.ReceiveChannel():
 			{
 				if fromBrowserMessage == nil {

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -41,7 +41,6 @@ func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c 
 		}
 
 		log.Tracef("received from browser: %v", v)
-		//fmt.Println("received from browser: %v", v)
 
 		fromBrowserToHasuraChannel.Send(v)
 		fromBrowserToHasuraConnectionEstablishingChannel.Send(v)

--- a/bbb-graphql-middleware/internal/websrv/writer/writer.go
+++ b/bbb-graphql-middleware/internal/websrv/writer/writer.go
@@ -10,7 +10,7 @@ import (
 	"nhooyr.io/websocket/wsjson"
 )
 
-func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromHasuratoBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
+func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromHasuraToBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "BrowserConnectionWriter").WithField("browserConnectionId", browserConnectionId)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
@@ -21,7 +21,7 @@ RangeLoop:
 		select {
 		case <-ctx.Done():
 			break RangeLoop
-		case toBrowserMessage := <-fromHasuratoBrowserChannel.ReceiveChannel():
+		case toBrowserMessage := <-fromHasuraToBrowserChannel.ReceiveChannel():
 			{
 				var toBrowserMessageAsMap = toBrowserMessage.(map[string]interface{})
 


### PR DESCRIPTION
As suggested by @TiagoJacobs at https://github.com/bigbluebutton/bigbluebutton/pull/19535#issuecomment-1915619510

This PR updates the middleware to halt the acceptance of new messages from the browser when it is in the process of disconnecting from the Hasura connection. 
Messages received during this period will be queued and subsequently processed once a connection to Hasura is re-established.