### PR TITLE
fix: share camera on grid mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -517,13 +517,13 @@ class VideoService {
     const { viewParticipantsWebcams } = Settings.dataSaving;
     if (!viewParticipantsWebcams) streams = this.filterLocalOnly(streams);
 
-    if (!isPaginationDisabled) {
-      return this.getVideoPage(streams, pageSize);
-    }
-
     const connectingStream = this.getConnectingStream(streams);
     if (connectingStream) {
       streams.push(connectingStream);
+    }
+
+    if (!isPaginationDisabled) {
+      return this.getVideoPage(streams, pageSize);
     }
 
     return streams;


### PR DESCRIPTION
### What does this PR do?

Fix bug where a viewer could not share webcam when grid mode is enabled