### PR TITLE
Fix: When timer elapses, it still shows Stop

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/timer/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/component.jsx
@@ -67,6 +67,10 @@ const intlMessages = defineMessages({
     id: 'app.timer.track3',
     description: 'Track 3 radio label',
   },
+  warningPositiveTime: {
+    id: 'app.timer.warning.positiveTime',
+    description: 'Warning for no time',
+  },
 });
 
 const propTypes = {
@@ -225,6 +229,11 @@ class Timer extends Component {
     const { current } = this.timeRef;
     if (current) {
       current.textContent = this.getTimeString();
+      const { timer, stopTimer } = this.props;
+      const { running } = timer;
+      if (running && this.getTime() <= 0) {
+        stopTimer();
+      }
     }
   }
 
@@ -252,22 +261,31 @@ class Timer extends Component {
 
     const label = running ? intlMessages.stop : intlMessages.start;
     const color = running ? 'danger' : 'primary';
+    const isTimeZeroOrLess = this.getTime() <= 0;
 
     return (
-      <Styled.TimerControls>
-        <Styled.TimerControlButton
-          color={color}
-          label={intl.formatMessage(label)}
-          onClick={() => this.handleControlClick()}
-          data-test="startStopTimer"
-        />
-        <Styled.TimerControlButton
-          color="secondary"
-          label={intl.formatMessage(intlMessages.reset)}
-          onClick={() => timerReset()}
-          data-test="resetTimerStopWatch"
-        />
-      </Styled.TimerControls>
+      <div>
+        <Styled.TimerControls>
+          <Styled.TimerControlButton
+            color={color}
+            label={intl.formatMessage(label)}
+            onClick={() => this.handleControlClick()}
+            disabled={isTimeZeroOrLess}
+            data-test="startStopTimer"
+          />
+          <Styled.TimerControlButton
+            color="secondary"
+            label={intl.formatMessage(intlMessages.reset)}
+            onClick={() => timerReset()}
+            data-test="resetTimerStopWatch"
+          />
+        </Styled.TimerControls>
+        {isTimeZeroOrLess && (
+          <Styled.WarningPositiveTime>
+            {intl.formatMessage(intlMessages.warningPositiveTime)}
+          </Styled.WarningPositiveTime>
+        )}
+      </div>
     );
   }
 

--- a/bigbluebutton-html5/imports/ui/components/timer/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/timer/styles.js
@@ -202,6 +202,11 @@ const TimerControls = styled.div`
   margin-top: 4rem;
 `;
 
+const WarningPositiveTime = styled.div`
+  margin-top: 2rem;
+  text-align: center;
+  `;
+
 const TimerControlButton = styled(Button)`
   width: 6rem;
   margin: 0 1rem;
@@ -255,4 +260,5 @@ export default {
   TimerControls,
   TimerControlButton,
   TimerInput,
+  WarningPositiveTime,
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -44,6 +44,7 @@
     "app.timer.toolTipTimerRunningMod": "Press to pause timer.",
     "app.timer.toolTipStopwatchStoppedMod": "Press to resume stopwatch.",
     "app.timer.toolTipStopwatchRunningMod": "Press to pause stopwatch.",
+    "app.timer.warning.positiveTime": "The timer needs a positive value to start.",
     "app.emojiPicker.search": "Search",
     "app.emojiPicker.notFound": "No Emoji Found",
     "app.emojiPicker.skintext": "Choose your default skin tone",


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug with the timer, where the timer would end and the button would still behave as if the timer was running.

### Closes Issue(s)

Closes #19857 

After fix:

[Screencast from 27-03-2024 15:49:11.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/b6630bfa-2fb5-4a82-93c0-222df71a1d79)

OBS: I took the liberty of adding a warning informing the user that the timer must have a positive number as time to function.