### PR TITLE
Fix: Wrong chat name in grid layout when shared notes are pinned

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -12,7 +12,7 @@ import NotesDropdown from '/imports/ui/components/notes/notes-dropdown/container
 import { isPresentationEnabled } from '../../services/features';
 
 const CHAT_CONFIG = Meteor.settings.public.chat;
-const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
+const PUBLIC_CHAT_ID = CHAT_CONFIG.public_group_id;
 const DELAY_UNMOUNT_SHARED_NOTES = Meteor.settings.public.app.delayForUnmountOfSharedNote;
 const intlMessages = defineMessages({
   hide: {


### PR DESCRIPTION
### What does this PR do?

This PR corrects the chat name when using grid layout with shared notes pinned.

### Motivation

This PR was motivated by the output of a testing party made by our testing team.
