### PR TITLE
Graphql: Insert joining users to db even when they are banned

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -91,7 +91,7 @@ object RegisteredUsers {
           // will fail and can't join.
           // ralam april 21, 2020
           val bannedUser = user.copy(banned = true)
-          //UserDAO.insert(meetingId, bannedUser)
+          UserDAO.insert(meetingId, bannedUser)
           users.save(bannedUser)
         } else {
           // If user hasn't been ejected, we allow user to join


### PR DESCRIPTION
In favor of #19507

It will be necessary to insert even banned users, once they will need to fetch the reason why they are unable to join using `user_current`.