### PR TITLE
Introduces learningDashboard-AccessToken through Graphql

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -181,6 +181,7 @@ public class MeetingService implements MessageListener {
       removedUser.meetingId = us.meetingID;
       removedUser.userId = us.internalUserId;
       removedUser.sessionToken = us.authToken;
+      removedUser.role = us.role;
       removedSessions.put(token, removedUser);
       sessions.remove(token);
     } else {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSessionBasicData.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSessionBasicData.java
@@ -23,6 +23,11 @@ public class UserSessionBasicData {
   public String sessionToken = null;
   public String userId = null;
   public String meetingId = null;
+  public String role = null;
+
+  public Boolean isModerator() {
+    return "MODERATOR".equalsIgnoreCase(this.role);
+  }
 
   public String toString() {
     return meetingId + " " + userId + " " + sessionToken;

--- a/bbb-graphql-client-test/src/Auth.js
+++ b/bbb-graphql-client-test/src/Auth.js
@@ -90,6 +90,9 @@ export default function Auth() {
         meeting {
             name
             ended
+            learningDashboard {
+              learningDashboardAccessToken
+            }
         }
       }
     }`
@@ -130,6 +133,12 @@ export default function Auth() {
                     <span>You are waiting for approval.</span>
                     <span>{curr.guestStatusDetails.guestLobbyMessage}</span>
                     <span>Your position is: {curr.guestStatusDetails.positionInWaitingQueue}</span>
+                </div>
+            } else if(curr.loggedOut) {
+                return <div>
+                    {curr.meeting.name}
+                    <br/><br/>
+                    <span>You left the meeting.</span>
                 </div>
             } else if(!curr.joined) {
                 return <div>

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -798,6 +798,10 @@ from "meeting"
 left join "user" "user_ended" on "user_ended"."userId" = "meeting"."endedBy"
 ;
 
+create view "v_meeting_learningDashboard" as
+select "meetingId", "learningDashboardAccessToken"
+from "v_meeting";
+
 
 -- ===================== CHAT TABLES
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -52,6 +52,15 @@ object_relationships:
         remote_table:
           name: v_layout
           schema: public
+  - name: learningDashboard
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+        insertion_order: null
+        remote_table:
+          name: v_meeting_learningDashboard
+          schema: public
   - name: lockSettings
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_learningDashboard.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_learningDashboard.yaml
@@ -1,0 +1,20 @@
+table:
+  name: v_meeting_learningDashboard
+  schema: public
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - learningDashboardAccessToken
+      filter:
+        meetingId:
+          _eq: X-Hasura-ModeratorInMeeting
+    comment: ""
+  - role: not_joined_bbb_client
+    permission:
+      columns:
+        - learningDashboardAccessToken
+      filter:
+        meetingId:
+          _eq: X-Hasura-ModeratorInMeeting
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -16,6 +16,7 @@
 - "!include public_v_meeting_clientSettings.yaml"
 - "!include public_v_meeting_componentsFlags.yaml"
 - "!include public_v_meeting_group.yaml"
+- "!include public_v_meeting_learningDashboard.yaml"
 - "!include public_v_meeting_lockSettings.yaml"
 - "!include public_v_meeting_recording.yaml"
 - "!include public_v_meeting_recordingPolicies.yaml"

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -124,7 +124,7 @@ class ConnectionController {
               builder {
                 "response" "authorized"
                 "X-Hasura-Role" "not_joined_bbb_client"
-                "X-Hasura-ModeratorInMeeting" ""
+                "X-Hasura-ModeratorInMeeting" removedUserSession.isModerator()  ? removedUserSession.meetingId : ""
                 "X-Hasura-PresenterInMeeting" ""
                 "X-Hasura-UserId" removedUserSession.userId
                 "X-Hasura-MeetingId" removedUserSession.meetingId


### PR DESCRIPTION
In favor of: #19507

The new property, `meeting.learningDashboard.learningDashboardAccessToken`, is accessible to all users. However, it only provides data for users with Moderator privileges. This approach simplifies client-side operations by eliminating the need for the client to verify whether a user is a Moderator before requesting the token. Instead, the client can always request the token, and a successful return will indicate that the user has the necessary permissions to access the Dashboard.

```gql
query {
  meeting {
    learningDashboard {
      learningDashboardAccessToken
    }
  }
}
```

Moreover:
This PR will make the session variable `X-Hasura-ModeratorInMeeting` be populated even for users that already left the meeting. It is important because moderators need to obtain the Dashboard-token after the meeting has ended.
