### PR TITLE
fix(bbb-html5): Use CDN for resource of layouts (port)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -22,7 +22,7 @@ const LayoutModalComponent = (props) => {
 
   const [selectedLayout, setSelectedLayout] = useState(application.selectedLayout);
 
-  const BASE_NAME = window.meetingClientSettings.public.app.basename;
+  const BASE_NAME = window.meetingClientSettings.public.app.cdn + window.meetingClientSettings.public.app.basename;
 
   const LAYOUTS_PATH = `${BASE_NAME}/resources/images/layouts/`;
   const isKeepPushingLayoutEnabled = SettingsService.isKeepPushingLayoutEnabled();


### PR DESCRIPTION
Porting #19755 to BigBlueButton 3.0+
Adjusting the path for `cdn` as we no longer use `Meteor.settings`.
