### PR TITLE
refactor (graphql-middleware): Improve activities status logs and add option to disable JsonPatch

### DIFF
--- a/bbb-graphql-middleware/internal/common/GlobalState.go
+++ b/bbb-graphql-middleware/internal/common/GlobalState.go
@@ -15,21 +15,44 @@ func GetUniqueID() string {
 	return uniqueID
 }
 
-var activitiesOverview = make(map[string]int64)
+type ActivitiesOverviewObj struct {
+	Started   int64
+	Completed int64
+}
+
+var activitiesOverview = make(map[string]ActivitiesOverviewObj)
 var activitiesOverviewMux = sync.Mutex{}
 
-func ActivitiesOverviewIncIndex(index string) {
+func ActivitiesOverviewStarted(index string) {
 	activitiesOverviewMux.Lock()
 	defer activitiesOverviewMux.Unlock()
 
 	if _, exists := activitiesOverview[index]; !exists {
-		activitiesOverview[index] = 0
+		activitiesOverview[index] = ActivitiesOverviewObj{
+			Started:   0,
+			Completed: 0,
+		}
 	}
 
-	activitiesOverview[index]++
+	updatedValues := activitiesOverview[index]
+	updatedValues.Started++
+
+	activitiesOverview[index] = updatedValues
 }
 
-func GetActivitiesOverview() map[string]int64 {
+func ActivitiesOverviewCompleted(index string) {
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if updatedValues, exists := activitiesOverview[index]; exists {
+		updatedValues.Completed++
+
+		activitiesOverview[index] = updatedValues
+	}
+
+}
+
+func GetActivitiesOverview() map[string]ActivitiesOverviewObj {
 	activitiesOverviewMux.Lock()
 	defer activitiesOverviewMux.Unlock()
 

--- a/bbb-graphql-middleware/internal/hascli/client.go
+++ b/bbb-graphql-middleware/internal/hascli/client.go
@@ -24,15 +24,15 @@ var hasuraEndpoint = os.Getenv("BBB_GRAPHQL_MIDDLEWARE_HASURA_WS")
 // Hasura client connection
 func HasuraClient(browserConnection *common.BrowserConnection, cookies []*http.Cookie, fromBrowserToHasuraChannel *common.SafeChannel, fromHasuraToBrowserChannel *common.SafeChannel) error {
 	log := log.WithField("_routine", "HasuraClient").WithField("browserConnectionId", browserConnection.Id)
-	common.ActivitiesOverviewIncIndex("__HasuraConnection-Added")
-	defer common.ActivitiesOverviewIncIndex("__HasuraConnection-Removed")
+	common.ActivitiesOverviewStarted("__HasuraConnection")
+	defer common.ActivitiesOverviewCompleted("__HasuraConnection")
 
 	defer func() {
 		//Remove subscriptions from ActivitiesOverview here once Hasura-Reader will ignore "complete" msg for them
 		browserConnection.ActiveSubscriptionsMutex.RLock()
 		for _, subscription := range browserConnection.ActiveSubscriptions {
-			common.ActivitiesOverviewIncIndex("Hasura-" + subscription.OperationName + "-Completed")
-			common.ActivitiesOverviewIncIndex("_Hasura-" + string(subscription.Type) + "-Completed")
+			common.ActivitiesOverviewStarted(string(subscription.Type) + "-" + subscription.OperationName)
+			common.ActivitiesOverviewStarted("_Sum-" + string(subscription.Type))
 		}
 		browserConnection.ActiveSubscriptionsMutex.RUnlock()
 	}()

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -61,8 +61,8 @@ func handleMessageReceivedFromHasura(hc *common.HasuraConnection, fromHasuraToBr
 			//When Hasura send msg type "complete", this query is finished
 			if messageType == "complete" {
 				handleCompleteMessage(hc, queryId)
-				common.ActivitiesOverviewIncIndex("Hasura-" + subscription.OperationName + "-Completed")
-				common.ActivitiesOverviewIncIndex("_Hasura-" + string(subscription.Type) + "-Completed")
+				common.ActivitiesOverviewCompleted(string(subscription.Type) + "-" + subscription.OperationName)
+				common.ActivitiesOverviewCompleted("_Sum-" + string(subscription.Type))
 			}
 
 			if messageType == "data" &&

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -29,8 +29,8 @@ var BrowserConnectionsMutex = &sync.RWMutex{}
 // This is the connection that comes from browser
 func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	log := log.WithField("_routine", "ConnectionHandler")
-	common.ActivitiesOverviewIncIndex("__BrowserConnection-Added")
-	defer common.ActivitiesOverviewIncIndex("__BrowserConnection-Removed")
+	common.ActivitiesOverviewStarted("__BrowserConnection")
+	defer common.ActivitiesOverviewCompleted("__BrowserConnection")
 
 	// Obtain id for this connection
 	lastBrowserConnectionId++


### PR DESCRIPTION
Improve #19926

- Also add env var `BBB_GRAPHQL_MIDDLEWARE_JSON_PATCH_DISABLED` for performance tests
- It will log only messages requested too frequently
- New log format:
```json
{
  "_Sum-mutation":{
    "Started":1232,
    "Completed":1232
  },
  "_Sum-streaming":{
    "Started":6,
    "Completed":0
  },
  "_Sum-subscription":{
    "Started":58,
    "Completed":0
  },
  "_Sum-subscription_aggregate":{
    "Started":5,
    "Completed":0
  },
  "__BrowserConnection":{
    "Started":2,
    "Completed":0
  },
  "__HasuraConnection":{
    "Started":2,
    "Completed":0
  },
  "__WebsocketConnection":{
    "Started":2,
    "Completed":0
  },
  "mutation-UpdateConnectionAliveAt":{
    "Started":616,
    "Completed":616
  },
  "mutation-UpdateConnectionRtt":{
    "Started":616,
    "Completed":616
  }
}
```