### PR TITLE
Graphql: Allow not-joined-users query ClientSettings

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientSettings.yaml
@@ -15,3 +15,11 @@ select_permissions:
         meetingId:
           _eq: X-Hasura-MeetingId
     comment: ""
+  - role: not_joined_bbb_client
+    permission:
+      columns:
+        - clientSettingsJson
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""


### PR DESCRIPTION
The client needs to adjust certain settings when a user has left the room. One example of these settings is `askForFeedbackOnLogout`. Therefore, it is essential to allow users to access the ClientSettings type, even if they are no longer present in the room.

It's also crucial to note that in order to connect to the GraphQL server, a valid session on the bbb-web is required. This means that the user must possess a valid `/join` link.

Related #18926