### PR TITLE
fix: User avatar not appearing correctly when poll results on chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -120,6 +120,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
     isModerator: boolean,
     isPresentationUpload?: boolean,
     component: React.ReactElement,
+    avatarIcon?: string,
   } = useMemo(() => {
     switch (message.messageType) {
       case ChatMessageType.POLL:
@@ -130,6 +131,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
           component: (
             <ChatPollContent metadata={message.messageMetadata} />
           ),
+          avatarIcon: 'icon-bbb-polling',
         };
       case ChatMessageType.PRESENTATION:
         return {
@@ -142,6 +144,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
               metadata={message.messageMetadata}
             />
           ),
+          avatarIcon: 'icon-bbb-download',
         };
       case ChatMessageType.CHAT_CLEAR:
         return {
@@ -221,10 +224,10 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
             color={messageContent.color}
             moderator={messageContent.isModerator}
           >
-            {message.messageType !== ChatMessageType.PRESENTATION ? (
+            {!messageContent.avatarIcon ? (
               !message.user || (message.user?.avatar.length === 0 ? messageContent.name.toLowerCase().slice(0, 2) : '')
             ) : (
-              <i className="icon-bbb-download" />
+              <i className={messageContent.avatarIcon} />
             )}
           </ChatAvatar>
       )}


### PR DESCRIPTION
### What does this PR do?

Restores poll results icon - chat

#### before

![2024-02-28_08-56](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/ff602531-792e-470e-bf66-1359d0d5f716)

#### after

![2024-02-28_08-55](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/1950c941-e922-4f60-ba49-1972d16a94ac)



### Closes Issue(s)
Closes #19695