### PR TITLE
fix: users count not available on end meeting modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/component.jsx
@@ -46,8 +46,8 @@ class EndMeetingComponent extends PureComponent {
 
     const title = intl.formatMessage(intlMessages.endMeetingTitle, { 0: meetingTitle });
 
-    let description = users > 0
-      ? intl.formatMessage(intlMessages.endMeetingDescription, { 0: users })
+    let description = users > 1
+      ? intl.formatMessage(intlMessages.endMeetingDescription, { 0: users - 1 })
       : intl.formatMessage(intlMessages.endMeetingNoUserDescription);
 
     if (warnAboutUnsavedContentOnMeetingEnd) {

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/container.jsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import { useMutation } from '@apollo/client';
+import { useMutation, useSubscription } from '@apollo/client';
 import EndMeetingComponent from './component';
 import Service from './service';
 import logger from '/imports/startup/client/logger';
 import { MEETING_END } from './mutations';
+import { USER_AGGREGATE_COUNT_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
 
 const EndMeetingContainer = (props) => {
   const [meetingEnd] = useMutation(MEETING_END);
+  const {
+    data: countData,
+  } = useSubscription(USER_AGGREGATE_COUNT_SUBSCRIPTION);
+  const users = countData?.user_aggregate?.aggregate?.count || 0;
+
   const { setIsOpen } = props;
 
   const endMeeting = () => {
@@ -19,10 +25,9 @@ const EndMeetingContainer = (props) => {
     setIsOpen(false);
   };
 
-  return <EndMeetingComponent endMeeting={endMeeting} {...props} />;
+  return <EndMeetingComponent endMeeting={endMeeting} users={users} {...props} />;
 };
 
 export default withTracker(() => ({
   meetingTitle: Service.getMeetingTitle(),
-  users: Service.getUsers(),
 }))(EndMeetingContainer);

--- a/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/service.js
+++ b/bigbluebutton-html5/imports/ui/components/end-meeting-confirmation/service.js
@@ -1,4 +1,3 @@
-import Users from '/imports/api/users';
 import Auth from '/imports/ui/services/auth';
 import Meetings from '/imports/api/meetings';
 
@@ -10,16 +9,6 @@ const getMeetingTitle = () => {
   return meeting.name;
 };
 
-const getUsers = () => {
-  const numUsers = Users.find({
-    meetingId: Auth.meetingID,
-    userId: { $ne: Auth.userID },
-  }, { fields: { _id: 1 } }).count();
-
-  return numUsers;
-};
-
 export default {
-  getUsers,
   getMeetingTitle,
 };


### PR DESCRIPTION
### What does this PR do?

Get users count from graphql instead of meteor collection (a generic message is displayed when the number is not available)

#### before

![Screenshot from 2024-04-11 09-55-41](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/8c91a675-d86c-4204-b488-15ea7d521ad3)


#### after

![Screenshot from 2024-04-11 09-51-55](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/67833280-fc65-40db-bae9-c52a89fa143a)
