### PR TITLE
Introduces graphql Notification

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomEndedInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomEndedInternalMsgHdlr.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.core.api.BreakoutRoomEndedInternalMsg
-import org.bigbluebutton.core.db.BreakoutRoomDAO
+import org.bigbluebutton.core.db.{ BreakoutRoomDAO, NotificationDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
@@ -37,6 +37,7 @@ trait BreakoutRoomEndedInternalMsgHdlr {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           BreakoutRoomDAO.updateRoomsEnded(liveMeeting.props.meetingProp.intId)
           state.update(None)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
@@ -5,7 +5,7 @@ import org.bigbluebutton.core.api.EjectUserFromBreakoutInternalMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers.getRedirectUrls
 import org.bigbluebutton.core.apps.{PermissionCheck, RightsManagementTrait}
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
-import org.bigbluebutton.core.db.BreakoutRoomUserDAO
+import org.bigbluebutton.core.db.{BreakoutRoomUserDAO, NotificationDAO}
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.EjectReasonCode
 import org.bigbluebutton.core.running.{MeetingActor, OutMsgRouter}
@@ -75,6 +75,7 @@ trait ChangeUserBreakoutReqMsgHdlr extends RightsManagementTrait {
             Vector(roomTo.shortName)
           )
           outGW.send(notifyUserEvent)
+          NotificationDAO.insert(notifyUserEvent)
         }
       }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndAllBreakoutRoomsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndAllBreakoutRoomsMsgHdlr.scala
@@ -6,9 +6,8 @@ import org.bigbluebutton.core.bus.BigBlueButtonEvent
 import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core.db.UserBreakoutRoomDAO
+import org.bigbluebutton.core.db.{ BreakoutRoomDAO, NotificationDAO, UserBreakoutRoomDAO }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
-import org.bigbluebutton.core.db.BreakoutRoomDAO
 
 trait EndAllBreakoutRoomsMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -39,6 +38,7 @@ trait EndAllBreakoutRoomsMsgHdlr extends RightsManagementTrait {
           Vector()
         )
         outGW.send(notifyEvent)
+        NotificationDAO.insert(notifyEvent)
       }
       BreakoutRoomDAO.updateRoomsEnded(meetingId)
       state.update(None)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToAllBreakoutRoomsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToAllBreakoutRoomsMsgHdlr.scala
@@ -1,13 +1,14 @@
 package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.api.{ SendMessageToBreakoutRoomInternalMsg }
+import org.bigbluebutton.core.api.SendMessageToBreakoutRoomInternalMsg
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
+import org.bigbluebutton.core.db.NotificationDAO
 import org.bigbluebutton.core.domain.MeetingState2x
