### PR TITLE
Fix: Inactivity modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/activity-check/component.jsx
@@ -97,6 +97,8 @@ class ActivityCheck extends Component {
         onRequestClose={handleInactivityDismiss}
         shouldCloseOnOverlayClick={false}
         shouldShowCloseButton={false}
+        priority="high"
+        isOpen
       >
         <Styled.ActivityModalContent>
           <h1>{intl.formatMessage(intlMessages.activityCheckTitle)}</h1>


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the inactivity modal was not popping up.

### Closes Issue(s)

Does not close any issues in 30, but 30 has the same bug that happened in 27, mentioned in issue https://github.com/bigbluebutton/bigbluebutton/issues/18917 