### PR TITLE
fix: [3.0] - Publishing empty typed response question crashes public chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -46,9 +46,6 @@ function assertAsMetadata(metadata: unknown): asserts metadata is Metadata {
   if (!Array.isArray((metadata as Metadata).answers)) {
     throw new Error('metadata.answers is not an array');
   }
-  if ((metadata as Metadata).answers.length === 0) {
-    throw new Error('metadata.answers is empty');
-  }
 }
 
 const ChatPollContent: React.FC<ChatPollContentProps> = ({


### PR DESCRIPTION
### What does this PR do?

Allows empty typed poll to be published.

### Closes Issue(s)
Closes #19443
