### PR TITLE
Graphql: Introduces flag `showRemainingTime`

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1750,6 +1750,11 @@ ORDER BY m."createdAt";
 
 create view "v_meeting_componentsFlags" as
 select "meeting"."meetingId",
+        (case
+            when NULLIF("durationInSeconds",0) is null then false
+            when current_timestamp + '30 minutes'::interval > ("createdAt" + ("durationInSeconds" * '1 second'::interval)) then true
+            else false
+        end) "showRemainingTime",
         exists (
             select 1
             from "breakoutRoom"

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
@@ -11,11 +11,12 @@ select_permissions:
     permission:
       columns:
         - hasBreakoutRoom
+        - hasCaption
         - hasExternalVideo
         - hasPoll
         - hasScreenshare
         - hasTimer
-        - hasCaption
+        - showRemainingTime
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId


### PR DESCRIPTION
```gql
subscription {
  meeting_componentFlags {
    showRemainingTime
  }
}
```

I'll send a subsequent PR to obtain the threshold from settings `public.app.remainingTimeThreshold` instead of using 30 minutes hard-coded.