### PR TITLE
graphql-middleware: Implement Rate Limit for new Ws Connections

### DIFF
--- a/bbb-graphql-middleware/bbb-graphql-middleware-config.env
+++ b/bbb-graphql-middleware/bbb-graphql-middleware-config.env
@@ -3,6 +3,7 @@ BBB_GRAPHQL_MIDDLEWARE_LISTEN_PORT=8378
 BBB_GRAPHQL_MIDDLEWARE_REDIS_ADDRESS=127.0.0.1:6379
 BBB_GRAPHQL_MIDDLEWARE_REDIS_PASSWORD=
 BBB_GRAPHQL_MIDDLEWARE_HASURA_WS=ws://127.0.0.1:8080/v1/graphql
+BBB_GRAPHQL_MIDDLEWARE_RATE_LIMIT_IN_MS=50
 
 # If you are running a cluster proxy setup, you need to configure the Origin of
 # the frontend. See https://docs.bigbluebutton.org/administration/cluster-proxy

--- a/bbb-graphql-middleware/go.mod
+++ b/bbb-graphql-middleware/go.mod
@@ -16,4 +16,5 @@ require (
 	github.com/evanphx/json-patch v0.5.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/time v0.5.0 // indirect
 )

--- a/bbb-graphql-middleware/go.sum
+++ b/bbb-graphql-middleware/go.sum
@@ -27,6 +27,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
In this update to our `bbb-graphql-middleware` application, we've implemented a configurable rate-limiting mechanism for managing WebSocket GraphQL connections. 
The established default rate limit is set at **one new connection every 50 milliseconds (20 users per second)**. This configuration is carefully chosen to align with the minimum BigBlueButton system requirements of an 8-Core CPU server.
This approach ensures that the usability and responsiveness for existing users in a meeting are maintained at optimal levels, protecting the overall meeting quality from being compromised by a surge in new connections.

Recognizing the diverse performance capabilities of server setups, we've introduced the `BBB_GRAPHQL_MIDDLEWARE_RATE_LIMIT_IN_MS` environment variable. This addition allows system administrators to adjust the rate limit to better suit the performance characteristics of their specific server hardware. 
For servers boasting higher performance metrics, decreasing this rate limit can lead to an increased rate of new connections, thus accommodating more users efficiently. 
Conversely, on systems with lesser capabilities than the BBB's recommended minimum, increasing the rate limit is advisable to prevent overloads and ensure a seamless experience for all users.