### PR TITLE
fix(locale): Remove duplicate localization row

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -607,7 +607,6 @@
     "app.settings.audioTab.label": "Audio",
     "app.settings.videoTab.label": "Video",
     "app.settings.usersTab.label": "Participants",
-    "app.settings.transcriptionTab.label": "Transcription",
     "app.settings.main.label": "Settings",
     "app.settings.main.cancel.label": "Cancel",
     "app.settings.main.cancel.label.description": "Discards the changes and closes the settings menu",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Removes a duplicated localization row
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #


### Motivation
This duplication led to Transifex pickup to fail, resulting in missing strings.
<!-- What inspired you to submit this pull request? -->

### More
Transifex should pick this change right away, allowing for people to translate `End meeting for all` and possibly other missing strings.
