### PR TITLE
fix: Aviod presentation conversion causing a crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -595,6 +595,7 @@ class PresentationUploader extends Component {
 
     commands[newCurrentIndex] = {
       $apply: (presentation) => {
+        if (!presentation) return;
         const p = presentation;
         p.isCurrent = true;
         return p;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Checks if a presentation object is undefined before trying to set its `isCurrent` value. Addresses a rare crash.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Mitigates https://github.com/bigbluebutton/bigbluebutton/issues/19601 but does not fully close it.


### Motivation

<!-- What inspired you to submit this pull request? -->

### More
This patch avoids the crash but I am not quite sure of the exact reason why this object is undefined in some cases.
Also, it seems in some cases the list of presentations in the dialog is missing one of the presentations (with this patch). On re-opening of the dialog it seems fine. Let's see if others perhaps have better ideas about patching this.

In order to debug this and try the fix I resorted to spinning up a temporary 2.7.4 server with a dev environment. I used the ./deploy_to_usr_share.sh script in bbb-html5 to deploy changes as I could not hit the issue while in dev mode. **I am happy to assist with the testing or further investigation work.**
