### PR TITLE
refactor (graphq-middleware): Revert using go routine to process Hasura messages

### DIFF
--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -36,7 +36,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 
 		log.Tracef("received from hasura: %v", message)
 
-		go handleMessageReceivedFromHasura(hc, fromHasuraToBrowserChannel, fromBrowserToHasuraChannel, message)
+		handleMessageReceivedFromHasura(hc, fromHasuraToBrowserChannel, fromBrowserToHasuraChannel, message)
 	}
 }
 


### PR DESCRIPTION
Revert **`GoRoutines to manage the messages received from Hasura`** once it is better to guarantee that the messages will be delivered to browser in the correct order.

Related: #19559