### PR TITLE
fix(bbb-export-annotations): handle missing textbox size in Tldraw

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -703,6 +703,10 @@ function overlay_triangle(svg, annotation) {
 }
 
 function overlay_text(svg, annotation) {
+  if (annotation.size == null || annotation.size.length < 2) {
+    return
+  }
+  
   const [textBoxWidth, textBoxHeight] = annotation.size;
   const fontColor = color_to_hex(annotation.style.color);
   const font = determine_font_from_family(annotation.style.font);
@@ -731,30 +735,34 @@ function overlay_text(svg, annotation) {
 }
 
 function overlay_annotation(svg, currentAnnotation) {
-  switch (currentAnnotation.type) {
-    case 'arrow':
-      overlay_arrow(svg, currentAnnotation);
-      break;
-    case 'draw':
-      overlay_draw(svg, currentAnnotation);
-      break;
-    case 'ellipse':
-      overlay_ellipse(svg, currentAnnotation);
-      break;
-    case 'rectangle':
-      overlay_rectangle(svg, currentAnnotation);
-      break;
-    case 'sticky':
-      overlay_sticky(svg, currentAnnotation);
-      break;
-    case 'triangle':
-      overlay_triangle(svg, currentAnnotation);
-      break;
-    case 'text':
-      overlay_text(svg, currentAnnotation);
-      break;
-    default:
-      logger.info(`Unknown annotation type ${currentAnnotation.type}.`);
+  try {
+    switch (currentAnnotation.type) {
+      case 'arrow':
+        overlay_arrow(svg, currentAnnotation);
+        break;
+      case 'draw':
+        overlay_draw(svg, currentAnnotation);
+        break;
+      case 'ellipse':
+        overlay_ellipse(svg, currentAnnotation);
+        break;
+      case 'rectangle':
+        overlay_rectangle(svg, currentAnnotation);
+        break;
+      case 'sticky':
+        overlay_sticky(svg, currentAnnotation);
+        break;
+      case 'triangle':
+        overlay_triangle(svg, currentAnnotation);
+        break;
+      case 'text':
+        overlay_text(svg, currentAnnotation);
+        break;
+      default:
+        logger.info(`Unknown annotation type ${currentAnnotation.type}.`);
+    }
+  } catch (error) {
+    logger.warn("Failed to overlay annotation", { failedAnnotation: currentAnnotation, error: error });
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
In certain situations, Tldraw fails to specify a size for the textbox shape, causing text rendering issues that crash the export process. This pull request introduces a check for this scenario, preventing the crash and adding appropriate exception handling to contain such errors to a single shape.

### Closes Issue
Closes #19668

### More
Thanks to @thuh-reflact for providing the fix.