### PR TITLE
fix: grid mode webcam order

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -61,8 +61,8 @@ const sortUsersByUserId = (a, b) => {
 };
 
 const sortUsersByName = (a, b) => {
-  const aName = a.sortName || '';
-  const bName = b.sortName || '';
+  const aName = a.sortName || a.nameSortable || '';
+  const bName = b.sortName || b.nameSortable || '';
 
   // Extending for sorting strings with non-ASCII characters
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sorting_non-ascii_characters

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -14,6 +14,7 @@ subscription getvideoData($userIds: [String]!) {
     disconnected
     emoji
     name
+    nameSortable
     role
     avatar
     color
@@ -37,6 +38,7 @@ subscription getVideoDataGrid {
     disconnected
     emoji
     name
+    nameSortable
     role
     avatar
     color


### PR DESCRIPTION
### What does this PR do?

fix grid mode webcam ordering

#### before

self -> users not sharing camera  -> users sharing camera camera

![Screenshot from 2024-04-17 09-32-14](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/43a5325b-5bea-405f-ab66-3aa09caad821)

#### after

self -> users in alphabetic order

![Screenshot from 2024-04-17 09-31-24](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/ae096cd5-d2de-4c84-8b90-f32ebb9d4a7d)


