### PR TITLE
Graphqh: Automatically set running=false when timer has counted down to 0

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
@@ -14,8 +14,8 @@ case class TimerDbModel(
     active:           Boolean,
     time:             Long,
     accumulated:      Long,
-    startedAt:        Long,
-    endedAt:          Long,
+    startedOn:        Long,
+    endedOn:          Long,
     songTrack:        String,
 )
 
@@ -26,10 +26,10 @@ class TimerDbTableDef(tag: Tag) extends Table[TimerDbModel](tag, None, "timer") 
   val active = column[Boolean]("active")
   val time = column[Long]("time")
   val accumulated = column[Long]("accumulated")
-  val startedAt = column[Long]("startedAt")
-  val endedAt = column[Long]("endedAt")
+  val startedOn = column[Long]("startedOn")
+  val endedOn = column[Long]("endedOn")
   val songTrack = column[String]("songTrack")
-  override def * = (meetingId, stopwatch, running, active, time, accumulated, startedAt, endedAt, songTrack) <> (TimerDbModel.tupled, TimerDbModel.unapply)
+  override def * = (meetingId, stopwatch, running, active, time, accumulated, startedOn, endedOn, songTrack) <> (TimerDbModel.tupled, TimerDbModel.unapply)
 }
 
 object TimerDAO {
@@ -43,8 +43,8 @@ object TimerDAO {
           active = false,
           time = 300000,
           accumulated = 0,
-          startedAt = 0,
-          endedAt = 0,
+          startedOn = 0,
+          endedOn = 0,
           songTrack = "noTrack",
         )
       )
@@ -58,7 +58,7 @@ object TimerDAO {
     DatabaseConnection.db.run(
       TableQuery[TimerDbTableDef]
         .filter(_.meetingId === meetingId)
-        .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedAt, t.endedAt, t.songTrack))
+        .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedOn, t.endedOn, t.songTrack))
         .update((getStopwatch(timerModel), getRunning(timerModel), getIsActive(timerModel), getTime(timerModel), getAccumulated(timerModel), getStartedAt(timerModel), getEndedAt(timerModel), getTrack(timerModel))
         )
     ).onComplete {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1467,13 +1467,31 @@ CREATE TABLE "timer" (
 	"active" boolean,
 	"time" bigint,
 	"accumulated" bigint,
-	"startedAt" bigint,
-	"endedAt" bigint,
+	"startedOn" bigint,
+	"endedOn" bigint,
 	"songTrack" varchar(50)
 );
 
-CREATE VIEW "v_timer" AS
-SELECT * FROM "timer";
+ALTER TABLE "timer" ADD COLUMN "startedAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("startedOn"::double precision / 1000)) STORED;
+ALTER TABLE "timer" ADD COLUMN "endedAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("endedOn"::double precision / 1000)) STORED;
+
+CREATE OR REPLACE VIEW "v_timer" AS
+SELECT
+     "meetingId",
+     "stopwatch",
+     case
+        when "stopwatch" is true or "running" is false then "running"
+        when "startedAt" + ("time" * interval '1 milliseconds') >= current_timestamp then true else false
+     end "running",
+     "active",
+     "time",
+     "accumulated",
+     "startedAt",
+     "startedOn",
+     "endedAt",
+     "endedOn",
+     "songTrack"
+ FROM "timer";
 
 ------------------------------------
 ----breakoutRoom

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_timer.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_timer.yaml
@@ -13,9 +13,11 @@ select_permissions:
         - accumulated
         - active
         - endedAt
+        - endedOn
         - running
         - songTrack
         - startedAt
+        - startedOn
         - stopwatch
         - time
       filter:

--- a/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/component.tsx
@@ -25,7 +25,7 @@ interface TimerIndicatorProps {
   isModerator: boolean;
   sidebarNavigationIsOpen: boolean;
   sidebarContentIsOpen: boolean;
-  startedAt: number;
+  startedOn: number;
 }
 
 const TimerIndicator: React.FC<TimerIndicatorProps> = ({
@@ -36,7 +36,7 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
   isModerator,
   sidebarNavigationIsOpen,
   sidebarContentIsOpen,
-  startedAt,
+  startedOn,
 }) => {
   const [time, setTime] = useState<number>(0);
   const timeRef = useRef<HTMLSpanElement>(null);
@@ -110,7 +110,7 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
       if (timePassed > prev) return timePassed;
       return prev;
     });
-  }, [passedTime, stopwatch, startedAt]);
+  }, [passedTime, stopwatch, startedOn]);
 
   useEffect(() => {
     if (!timeRef.current) {
@@ -121,10 +121,10 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
   }, [time]);
 
   useEffect(() => {
-    if (startedAt === 0) {
+    if (startedOn === 0) {
       setTime(passedTime);
     }
-  }, [startedAt]);
+  }, [startedOn]);
 
   const onClick = running ? stopTimer : startTimer;
 
@@ -189,13 +189,13 @@ const TimerIndicatorContainer: React.FC = () => {
   const {
     accumulated,
     running,
-    startedAt,
+    startedOn,
     stopwatch,
     songTrack,
     time,
   } = currentTimer;
   const currentDate: Date = new Date();
-  const startedAtDate: Date = new Date(startedAt || Date.now());
+  const startedAtDate: Date = new Date(startedOn || Date.now());
   const adjustedCurrent: Date = new Date(currentDate.getTime() + timeSync);
   const timeDifferenceMs: number = adjustedCurrent.getTime() - startedAtDate.getTime();
 
@@ -214,7 +214,7 @@ const TimerIndicatorContainer: React.FC = () => {
       isModerator={currentUser.isModerator ?? false}
       sidebarNavigationIsOpen={sidebarNavigationIsOpen}
       sidebarContentIsOpen={sidebarContentIsOpen}
-      startedAt={startedAt}
+      startedOn={startedOn}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/queries.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/queries.tsx
@@ -8,8 +8,8 @@ export interface GetTimerResponse {
     time: number;
     stopwatch: boolean;
     running: boolean;
-    startedAt: number;
-    endedAt: number;
+    startedOn: number;
+    endedOn: number;
   }>;
 }
 
@@ -22,8 +22,8 @@ export const GET_TIMER = gql`
       time
       stopwatch
       running
-      startedAt
-      endedAt
+      startedOn
+      endedOn
     }
   }
 `;


### PR DESCRIPTION
As highlighted by @Scroody, the issue at hand is that `Timer.running` remains set to `true` indefinitely, even after the timer has counted down to 0. The proposed change in this PR is to adjust the timer's behavior so that running becomes `false` once the timer reaches its conclusion.

Additionally, the PR includes a refactoring of column names: changing `startedAt` to `startedOn` and `endedAt` to `endedOn`. This alteration aims to standardize naming conventions within the database, where `On` is used for bigint values and `At` indicates PostgreSQL timestamps.