### PR TITLE
fix (graphql-sever): Option "Join audio" in breakout rooms not working

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectedToGlobalAudioMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectedToGlobalAudioMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.db.UserDAO
 import org.bigbluebutton.core.models.{ Users2x, VoiceUserState, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 
@@ -29,11 +30,10 @@ trait UserConnectedToGlobalAudioMsgHdlr {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
-
       val vu = VoiceUserState(
         intId = user.intId,
         voiceUserId = user.intId,
-        meetingId = user.meetingId,
+        meetingId = props.meetingProp.intId,
         callingWith = "flash",
         callerName = user.name,
         callerNum = user.name,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -302,7 +302,6 @@ object VoiceApp extends SystemConfiguration {
       )
       outGW.send(msgEvent)
     }
-
     checkAndEjectOldDuplicateVoiceConfUser(intId, liveMeeting, outGW)
 
     val isListenOnly = if (callerIdName.startsWith("LISTENONLY")) true else false

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -279,6 +279,7 @@ CREATE TABLE "user" (
 	"guestLobbyMessage" text,
 	"mobile" bool,
 	"clientType" varchar(50),
+	"transferredFromParentMeeting" bool default false, --when a user join in breakoutRoom only in audio
 	"disconnected" bool default false, -- this is the old leftFlag (that was renamed), set when the user just closed the client
 	"expired" bool default false, -- when it is been some time the user is disconnected
 	"ejected" bool,

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1620,7 +1620,7 @@ SELECT *,
     	AND ("isModerator" is false OR "sendInvitationToModerators")
     	THEN TRUE ELSE FALSE END "showInvitation"
 from (
-    SELECT u."meetingId", u."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin", b."sequence", b."name", b."isDefaultName",
+    SELECT u."meetingId" as "userMeetingId", u."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin", b."sequence", b."name", b."isDefaultName",
             b."shortName", b."startedAt", b."endedAt", b."durationInSeconds", b."sendInvitationToModerators",
                 bu."assignedAt", bu."joinURL", bu."inviteDismissedAt", u."role" = 'MODERATOR' as "isModerator",
                 --CASE WHEN b."durationInSeconds" = 0 THEN NULL ELSE b."startedAt" + b."durationInSeconds" * '1 second'::INTERVAL END AS "willEndAt",
@@ -1643,15 +1643,25 @@ from (
 ) a;
 
 CREATE OR REPLACE VIEW "v_breakoutRoom_assignedUser" AS
-SELECT "parentMeetingId", "breakoutRoomId", "meetingId", "userId"
+SELECT "parentMeetingId", "breakoutRoomId", "userMeetingId", "userId"
 FROM "v_breakoutRoom"
 WHERE "assignedAt" IS NOT NULL;
 
 --TODO improve performance (and handle two users with same extId)
-CREATE OR REPLACE VIEW "v_breakoutRoom_participant" AS
-SELECT DISTINCT "parentMeetingId", "breakoutRoomId", "meetingId", "userId"
+CREATE OR REPLACE VIEW "v_breakoutRoom_participant" as
+SELECT DISTINCT "parentMeetingId", "breakoutRoomId", "userMeetingId", "userId"
 FROM "v_breakoutRoom"
-WHERE "currentRoomIsOnline" IS TRUE;
+WHERE "currentRoomIsOnline" IS TRUE
+union all --include users that joined only with audio
+select parent_user."meetingId" as "parentMeetingId",
+        bk_user."meetingId" as "breakoutRoomId",
+        bk_user."meetingId" as "userMeetingId",
+        bk_user."userId"
+from "user" bk_user
+join "user" parent_user on parent_user."userId" = bk_user."userId" and parent_user."transferredFromParentMeeting" is false
+where bk_user."transferredFromParentMeeting" is true
+and bk_user."loggedOut" is false;
+
 --SELECT DISTINCT br."parentMeetingId", br."breakoutRoomId", "user"."meetingId", "user"."userId"
 --FROM v_user "user"
 --JOIN "meeting" m using("meetingId")

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
@@ -52,7 +52,7 @@ select_permissions:
         - startedAt
       filter:
         _and:
-          - meetingId:
+          - userMeetingId:
               _eq: X-Hasura-MeetingId
           - userId:
               _eq: X-Hasura-UserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_assignedUser.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_assignedUser.yaml
@@ -11,7 +11,7 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          meetingId: meetingId
+          userMeetingId: meetingId
           userId: userId
         insertion_order: null
         remote_table:
@@ -27,7 +27,7 @@ select_permissions:
           - parentMeetingId:
               _eq: X-Hasura-ModeratorInMeeting
           - _and:
-              - meetingId:
+              - userMeetingId:
                   _eq: X-Hasura-MeetingId
               - userId:
                   _eq: X-Hasura-UserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_participant.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_participant.yaml
@@ -11,7 +11,7 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          meetingId: meetingId
+          userMeetingId: meetingId
           userId: userId
         insertion_order: null
         remote_table:


### PR DESCRIPTION
It fix this button:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/04e02001-aac7-4e48-8655-62a61eaa37e5)

Reported by @Tainan404 !

----

This PR implements the option "Transfer User" in Graphql.

It will create a copy of the user and insert using the `meetingId` of the breakoutRoom (just like it was done in Mongodb).
https://github.com/bigbluebutton/bigbluebutton/blob/d19d2868110a52cab8d1e0864da40907300b95ed/bigbluebutton-html5/imports/api/voice-users/server/handlers/joinVoiceUser.js#L36

And this users will be flagged in the database with the option `transferredFromParentMeeting=true`.