### PR TITLE
fix: wrong chat name displayed when poll is published

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/container.jsx
@@ -11,7 +11,7 @@ import { POLL_PUBLISH_RESULT, POLL_CANCEL, POLL_CREATE } from './mutations';
 import { ACTIONS, PANELS } from '../layout/enums';
 
 const CHAT_CONFIG = window.meetingClientSettings.public.chat;
-const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_id;
+const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_group_id;
 
 const PollContainer = (props) => {
   const layoutContextDispatch = layoutDispatch();


### PR DESCRIPTION
### What does this PR do?

fix wrong chat id being set on poll publish

![2024-03-15_09-33](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/c883f036-e65d-4ca1-9045-837852584336)
