### PR TITLE
fix(whiteboard): restore `Hide toolbars` button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -358,7 +358,7 @@ const PresentationMenu = (props) => {
       );
     }
     
-    const tools = document.querySelector('#TD-Tools');
+    const tools = document.querySelector('.tlui-toolbar, .tlui-style-panel__wrapper');
     if (tools && (props.hasWBAccess || props.amIPresenter)){
       menuItems.push(
         {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -358,7 +358,7 @@ const PresentationMenu = (props) => {
       );
     }
     
-    const tools = document.querySelector('.tlui-toolbar, .tlui-style-panel__wrapper');
+    const tools = document.querySelector('.tlui-toolbar, .tlui-style-panel__wrapper, .tlui-menu-zone');
     if (tools && (props.hasWBAccess || props.amIPresenter)){
       menuItems.push(
         {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -884,7 +884,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
         onMount={handleTldrawMount}
       />
       <Styled.TldrawV2GlobalStyle
-        {...{ hasWBAccess, isPresenter, isRTL, isMultiUserActive }}
+        {...{ hasWBAccess, isPresenter, isRTL, isMultiUserActive, isToolbarVisible }}
       />
     </div>
   );

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -33,6 +33,16 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     }
   `}
 
+  ${({ isToolbarVisible }) => (!isToolbarVisible) && `
+    .tlui-toolbar {
+      visibility: hidden;
+    }
+
+    .tlui-style-panel__wrapper {
+      visibility: hidden;
+    }
+  `}
+
   #presentationInnerWrapper > div:last-child {
     position: relative;
     height: 100%;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -34,11 +34,9 @@ const TldrawV2GlobalStyle = createGlobalStyle`
   `}
 
   ${({ isToolbarVisible }) => (!isToolbarVisible) && `
-    .tlui-toolbar {
-      visibility: hidden;
-    }
-
-    .tlui-style-panel__wrapper {
+    .tlui-toolbar,
+    .tlui-style-panel__wrapper,
+    .tlui-menu-zone {
       visibility: hidden;
     }
   `}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -39,6 +39,9 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     .tlui-menu-zone {
       visibility: hidden;
     }
+    #WhiteboardOptionButton {
+      opacity: 0.2;
+    }
   `}
 
   #presentationInnerWrapper > div:last-child {


### PR DESCRIPTION
### What does this PR do?

Restores button for hiding tldraw tools.

![Screenshot from 2024-02-02 09-19-17](https://github.com/bigbluebutton/bigbluebutton/assets/62393923/73252d7a-abef-4d5d-b5c5-55c89c2c4ad0)

### Closes Issue(s)

Closes none