### PR TITLE
fix(whiteboard): Update CSS To Disable Asset And Laser Tool

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -1,10 +1,4 @@
 import styled, { createGlobalStyle } from 'styled-components';
-import { borderSize, borderSizeLarge } from '/imports/ui/stylesheets/styled-components/general';
-import { toolbarButtonColor, colorWhite, colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
-import {
-  fontSizeLarger,
-} from '/imports/ui/stylesheets/styled-components/typography';
-import Button from '/imports/ui/components/common/button/component';
 
 const TldrawV2GlobalStyle = createGlobalStyle`
   ${({ isPresenter, hasWBAccess }) => (!isPresenter && hasWBAccess) && `
@@ -91,11 +85,11 @@ const TldrawV2GlobalStyle = createGlobalStyle`
 
   [data-testid="main.page-menu"],
   [data-testid="main.menu"],
-  [data-testid="tools.laser"],
+  [data-testid="tools.more.laser"],
   [data-testid="tools.asset"],
   .tlui-buttons__horizontal > :nth-child(1),
   .tlui-buttons__horizontal > :nth-child(2) {
-    display: none;
+    display: none !important;
   }
 
   .tl-collaborator__cursor {


### PR DESCRIPTION
### What does this PR do?

Updates the css to disable the `assets` and `lazer` tool.

before:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/b58d39c0-ea30-48e8-bf95-2d47793d4f2c)

after:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/13d2f04a-b642-411f-9791-131cf26c8def)

### Closes Issue(s)

Closes #19861

