### PR TITLE
graphql-server: Add flag `isAudioOnly` for breakoutRoom participant

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1649,14 +1649,20 @@ WHERE "assignedAt" IS NOT NULL;
 
 --TODO improve performance (and handle two users with same extId)
 CREATE OR REPLACE VIEW "v_breakoutRoom_participant" as
-SELECT DISTINCT "parentMeetingId", "breakoutRoomId", "userMeetingId", "userId"
+SELECT DISTINCT
+        "parentMeetingId",
+        "breakoutRoomId",
+        "userMeetingId",
+        "userId",
+        false as "isAudioOnly"
 FROM "v_breakoutRoom"
 WHERE "currentRoomIsOnline" IS TRUE
-union all --include users that joined only with audio
+union --include users that joined only with audio
 select parent_user."meetingId" as "parentMeetingId",
         bk_user."meetingId" as "breakoutRoomId",
-        bk_user."meetingId" as "userMeetingId",
-        bk_user."userId"
+        parent_user."meetingId" as "userMeetingId",
+        parent_user."userId",
+        true as "isAudioOnly"
 from "user" bk_user
 join "user" parent_user on parent_user."userId" = bk_user."userId" and parent_user."transferredFromParentMeeting" is false
 where bk_user."transferredFromParentMeeting" is true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_assignedUser.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_assignedUser.yaml
@@ -11,8 +11,8 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          userMeetingId: meetingId
           userId: userId
+          userMeetingId: meetingId
         insertion_order: null
         remote_table:
           name: v_user_ref

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_participant.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom_participant.yaml
@@ -11,8 +11,8 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          userMeetingId: meetingId
           userId: userId
+          userMeetingId: meetingId
         insertion_order: null
         remote_table:
           name: v_user_ref
@@ -21,6 +21,7 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
+        - isAudioOnly
         - userId
       filter:
         parentMeetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pluginDataChannelMessage.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pluginDataChannelMessage.yaml
@@ -11,8 +11,8 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          meetingId: meetingId
           fromUserId: userId
+          meetingId: meetingId
         insertion_order: null
         remote_table:
           name: v_user_ref


### PR DESCRIPTION
- Fix a problem that main user could not get info of breakoutRoom audio-only participants
- Add a flag `isAudioOnly` to indicate that user joined in the breakoutRoom as audio-only

```gql
subscription {
    breakoutRoom(order_by: {sequence: asc}){
      shortName
      participants {
        userId
        isAudioOnly
        user {
          name
          nameSortable
        }
      }
    }
  }
```

Related: #20031