### PR TITLE
Add workflow to compute Hasura permission diff using Metadelta

### DIFF
--- a/.github/workflows/compute-hasura-permission-diff.yaml
+++ b/.github/workflows/compute-hasura-permission-diff.yaml
@@ -1,0 +1,18 @@
+name: Compute Hasura permission diff on PR
+
+on:
+  pull_request:
+
+jobs:
+  compute-diff:
+    permissions:
+      # To upload artifacts
+      contents: write
+      # To write a comment on the PR
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: InvariantClub/metadelta-github-action@v1.2
+        with:
+          # Repo-relative path to the hasura metadata folder.
+          hasura_path: bbb-graphql-server/metadata


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Hello :)

I've built a (free for open-source) tool to help out with Hasura permission changes. In developing it, I found this repository as a big user of Hasura.

So, I thought I'd make a PR to add an automatic step to compute a permission diff, following the guide - https://invariant.club/guides/getting-started-with-metadelta.html.

This doesn't address any particular issue on the repo, and I won't be offended if you ignore it, but I thought I'd prepare this PR anyway, in case you would like to try it out!

### Motivation

This repo uses Hasura extenstively, and in particular has frequent hasura-related permission changes that are (probably) hard to review from the source-code changes alone.

### More

It'd be extremely valuable for me to get feedback on the tool I've built; and in particular any features you may want/think are missing.

Please let me know! I'm always happy to chat and can be reached via the email on my GitHub profile :)