-import org.bigbluebutton.core.models.{ RegisteredUsers }
+import org.bigbluebutton.core.models.RegisteredUsers
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait SendMessageToAllBreakoutRoomsMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -32,7 +33,7 @@ trait SendMessageToAllBreakoutRoomsMsgHdlr extends RightsManagementTrait {
         val event = buildSendMessageToAllBreakoutRoomsEvtMsg(msg.header.userId, msg.body.msg, breakoutModel.rooms.size)
         outGW.send(event)
 
-        val notifyModeratorEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
+        val notifyUserEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
           msg.header.userId,
           liveMeeting.props.meetingProp.intId,
           "info",
@@ -41,7 +42,8 @@ trait SendMessageToAllBreakoutRoomsMsgHdlr extends RightsManagementTrait {
           "Message for chat sent successfully",
           Vector(s"${breakoutModel.rooms.size}")
         )
-        outGW.send(notifyModeratorEvent)
+        outGW.send(notifyUserEvent)
+        NotificationDAO.insert(notifyUserEvent)
 
         log.debug("Sending message '{}' to all breakout rooms in meeting {}", msg.body.msg, props.meetingProp.intId)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.{ SendTimeRemainingAuditInternalMsg, UpdateBreakoutRoomTimeInternalMsg }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
-import org.bigbluebutton.core.db.{ BreakoutRoomDAO, MeetingDAO }
+import org.bigbluebutton.core.db.{ BreakoutRoomDAO, MeetingDAO, NotificationDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
@@ -63,9 +63,10 @@ trait UpdateBreakoutRoomsTimeMsgHdlr extends RightsManagementTrait {
               Vector(s"${msg.body.timeInMinutes}")
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
 
-          val notifyModeratorEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
+          val notifyUserEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
             msg.header.userId,
             liveMeeting.props.meetingProp.intId,
             "info",
@@ -74,7 +75,8 @@ trait UpdateBreakoutRoomsTimeMsgHdlr extends RightsManagementTrait {
             "Sent to the moderator that requested breakout duration change",
             Vector(s"${msg.body.timeInMinutes}")
           )
-          outGW.send(notifyModeratorEvent)
+          outGW.send(notifyUserEvent)
+          NotificationDAO.insert(notifyUserEvent)
 
           log.debug("Updating {} minutes for breakout rooms time in meeting {}", msg.body.timeInMinutes, props.meetingProp.intId)
           BreakoutRoomDAO.updateRoomsDuration(props.meetingProp.intId, newDurationInSeconds)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -5,8 +5,8 @@ import org.bigbluebutton.core.models.{ Layouts, LayoutsType }
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core.db.LayoutDAO
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core.db.{ LayoutDAO, NotificationDAO }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
   this: LayoutApp2x =>
@@ -73,6 +73,7 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
         Vector()
       )
       outGW.send(notifyEvent)
+      NotificationDAO.insert(notifyEvent)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/ShowPollResultReqMsgHdlr.scala
@@ -7,8 +7,8 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Polls
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core.db.{ ChatMessageDAO, JsonUtils }
+import org.bigbluebutton.core.apps.{PermissionCheck, RightsManagementTrait}
+import org.bigbluebutton.core.db.{ChatMessageDAO, JsonUtils, NotificationDAO}
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 import spray.json.DefaultJsonProtocol.jsonFormat2
 
@@ -37,6 +37,7 @@ trait ShowPollResultReqMsgHdlr extends RightsManagementTrait {
         Vector()
       )
       bus.outGW.send(notifyEvent)
+      NotificationDAO.insert(notifyEvent)
 
       // SendWhiteboardAnnotationPubMsg
       val annotationRouting = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core.db.MeetingLockSettingsDAO
+import org.bigbluebutton.core.db.{ MeetingLockSettingsDAO, NotificationDAO }
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core.running.MeetingActor
@@ -66,6 +66,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
 
             LockSettingsUtil.enforceCamLockSettingsForAllUsers(liveMeeting, outGW)
           } else {
@@ -78,6 +79,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
         }
 
@@ -92,6 +94,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
             VoiceUsers.findAll(liveMeeting.voiceUsers) foreach { vu =>
               if (vu.intId.startsWith(IntIdPrefixType.DIAL_IN)) { // only Dial-in users need this
                 val eventExplicitLock = buildLockMessage(liveMeeting.props.meetingProp.intId, vu.intId, msg.body.setBy, settings.disableMic)
@@ -109,6 +112,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
         }
 
@@ -123,6 +127,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           } else {
             val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
               liveMeeting.props.meetingProp.intId,
@@ -133,6 +138,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
         }
 
@@ -147,6 +153,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           } else {
             val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
               liveMeeting.props.meetingProp.intId,
@@ -157,6 +164,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
         }
 
@@ -171,6 +179,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           } else {
             val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
               liveMeeting.props.meetingProp.intId,
@@ -181,6 +190,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
         }
 
