### PR TITLE
fix(bbb-export-annotations): Flag to force CairoSVG to embed images

### DIFF
--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -20,7 +20,8 @@
       "maxImageHeight": 1080,
       "textScaleFactor": 2,
       "pointsPerInch": 72,
-      "pixelsPerInch": 96
+      "pixelsPerInch": 96,
+      "cairoSVGUnsafeFlag": true
     },
     "notifier": {
       "pod_id": "DEFAULT_PRESENTATION_POD",

--- a/bbb-export-annotations/config/settings.json
+++ b/bbb-export-annotations/config/settings.json
@@ -21,7 +21,7 @@
       "textScaleFactor": 2,
       "pointsPerInch": 72,
       "pixelsPerInch": 96,
-      "cairoSVGUnsafeFlag": true
+      "cairoSVGUnsafeFlag": false
     },
     "notifier": {
       "pod_id": "DEFAULT_PRESENTATION_POD",

--- a/bbb-export-annotations/master.js
+++ b/bbb-export-annotations/master.js
@@ -11,9 +11,11 @@ logger.info('Running bbb-export-annotations');
 
 (async () => {
   const client = redis.createClient({
-    host: config.redis.host,
-    port: config.redis.port,
     password: config.redis.password,
+    socket: {
+        host: config.redis.host,
+        port: config.redis.port
+    }
   });
 
   await client.connect();

--- a/bbb-export-annotations/workers/collector.js
+++ b/bbb-export-annotations/workers/collector.js
@@ -25,9 +25,11 @@ const jobType = exportJob.jobType;
 
 async function collectAnnotationsFromRedis() {
   const client = redis.createClient({
-    host: config.redis.host,
-    port: config.redis.port,
     password: config.redis.password,
+    socket: {
+        host: config.redis.host,
+        port: config.redis.port
+    }
   });
 
   client.on('error', (err) => logger.info('Redis Client Error', err));

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -20,9 +20,11 @@ const exportJob = JSON.parse(job);
  * sending a message through Redis PubSub */
 async function notifyMeetingActor() {
   const client = redis.createClient({
-    host: config.redis.host,
-    port: config.redis.port,
     password: config.redis.password,
+    socket: {
+        host: config.redis.host,
+        port: config.redis.port
+    }
   });
 
   await client.connect();

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -794,9 +794,11 @@ function overlay_annotations(svg, currentSlideAnnotations) {
 // Process the presentation pages and annotations into a PDF file
 async function process_presentation_annotations() {
   const client = redis.createClient({
-    host: config.redis.host,
-    port: config.redis.port,
     password: config.redis.password,
+    socket: {
+        host: config.redis.host,
+        port: config.redis.port
+    }
   });
 
   await client.connect();
@@ -873,6 +875,7 @@ async function process_presentation_annotations() {
       SVGfile,
       '--output-width', to_px(slideWidth),
       '--output-height', to_px(slideHeight),
+      '-u',
       '-o', PDFfile,
     ];
 

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -870,12 +870,18 @@ async function process_presentation_annotations() {
       }
     });
 
-    // Scale slide back to its original size
+/**
+ * Constructs the command arguments for converting an annotated slide from SVG to PDF format.
+ * `cairoSVGUnsafeFlag` should be enabled (true) for CairoSVG versions >= 2.7.0
+ * to allow external resources, such as presentation slides, to be loaded.
+ *
+ * @const {string[]} convertAnnotatedSlide - The command arguments for the conversion process.
+ */
     const convertAnnotatedSlide = [
       SVGfile,
       '--output-width', to_px(slideWidth),
       '--output-height', to_px(slideHeight),
-      '-u',
+      ...(config.process.cairoSVGUnsafeFlag ? ['-u'] : []),
       '-o', PDFfile,
     ];
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

The pull request #19707 sets CairoSVG's `--unsafe` option to let external resources be loaded. Albeit necessary to, e.g., load presentation slides, some server admins may choose to disable it out of an abundance of caution.

### More
CairoSVG versions before 2.7 can set the flag to false.