### PR TITLE
Fix: Messages from the previous chat  being carried on chat switch.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -116,7 +116,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   }, []);
 
   if (!chatMessageData) return null;
-  if (chatId !== chatMessageData[0].chatId) return <ChatLoading isRTL={document.dir === 'rtl'} />;
+  if (chatMessageData.length > 0 && chatId !== chatMessageData[0].chatId) return <ChatLoading isRTL={document.dir === 'rtl'} />;
   if (chatMessageData.length > 0 && chatMessageData[chatMessageData.length - 1].user?.userId) {
     setLastSender(page, chatMessageData[chatMessageData.length - 1].user?.userId);
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -14,6 +14,7 @@ import ChatMessage from './chat-message/component';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 import { setLoadedMessageGathering } from '/imports/ui/core/hooks/useLoadedChatMessages';
+import { ChatLoading } from '../../component';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = window.meetingClientSettings.public.chat;
@@ -113,7 +114,9 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       setLoadedMessageGathering(page, []);
     };
   }, []);
+
   if (!chatMessageData) return null;
+  if (chatId !== chatMessageData[0].chatId) return <ChatLoading isRTL={document.dir === 'rtl'} />;
   if (chatMessageData.length > 0 && chatMessageData[chatMessageData.length - 1].user?.userId) {
     setLastSender(page, chatMessageData[chatMessageData.length - 1].user?.userId);
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -31,7 +31,7 @@ const Chat: React.FC<ChatProps> = ({ isRTL }) => {
   );
 };
 
-const ChatLoading: React.FC<ChatProps> = ({ isRTL }) => {
+export const ChatLoading: React.FC<ChatProps> = ({ isRTL }) => {
   const { isChrome } = browserInfo;
   return (
     <Styled.Chat isRTL={isRTL} isChrome={isChrome}>


### PR DESCRIPTION
### What does this PR do?

This pull request resolves the issue where messages from the previous chat were displayed prematurely, appearing before messages from the subsequent chat. This fix ensures that messages are displayed in the correct chronological order.

### Closes Issue(s)

#19200
