### PR TITLE
fix (graphql-middleware): User get Presenter status but can't stop external video

### DIFF
--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -48,7 +48,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 				hc.Browserconn.ActiveSubscriptionsMutex.RUnlock()
 				if !ok {
 					log.Debugf("Subscription with Id %s doesn't exist anymore, skiping response.", queryId)
-					return
+					continue
 				}
 
 				//When Hasura send msg type "complete", this query is finished

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -136,16 +136,17 @@ func InvalidateSessionTokenConnections(sessionTokenToInvalidate string) {
 	for _, browserConnection := range BrowserConnections {
 		if browserConnection.SessionToken == sessionTokenToInvalidate {
 			if browserConnection.HasuraConnection != nil {
-
 				// Wait until there are no active mutations
-				for iterationCount := 0; iterationCount < 100; iterationCount++ {
+				for iterationCount := 0; iterationCount < 20; iterationCount++ {
 					activeMutationFound := false
+					browserConnection.ActiveSubscriptionsMutex.RLock()
 					for _, subscription := range browserConnection.ActiveSubscriptions {
 						if subscription.Type == common.Mutation {
 							activeMutationFound = true
 							break
 						}
 					}
+					browserConnection.ActiveSubscriptionsMutex.RUnlock()
 					if !activeMutationFound {
 						break
 					}


### PR DESCRIPTION
During the latest development call, as highlighted by @antobinary, an issue was identified in the system. When a user is granted presenter status, they encounter a problem where they are unable to stop external video playback, among other presenter-specific functionalities.

This Pull Request (PR) addresses and resolves this issue. The root cause of the problem was identified as follows: when a user becomes a presenter, the client-side application ceases various data subscriptions. This led to an issue where, if the Hasura backend responded with data related to these subscriptions, the client's middleware no longer recognized or handled this data, as the subscriptions had been stopped. The PR contains fixes to ensure that this problem does not occur when a user is assigned presenter status.