### PR TITLE
refactor (graphql-middleware): Increase Ws Read Limit (necessary for annotations)

### DIFF
--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -48,6 +48,7 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	browserWsConn, err := websocket.Accept(w, r, &acceptOptions)
+	browserWsConn.SetReadLimit(999999)
 	if err != nil {
 		log.Errorf("error: %v", err)
 	}

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -39,7 +39,7 @@ func BrowserConnectionReader(browserConnectionId string, ctx context.Context, ct
 			if errors.Is(err, context.Canceled) {
 				log.Debugf("Closing Browser ws connection as Context was cancelled!")
 			} else {
-				log.Debugf("Hasura is disconnected, skipping reading of ws message: %v", err)
+				log.Debugf("Browser is disconnected, skipping reading of ws message: %v", err)
 			}
 			return
 		}


### PR DESCRIPTION
- Increase WS Read Limit from default `32768` to `999999`

It is necessary because Annotation mutations often exceeds the default limit!