### PR TITLE
fix(bbb-html5): Fix remote logger

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/logger.js
+++ b/bigbluebutton-html5/imports/startup/client/logger.js
@@ -109,8 +109,8 @@ class ServerLoggerStream extends ServerStream {
     if (fullInfo.meetingId != null) {
       this.rec.userInfo = fullInfo;
     }
-    this.rec.clientBuild = window.meetingClientSettings.public.app.html5ClientBuild;
-    this.rec.connectionId = Meteor.connection._lastSessionId;
+    this.rec.clientBuild = window.meetingClientSettings?.public?.app?.html5ClientBuild;
+    this.rec.connectionId = Meteor?.connection?._lastSessionId;
     if (this.logTagString) {
       this.rec.logTag = this.logTagString;
     }


### PR DESCRIPTION
Fixes the errors that were happening when using the client remote logger (disabled by default).

Errors that this PR fixes:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/2075267/43ead75e-4f8c-4415-8fdc-0c50d4f7019e)

![image](https://github.com/bigbluebutton/bigbluebutton/assets/2075267/10b2716c-ab63-4633-a49d-6cbbae23b238)
