### PR TITLE
refactor (akka-apps): Increase Slick/Postgres queueSize

### DIFF
--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -51,6 +51,7 @@ postgres {
         }
         numThreads = 1
         maxConnections = 1
+        queueSize = 20000
 }
 
 


### PR DESCRIPTION
This PR increases the `queueSize` parameter in our Scala/Slick setup for Postgres from the default 1,000 to 20,000 to handle spikes of up to 1,000 simultaneous users more effectively. 
This change aims to prevent queue overflow, ensuring smoother operation and enhanced stability during high load scenarios.

https://scala-slick.org/doc/3.3.0/database.html