### PR TITLE
fix: meeting end screen

### DIFF
--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -26,6 +26,7 @@
               allowDefaultLogoutUrl: clientSettingsJson(path: "$.public.app.allowDefaultLogoutUrl")
               learningDashboardBase: clientSettingsJson(path: "$.public.app.learningDashboardBase")
               fallbackLocale: clientSettingsJson(path: "$.public.app.defaultSettings.application.fallbackLocale")
+              overrideLocale: clientSettingsJson(path: "$.public.app.defaultSettings.application.overrideLocale")
               fallbackOnEmptyString: clientSettingsJson(path: "$.public.app.fallbackOnEmptyLocaleString")
               clientLog: clientSettingsJson(path: "$.public.clientLog")
             }

--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -7,7 +7,8 @@ import ErrorBoundary from '/imports/ui/components/common/error-boundary/componen
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 import PresenceManager from '/imports/ui/components/join-handler/presenceManager/component';
 import LoadingScreenHOC from '/imports/ui/components/common/loading-screen/loading-screen-HOC/component';
-import StartupDataFetch from '/imports/ui/components/connection-manager/startup-data-fetch/component';
+import IntlLoaderContainer from '/imports/startup/client/intlLoader';
+import LocatedErrorBoundary from '/imports/ui/components/common/error-boundary/located-error-boundary/component';import StartupDataFetch from '/imports/ui/components/connection-manager/startup-data-fetch/component';
 import UserGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/userGrapQlMiniMongoAdapter/component';
 import VoiceUserGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/voiceUserGraphQlMiniMongoAdapter/component';
 
@@ -16,13 +17,18 @@ const Main: React.FC = () => {
     <StartupDataFetch>
       <ErrorBoundary Fallback={ErrorScreen}>
         <LoadingScreenHOC>
-          <ConnectionManager>
-            <PresenceManager>
-              <SettingsLoader />
-              <UserGrapQlMiniMongoAdapter />
-              <VoiceUserGrapQlMiniMongoAdapter />
-            </PresenceManager>
-          </ConnectionManager>
+          <IntlLoaderContainer>
+            {/* from there the error messages are located */}
+            <LocatedErrorBoundary Fallback={ErrorScreen}>
+              <ConnectionManager>
+                <PresenceManager>
+                  <SettingsLoader />
+                  <UserGrapQlMiniMongoAdapter />
+                  <VoiceUserGrapQlMiniMongoAdapter />
+                </PresenceManager>
+              </ConnectionManager>
+            </LocatedErrorBoundary>
+          </IntlLoaderContainer>
         </LoadingScreenHOC>
       </ErrorBoundary>
     </StartupDataFetch>

--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -8,7 +8,8 @@ import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 import PresenceManager from '/imports/ui/components/join-handler/presenceManager/component';
 import LoadingScreenHOC from '/imports/ui/components/common/loading-screen/loading-screen-HOC/component';
 import IntlLoaderContainer from '/imports/startup/client/intlLoader';
-import LocatedErrorBoundary from '/imports/ui/components/common/error-boundary/located-error-boundary/component';import StartupDataFetch from '/imports/ui/components/connection-manager/startup-data-fetch/component';
+import LocatedErrorBoundary from '/imports/ui/components/common/error-boundary/located-error-boundary/component';
+import StartupDataFetch from '/imports/ui/components/connection-manager/startup-data-fetch/component';
 import UserGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/userGrapQlMiniMongoAdapter/component';
 import VoiceUserGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/voiceUserGraphQlMiniMongoAdapter/component';
 

--- a/bigbluebutton-html5/client/meetingClient.jsx
+++ b/bigbluebutton-html5/client/meetingClient.jsx
@@ -39,9 +39,6 @@ import { LoadingContext } from '/imports/ui/components/common/loading-screen/loa
 import IntlAdapter from '/imports/startup/client/intlAdapter';
 import PresenceAdapter from '/imports/ui/components/authenticated-handler/presence-adapter/component';
 import CustomUsersSettings from '/imports/ui/components/join-handler/custom-users-settings/component';
-import IntlLoaderContainer from '/imports/startup/client/intlLoader';
-import LocatedErrorBoundary from '/imports/ui/components/common/error-boundary/located-error-boundary/component';
-import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 
 import('/imports/api/audio/client/bridge/bridge-whitelist').catch(() => {
   // bridge loading
@@ -87,19 +84,14 @@ const Startup = () => {
 
   return (
     <ContextProviders>
-      <IntlLoaderContainer>
-        {/* from there the error messages are located */}
-        <LocatedErrorBoundary Fallback={ErrorScreen}>
-          <PresenceAdapter>
-            <Subscriptions>
-              <IntlAdapter>
-                <Base />
-              </IntlAdapter>
-            </Subscriptions>
-          </PresenceAdapter>
-          <UsersAdapter />
-        </LocatedErrorBoundary>
-      </IntlLoaderContainer>
+      <PresenceAdapter>
+        <Subscriptions>
+          <IntlAdapter>
+            <Base />
+          </IntlAdapter>
+        </Subscriptions>
+      </PresenceAdapter>
+      <UsersAdapter />
     </ContextProviders>
   );
 };

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -36,12 +36,12 @@ const buildFetchLocale = (locale: string) => {
 };
 
 const fetchLocaleOptions = (locale: string, init: boolean, localesList: string[] = []) => {
-  const APP_CONFIG = window.meetingClientSettings.public.app;
-  const fallback = APP_CONFIG.defaultSettings.application.fallbackLocale;
-  const override = APP_CONFIG.defaultSettings.application.overrideLocale;
+  const clientSettings = JSON.parse(sessionStorage.getItem('clientStartupSettings') || '{}');
+  const fallback = clientSettings.fallbackLocale;
+  const override = clientSettings.overrideLocale;
   const browserLocale = override && init ? override.split(/[-_]/g) : locale.split(/[-_]/g);
-  const defaultLanguage = APP_CONFIG.defaultSettings.application.fallbackLocale;
-  const fallbackOnEmptyString = APP_CONFIG.fallbackOnEmptyLocaleString;
+  const defaultLanguage = clientSettings.fallbackLocale;
+  const fallbackOnEmptyString = clientSettings.fallbackOnEmptyLocaleString;
 
   let localeFile = fallback;
   let normalizedLocale: string = '';


### PR DESCRIPTION
### What does this PR do?

Prevent end meeting screen error by restoring intlLoader location and using `clientStartupSettings` for intl settings.