### PR TITLE
CI: Test workflow improvements + (backport) Update github actions with deprecated Node.js 16

### DIFF
--- a/.github/actions/merge-branches/action.yml
+++ b/.github/actions/merge-branches/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout ${{ github.event.pull_request.base.ref || 'master' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.base.ref || '' }}
         fetch-depth: 0 # Fetch all history

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -352,7 +352,7 @@ jobs:
           name: bbb-logs-${{ env.MATRIX_SHARD }}
           path: ./bbb-logs.tar.gz
   upload-report:
-    if: always()
+    if: always() && !contains(github.event.head_commit.message, 'Merge pull request')
     needs: install-and-run-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -282,7 +282,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 25
-          max_attempts: 3
+          max_attempts: 2
           command: |
             cd ./bigbluebutton-tests/playwright
             npm run test-chromium-ci -- --shard ${{ matrix.shard }}

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -355,12 +355,15 @@ jobs:
     if: always() && !contains(github.event.head_commit.message, 'Merge pull request')
     needs: install-and-run-tests
     runs-on: ubuntu-latest
+    env:
+      hasReportData: ${{ needs.install-and-run-tests.result == 'success' || needs.install-and-run-tests.result == 'failure' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Install dependencies
+        if: ${{ env.hasReportData }}
         working-directory: ./bigbluebutton-tests/playwright
         run: npm ci
       - name: Merge artifacts
@@ -369,13 +372,16 @@ jobs:
           name: all-blob-reports
           pattern: blob-report-*
       - name: Download all blob reports from GitHub Actions Artifacts
+        if: ${{ env.hasReportData }}
         uses: actions/download-artifact@v4
         with:
           name: all-blob-reports
       - name: Merge into HTML Report
+        if: ${{ env.hasReportData }}
         working-directory: ./bigbluebutton-tests/playwright
         run: npx playwright merge-reports --reporter html ./all-blob-reports
       - name: Upload HTML tests report
+        if: ${{ env.hasReportData }}
         uses: actions/upload-artifact@v4
         with:
           name: tests-report

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -371,11 +371,13 @@ jobs:
         with:
           name: all-blob-reports
           pattern: blob-report-*
+          delete-merged: true
       - name: Download all blob reports from GitHub Actions Artifacts
         if: ${{ env.hasReportData }}
         uses: actions/download-artifact@v4
         with:
           name: all-blob-reports
+          path: bigbluebutton-tests/playwright/all-blob-reports
       - name: Merge into HTML Report
         if: ${{ env.hasReportData }}
         working-directory: ./bigbluebutton-tests/playwright

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -75,7 +75,7 @@ jobs:
           - package: others
             build-list: bbb-mkclean bbb-pads bbb-libreoffice-docker bbb-transcription-controller bigbluebutton bbb-livekit
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Merge branches
         uses: ./.github/actions/merge-branches
       - name: Set cache-key vars
@@ -90,7 +90,7 @@ jobs:
       - name: Handle cache
         if: matrix.cache-files-list != ''
         id: cache-action
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: artifacts.tar
           key: ${{ runner.os }}-${{ matrix.package }}-${{ env.BIGBLUEBUTTON_RELEASE }}-commits-${{ env.CACHE_KEY_FILES }}-urls-${{ env.CACHE_KEY_URLS }}
@@ -102,7 +102,7 @@ jobs:
           echo "${{ matrix.build-list || matrix.package }}" | xargs -n 1 ./build/setup.sh
           tar cvf artifacts.tar artifacts/
       - name: Archive packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts_${{ matrix.package }}.tar
           path: artifacts.tar
@@ -112,74 +112,76 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/8, 2/8, 3/8, 4/8, 5/8, 6/8, 7/8, 8/8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+    env:
+        shard: ${{ matrix.shard }}/8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Merge branches
         uses: ./.github/actions/merge-branches
       - run: ./build/get_external_dependencies.sh
       - name: Download artifacts_bbb-apps-akka
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-apps-akka.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-config
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-config.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-export-annotations
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-export-annotations.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-learning-dashboard
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-learning-dashboard.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-playback-record
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-playback-record.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-graphql-server
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-graphql-server.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-etherpad
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-etherpad.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-freeswitch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-freeswitch.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-webrtc
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-webrtc.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-web
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-web.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-fsesl-akka
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-fsesl-akka.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts_bbb-html5
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_bbb-html5.tar
       - run: tar xf artifacts.tar
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts_others.tar
       - run: tar xf artifacts.tar
@@ -279,13 +281,13 @@ jobs:
           npx playwright install
           '
       - name: Run tests
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 25
           max_attempts: 2
           command: |
             cd ./bigbluebutton-tests/playwright
-            npm run test-chromium-ci -- --shard ${{ matrix.shard }}
+            npm run test-chromium-ci -- --shard ${{ env.shard }}
         env:
           NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
           ACTIONS_RUNNER_DEBUG: true
@@ -305,13 +307,13 @@ jobs:
         run: |
           sh -c '
           find $HOME/.cache/ms-playwright -name libnssckbi.so -exec rm {} \; -exec ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so {} \;
-          npm run test-firefox-ci -- --shard ${{ matrix.shard }}
+          npm run test-firefox-ci -- --shard ${{ env.shard }}
           '
       - if: always() && github.event_name == 'pull_request'
         name: Upload blob report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: all-blob-reports
+          name: all-blob-reports-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/blob-report
       - if: failure()
         name: Prepare artifacts (configs and logs)
@@ -337,15 +339,15 @@ jobs:
           chmod a+r -R /home/runner/work/bigbluebutton/bigbluebutton/configs
           bbb-conf --zip
           ls -t /root/*.tar.gz | head -1 | xargs -I '{}' cp '{}' /home/runner/work/bigbluebutton/bigbluebutton/bbb-logs.tar.gz
-          echo "MATRIX_SHARD=$(echo ${{ matrix.shard }} | tr '/' '_')" >> $GITHUB_ENV
+          echo "MATRIX_SHARD=${{ matrix.shard }}_8" >> $GITHUB_ENV
           EOF
       - if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bbb-configs-${{ env.MATRIX_SHARD }}
           path: configs
       - if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bbb-logs-${{ env.MATRIX_SHARD }}
           path: ./bbb-logs.tar.gz
@@ -354,23 +356,24 @@ jobs:
     needs: install-and-run-tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Install dependencies
         working-directory: ./bigbluebutton-tests/playwright
         run: npm ci
       - name: Download all blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: all-blob-reports
+          pattern: all-blob-reports-*
           path: bigbluebutton-tests/playwright/all-blob-reports
+          merge-multiple: true
       - name: Merge into HTML Report
         working-directory: ./bigbluebutton-tests/playwright
         run: npx playwright merge-reports --reporter html ./all-blob-reports
       - name: Upload HTML tests report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tests-report
           path: |
@@ -385,7 +388,7 @@ jobs:
           echo ${{ github.run_id }} > ./pr-comment-data/workflow_id
       - name: Upload PR data for auto-comment
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-comment-data
           path: pr-comment-data

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
-        shard: ${{ matrix.shard }}/8
+      shard: ${{ matrix.shard }}/8
     steps:
       - uses: actions/checkout@v4
       - name: Merge branches
@@ -313,7 +313,7 @@ jobs:
         name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: all-blob-reports-${{ matrix.shard }}
+          name: blob-report-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/blob-report
       - if: failure()
         name: Prepare artifacts (configs and logs)
@@ -363,12 +363,15 @@ jobs:
       - name: Install dependencies
         working-directory: ./bigbluebutton-tests/playwright
         run: npm ci
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: all-blob-reports
+          pattern: blob-report-*
       - name: Download all blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: all-blob-reports-*
-          path: bigbluebutton-tests/playwright/all-blob-reports
-          merge-multiple: true
+          name: all-blob-reports
       - name: Merge into HTML Report
         working-directory: ./bigbluebutton-tests/playwright
         run: npx playwright merge-reports --reporter html ./all-blob-reports
@@ -376,6 +379,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tests-report
+          overwrite: true
           path: |
             bigbluebutton-tests/playwright/playwright-report
             bigbluebutton-tests/playwright/test-results

--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for dirty pull requests
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: "status: conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,8 +22,8 @@ jobs:
         working-directory: ./docs
     steps:
       # Setup
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn

--- a/.github/workflows/ts-code-compilation.yml
+++ b/.github/workflows/ts-code-compilation.yml
@@ -23,7 +23,7 @@ jobs:
   ts-code-compilation:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Merge branches

--- a/.github/workflows/ts-code-validation.yml
+++ b/.github/workflows/ts-code-validation.yml
@@ -23,7 +23,7 @@ jobs:
   ts-code-validation:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Merge branches


### PR DESCRIPTION
### What does this PR do?

- Backport of #19777;
- Decreases `install-and-run-test` attempts from 3 to 2;
- Merges all blob-reports and remove the merged;
- Avoids `upload-report` step failure when there are no artifacts to upload + Avoids step running on merges
