### PR TITLE
fix(whiteboard): check before manipulating pan tool class list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -145,8 +145,11 @@ export default function Whiteboard(props) {
     } else {
       setIsPanning(false);
       setPanSelected(false);
-      panButton.classList.add('selectOverride');
-      panButton.classList.remove('select');
+      if (panButton) {
+        // only presenter has the pan button
+        panButton.classList.add('selectOverride');
+        panButton.classList.remove('select');
+      }
     }
   };
 


### PR DESCRIPTION
### What does this PR do?

Since the pan tool is only available for the presenter, it has to be checked whether it actually exists before attempting to modify its class list.

### Closes Issue(s)
Closes #20025 
