### PR TITLE
Fix (akka-apps): Config from /etc not being read when running through `sbt reStart`

### DIFF
--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -77,5 +77,4 @@ daemonGroup in Linux := group
 javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
 javaOptions in reStart ++= Seq("-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
 
-
 debianPackageDependencies in Debian ++= Seq("java17-runtime-headless", "bash")

--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -75,5 +75,7 @@ daemonUser in Linux := user
 daemonGroup in Linux := group
 
 javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
+javaOptions in reStart ++= Seq("-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
+
 
 debianPackageDependencies in Debian ++= Seq("java17-runtime-headless", "bash")


### PR DESCRIPTION
As reported by @antobinary .

When using the script `./run-dev.sh`  to run Akka-apps from source, it is ignoring the configs from `/etc/bigbluebutton/bbb-apps-akka.conf`.