### PR TITLE
fix(audio modal): show loading state while autoplay not checked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Session } from 'meteor/session';
 import {
@@ -13,6 +13,7 @@ import AudioDial from '../audio-dial/component';
 import AudioAutoplayPrompt from '../autoplay/component';
 import Settings from '/imports/ui/services/settings';
 import CaptionsSelectContainer from '/imports/ui/components/audio/captions/select/container';
+import { usePreviousValue } from '../../utils/hooks';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -48,6 +49,14 @@ const propTypes = {
   localEchoEnabled: PropTypes.bool.isRequired,
   showVolumeMeter: PropTypes.bool.isRequired,
   notify: PropTypes.func.isRequired,
+  isRTL: PropTypes.bool.isRequired,
+  priority: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  AudioError: PropTypes.shape({
+    MIC_ERROR: PropTypes.number.isRequired,
+    NO_SSL: PropTypes.number.isRequired,
+  }).isRequired,
 };
 
 const defaultProps = {
@@ -124,288 +133,169 @@ const intlMessages = defineMessages({
   },
 });
 
-class AudioModal extends Component {
-  constructor(props) {
-    super(props);
+const AudioModal = (props) => {
+  const [content, setContent] = useState(null);
+  const [hasError, setHasError] = useState(false);
+  const [disableActions, setDisableActions] = useState(false);
+  const [errCode, setErrCode] = useState(null);
+  const [autoplayChecked, setAutoplayChecked] = useState(false);
 
-    this.state = {
-      content: null,
-      hasError: false,
-      errCode: null,
-    };
+  const {
+    forceListenOnlyAttendee,
+    joinFullAudioImmediately,
+    listenOnlyMode,
+    audioLocked,
+    isUsingAudio,
+    autoplayBlocked,
+    closeModal,
+    isEchoTest,
+    exitAudio,
+    resolve,
+    leaveEchoTest,
+    AudioError,
+    joinEchoTest,
+    isConnecting,
+    localEchoEnabled,
+    joinListenOnly,
+    changeInputStream,
+    joinMicrophone,
+    intl,
+    isMobileNative,
+    formattedDialNum,
+    isRTL,
+    isConnected,
+    inputDeviceId,
+    outputDeviceId,
+    changeInputDevice,
+    changeOutputDevice,
+    showVolumeMeter,
+    notify,
+    formattedTelVoice,
+    handleAllowAutoplay,
+    showPermissionsOvelay,
+    isIE,
+    isOpen,
+    priority,
+    setIsOpen,
+  } = props;
 
-    this.handleGoToAudioOptions = this.handleGoToAudioOptions.bind(this);
-    this.handleGoToAudioSettings = this.handleGoToAudioSettings.bind(this);
-    this.handleRetryGoToEchoTest = this.handleRetryGoToEchoTest.bind(this);
-    this.handleGoToEchoTest = this.handleGoToEchoTest.bind(this);
-    this.handleJoinMicrophone = this.handleJoinMicrophone.bind(this);
-    this.handleJoinLocalEcho = this.handleJoinLocalEcho.bind(this);
-    this.handleJoinListenOnly = this.handleJoinListenOnly.bind(this);
-    this.skipAudioOptions = this.skipAudioOptions.bind(this);
+  const prevAutoplayBlocked = usePreviousValue(autoplayBlocked);
 
-    this.contents = {
-      echoTest: {
-        title: intlMessages.echoTestTitle,
-        component: () => this.renderEchoTest(),
-      },
-      settings: {
-        title: intlMessages.settingsTitle,
-        component: () => this.renderAudioSettings(),
-      },
-      help: {
-        title: intlMessages.helpTitle,
-        component: () => this.renderHelp(),
-      },
-      audioDial: {
-        title: intlMessages.audioDialTitle,
-        component: () => this.renderAudioDial(),
-      },
-      autoplayBlocked: {
-        title: intlMessages.autoplayPromptTitle,
-        component: () => this.renderAutoplayOverlay(),
-      },
-    };
-    this.failedMediaElements = [];
-  }
-
-  componentDidMount() {
-    const {
-      forceListenOnlyAttendee,
-      joinFullAudioImmediately,
-      listenOnlyMode,
-      audioLocked,
-      isUsingAudio,
-    } = this.props;
-
-    if (!isUsingAudio) {
-      if (forceListenOnlyAttendee || audioLocked) return this.handleJoinListenOnly();
-
-      if (joinFullAudioImmediately && !listenOnlyMode) return this.handleJoinMicrophone();
-
-      if (!listenOnlyMode) return this.handleGoToEchoTest();
+  useEffect(() => {
+    if (prevAutoplayBlocked && !autoplayBlocked) {
+      setAutoplayChecked(true);
     }
-    return false;
-  }
+  }, [autoplayBlocked]);
 
-  componentDidUpdate(prevProps) {
-    const { autoplayBlocked, closeModal } = this.props;
-
-    if (autoplayBlocked !== prevProps.autoplayBlocked) {
-      if (autoplayBlocked) {
-        this.setContent({ content: 'autoplayBlocked' });
-      } else {
-        closeModal();
-      }
+  const handleJoinMicrophoneError = (err) => {
+    const { type } = err;
+    switch (type) {
+      case 'MEDIA_ERROR':
+        setContent('help');
+        setErrCode(0);
+        setDisableActions(false);
+        break;
+      case 'CONNECTION_ERROR':
+      default:
+        setErrCode(0);
+        setDisableActions(false);
+        break;
     }
-  }
+  };
 
-  componentWillUnmount() {
-    const {
-      isEchoTest,
-      exitAudio,
-      resolve,
-    } = this.props;
-
-    if (isEchoTest) {
-      exitAudio();
-    }
-    if (resolve) resolve();
-    Session.set('audioModalIsOpen', false);
-  }
-
-  handleGoToAudioOptions() {
-    this.setState({
-      content: null,
-      hasError: true,
-      disableActions: false,
-    });
-  }
-
-  handleGoToAudioSettings() {
-    const { leaveEchoTest } = this.props;
-    leaveEchoTest().then(() => {
-      this.setState({
-        content: 'settings',
-      });
-    });
-  }
-
-  handleRetryGoToEchoTest() {
-    this.setState({
-      hasError: false,
-      content: null,
-    });
-
-    return this.handleGoToEchoTest();
-  }
-
-  handleGoToLocalEcho() {
+  const handleGoToLocalEcho = () => {
     // Simplified echo test: this will return the AudioSettings with:
     //   - withEcho: true
     // Echo test will be local and done in the AudioSettings view instead of the
     // old E2E -> yes/no -> join view
-    this.setState({
-      content: 'settings',
-    });
-  }
+    setContent('settings');
+  };
 
-  handleGoToEchoTest() {
-    const { AudioError } = this.props;
+  const handleGoToEchoTest = () => {
     const { MIC_ERROR } = AudioError;
     const noSSL = !window.location.protocol.includes('https');
 
     if (noSSL) {
-      return this.setState({
-        content: 'help',
-        errCode: MIC_ERROR.NO_SSL,
-      });
+      setContent('help');
+      setErrCode(MIC_ERROR.NO_SSL);
+      return null;
     }
-
-    const {
-      joinEchoTest,
-      isConnecting,
-      localEchoEnabled,
-    } = this.props;
-
-    const {
-      disableActions,
-    } = this.state;
 
     if (disableActions && isConnecting) return null;
 
-    if (localEchoEnabled) return this.handleGoToLocalEcho();
+    if (localEchoEnabled) return handleGoToLocalEcho();
 
-    this.setState({
-      hasError: false,
-      disableActions: true,
-    });
+    setHasError(false);
+    setDisableActions(true);
 
     return joinEchoTest().then(() => {
-      this.setState({
-        content: 'echoTest',
-        disableActions: false,
-      });
+      setContent('echoTest');
+      setDisableActions(true);
     }).catch((err) => {
-      this.handleJoinMicrophoneError(err);
+      handleJoinMicrophoneError(err);
     });
-  }
+  };
 
-  handleJoinListenOnly() {
-    const {
-      joinListenOnly,
-      isConnecting,
-    } = this.props;
+  const handleGoToAudioOptions = () => {
+    setContent(null);
+    setHasError(true);
+    setDisableActions(false);
+  };
 
-    const {
-      disableActions,
-    } = this.state;
+  const handleGoToAudioSettings = () => {
+    leaveEchoTest().then(() => {
+      setContent('settings');
+    });
+  };
 
+  const handleRetryGoToEchoTest = () => {
+    setHasError(false);
+    setContent(null);
+
+    return handleGoToEchoTest();
+  };
+
+  const handleJoinListenOnly = () => {
     if (disableActions && isConnecting) return null;
 
-    this.setState({
-      disableActions: true,
-    });
+    setDisableActions(true);
 
     return joinListenOnly().then(() => {
-      this.setState({
-        disableActions: false,
-      });
+      setDisableActions(false);
     }).catch((err) => {
       if (err.type === 'MEDIA_ERROR') {
-        this.setState({
-          content: 'help',
-        });
+        setContent('help');
       }
     });
-  }
+  };
 
-  handleJoinLocalEcho(inputStream) {
-    const { changeInputStream } = this.props;
-    // Reset the modal to a connecting state - this kind of sucks?
-    // prlanzarin Apr 04 2022
-    this.setState({
-      content: null,
-    });
-    if (inputStream) changeInputStream(inputStream);
-    this.handleJoinMicrophone();
-  }
-
-  handleJoinMicrophone() {
-    const {
-      joinMicrophone,
-      isConnecting,
-    } = this.props;
-
-    const {
-      disableActions,
-    } = this.state;
-
+  const handleJoinMicrophone = () => {
     if (disableActions && isConnecting) return;
 
-    this.setState({
-      hasError: false,
-      disableActions: true,
-    });
+    setHasError(false);
+    setDisableActions(true);
 
     joinMicrophone().then(() => {
-      this.setState({
-        disableActions: false,
-      });
+      setDisableActions(false);
     }).catch((err) => {
-      this.handleJoinMicrophoneError(err);
+      handleJoinMicrophoneError(err);
     });
-  }
+  };
 
-  handleJoinMicrophoneError(err) {
-    const { type } = err;
-    switch (type) {
-      case 'MEDIA_ERROR':
-        this.setState({
-          content: 'help',
-          errCode: 0,
-          disableActions: false,
-        });
-        break;
-      case 'CONNECTION_ERROR':
-      default:
-        this.setState({
-          errCode: 0,
-          disableActions: false,
-        });
-        break;
-    }
-  }
+  const handleJoinLocalEcho = (inputStream) => {
+    // Reset the modal to a connecting state - this kind of sucks?
+    // prlanzarin Apr 04 2022
+    setContent(null);
+    if (inputStream) changeInputStream(inputStream);
+    handleJoinMicrophone();
+  };
 
-  setContent(content) {
-    this.setState(content);
-  }
+  const skipAudioOptions = () => (isConnecting || (forceListenOnlyAttendee && !autoplayChecked))
+    && !content
+    && !hasError;
 
-  skipAudioOptions() {
-    const {
-      isConnecting,
-    } = this.props;
-
-    const {
-      content,
-      hasError,
-    } = this.state;
-
-    return isConnecting && !content && !hasError;
-  }
-
-  renderAudioOptions() {
-    const {
-      intl,
-      listenOnlyMode,
-      forceListenOnlyAttendee,
-      joinFullAudioImmediately,
-      audioLocked,
-      isMobileNative,
-      formattedDialNum,
-      isRTL,
-    } = this.props;
-
-    const showMicrophone = forceListenOnlyAttendee || audioLocked;
+  const renderAudioOptions = () => {
+    const hideMicrophone = forceListenOnlyAttendee || audioLocked;
 
     const arrow = isRTL ? '←' : '→';
     const dialAudioLabel = `${intl.formatMessage(intlMessages.audioDialTitle)} ${arrow}`;
@@ -413,45 +303,43 @@ class AudioModal extends Component {
     return (
       <div>
         <Styled.AudioOptions data-test="audioModalOptions">
-          {!showMicrophone && !isMobileNative
-              && (
-              <>
-                <Styled.AudioModalButton
-                  label={intl.formatMessage(intlMessages.microphoneLabel)}
-                  data-test="microphoneBtn"
-                  aria-describedby="mic-description"
-                  icon="unmute"
-                  circle
-                  size="jumbo"
-                  disabled={audioLocked}
-                  onClick={
-                    joinFullAudioImmediately
-                      ? this.handleJoinMicrophone
-                      : this.handleGoToEchoTest
-                  }
-                />
-                <span className="sr-only" id="mic-description">
-                  {intl.formatMessage(intlMessages.microphoneDesc)}
-                </span>
-              </>
-              )}
-          {listenOnlyMode
-              && (
-              <>
-                <Styled.AudioModalButton
-                  label={intl.formatMessage(intlMessages.listenOnlyLabel)}
-                  data-test="listenOnlyBtn"
-                  aria-describedby="listenOnly-description"
-                  icon="listen"
-                  circle
-                  size="jumbo"
-                  onClick={this.handleJoinListenOnly}
-                />
-                <span className="sr-only" id="listenOnly-description">
-                  {intl.formatMessage(intlMessages.listenOnlyDesc)}
-                </span>
-              </>
-              )}
+          {!hideMicrophone && !isMobileNative && (
+            <>
+              <Styled.AudioModalButton
+                label={intl.formatMessage(intlMessages.microphoneLabel)}
+                data-test="microphoneBtn"
+                aria-describedby="mic-description"
+                icon="unmute"
+                circle
+                size="jumbo"
+                disabled={audioLocked}
+                onClick={
+                  joinFullAudioImmediately
+                    ? handleJoinMicrophone
+                    : handleGoToEchoTest
+                }
+              />
+              <span className="sr-only" id="mic-description">
+                {intl.formatMessage(intlMessages.microphoneDesc)}
+              </span>
+            </>
+          )}
+          {listenOnlyMode && (
+            <>
+              <Styled.AudioModalButton
+                label={intl.formatMessage(intlMessages.listenOnlyLabel)}
+                data-test="listenOnlyBtn"
+                aria-describedby="listenOnly-description"
+                icon="listen"
+                circle
+                size="jumbo"
+                onClick={handleJoinListenOnly}
+              />
+              <span className="sr-only" id="listenOnly-description">
+                {intl.formatMessage(intlMessages.listenOnlyDesc)}
+              </span>
+            </>
+          )}
         </Styled.AudioOptions>
         {formattedDialNum ? (
           <Styled.AudioDial
@@ -459,78 +347,36 @@ class AudioModal extends Component {
             size="md"
             color="secondary"
             onClick={() => {
-              this.setState({
-                content: 'audioDial',
-              });
+              setContent('audioDial');
             }}
           />
         ) : null}
         <CaptionsSelectContainer />
       </div>
     );
-  }
+  };
 
-  renderContent() {
-    const {
-      isEchoTest,
-      intl,
-    } = this.props;
+  const renderEchoTest = () => (
+    <EchoTest
+      handleNo={handleGoToAudioSettings}
+      handleYes={handleJoinMicrophone}
+    />
+  );
 
-    const { content } = this.state;
-    const { animations } = Settings.application;
-
-    if (this.skipAudioOptions()) {
-      return (
-        <Styled.Connecting role="alert">
-          <span data-test={!isEchoTest ? 'establishingAudioLabel' : 'connectingToEchoTest'}>
-            {intl.formatMessage(intlMessages.connecting)}
-          </span>
-          <Styled.ConnectingAnimation animations={animations} />
-        </Styled.Connecting>
-      );
-    }
-    return content ? this.contents[content].component() : this.renderAudioOptions();
-  }
-
-  renderEchoTest() {
-    return (
-      <EchoTest
-        handleNo={this.handleGoToAudioSettings}
-        handleYes={this.handleJoinMicrophone}
-      />
-    );
-  }
-
-  renderAudioSettings() {
-    const {
-      isConnecting,
-      isConnected,
-      isEchoTest,
-      inputDeviceId,
-      outputDeviceId,
-      joinEchoTest,
-      changeInputDevice,
-      changeOutputDevice,
-      localEchoEnabled,
-      showVolumeMeter,
-      notify,
-    } = this.props;
-
+  const renderAudioSettings = () => {
     const confirmationCallback = !localEchoEnabled
-      ? this.handleRetryGoToEchoTest
-      : this.handleJoinLocalEcho;
+      ? handleRetryGoToEchoTest
+      : handleJoinLocalEcho;
 
     const handleGUMFailure = () => {
-      this.setState({
-        content: 'help',
-        errCode: 0,
-        disableActions: false,
-      });
+      setContent('help');
+      setErrCode(0);
+      setDisableActions(false);
     };
 
     return (
       <AudioSettings
-        handleBack={this.handleGoToAudioOptions}
+        handleBack={handleGoToAudioOptions}
         handleConfirmation={confirmationCallback}
         handleGUMFailure={handleGUMFailure}
         joinEchoTest={joinEchoTest}
@@ -547,12 +393,9 @@ class AudioModal extends Component {
         notify={notify}
       />
     );
-  }
+  };
 
-  renderHelp() {
-    const { errCode } = this.state;
-    const { AudioError } = this.props;
-
+  const renderHelp = () => {
     const audioErr = {
       ...AudioError,
       code: errCode,
@@ -560,88 +403,138 @@ class AudioModal extends Component {
 
     return (
       <Help
-        handleBack={this.handleGoToAudioOptions}
+        handleBack={handleGoToAudioOptions}
         audioErr={audioErr}
       />
     );
-  }
+  };
 
-  renderAudioDial() {
-    const { formattedDialNum, formattedTelVoice } = this.props;
-    return (
-      <AudioDial
-        formattedDialNum={formattedDialNum}
-        telVoice={formattedTelVoice}
-        handleBack={this.handleGoToAudioOptions}
-      />
-    );
-  }
+  const renderAudioDial = () => (
+    <AudioDial
+      formattedDialNum={formattedDialNum}
+      telVoice={formattedTelVoice}
+      handleBack={handleGoToAudioOptions}
+    />
+  );
 
-  renderAutoplayOverlay() {
-    const { handleAllowAutoplay } = this.props;
-    return (
-      <AudioAutoplayPrompt
-        handleAllowAutoplay={handleAllowAutoplay}
-      />
-    );
-  }
+  const renderAutoplayOverlay = () => (
+    <AudioAutoplayPrompt
+      handleAllowAutoplay={handleAllowAutoplay}
+    />
+  );
 
-  render() {
-    const {
-      intl,
-      showPermissionsOvelay,
-      closeModal,
-      isIE,
-      isOpen,
-      priority,
-      setIsOpen,
-    } = this.props;
+  const contents = {
+    echoTest: {
+      title: intlMessages.echoTestTitle,
+      component: renderEchoTest,
+    },
+    settings: {
+      title: intlMessages.settingsTitle,
+      component: renderAudioSettings,
+    },
+    help: {
+      title: intlMessages.helpTitle,
+      component: renderHelp,
+    },
+    audioDial: {
+      title: intlMessages.audioDialTitle,
+      component: renderAudioDial,
+    },
+    autoplayBlocked: {
+      title: intlMessages.autoplayPromptTitle,
+      component: renderAutoplayOverlay,
+    },
+  };
 
-    const { content } = this.state;
+  const renderContent = () => {
+    const { animations } = Settings.application;
 
-    return (
-      <>
-        {showPermissionsOvelay ? <PermissionsOverlay closeModal={closeModal} /> : null}
-        <Styled.AudioModal
-          modalName="AUDIO"
-          onRequestClose={closeModal}
-          data-test="audioModal"
-          contentLabel={intl.formatMessage(intlMessages.ariaModalTitle)}
-          title={
-            !this.skipAudioOptions()
-              ? (
-                content
-                  ? intl.formatMessage(this.contents[content].title)
-                  : intl.formatMessage(intlMessages.audioChoiceLabel)
-              )
-              : null
-          }
-          {...{
-            setIsOpen,
-            isOpen,
-            priority,
-          }}
-        >
-          {isIE ? (
-            <Styled.BrowserWarning>
-              <FormattedMessage
-                id="app.audioModal.unsupportedBrowserLabel"
-                description="Warning when someone joins with a browser that isn't supported"
-                values={{
-                  0: <a href="https://www.google.com/chrome/">Chrome</a>,
-                  1: <a href="https://getfirefox.com">Firefox</a>,
-                }}
-              />
-            </Styled.BrowserWarning>
-          ) : null}
-          <Styled.Content>
-            {this.renderContent()}
-          </Styled.Content>
-        </Styled.AudioModal>
-      </>
-    );
-  }
-}
+    if (skipAudioOptions()) {
+      return (
+        <Styled.Connecting role="alert">
+          <span data-test={!isEchoTest ? 'establishingAudioLabel' : 'connectingToEchoTest'}>
+            {intl.formatMessage(intlMessages.connecting)}
+          </span>
+          <Styled.ConnectingAnimation animations={animations} />
+        </Styled.Connecting>
+      );
+    }
+    return content ? contents[content].component() : renderAudioOptions();
+  };
+
+  useEffect(() => {
+    if (!isUsingAudio) {
+      if (forceListenOnlyAttendee || audioLocked) {
+        handleJoinListenOnly();
+        return;
+      }
+
+      if (joinFullAudioImmediately && !listenOnlyMode) {
+        handleJoinMicrophone();
+        return;
+      }
+
+      if (!listenOnlyMode) {
+        handleGoToEchoTest();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (autoplayBlocked) {
+      setContent('autoplayBlocked');
+    } else if (prevAutoplayBlocked) {
+      closeModal();
+    }
+  }, [autoplayBlocked]);
+
+  useEffect(() => () => {
+    if (isEchoTest) {
+      exitAudio();
+    }
+    if (resolve) resolve();
+    Session.set('audioModalIsOpen', false);
+  }, []);
+
+  let title = content
+    ? intl.formatMessage(contents[content].title)
+    : intl.formatMessage(intlMessages.audioChoiceLabel);
+  title = !skipAudioOptions() ? title : null;
+
+  return (
+    <>
+      {showPermissionsOvelay ? <PermissionsOverlay closeModal={closeModal} /> : null}
+      <Styled.AudioModal
+        modalName="AUDIO"
+        onRequestClose={closeModal}
+        data-test="audioModal"
+        contentLabel={intl.formatMessage(intlMessages.ariaModalTitle)}
+        title={title}
+        {...{
+          setIsOpen,
+          isOpen,
+          priority,
+        }}
+      >
+        {isIE ? (
+          <Styled.BrowserWarning>
+            <FormattedMessage
+              id="app.audioModal.unsupportedBrowserLabel"
+              description="Warning when someone joins with a browser that isn't supported"
+              values={{
+                0: <a href="https://www.google.com/chrome/">Chrome</a>,
+                1: <a href="https://getfirefox.com">Firefox</a>,
+              }}
+            />
+          </Styled.BrowserWarning>
+        ) : null}
+        <Styled.Content>
+          {renderContent()}
+        </Styled.Content>
+      </Styled.AudioModal>
+    </>
+  );
+};
 
 AudioModal.propTypes = propTypes;
 AudioModal.defaultProps = defaultProps;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

- Rewrites the audio modal component as function component.
- If the user has `userdata-bbb_force_listen_only=true`, shows modal loading state until the autoplay check is shown. This prevents rendering useless stuff.

The main change is the `skipAudioOptions` function which decides when to show the loading screen:

Then

```js
skipAudioOptions() {
    const {
      isConnecting,
    } = this.props;

    const {
      content,
      hasError,
    } = this.state;

    return isConnecting && !content && !hasError;
}
```

Now

```js
const skipAudioOptions = () => (isConnecting || (forceListenOnlyAttendee && !autoplayChecked))
    && !content
    && !hasError;
```

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #19428