### PR TITLE
style: Increase answer size in poll results annotation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/service.js
+++ b/bigbluebutton-html5/imports/ui/components/poll/service.js
@@ -4,8 +4,8 @@ import { escapeHtml } from '/imports/utils/string-utils';
 import { defineMessages } from 'react-intl';
 
 const POLL_AVATAR_COLOR = '#3B48A9';
-const MAX_POLL_RESULT_BARS = 20;
-const MAX_POLL_RESULT_KEY_LENGTH = 10;
+const MAX_POLL_RESULT_BARS = 10;
+const MAX_POLL_RESULT_KEY_LENGTH = 30;
 const POLL_BAR_CHAR = '\u220E';
 
 // 'YN' = Yes,No

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -196,7 +196,7 @@ const formatAnnotations = (annotations, intl, curPageId, currentPresentationPage
         }).join('\n');
 
         // Text measurement estimation
-        const averageCharWidth = 16;
+        const averageCharWidth = 14;
         const lineHeight = 32;
 
         const annotationWidth = longestLine * averageCharWidth; // Estimate width


### PR DESCRIPTION
### What does this PR do?

Increase maximum size for poll answer text in whiteboard annotation.

#### before

![Presentation__2024-02-29T13_35_55 543Z](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/4929e99d-d5b8-4632-979a-0f2774684e5a)


#### after

![Presentation__2024-02-29T13_34_35 062Z](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/236d8e14-00ee-4f68-92a9-b86de3532b82)
