### PR TITLE
fix(chat): combine chat poll responses

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Bar, BarChart, ResponsiveContainer, XAxis, YAxis,
 } from 'recharts';
+import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import Styled from './styles';
 
 interface ChatPollContentProps {
@@ -53,7 +54,12 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
 }) => {
   const pollData = JSON.parse(string) as unknown;
   assertAsMetadata(pollData);
-  const height = pollData.answers.length * 50;
+
+  const answers = pollData.answers.reduce(
+    caseInsensitiveReducer, [],
+  );
+
+  const height = answers.length * 50;
   return (
     <div data-test="chatPollMessageText">
       <Styled.PollText>
@@ -61,7 +67,7 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
       </Styled.PollText>
       <ResponsiveContainer width="90%" height={height}>
         <BarChart
-          data={pollData.answers}
+          data={answers}
           layout="vertical"
         >
           <XAxis type="number" />


### PR DESCRIPTION
### What does this PR do?

Combine (case insensitive) the poll responses when displayed in chat area.

#### before

![2024-02-28_10-37_1](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/fca20ced-2368-45d2-b56b-f5b2b20095e1)

#### after

![2024-02-28_10-37](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/9a87e213-4943-4ab3-b733-65856fb330d9)
