### PR TITLE
[2.7] fix(screen-reader): add safeguards for adding alerts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenreader-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenreader-alert/component.jsx
@@ -9,7 +9,10 @@ const ScreenReaderAlert = ({ olderAlert }) => {
     if (olderAlert) setTimeout(() => removeAlert(olderAlert.id), ARIA_ALERT_EXT_TIMEOUT);
   }, [olderAlert?.id]);
 
-  return olderAlert ? createPortal(olderAlert.text, document.getElementById('aria-polite-alert')) : null;
+  const ariaAlertsElement = document.getElementById('aria-polite-alert');
+  const shouldAddAlert = olderAlert && olderAlert.text && ariaAlertsElement !== null;
+
+  return shouldAddAlert ? createPortal(olderAlert.text, ariaAlertsElement) : null;
 };
 
 export default ScreenReaderAlert;


### PR DESCRIPTION
### What does this PR do?

Credits to @Arthurk12 

- [fix(screen-reader): add safeguards for adding alerts](https://github.com/bigbluebutton/bigbluebutton/commit/6cb0e914ab9fd38e16ac943317a6b8809bb5b645) 
  - Adds checks for the alert's text and DOM element before adding screen
reader alerts.
  - Fixes a potential client crash

### Closes Issue(s)

None