### PR TITLE
fix (graphql-server): Give permission for bbb_frontend every time tables are created

### DIFF
--- a/bbb-graphql-server/install-hasura.sh
+++ b/bbb-graphql-server/install-hasura.sh
@@ -29,9 +29,10 @@ else
     sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
     sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
     sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
-    sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
     echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
 fi
+
+sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
 
 echo "Postgresql installed!"
 

--- a/bbb-graphql-server/update_graphql_data.sh
+++ b/bbb-graphql-server/update_graphql_data.sh
@@ -35,10 +35,10 @@ else
     sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
     sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
     sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
-    sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
     echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
 fi
 
+sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
 
 if [ "$hasura_status" = "active" ]; then
   echo "Starting Hasura"

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -32,10 +32,10 @@ case "$1" in
       sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
       sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
       sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
-      sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
       echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
   fi
 
+  sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
 
   echo "Postgresql configured"
 


### PR DESCRIPTION
All the tables of the database are created on each server update.
So it needs to give permission for user `bbb_frontend` every time as well.

Related: #19537