### PR TITLE
fix(sec): bump postgresql to 42.7.2

### DIFF
--- a/bbb-common-web/build.sbt
+++ b/bbb-common-web/build.sbt
@@ -106,7 +106,7 @@ libraryDependencies ++= Seq(
   "org.springframework.boot" % "spring-boot-starter-validation" % "2.7.17",
   "org.springframework.data" % "spring-data-commons" % "2.7.6",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",
-  "org.postgresql" % "postgresql" % "42.4.3",
+  "org.postgresql" % "postgresql" % "42.7.2",
   "org.hibernate" % "hibernate-core" % "5.6.1.Final",
   "org.flywaydb" % "flyway-core" % "7.8.2",
   "com.zaxxer" % "HikariCP" % "4.0.3",

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
   implementation 'javax.validation:validation-api:2.0.1.Final'
   implementation "org.springframework.boot:spring-boot-starter-validation:${springVersion}"
-  implementation 'org.postgresql:postgresql:42.4.3'
+  implementation 'org.postgresql:postgresql:42.7.2'
   implementation 'org.hibernate:hibernate-core:5.6.1.Final'
 
   //--- BigBlueButton Dependencies End


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Bumps up postgress driver to 42.7.2 (used in bbb-recording-imex optional component https://github.com/bigbluebutton/bigbluebutton/pull/14786) 
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none


### Motivation
https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56
<!-- What inspired you to submit this pull request? -->

### More
Alternatively can remove `/usr/share/bbb-web/WEB-INF/lib/postgresql-42.4.3.jar` and restart BBB. The dependency is only used for an optional recording API via database setup.

