### PR TITLE
fix: intl invalid hook call

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intl.jsx
+++ b/bigbluebutton-html5/imports/startup/client/intl.jsx
@@ -185,18 +185,28 @@ class IntlStartup extends Component {
   }
 }
 
-const IntlStartupContainer = withTracker(() => {
+const IntlStartupContainer = (props) => {
+  const setLocalSettings = useUserChangedLocalSettings();
+
+  return (
+    <IntlStartup
+      {...{
+        setLocalSettings,
+        ...props,
+      }}
+    />
+  );
+};
+
+export default withTracker(() => {
   const { locale } = Settings.application;
   const overrideLocaleFromPassedParameter = getFromUserSettings('bbb_override_default_locale', null);
-  const setLocalSettings = useUserChangedLocalSettings();
+
   return {
     locale,
     overrideLocaleFromPassedParameter,
-    setLocalSettings,
   };
-})(IntlStartup);
-
-export default IntlStartupContainer;
+})(IntlStartupContainer);
 
 IntlStartup.propTypes = propTypes;
 IntlStartup.defaultProps = defaultProps;


### PR DESCRIPTION
### What does this PR do?

Fix invalid hook call error on intl component.

`Error: Invalid hook call. Hooks can only be called inside of the body of a function component.` 