### PR TITLE
test: Re-add breakout test to CI

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -106,7 +106,7 @@ test.describe.parallel('Breakout', () => {
       await join.endAllBreakoutRooms();
     });
 
-    test('Invite user after creating rooms @ci @flaky', async ({ browser, context, page }) => {
+    test('Invite user after creating rooms @ci', async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);
       await join.create();


### PR DESCRIPTION
### What does this PR do?
Re-adds `Breakout › After creating › Invite user after creating rooms` test to CI since it was fixed on #19753 and it's passing locally
