### PR TITLE
refactor (html5): Add operationName for subscriptions that lacks it

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription {
+export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription ConnStatusReport {
   user_connectionStatusReport {
     user {
       userId
@@ -17,7 +17,7 @@ export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription {
   }
 }`;
 
-export const CONNECTION_STATUS_SUBSCRIPTION = gql`subscription {
+export const CONNECTION_STATUS_SUBSCRIPTION = gql`subscription ConnStatus {
   user_connectionStatus {
     connectionAliveAt
     userClientResponseAt

--- a/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/queries.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/timer-graphql/indicator/queries.tsx
@@ -14,7 +14,7 @@ export interface GetTimerResponse {
 }
 
 export const GET_TIMER = gql`
-  subscription MySubscription {
+  subscription Timer {
     timer {
       accumulated
       active

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/queries.ts
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-export const CHATS_SUBSCRIPTION = gql`subscription {
+export const CHATS_SUBSCRIPTION = gql`subscription Chats {
     chat (order_by: [
         {public: desc}, 
         {totalUnread: desc}, 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client';
 
-export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription {
+export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription MeetingPermissions {
   meeting {
     meetingId
     isBreakout
@@ -29,7 +29,7 @@ export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription {
   }
 }`;
 
-export const CURRENT_USER_SUBSCRIPTION = gql`subscription {
+export const CURRENT_USER_SUBSCRIPTION = gql`subscription UserListCurrUser {
   user_current {
     userId 
     isModerator
@@ -40,7 +40,7 @@ export const CURRENT_USER_SUBSCRIPTION = gql`subscription {
 }`;
 
 export const USER_AGGREGATE_COUNT_SUBSCRIPTION = gql`
-subscription {
+subscription UserListCount {
   user_aggregate {
     aggregate {
       count

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/chatSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/chatSubscription.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 const CHATS_SUBSCRIPTION = gql`
-  subscription {
+  subscription ChatSubscription {
     chat(
       order_by: [
         { public: desc }

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/pollResultsSubscription.js
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/pollResultsSubscription.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 const POLL_RESULTS_SUBSCRIPTION = gql`
-  subscription {
+  subscription PollResults {
     poll (where: {published: {_eq: true}}, order_by: [{ publishedAt: desc }], limit: 1) {
       ended
       published

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/pollSubscription.js
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/pollSubscription.js
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 const POLL_SUBSCRIPTION = gql`
-  subscription {
+  subscription PollPublished {
     poll {
       published
     }

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -62,7 +62,7 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
 }`;
 
 export const USER_AGGREGATE_COUNT_SUBSCRIPTION = gql`
-  subscription {
+  subscription UsersCount {
     user_aggregate {
       aggregate {
         count
@@ -72,7 +72,7 @@ export const USER_AGGREGATE_COUNT_SUBSCRIPTION = gql`
 `;
 
 export const USERS_OVERVIEW = gql`
-subscription Users {
+subscription UsersOverview {
   user {
     userId
     name


### PR DESCRIPTION
Ensuring easier identification of subscriptions that might be requested too frequently. This enhancement is particularly useful in conjunction with the middleware logs introduced in PR #19926, enhancing our ability to monitor and analyze subscription usage effectively.