### PR TITLE
refactor (graphql-middleware): Increase Ws Read Limit to 10MB (necessary for annotations)

### DIFF
--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -1,6 +1,8 @@
 package writer
 
 import (
+	"context"
+	"errors"
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
 	"github.com/iMDT/bbb-graphql-middleware/internal/msgpatch"
 	log "github.com/sirupsen/logrus"
@@ -144,7 +146,9 @@ RangeLoop:
 				log.Tracef("sending to hasura: %v", fromBrowserMessageAsMap)
 				err := wsjson.Write(hc.Context, hc.Websocket, fromBrowserMessageAsMap)
 				if err != nil {
-					log.Errorf("error on write (we're disconnected from hasura): %v", err)
+					if !errors.Is(err, context.Canceled) {
+						log.Errorf("error on write (we're disconnected from hasura): %v", err)
+					}
 					return
 				}
 			}

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -48,7 +48,7 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	browserWsConn, err := websocket.Accept(w, r, &acceptOptions)
-	browserWsConn.SetReadLimit(999999)
+	browserWsConn.SetReadLimit(9999999) //10MB
 	if err != nil {
 		log.Errorf("error: %v", err)
 	}


### PR DESCRIPTION
- Increase WS Read Limit from default 32768 to 999999 (10MB)

<img src="https://github.com/bigbluebutton/bigbluebutton/assets/5660191/a67f5987-248c-4730-a246-673e8ad40a9b" width="400" />



#19913 was not enough