### PR TITLE
fix: Minor changes related to the new leave meeting button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -244,6 +244,8 @@ export default class Button extends BaseButton {
   renderLabel() {
     const { label, hideLabel } = this.props;
 
+    if (!label) return null;
+
     return (
       <Styled.ButtonLabel hideLabel={hideLabel}>
         {label}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -301,7 +301,7 @@ class OptionsDropdown extends PureComponent {
           icon: 'popout_window',
           label: intl.formatMessage(intlMessages.openAppLabel),
           onClick: () => this.setMobileAppModalIsOpen(true),
-         }
+        },
       );
     }
 
@@ -327,10 +327,6 @@ class OptionsDropdown extends PureComponent {
         description: intl.formatMessage(intlMessages.hotkeysDesc),
         onClick: () => this.setShortcutHelpModalIsOpen(true),
       },
-      {
-        key: 'separator-01',
-        isSeparator: true,
-      },
     );
 
     optionsDropdownItems.forEach((item) => {
@@ -354,32 +350,37 @@ class OptionsDropdown extends PureComponent {
       }
     });
 
-    if (allowLogoutSetting && isMeteorConnected && !isDirectLeaveButtonEnabled) {
-      this.menuItems.push(
-        {
+    if (isMeteorConnected && !isDirectLeaveButtonEnabled) {
+      const bottomItems = [{
+        key: 'list-item-separator',
+        isSeparator: true,
+      }];
+
+      if (allowLogoutSetting) {
+        bottomItems.push({
           key: 'list-item-logout',
           dataTest: 'logout',
           icon: 'logout',
           label: intl.formatMessage(intlMessages.leaveSessionLabel),
           description: intl.formatMessage(intlMessages.leaveSessionDesc),
           onClick: () => this.leaveSession(),
-        },
-      );
-    }
+        });
+      }
 
-    if (allowedToEndMeeting && isMeteorConnected && !isDirectLeaveButtonEnabled) {
-      const customStyles = { background: colorDanger, color: colorWhite };
+      if (allowedToEndMeeting) {
+        const customStyles = { background: colorDanger, color: colorWhite };
 
-      this.menuItems.push(
-        {
+        bottomItems.push({
           key: 'list-item-end-meeting',
           icon: 'close',
           label: intl.formatMessage(intlMessages.endMeetingLabel),
           description: intl.formatMessage(intlMessages.endMeetingDesc),
           customStyles,
           onClick: () => this.setEndMeetingConfirmationModalIsOpen(true),
-        },
-      );
+        });
+      }
+
+      if (bottomItems.length > 1) this.menuItems.push(...bottomItems);
     }
 
     return this.menuItems;


### PR DESCRIPTION
### What does this PR do?
This PR adds 2 minor changes related to the new (direct) leave button:
- Don't render the inner empty span
- Only show the separator element in the options dropdown when there's at least one item below

|Before|After|
|:-:|:-:|
|![](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/1158784d-9ef3-4458-93bd-22650cbe09b0)|![](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/431ca710-8c1e-41a1-96d4-8fb5b0fa31c5) ![](https://github.com/bigbluebutton/bigbluebutton/assets/56703993/9b000702-2ccf-47ed-a69d-8410d4623fa3)|

