### PR TITLE
build: Force hasura cli v2.36.2 to avoid error

### DIFF
--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -35,7 +35,7 @@ cp ./bbb-graphql-server.service staging/lib/systemd/system/bbb-graphql-server.se
 
 mkdir -p hasura-cli
 cd hasura-cli
-npm install --save-dev hasura-cli
+npm install --save-dev hasura-cli@2.36.2
 cp node_modules/hasura-cli/hasura ../staging/usr/local/bin/hasura
 cd ..
 rm -rf hasura-cli


### PR DESCRIPTION
It's throwing an error while trying to install Hasura-CLI:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/b17308c6-9f93-4bea-8dc2-96be4d9be17a)

In order to avoid it, this PR force the last version that it can install without errors: `v2.36.2`.

Let's follow the issue: https://github.com/jjangga0214/hasura-cli/issues/116