### PR TITLE
fix: unpin notes when sharing external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -13,6 +13,8 @@ import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import { UI_DATA_LISTENER_SUBSCRIBED } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/consts';
 import { ExternalVideoVolumeUiDataNames } from 'bigbluebutton-html-plugin-sdk';
 import { ExternalVideoVolumeUiDataPayloads } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/external-video/volume/types';
+import MediaService from '/imports/ui/components/media/service';
+import NotesService from '/imports/ui/components/notes/service';
 
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import {
@@ -74,6 +76,8 @@ interface ExternalVideoPlayerProps {
   layoutContextDispatch: ReturnType<typeof layoutDispatch>;
   key: string;
   setKey: (key: string) => void;
+  shouldShowSharedNotes(): boolean;
+  pinSharedNotes(pinned: boolean): void;
 }
 
 // @ts-ignore - PeerTubePlayer is not typed
@@ -96,6 +100,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   layoutContextDispatch,
   key,
   setKey,
+  shouldShowSharedNotes,
+  pinSharedNotes,
 }) => {
   const intl = useIntl();
 
@@ -249,6 +255,16 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       playerRef.current.seekTo(currentTime, 'seconds');
     }
   }, [playerRef.current]);
+
+  useEffect(() => {
+    if (shouldShowSharedNotes()) {
+      pinSharedNotes(false);
+      return () => {
+        pinSharedNotes(true);
+      };
+    }
+    return undefined;
+  }, []);
 
   // --- Plugin related code ---;
   const internalPlayer = playerRef.current?.getInternalPlayer ? playerRef.current?.getInternalPlayer() : null;
@@ -526,6 +542,8 @@ const ExternalVideoPlayerContainer: React.FC = () => {
       currentTime={isPresenter ? playerCurrentTime : currentTime}
       key={key}
       setKey={setKey}
+      shouldShowSharedNotes={MediaService.shouldShowSharedNotes}
+      pinSharedNotes={NotesService.pinSharedNotes}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/pads/service.js
+++ b/bigbluebutton-html5/imports/ui/components/pads/service.js
@@ -113,7 +113,7 @@ const getPinnedPad = () => {
 const pinPad = (externalId, pinned, stopWatching) => {
   if (pinned) {
     // Stop external video sharing if it's running.
-    stopWatching();
+    if (typeof stopWatching === 'function') stopWatching();
 
     // Stop screen sharing if it's running.
     if (isScreenBroadcasting()) screenshareHasEnded();


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Unpin shared notes from media area when sharing an external video.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #19800