### PR TITLE
Fix: External video autoplay block

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -225,7 +225,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   useEffect(() => {
     timeoutRef.current = setTimeout(() => {
       setAutoPlayBlocked(true);
-    }, AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS * 1000);
+    }, AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS * 100);
 
     const handleExternalVideoVolumeSet = ((
       event: CustomEvent<SetExternalVideoVolumeCommandArguments>,

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -223,9 +223,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   };
 
   useEffect(() => {
-    timeoutRef.current = setTimeout(() => {
-      setAutoPlayBlocked(true);
-    }, AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS * 100);
+    if (playing) {
+      timeoutRef.current = setTimeout(() => {
+        setAutoPlayBlocked(true);
+      }, AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS * 1000);
+    }
 
     const handleExternalVideoVolumeSet = ((
       event: CustomEvent<SetExternalVideoVolumeCommandArguments>,
@@ -326,8 +328,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   // @ts-ignore accessing lib private property
   const playerName = playerRef.current && playerRef.current.player
-  // @ts-ignore accessing lib private property
-  && playerRef.current.player.player && playerRef.current.player.player.constructor.name as string;
+    // @ts-ignore accessing lib private property
+    && playerRef.current.player.player && playerRef.current.player.player.constructor.name as string;
   let toolbarStyle = 'hoverToolbar';
 
   if (deviceInfo.isMobile && !showHoverToolBar) {
@@ -408,7 +410,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
               hideVolume={hideVolume[playerName as keyof typeof hideVolume]}
             />
           ) : null
-      }
+        }
       </Styled.VideoPlayerWrapper>
     </Styled.Container>
   );
@@ -515,7 +517,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const currentDate = new Date(Date.now() + timeSync);
   const isPaused = !currentMeeting.externalVideo?.playerPlaying ?? false;
   const currentTime = isPaused ? playerCurrentTime : (((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
-  + playerCurrentTime) * playerPlaybackRate;
+    + playerCurrentTime) * playerPlaybackRate;
   const isPresenter = currentUser.presenter ?? false;
 
   return (


### PR DESCRIPTION
### What does this PR do?

This PR refactors the logic behind the unsynched player message to the BBB external video.

### The bug
Showing the unsynched message when it shouldn't in this example changing moderator with external video paused:

[bug.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/fe47e652-15df-48cf-95bd-9fbeb0d9257f)

### The right ocasion to show the message
The message should be shown when the video is unsynchronized, for example, when a person joins the external video activity and the video was already playing a period of time.

[shouldShowMsg.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/7c38511e-9b61-431b-bb2c-a22e955c4147)

### The resolution
The solving of the problem was adding some kind of conditional for the message to show (before it showed on components mounting if the player was not playing - not ideal) and then comparing the graphQL data of the meeting's player playing and the clients player playing to see if they were unsynched for any reason.

[fix.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/0d384fff-ca56-4dbb-8dec-35a65c8f1622)

Furthermore, variable re-naming happened to better express the value inside of them.