### PR TITLE
Prevent from exposing client private configs through Graphql

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -38,6 +38,9 @@ object ClientSettings extends SystemConfiguration {
             Map[String, Object]()
         }
       )
+
+    //Remove `:private` once it's used only by Meteor internally configs
+    clientSettingsFromFile -= "private"
   }
 
   def getClientSettingsWithOverride(clientSettingsOverrideJson: String): Map[String, Object] = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -39,7 +39,7 @@ object ClientSettings extends SystemConfiguration {
         }
       )
 
-    //Remove `:private` once it's used only by Meteor internally configs
+    //Remove `:private` once it's used only by Meteor internal configs
     clientSettingsFromFile -= "private"
   }
 


### PR DESCRIPTION
The `settings.yml` file includes sensitive configurations under the `:private` property. It is crucial that this information is not exposed to users via GraphQL. Additionally, there is no need for Akka applications to load these settings. Therefore, the purpose of this PR is to prevent Akka applications from reading these sensitive settings to enhance security measures.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/464cb2f0-24d3-4e6f-aacd-5a2c2b6e80c3)
