### PR TITLE
fix: poll results on chat export

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
@@ -22,6 +22,7 @@ query getChatMessageHistory {
     message
     messageId
     messageType
+    messageMetadata
     chatEmphasizedText
     createdAt
     user {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -2,11 +2,16 @@ import { Message } from '/imports/ui/Types/message';
 import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { IntlShape, defineMessages } from 'react-intl';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
+import PollService from '/imports/ui/components/poll/service';
 
 const intlMessages = defineMessages({
   chatClear: {
     id: 'app.chat.clearPublicChatMessage',
     description: 'message of when clear the public chat',
+  },
+  pollResult: {
+    id: 'app.chat.pollResult',
+    description: 'used in place of user name who published poll to chat',
   },
 });
 
@@ -29,13 +34,22 @@ export const generateExportedMessages = (
     const hour = date.getHours().toString().padStart(2, '0');
     const min = date.getMinutes().toString().padStart(2, '0');
     const hourMin = `[${hour}:${min}]`;
-    const userName = message.user ? `[${message.user.name} : ${message.user.role}]: ` : '';
+    let userName = message.user ? `[${message.user.name} : ${message.user.role}]: ` : '';
     let messageText = '';
 
     switch (message.messageType) {
       case ChatMessageType.CHAT_CLEAR:
         messageText = intl.formatMessage(intlMessages.chatClear);
         break;
+      case ChatMessageType.POLL: {
+        userName = `${intl.formatMessage(intlMessages.pollResult)}:\n`;
+
+        const metadata = JSON.parse(message.messageMetadata);
+        const pollText = htmlDecode(PollService.getPollResultString(metadata, intl).split('<br/>').join('\n'));
+        // remove last \n to avoid empty line
+        messageText = pollText.slice(0, -1);
+        break;
+      }
       case ChatMessageType.TEXT:
       default:
         messageText = htmlDecode(message.message);


### PR DESCRIPTION
### What does this PR do?

Restores poll results on chat export

#### before

![2024-02-09_10-12](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/b6f1bd43-40fd-4f4a-9c80-0d140e24b36d)

#### after

![2024-02-09_10-11](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/3e6b2923-4e8f-4b6e-8d13-b5656a2af8f8)
