### PR TITLE
fix: Taking the presenter plays the external video again

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -266,7 +266,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   };
 
-  const handleOnPause = () => {
+  const handleOnStop = () => {
     if (isPresenter) {
       const rate = playerRef.current?.getInternalPlayer()?.getPlaybackRate() as number ?? 1;
       const currentTime = playerRef.current?.getCurrentTime() ?? 0;
@@ -341,7 +341,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
             setPlayed(state.played);
             setLoaded(state.loaded);
           }}
-          onPause={handleOnPause}
+          onPause={handleOnStop}
+          onEnded={handleOnStop}
           muted={mute}
         />
         {


### PR DESCRIPTION
### What does this PR do?

Adds onEnded event to stop video playback for all users when external video ends.

### Closes Issue(s)
Closes #19620