### PR TITLE
fix: Viewer presenter (non moderator) cannot push layout to all

### DIFF
--- a/bbb-graphql-actions/src/actions/meetingLayoutSetProps.ts
+++ b/bbb-graphql-actions/src/actions/meetingLayoutSetProps.ts
@@ -1,8 +1,8 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
-  throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfNotPresenter(sessionVariables);
   const eventName = 'BroadcastLayoutMsg';
 
   const routing = {

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -158,7 +158,7 @@ const AppContainer = (props) => {
         syncWithPresenterLayout: pushLayout,
         presentationIsOpen,
         isResizing,
-        cameraPosition: cameraDock.position,
+        cameraPosition: cameraDock.position || 'contentTop',
         focusedCamera: focusedId,
         presentationVideoRate,
       },


### PR DESCRIPTION
### What does this PR do?

Adjusts meetingLayoutSetProps permissions to check if the user is presenter instead of checking for moderator status

### Closes Issue(s)
Closes #19859