### PR TITLE
refactor (graphql-server): Makes it faster to update annotations

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -70,7 +70,6 @@ class WhiteboardModel extends SystemConfiguration {
           val newAnnotation = oldAnnotation.get.copy(annotationInfo = finalAnnotationInfo)
           newAnnotationsMap += (annotation.id -> newAnnotation)
           annotationsAdded :+= newAnnotation
-          PresAnnotationDAO.insertOrUpdate(newAnnotation, newAnnotation)
           println(s"Updated annotation on page [${wb.id}]. After numAnnotations=[${newAnnotationsMap.size}].")
         } else {
           println(s"User $userId doesn't have permission to edit annotation ${annotation.id}, ignoring...")
@@ -78,12 +77,13 @@ class WhiteboardModel extends SystemConfiguration {
       } else if (annotation.annotationInfo.contains("type")) {
         newAnnotationsMap += (annotation.id -> annotation)
         annotationsAdded :+= annotation
-        PresAnnotationDAO.insertOrUpdate(annotation, annotation)
         println(s"Adding annotation to page [${wb.id}]. After numAnnotations=[${newAnnotationsMap.size}].")
       } else {
         println(s"New annotation [${annotation.id}] with no type, ignoring...")
       }
     }
+
+    PresAnnotationDAO.insertOrUpdateMap(newAnnotationsMap)
 
     val newWb = wb.copy(annotationsMap = newAnnotationsMap)
     saveWhiteboard(newWb)
@@ -143,7 +143,7 @@ class WhiteboardModel extends SystemConfiguration {
     val updatedWb = wb.copy(annotationsMap = newAnnotationsMap)
     saveWhiteboard(updatedWb)
 
-    annotationsIdsRemoved.map(PresAnnotationDAO.delete(wbId, userId, _))
+    PresAnnotationDAO.delete(annotationsIdsRemoved)
 
     annotationsIdsRemoved
   }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -119,7 +119,7 @@ export const CURRENT_PAGE_ANNOTATIONS_QUERY = gql`query CurrentPageAnnotationsQu
 }`;
 
 export const CURRENT_PAGE_ANNOTATIONS_STREAM = gql`subscription annotationsStream($lastUpdatedAt: timestamptz){
-  pres_annotation_curr_stream(batch_size: 10, cursor: {initial_value: {lastUpdatedAt: $lastUpdatedAt}}) {
+  pres_annotation_curr_stream(batch_size: 100, cursor: {initial_value: {lastUpdatedAt: $lastUpdatedAt}}) {
     annotationId
     annotationInfo
     lastUpdatedAt


### PR DESCRIPTION
- It will gather all annotations received and update it into the database in one single transaction.
- It will also send a single update to delete a batch of annotations.
- It will stop populating the table `pres_annotation_history` while it is not being used (in the future we will discuss about start to use it or completely remove it).
- And it will receive batches of 100 annotations in the Client, instead of 10.


It aims to improve the experience of drawing in the whiteboard!