### PR TITLE
style: adjust sidebar content styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/styles.js
@@ -1,6 +1,6 @@
 import styled, { css, keyframes } from 'styled-components';
 import {
-  mdPaddingX,
+  smPaddingX,
   borderSize,
   listItemBgHover, borderSizeSmall,
   borderRadius,
@@ -14,7 +14,7 @@ import {
   colorWhite,
   colorGrayLighter,
   colorGrayLightest,
-  colorBlueLight
+  colorBlueLight,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   headingsFontWeight,
@@ -91,7 +91,7 @@ const ellipsis = keyframes`
   to {
     width: 1.5em;
   }
-`
+`;
 
 const ConnectingAnimation = styled.span`
   &:after {
@@ -224,7 +224,7 @@ const Panel = styled(ScrollboxVertical)`
     radial-gradient(farthest-side at 50% 100%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
 
   background-color: #fff;
-  padding: ${mdPaddingX};
+  padding: ${smPaddingX};
   display: flex;
   flex-grow: 1;
   flex-direction: column;

--- a/bigbluebutton-html5/imports/ui/components/captions/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/captions/styles.js
@@ -1,14 +1,11 @@
 import styled from 'styled-components';
 import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
-import {
-  mdPaddingX,
-  mdPaddingY,
-} from '/imports/ui/stylesheets/styled-components/general';
+import { smPaddingX } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 
 const Captions = styled.div`
   background-color: ${colorWhite};
-  padding: ${mdPaddingY} ${mdPaddingY} ${mdPaddingX} ${mdPaddingX};
+  padding: ${smPaddingX};
   display: flex;
   flex-grow: 1;
   flex-direction: column;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 import {
-  smPaddingX,
   mdPaddingX,
-  mdPaddingY,
   borderRadius,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
@@ -17,18 +15,7 @@ export const MessageListWrapper = styled.div`
   position: relative;
   overflow-x: hidden;
   overflow-y: auto;
-  padding-left: ${smPaddingX};
-  margin-left: calc(-1 * ${mdPaddingX});
-  padding-right: ${smPaddingX};
-  margin-right: calc(-1 * ${mdPaddingY});
-  padding-bottom: ${mdPaddingX};
   z-index: 2;
-  [dir='rtl'] & {
-    padding-right: ${mdPaddingX};
-    margin-right: calc(-1 * ${mdPaddingX});
-    padding-left: ${mdPaddingY};
-    margin-left: calc(-1 * ${mdPaddingX});
-  }
 `;
 
 export const MessageList = styled(ScrollboxVertical)`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { colorWhite, colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
-import { mdPaddingX } from '/imports/ui/stylesheets/styled-components/general';
+import { smPaddingX } from '/imports/ui/stylesheets/styled-components/general';
 
 interface ChatProps {
   isChrome: boolean;
@@ -9,7 +9,7 @@ interface ChatProps {
 
 export const Chat = styled.div<ChatProps>`
   background-color: ${colorWhite};
-  padding: ${mdPaddingX};
+  padding: ${smPaddingX};
   padding-bottom: 0;
   display: flex;
   flex-grow: 1;

--- a/bigbluebutton-html5/imports/ui/components/notes/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/notes/styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import {
-  mdPaddingX,
+  smPaddingX,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
@@ -8,7 +8,7 @@ import CommonHeader from '/imports/ui/components/common/control-header/component
 
 const Notes = styled.div`
   background-color: ${colorWhite};
-  padding: ${mdPaddingX};
+  padding: ${smPaddingX};
   display: flex;
   flex-grow: 1;
   flex-direction: column;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
-import { borderSize, navbarHeight } from '/imports/ui/stylesheets/styled-components/general';
+import { borderSize, navbarHeight, smPaddingX } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly, mediumUp } from '/imports/ui/stylesheets/styled-components/breakpoints';
 
 const Poll = styled.div`
@@ -16,7 +16,7 @@ const Poll = styled.div`
   height: 100%;
   background-color: ${colorWhite};
   min-width: 20em;
-  padding: 1rem;
+  padding: ${smPaddingX};
 
   @media ${smallOnly} {
     top: 0;

--- a/bigbluebutton-html5/imports/ui/components/timer/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Service from './service';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
+import Header from '/imports/ui/components/common/control-header/component';
 import Styled from './styles';
 
 const intlMessages = defineMessages({
@@ -81,7 +82,6 @@ const propTypes = {
   }).isRequired,
   layoutContextDispatch: PropTypes.shape().isRequired,
   timeOffset: PropTypes.number.isRequired,
-  isRTL: PropTypes.bool.isRequired,
   isActive: PropTypes.bool.isRequired,
   isModerator: PropTypes.bool.isRequired,
   currentTrack: PropTypes.string.isRequired,
@@ -434,7 +434,6 @@ class Timer extends Component {
   render() {
     const {
       intl,
-      isRTL,
       isActive,
       isModerator,
       layoutContextDispatch,
@@ -453,16 +452,13 @@ class Timer extends Component {
       <Styled.TimerSidebarContent
         data-test="timer"
       >
-        <Styled.TimerHeader>
-          <Styled.TimerTitle>
-            <Styled.TimerMinimizeButton
-              onClick={() => Service.closePanel(layoutContextDispatch)}
-              aria-label={intl.formatMessage(intlMessages.hideTimerLabel)}
-              label={intl.formatMessage(message)}
-              icon={isRTL ? 'right_arrow' : 'left_arrow'}
-            />
-          </Styled.TimerTitle>
-        </Styled.TimerHeader>
+        <Header
+          leftButtonProps={{
+            onClick: () => { Service.closePanel(layoutContextDispatch); },
+            'aria-label': intl.formatMessage(intlMessages.hideTimerLabel),
+            label: intl.formatMessage(message),
+          }}
+        />
         {this.renderContent()}
       </Styled.TimerSidebarContent>
     );

--- a/bigbluebutton-html5/imports/ui/components/timer/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/container.jsx
@@ -115,13 +115,9 @@ const TimerContainer = ({ children, ...props }) => {
   );
 };
 
-export default withTracker(() => {
-  const isRTL = document.documentElement.getAttribute('dir') === 'rtl';
-  return {
-    isRTL,
-    isActive: Service.isActive(),
-    timeOffset: Service.getTimeOffset(),
-    timer: Service.getTimer(),
-    currentTrack: Service.getCurrentTrack(),
-  };
-})(TimerContainer);
+export default withTracker(() => ({
+  isActive: Service.isActive(),
+  timeOffset: Service.getTimeOffset(),
+  timer: Service.getTimer(),
+  currentTrack: Service.getCurrentTrack(),
+}))(TimerContainer);

--- a/bigbluebutton-html5/imports/ui/components/timer/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/timer/styles.js
@@ -2,9 +2,7 @@ import styled from 'styled-components';
 import {
   borderSize,
   borderSizeLarge,
-  mdPaddingX,
-  mdPaddingY,
-  pollHeaderOffset,
+  smPaddingX,
   toastContentWidth,
   borderRadius,
 } from '../../stylesheets/styled-components/general';
@@ -22,12 +20,7 @@ import Button from '/imports/ui/components/common/button/component';
 
 const TimerSidebarContent = styled.div`
   background-color: ${colorWhite};
-  padding:
-    ${mdPaddingX}
-    ${mdPaddingY}
-    ${mdPaddingX}
-    ${mdPaddingX};
-
+  padding: ${smPaddingX};
   display: flex;
   flex-grow: 1;
   flex-direction: column;
@@ -39,7 +32,6 @@ const TimerSidebarContent = styled.div`
 
 const TimerHeader = styled.header`
   position: relative;
-  top: ${pollHeaderOffset};
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/waiting-users-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/waiting-users-graphql/styles.ts
@@ -14,7 +14,7 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   borderSize,
-  mdPaddingX,
+  smPaddingX,
   mdPaddingY,
   userIndicatorsOffset,
   indicatorPadding,
@@ -198,8 +198,7 @@ const CustomButton = styled(Button)`
 
 const Panel = styled.div<PanelProps>`
   background-color: ${colorWhite};
-  padding: ${mdPaddingX} ${mdPaddingY} ${mdPaddingX} ${mdPaddingX};
-
+  padding: ${smPaddingX};
   display: flex;
   flex-grow: 1;
   flex-direction: column;


### PR DESCRIPTION
### What does this PR do?

- adjusts sidebar content panels left/right padding so the spacing in both sides is the same
- makes Timer panel use the same header component as the other panels

#### before
![sidebar-before](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/fde67317-99b4-4b88-aa92-8d59d25740bb)


#### after
![sidebar-after](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/46c8915c-19b4-4228-85e8-52ff8dc6561e)



### Motivation

