### PR TITLE
fix(whiteboard): Use canMoveCamera To Disable Viewer Mouse Wheel Pan

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -1,8 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
-import {
-    HUNDRED_PERCENT,
-    MAX_PERCENT,
-} from "/imports/utils/slideCalcUtils";
+import React, { useState, useEffect } from 'react';
 
 const useCursor = (publishCursorUpdate, whiteboardId) => {
     const [cursorPosition, setCursorPosition] = useState({ x: -1, y: -1 });
@@ -25,16 +21,16 @@ const useCursor = (publishCursorUpdate, whiteboardId) => {
 const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoomRef }, {
     isPresenter,
     hasWBAccess,
-    isMouseDownRef,
     whiteboardToolbarAutoHide,
     animations,
-    publishCursorUpdate,
-    whiteboardId,
     cursorPosition,
     updateCursorPosition,
     toggleToolsAnimations,
     currentPresentationPage,
     zoomChanger,
+    setIsMouseDown,
+    setIsWheelZoom,
+    setWheelZoomTimeout,
 }) => {
 
     const timeoutIdRef = React.useRef();
@@ -49,26 +45,35 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
         }
 
         timeoutIdRef.current = setTimeout(() => {
-            isMouseDownRef.current = false;
+            setIsMouseDown(false);
         }, 1000);
+
+        tlEditorRef?.current?.updateInstanceState({ canMoveCamera: true });
     };
 
-    const handleMouseDown = () => {
-        !isPresenter &&
-            !hasWBAccess &&
-            tlEditorRef?.current?.updateInstanceState({ isReadonly: true });
+    const handleMouseDown = (event) => {
+        if (!isPresenter && !hasWBAccess) {
+            const updateProps = { isReadonly: true };
 
-        isMouseDownRef.current = true;
+            if (event.button === 1) {
+                updateProps.canMoveCamera = false;
+            }
+
+            tlEditorRef?.current?.updateInstanceState(updateProps);
+        }
+
+        setIsMouseDown(true);
     };
 
     const handleMouseEnter = () => {
-        whiteboardToolbarAutoHide &&
+        if (whiteboardToolbarAutoHide) {
             toggleToolsAnimations(
                 "fade-out",
                 "fade-in",
                 animations ? ".3s" : "0s",
                 hasWBAccess || isPresenter
             );
+        }
     };
 
     const handleMouseLeave = () => {
@@ -86,7 +91,6 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
         }, 150);
     };
 
-
     const handleMouseWheel = (event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -94,7 +98,7 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
             return;
         }
 
-        isWheelZoomRef.current = true;
+        setIsWheelZoom(true);
 
         const MAX_ZOOM_FACTOR = 4; // Represents 400%
         const MIN_ZOOM_FACTOR = 1; // Represents 100%
@@ -117,9 +121,19 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
         // Calculate the new camera zoom factor
         const newCameraZoomFactor = currentZoomLevel * initialZoomRef.current;
 
+        // Break down the calculations for deltaX
+        const scaleAdjustmentX = cursorPosition.x / newCameraZoomFactor - cursorPosition.x;
+        const zoomAdjustmentX = cursorPosition.x / cz - cursorPosition.x;
+        const deltaX = scaleAdjustmentX - zoomAdjustmentX;
+
+        // Break down the calculations for deltaY
+        const scaleAdjustmentY = cursorPosition.y / newCameraZoomFactor - cursorPosition.y;
+        const zoomAdjustmentY = cursorPosition.y / cz - cursorPosition.y;
+        const deltaY = scaleAdjustmentY - zoomAdjustmentY;
+
         const nextCamera = {
-            x: cx + (cursorPosition.x / newCameraZoomFactor - cursorPosition.x) - (cursorPosition.x / cz - cursorPosition.x),
-            y: cy + (cursorPosition.y / newCameraZoomFactor - cursorPosition.y) - (cursorPosition.y / cz - cursorPosition.y),
+            x: cx + deltaX,
+            y: cy + deltaY,
             z: newCameraZoomFactor,
         };
 
@@ -146,11 +160,8 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
             clearTimeout(isWheelZoomRef.currentTimeout);
         }
 
-        isWheelZoomRef.currentTimeout = setTimeout(() => {
-            isWheelZoomRef.current = false;
-        }, 300);
+        setWheelZoomTimeout();
     };
-
 
     React.useEffect(() => {
         if (whiteboardToolbarAutoHide) {
@@ -190,10 +201,16 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
                 whiteboardElement.removeEventListener("wheel", handleMouseWheel);
             }
         };
-    }, [whiteboardRef, tlEditorRef, handleMouseDown, handleMouseUp, handleMouseEnter, handleMouseLeave, handleMouseWheel]);
+    }, [
+        whiteboardRef,
+        tlEditorRef, 
+        handleMouseDown,
+        handleMouseUp, 
+        handleMouseEnter,
+        handleMouseLeave, 
+        handleMouseWheel
+    ]);
 };
-
-
 
 export {
     useMouseEvents,


### PR DESCRIPTION
### What does this PR do?
This PR implements a configuration change utilizing the `canMoveCamera` setting from `tldraw` to disable the mouse wheel's pan shortcut. This ensures that viewers are unable to activate the panning feature inadvertently. This approach is more efficient as it avoids direct modifications to the `tldraw` codebase, which was previously considered. It also fixes the lint issues in the hooks.

### Closes Issue(s)
Closes #19580 
