### PR TITLE
Introduces a ping-pong mechanism designed to verify the availability of a middleware service

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
@@ -10,7 +10,7 @@ import org.bigbluebutton.core.bus._
 import org.bigbluebutton.core.pubsub.senders.ReceivedJsonMsgHandlerActor
 import org.bigbluebutton.core2.AnalyticsActor
 import org.bigbluebutton.core2.FromAkkaAppsMsgSenderActor
-import org.bigbluebutton.endpoint.redis.{AppsRedisSubscriberActor, ExportAnnotationsActor, GraphqlActionsActor, LearningDashboardActor, RedisRecorderActor}
+import org.bigbluebutton.endpoint.redis.{AppsRedisSubscriberActor, ExportAnnotationsActor, GraphqlConnectionsActor, LearningDashboardActor, RedisRecorderActor}
 import org.bigbluebutton.common2.bus.IncomingJsonMessageBus
 import org.bigbluebutton.service.{HealthzService, MeetingInfoActor, MeetingInfoService}
 
@@ -67,9 +67,9 @@ object Boot extends App with SystemConfiguration {
     "LearningDashboardActor"
   )
 
-  val graphqlActionsActor = system.actorOf(
-    GraphqlActionsActor.props(system, eventBus),
-    "GraphqlActionsActor"
+  val graphqlConnectionsActor = system.actorOf(
+    GraphqlConnectionsActor.props(system, eventBus, outGW),
+    "GraphqlConnectionsActor"
   )
 
   ClientSettings.loadClientSettingsFromFile()
@@ -89,8 +89,8 @@ object Boot extends App with SystemConfiguration {
   outBus2.subscribe(learningDashboardActor, outBbbMsgMsgChannel)
   bbbMsgBus.subscribe(learningDashboardActor, analyticsChannel)
 
-  eventBus.subscribe(graphqlActionsActor, meetingManagerChannel)
-  bbbMsgBus.subscribe(graphqlActionsActor, analyticsChannel)
+  eventBus.subscribe(graphqlConnectionsActor, meetingManagerChannel)
+  bbbMsgBus.subscribe(graphqlConnectionsActor, analyticsChannel)
 
   val bbbActor = system.actorOf(BigBlueButtonActor.props(system, eventBus, bbbMsgBus, outGW, healthzService), "bigbluebutton-actor")
   eventBus.subscribe(bbbActor, meetingManagerChannel)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -83,6 +83,7 @@ class BigBlueButtonActor(
       case m: ValidateConnAuthTokenSysMsg            => handleValidateConnAuthTokenSysMsg(m)
       case _: UserGraphqlConnectionEstablishedSysMsg => //Ignore
       case _: UserGraphqlConnectionClosedSysMsg      => //Ignore
+      case _: CheckGraphqlMiddlewareAlivePongSysMsg  => //Ignore
       case _                                         => log.warning("Cannot handle " + msg.envelope.name)
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -462,6 +462,9 @@ class ReceivedJsonMsgHandlerActor(
       case UserGraphqlConnectionClosedSysMsg.NAME =>
         route[UserGraphqlConnectionClosedSysMsg](meetingManagerChannel, envelope, jsonNode)
 
+      case CheckGraphqlMiddlewareAlivePongSysMsg.NAME =>
+        route[CheckGraphqlMiddlewareAlivePongSysMsg](meetingManagerChannel, envelope, jsonNode)
+
       case _ =>
         log.error("Cannot route envelope name " + envelope.name)
       // do nothing

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -256,6 +256,16 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildCheckGraphqlMiddlewareAlivePingSysMsg(middlewareUid: String): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.SYSTEM, "", "")
+    val envelope = BbbCoreEnvelope(CheckGraphqlMiddlewareAlivePingSysMsg.NAME, routing)
+    val header = BbbCoreHeaderWithMeetingId(CheckGraphqlMiddlewareAlivePingSysMsg.NAME, "")
+    val body = CheckGraphqlMiddlewareAlivePingSysMsgBody(middlewareUid)
+    val event = CheckGraphqlMiddlewareAlivePingSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
   def buildEjectAllFromVoiceConfMsg(meetingId: String, voiceConf: String): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(EjectAllFromVoiceConfMsg.NAME, routing)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/GraphqlConnectionsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/GraphqlConnectionsActor.scala
@@ -2,18 +2,28 @@ package org.bigbluebutton.endpoint.redis
 
 import org.apache.pekko.actor.{Actor, ActorLogging, ActorSystem, Props}
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.OutMessageGateway
 import org.bigbluebutton.core.api.{UserClosedAllGraphqlConnectionsInternalMsg, UserEstablishedGraphqlConnectionInternalMsg}
 import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
 import org.bigbluebutton.core.db.UserGraphqlConnectionDAO
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
-object GraphqlActionsActor {
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import ExecutionContext.Implicits.global
+
+case object CheckGraphqlMiddlewareAlive
+
+object GraphqlConnectionsActor {
   def props(system: ActorSystem,
             eventBus:       InternalEventBus,
+            outGW:          OutMessageGateway,
            ): Props =
     Props(
-      classOf[GraphqlActionsActor],
+      classOf[GraphqlConnectionsActor],
       system,
       eventBus,
+      outGW,
     )
 }
 
@@ -31,18 +41,24 @@ case class GraphqlUserConnection(
                )
 
 
-class GraphqlActionsActor(
+class GraphqlConnectionsActor(
     system:         ActorSystem,
     val eventBus:   InternalEventBus,
+    val outGW:      OutMessageGateway,
 ) extends Actor with ActorLogging {
 
   private var users: Map[String, GraphqlUser] = Map()
   private var graphqlConnections: Map[String, GraphqlUserConnection] = Map()
+  private var pendingResponseMiddlewareUIDs: Map[String, BigInt] = Map()
+
+  system.scheduler.schedule(10.seconds, 10.seconds, self, CheckGraphqlMiddlewareAlive)
+  private val maxMiddlewareInactivityInMillis = 11000
 
   def receive = {
     //=============================
     // 2x messages
     case msg: BbbCommonEnvCoreMsg => handleBbbCommonEnvCoreMsg(msg)
+    case CheckGraphqlMiddlewareAlive => checkGraphqlMiddlewareAlive()
     case _                        => // do nothing
   }
 
@@ -53,6 +69,7 @@ class GraphqlActionsActor(
       // Messages from bbb-graphql-middleware
       case m: UserGraphqlConnectionEstablishedSysMsg  => handleUserGraphqlConnectionEstablishedSysMsg(m)
       case m: UserGraphqlConnectionClosedSysMsg       => handleUserGraphqlConnectionClosedSysMsg(m)
+      case m: CheckGraphqlMiddlewareAlivePongSysMsg   => handleCheckGraphqlMiddlewareAlivePongSysMsg(m)
       case _                                          => // message not to be handled.
     }
   }
@@ -71,7 +88,7 @@ class GraphqlActionsActor(
   }
 
   private def handleUserGraphqlConnectionEstablishedSysMsg(msg: UserGraphqlConnectionEstablishedSysMsg): Unit = {
-    UserGraphqlConnectionDAO.insert(msg.body.sessionToken, msg.body.browserConnectionId)
+    UserGraphqlConnectionDAO.insert(msg.body.sessionToken, msg.body.middlewareUID, msg.body.browserConnectionId)
 
     for {
       user <- users.get(msg.body.sessionToken)
@@ -92,18 +109,58 @@ class GraphqlActionsActor(
   }
 
   private def handleUserGraphqlConnectionClosedSysMsg(msg: UserGraphqlConnectionClosedSysMsg): Unit = {
-    UserGraphqlConnectionDAO.updateClosed(msg.body.sessionToken, msg.body.browserConnectionId)
+    handleUserGraphqlConnectionClosed(msg.body.sessionToken, msg.body.middlewareUID, msg.body.browserConnectionId)
+  }
+
+  private def handleUserGraphqlConnectionClosed(sessionToken: String, middlewareUID: String, browserConnectionId: String): Unit = {
+    UserGraphqlConnectionDAO.updateClosed(sessionToken, middlewareUID, browserConnectionId)
 
     for {
-      user <- users.get(msg.body.sessionToken)
+      user <- users.get(sessionToken)
     } yield {
-      graphqlConnections = graphqlConnections.-(msg.body.browserConnectionId)
+      graphqlConnections = graphqlConnections.-(browserConnectionId)
 
       //Send internal message informing user disconnected
-      if (!graphqlConnections.values.exists(c => c.sessionToken == msg.body.sessionToken)) {
+      if (!graphqlConnections.values.exists(c => c.sessionToken == sessionToken)) {
         eventBus.publish(BigBlueButtonEvent(user.meetingId, UserClosedAllGraphqlConnectionsInternalMsg(user.intId)))
       }
     }
+  }
+
+  private def checkGraphqlMiddlewareAlive(): Unit = {
+    //Remove all connections from middleware if it didn't answer within 11 seconds
+    for {
+      (middlewareUid, pingSentAt) <- pendingResponseMiddlewareUIDs
+      if (System.currentTimeMillis - pingSentAt) > maxMiddlewareInactivityInMillis
+    } yield {
+      log.info("Removing connections from the middleware {} due to inactivity of the service.",middlewareUid)
+      for {
+        (_, graphqlConn) <- graphqlConnections
+        if graphqlConn.middlewareUID == middlewareUid
+      } yield {
+        handleUserGraphqlConnectionClosed(graphqlConn.sessionToken, graphqlConn.middlewareUID, graphqlConn.browserConnectionId)
+      }
+
+      pendingResponseMiddlewareUIDs -= middlewareUid
+    }
+
+    //Send Ping message to all middlewares with established connections
+    graphqlConnections.map(c => {
+      c._2.middlewareUID
+    }).toVector.distinct.map(middlewareUID => {
+      val event = MsgBuilder.buildCheckGraphqlMiddlewareAlivePingSysMsg(middlewareUID)
+      outGW.send(event)
+      log.debug(s"Sent ping message from graphql middleware ${middlewareUID}.")
+      pendingResponseMiddlewareUIDs.get(middlewareUID) match {
+        case None => pendingResponseMiddlewareUIDs += (middlewareUID -> System.currentTimeMillis)
+        case _ => //Ignore
+      }
+    })
+  }
+
+  private def handleCheckGraphqlMiddlewareAlivePongSysMsg(msg: CheckGraphqlMiddlewareAlivePongSysMsg): Unit = {
+    log.debug(s"Received pong message from graphql middleware ${msg.body.middlewareUID}.")
+    pendingResponseMiddlewareUIDs -= msg.body.middlewareUID
   }
 
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/SystemMsgs.scala
@@ -235,6 +235,26 @@ case class DeletedRecordingSysMsgBody(recordId: String)
 /**
  * Sent from akka-apps to graphql-middleware
  */
+object CheckGraphqlMiddlewareAlivePingSysMsg { val NAME = "CheckGraphqlMiddlewareAlivePingSysMsg" }
+case class CheckGraphqlMiddlewareAlivePingSysMsg(
+    header: BbbCoreHeaderWithMeetingId,
+    body:   CheckGraphqlMiddlewareAlivePingSysMsgBody
+) extends BbbCoreMsg
+case class CheckGraphqlMiddlewareAlivePingSysMsgBody(middlewareUID: String)
+
+/**
+ * Sent from graphql-middleware to akka-apps
+ */
+object CheckGraphqlMiddlewareAlivePongSysMsg { val NAME = "CheckGraphqlMiddlewareAlivePongSysMsg" }
+case class CheckGraphqlMiddlewareAlivePongSysMsg(
+    header: BbbCoreBaseHeader,
+    body:   CheckGraphqlMiddlewareAlivePongSysMsgBody
+) extends BbbCoreMsg
+case class CheckGraphqlMiddlewareAlivePongSysMsgBody(middlewareUID: String)
+
+/**
+ * Sent from akka-apps to graphql-middleware
+ */
 object ForceUserGraphqlReconnectionSysMsg { val NAME = "ForceUserGraphqlReconnectionSysMsg" }
 case class ForceUserGraphqlReconnectionSysMsg(
     header: BbbCoreHeaderWithMeetingId,

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -714,6 +714,7 @@ CREATE INDEX "idx_user_connectionStatusMetrics_UnstableReport" ON "user_connecti
 CREATE TABLE "user_graphqlConnection" (
 	"graphqlConnectionId" serial PRIMARY KEY,
 	"sessionToken" varchar(16),
+	"middlewareUID" varchar(36),
 	"middlewareConnectionId" varchar(12),
 	"establishedAt" timestamp with time zone,
 	"closedAt" timestamp with time zone


### PR DESCRIPTION
This PR introduces a ping-pong mechanism designed to verify the availability of a middleware service. If the middleware fails to respond, the Akka-applications will infer that the middleware has crashed and will proceed to terminate all connections associated with it. This is a critical step to ensure that users from a process that has been terminated are not mistakenly treated as active participants in the meeting indefinitely.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/de3e37af-2869-465b-8fbd-d5d4650d217c)