### PR TITLE
recording: work around invalid locale in caption events

### DIFF
--- a/record-and-playback/core/scripts/utils/gen_webvtt
+++ b/record-and-playback/core/scripts/utils/gen_webvtt
@@ -383,6 +383,11 @@ def parse_events(directory="."):
                 have_record_events = True
             elif name == "EditCaptionHistoryEvent":
                 parse_caption_edit(event, element)
+                if event["locale"] is None:
+                    logger.warn(
+                        "Skipping invalid caption event with unset locale. See https://github.com/bigbluebutton/bigbluebutton/issues/19178 for details"
+                    )
+                    continue
             else:
                 logger.debug("Unhandled event: %s", name)
                 continue


### PR DESCRIPTION
This is a workaround for #19178 - but it does not fix the issue. The caption recording events with invalid empty `<locale/>` are simply dropped with a warning message, to allow the recording and any valid caption streams present to be processed.

This workaround also needs to be applied to 3.0; the commit is trivial to cherry-pick. It also applies to 2.6, but I'm not sure if it's important enough to be worth a new 2.6 release?