### PR TITLE
Remove LimitNOFILE=1024 Restriction from bbb-graphql-middleware

### DIFF
--- a/bbb-graphql-middleware/bbb-graphql-middleware.service
+++ b/bbb-graphql-middleware/bbb-graphql-middleware.service
@@ -18,7 +18,6 @@ RestartSec=60
 SuccessExitStatus=143
 TimeoutStopSec=5
 PermissionsStartOnly=true
-LimitNOFILE=1024
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target


### PR DESCRIPTION
This PR removes the `LimitNOFILE=1024` setting from the `bbb-graphql-middleware` service's systemd configuration to address the service's need to support more than 1024 WebSocket connections concurrently. By eliminating this limit, we aim to enhance the service's capability to handle a greater number of user connections without hitting the open file descriptor ceiling, thus ensuring improved scalability and reliability for user interactions.