### PR TITLE
Refactor: make cursor coordinates be cosumed from stream

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -8,7 +8,6 @@ import {
   CURRENT_PAGE_ANNOTATIONS_STREAM,
   CURRENT_PAGE_WRITERS_SUBSCRIPTION,
 } from './queries';
-import { CURSOR_SUBSCRIPTION } from './cursors/queries';
 import {
   initDefaultPages,
   persistShape,
@@ -36,6 +35,7 @@ import {
   PRES_ANNOTATION_SUBMIT,
   PRESENTATION_SET_PAGE,
 } from '../presentation/mutations';
+import { useMergedCursorData } from './hooks.ts';
 
 const WHITEBOARD_CONFIG = window.meetingClientSettings.public.whiteboard;
 
@@ -139,8 +139,7 @@ const WhiteboardContainer = (props) => {
     userId: user.userId,
   }));
 
-  const { data: cursorData } = useSubscription(CURSOR_SUBSCRIPTION);
-  const { pres_page_cursor: cursorArray } = (cursorData || []);
+  const cursorArray = useMergedCursorData();
 
   const { data: annotationStreamData } = useSubscription(
     CURRENT_PAGE_ANNOTATIONS_STREAM,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react';
+import { useSubscription } from '@apollo/client';
+import {
+  CursorCoordinates,
+  CursorCoordinatesResponse,
+  CursorSubscriptionResponse,
+  cursorUserSubscription,
+  getcursorsCoordinatesStream,
+  userCursorResponse,
+} from './queries';
+
+interface mergedData extends CursorCoordinates, userCursorResponse {}
+
+// Custom hook to fetch and merge data
+export const useMergedCursorData = () => {
+  const [
+    cursorCoordinates,
+    setCursorCoordinates,
+  ] = useState<{[key :string]: CursorCoordinates}>({});
+
+  const [
+    userCursor,
+    setUserCursor,
+  ] = useState<{[key :string]: userCursorResponse}>({});
+
+  const [
+    userCursorMerged,
+    setUserCursorMerged,
+  ] = useState<mergedData[]>([]);
+  // Fetch cursor coordinates
+  const { data: cursorSubscriptionData } = useSubscription<CursorSubscriptionResponse>(cursorUserSubscription);
+  const cursorSubscriptionDataString = JSON.stringify(cursorSubscriptionData);
+
+  const { data: cursorCoordinatesData } = useSubscription<CursorCoordinatesResponse>(getcursorsCoordinatesStream);
+  const cursorCoordinatesDataString = JSON.stringify(cursorCoordinatesData);
+
+  useEffect(() => {
+    if (cursorCoordinatesData) {
+      const cursorData = cursorCoordinatesData.pres_page_cursor_stream.reduce((acc, cursor) => {
+        acc[cursor.userId] = cursor;
+        return acc;
+      }, {} as {[key :string]: CursorCoordinates});
+      setCursorCoordinates((prev) => {
+        return {
+          ...prev,
+          ...cursorData,
+        };
+      });
+    }
+  }, [cursorCoordinatesDataString]);
+
+  useEffect(() => {
+    if (cursorSubscriptionData) {
+      const cursorData = cursorSubscriptionData.pres_page_cursor.reduce((acc, cursor) => {
+        acc[cursor.userId] = cursor;
+        return acc;
+      }, {} as {[key :string]: userCursorResponse});
+      setUserCursor(cursorData);
+    }
+  }, [cursorSubscriptionDataString]);
+
+  useEffect(() => {
+    if (userCursor) {
+      const mergedData = Object.keys(userCursor).map((userId) => {
+        const cursor = userCursor[userId];
+        const coordinates = cursorCoordinates[userId];
+        if (coordinates) {
+          return {
+            ...coordinates,
+            ...cursor,
+          };
+        }
+
+        return {
+          ...cursor,
+          userId,
+          xPercent: -1,
+          yPercent: -1,
+        };
+      }) as mergedData[];
+      setUserCursorMerged(mergedData);
+    }
+  }, [cursorCoordinates, userCursor]);
+
+  return userCursorMerged;
+};
+
+export default {
+  useMergedCursorData,
+};

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -1,5 +1,37 @@
 import { gql } from '@apollo/client';
 
+// Interface for a single cursor coordinates object
+export interface CursorCoordinates {
+  xPercent: number;
+  yPercent: number;
+  userId: string;
+}
+
+// Interface for the response data
+export interface CursorCoordinatesResponse {
+  pres_page_cursor_stream: CursorCoordinates[];
+}
+
+export interface UserCursor {
+  name: string;
+  presenter: boolean;
+  role: string;
+}
+
+export interface userCursorResponse {
+  userId: string;
+  isCurrentPage: boolean;
+  lastUpdatedAt: string;
+  pageId: string;
+  presentationId: string;
+  user: UserCursor;
+}
+
+// Interface for the pres_page_cursor subscription
+export interface CursorSubscriptionResponse {
+  pres_page_cursor: Array<userCursorResponse>;
+}
+
 export const CURRENT_PRESENTATION_PAGE_SUBSCRIPTION = gql`subscription CurrentPresentationPagesSubscription {
   pres_page_curr {
     height
@@ -111,5 +143,30 @@ export const CURRENT_PAGE_WRITERS_QUERY = gql`query currentPageWritersQuery {
     pageId
   }
 }`;
+
+export const cursorUserSubscription = gql`subscription CursorSubscription {
+  pres_page_cursor {
+    userId
+    isCurrentPage
+    pageId
+    presentationId
+    user {
+      name
+      presenter
+      role
+    }
+  }  
+}`;
+
+export const getcursorsCoordinatesStream = gql`
+  subscription getCursorCoordinatesStream {
+    pres_page_cursor_stream(cursor: {initial_value: {lastUpdatedAt: "2020-01-01"}}, batch_size: 100) {
+      xPercent
+      yPercent
+      lastUpdatedAt
+      userId
+    }
+  }
+`;
 
 export default CURRENT_PAGE_ANNOTATIONS_QUERY;


### PR DESCRIPTION
### What does this PR do?

This PR introduces a hook that consume two different subscriptions and merge them, the goal of this change is make the consumption of the cursor be lightweight, consuming the active cursors from a subscription and their coordinates and updates from a stream make we fetch only the needed data, because stream only sends to client the last updates from and not the entirely schema.

Before (returning the data of all cursors when only one update):
![Screenshot from 2024-03-15 15-11-28](https://github.com/bigbluebutton/bigbluebutton/assets/15806883/eb7047dd-1663-4b8d-8478-49b2261aafd0)

After (returning only the coordinates and update of the last cursor change):
![Screenshot from 2024-03-15 15-10-30](https://github.com/bigbluebutton/bigbluebutton/assets/15806883/947dc2ed-6fa5-4b0f-b83e-71cc177eb1b2)
