### PR TITLE
graphql-middleware: Add periodic log with Activities Overview

### DIFF
--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -38,7 +38,6 @@ func main() {
 			log.WithField("data", string(jsonOverviewBytes)).Info("Activities Overview")
 
 			activitiesOverviewSummary := make(map[string]int64)
-			activitiesOverviewSummary["activeBla"] = common.GetActivitiesOverview()["bla-Added"] - common.GetActivitiesOverview()["bla-Removed"]
 			activitiesOverviewSummary["activeWsConnections"] = common.GetActivitiesOverview()["__WebsocketConnection-Added"] - common.GetActivitiesOverview()["__WebsocketConnection-Removed"]
 			activitiesOverviewSummary["activeBrowserHandlers"] = common.GetActivitiesOverview()["__BrowserConnection-Added"] - common.GetActivitiesOverview()["__BrowserConnection-Removed"]
 			activitiesOverviewSummary["activeSubscriptions"] = common.GetActivitiesOverview()["_Hasura-subscription-Added"] - common.GetActivitiesOverview()["_Hasura-subscription-Completed"]

--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -32,7 +32,7 @@ func main() {
 			time.Sleep(5 * time.Second)
 			jsonOverviewBytes, err := json.Marshal(common.GetActivitiesOverview())
 			if err != nil {
-				log.Fatalf("Error occurred during marshaling. Error: %s", err.Error())
+				log.Errorf("Error occurred during marshaling. Error: %s", err.Error())
 			}
 
 			log.WithField("data", string(jsonOverviewBytes)).Info("Activities Overview")

--- a/bbb-graphql-middleware/internal/common/GlobalState.go
+++ b/bbb-graphql-middleware/internal/common/GlobalState.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/google/uuid"
+	"sync"
 )
 
 var uniqueID string
@@ -12,4 +13,25 @@ func InitUniqueID() {
 
 func GetUniqueID() string {
 	return uniqueID
+}
+
+var activitiesOverview = make(map[string]int64)
+var activitiesOverviewMux = sync.Mutex{}
+
+func ActivitiesOverviewIncIndex(index string) {
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if _, exists := activitiesOverview[index]; !exists {
+		activitiesOverview[index] = 0
+	}
+
+	activitiesOverview[index]++
+}
+
+func GetActivitiesOverview() map[string]int64 {
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	return activitiesOverview
 }

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -61,6 +61,8 @@ func handleMessageReceivedFromHasura(hc *common.HasuraConnection, fromHasuraToBr
 			//When Hasura send msg type "complete", this query is finished
 			if messageType == "complete" {
 				handleCompleteMessage(hc, queryId)
+				common.ActivitiesOverviewIncIndex("Hasura-" + subscription.OperationName + "-Completed")
+				common.ActivitiesOverviewIncIndex("_Hasura-" + string(subscription.Type) + "-Completed")
 			}
 
 			if messageType == "data" &&

--- a/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/writer/writer.go
@@ -123,12 +123,20 @@ RangeLoop:
 					}
 					// log.Tracef("Current queries: %v", browserConnection.ActiveSubscriptions)
 					browserConnection.ActiveSubscriptionsMutex.Unlock()
+
+					common.ActivitiesOverviewIncIndex("Hasura-" + operationName + "-Added")
+					common.ActivitiesOverviewIncIndex("_Hasura-" + string(messageType) + "-Added")
 				}
 
 				if fromBrowserMessageAsMap["type"] == "stop" {
 					var queryId = fromBrowserMessageAsMap["id"].(string)
 					browserConnection.ActiveSubscriptionsMutex.RLock()
 					jsonPatchSupported := browserConnection.ActiveSubscriptions[queryId].JsonPatchSupported
+
+					//Remove subscriptions from ActivitiesOverview here once Hasura-Reader will ignore "complete" msg for them
+					common.ActivitiesOverviewIncIndex("Hasura-" + browserConnection.ActiveSubscriptions[queryId].OperationName + "-Completed")
+					common.ActivitiesOverviewIncIndex("_Hasura-" + string(browserConnection.ActiveSubscriptions[queryId].Type) + "-Completed")
+
 					browserConnection.ActiveSubscriptionsMutex.RUnlock()
 					if jsonPatchSupported {
 						msgpatch.RemoveConnSubscriptionCacheFile(browserConnection, queryId)

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -29,6 +29,8 @@ var BrowserConnectionsMutex = &sync.RWMutex{}
 // This is the connection that comes from browser
 func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	log := log.WithField("_routine", "ConnectionHandler")
+	common.ActivitiesOverviewIncIndex("__BrowserConnection-Added")
+	defer common.ActivitiesOverviewIncIndex("__BrowserConnection-Removed")
 
 	// Obtain id for this connection
 	lastBrowserConnectionId++


### PR DESCRIPTION
It will help to monitor the current status of the Middleware.
Especially useful for overload scenarios.

It adds two logs:

- Summary:
```json
{
  "activeBrowserHandlers":1,
  "activeSubscriptions":28,
  "activeWsConnections":1,
  "numGoroutine":14,
  "pendingMutations":0
}

```

- Detailed:
```json
{
  "Hasura-CurrentPresentationPagesSubscription-Added":3,
  "Hasura-CurrentPresentationPagesSubscription-Completed":3,
  "Hasura-CursorSubscription-Added":3,
  "Hasura-CursorSubscription-Completed":3,
  "Hasura-GetChatData-Added":3,
  "Hasura-GetChatData-Completed":3,
  "Hasura-IsTyping-Added":5,
  "Hasura-IsTyping-Completed":5,
  "Hasura-MeetingSubscription-Added":8,
  "Hasura-MeetingSubscription-Completed":8,
  "Hasura-MySubscription-Added":3,
  "Hasura-MySubscription-Completed":3,
  "Hasura-Patched_MeetingSubscription-Added":3,
  "Hasura-Patched_MeetingSubscription-Completed":3,
  "Hasura-Patched_UserListSubscription-Added":4,
  "Hasura-Patched_UserListSubscription-Completed":4,
  "Hasura-Patched_chatMessages-Added":5,
  "Hasura-Patched_chatMessages-Completed":5,
  "Hasura-Patched_userCurrentSubscription-Added":5,
  "Hasura-Patched_userCurrentSubscription-Completed":5,
  "Hasura-PresentationPublishCursor-Added":66,
  "Hasura-PresentationPublishCursor-Completed":66,
  "Hasura-PresentationSetPage-Added":5,
  "Hasura-PresentationSetPage-Completed":5,
  "Hasura-PresentationSetZoom-Added":1,
  "Hasura-PresentationSetZoom-Completed":1,
  "Hasura-PresentationsSubscription-Added":6,
  "Hasura-PresentationsSubscription-Completed":6,
  "Hasura-ProcessedPresentationsSubscription-Added":3,
  "Hasura-ProcessedPresentationsSubscription-Completed":3,
  "Hasura-RaisedHandUsers-Added":3,
  "Hasura-RaisedHandUsers-Completed":3,
  "Hasura-SetSpeechLocale-Added":3,
  "Hasura-SetSpeechLocale-Completed":3,
  "Hasura-UpdateConnectionAliveAt-Added":37,
  "Hasura-UpdateConnectionAliveAt-Completed":37,
  "Hasura-UpdateConnectionRtt-Added":28,
  "Hasura-UpdateConnectionRtt-Completed":28,
  "Hasura-UserChangedLocalSettings-Added":6,
  "Hasura-UserChangedLocalSettings-Completed":6,
  "Hasura-UserJoin-Added":3,
  "Hasura-UserJoin-Completed":3,
  "Hasura-UserMuted-Added":4,
  "Hasura-UserMuted-Completed":4,
  "Hasura-annotationsStream-Added":3,
  "Hasura-annotationsStream-Completed":3,
  "Hasura-currentPageWritersSubscription-Added":18,
  "Hasura-currentPageWritersSubscription-Completed":18,
  "Hasura-getClientSettings-Added":6,
  "Hasura-getClientSettings-Completed":6,
  "Hasura-getCursorCoordinatesStream-Added":3,
  "Hasura-getCursorCoordinatesStream-Completed":3,
  "Hasura-getCustomParameter-Added":3,
  "Hasura-getCustomParameter-Completed":3,
  "Hasura-getGuestsCount-Added":1,
  "Hasura-getGuestsCount-Completed":1,
  "Hasura-getIsBreakout-Added":3,
  "Hasura-getIsBreakout-Completed":3,
  "Hasura-getMeetingEndData-Added":6,
  "Hasura-getMeetingEndData-Completed":6,
  "Hasura-getMeetingRecordingData-Added":3,
  "Hasura-getMeetingRecordingData-Completed":3,
  "Hasura-getMeetingRecordingPolicies-Added":3,
  "Hasura-getMeetingRecordingPolicies-Completed":3,
  "Hasura-getServerTime-Added":3,
  "Hasura-getServerTime-Completed":3,
  "Hasura-getUserCurrent-Added":6,
  "Hasura-getUserCurrent-Completed":6,
  "Hasura-getUserInfo-Added":9,
  "Hasura-getUserInfo-Completed":9,
  "Hasura-hasPendingPoll-Added":6,
  "Hasura-hasPendingPoll-Completed":6,
  "Hasura-talkingIndicatorSubscription-Added":3,
  "Hasura-talkingIndicatorSubscription-Completed":3,
  "Hasura-userCurrentSubscription-Added":3,
  "Hasura-userCurrentSubscription-Completed":3,
  "Hasura-voiceUserStream-Added":3,
  "Hasura-voiceUserStream-Completed":3,
  "_Hasura-mutation-Added":150,
  "_Hasura-mutation-Completed":150,
  "_Hasura-query-Added":33,
  "_Hasura-query-Completed":33,
  "_Hasura-streaming-Added":9,
  "_Hasura-streaming-Completed":9,
  "_Hasura-subscription-Added":120,
  "_Hasura-subscription-Completed":120,
  "_Hasura-subscription_aggregate-Added":4,
  "_Hasura-subscription_aggregate-Completed":4,
  "__BrowserConnection-Added":3,
  "__BrowserConnection-Removed":3,
  "__HasuraConnection-Added":6,
  "__HasuraConnection-Removed":6
}
```