### PR TITLE
fix: Upload the exported users list to presentation breaks the whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -1038,11 +1038,13 @@ class PresentationUploader extends Component {
 
     const formattedDownloadAriaLabel = `${formattedDownloadLabel} ${item.filename}`;
 
-    const hasAnyAnnotation = hasAnnotations(item.id);
+    const isNew = item.id.indexOf(item.filename) !== -1;
+    const hasAnyAnnotation = isNew ? false : hasAnnotations(item.id);
+
     return (
       <Styled.PresentationItem
         key={item.id}
-        isNew={item.id.indexOf(item.filename) !== -1}
+        isNew={isNew}
         uploading={isUploading}
         converting={isConverting}
         error={hasError}


### PR DESCRIPTION
### What does this PR do?

Fix presentation uploader crash by not checking for annotations if the presentation is not yet uploaded.

#### More

The query used to check for annotations uses the presentationId, which includes the filename for files that are not uploaded and may cause a crash if the filename contains certain characters

### Closes Issue(s)
Closes #19505