### PR TITLE
fix: move users to the correct breakout room in manage users modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room-graphql/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room-graphql/create-breakout-room/room-managment-state/component.tsx
@@ -174,13 +174,21 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
 
   useEffect(() => {
     if (runningRooms && init) {
+      const usersToMove: string[] = [];
+      const toRooms: number[] = [];
+
       runningRooms.forEach((r: breakoutRoom) => {
         r.participants.forEach((u) => {
           if (!rooms[r.sequence]?.users?.find((user) => user.userId === u.user.userId)) {
-            moveUser(u.user.userId, 0, r.sequence);
+            usersToMove.push(u.user.userId);
+            toRooms.push(r.sequence);
           }
         });
       });
+
+      if (usersToMove.length > 0) {
+        moveUser(usersToMove, 0, toRooms);
+      }
     }
   }, [runningRooms, init]);
 


### PR DESCRIPTION
### What does this PR do?

Similar to #20014, but for displaying users in the correct breakout room in the "manage users" modal