### PR TITLE
fix(whiteboard): Enable Slide Change By Arrow Keys

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -365,7 +365,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
       const undoCondition = event.ctrlKey && event.key === 'z' && !event.shiftKey;
       const redoCondition = event.ctrlKey && event.shiftKey && event.key === 'Z';
 
-      if (undoCondition || redoCondition) {
+      if ((undoCondition || redoCondition) && (isPresenter || hasWBAccessRef.current)) {
         event.preventDefault();
         event.stopPropagation();
 
@@ -377,7 +377,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
         }
       }
 
-      if (event.keyCode === KEY_CODES.ARROW_RIGHT || event.keyCode === KEY_CODES.ARROW_LEFT) {
+      if ((event.keyCode === KEY_CODES.ARROW_RIGHT || event.keyCode === KEY_CODES.ARROW_LEFT) && isPresenter) {
         handleArrowPress(event)
       }
     };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -347,9 +347,9 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
       };
 
       if (!shapeSelected) {
-        if (event.key === 'ArrowRight') {
+        if (event.keyCode === KEY_CODES.ARROW_RIGHT) {
           changeSlide(1); // Move to the next slide
-        } else if (event.key === 'ArrowLeft') {
+        } else if (event.keyCode === KEY_CODES.ARROW_LEFT) {
           changeSlide(-1); // Move to the previous slide
         }
       }
@@ -377,7 +377,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
         }
       }
 
-      if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      if (event.keyCode === KEY_CODES.ARROW_RIGHT || event.keyCode === KEY_CODES.ARROW_LEFT) {
         handleArrowPress(event)
       }
     };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -35,6 +35,7 @@ import {
   PRESENTATION_SET_ZOOM,
   PRES_ANNOTATION_DELETE,
   PRES_ANNOTATION_SUBMIT,
+  PRESENTATION_SET_PAGE,
 } from '../presentation/mutations';
 
 const WHITEBOARD_CONFIG = Meteor.settings.public.whiteboard;
@@ -68,8 +69,23 @@ const WhiteboardContainer = (props) => {
   const hasWBAccess = whiteboardWriters?.some((writer) => writer.userId === Auth.userID);
 
   const [presentationSetZoom] = useMutation(PRESENTATION_SET_ZOOM);
+  const [presentationSetPage] = useMutation(PRESENTATION_SET_PAGE);
   const [presentationDeleteAnnotations] = useMutation(PRES_ANNOTATION_DELETE);
   const [presentationSubmitAnnotations] = useMutation(PRES_ANNOTATION_SUBMIT);
+
+  const setPresentationPage = (pageId) => {
+    presentationSetPage({
+      variables: {
+        presentationId,
+        pageId,
+      },
+    });
+  };
+
+  const skipToSlide = (slideNum) => {
+    const slideId = `${presentationId}/${slideNum}`;
+    setPresentationPage(slideId);
+  };
 
   const removeShapes = (shapeIds) => {
     presentationDeleteAnnotations({
@@ -259,6 +275,7 @@ const WhiteboardContainer = (props) => {
         hasWBAccess,
         whiteboardWriters,
         zoomChanger,
+        skipToSlide,
       }}
       {...props}
       meetingId={Auth.meetingID}


### PR DESCRIPTION
### What does this PR do?
This PR restores the ability for the presenter to switch slides via the arrow keys without having to click on the presentation toolbar to get back the pointer focus after drawing or pan/zoom.

### Closes Issue(s)
Closes #19687
