### PR TITLE
graphql-middleware: Track most requested  messages for performance analysis

### DIFF
--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -35,7 +35,7 @@ func main() {
 			hasuraConnections := common.GetActivitiesOverview()["__HasuraConnection"].Started
 			topMessages := make(map[string]common.ActivitiesOverviewObj)
 			for index, item := range common.GetActivitiesOverview() {
-				if strings.HasPrefix(index, "_") || item.Started > hasuraConnections*3 {
+				if strings.HasPrefix(index, "_") || item.Started > hasuraConnections*3 || item.DataReceived > hasuraConnections*5 {
 					topMessages[index] = item
 				}
 			}

--- a/bbb-graphql-middleware/internal/common/GlobalState.go
+++ b/bbb-graphql-middleware/internal/common/GlobalState.go
@@ -16,8 +16,9 @@ func GetUniqueID() string {
 }
 
 type ActivitiesOverviewObj struct {
-	Started   int64
-	Completed int64
+	Started      int64
+	Completed    int64
+	DataReceived int64
 }
 
 var activitiesOverview = make(map[string]ActivitiesOverviewObj)
@@ -29,8 +30,9 @@ func ActivitiesOverviewStarted(index string) {
 
 	if _, exists := activitiesOverview[index]; !exists {
 		activitiesOverview[index] = ActivitiesOverviewObj{
-			Started:   0,
-			Completed: 0,
+			Started:      0,
+			Completed:    0,
+			DataReceived: 0,
 		}
 	}
 
@@ -38,6 +40,18 @@ func ActivitiesOverviewStarted(index string) {
 	updatedValues.Started++
 
 	activitiesOverview[index] = updatedValues
+}
+
+func ActivitiesOverviewDataReceived(index string) {
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if updatedValues, exists := activitiesOverview[index]; exists {
+		updatedValues.DataReceived++
+
+		activitiesOverview[index] = updatedValues
+	}
+
 }
 
 func ActivitiesOverviewCompleted(index string) {

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -65,6 +65,10 @@ func handleMessageReceivedFromHasura(hc *common.HasuraConnection, fromHasuraToBr
 				common.ActivitiesOverviewCompleted("_Sum-" + string(subscription.Type))
 			}
 
+			if messageType == "data" {
+				common.ActivitiesOverviewDataReceived(string(subscription.Type) + "-" + subscription.OperationName)
+			}
+
 			if messageType == "data" &&
 				subscription.Type == common.Subscription {
 				hasNoPreviousOccurrence := handleSubscriptionMessage(hc, messageMap, subscription, queryId)


### PR DESCRIPTION
Now it will log number of times each subscription received data.
It will help to identify messages fetched too frequently.

```json
{
  "_Sum-mutation":{
    "Started":233,
    "Completed":233,
    "DataReceived":0
  },
  "_Sum-query":{
    "Started":24,
    "Completed":24,
    "DataReceived":0
  },
  "_Sum-streaming":{
    "Started":12,
    "Completed":0,
    "DataReceived":0
  },
  "_Sum-subscription":{
    "Started":134,
    "Completed":9,
    "DataReceived":0
  },
  "_Sum-subscription_aggregate":{
    "Started":10,
    "Completed":0,
    "DataReceived":0
  },
  "__BrowserConnection":{
    "Started":4,
    "Completed":0,
    "DataReceived":0
  },
  "__HasuraConnection":{
    "Started":7,
    "Completed":3,
    "DataReceived":0
  },
  "__WebsocketConnection":{
    "Started":4,
    "Completed":0,
    "DataReceived":0
  },
  "mutation-PresentationPublishCursor":{
    "Started":83,
    "Completed":83,
    "DataReceived":80
  },
  "mutation-UpdateConnectionAliveAt":{
    "Started":37,
    "Completed":37,
    "DataReceived":37
  },
  "mutation-UpdateConnectionRtt":{
    "Started":37,
    "Completed":37,
    "DataReceived":37
  },
  "mutation-UserSetMuted":{
    "Started":62,
    "Completed":62,
    "DataReceived":62
  },
  "streaming-getCursorCoordinatesStream":{
    "Started":4,
    "Completed":0,
    "DataReceived":223
  },
  "streaming-voiceUserStream":{
    "Started":4,
    "Completed":0,
    "DataReceived":120
  },
  "subscription-ConnStatus":{
    "Started":4,
    "Completed":0,
    "DataReceived":75
  },
  "subscription-Patched_UserListSubscription":{
    "Started":5,
    "Completed":1,
    "DataReceived":45
  },
  "subscription-Patched_userCurrentSubscription":{
    "Started":7,
    "Completed":2,
    "DataReceived":86
  },
  "subscription-UserMuted":{
    "Started":7,
    "Completed":0,
    "DataReceived":206
  },
  "subscription-userCurrentSubscription":{
    "Started":4,
    "Completed":0,
    "DataReceived":48
  }
}
```

Following: #19931 and #19926