@@ -195,6 +205,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           } else {
             val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
               liveMeeting.props.meetingProp.intId,
@@ -205,6 +216,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
               Vector()
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
           }
         }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.models.{ RegisteredUsers, Roles, UserState, Users2
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.LockSettingsUtil
+import org.bigbluebutton.core.db.NotificationDAO
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
 
 trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
@@ -43,6 +44,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,
@@ -59,6 +61,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           val newUvo: UserState = Users2x.changeRole(liveMeeting.users2x, uvo, msg.body.role)
           val event = buildUserRoleChangedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.userId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.db.NotificationDAO
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.util.ColorPicker
@@ -107,6 +108,7 @@ trait RegisterUserReqMsgHdlr {
           Vector(s"${regUser.name}")
         )
         outGW.send(notifyEvent)
+        NotificationDAO.insert(notifyEvent)
       case GuestStatus.DENY =>
         val g = GuestApprovedVO(regUser.id, GuestStatus.DENY)
         UsersApp.approveOrRejectGuest(liveMeeting, outGW, g, SystemUser.ID)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/SetRecordingStatusCmdMsgHdlr.scala
@@ -10,7 +10,7 @@ import org.bigbluebutton.core.api.SendRecordingTimerInternalMsg
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 import org.bigbluebutton.core.apps.voice.VoiceApp
-import org.bigbluebutton.core.db.MeetingRecordingDAO
+import org.bigbluebutton.core.db.{ MeetingRecordingDAO, NotificationDAO }
 
 trait SetRecordingStatusCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -49,6 +49,7 @@ trait SetRecordingStatusCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           MeetingStatus2x.recordingStarted(liveMeeting.status)
           MeetingRecordingDAO.insertRecording(liveMeeting.props.meetingProp.intId, msg.body.setBy)
@@ -75,6 +76,7 @@ trait SetRecordingStatusCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           MeetingStatus2x.recordingStopped(liveMeeting.status)
           MeetingRecordingDAO.updateStopped(liveMeeting.props.meetingProp.intId, msg.body.setBy)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserJoinMeetingReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
-import org.bigbluebutton.core.db.{ UserDAO, UserStateDAO }
+import org.bigbluebutton.core.db.{ NotificationDAO, UserDAO, UserStateDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running._
@@ -137,6 +137,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
       Vector(newUser.name)
     )
     outGW.send(notifyUserEvent)
+    NotificationDAO.insert(notifyUserEvent)
   }
 
   private def clearCachedVoiceUser(regUser: RegisteredUser) =

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core.apps.webcam
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.db.MeetingUsersPoliciesDAO
+import org.bigbluebutton.core.db.{ MeetingUsersPoliciesDAO, NotificationDAO }
 import org.bigbluebutton.core.models.{ RegisteredUsers, Roles, Users2x }
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
@@ -64,6 +64,7 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
                 Vector()
               )
               bus.outGW.send(notifyEvent)
+              NotificationDAO.insert(notifyEvent)
             } else {
               val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
                 meetingId,
@@ -74,6 +75,7 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
                 Vector()
               )
               bus.outGW.send(notifyEvent)
+              NotificationDAO.insert(notifyEvent)
             }
 
             broadcastEvent(meetingId, msg.body.setBy, value)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/NotificationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/NotificationDAO.scala
