### PR TITLE
Fix: Poll results in chat showing the wrong graphic

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -58,13 +58,13 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
       <Styled.PollText>
         {pollData.questionText}
       </Styled.PollText>
-      <ResponsiveContainer width="90%" height={250}>
+      <ResponsiveContainer width="90%" height={500}>
         <BarChart
           data={pollData.answers}
           layout="vertical"
         >
           <XAxis type="number" />
-          <YAxis width={70} type="category" dataKey="key" />
+          <YAxis width={80} type="category" dataKey="key" />
           <Bar dataKey="numVotes" fill="#0C57A7" />
         </BarChart>
       </ResponsiveContainer>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -53,12 +53,13 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
 }) => {
   const pollData = JSON.parse(string) as unknown;
   assertAsMetadata(pollData);
+  const height = pollData.answers.length * 50;
   return (
     <div data-test="chatPollMessageText">
       <Styled.PollText>
         {pollData.questionText}
       </Styled.PollText>
-      <ResponsiveContainer width="90%" height={500}>
+      <ResponsiveContainer width="90%" height={height}>
         <BarChart
           data={pollData.answers}
           layout="vertical"


### PR DESCRIPTION
### What does this PR do?

This PR aims to fix a bgu where the graphic for poll results in chat were visually incorrect.

### More

After the fix:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/504833ec-9296-4a32-a899-eb2b2902f5c7)

