### PR TITLE
fix: inactivity warning - front-end

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -390,10 +390,10 @@ export default withTracker(() => {
     loggedOut: 1,
     meetingId: 1,
     userId: 1,
-    inactivityCheck: 1,
-    responseDelay: 1,
     currentConnectionId: 1,
     connectionIdUpdateTime: 1,
+    inactivityWarningDisplay: 1,
+    inactivityWarningTimeoutSecs: 1,
   };
   const User = Users.findOne({ userId: credentials.requesterUserId }, { fields });
   const meeting = Meetings.findOne({ meetingId }, {

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -476,12 +476,12 @@ class App extends Component {
   renderActivityCheck() {
     const { User } = this.props;
 
-    const { inactivityCheck, responseDelay } = User;
+    const { inactivityWarningDisplay, inactivityWarningTimeoutSecs } = User;
 
-    return (inactivityCheck ? (
+    return (inactivityWarningDisplay ? (
       <ActivityCheckContainer
-        inactivityCheck={inactivityCheck}
-        responseDelay={responseDelay}
+        inactivityCheck={inactivityWarningDisplay}
+        responseDelay={inactivityWarningTimeoutSecs}
       />
     ) : null);
   }

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -22,6 +22,8 @@ subscription userCurrentSubscription {
     guest
     guestStatus
     hasDrawPermissionOnCurrentPage
+    inactivityWarningDisplay
+    inactivityWarningTimeoutSecs
     isDialIn
     isModerator
     isOnline


### PR DESCRIPTION
### What does this PR do?

Restores inactivity check feature, using data from graphQL

Back-end part: #19851

### Closes Issue(s)
Closes #19826