### PR TITLE
fix: Invite users after creating breakout rooms not working

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room-graphql/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room-graphql/create-breakout-room/component.tsx
@@ -314,7 +314,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         moveUser({
           variables: {
             userId,
-            fromBreakoutRoomId: fromRoomId,
+            fromBreakoutRoomId: fromRoomId || '',
             toBreakoutRoomId: toRoomId,
           },
         });


### PR DESCRIPTION
### What does this PR do?

Fix move user to breakout after breakout creation.

### Closes Issue(s)
Closes #19244