### PR TITLE
fix: invalid UA version number in WKWebView

### DIFF
--- a/bigbluebutton-html5/imports/utils/browserInfo.js
+++ b/bigbluebutton-html5/imports/utils/browserInfo.js
@@ -1,4 +1,5 @@
 import Bowser from 'bowser';
+import logger from '/imports/startup/client/logger';
 
 const userAgent = window.navigator.userAgent;
 const BOWSER_RESULTS = Bowser.parse(userAgent);
@@ -10,7 +11,29 @@ const isIe = BOWSER_RESULTS.browser.name === 'Internet Explorer';
 const isFirefox = BOWSER_RESULTS.browser.name === 'Firefox';
 
 const browserName = BOWSER_RESULTS.browser.name;
-const versionNumber = BOWSER_RESULTS.browser.version;
+
+const getVersionNumber = () => {
+  if (BOWSER_RESULTS.browser.version) return BOWSER_RESULTS.browser.version;
+
+  // There are some scenarios (e.g.; WKWebView) where Bowser can't detect the
+  // Safari version. In such cases, we can use the WebKit version to determine
+  // it.
+  if (isSafari && BOWSER_RESULTS.engine.version) return BOWSER_RESULTS.engine.version;
+
+  // If the version number is not available, log an warning and return Infinity
+  // so that we do not deny access to the user (even if we're uncertain about
+  // whether it's a supported browser).
+  logger.warn({
+    logCode: 'browserInfo_invalid_version',
+    extraInfo: {
+      userAgent,
+    },
+  }, 'Unable to determine the browser version number');
+
+  return 'Infinity';
+};
+
+const versionNumber = getVersionNumber();
 
 const isValidSafariVersion = Bowser.getParser(userAgent).satisfies({
   safari: '>12',


### PR DESCRIPTION
### What does this PR do?

- [fix: invalid UA version number in WKWebView](https://github.com/bigbluebutton/bigbluebutton/commit/f3e4e583984bdcb74549cf9d9261d16d1bff954d) 
  - There are some scenarios (e.g. WKWebView) where Bowser can't detect the
Safari version number correctly, which may lead to unexpected behavior
if any code that relies on this utils use the version number
unchecked.
  - In such cases, use the WebKit version to determine it. If that's not the
case and the version number is still unavailable, log an warning and
return Infinity so that we do not deny access to the user (even if
we're uncertain about whether it's a supported browser);

### Closes Issue(s)

n/a