### PR TITLE
Fix: External video plays while paused when it has some user action

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -505,7 +505,8 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const playerUpdatedAt = currentMeeting.externalVideo?.updatedAt ?? Date.now();
   const playerUpdatedAtDate = new Date(playerUpdatedAt);
   const currentDate = new Date(Date.now() + timeSync);
-  const currentTime = (((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
+  const isPaused = !currentMeeting.externalVideo?.playerPlaying ?? false;
+  const currentTime = isPaused ? playerCurrentTime : (((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
   + playerCurrentTime) * playerPlaybackRate;
   const isPresenter = currentUser.presenter ?? false;
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the problem with the paused external video skipping when user actions happened.

### Closes Issue(s)

#19775

### Example

https://github.com/bigbluebutton/bigbluebutton/assets/36093456/aa348459-f13f-4ce7-9a8c-fd6f0bdecf00



