### PR TITLE
Introduces graphql adapter for mongodb voice-users

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_voice_mongodb_adapter.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_voice_mongodb_adapter.yaml
@@ -1,0 +1,40 @@
+table:
+  name: v_user_voice_mongodb_adapter
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_voice_mongodb_adapter
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - callerName
+        - callerNum
+        - callingWith
+        - endTime
+        - endedAt
+        - floor
+        - hideTalkingIndicatorAt
+        - joined
+        - lastFloorTime
+        - lastSpeakChangedAt
+        - listenOnly
+        - muted
+        - showTalkingIndicator
+        - spoke
+        - startTime
+        - startedAt
+        - talking
+        - userId
+        - voiceConf
+        - voiceConfCallSession
+        - voiceConfCallState
+        - voiceConfClientSession
+        - voiceUpdatedAt
+        - voiceUserId
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -56,4 +56,5 @@
 - "!include public_v_user_typing_private.yaml"
 - "!include public_v_user_typing_public.yaml"
 - "!include public_v_user_voice.yaml"
+- "!include public_v_user_voice_mongodb_adapter.yaml"
 - "!include public_v_user_welcomeMsgs.yaml"


### PR DESCRIPTION
While a few client components still depends on mini-mongo collections, it is necessary to populate these collections.
So @Tainan404 is working on query Graphql data to populate the mini-mongo collections.

This PR introduces a new graphql Type `user_voice_mongodb_adapter` that will be used to populate the collection `voice-users`.

```gql
subscription {
  user_voice_mongodb_adapter_stream(cursor: {initial_value: {voiceUpdatedAt: "2020-01-01"}}, batch_size: 100) {
    callerName
    callerNum
    callingWith
    endTime
    endedAt
    floor
    hideTalkingIndicatorAt
    joined
    lastFloorTime
    lastSpeakChangedAt
    listenOnly
    muted
    showTalkingIndicator
    spoke
    startTime
    startedAt
    talking
    userId
    voiceConf
    voiceConfCallSession
    voiceConfCallState
    voiceConfClientSession
    voiceUpdatedAt
    voiceUserId
  }
}
```