### PR TITLE
fix: Muting via who-is-talking -- queue via timestamp again

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/userVoiceSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/userVoiceSubscription.ts
@@ -4,7 +4,7 @@ const TALKING_INDICATOR_SUBSCRIPTION = gql`
   subscription TalkingIndicatorSubscription($limit: Int!) {
     user_voice(
       where: { showTalkingIndicator: { _eq: true } }
-      order_by: [{ startTime: desc_nulls_last }, { endTime: desc_nulls_last }]
+      order_by: [{ startTime: asc_nulls_last }]
       limit: $limit
     ) {
       callerName


### PR DESCRIPTION
### What does this PR do?

Changes talking indicator order to be the same as 2.7.

### Closes Issue(s)
Closes #19544