### PR TITLE
Fix (akka-apps) (2.7): Config from /etc not being read when running through `sbt reStart`

### DIFF
--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -75,5 +75,6 @@ daemonUser in Linux := user
 daemonGroup in Linux := group
 
 javaOptions in Universal ++= Seq("-J-Xms130m", "-J-Xmx256m", "-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
+javaOptions in reStart ++= Seq("-Dconfig.file=/etc/bigbluebutton/bbb-apps-akka.conf", "-Dlogback.configurationFile=conf/logback.xml")
 
 debianPackageDependencies in Debian ++= Seq("java17-runtime-headless", "bash")


### PR DESCRIPTION
Backport of #19756