### PR TITLE
Fix: loading client with invalid session token

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
+import { Session } from 'meteor/session';
 import { ErrorScreen } from '../../error-screen/component';
 import LoadingScreen from '../../common/loading-screen/component';
-import { Session } from 'meteor/session';
 
 const connectionTimeout = 60000;
 

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { ErrorScreen } from '../../error-screen/component';
 import LoadingScreen from '../../common/loading-screen/component';
+import { Session } from 'meteor/session';
 
 const connectionTimeout = 60000;
 
@@ -69,6 +70,10 @@ const StartupDataFetch: React.FC<StartupDataFetchProps> = ({
         setSettingsFetched(true);
         clearTimeout(timeoutRef.current);
         setLoading(false);
+      }).catch(() => {
+        Session.set('errorMessageDescription', 'meeting_ended');
+        setError('Error fetching startup data');
+        setLoading(false);
       });
   }, []);
 
@@ -79,6 +84,7 @@ const StartupDataFetch: React.FC<StartupDataFetchProps> = ({
         ? (
           <ErrorScreen
             endedReason={error}
+            code={404}
           />
         )
         : null}

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
@@ -84,7 +84,7 @@ const StartupDataFetch: React.FC<StartupDataFetchProps> = ({
         ? (
           <ErrorScreen
             endedReason={error}
-            code={404}
+            code={403}
           />
         )
         : null}


### PR DESCRIPTION
### What does this PR do?

When a session is invalid user can't fetch settings data from server, the error wasn't handle, this PR implements a catch to handle it.