### PR TITLE
feat(config): Add option to disabled "Download session data" on Learning Dashboard

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -20,6 +20,7 @@ case class Meeting(
   intId: String,
   extId: String,
   name:  String,
+  downloadSessionDataEnabled: Boolean,
   users: Map[String, User] = Map(),
   polls: Map[String, Poll] = Map(),
   screenshares: Vector[Screenshare] = Vector(),
@@ -585,6 +586,7 @@ class LearningDashboardActor(
         msg.body.props.meetingProp.intId,
         msg.body.props.meetingProp.extId,
         msg.body.props.meetingProp.name,
+        downloadSessionDataEnabled = !msg.body.props.meetingProp.disabledFeatures.contains("learningDashboardDownloadSessionData"),
       )
 
       meetings += (newMeeting.intId -> newMeeting)

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -54,8 +54,11 @@ class App extends React.Component {
     const { intl } = this.props;
     const { activitiesJson } = this.state;
     const {
-      name: meetingName, createdOn, users, polls,
+      name: meetingName, createdOn, users, polls, downloadSessionDataEnabled,
     } = activitiesJson;
+
+    if (downloadSessionDataEnabled === false) return;
+
     const link = document.createElement('a');
     const data = makeUserCSVData(users, polls, intl);
     const filename = `LearningDashboard_${meetingName}_${new Date(createdOn).toISOString().substr(0, 10)}.csv`.replace(/ /g, '-');
@@ -581,17 +584,23 @@ class App extends React.Component {
               }
             </p>
           </div>
-          <button
-            data-test="downloadSessionDataDashboard"
-            type="button"
-            className="border-2 text-gray-700 border-gray-200 rounded-md px-4 py-2 bg-white focus:outline-none focus:ring ring-offset-2 focus:ring-gray-500 focus:ring-opacity-50"
-            onClick={this.handleSaveSessionData.bind(this)}
-          >
-            <FormattedMessage
-              id="app.learningDashboard.downloadSessionDataLabel"
-              defaultMessage="Download Session Data"
-            />
-          </button>
+          {
+            (activitiesJson.downloadSessionDataEnabled || false)
+              ? (
+                <button
+                  data-test="downloadSessionDataDashboard"
+                  type="button"
+                  className="border-2 text-gray-700 border-gray-200 rounded-md px-4 py-2 bg-white focus:outline-none focus:ring ring-offset-2 focus:ring-gray-500 focus:ring-opacity-50"
+                  onClick={this.handleSaveSessionData.bind(this)}
+                >
+                  <FormattedMessage
+                    id="app.learningDashboard.downloadSessionDataLabel"
+                    defaultMessage="Download Session Data"
+                  />
+                </button>
+              )
+              : null
+          }
         </div>
       </div>
     );

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -441,11 +441,13 @@ endWhenNoModerator=false
 endWhenNoModeratorDelayInMinutes=1
 
 # List of features to disable (comma-separated)
+# https://docs.bigbluebutton.org/3.0/development/api/#create
 # Available options:
-# chat, sharedNotes, polls, screenshare, externalVideos, presentation, downloadPresentationWithAnnotations
-# learningDashboard, layouts, captions, liveTranscription, virtualBackgrounds, customVirtualBackgrounds
-# breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms, 
-# downloadPresentationOriginalFile, downloadPresentationConvertedToPdf
+# chat, sharedNotes, polls, screenshare, externalVideos, layouts, captions, liveTranscription,
+# breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms,
+# presentation, downloadPresentationWithAnnotations, downloadPresentationOriginalFile, downloadPresentationConvertedToPdf,
+# learningDashboard, learningDashboardDownloadSessionData,
+# virtualBackgrounds, customVirtualBackgrounds,
 disabledFeatures=
 
 # Notify users that recording is on


### PR DESCRIPTION
Introduces `disabledFeatures=learningDashboardDownloadSessionData`

[screen-recorder-wed-feb-14-2024-10-14-13.webm](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/e07512db-20bd-4aa2-ab49-1d5f9c85b466)


Related #14203