### PR TITLE
fix(whiteboard): Correct Slide Position On Zoom Reset And Resize

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -396,10 +396,10 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
       if (maxY > scaledHeight) {
         nextCamera.y += maxY - scaledHeight;
       }
-      if (nextCamera.x > 0 || minX < 0) {
+      if (nextCamera.x > 0 || minX < 0 || zoomValueRef.current === HUNDRED_PERCENT) {
         nextCamera.x = 0;
       }
-      if (nextCamera.y > 0 || minY < 0) {
+      if (nextCamera.y > 0 || minY < 0 || zoomValueRef.current === HUNDRED_PERCENT) {
         nextCamera.y = 0;
       }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -449,12 +449,8 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
 
   React.useEffect(() => {
     // Calculate the absolute difference
-    const heightDifference = Math.abs(
-      presentationAreaHeight - lastKnownHeight.current
-    );
-    const widthDifference = Math.abs(
-      presentationAreaWidth - lastKnownWidth.current
-    );
+    const heightDifference = Math.abs(presentationAreaHeight - lastKnownHeight.current);
+    const widthDifference = Math.abs(presentationAreaWidth - lastKnownWidth.current);
 
     // Check if the difference is greater than the threshold
     if (heightDifference > THRESHOLD || widthDifference > THRESHOLD) {
@@ -470,23 +466,19 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
         currentPresentationPage.scaledWidth > 0 &&
         currentPresentationPage.scaledHeight > 0
       ) {
-        let adjustedZoom = HUNDRED_PERCENT;
+        const currentZoom = zoomValueRef.current || HUNDRED_PERCENT;
+        const baseZoom = calculateZoomValue(
+          currentPresentationPage.scaledWidth,
+          currentPresentationPage.scaledHeight
+        );
+        let adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
 
         if (isPresenter) {
-          // Presenter logic
-          const currentZoom = zoomValueRef.current || HUNDRED_PERCENT;
-          const baseZoom = calculateZoomValue(
-            currentPresentationPage.scaledWidth,
-            currentPresentationPage.scaledHeight
-          );
-
-          adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
+          const camera = tlEditorRef.current.camera;
 
           if (fitToWidth && currentPresentationPage) {
             const currentAspectRatio =
-              Math.round(
-                (presentationAreaWidth / presentationAreaHeight) * 100
-              ) / 100;
+              Math.round((presentationAreaWidth / presentationAreaHeight) * 100) / 100;
             const previousAspectRatio =
               Math.round(
                 (currentPresentationPage.scaledViewBoxWidth /
@@ -494,11 +486,7 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
                   100
               ) / 100;
 
-            if (currentAspectRatio !== previousAspectRatio) {
-              setCamera(adjustedZoom);
-            } else {
-              setCamera(adjustedZoom);
-            }
+            setCamera(adjustedZoom, camera.x, camera.y);
 
             const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
               tlEditorRef.current?.viewportPageBounds.height,
@@ -509,12 +497,12 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
             zoomSlide(
               HUNDRED_PERCENT,
               viewedRegionH,
-              0,
-              0,
+              camera.x,
+              camera.y,
               presentationId
             );
           } else {
-            setCamera(adjustedZoom);
+            setCamera(adjustedZoom, camera.x, camera.y);
           }
         } else {
           // Viewer logic
@@ -522,13 +510,10 @@ export default Whiteboard = React.memo(function Whiteboard(props) {
             initialViewBoxWidth,
             currentPresentationPage.scaledViewBoxWidth
           );
-          const baseZoom = calculateZoomValue(
-            currentPresentationPage.scaledWidth,
-            currentPresentationPage.scaledHeight,
-            true
-          );
           adjustedZoom = baseZoom * (effectiveZoom / HUNDRED_PERCENT);
-          setCamera(adjustedZoom);
+
+          const camera = tlEditorRef.current.camera;
+          setCamera(adjustedZoom, camera.x, camera.y);
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
This PR addresses two issues in the whiteboard functionality:

- It corrects the slide's position when the zoom is reset to 100% following a pan operation.
- It ensures the slide maintains its intended position after a resize event, rather than resetting to a default position.

### Motivation
before:
![pan-reset-bug](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/5b83510b-7b6d-4f9a-b216-32000338ea48)

after:
![pan-reset-no-bug](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/82fa3e65-ca14-46ce-9eca-0a18f23e1fe4)
