### PR TITLE
fix(whiteboard): Hide Tldraw Native Navigation And Control Elements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -62,7 +62,7 @@ const TldrawV2GlobalStyle = createGlobalStyle`
   .tlui-navigation-zone,
   .tlui-help-menu,
   .tlui-debug-panel {
-    display: none;
+    display: none !important;
   }
 
   .tlui-style-panel__wrapper {
@@ -93,8 +93,8 @@ const TldrawV2GlobalStyle = createGlobalStyle`
   [data-testid="main.menu"],
   [data-testid="tools.laser"],
   [data-testid="tools.asset"],
-  .tlui-menu-zone__controls > :nth-child(1),
-  .tlui-menu-zone__controls > :nth-child(2) {
+  .tlui-buttons__horizontal > :nth-child(1),
+  .tlui-buttons__horizontal > :nth-child(2) {
     display: none;
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the CSS to handle the hiding of the Tldraw native navigation and control UI elements

### Motivation
before:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/0c37ba83-4e3b-4fc7-a525-e32bc74a55f0)

after:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/d2ebdd57-981f-47b4-9c98-57f5f27b6ed0)
