### PR TITLE
Fix: Avatar overlaping other notifications on toast area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
@@ -165,7 +165,9 @@ class RaiseHandNotifier extends Component {
           <Styled.IconWrapper>
             <Icon iconName="hand" />
           </Styled.IconWrapper>
-          {this.raisedHandAvatars()}
+          <Styled.AvatarWrapper>
+            {this.raisedHandAvatars()}
+          </Styled.AvatarWrapper>
         </Styled.ToastContent>
         <Styled.ToastMessage>
           <div>{intl.formatMessage(messages.raisedHandsTitle)}</div>

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
@@ -161,14 +161,12 @@ class RaiseHandNotifier extends Component {
     const formattedRaisedHands = this.getRaisedHandNames();
     return (
       <div>
-        <Styled.ToastIcon>
+        <Styled.ToastContent>
           <Styled.IconWrapper>
             <Icon iconName="hand" />
           </Styled.IconWrapper>
-        </Styled.ToastIcon>
-        <Styled.AvatarsWrapper data-test="avatarsWrapper">
           {this.raisedHandAvatars()}
-        </Styled.AvatarsWrapper>
+        </Styled.ToastContent>
         <Styled.ToastMessage>
           <div>{intl.formatMessage(messages.raisedHandsTitle)}</div>
           {formattedRaisedHands}

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
@@ -124,6 +124,10 @@ const ClearButton = styled(Button)`
   }
 `;
 
+const AvatarWrapper = styled.div`
+  display: flex;
+`;
+
 const ToastSeparator = styled(ToastStyled.Separator)``;
 
 export default {
@@ -134,4 +138,5 @@ export default {
   ToastMessage,
   ClearButton,
   ToastSeparator,
+  AvatarWrapper,
 };

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
@@ -7,8 +7,6 @@ import {
   toastIconSide,
   toastMargin,
   toastMarginMobile,
-  avatarWrapperOffset,
-  jumboPaddingY,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
   colorWhite,
@@ -61,8 +59,11 @@ const AvatarsExtra = styled.div`
   padding: 5px 0;
 `;
 
-const ToastIcon = styled.div`
+const ToastContent = styled.div`
   margin-right: ${smPaddingX};
+  display: flex;
+  justify-content: space-between;
+  // justify-content: flex-end;
   [dir="rtl"] & {
     margin-right: 0;
     margin-left: ${smPaddingX};
@@ -100,20 +101,6 @@ const IconWrapper = styled.div`
   }
 `;
 
-const AvatarsWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  position: absolute;
-  top: ${avatarWrapperOffset};
-  right: 1rem;
-  left: auto;
-  
-  [dir="rtl"] & {
-    left: ${jumboPaddingY};
-    right: auto;
-  }
-`;
-
 const ToastMessage = styled.div`
   font-size: ${fontSizeSmall};
   margin-top: ${toastMargin};
@@ -142,9 +129,8 @@ const ToastSeparator = styled(ToastStyled.Separator)``;
 export default {
   Avatar,
   AvatarsExtra,
-  ToastIcon,
+  ToastContent,
   IconWrapper,
-  AvatarsWrapper,
   ToastMessage,
   ClearButton,
   ToastSeparator,


### PR DESCRIPTION
### What does this PR do?

This PR addresses an issue where elements are overlapping in the raise hand toast notifier. It aims to fix this problem to ensure a smoother user experience.

### Closes Issue(s)

#18969 

### BEFORE

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/cba6b025-ade9-407d-88ef-a6e03515bdc7)

### AFTER

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/a3733b88-212c-44f1-b581-6511b23589f4)
