### PR TITLE
Fix some typos (found by typos)

### DIFF
--- a/docs/docs/accessibility.md
+++ b/docs/docs/accessibility.md
@@ -69,7 +69,7 @@ HTML5 by default uses the `outline` attribute to visually indicate focus. Due to
 
 ![Image showing join audio aria label over the join audio icon](/img/accessibility-focusring-hc.jpg)
 
-Aria labels are important to focus when navigating with a screen reader, these labels have been used extensivley through out the client to provide audible announcements for selected
+Aria labels are important to focus when navigating with a screen reader, these labels have been used extensively through out the client to provide audible announcements for selected
 elements.
 
 #### Keyboard Navigation

--- a/docs/docs/administration/configure-firewall.md
+++ b/docs/docs/administration/configure-firewall.md
@@ -400,7 +400,7 @@ If you don't see this, follow the steps below on your BigBlueButton server to se
 
 ![Install](/img/11-install-net3.png)
 
-In this diagram, we've setup a dummy NIC for 203.0.113.1, which will allow FreeSWITCH to connect back to itself. This way, when FreeSWICH receives an internal connection from other parts of BigBlueButton, it will think that it's on the external interface. This will cause it to use the correct IP address on the response.
+In this diagram, we've setup a dummy NIC for 203.0.113.1, which will allow FreeSWITCH to connect back to itself. This way, when FreeSWITCH receives an internal connection from other parts of BigBlueButton, it will think that it's on the external interface. This will cause it to use the correct IP address on the response.
 
 To setup a dummy NIC, on your BigBlueButton enter the following command and substitute `EXTERNAL_IP_ADDRESS` with the external IP address of your firewall.
 

--- a/docs/docs/administration/install.md
+++ b/docs/docs/administration/install.md
@@ -334,7 +334,7 @@ You can upgrade by re-running the `bbb-install.sh` script again -- it will downl
 
 If you are upgrading BigBlueButton 2.6 or 2.7 we recommend you set up a new Ubuntu 22.04 server with BigBlueButton 3.0 and then [copy over your existing recordings from the old server](/administration/customize#transfer-published-recordings-from-another-server).
 
-Make sure you read through the "what's new in 3.0" document https://docs.bigbluebutton.org/3.0/new and especifically https://docs.bigbluebutton.org/3.0/new#other-notable-changes
+Make sure you read through the "what's new in 3.0" document https://docs.bigbluebutton.org/3.0/new and especially https://docs.bigbluebutton.org/3.0/new#other-notable-changes
 
 ### Restart your server
 

--- a/docs/docs/administration/nextcloud.md
+++ b/docs/docs/administration/nextcloud.md
@@ -129,4 +129,4 @@ It may look something like this (`/etc/apache2/sites-available/000-default.conf`
  - If even with all these solutions your let's encrypt is not working, follow on with one of
  [these alternatives](https://help.nextcloud.com/t/domain-not-working-after-letsencrypt/83862), particularly this one:
 
-`"The default vhost is used whenever a client is accessing your server by direct IP-addres(...)"`
+`"The default vhost is used whenever a client is accessing your server by direct IP-address(...)"`

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -489,7 +489,7 @@ Here are the list of issues we fixed on this release:
 * [Issue 885](https://github.com/bigbluebutton/bigbluebutton/issues/885) Hearing voices after logging out
 * [Issue 890](https://github.com/bigbluebutton/bigbluebutton/issues/890) Participant entry sound plays when user icon is clicked
 * [Issue 891](https://github.com/bigbluebutton/bigbluebutton/issues/891) Phone Logout null pointer exception
-* [Issue 893](https://github.com/bigbluebutton/bigbluebutton/issues/893) Unmute-all icon mis-aligned
+* [Issue 893](https://github.com/bigbluebutton/bigbluebutton/issues/893) Unmute-all icon misaligned
 * [Issue 894](https://github.com/bigbluebutton/bigbluebutton/issues/894) bbb-setip not detecting rtmp port
 
 #### Known Issues

--- a/docs/docs/support/road-map.md
+++ b/docs/docs/support/road-map.md
@@ -73,7 +73,7 @@ When uploading slides with clickable links, they could be clicked in the Flash c
 
 ### Layout Dropdown
 
-The Flash client had a layout menu that let moderators push down layout changes in windows to all viewers.  The HMTL5 client does not use windows (it uses panels that show/hide).  We are going to add capabilities for the moderator to show/hide the presentation area in a future update.
+The Flash client had a layout menu that let moderators push down layout changes in windows to all viewers.  The HTML5 client does not use windows (it uses panels that show/hide).  We are going to add capabilities for the moderator to show/hide the presentation area in a future update.
 
 ### Show Slide Thumbnails
 

--- a/docs/docs/testing/release-testing.md
+++ b/docs/docs/testing/release-testing.md
@@ -158,7 +158,7 @@ all of these tests.
 
 2. Click "Options" (three dots icon on top-right of the presentation area), select "Snapshot of current presentation".
 
-3. You should get promted to save the file. The file should contains the image of the current slide of the presentation, including the annotations applied.
+3. You should get prompted to save the file. The file should contains the image of the current slide of the presentation, including the annotations applied.
 
 ### Fit to width option
 


### PR DESCRIPTION
Note that is PR also renames docs/docs/accessiblity.md → docs/docs/accessibility.md.

There exists another file with a typo in the filename (docs/static/img/23-user-reponse.png) which might be unused.