### PR TITLE
[2.7] fix(bbb-html5): crash due to undefined metadataProp access

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
@@ -2,11 +2,10 @@ import Auth from '/imports/ui/services/auth';
 import Meetings from '/imports/api/meetings';
 
 export default function getFromMeetingSettings(setting, defaultValue) {
-  const prop = Meetings.findOne(
+  const meeting = Meetings.findOne(
     { meetingId: Auth.meetingID },
-    { fields: { 'metadataProp': 1 } },
-  ).metadataProp;
-  const value = prop.metadata ? prop.metadata[setting] : undefined;
+    { fields: { metadataProp: 1 } },
+  );
 
-  return value || defaultValue;
+  return meeting?.metadataProp?.metadata?.[setting] ?? defaultValue;
 }


### PR DESCRIPTION
### What does this PR do?

- [fix(bbb-html5): crash due to undefined metadataProp access](https://github.com/bigbluebutton/bigbluebutton/commit/71f958ca472f4faf2a8a6c83931f40165dbaf63f) 
  - A client crash may happen if either the Meeting collection or the
document's metadataProp attribute are undefined whenever the
getFromMeetingSettings util is called to fetch metadata.
It's debatable whether anything is working in the client if the
documents being accessed here are unavailable, but it'll still be logged
and might bork an ongoing reconnect.
  - Use optional chaining + nullish coalescing to avoid causing TypeErrors
in those situations while also returning default metadata values
properly.

### Closes Issue(s)

None