### PR TITLE
Fix: Modal of the inactivity inspection does not show up

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
@@ -97,6 +97,8 @@ class ActivityCheck extends Component {
         onRequestClose={handleInactivityDismiss}
         shouldCloseOnOverlayClick={false}
         shouldShowCloseButton={false}
+        priority="high"
+        isOpen
       >
         <Styled.ActivityModalContent>
           <h1>{intl.formatMessage(intlMessages.activityCheckTitle)}</h1>


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the inactivity modal was not popping up.

### Closes Issue(s)

#18917
