### PR TITLE
fix(whiteboard): Ensure Only Presenter Has Ability to Pan Canvas

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -154,6 +154,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
   const isMouseDownRef = useRef(false);
   const isMountedRef = useRef(false);
   const isWheelZoomRef = useRef(false);
+  const isPresenterRef = useRef(isPresenter);
   const whiteboardIdRef = React.useRef(whiteboardId);
   const curPageIdRef = React.useRef(curPageId);
   const hasWBAccessRef = React.useRef(hasWBAccess);
@@ -187,6 +188,29 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
     whiteboardIdRef.current
   );
 
+  const handleKeyDown = (event) => {
+    if (!isPresenterRef.current) {
+      if (!hasWBAccessRef.current || (hasWBAccessRef.current && (!tlEditorRef.current.editingShape))) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    if (!isEqual(isPresenterRef.current, isPresenter)) {
+      isPresenterRef.current = isPresenter;
+    }
+  }, [isPresenter]);
+
+  React.useEffect(() => {
+    if (!isEqual(hasWBAccessRef.current, hasWBAccess)) {
+      hasWBAccessRef.current = hasWBAccess;
+    }
+  }, [hasWBAccess]);
+
+
   React.useEffect(() => {
     if (!isEqual(prevShapesRef.current, shapes)) {
       prevShapesRef.current = shapes;
@@ -198,6 +222,16 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
       prevOtherCursorsRef.current = otherCursors;
     }
   }, [otherCursors]);
+
+  React.useEffect(() => {
+    if (whiteboardRef.current) {
+      whiteboardRef.current.addEventListener('keydown', handleKeyDown, { capture: true });
+    }
+
+    return () => {
+      whiteboardRef.current.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [whiteboardRef.current]);
 
   const { shapesToAdd, shapesToUpdate, shapesToRemove } = React.useMemo(() => {
     const selectedShapeIds = tlEditorRef.current?.selectedShapeIds || [];
@@ -840,7 +874,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
 
           const panned = prevCam.x !== nextCam.x || prevCam.y !== nextCam.y;
 
-          if (panned) {
+          if (panned && isPresenter) {
             let viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
               editor?.viewportPageBounds.width,
               currentPresentationPage?.scaledWidth
@@ -931,7 +965,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
           next?.id?.includes("camera") &&
           (prev.x !== next.x || prev.y !== next.y);
         const zoomed = next?.id?.includes("camera") && prev.z !== next.z;
-        if (panned && isPresenter) {
+        if (panned) {
           // // limit bounds
           if (
             editor?.viewportPageBounds?.maxX >

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -229,7 +229,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
     }
 
     return () => {
-      whiteboardRef.current.removeEventListener('keydown', handleKeyDown);
+      whiteboardRef?.current.removeEventListener('keydown', handleKeyDown);
     };
   }, [whiteboardRef.current]);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -229,7 +229,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
     }
 
     return () => {
-      whiteboardRef?.current.removeEventListener('keydown', handleKeyDown);
+      whiteboardRef.current?.removeEventListener('keydown', handleKeyDown);
     };
   }, [whiteboardRef.current]);
 


### PR DESCRIPTION
### What does this PR do?
This PR resolves an issue that allowed non-presenters to pan the canvas, a feature meant to be exclusive to the presenter until further controls for the infinite canvas are implemented. After this fix, only presenters will have the ability to pan the canvas, aligning with the intended functionality.


### Closes Issue(s)
Partially closes #19580
