### PR TITLE
fix: external video z-index

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/styles.ts
@@ -16,7 +16,7 @@ export const Container = styled.span<ContainerProps>`
   position: absolute;
   pointer-events: inherit;
   background: var(--color-black);
-  z-index: 5;
+
   ${({ isResizing }) => isResizing && `
     pointer-events: none;
   `}


### PR DESCRIPTION
### What does this PR do?

Adjusts external video z-index value so emoji rain does not go behind it

#### before

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/09f27f0d-ec9a-47b4-99a1-6bfb1f03eafc

#### after

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/953e0d9a-11be-4acb-9d1c-012f07df460f



