### PR TITLE
fix(whiteboard): Remove Conditionally Called Hooks Error

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -96,8 +96,6 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
   clearTldrawCache();
 
-  if (!currentPresentationPage) return null;
-
   const [tlEditor, setTlEditor] = React.useState(null);
   const [isMounting, setIsMounting] = React.useState(true);
   const [initialViewBoxWidth, setInitialViewBoxWidth] = React.useState(null);
@@ -352,6 +350,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       const currPageNum = parseInt(curPageIdRef.current);
       const shapeSelected = tlEditorRef.current.selectedShapes.length > 0;
       const changeSlide = (direction) => {
+        if (!currentPresentationPage) return;
         let newSlideNum = currPageNum + direction;
         const outOfBounds = direction > 0
           ? newSlideNum > currentPresentationPage?.totalPages
@@ -585,11 +584,11 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   }, [fitToWidth, isPresenter]);
 
   React.useEffect(() => {
-    if (currentPresentationPage.scaledViewBoxWidth && !initialViewBoxWidth) {
-      setInitialViewBoxWidth(currentPresentationPage.scaledViewBoxWidth);
+    if (currentPresentationPage && currentPresentationPage?.scaledViewBoxWidth && !initialViewBoxWidth) {
+      setInitialViewBoxWidth(currentPresentationPage?.scaledViewBoxWidth);
     }
 
-    if (!isPresenter && tlEditorRef.current && initialViewBoxWidth) {
+    if (!isPresenter && tlEditorRef.current && initialViewBoxWidth && currentPresentationPage) {
       const viewerFitToWidth = determineViewerFitToWidth(
         currentPresentationPage
       );
@@ -597,12 +596,12 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       // Calculate the effective zoom based on the change in viewBoxWidth
       const effectiveZoom = calculateEffectiveZoom(
         initialViewBoxWidth,
-        currentPresentationPage.scaledViewBoxWidth
+        currentPresentationPage?.scaledViewBoxWidth
       );
 
       const zoomFitSlide = calculateZoomValue(
-        currentPresentationPage.scaledWidth,
-        currentPresentationPage.scaledHeight,
+        currentPresentationPage?.scaledWidth,
+        currentPresentationPage?.scaledHeight,
         true
       );
       const zoomCamera = (zoomFitSlide * effectiveZoom) / HUNDRED_PERCENT;
@@ -876,13 +875,13 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
           const panned = prevCam.x !== nextCam.x || prevCam.y !== nextCam.y;
 
-          if (panned && isPresenter) {
+          if (panned && isPresenter && currentPresentationPage) {
             let viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
-              editor?.viewportPageBounds.width,
+              editor?.viewportPageBounds?.width,
               currentPresentationPage?.scaledWidth
             );
             let viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
-              editor?.viewportPageBounds.height,
+              editor?.viewportPageBounds?.height,
               currentPresentationPage?.scaledHeight
             );
 
@@ -979,7 +978,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
           next?.id?.includes("camera") &&
           (prev.x !== next.x || prev.y !== next.y);
         const zoomed = next?.id?.includes("camera") && prev.z !== next.z;
-        if (panned) {
+        if (panned && currentPresentationPage) {
           // // limit bounds
           if (
             editor?.viewportPageBounds?.maxX >

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -261,6 +261,8 @@ const WhiteboardContainer = (props) => {
     typeName: 'shape',
   });
 
+  if (!currentPresentationPage) return;
+
   return (
     <Whiteboard
       {...{

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -94,7 +94,7 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
     const handleMouseWheel = (event) => {
         event.preventDefault();
         event.stopPropagation();
-        if (!tlEditorRef.current || !isPresenter) {
+        if (!tlEditorRef.current || !isPresenter || !currentPresentationPage) {
             return;
         }
 


### PR DESCRIPTION
### What does this PR do?

This PR resolves an issue where some hooks were called conditionally, which is not permitted by Reacts rules of hooks. By ensuring that all hooks are called unconditionally at the top level of functional components, we maintain the correct execution order of hooks ensuring consistency across renders.

same changes in #19831


### Motivation
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/9ba11fef-35ba-48de-ab1f-c7bff92b8391)
