### PR TITLE
Graphql: Provide meeting ending details

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -190,7 +190,7 @@ class BigBlueButtonActor(
       }
 
       //      MeetingDAO.delete(msg.meetingId)
-      MeetingDAO.setMeetingEnded(msg.meetingId)
+      //      MeetingDAO.setMeetingEnded(msg.meetingId)
       //      Removing the meeting is enough, all other tables has "ON DELETE CASCADE"
       //      UserDAO.softDeleteAllFromMeeting(msg.meetingId)
       //      MeetingRecordingDAO.updateStopped(msg.meetingId, "")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -7,7 +7,7 @@ import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.apps.users.UsersApp
 import org.bigbluebutton.core.apps.voice.VoiceApp
 import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
-import org.bigbluebutton.core.db.{BreakoutRoomUserDAO, MeetingRecordingDAO, UserBreakoutRoomDAO}
+import org.bigbluebutton.core.db.{BreakoutRoomUserDAO, MeetingDAO, MeetingRecordingDAO, UserBreakoutRoomDAO}
 import org.bigbluebutton.core.domain.{MeetingEndReason, MeetingState2x}
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
@@ -206,6 +206,8 @@ trait HandlerHelpers extends SystemConfiguration {
 
     val endedEvnt = buildMeetingEndedEvtMsg(liveMeeting.props.meetingProp.intId)
     outGW.send(endedEvnt)
+
+    MeetingDAO.setMeetingEnded(liveMeeting.props.meetingProp.intId, reason, userId)
   }
 
   def destroyMeeting(eventBus: InternalEventBus, meetingId: String): Unit = {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -26,14 +26,14 @@ create table "meeting" (
 	"bannerColor" varchar(50),
 	"createdTime" bigint,
 	"durationInSeconds" integer,
-	"endedAt" timestamp with time zone
+	"endedAt" timestamp with time zone,
+	"endedReasonCode" varchar(200),
+	"endedBy" varchar(50)
 );
 ALTER TABLE "meeting" ADD COLUMN "createdAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("createdTime"::double precision / 1000)) STORED;
 ALTER TABLE "meeting" ADD COLUMN "ended" boolean GENERATED ALWAYS AS ("endedAt" is not null) STORED;
 
 create index "idx_meeting_extId" on "meeting"("extId");
-
-create view "v_meeting" as select * from "meeting";
 
 create table "meeting_breakout" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
@@ -788,6 +788,14 @@ SELECT u."meetingId", ur."userId", (array_agg(ur."reactionEmoji" ORDER BY ur."ex
 FROM "user" u
 JOIN "user_reaction" ur ON u."userId" = ur."userId" AND "expiresAt" > current_timestamp
 GROUP BY u."meetingId", ur."userId";
+
+
+
+create view "v_meeting" as
+select "meeting".*,  "user_ended"."name" as "endedByUserName"
+from "meeting"
+left join "user" "user_ended" on "user_ended"."userId" = "meeting"."endedBy"
+;
 
 
 -- ===================== CHAT TABLES

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -145,11 +145,15 @@ select_permissions:
         - customLogoUrl
         - disabledFeatures
         - durationInSeconds
+        - ended
+        - endedAt
+        - endedBy
+        - endedByUserName
+        - endedReasonCode
         - extId
         - html5InstanceId
         - isBreakout
         - logoutUrl
-        - ended
         - maxPinnedCameras
         - meetingCameraCap
         - meetingId
@@ -166,8 +170,12 @@ select_permissions:
         - bannerColor
         - bannerText
         - customLogoUrl
-        - logoutUrl
         - ended
+        - endedAt
+        - endedBy
+        - endedByUserName
+        - endedReasonCode
+        - logoutUrl
         - meetingId
         - name
       filter:


### PR DESCRIPTION
It's necessary for the `meeting-end` component.

```gql
query {
  meeting {
    ended 
    endedAt 
    endedReasonCode
    endedBy
    endedByUserName
  }
}
```

```json
{
    "data": {
          "meeting": [
                            {
                                    "ended": true,
                                    "endedAt": "2024-02-06T16:24:52.262+00:00",
                                    "endedReasonCode": "ENDED_AFTER_USER_LOGGED_OUT",
                                    "endedBy": "w_uwcx5kivyhts",
                                    "endedByUserName": "teacher 1"
                            },
          ]
    }
}
```