### PR TITLE
Client: Poll answer verification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -217,7 +217,7 @@ class LiveResult extends PureComponent {
           ? (
             <Styled.ButtonsActions>
               <Styled.PublishButton
-                disabled={!isMeteorConnected || currentPoll.answers.length === 0}
+                disabled={!isMeteorConnected || !currentPoll.responses}
                 onClick={() => {
                   Session.set('pollInitiated', false);
                   publishPoll(currentPoll?.id);
@@ -248,9 +248,8 @@ class LiveResult extends PureComponent {
               color="primary"
               data-test="restartPoll"
             />
-          )
-        }
-        {currentPoll && currentPoll.answers.length === 0
+          )}
+        {currentPoll && !currentPoll.responses
         && intl.formatMessage(intlMessages.noAnswersLabel)}
         <Styled.Separator />
         { currentPoll && !currentPoll.secretPoll

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -41,6 +41,10 @@ const intlMessages = defineMessages({
     id: 'app.poll.liveResult.secretLabel',
     description: 'label shown instead of users in poll responses if poll is secret',
   },
+  noAnswersLabel: {
+    id: 'app.poll.noAnswerWarning',
+    description: 'label shown when no answers have been received',
+  },
 });
 
 const getResponseString = (obj) => {
@@ -213,7 +217,7 @@ class LiveResult extends PureComponent {
           ? (
             <Styled.ButtonsActions>
               <Styled.PublishButton
-                disabled={!isMeteorConnected}
+                disabled={!isMeteorConnected || currentPoll.answers.length === 0}
                 onClick={() => {
                   Session.set('pollInitiated', false);
                   publishPoll(currentPoll?.id);
@@ -246,6 +250,8 @@ class LiveResult extends PureComponent {
             />
           )
         }
+        {currentPoll && currentPoll.answers.length === 0
+        && intl.formatMessage(intlMessages.noAnswersLabel)}
         <Styled.Separator />
         { currentPoll && !currentPoll.secretPoll
           ? (

--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/styles.js
@@ -172,6 +172,7 @@ const ButtonsActions = styled.div`
 
 const PublishButton = styled(Button)`
   width: 48%;
+  margin-bottom: ${smPaddingY};
   overflow-wrap: break-word;
   white-space: pre-wrap;
 `;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -395,6 +395,7 @@
     "app.poll.showRespDesc": "Displays response configuration",
     "app.poll.addRespDesc": "Adds poll response input",
     "app.poll.deleteRespDesc": "Removes option {0}",
+    "app.poll.noAnswerWarning": "To publish a poll, at least one response is required",
     "app.poll.t": "True",
     "app.poll.f": "False",
     "app.poll.tf": "True / False",

--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -69,7 +69,7 @@ test.describe.parallel('Notifications', () => {
   });
 
   test.describe.parallel('Presenter @ci', () => {
-    test('Poll results notification', async ({ browser, context, page }) => {
+    test('Poll results notification @flaky', async ({ browser, context, page }) => {
       const presenterNotifications = new PresenterNotifications(browser, context);
       await presenterNotifications.initModPage(page);
       await presenterNotifications.publishPollResults();

--- a/bigbluebutton-tests/playwright/polling/polling.spec.js
+++ b/bigbluebutton-tests/playwright/polling/polling.spec.js
@@ -53,7 +53,7 @@ test.describe('Polling', async () => {
   });
 
   // Results
-  test('Poll results in chat message @ci', async () => {
+  test('Poll results in chat message @ci @flaky', async () => {
     await polling.pollResultsOnChat();
   });
 


### PR DESCRIPTION
### What does this PR do?

This pull request introduces an answer verification feature for polls.

### Motivation

The motivation behind this update stems from instances where polls remained unanswered, leading to unexpected behaviors like system messages lacking content for Typed polls or displaying empty graphic responses in True or False polls.

### More

Now polling modal look after the changes:

No answers: 
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/effb5c55-a990-45a3-ab92-d5ea87869169)

With answers:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/0e54f2a5-13e1-4799-8129-ea607ced850c)