@@ -1,0 +1,70 @@
+package org.bigbluebutton.core.db
+import org.bigbluebutton.common2.msgs.{BbbCommonEnvCoreMsg, NotifyAllInMeetingEvtMsg, NotifyRoleInMeetingEvtMsg, NotifyUserInMeetingEvtMsg}
+import PostgresProfile.api._
+import spray.json.JsValue
+
+import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+case class NotificationDbModel(
+//    notificationId:        String,
+    meetingId:          String,
+    notificationType:   String,
+    icon:               String,
+    messageId:          String,
+    messageDescription: String,
+    messageValues:      JsValue,
+    role:               Option[String],
+    userId:             Option[String],
+    createdAt:          java.sql.Timestamp,
+)
+
+class NotificationDbTableDef(tag: Tag) extends Table[NotificationDbModel](tag, None, "notification") {
+  val meetingId = column[String]("meetingId")
+  val notificationType = column[String]("notificationType")
+  val icon = column[String]("icon")
+  val messageId = column[String]("messageId")
+  val messageDescription = column[String]("messageDescription")
+  val messageValues = column[JsValue]("messageValues")
+  val role = column[Option[String]]("role")
+  val userId = column[Option[String]]("userId")
+  val createdAt = column[java.sql.Timestamp]("createdAt")
+  override def * = (meetingId, notificationType, icon, messageId, messageDescription, messageValues, role, userId, createdAt) <> (NotificationDbModel.tupled, NotificationDbModel.unapply)
+}
+
+object NotificationDAO {
+  def insert(notification: BbbCommonEnvCoreMsg) = {
+
+    val (meetingId, notificationType, icon, messageId, messageDescription, messageValues, role, userId) = notification.core match {
+      case event: NotifyAllInMeetingEvtMsg =>
+        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, None, None)
+      case event: NotifyRoleInMeetingEvtMsg =>
+        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, Some(event.body.role), None)
+      case event: NotifyUserInMeetingEvtMsg =>
+        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, None, Some(event.body.userId))
+      case _ =>
+        ("","", "", "", "", Vector(""), None, None)
+    }
+
+    if (notificationType != "") {
+      DatabaseConnection.db.run(
+        TableQuery[NotificationDbTableDef].forceInsert(
+          NotificationDbModel(
+            meetingId,
+            notificationType,
+            icon,
+            messageId,
+            messageDescription,
+            JsonUtils.vectorToJson(messageValues),
+            role,
+            userId,
+            createdAt = new java.sql.Timestamp(System.currentTimeMillis())
+          )
+        )
+      ).onComplete {
+        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted/updated on Notification table!")
+        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting/updating Notification: $e")
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PostgresProfile.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PostgresProfile.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.db
 import com.github.tminglei.slickpg._
 import org.apache.pekko.http.scaladsl.model.ParsingException
 import org.bigbluebutton.common2.domain.SimpleVoteOutVO
+import spray.json.DefaultJsonProtocol.{ StringJsonFormat, vectorFormat }
 import spray.json.{ JsArray, JsBoolean, JsNumber, JsObject, JsString, JsValue, JsonWriter, _ }
 
 import scala.util.{ Failure, Success, Try }
@@ -53,6 +54,10 @@ object JsonUtils {
 
   def mapToJson(genericMap: Map[String, Any]) = {
     genericMap.toJson
+  }
+
+  def vectorToJson(genericVector: Vector[String]) = {
+    genericVector.toJson
   }
 
   def stringToJson(jsonString: String): JsValue = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -7,7 +7,7 @@ import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.apps.users.UsersApp
 import org.bigbluebutton.core.apps.voice.VoiceApp
 import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
-import org.bigbluebutton.core.db.{BreakoutRoomUserDAO, MeetingDAO, MeetingRecordingDAO, UserBreakoutRoomDAO}
+import org.bigbluebutton.core.db.{BreakoutRoomUserDAO, MeetingDAO, MeetingRecordingDAO, NotificationDAO, UserBreakoutRoomDAO}
 import org.bigbluebutton.core.domain.{MeetingEndReason, MeetingState2x}
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
@@ -101,6 +101,7 @@ trait HandlerHelpers extends SystemConfiguration {
               Vector(s"${newUser.name}")
             )
             outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
 
             val newState = startRecordingIfAutoStart2x(outGW, liveMeeting, state)
             if (!Users2x.hasPresenter(liveMeeting.users2x)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -41,7 +41,7 @@ import org.bigbluebutton.core.apps.layout.LayoutApp2x
 import org.bigbluebutton.core.apps.meeting.{ SyncGetMeetingInfoRespMsgHdlr, ValidateConnAuthTokenSysMsgHdlr }
 import org.bigbluebutton.core.apps.plugin.PluginHdlrs
 import org.bigbluebutton.core.apps.users.ChangeLockSettingsInMeetingCmdMsgHdlr
-import org.bigbluebutton.core.db.UserStateDAO
+import org.bigbluebutton.core.db.{ NotificationDAO, UserStateDAO }
 import org.bigbluebutton.core.models.VoiceUsers.{ findAllFreeswitchCallers, findAllListenOnlyVoiceUsers }
 import org.bigbluebutton.core.models.Webcams.findAll
 import org.bigbluebutton.core2.MeetingStatus2x.hasAuthedUserJoined
@@ -924,6 +924,7 @@ class MeetingActor(
           Vector(s"${u.name}")
         )
         outGW.send(notifyEvent)
+        NotificationDAO.insert(notifyEvent)
 
         if (u.presenter) {
           log.info("removeUsersWithExpiredUserLeftFlag will cause an automaticallyAssignPresenter because user={} left", u)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
@@ -5,7 +5,8 @@ import org.bigbluebutton.core.models.{ UserState, Users2x, VoiceUserState, Voice
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core.db.NotificationDAO
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -29,6 +30,7 @@ trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           MeetingStatus2x.muteMeeting(liveMeeting.status)
         } else {
@@ -41,6 +43,7 @@ trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           MeetingStatus2x.unmuteMeeting(liveMeeting.status)
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteMeetingCmdMsgHdlr.scala
@@ -2,10 +2,11 @@ package org.bigbluebutton.core2.message.handlers
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.db.NotificationDAO
 import org.bigbluebutton.core.models.{ VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait MuteMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -54,6 +55,7 @@ trait MuteMeetingCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           MeetingStatus2x.muteMeeting(liveMeeting.status)
         } else {
@@ -66,6 +68,7 @@ trait MuteMeetingCmdMsgHdlr extends RightsManagementTrait {
             Vector()
           )
           outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
 
           MeetingStatus2x.unmuteMeeting(liveMeeting.status)
         }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1753,6 +1753,7 @@ where  (
             n."role" = u."role" or
             (n."role" = 'PRESENTER' and u.presenter is true)
 		)
+and n."createdAt" > u."registeredAt"
 and n."createdAt" > current_timestamp - '5 seconds'::interval;
 
 create index idx_notification on notification("meetingId","userId","role","createdAt");

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1718,6 +1718,45 @@ CREATE TABLE "layout" (
 CREATE VIEW "v_layout" AS
 SELECT * FROM "layout";
 
+------------------------------------
+----
+
+CREATE TABLE "notification" (
+	"notificationId"        serial primary key,
+	"meetingId" 			varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
+	"notificationType"      varchar(100),
+	"icon"                  varchar(100),
+	"messageId"             varchar(100),
+	"messageDescription"    varchar(100),
+	"messageValues"         jsonb,
+	"role"                  varchar(100), --MODERATOR, PRESENTER, VIEWER
+	"userId"                varchar(50) references "user"("userId") ON DELETE CASCADE,
+	"createdAt"             timestamp with time zone DEFAULT current_timestamp
+);
+
+create or replace VIEW "v_notification" AS
+select 	u."meetingId",
+        u."userId",
+		n."notificationId",
+		n."notificationType",
+		n."icon",
+		n."messageId",
+		n."messageDescription",
+		n."messageValues",
+		n."role",
+		case when n."userId" = u."userId" then true else false end "isSingleUserNotification",
+		n."createdAt"
+from notification n
+join "user" u on n."meetingId" = u."meetingId" and (n."userId" is null or n."userId" = u."userId")
+where  (
+            n."role" is null or
+            n."role" = u."role" or
+            (n."role" = 'PRESENTER' and u.presenter is true)
+		)
+and n."createdAt" > current_timestamp - '5 seconds'::interval;
+
+create index idx_notification on notification("meetingId","userId","role","createdAt");
+
 
 --------------------------------
 ---Plugins Data Channel

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_notification.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_notification.yaml
@@ -1,0 +1,28 @@
+table:
+  name: v_notification
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: notification
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - createdAt
+        - icon
+        - isSingleUserNotification
+        - messageDescription
+        - messageId
+        - messageValues
+        - notificationId
+        - notificationType
+        - role
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - userId:
+              _eq: X-Hasura-UserId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -24,6 +24,7 @@
 - "!include public_v_meeting_recordingPolicies.yaml"
 - "!include public_v_meeting_usersPolicies.yaml"
 - "!include public_v_meeting_voiceSettings.yaml"
+- "!include public_v_notification.yaml"
 - "!include public_v_pluginDataChannelMessage.yaml"
 - "!include public_v_poll.yaml"
 - "!include public_v_poll_option.yaml"


### PR DESCRIPTION
Users can receive all notifications through Graphql type `notification`.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/c3f788c0-9469-41b0-8a53-5cdde1fe24ba)


It's recommended to use it as stream with `createdAt` as `Date.now()` (for instance the stream `chat_message_public_stream`).

```gql
subscription {
  notification_stream(batch_size: 10, cursor: {initial_value: {createdAt: "2024-04-12"}}) {
    notificationType
    icon
    messageId
    messageValues
    isSingleUserNotification
    createdAt
  }
}
```

It will provide only the notifications created in the last 5 seconds.
This way if a user is promoted to Moderator, he will not be able to fetch old notifications sent before he was moderator.