### PR TITLE
refactor (events.xml): Record raiseHand, away and reaction events

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -85,6 +85,9 @@ class RedisRecorderActor(
       case m: UserLeftMeetingEvtMsg                 => handleUserLeftMeetingEvtMsg(m)
       case m: PresenterAssignedEvtMsg               => handlePresenterAssignedEvtMsg(m)
       case m: UserEmojiChangedEvtMsg                => handleUserEmojiChangedEvtMsg(m)
+      case m: UserAwayChangedEvtMsg                 => handleUserAwayChangedEvtMsg(m)
+      case m: UserRaiseHandChangedEvtMsg            => handleUserRaiseHandChangedEvtMsg(m)
+      case m: UserReactionEmojiChangedEvtMsg        => handleUserReactionEmojiChangedEvtMsg(m)
       case m: UserRoleChangedEvtMsg                 => handleUserRoleChangedEvtMsg(m)
       case m: UserBroadcastCamStartedEvtMsg         => handleUserBroadcastCamStartedEvtMsg(m)
       case m: UserBroadcastCamStoppedEvtMsg         => handleUserBroadcastCamStoppedEvtMsg(m)
@@ -377,6 +380,18 @@ class RedisRecorderActor(
   }
   private def handleUserEmojiChangedEvtMsg(msg: UserEmojiChangedEvtMsg) {
     handleUserStatusChange(msg.header.meetingId, msg.body.userId, "emojiStatus", msg.body.emoji)
+  }
+
+  private def handleUserAwayChangedEvtMsg(msg: UserAwayChangedEvtMsg) {
+    handleUserStatusChange(msg.header.meetingId, msg.body.userId, "away", if (msg.body.away) "true" else "false")
+  }
+
+  private def handleUserRaiseHandChangedEvtMsg(msg: UserRaiseHandChangedEvtMsg) {
+    handleUserStatusChange(msg.header.meetingId, msg.body.userId, "raiseHand", if (msg.body.raiseHand) "true" else "false")
+  }
+
+  private def handleUserReactionEmojiChangedEvtMsg(msg: UserReactionEmojiChangedEvtMsg) {
+    handleUserStatusChange(msg.header.meetingId, msg.body.userId, "reactionEmoji", msg.body.reactionEmoji)
   }
 
   private def handleUserRoleChangedEvtMsg(msg: UserRoleChangedEvtMsg) {


### PR DESCRIPTION
Add new events to be handled by `RedisRecorderActor`:
- Away
- Raise Hand
- Reaction

It will be recorded using the event `ParticipantStatusChangeEvent`:

```xml
<recording>
  <event timestamp="7192468" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2024-02-13T09:37:40.314-03</date>
    <status>reactionEmoji</status>
    <userId>w_xovgdgnftlik</userId>
    <value>👍</value>
    <timestampUTC>1707827860314</timestampUTC>
  </event>
  <event timestamp="7195174" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2024-02-13T09:37:43.020-03</date>
    <status>raiseHand</status>
    <userId>w_ehofmeh9rkmy</userId>
    <value>true</value>
    <timestampUTC>1707827863020</timestampUTC>
  </event>
  <event timestamp="7197737" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2024-02-13T09:37:45.583-03</date>
    <status>away</status>
    <userId>w_ehofmeh9rkmy</userId>
    <value>true</value>
    <timestampUTC>1707827865583</timestampUTC>
  </event>
  <event timestamp="7199490" module="PARTICIPANT" eventname="ParticipantStatusChangeEvent">
    <date>2024-02-13T09:37:47.336-03</date>
    <status>away</status>
    <userId>w_ehofmeh9rkmy</userId>
    <value>false</value>
    <timestampUTC>1707827867336</timestampUTC>
  </event>
  <event timestamp="7210113" module="PARTICIPANT" eventname="EndAndKickAllEvent">
    <reason>ENDED_AFTER_USER_LOGGED_OUT</reason>
    <date>2024-02-13T09:37:57.959-03</date>
    <timestampUTC>1707827877959</timestampUTC>
  </event>
</recording>
```

Closes #19617
Related: #18121

Once it is approved I will send a backport to 2.7.