### PR TITLE
refactor (html5): Rename similar subscriptions to reuse it automatically

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client';
 
-export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription MeetingPermissions {
+export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`
+subscription MeetingPermissions {
   meeting {
     meetingId
     isBreakout
@@ -29,7 +30,8 @@ export const MEETING_PERMISSIONS_SUBSCRIPTION = gql`subscription MeetingPermissi
   }
 }`;
 
-export const CURRENT_USER_SUBSCRIPTION = gql`subscription UserListCurrUser {
+export const CURRENT_USER_SUBSCRIPTION = gql`
+subscription UserListCurrUser {
   user_current {
     userId 
     isModerator
@@ -40,7 +42,7 @@ export const CURRENT_USER_SUBSCRIPTION = gql`subscription UserListCurrUser {
 }`;
 
 export const USER_AGGREGATE_COUNT_SUBSCRIPTION = gql`
-subscription UserListCount {
+subscription UsersCount {
   user_aggregate {
     aggregate {
       count


### PR DESCRIPTION
It was sending two similar subscriptions:

```gql
subscription UsersCount {
  user_aggregate {
    aggregate {
      count
    }
  }
}
```

and 

```gql
subscription UserListCount {
  user_aggregate {
    aggregate {
      count
    }
  }
}
```

By renaming `UserListCount` to `UsersCount`, Apollo Client is able to identify they are the same and send it only once.