### PR TITLE
Fix: Shape Access Logic for Non-Moderator Viewers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -48,6 +48,7 @@ const WhiteboardContainer = (props) => {
   } = props;
 
   const [annotations, setAnnotations] = useState([]);
+  const [shapes, setShapes] = useState({});
 
   const meeting = useMeeting((m) => ({
     lockSettings: m?.lockSettings,
@@ -151,18 +152,17 @@ const WhiteboardContainer = (props) => {
     }
   }, [annotationStreamData]);
 
-  let shapes = {};
   let bgShape = [];
 
-  const pageAnnotations = annotations
-    .filter((annotation) => annotation.pageId === currentPresentationPage?.pageId);
-
-  shapes = formatAnnotations(
-    pageAnnotations,
-    intl,
-    curPageId,
-    currentPresentationPage,
-  );
+  React.useEffect(() => {
+    const updatedShapes = formatAnnotations(
+      annotations.filter((annotation) => annotation.pageId === currentPresentationPage?.pageId),
+      intl,
+      curPageId,
+      currentPresentationPage,
+    );
+    setShapes(updatedShapes);
+  }, [annotations, intl, curPageId, currentPresentationPage]);
 
   const { isIphone } = deviceInfo;
 
@@ -218,15 +218,6 @@ const WhiteboardContainer = (props) => {
     typeName: "shape",
   });
 
-  const hasShapeAccess = (id) => {
-    const owner = shapes[id]?.meta?.createdBy;
-    const isBackgroundShape = id?.includes(':BG-');
-    const hasAccess = (!isBackgroundShape
-      && ((owner && owner === currentUser?.userId) || isPresenter || isModerator)) || !shapes[id];
-
-    return hasAccess;
-  };
-
   return (
     <Whiteboard
       {...{
@@ -244,7 +235,6 @@ const WhiteboardContainer = (props) => {
         fillStyle,
         fontStyle,
         sizeStyle,
-        hasShapeAccess,
         handleToggleFullScreen,
         sidebarNavigationWidth,
         layoutContextDispatch,


### PR DESCRIPTION
### What does this PR do?
This PR revises the shape access logic in the whiteboard component to ensure proper interaction permissions. With these changes, viewers are restricted to interacting only with shapes they have created unless they have presenter or moderator privileges, in which case they can interact with any shapes.

### Motivation
Before this fix, a flaw in the `hasShapeAccess` function allowed all users to interact with any shape on the whiteboard, regardless of the creator. This oversight led to viewers being able to make changes to shapes they didn't own, but these changes wouldn't be reflected for others because they weren't propagated to `akka`.