### PR TITLE
graphql-middleware: Disable activities overview logs by default

### DIFF
--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
@@ -11,9 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
-	"runtime"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -28,35 +25,9 @@ func main() {
 	log.SetFormatter(&log.JSONFormatter{})
 	log := log.WithField("_routine", "main")
 
-	go func() {
-		for {
-			time.Sleep(5 * time.Second)
-
-			hasuraConnections := common.GetActivitiesOverview()["__HasuraConnection"].Started
-			topMessages := make(map[string]common.ActivitiesOverviewObj)
-			for index, item := range common.GetActivitiesOverview() {
-				if strings.HasPrefix(index, "_") || item.Started > hasuraConnections*3 || item.DataReceived > hasuraConnections*5 {
-					topMessages[index] = item
-				}
-			}
-
-			jsonOverviewBytes, err := json.Marshal(topMessages)
-			if err != nil {
-				log.Errorf("Error occurred during marshaling. Error: %s", err.Error())
-			}
-
-			log.WithField("data", string(jsonOverviewBytes)).Info("Top Activities Overview")
-
-			activitiesOverviewSummary := make(map[string]int64)
-			activitiesOverviewSummary["activeWsConnections"] = common.GetActivitiesOverview()["__WebsocketConnection"].Started - common.GetActivitiesOverview()["__WebsocketConnection"].Completed
-			activitiesOverviewSummary["activeBrowserHandlers"] = common.GetActivitiesOverview()["__BrowserConnection"].Started - common.GetActivitiesOverview()["__BrowserConnection"].Completed
-			activitiesOverviewSummary["activeSubscriptions"] = common.GetActivitiesOverview()["_Sum-subscription"].Started - common.GetActivitiesOverview()["_Sum-subscription"].Completed
-			activitiesOverviewSummary["pendingMutations"] = common.GetActivitiesOverview()["_Sum-mutation"].Started - common.GetActivitiesOverview()["_Sum-mutation"].Completed
-			activitiesOverviewSummary["numGoroutine"] = int64(runtime.NumGoroutine())
-			jsonOverviewSummaryBytes, _ := json.Marshal(activitiesOverviewSummary)
-			log.WithField("data", string(jsonOverviewSummaryBytes)).Info("Activities Overview Summary")
-		}
-	}()
+	if activitiesOverviewEnabled := os.Getenv("BBB_GRAPHQL_MIDDLEWARE_ACTIVITIES_OVERVIEW_ENABLED"); activitiesOverviewEnabled == "true" {
+		go common.ActivitiesOverviewLogRoutine()
+	}
 
 	common.InitUniqueID()
 	log = log.WithField("graphql-middleware-uid", common.GetUniqueID())

--- a/bbb-graphql-middleware/deploy.sh
+++ b/bbb-graphql-middleware/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 ./local-build.sh
-mv bbb-graphql-middleware /usr/local/bin/bbb-graphql-middleware
-systemctl restart bbb-graphql-middleware
+sudo mv bbb-graphql-middleware /usr/local/bin/bbb-graphql-middleware
+sudo systemctl restart bbb-graphql-middleware

--- a/bbb-graphql-middleware/internal/common/ActivitiesOverview.go
+++ b/bbb-graphql-middleware/internal/common/ActivitiesOverview.go
@@ -70,16 +70,8 @@ func ActivitiesOverviewDataSize(index string, dataSize int64, dataCount int64) {
 	defer activitiesOverviewMux.Unlock()
 
 	if updatedValues, exists := activitiesOverview[index]; exists {
-
-		//fmt.Println("---------------" + index)
-		//fmt.Printf("Received dataCount: %d\n", dataCount)
-		//fmt.Printf("It was dataCount: %d\n", updatedValues.DataCountAvg)
-
 		updatedValues.DataSizeAvg = ((updatedValues.DataSizeAvg*updatedValues.DataReceived - 1) + dataSize) / updatedValues.DataReceived
 		updatedValues.DataCountAvg = ((updatedValues.DataCountAvg * (updatedValues.DataReceived - 1)) + dataCount) / updatedValues.DataReceived
-
-		//fmt.Printf("New value dataCount: %d\n", updatedValues.DataCountAvg)
-
 		activitiesOverview[index] = updatedValues
 	}
 }

--- a/bbb-graphql-middleware/internal/common/ActivitiesOverview.go
+++ b/bbb-graphql-middleware/internal/common/ActivitiesOverview.go
@@ -18,12 +18,12 @@ type ActivitiesOverviewObj struct {
 	DataCountAvg int64
 }
 
-var activitiesOverviewEnabled = false
+var ActivitiesOverviewEnabled = false
 var activitiesOverview = make(map[string]ActivitiesOverviewObj)
 var activitiesOverviewMux = sync.Mutex{}
 
 func ActivitiesOverviewStarted(index string) {
-	if !activitiesOverviewEnabled {
+	if !ActivitiesOverviewEnabled {
 		return
 	}
 
@@ -47,7 +47,7 @@ func ActivitiesOverviewStarted(index string) {
 }
 
 func ActivitiesOverviewDataReceived(index string) {
-	if !activitiesOverviewEnabled {
+	if !ActivitiesOverviewEnabled {
 		return
 	}
 
@@ -62,7 +62,7 @@ func ActivitiesOverviewDataReceived(index string) {
 }
 
 func ActivitiesOverviewDataSize(index string, dataSize int64, dataCount int64) {
-	if !activitiesOverviewEnabled {
+	if !ActivitiesOverviewEnabled {
 		return
 	}
 
@@ -77,7 +77,7 @@ func ActivitiesOverviewDataSize(index string, dataSize int64, dataCount int64) {
 }
 
 func ActivitiesOverviewCompleted(index string) {
-	if !activitiesOverviewEnabled {
+	if !ActivitiesOverviewEnabled {
 		return
 	}
 
@@ -100,7 +100,7 @@ func GetActivitiesOverview() map[string]ActivitiesOverviewObj {
 }
 
 func ActivitiesOverviewLogRoutine() {
-	activitiesOverviewEnabled = true
+	ActivitiesOverviewEnabled = true
 	log.Info("Activities Overview routine started!")
 
 	for {

--- a/bbb-graphql-middleware/internal/common/ActivitiesOverview.go
+++ b/bbb-graphql-middleware/internal/common/ActivitiesOverview.go
@@ -1,0 +1,152 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ActivitiesOverviewObj struct {
+	Started      int64
+	Completed    int64
+	DataReceived int64
+	DataSizeAvg  int64
+	DataCountAvg int64
+}
+
+var activitiesOverviewEnabled = false
+var activitiesOverview = make(map[string]ActivitiesOverviewObj)
+var activitiesOverviewMux = sync.Mutex{}
+
+func ActivitiesOverviewStarted(index string) {
+	if !activitiesOverviewEnabled {
+		return
+	}
+
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if _, exists := activitiesOverview[index]; !exists {
+		activitiesOverview[index] = ActivitiesOverviewObj{
+			Started:      0,
+			Completed:    0,
+			DataReceived: 0,
+			DataSizeAvg:  0,
+			DataCountAvg: 0,
+		}
+	}
+
+	updatedValues := activitiesOverview[index]
+	updatedValues.Started++
+
+	activitiesOverview[index] = updatedValues
+}
+
+func ActivitiesOverviewDataReceived(index string) {
+	if !activitiesOverviewEnabled {
+		return
+	}
+
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if updatedValues, exists := activitiesOverview[index]; exists {
+		updatedValues.DataReceived++
+
+		activitiesOverview[index] = updatedValues
+	}
+}
+
+func ActivitiesOverviewDataSize(index string, dataSize int64, dataCount int64) {
+	if !activitiesOverviewEnabled {
+		return
+	}
+
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if updatedValues, exists := activitiesOverview[index]; exists {
+
+		//fmt.Println("---------------" + index)
+		//fmt.Printf("Received dataCount: %d\n", dataCount)
+		//fmt.Printf("It was dataCount: %d\n", updatedValues.DataCountAvg)
+
+		updatedValues.DataSizeAvg = ((updatedValues.DataSizeAvg*updatedValues.DataReceived - 1) + dataSize) / updatedValues.DataReceived
+		updatedValues.DataCountAvg = ((updatedValues.DataCountAvg * (updatedValues.DataReceived - 1)) + dataCount) / updatedValues.DataReceived
+
+		//fmt.Printf("New value dataCount: %d\n", updatedValues.DataCountAvg)
+
+		activitiesOverview[index] = updatedValues
+	}
+}
+
+func ActivitiesOverviewCompleted(index string) {
+	if !activitiesOverviewEnabled {
+		return
+	}
+
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	if updatedValues, exists := activitiesOverview[index]; exists {
+		updatedValues.Completed++
+
+		activitiesOverview[index] = updatedValues
+	}
+
+}
+
+func GetActivitiesOverview() map[string]ActivitiesOverviewObj {
+	activitiesOverviewMux.Lock()
+	defer activitiesOverviewMux.Unlock()
+
+	return activitiesOverview
+}
+
+func ActivitiesOverviewLogRoutine() {
+	activitiesOverviewEnabled = true
+	log.Info("Activities Overview routine started!")
+
+	for {
+		time.Sleep(5 * time.Second)
+		fmt.Println("===================================================")
+
+		hasuraConnections := GetActivitiesOverview()["__HasuraConnection"].Started
+		topMessages := make(map[string]ActivitiesOverviewObj)
+		activitiesOverview := GetActivitiesOverview()
+		for index, item := range activitiesOverview {
+			if strings.HasPrefix(index, "_") ||
+				item.Started > hasuraConnections*3 ||
+				item.DataReceived > hasuraConnections*5 ||
+				item.DataSizeAvg > 3000 ||
+				item.DataCountAvg > 5 {
+				topMessages[index] = item
+			}
+		}
+
+		jsonIndentOverviewBytes, err := json.MarshalIndent(topMessages, "", "   ")
+		if err != nil {
+			log.Errorf("Error occurred during marshaling. Error: %s", err.Error())
+		}
+		fmt.Println(string(jsonIndentOverviewBytes))
+
+		jsonOverviewBytes, err := json.Marshal(topMessages)
+		fmt.Println(string(jsonOverviewBytes))
+
+		//log.WithField("data", string(jsonOverviewBytes)).Info("Top Activities Overview")
+
+		activitiesOverviewSummary := make(map[string]int64)
+		activitiesOverviewSummary["activeWsConnections"] = GetActivitiesOverview()["__WebsocketConnection"].Started - GetActivitiesOverview()["__WebsocketConnection"].Completed
+		activitiesOverviewSummary["activeBrowserHandlers"] = GetActivitiesOverview()["__BrowserConnection"].Started - GetActivitiesOverview()["__BrowserConnection"].Completed
+		activitiesOverviewSummary["activeSubscriptions"] = GetActivitiesOverview()["_Sum-subscription"].Started - GetActivitiesOverview()["_Sum-subscription"].Completed
+		activitiesOverviewSummary["pendingMutations"] = GetActivitiesOverview()["_Sum-mutation"].Started - GetActivitiesOverview()["_Sum-mutation"].Completed
+		activitiesOverviewSummary["numGoroutine"] = int64(runtime.NumGoroutine())
+		jsonOverviewSummaryBytes, _ := json.MarshalIndent(activitiesOverviewSummary, "", "")
+		//log.WithField("data", string(jsonOverviewSummaryBytes)).Info("Activities Overview Summary")
+		fmt.Println(string(jsonOverviewSummaryBytes))
+	}
+}

--- a/bbb-graphql-middleware/internal/common/GlobalState.go
+++ b/bbb-graphql-middleware/internal/common/GlobalState.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"github.com/google/uuid"
-	"sync"
 )
 
 var uniqueID string
@@ -13,62 +12,4 @@ func InitUniqueID() {
 
 func GetUniqueID() string {
 	return uniqueID
-}
-
-type ActivitiesOverviewObj struct {
-	Started      int64
-	Completed    int64
-	DataReceived int64
-}
-
-var activitiesOverview = make(map[string]ActivitiesOverviewObj)
-var activitiesOverviewMux = sync.Mutex{}
-
-func ActivitiesOverviewStarted(index string) {
-	activitiesOverviewMux.Lock()
-	defer activitiesOverviewMux.Unlock()
-
-	if _, exists := activitiesOverview[index]; !exists {
-		activitiesOverview[index] = ActivitiesOverviewObj{
-			Started:      0,
-			Completed:    0,
-			DataReceived: 0,
-		}
-	}
-
-	updatedValues := activitiesOverview[index]
-	updatedValues.Started++
-
-	activitiesOverview[index] = updatedValues
-}
-
-func ActivitiesOverviewDataReceived(index string) {
-	activitiesOverviewMux.Lock()
-	defer activitiesOverviewMux.Unlock()
-
-	if updatedValues, exists := activitiesOverview[index]; exists {
-		updatedValues.DataReceived++
-
-		activitiesOverview[index] = updatedValues
-	}
-
-}
-
-func ActivitiesOverviewCompleted(index string) {
-	activitiesOverviewMux.Lock()
-	defer activitiesOverviewMux.Unlock()
-
-	if updatedValues, exists := activitiesOverview[index]; exists {
-		updatedValues.Completed++
-
-		activitiesOverview[index] = updatedValues
-	}
-
-}
-
-func GetActivitiesOverview() map[string]ActivitiesOverviewObj {
-	activitiesOverviewMux.Lock()
-	defer activitiesOverviewMux.Unlock()
-
-	return activitiesOverview
 }

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -101,10 +101,11 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, messageMap map[strin
 			for dataKey, dataItem := range data {
 				if currentDataProp, okCurrentDataProp := dataItem.([]interface{}); okCurrentDataProp {
 					if dataAsJson, err := json.Marshal(currentDataProp); err == nil {
-
-						dataSize := len(string(dataAsJson))
-						dataCount := len(currentDataProp)
-						common.ActivitiesOverviewDataSize(string(subscription.Type)+"-"+subscription.OperationName, int64(dataSize), int64(dataCount))
+						if common.ActivitiesOverviewEnabled {
+							dataSize := len(string(dataAsJson))
+							dataCount := len(currentDataProp)
+							common.ActivitiesOverviewDataSize(string(subscription.Type)+"-"+subscription.OperationName, int64(dataSize), int64(dataCount))
+						}
 
 						//Check whether ReceivedData is different from the LastReceivedData
 						//Otherwise stop forwarding this message

--- a/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hascli/conn/reader/reader.go
@@ -101,6 +101,11 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, messageMap map[strin
 			for dataKey, dataItem := range data {
 				if currentDataProp, okCurrentDataProp := dataItem.([]interface{}); okCurrentDataProp {
 					if dataAsJson, err := json.Marshal(currentDataProp); err == nil {
+
+						dataSize := len(string(dataAsJson))
+						dataCount := len(currentDataProp)
+						common.ActivitiesOverviewDataSize(string(subscription.Type)+"-"+subscription.OperationName, int64(dataSize), int64(dataCount))
+
 						//Check whether ReceivedData is different from the LastReceivedData
 						//Otherwise stop forwarding this message
 						dataChecksum := crc32.ChecksumIEEE(dataAsJson)

--- a/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
@@ -1,16 +1,15 @@
-import createUseSubscription from './createUseSubscription';
+import useCreateUseSubscription from './createUseSubscription';
 import MEETING_SUBSCRIPTION from '../graphql/queries/meetingSubscription';
 import { Meeting } from '../../Types/meeting';
 
-const useMeetingSubscription = createUseSubscription<Meeting>(MEETING_SUBSCRIPTION);
+const useMeetingSubscription = useCreateUseSubscription<Meeting>(MEETING_SUBSCRIPTION, {}, true);
 
 export const useMeeting = (fn: (c: Partial<Meeting>) => Partial<Meeting>) => {
   const response = useMeetingSubscription(fn);
-  const returnObject = {
+  return {
     ...response,
     data: response.data?.[0],
   };
-  return returnObject;
 };
 
 export default useMeeting;


### PR DESCRIPTION
- Now it requires an env var `BBB_GRAPHQL_MIDDLEWARE_ACTIVITIES_OVERVIEW_ENABLED=true` to enable the Activities Overview Logs
- Add more info like `DataSizeAvg` and `DataCountAvg` to identify heavy subscriptions