### PR TITLE
Graphql: Add missing fields to lockSettings and endWhenNoModerator

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -25,6 +25,8 @@ case class MeetingDbModel(
     bannerColor:                           Option[String],
     createdTime:                           Long,
     durationInSeconds:                     Int,
+    endWhenNoModerator:                    Boolean,
+    endWhenNoModeratorDelayInMinutes:      Int,
     endedAt:                               Option[java.sql.Timestamp],
     endedReasonCode:                       Option[String],
     endedBy:                               Option[String],
@@ -49,6 +51,8 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
     bannerColor,
     createdTime,
     durationInSeconds,
+    endWhenNoModerator,
+    endWhenNoModeratorDelayInMinutes,
     endedAt,
     endedReasonCode,
     endedBy
@@ -70,6 +74,8 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
   val bannerColor = column[Option[String]]("bannerColor")
   val createdTime = column[Long]("createdTime")
   val durationInSeconds = column[Int]("durationInSeconds")
+  val endWhenNoModerator = column[Boolean]("endWhenNoModerator")
+  val endWhenNoModeratorDelayInMinutes = column[Int]("endWhenNoModeratorDelayInMinutes")
   val endedAt = column[Option[java.sql.Timestamp]]("endedAt")
   val endedReasonCode = column[Option[String]]("endedReasonCode")
   val endedBy = column[Option[String]]("endedBy")
@@ -106,6 +112,8 @@ object MeetingDAO {
           },
           createdTime = meetingProps.durationProps.createdTime,
           durationInSeconds = meetingProps.durationProps.duration * 60,
+          endWhenNoModerator = meetingProps.durationProps.endWhenNoModerator,
+          endWhenNoModeratorDelayInMinutes = meetingProps.durationProps.endWhenNoModeratorDelayInMinutes,
           endedAt = None,
           endedReasonCode = None,
           endedBy = None

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -26,6 +26,8 @@ create table "meeting" (
 	"bannerColor" varchar(50),
 	"createdTime" bigint,
 	"durationInSeconds" integer,
+	"endWhenNoModerator"        boolean,
+    "endWhenNoModeratorDelayInMinutes" integer,
 	"endedAt" timestamp with time zone,
 	"endedReasonCode" varchar(200),
 	"endedBy" varchar(50)
@@ -126,16 +128,16 @@ create view "v_meeting_voiceSettings" as select * from meeting_voice;
 
 create table "meeting_usersPolicies" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
-    "maxUsers"                 integer,
+    "maxUsers"                  integer,
     "maxUserConcurrentAccesses" integer,
-    "webcamsOnlyForModerator"  boolean,
-    "userCameraCap"            integer,
-    "guestPolicy"              varchar(100),
-    "guestLobbyMessage"        text,
-    "meetingLayout"            varchar(100),
-    "allowModsToUnmuteUsers"   boolean,
-    "allowModsToEjectCameras"  boolean,
-    "authenticatedGuest"       boolean
+    "webcamsOnlyForModerator"   boolean,
+    "userCameraCap"             integer,
+    "guestPolicy"               varchar(100),
+    "guestLobbyMessage"         text,
+    "meetingLayout"             varchar(100),
+    "allowModsToUnmuteUsers"    boolean,
+    "allowModsToEjectCameras"   boolean,
+    "authenticatedGuest"        boolean
 );
 create index "idx_meeting_usersPolicies_meetingId" on "meeting_usersPolicies"("meetingId");
 
@@ -196,6 +198,8 @@ SELECT
 	mls."hideUserList",
 	mls."hideViewersCursor",
 	mls."hideViewersAnnotation",
+	mls."lockOnJoin",
+    mls."lockOnJoinConfigurable",
 	mup."webcamsOnlyForModerator",
 	CASE WHEN
 	mls."disableCam" IS TRUE THEN TRUE

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -163,6 +163,8 @@ select_permissions:
         - customLogoUrl
         - disabledFeatures
         - durationInSeconds
+        - endWhenNoModerator
+        - endWhenNoModeratorDelayInMinutes
         - ended
         - endedAt
         - endedBy

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_lockSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_lockSettings.yaml
@@ -17,8 +17,10 @@ select_permissions:
         - disablePublicChat
         - hasActiveLockSetting
         - hideUserList
-        - hideViewersCursor
         - hideViewersAnnotation
+        - hideViewersCursor
+        - lockOnJoin
+        - lockOnJoinConfigurable
         - webcamsOnlyForModerator
       filter:
         meetingId:


### PR DESCRIPTION
Add missing fields that is required by the client, as reported by @Tainan404 

```gql
subscription {
  meeting {
    lockSettings {
      lockOnJoin
      lockOnJoinConfigurable
    }
    endWhenNoModerator
    endWhenNoModeratorDelayInMinutes
  }
}
```