### PR TITLE
Create an endpoint to get client-startup-settings via REST API

### DIFF
--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -18,3 +18,15 @@
               }
             }
           }
+      - name: clientStartupSettings
+        query: |
+          query clientStartupSettings {
+            meeting_clientSettings {
+              askForFeedbackOnLogout: clientSettingsJson(path: "$.public.app.askForFeedbackOnLogout")
+              allowDefaultLogoutUrl: clientSettingsJson(path: "$.public.app.allowDefaultLogoutUrl")
+              learningDashboardBase: clientSettingsJson(path: "$.public.app.learningDashboardBase")
+              fallbackLocale: clientSettingsJson(path: "$.public.app.defaultSettings.application.fallbackLocale")
+              fallbackOnEmptyString: clientSettingsJson(path: "$.public.app.fallbackOnEmptyLocaleString")
+              clientLog: clientSettingsJson(path: "$.public.clientLog")
+            }
+          }

--- a/bbb-graphql-server/metadata/rest_endpoints.yaml
+++ b/bbb-graphql-server/metadata/rest_endpoints.yaml
@@ -2,6 +2,15 @@
   definition:
     query:
       collection_name: allowed-queries
+      query_name: clientStartupSettings
+  methods:
+    - GET
+  name: clientStartupSettings
+  url: clientStartupSettings
+- comment: ""
+  definition:
+    query:
+      collection_name: allowed-queries
       query_name: UserCurrent
   methods:
     - GET


### PR DESCRIPTION
In favor of #19507
This PR introduces a new Hasura REST endpoint `api/rest/clientStartupSettings` that will return the props used by the client before rendering the meeting itself.

- askForFeedbackOnLogout
- allowDefaultLogoutUrl
- learningDashboardBase
- fallbackLocale
- fallbackOnEmptyString
- clientLog


A similar strategy was previously used on https://github.com/bigbluebutton/bigbluebutton/blob/7d1f2a9f18a319f582e60a21dfefd37d4758eb91/bigbluebutton-html5/private/static/guest-wait/guest-wait.html#L293

How to test it:
```js
const sessionToken = 'd2c0q6nrhq7czhzn';
const GUEST_WAIT_ENDPOINT = '/api/rest/clientStartupSettings/';
const url = new URL(`${window.location.origin}${GUEST_WAIT_ENDPOINT}`);
const headers = new Headers({'X-Session-Token': sessionToken,'Content-Type': 'application/json',});

fetch(url, { method: 'get', headers: headers })
.then(resp => resp.json())
.then(data => {
        const settings = data.meeting_clientSettings[0];
        console.log(settings);
     }
);
```

And it will return:
```json
{
    "askForFeedbackOnLogout": false,
    "allowDefaultLogoutUrl": true,
    "learningDashboardBase": "/learning-analytics-dashboard",
    "fallbackLocale": "en",
    "fallbackOnEmptyString": true,
    "clientLog": {
        "server": {
            "level": "info",
            "enabled": false
        },
        "console": {
            "level": "debug",
            "enabled": true
        },
        "external": {
            "url": "https://LOG_HOST/html5Log",
            "level": "info",
            "logTag": "",
            "method": "POST",
            "enabled": false,
            "flushOnClose": true,
            "throttleInterval": 400
        }
    }
}
```

My test:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/00abc6a6-3990-4757-bc20-5f01163347d7)
