### PR TITLE
build (html5): Add step to clear Nginx cache to refresh Meteor assets

### DIFF
--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -77,5 +77,11 @@ chown root:root /usr/lib/systemd/system/disable-transparent-huge-pages.service
 # Ensure settings is readable
 chmod go+r /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 
+# Clear nginx cache for meteor-assets
+if [ -d /tmp/meteor-assets-nginx-cache/ ] && [ "$(ls -A /tmp/meteor-assets-nginx-cache/)" ] ; then
+  echo "Clearing Nginx cache to refresh Meteor assets"
+  sudo find /tmp/meteor-assets-nginx-cache/ -type f -exec rm {} +
+fi
+
 startService bbb-html5 || echo "bbb-html5 service could not be registered or started"
 

--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -80,7 +80,7 @@ chmod go+r /usr/share/meteor/bundle/programs/server/assets/app/config/settings.y
 # Clear nginx cache for meteor-assets
 if [ -d /tmp/meteor-assets-nginx-cache/ ] && [ "$(ls -A /tmp/meteor-assets-nginx-cache/)" ] ; then
   echo "Clearing Nginx cache to refresh Meteor assets"
-  sudo find /tmp/meteor-assets-nginx-cache/ -type f -exec rm {} +
+  rm -rf /tmp/meteor-assets-nginx-cache/*
 fi
 
 startService bbb-html5 || echo "bbb-html5 service could not be registered or started"


### PR DESCRIPTION
Fix a problem where html5 package is upgraded but nginx provide old assets!

Related: #19942 #19968