### PR TITLE
refactor (graphql-middleware): Improve performance when browser finish graphql connection

### DIFF
--- a/bbb-graphql-middleware/internal/common/SafeChannel.go
+++ b/bbb-graphql-middleware/internal/common/SafeChannel.go
@@ -47,6 +47,10 @@ func (s *SafeChannel) Close() {
 	}
 }
 
+func (s *SafeChannel) Frozen() bool {
+	return s.freezeFlag
+}
+
 func (s *SafeChannel) FreezeChannel() {
 	if !s.freezeFlag {
 		s.mux.Lock()

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -134,9 +134,11 @@ func handleStreamingMessage(hc *common.HasuraConnection, messageMap map[string]i
 
 func handleCompleteMessage(hc *common.HasuraConnection, queryId string) {
 	hc.Browserconn.ActiveSubscriptionsMutex.Lock()
+	queryType := hc.Browserconn.ActiveSubscriptions[queryId].Type
+	operationName := hc.Browserconn.ActiveSubscriptions[queryId].OperationName
 	delete(hc.Browserconn.ActiveSubscriptions, queryId)
 	hc.Browserconn.ActiveSubscriptionsMutex.Unlock()
-	log.Debugf("Subscription with Id %s finished by Hasura.", queryId)
+	log.Debugf("%s (%s) with Id %s finished by Hasura.", queryType, operationName, queryId)
 }
 
 func handleConnectionAckMessage(hc *common.HasuraConnection, messageMap map[string]interface{}, fromHasuraToBrowserChannel *common.SafeChannel, fromBrowserToHasuraChannel *common.SafeChannel) {

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -39,9 +39,11 @@ RangeLoop:
 		case <-hc.Context.Done():
 			break RangeLoop
 		case <-hc.MsgReceivingActiveChan.ReceiveChannel():
-			log.Debugf("freezing channel fromBrowserToHasuraChannel")
-			//Freeze channel once it's about to close Hasura connection
-			fromBrowserToHasuraChannel.FreezeChannel()
+			if !fromBrowserToHasuraChannel.Frozen() {
+				log.Debugf("freezing channel fromBrowserToHasuraChannel")
+				//Freeze channel once it's about to close Hasura connection
+				fromBrowserToHasuraChannel.FreezeChannel()
+			}
 		case fromBrowserMessage := <-fromBrowserToHasuraChannel.ReceiveChannel():
 			{
 				if fromBrowserMessage == nil {

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -47,11 +47,11 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 		acceptOptions.OriginPatterns = append(acceptOptions.OriginPatterns, bbbOrigin)
 	}
 
-	c, err := websocket.Accept(w, r, &acceptOptions)
+	browserWsConn, err := websocket.Accept(w, r, &acceptOptions)
 	if err != nil {
 		log.Errorf("error: %v", err)
 	}
-	defer c.Close(websocket.StatusInternalError, "the sky is falling")
+	defer browserWsConn.Close(websocket.StatusInternalError, "the sky is falling")
 
 	var thisConnection = common.BrowserConnection{
 		Id:                   browserConnectionId,
@@ -116,14 +116,16 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	wgReader.Add(1)
 
 	// Reads from browser connection, writes into fromBrowserToHasuraChannel and fromBrowserToHasuraConnectionEstablishingChannel
-	go reader.BrowserConnectionReader(browserConnectionId, browserConnectionContext, c, fromBrowserToHasuraChannel, fromBrowserToHasuraConnectionEstablishingChannel, []*sync.WaitGroup{&wgAll, &wgReader})
+	go reader.BrowserConnectionReader(browserConnectionId, browserConnectionContext, browserConnectionContextCancel, browserWsConn, fromBrowserToHasuraChannel, fromBrowserToHasuraConnectionEstablishingChannel, []*sync.WaitGroup{&wgAll, &wgReader})
 	go func() {
 		wgReader.Wait()
+		log.Debug("BrowserConnectionReader finished, closing Write Channel")
+		fromHasuraToBrowserChannel.Close()
 		thisConnection.Disconnected = true
 	}()
 
 	// Reads from fromHasuraToBrowserChannel, writes to browser connection
-	go writer.BrowserConnectionWriter(browserConnectionId, browserConnectionContext, c, fromHasuraToBrowserChannel, &wgAll)
+	go writer.BrowserConnectionWriter(browserConnectionId, browserConnectionContext, browserWsConn, fromHasuraToBrowserChannel, &wgAll)
 
 	go ConnectionInitHandler(browserConnectionId, browserConnectionContext, fromBrowserToHasuraConnectionEstablishingChannel, &wgAll)
 
@@ -157,9 +159,10 @@ func InvalidateSessionTokenConnections(sessionTokenToInvalidate string) {
 					time.Sleep(100 * time.Millisecond)
 				}
 
-				log.Debugf("Processing invalidate request for sessionToken %v (hasura connection %v)", sessionTokenToInvalidate, browserConnection.HasuraConnection.Id)
+				hasuraConnectionId := browserConnection.HasuraConnection.Id
+				log.Debugf("Processing invalidate request for sessionToken %v (hasura connection %v)", sessionTokenToInvalidate, hasuraConnectionId)
 				browserConnection.HasuraConnection.ContextCancelFunc()
-				log.Debugf("Processed invalidate request for sessionToken %v (hasura connection %v)", sessionTokenToInvalidate, browserConnection.HasuraConnection.Id)
+				log.Debugf("Processed invalidate request for sessionToken %v (hasura connection %v)", sessionTokenToInvalidate, hasuraConnectionId)
 
 				go SendUserGraphqlReconnectionForcedEvtMsg(browserConnection.SessionToken)
 			}

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromBrowserToHasuraChannel *common.SafeChannel, fromBrowserToHasuraConnectionEstablishingChannel *common.SafeChannel, waitGroups []*sync.WaitGroup) {
+func BrowserConnectionReader(browserConnectionId string, ctx context.Context, ctxCancel context.CancelFunc, browserWsConn *websocket.Conn, fromBrowserToHasuraChannel *common.SafeChannel, fromBrowserToHasuraConnectionEstablishingChannel *common.SafeChannel, waitGroups []*sync.WaitGroup) {
 	log := log.WithField("_routine", "BrowserConnectionReader").WithField("browserConnectionId", browserConnectionId)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
@@ -29,12 +29,11 @@ func BrowserConnectionReader(browserConnectionId string, ctx context.Context, c 
 		time.Sleep(100 * time.Millisecond)
 	}()
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	defer ctxCancel()
 
 	for {
 		var v interface{}
-		err := wsjson.Read(ctx, c, &v)
+		err := wsjson.Read(ctx, browserWsConn, &v)
 		if err != nil {
 			log.Debugf("Browser is disconnected, skiping reading of ws message: %v", err)
 			return

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -55,7 +55,8 @@ func StartRedisListener() {
 			messageCoreAsMap := messageAsMap["core"].(map[string]interface{})
 			messageBodyAsMap := messageCoreAsMap["body"].(map[string]interface{})
 			sessionTokenToInvalidate := messageBodyAsMap["sessionToken"]
-			log.Debugf("Received invalidate request for sessionToken %v", sessionTokenToInvalidate)
+			reason := messageBodyAsMap["reason"]
+			log.Debugf("Received invalidate request for sessionToken %v (%v)", sessionTokenToInvalidate, reason)
 
 			//Not being used yet
 			go InvalidateSessionTokenConnections(sessionTokenToInvalidate.(string))

--- a/bbb-graphql-middleware/internal/websrv/writer/writer.go
+++ b/bbb-graphql-middleware/internal/websrv/writer/writer.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
 	log "github.com/sirupsen/logrus"
-	"sync"
-
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
+	"sync"
 )
 
-func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, c *websocket.Conn, fromHasuraToBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
+func BrowserConnectionWriter(browserConnectionId string, ctx context.Context, browserWsConn *websocket.Conn, fromHasuraToBrowserChannel *common.SafeChannel, wg *sync.WaitGroup) {
 	log := log.WithField("_routine", "BrowserConnectionWriter").WithField("browserConnectionId", browserConnectionId)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
@@ -20,13 +19,18 @@ RangeLoop:
 	for {
 		select {
 		case <-ctx.Done():
+			log.Debug("Browser context cancelled.")
 			break RangeLoop
 		case toBrowserMessage := <-fromHasuraToBrowserChannel.ReceiveChannel():
 			{
+				if toBrowserMessage == nil {
+					continue
+				}
+
 				var toBrowserMessageAsMap = toBrowserMessage.(map[string]interface{})
 
 				log.Tracef("sending to browser: %v", toBrowserMessage)
-				err := wsjson.Write(ctx, c, toBrowserMessage)
+				err := wsjson.Write(ctx, browserWsConn, toBrowserMessage)
 				if err != nil {
 					log.Debugf("Browser is disconnected, skiping writing of ws message: %v", err)
 					return
@@ -36,7 +40,7 @@ RangeLoop:
 				// Authentication hook unauthorized this request
 				if toBrowserMessageAsMap["type"] == "connection_error" {
 					var payloadAsString = toBrowserMessageAsMap["payload"].(string)
-					c.Close(websocket.StatusInternalError, payloadAsString)
+					browserWsConn.Close(websocket.StatusInternalError, payloadAsString)
 				}
 			}
 		}

--- a/bbb-graphql-middleware/run-dev.sh
+++ b/bbb-graphql-middleware/run-dev.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
-nodemon --exec go run cmd/bbb-graphql-middleware/main.go  --signal SIGTERM
+
+sudo systemctl stop bbb-graphql-middleware
+set -a # Automatically export all variables
+source ./bbb-graphql-middleware-config.env
+set +a # Stop automatically exporting
+go run cmd/bbb-graphql-middleware/main.go  --signal SIGTERM


### PR DESCRIPTION
This PR tackle an issue where BBB was increasing CPU usage when 400+ connections was being closed at the same time.
It would impact when the meeting is finished and all the browsers has its ws connection closed!

The main change is at `bbb-graphql-middleware/internal/websrv/reader/reader.go` that is now receiving the browser `contextCancel` func and call it when the browser connection is closed.

Moreover:
- Improve logs
- Improve `run-dev.sh` 
- Improve var names