### PR TITLE
fix(poll): poll element covering the whole presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/polling-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/polling/polling-graphql/styles.ts
@@ -117,8 +117,7 @@ const MultipleResponseAnswersTableAnswerText = styled.td`
 
 const Overlay = styled.div`
   position: absolute;
-  height: 100vh;
-  width: 100vw;
+  inset: 0;
   z-index: ${overlayIndex};
   pointer-events: none;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -1,10 +1,4 @@
 import styled, { createGlobalStyle } from 'styled-components';
-import { borderSize, borderSizeLarge } from '/imports/ui/stylesheets/styled-components/general';
-import { toolbarButtonColor, colorWhite, colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
-import {
-  fontSizeLarger,
-} from '/imports/ui/stylesheets/styled-components/typography';
-import Button from '/imports/ui/components/common/button/component';
 
 const TldrawV2GlobalStyle = createGlobalStyle`
   ${({ isPresenter, hasWBAccess }) => (!isPresenter && hasWBAccess) && `
@@ -44,17 +38,17 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     }
   `}
 
-  #presentationInnerWrapper > div:last-child {
+  #whiteboard-element {
     position: relative;
     height: 100%;
   }
 
-  #presentationInnerWrapper > div:last-child > * {
+  #whiteboard-element > * {
     position: relative; 
     height: 100%;
   }
 
-  #presentationInnerWrapper > div:last-child .tl-overlays {
+  #whiteboard-element .tl-overlays {
     left: 0px;
     bottom: 0px;
   }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Fixes polling box covering the whole presentation when it's in fullscreen.

Before (while in fullscreen)

![Screenshot from 2024-03-14 12-21-25](https://github.com/bigbluebutton/bigbluebutton/assets/62393923/3a830e3b-dc8b-41f7-adf6-165bcd485a2b)

After (while in fullscreen)

![Screenshot from 2024-03-14 12-20-23](https://github.com/bigbluebutton/bigbluebutton/assets/62393923/9ee6e27c-2a10-4213-962d-0e4e01025841)