### PR TITLE
fix(layout): priority for determining whether presentation is open

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -67,6 +67,7 @@ class PushLayoutEngine extends React.Component {
       shouldShowExternalVideo,
       enforceLayout,
       setLocalSettings,
+      pushLayoutMeeting,
     } = this.props;
 
     const userLayout = LAYOUT_TYPE[getFromUserSettings('bbb_change_layout', false)];
@@ -81,9 +82,12 @@ class PushLayoutEngine extends React.Component {
 
     Settings.save(setLocalSettings);
 
-    const initialPresentation = !getFromUserSettings('bbb_hide_presentation_on_join', HIDE_PRESENTATION || !meetingPresentationIsOpen) || shouldShowScreenshare || shouldShowExternalVideo;
-    MediaService.setPresentationIsOpen(layoutContextDispatch, initialPresentation);
-    Session.set('presentationLastState', initialPresentation);
+    const shouldOpenPresentation = shouldShowScreenshare || shouldShowExternalVideo;
+    let presentationIsOpen = !getFromUserSettings('bbb_hide_presentation_on_join', HIDE_PRESENTATION);
+    presentationIsOpen = pushLayoutMeeting ? meetingPresentationIsOpen : presentationIsOpen;
+    presentationIsOpen = shouldOpenPresentation || presentationIsOpen;
+    MediaService.setPresentationIsOpen(layoutContextDispatch, presentationIsOpen);
+    Session.set('presentationLastState', presentationIsOpen);
 
     if (selectedLayout === 'custom') {
       setTimeout(() => {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

This PR determines a new priority for determining whether the presentation is open when the user enters a meeting as follows:

1. Check if the user has provided `userdata-bbb_hide_presentation_on_join` (`/join` parameter). If so, start with this value. If not, start with `hidePresentationOnJoin` defined in `settings.yml`.
2. If the presenter is pushing layout, overwrite the previous value with the meeting layout. Otherwise, keep the previous value.
3. If there is screensharing or external video sharing, open the presentation anyways, overwriting the previous value.

So, the priority order for determining whether the presentation should be opened is as follows:

`There is either screensharing or external video sharing` > `push layout` > `userdata-bbb_hide_presentation_on_join` > `hidePresentationOnJoin`.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #19456
Closes #17030