### PR TITLE
fix: connection status button subscribing to data of all users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/common/button/component';
-import ConnectionStatusModalComponent from '/imports/ui/components/connection-status/modal/component';
+import ConnectionStatusModalComponent from '/imports/ui/components/connection-status/modal/container';
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 import Icon from '/imports/ui/components/connection-status/icon/component';
 import Styled from './styles';
@@ -40,17 +40,12 @@ class ConnectionStatusButton extends PureComponent {
   setModalIsOpen = (isOpen) => this.setState({ isModalOpen: isOpen }); 
 
   renderModal(isModalOpen) {
-    const {
-      connectionData,
-    } = this.props;
-
     return (
       isModalOpen ?
       <ConnectionStatusModalComponent
         {...{
           isModalOpen,
           setModalIsOpen: this.setModalIsOpen,
-          connectionData,
         }}
       /> : null
     )
@@ -85,17 +80,11 @@ class ConnectionStatusButton extends PureComponent {
     }
 
     const {
-      connectionData,
+      myCurrentStatus,
     } = this.props;
 
-    const ownConnectionData = connectionData.filter((curr) => curr.user.userId === Auth.userID);
-
-    const currentStatus = ownConnectionData && ownConnectionData.length > 0
-      ? ownConnectionData[0].currentStatus
-      : 'normal';
-
     let color;
-    switch (currentStatus) {
+    switch (myCurrentStatus) {
       case 'warning':
         color = 'success';
         break;
@@ -114,7 +103,7 @@ class ConnectionStatusButton extends PureComponent {
     return (
       <Styled.ButtonWrapper>
         <Button
-          customIcon={this.renderIcon(currentStatus)}
+          customIcon={this.renderIcon(myCurrentStatus)}
           label={intl.formatMessage(intlMessages.label)}
           hideLabel
           aria-label={intl.formatMessage(intlMessages.description)}

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
@@ -3,15 +3,18 @@ import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import { useSubscription } from '@apollo/client';
 import ConnectionStatusButtonComponent from './component';
-import Service from '../service';
-import { CONNECTION_STATUS_REPORT_SUBSCRIPTION } from '../queries';
+import { USER_CURRENT_STATUS_SUBSCRIPTION } from '../queries';
+import Auth from '/imports/ui/services/auth';
 
 const connectionStatusButtonContainer = (props) => {
-  const { data } = useSubscription(CONNECTION_STATUS_REPORT_SUBSCRIPTION);
+  const { data } = useSubscription(USER_CURRENT_STATUS_SUBSCRIPTION, {
+    variables: { userId: Auth.userID },
+  });
+  const myCurrentStatus = data && data.length > 0
+    ? data[0].currentStatus
+    : 'normal';
 
-  const connectionData = data ? Service.sortConnectionData(data.user_connectionStatusReport) : [];
-
-  return <ConnectionStatusButtonComponent connectionData={connectionData} {...props} />;
+  return <ConnectionStatusButtonComponent myCurrentStatus={myCurrentStatus} {...props} />;
 };
 
 export default withTracker(() => {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useSubscription } from '@apollo/client';
+import { CONNECTION_STATUS_REPORT_SUBSCRIPTION } from '../queries';
+import Service from '../service';
+import Component from './component';
+
+const ConnectionStatusContainer = (props) => {
+  const { data } = useSubscription(CONNECTION_STATUS_REPORT_SUBSCRIPTION);
+  const connectionData = data ? Service.sortConnectionData(data.user_connectionStatusReport) : [];
+  return (
+    <Component
+      connectionData={connectionData}
+      {...props}
+    />
+  );
+};
+
+export default ConnectionStatusContainer;

--- a/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
@@ -1,7 +1,13 @@
 import { gql } from '@apollo/client';
 
 export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription ConnStatusReport {
-  user_connectionStatusReport {
+  user_connectionStatusReport(
+  where: {
+    _or: [
+            { clientNotResponding: { _eq: true } }, 
+            { lastUnstableStatus: { _is_null: false } }
+          ]
+  }) {
     user {
       userId
       name

--- a/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
@@ -17,6 +17,20 @@ export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription ConnStatus
   }
 }`;
 
+export const USER_CURRENT_STATUS_SUBSCRIPTION = gql`
+  subscription CurrentUserConnStatus($userId: String!) {
+    user_connectionStatusReport(
+      where: {
+        user: {
+          userId: { _eq: $userId }
+        }
+      }
+    ) {
+      currentStatus
+    }
+  }
+`;
+
 export const CONNECTION_STATUS_SUBSCRIPTION = gql`subscription ConnStatus {
   user_connectionStatus {
     connectionAliveAt


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

Makes the connection status button use just the current user's status data. There is no need to subscribe to every user's data there. The modal will subscribe when opened.