### PR TITLE
fix: breakout styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -104,12 +104,13 @@ const SpanWarn = styled.span`
   `}
 
   ${({ valid }) => !valid && `
-    margin: .25rem;
+    margin-top: .75rem;
     position: absolute;
     font-size: ${fontSizeSmall};
     color: ${colorDanger};
     font-weight: 200;
     white-space: nowrap;
+    z-index: 1;
   `}
 `;
 


### PR DESCRIPTION
### What does this PR do?

Fix issue with parts of the breakout modal disappearing when a warning is displayed.

<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
### Closes Issue(s)
Closes #123456
Closes #
-->

#### before
https://github.com/bigbluebutton/bigbluebutton/assets/3728706/0133d8a2-72b6-47b3-9bf8-88e28a3a660f

#### after
https://github.com/bigbluebutton/bigbluebutton/assets/3728706/d885054c-3d73-4d01-9aef-f30ca855483b



