### PR TITLE
fix: missing internationalization warnings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -21,7 +21,7 @@ const intlMessages = defineMessages({
     description: 'Leave session button label',
   },
   leaveSessionDesc: {
-    id: 'app.navBar.settingsDropdown.leaveSessionDesc',
+    id: 'app.navBar.optionsDropdown.leaveSessionDesc',
     description: 'Describes leave session option',
   },
   endMeetingLabel: {
@@ -29,7 +29,7 @@ const intlMessages = defineMessages({
     description: 'End meeting button label',
   },
   endMeetingDesc: {
-    id: 'app.navBar.settingsDropdown.endMeetingDesc',
+    id: 'app.navBar.optionsDropdown.endMeetingDesc',
     description: 'Describes settings option closing the current meeting',
   },
 });

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -439,6 +439,7 @@
     "app.muteWarning.disableMessage": "Mute alerts disabled until unmute",
     "app.muteWarning.tooltip": "Click to close and disable warning until next unmute",
     "app.navBar.leaveMeetingBtnLabel": "Leave",
+    "app.navBar.leaveMeetingBtnDesc": "Leave the meeting",
     "app.navBar.optionsDropdown.optionsLabel": "Options",
     "app.navBar.optionsDropdown.fullscreenLabel": "Fullscreen Application",
     "app.navBar.optionsDropdown.settingsLabel": "Settings",


### PR DESCRIPTION
### What does this PR do?

Adds missing internationalization strings