### PR TITLE
fix: decrease total number of subscriptions for some hooks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/context.tsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState } from 'react';
 import { ExtensibleArea } from '/imports/ui/components/plugins-engine/extensible-areas/types';
-import { PluginsContextType, UserListGraphqlVariables } from './types';
+import { PluginsContextType } from './types';
 
 export const PluginsContext = createContext<PluginsContextType>({} as PluginsContextType);
 
@@ -8,9 +8,6 @@ export const PluginsContext = createContext<PluginsContextType>({} as PluginsCon
 export const PluginsContextProvider = ({ children, ...props }: any) => {
   const [pluginsExtensibleAreasAggregatedState, setPluginsExtensibleAreasAggregatedState] = useState<ExtensibleArea>(
     {} as ExtensibleArea,
-  );
-  const [userListGraphqlVariables, setUserListGraphqlVariables] = useState<UserListGraphqlVariables>(
-    {} as UserListGraphqlVariables,
   );
   const [domElementManipulationMessageIds, setDomElementManipulationMessageIds] = useState<string[]>([]);
 
@@ -20,8 +17,6 @@ export const PluginsContextProvider = ({ children, ...props }: any) => {
         ...props,
         setPluginsExtensibleAreasAggregatedState,
         pluginsExtensibleAreasAggregatedState,
-        userListGraphqlVariables,
-        setUserListGraphqlVariables,
         domElementManipulationMessageIds,
         setDomElementManipulationMessageIds,
       }}

--- a/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/types.ts
@@ -18,9 +18,6 @@ export type ChatMessagesVariables = {
 export interface PluginsContextType {
     pluginsExtensibleAreasAggregatedState: ExtensibleArea;
     setPluginsExtensibleAreasAggregatedState: React.Dispatch<React.SetStateAction<ExtensibleArea>>;
-    userListGraphqlVariables: UserListGraphqlVariables;
-    setUserListGraphqlVariables: React.Dispatch<
-        React.SetStateAction<UserListGraphqlVariables>>;
     domElementManipulationMessageIds: string[];
     setDomElementManipulationMessageIds: React.Dispatch<
         React.SetStateAction<string[]>>;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/hook-manager.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/hook-manager.ts
@@ -5,14 +5,13 @@ import {
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
 import { DataConsumptionHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/enums';
 import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import formatTalkingIndicatorDataFromGraphql from './utils';
 import { UserVoice } from '/imports/ui/Types/userVoice';
-import useTalkingIndicator from '/imports/ui/core/hooks/useTalkingIndicator';
+import { useTalkingIndicatorList } from '/imports/ui/core/hooks/useTalkingIndicator';
 
 const TalkingIndicatorHookContainer = () => {
   const [sendSignal, setSendSignal] = useState(false);
-  const userVoice: GraphqlDataHookSubscriptionResponse<Partial<UserVoice>[]> = useTalkingIndicator(
+  const [userVoice] = useTalkingIndicatorList(
     (uv: Partial<UserVoice>) => ({
       talking: uv.talking,
       startTime: uv.startTime,
@@ -23,7 +22,7 @@ const TalkingIndicatorHookContainer = () => {
 
   const updateTalkingIndicatorForPlugin = () => {
     window.dispatchEvent(new CustomEvent<
-      UpdatedEventDetails<PluginSdk.GraphqlResponseWrapper<PluginSdk.UserVoice>>
+      UpdatedEventDetails<PluginSdk.GraphqlResponseWrapper<PluginSdk.UserVoice[]>>
     >(HookEvents.UPDATED, {
       detail: {
         data: formatTalkingIndicatorDataFromGraphql(userVoice),

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/utils.ts
@@ -1,18 +1,17 @@
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { UserVoice } from '/imports/ui/Types/userVoice';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 
 const formatTalkingIndicatorDataFromGraphql = (
-  responseDataFromGraphql: GraphqlDataHookSubscriptionResponse<Partial<UserVoice>[]>,
-) => ({
-  data: !responseDataFromGraphql.loading ? responseDataFromGraphql.data?.map((userVoice) => ({
+  talkingIndicatorList: Partial<UserVoice>[],
+): PluginSdk.GraphqlResponseWrapper<PluginSdk.UserVoice[]> => ({
+  data: talkingIndicatorList.map((userVoice) => ({
     talking: userVoice.talking,
     startTime: userVoice.startTime,
     muted: userVoice.muted,
     userId: userVoice.userId,
-  }) as PluginSdk.UserVoice) : undefined,
-  loading: responseDataFromGraphql.loading,
-  error: responseDataFromGraphql.errors?.[0],
-} as PluginSdk.GraphqlResponseWrapper<PluginSdk.UserVoice>);
+  }) as PluginSdk.UserVoice),
+  loading: !(talkingIndicatorList),
+  error: undefined,
+});
 
 export default formatTalkingIndicatorDataFromGraphql;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/loaded-user-list/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/loaded-user-list/hook-manager.tsx
@@ -7,12 +7,11 @@ import {
 import { DataConsumptionHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/enums';
 import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import formatLoadedUserListDataFromGraphql from './utils';
-import useLoadedUserList from '/imports/ui/core/hooks/useLoadedUserList';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
+import { useLoadedUserList } from '/imports/ui/core/hooks/useLoadedUserList';
 
 const LoadedUserListHookContainer = () => {
   const [sendSignal, setSendSignal] = useState(false);
-  const usersData: GraphqlDataHookSubscriptionResponse<Partial<User>[]> = useLoadedUserList((user: Partial<User>) => ({
+  const [usersData] = useLoadedUserList((user: Partial<User>) => ({
     userId: user.userId,
     name: user.name,
     role: user.role,

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/loaded-user-list/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/loaded-user-list/utils.ts
@@ -1,18 +1,17 @@
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { User } from '/imports/ui/Types/user';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const formatLoadedUserListDataFromGraphql = (
-  responseDataFromGraphql: GraphqlDataHookSubscriptionResponse<Partial<User>[]>,
+  responseDataFromGraphql: Partial<User>[],
 ) => ({
-  data: !responseDataFromGraphql.loading ? responseDataFromGraphql.data?.map((userItem) => ({
+  data: responseDataFromGraphql ? responseDataFromGraphql?.map((userItem) => ({
     userId: userItem.userId,
     name: userItem.name,
     role: userItem.role,
   }) as PluginSdk.LoadedUserListData) : undefined,
-  loading: responseDataFromGraphql.loading,
-  error: responseDataFromGraphql.errors?.[0],
+  loading: !(responseDataFromGraphql),
+  error: undefined,
 } as PluginSdk.GraphqlResponseWrapper<PluginSdk.LoadedUserListData>);
 
 export default formatLoadedUserListDataFromGraphql;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect } from 'react';
 import { useSubscription } from '@apollo/client';
 import { AutoSizer } from 'react-virtualized';
 import { debounce } from 'radash';
@@ -21,10 +21,9 @@ import {
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
-import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import Service from '/imports/ui/components/user-list/service';
-import useLoadedUserList from '/imports/ui/core/hooks/useLoadedUserList';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
+import { USER_LIST_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
+import { setLoadedUserList } from '/imports/ui/core/hooks/useLoadedUserList';
 
 interface UserListParticipantsProps {
   users: Array<User>;
@@ -161,16 +160,26 @@ const UserListParticipantsContainer: React.FC = () => {
   } = useSubscription(MEETING_PERMISSIONS_SUBSCRIPTION);
   const { meeting: meetingArray } = (meetingData || {});
   const meeting = meetingArray && meetingArray[0];
-
-  const { setUserListGraphqlVariables } = useContext(PluginsContext);
   const {
     data: countData,
   } = useSubscription(USER_AGGREGATE_COUNT_SUBSCRIPTION);
   const count = countData?.user_aggregate?.aggregate?.count || 0;
 
+  useEffect(() => {
+    return () => {
+      setLoadedUserList([]);
+    };
+  }, []);
+
   const {
-    data: users,
-  } = useLoadedUserList((u) => u) as GraphqlDataHookSubscriptionResponse<Array<User>>;
+    data: usersData,
+  } = useSubscription(USER_LIST_SUBSCRIPTION, {
+    variables: {
+      offset,
+      limit,
+    },
+  });
+  const { user: users } = (usersData || {});
 
   const { data: currentUser } = useCurrentUser((c: Partial<User>) => ({
     isModerator: c.isModerator,
@@ -182,13 +191,7 @@ const UserListParticipantsContainer: React.FC = () => {
   const presentationPage = presentationData?.pres_page_curr[0] || {};
   const pageId = presentationPage?.pageId;
 
-  useEffect(() => {
-    setUserListGraphqlVariables({
-      offset,
-      limit,
-    });
-  }, [offset, limit]);
-
+  setLoadedUserList(users);
   return (
     <>
       <UserListParticipants

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/userVoiceSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/userVoiceSubscription.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 const TALKING_INDICATOR_SUBSCRIPTION = gql`
-  subscription TalkingIndicatorSubscription($limit: Int!) {
+  subscription talkingIndicatorSubscription($limit: Int!) {
     user_voice(
       where: { showTalkingIndicator: { _eq: true } }
       order_by: [{ startTime: asc_nulls_last }]

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client';
 
-export const USER_LIST_SUBSCRIPTION = gql`subscription Users($offset: Int!, $limit: Int!) {
+export const USER_LIST_SUBSCRIPTION = gql`
+subscription UserListSubscription($offset: Int!, $limit: Int!) {
   user(limit:$limit, offset: $offset, 
                 order_by: [
                   {role: asc},


### PR DESCRIPTION
### What does this PR do?

It just decreases the total number of subscriptions made for talking indicator and loaded user-list hooks used by the plugin and in general by the core.

- [ ] Fix the problem for when there are plugins loaded in the front-end as well

### Motivation

It seems to make BBB more efficient (Needs validation through stress-test).

### More

Mind that this part of the fix should handle BBB without plugins loaded within the core. With them, there is still some room for improvement.
