### PR TITLE
fix(whiteboard): Selected Shapes Fail To Update On External Edits

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -268,7 +268,11 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
           typeName: remoteShape.typeName,
         };
 
-        if (!selectedShapeIds.includes(remoteShape.id) && prevShape?.meta?.updatedBy !== currentUser?.userId) {
+        if (
+          (prevShape?.meta?.updatedBy !== currentUser?.userId && !selectedShapeIds.includes(remoteShape.id)) ||
+          (prevShape?.meta?.createdBy === currentUser?.userId) ||
+          (prevShape?.meta?.createdBy !== currentUser?.userId && selectedShapeIds.includes(remoteShape.id) && (isPresenter || isModerator))
+        ) {
           Object.keys(remoteShape).forEach((key) => {
             if (key !== "isModerator" && !isEqual(remoteShape[key], localShape[key])) {
               diff[key] = remoteShape[key];

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -158,6 +158,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
   const whiteboardIdRef = React.useRef(whiteboardId);
   const curPageIdRef = React.useRef(curPageId);
   const hasWBAccessRef = React.useRef(hasWBAccess);
+  const isModeratorRef = React.useRef(isModerator);
 
   const THRESHOLD = 0.1;
   const lastKnownHeight = React.useRef(presentationAreaHeight);
@@ -168,6 +169,10 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
   React.useEffect(() => {
     curPageIdRef.current = curPageId;
   }, [curPageId]);
+
+  React.useEffect(() => {
+    isModeratorRef.current = isModerator;
+  }, [isModerator]);
 
   React.useEffect(() => {
     whiteboardIdRef.current = whiteboardId;
@@ -271,7 +276,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
         if (
           (prevShape?.meta?.updatedBy !== currentUser?.userId && !selectedShapeIds.includes(remoteShape.id)) ||
           (prevShape?.meta?.createdBy === currentUser?.userId) ||
-          (prevShape?.meta?.createdBy !== currentUser?.userId && selectedShapeIds.includes(remoteShape.id) && (isPresenter || isModerator))
+          (prevShape?.meta?.createdBy !== currentUser?.userId && selectedShapeIds.includes(remoteShape.id) && (isPresenter || isModeratorRef.current))
         ) {
           Object.keys(remoteShape).forEach((key) => {
             if (key !== "isModerator" && !isEqual(remoteShape[key], localShape[key])) {
@@ -859,7 +864,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
               createdBy: currentUser?.userId,
             },
           };
-          persistShapeWrapper(updatedRecord, whiteboardIdRef.current, isModerator);
+          persistShapeWrapper(updatedRecord, whiteboardIdRef.current, isModeratorRef.current);
         });
 
         Object.values(updated).forEach(([_, record]) => {
@@ -871,7 +876,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
               updatedBy: currentUser?.userId,
             },
           };
-          persistShapeWrapper(updatedRecord, whiteboardIdRef.current, isModerator);
+          persistShapeWrapper(updatedRecord, whiteboardIdRef.current, isModeratorRef.current);
         });
 
         Object.values(removed).forEach((record) => {
@@ -976,7 +981,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
       editor.store.onBeforeChange = (prev, next, source) => {
         if (next?.typeName === "instance_page_state") {
 
-          if ((isPresenter || isModerator)) return next;
+          if (isPresenter || isModeratorRef.current) return next;
 
           // Filter selectedShapeIds based on shape owner
           if (next.selectedShapeIds.length > 0 && !isEqual(prev.selectedShapeIds, next.selectedShapeIds)) {
@@ -1037,7 +1042,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
     <div
       ref={whiteboardRef}
       id={"whiteboard-element"}
-      key={`animations=-${animations}-${isPresenter}-${isModerator}-${whiteboardToolbarAutoHide}-${language}`}
+      key={`animations=-${animations}-${whiteboardToolbarAutoHide}-${language}`}
     >
       <Tldraw
         key={`tldrawv2-${presentationId}-${animations}`}


### PR DESCRIPTION
### What does this PR do?
This PR, following up on #19688, addresses a bug where shapes for viewers would not update correctly if selected while another user with appropriate privileges made updates to the same shape. This fix ensures that shape updates are reflected even while selected, improving the collaborative editing experience.

### Motivation
before: 
![no-update-when-selected](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/3174ebb6-7a2c-4d1b-9dac-f3e6fdb4176a)

after:
![update-when-selected](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/126cdc37-7995-4283-9ac0-9d2fec7965bd)
