### PR TITLE
[3.0] build(bbb-webrtc-recorder): v0.7.0

### DIFF
--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v0.6.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder
+git clone --branch v0.7.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder


### PR DESCRIPTION
### v0.7.0

* fix: panic due to invalid OPUS samples pushed to builder
* build(docker): go 1.21
* build: bump pion/webrtc/v3 to v3.2.24