### PR TITLE
fix: limit mutation payloads to 10MB by default

### DIFF
--- a/bbb-graphql-actions/src/config.ts
+++ b/bbb-graphql-actions/src/config.ts
@@ -3,4 +3,5 @@ export const REDIS_HOST = process.env.BBB_REDIS_HOST || '127.0.0.1';
 export const REDIS_PORT = Number(process.env.BBB_REDIS_PORT) || 6379;
 export const SERVER_HOST = process.env.SERVER_HOST || '127.0.0.1';
 export const SERVER_PORT = Number(process.env.SERVER_PORT) || 8093;
+export const MAX_BODY_SIZE = Number(process.env.MAX_BODY_SIZE) || 10485760; // 10MB
 export const DEBUG = false;

--- a/bbb-graphql-actions/src/index.ts
+++ b/bbb-graphql-actions/src/index.ts
@@ -1,13 +1,13 @@
 import express, { Request, Response } from 'express';
 import util from 'util';
 import { redisMessageFactory } from './imports/redisMessageFactory';
-import { DEBUG, SERVER_HOST, SERVER_PORT } from './config';
+import { DEBUG, SERVER_HOST, SERVER_PORT, MAX_BODY_SIZE } from './config';
 import { createRedisClient } from './imports/redis';
 import { ValidationError } from './types/ValidationError';
 
 // Initialize Express Application
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: MAX_BODY_SIZE }));
 
 // Create and configure Redis client
 const redisClient = createRedisClient();

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -98,6 +98,7 @@ export interface App {
   effectiveConnection: string[]
   fallbackOnEmptyLocaleString: boolean
   disableWebsocketFallback: boolean
+  maxMutationPayloadSize: number
 }
 
 export interface BbbTabletApp {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -202,6 +202,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       ],
       fallbackOnEmptyLocaleString: true,
       disableWebsocketFallback: true,
+      maxMutationPayloadSize: 10485760, // 10MB
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -287,6 +287,9 @@ public:
     # string will be returned.
     fallbackOnEmptyLocaleString: true
     disableWebsocketFallback: true
+    # Maximum number of bytes allowed in each mutation message payload.
+    # Defaults to 10485760 (10MB)
+    maxMutationPayloadSize: 10485760
   # plugins:
   #   - name: SamplePresentationToolbarPlugin
   #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

This PR defines a max size, in bytes, for mutation payloads. It defaults to 10MB. This prevents from sending big annotation mutations.

### More

See https://github.com/bigbluebutton/bigbluebutton/pull/19916 and https://github.com/bigbluebutton/bigbluebutton/pull/19913.
