### PR TITLE
feat(config): add checkSumAlgorithmForBreakouts in akka-apps

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -10,6 +10,7 @@ trait SystemConfiguration {
   lazy val bbbWebPort = Try(config.getInt("services.bbbWebPort")).getOrElse(8888)
   lazy val bbbWebAPI = Try(config.getString("services.bbbWebAPI")).getOrElse("localhost")
   lazy val bbbWebSharedSecret = Try(config.getString("services.sharedSecret")).getOrElse("changeme")
+  lazy val checkSumAlgorithmForBreakouts = Try(config.getString("services.checkSumAlgorithmForBreakouts")).getOrElse("sha256")
   lazy val bbbWebModeratorPassword = Try(config.getString("services.moderatorPassword")).getOrElse("changeme")
   lazy val bbbWebViewerPassword = Try(config.getString("services.viewerPassword")).getOrElse("changeme")
   lazy val keysExpiresInSec = Try(config.getInt("redis.keyExpiry")).getOrElse(14 * 86400) // 14 days

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.core.running.MeetingActor
 import java.net.URLEncoder
 import scala.collection.SortedSet
 import org.apache.commons.codec.digest.DigestUtils
+import org.bigbluebutton.SystemConfiguration
 
 trait BreakoutApp2x extends BreakoutRoomCreatedMsgHdlr
   with BreakoutRoomsListMsgHdlr
@@ -26,7 +27,7 @@ trait BreakoutApp2x extends BreakoutRoomCreatedMsgHdlr
 
 }
 
-object BreakoutRoomsUtil {
+object BreakoutRoomsUtil extends SystemConfiguration {
   def createMeetingIds(id: String, index: Int): (String, String) = {
     val timeStamp = System.currentTimeMillis()
     val externalHash = DigestUtils.sha1Hex(id.concat("-").concat(timeStamp.toString()).concat("-").concat(index.toString()))
@@ -48,7 +49,13 @@ object BreakoutRoomsUtil {
   //checksum() -- Return a checksum based on SHA-1 digest
   //
   def checksum(s: String): String = {
-    DigestUtils.sha256Hex(s);
+    checkSumAlgorithmForBreakouts match {
+      case "sha1"   => DigestUtils.sha1Hex(s);
+      case "sha256" => DigestUtils.sha256Hex(s);
+      case "sha384" => DigestUtils.sha384Hex(s);
+      case "sha512" => DigestUtils.sha512Hex(s);
+      case _        => DigestUtils.sha256Hex(s); // default
+    }
   }
 
   def calculateChecksum(apiCall: String, baseString: String, sharedSecret: String): String = {

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -44,6 +44,7 @@ expire {
 services {
   bbbWebAPI = "https://192.168.23.33/bigbluebutton/api"
   sharedSecret = "changeme"
+  checkSumAlgorithmForBreakouts = "sha256"
 }
 
 eventBus {

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -161,7 +161,26 @@ $ sudo bbb-conf --setsecret \$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+
 
 There are other configuration values in bbb-web's configuration `bigbluebutton.properties` (overwritten by `/etc/bigbluebutton/bbb-web.properties` ) related to the lifecycle of a meeting. You don't need to understand all of these to start using the BigBlueButton API. For most BigBlueButton servers, you can leave the [default values](https://github.com/bigbluebutton/bigbluebutton/blob/main/bigbluebutton-web/grails-app/conf/bigbluebutton.properties).
 
-In 2.5 support for additional hashing algorithms, besides sha1 and sha256, were added. These include sha384 and sha512. The `supportedChecksumAlgorithms` property in `bigbluebutton.properties` defines which algorithms are supported. By default checksums can be validated with any of the supported algorithms. To remove support for one or more of these algorithms simply delete it from the configuration file.
+In BigBlueButton 2.5 support for additional hashing algorithms, besides sha1 and sha256, were added. These include sha384 and sha512. The `supportedChecksumAlgorithms` property in bbb-web defines which algorithms are supported. By default checksums can be validated with any of the supported algorithms. To remove support for one or more of these algorithms simply delete it from the configuration file.
+If you drop support for sha256, (for example if you want to force only sha512 to be used) you will also need to update the `checkSumAlgorithmForBreakouts` property in akka-apps.
+
+In `/etc/bigbluebutton/bbb-web.properties`:
+
+```properties
+supportedChecksumAlgorithms=sha512
+```
+
+In `/etc/bigbluebutton/bbb-apps-akka.conf`:
+
+```properties
+services {
+  checkSumAlgorithmForBreakouts = "sha512"
+  #...
+}
+```
+
+And make sure to restart BigBlueButton.
+
 
 ### Usage
 

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -287,6 +287,11 @@ Also check the official docs for managing NodeJS installations https://github.co
 Up to BigBlueButton 2.6.12 we were using Java 11 (and were installing version 16 in bbb-install-26.sh) for several of the core components. Given that the LTS premium support ends in September 2023, we have backported support for Java 17 LTS and are modifying bbb-install-2.6.sh to install this newer version too.
 Whether you upgrade to BigBlueButton 2.6.14+ via bbb-install-2.6.sh or just through packages, the upgrade should go smoothly. No extra steps are required.
 
+#### Improved support for various SHA algorithms for checksum calculation
+
+In BigBlueButton 2.6.17 we added a new configuration property for bbb-apps-akka package under `services` called `checkSumAlgorithmForBreakouts`. By default the value is `"sha256"`. It controls the algorithm for checksum calculation for the breakout rooms join link. In case you overwrite bbb-web's `supportedChecksumAlgorithms` property removing sha256 you will need to set a supported algorithm here too. For example if you want to only use `sha512`, set `supportedChecksumAlgorithms=sha512` in `/etc/bigbluebutton/bbb-web.properties` and also set `checkSumAlgorithmForBreakouts="sha512"` in `/etc/bigbluebutton/bbb-apps-akka.conf` and then restart BigBlueButton.
+
+
 ### Development
 
 For information on developing in BigBlueButton, see [setting up a development environment for 2.6](/development/guide).


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Introduces a new config for akka-apps so that the use of `sha256` is no longer hardcoded in breakouts join url creation. Detailed docs are included in this PR.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/19726 / https://github.com/bigbluebutton/bigbluebutton/issues/19736


### Motivation
Breakouts joining would result in a screen complaining about the checksum.
<!-- What inspired you to submit this pull request? -->

### More
 - [ ] This change will be propagated in a separate PR to BBB 2.7 and also to BBB 3.0+
 - [ ] docs action needs to be triggered once the PR is merged.
