### PR TITLE
fix(html5): SharedNotes not unmounting when other components pile up in layout manager

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -585,7 +585,7 @@ setRandomUserSelectModalIsOpen(value) {
       pushAlertEnabled,
       shouldShowPresentation,
       shouldShowScreenshare,
-      shouldShowSharedNotes,
+      isSharedNotesPinned,
       isPresenter,
       selectedLayout,
       presentationIsOpen,
@@ -623,7 +623,7 @@ setRandomUserSelectModalIsOpen(value) {
           <BannerBarContainer />
           <NotificationsBarContainer />
           <SidebarNavigationContainer />
-          <SidebarContentContainer isSharedNotesPinned={shouldShowSharedNotes} />
+          <SidebarContentContainer isSharedNotesPinned={isSharedNotesPinned} />
           <NavBarContainer main="new" />
           <WebcamContainer isLayoutSwapped={!presentationIsOpen} layoutType={selectedLayout} />
           <ExternalVideoPlayerContainer />
@@ -653,11 +653,10 @@ setRandomUserSelectModalIsOpen(value) {
             )
             : null
           }
-          {shouldShowSharedNotes
+          {isSharedNotesPinned
             ? (
               <NotesContainer
                 area="media"
-                layoutType={selectedLayout}
               />
             ) : null}
           {this.renderCaptions()}

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -68,7 +68,6 @@ const AppContainer = (props) => {
     meetingLayoutCameraPosition,
     meetingLayoutFocusedCamera,
     meetingLayoutVideoRate,
-    isSharedNotesPinned,
     viewScreenshare,
     ...otherProps
   } = props;
@@ -81,6 +80,7 @@ const AppContainer = (props) => {
   const cameraDock = layoutSelectOutput((i) => i.cameraDock);
   const cameraDockInput = layoutSelectInput((i) => i.cameraDock);
   const presentation = layoutSelectInput((i) => i.presentation);
+  const sharedNotesInput = layoutSelectInput((i) => i.sharedNotes);
   const deviceType = layoutSelect((i) => i.deviceType);
   const layoutContextDispatch = layoutDispatch();
 
@@ -90,8 +90,9 @@ const AppContainer = (props) => {
   const toggleVoice = useToggleVoice();
   const setLocalSettings = useUserChangedLocalSettings();
   const { data: pinnedPadData } = useSubscription(PINNED_PAD_SUBSCRIPTION);
-  const shouldShowSharedNotes = !!pinnedPadData
+  const isSharedNotesPinnedFromGraphql = !!pinnedPadData
     && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
+  const isSharedNotesPinned = sharedNotesInput?.isPinned && isSharedNotesPinnedFromGraphql;
 
   const setMobileUser = (mobile) => {
     setMobileFlag({
@@ -185,7 +186,7 @@ const AppContainer = (props) => {
 
   const shouldShowScreenshare = propsShouldShowScreenshare
     && (viewScreenshare || isPresenter);
-  const shouldShowPresentation = (!shouldShowScreenshare && !shouldShowSharedNotes
+  const shouldShowPresentation = (!shouldShowScreenshare && !isSharedNotesPinned
     && !shouldShowExternalVideo && !shouldShowGenericComponent
     && (presentationIsOpen || presentationRestoreOnUpdate)) && isPresentationEnabled();
   return currentUserId
@@ -227,7 +228,7 @@ const AppContainer = (props) => {
           enforceLayout: validateEnforceLayout(currentUserData),
           isModerator,
           shouldShowScreenshare,
-          shouldShowSharedNotes,
+          isSharedNotesPinned,
           shouldShowPresentation,
           setMobileUser,
           toggleVoice,
@@ -335,7 +336,6 @@ export default withTracker(() => {
     hideActionsBar: getFromUserSettings('bbb_hide_actions_bar', false),
     hideNavBar: getFromUserSettings('bbb_hide_nav_bar', false),
     ignorePollNotifications: Session.get('ignorePollNotifications'),
-    isSharedNotesPinned: MediaService.shouldShowSharedNotes(),
     User: currentUser,
   };
 })(AppContainer);

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -12,8 +12,6 @@ import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import { UI_DATA_LISTENER_SUBSCRIBED } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/consts';
 import { ExternalVideoVolumeUiDataNames } from 'bigbluebutton-html-plugin-sdk';
 import { ExternalVideoVolumeUiDataPayloads } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/external-video/volume/types';
-import MediaService from '/imports/ui/components/media/service';
-import NotesService from '/imports/ui/components/notes/service';
 
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import {
@@ -74,8 +72,6 @@ interface ExternalVideoPlayerProps {
   currentTime: number;
   key: string;
   setKey: (key: string) => void;
-  shouldShowSharedNotes(): boolean;
-  pinSharedNotes(pinned: boolean): void;
 }
 
 // @ts-ignore - PeerTubePlayer is not typed
@@ -97,8 +93,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   isEchoTest,
   key,
   setKey,
-  shouldShowSharedNotes,
-  pinSharedNotes,
 }) => {
   const intl = useIntl();
 
@@ -225,7 +219,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   useEffect(() => {
     const unsynchedPlayer = reactPlayerState !== playing;
-    if (unsynchedPlayer) {
+    if (unsynchedPlayer && !!videoUrl) {
       timeoutRef.current = setTimeout(() => {
         setShowUnsynchedMsg(true);
       }, AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS * 1000);
@@ -256,16 +250,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       playerRef.current.seekTo(currentTime, 'seconds');
     }
   }, [playerRef.current]);
-
-  useEffect(() => {
-    if (shouldShowSharedNotes()) {
-      pinSharedNotes(false);
-      return () => {
-        pinSharedNotes(true);
-      };
-    }
-    return undefined;
-  }, []);
 
   // --- Plugin related code ---;
   const internalPlayer = playerRef.current?.getInternalPlayer ? playerRef.current?.getInternalPlayer() : null;
@@ -539,8 +523,6 @@ const ExternalVideoPlayerContainer: React.FC = () => {
       currentTime={isPresenter ? playerCurrentTime : currentTime}
       key={key}
       setKey={setKey}
-      shouldShowSharedNotes={MediaService.shouldShowSharedNotes}
-      pinSharedNotes={NotesService.pinSharedNotes}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useReducer, useRef } from 'react';
 import { createContext, useContextSelector } from 'use-context-selector';
 import PropTypes from 'prop-types';
+import { useSubscription } from '@apollo/client';
 import { equals } from 'ramda';
-import { ACTIONS, PRESENTATION_AREA } from '/imports/ui/components/layout/enums';
+import { PINNED_PAD_SUBSCRIPTION } from '/imports/ui/components/notes/notes-graphql/queries';
+import {
+  ACTIONS, PRESENTATION_AREA, PANELS, LAYOUT_TYPE,
+} from '/imports/ui/components/layout/enums';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE, INITIAL_OUTPUT_STATE } from './initState';
 import useUpdatePresentationAreaContentForPlugin from '/imports/ui/components/plugins-engine/ui-data-hooks/layout/presentation-area/utils';
+import { isPresentationEnabled } from '/imports/ui/services/features';
 
 // variable to debug in console log
 const debug = false;
@@ -37,6 +42,9 @@ const initPresentationAreaContentActions = [{
   },
 }];
 
+const CHAT_CONFIG = window.meetingClientSettings.public.chat;
+const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
+
 const initState = {
   presentationAreaContentActions: initPresentationAreaContentActions,
   deviceType: null,
@@ -55,7 +63,6 @@ const initState = {
 const reducer = (state, action) => {
   debugActions(action.type, action.value);
   switch (action.type) {
-
     case ACTIONS.SET_FOCUSED_CAMERA_ID: {
       const { cameraDock } = state.input;
       const { focusedId } = cameraDock;
@@ -1331,6 +1338,8 @@ const updatePresentationAreaContent = (
   previousPresentationAreaContentActions,
   layoutContextDispatch,
 ) => {
+  const { layoutType } = layoutContextState;
+  const { sidebarContent } = layoutContextState.input;
   const {
     presentationAreaContentActions: currentPresentationAreaContentActions,
   } = layoutContextState;
@@ -1355,6 +1364,32 @@ const updatePresentationAreaContent = (
         break;
       }
       case PRESENTATION_AREA.PINNED_NOTES: {
+        if (
+          (sidebarContent.isOpen || !isPresentationEnabled())
+          && (sidebarContent.sidebarContentPanel === PANELS.SHARED_NOTES
+            || !isPresentationEnabled())
+        ) {
+          if (layoutType === LAYOUT_TYPE.VIDEO_FOCUS) {
+            layoutContextDispatch({
+              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+              value: PANELS.CHAT,
+            });
+            layoutContextDispatch({
+              type: ACTIONS.SET_ID_CHAT_OPEN,
+              value: PUBLIC_CHAT_ID,
+            });
+          } else {
+            layoutContextDispatch({
+              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+              value: false,
+            });
+            layoutContextDispatch({
+              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+              value: PANELS.NONE,
+            });
+          }
+        }
+
         layoutContextDispatch({
           type: ACTIONS.SET_HAS_GENERIC_COMPONENT,
           value: undefined,
@@ -1371,6 +1406,10 @@ const updatePresentationAreaContent = (
           value: undefined,
         });
         layoutContextDispatch({
+          type: ACTIONS.SET_NOTES_IS_PINNED,
+          value: !lastPresentationContentInPile.value.open,
+        });
+        layoutContextDispatch({
           type: ACTIONS.SET_HAS_EXTERNAL_VIDEO,
           value: lastPresentationContentInPile.value.open,
         });
@@ -1380,6 +1419,10 @@ const updatePresentationAreaContent = (
         layoutContextDispatch({
           type: ACTIONS.SET_HAS_GENERIC_COMPONENT,
           value: undefined,
+        });
+        layoutContextDispatch({
+          type: ACTIONS.SET_NOTES_IS_PINNED,
+          value: !lastPresentationContentInPile.value.open,
         });
         layoutContextDispatch({
           type: ACTIONS.SET_HAS_SCREEN_SHARE,
@@ -1399,6 +1442,10 @@ const updatePresentationAreaContent = (
         layoutContextDispatch({
           type: ACTIONS.SET_HAS_GENERIC_COMPONENT,
           value: undefined,
+        });
+        layoutContextDispatch({
+          type: ACTIONS.PINNED_NOTES,
+          value: !lastPresentationContentInPile.value.open,
         });
         break;
       }
@@ -1422,6 +1469,8 @@ const LayoutContextProvider = (props) => {
       },
     }],
   );
+  const { data: pinnedPadData } = useSubscription(PINNED_PAD_SUBSCRIPTION);
+
   const [layoutContextState, layoutContextDispatch] = useReducer(reducer, initState);
   const { children } = props;
   useEffect(() => {
@@ -1431,6 +1480,27 @@ const LayoutContextProvider = (props) => {
       layoutContextDispatch,
     );
   }, [layoutContextState]);
+  useEffect(() => {
+    const isSharedNotesPinned = !!pinnedPadData
+      && pinnedPadData.sharedNotes[0]?.pinned;
+    if (isSharedNotesPinned) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
+        value: {
+          content: PRESENTATION_AREA.PINNED_NOTES,
+          open: true,
+        },
+      });
+    } else {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
+        value: {
+          content: PRESENTATION_AREA.PINNED_NOTES,
+          open: false,
+        },
+      });
+    }
+  }, [pinnedPadData]);
   useUpdatePresentationAreaContentForPlugin(layoutContextState);
   return (
     <LayoutContextSelector.Provider value={
@@ -1446,18 +1516,16 @@ const LayoutContextProvider = (props) => {
 };
 LayoutContextProvider.propTypes = providerPropTypes;
 
-const layoutSelect = (selector) => {
-  return useContextSelector(LayoutContextSelector, layout => selector(layout[0]));
-};
-const layoutSelectInput = (selector) => {
-  return useContextSelector(LayoutContextSelector, layout => selector(layout[0].input));
-};
-const layoutSelectOutput = (selector) => {
-  return useContextSelector(LayoutContextSelector, layout => selector(layout[0].output));
-};
-const layoutDispatch = () => {
-  return useContextSelector(LayoutContextSelector, layout => layout[1]);
-};
+const layoutSelect = (
+  selector,
+) => useContextSelector(LayoutContextSelector, (layout) => selector(layout[0]));
+const layoutSelectInput = (
+  selector,
+) => useContextSelector(LayoutContextSelector, (layout) => selector(layout[0].input));
+const layoutSelectOutput = (
+  selector,
+) => useContextSelector(LayoutContextSelector, (layout) => selector(layout[0].output));
+const layoutDispatch = () => useContextSelector(LayoutContextSelector, (layout) => layout[1]);
 
 export {
   LayoutContextProvider,
@@ -1465,4 +1533,4 @@ export {
   layoutSelectInput,
   layoutSelectOutput,
   layoutDispatch,
-}
+};

--- a/bigbluebutton-html5/imports/ui/components/notes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.jsx
@@ -7,16 +7,11 @@ import PadContainer from '/imports/ui/components/pads/container';
 import Styled from './styles';
 import {
   PANELS, ACTIONS,
-  LAYOUT_TYPE,
-  PRESENTATION_AREA,
 } from '../layout/enums';
 import browserInfo from '/imports/utils/browserInfo';
 import Header from '/imports/ui/components/common/control-header/component';
 import NotesDropdown from '/imports/ui/components/notes/notes-dropdown/container';
-import { isPresentationEnabled } from '../../services/features';
 
-const CHAT_CONFIG = window.meetingClientSettings.public.chat;
-const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 const DELAY_UNMOUNT_SHARED_NOTES = window.meetingClientSettings.public.app.delayForUnmountOfSharedNote;
 const intlMessages = defineMessages({
   hide: {
@@ -103,60 +98,6 @@ const Notes = ({
     }
     return () => clearTimeout(timoutRef);
   }, [isToSharedNotesBeShow, sidebarContent.sidebarContentPanel]);
-  useEffect(() => {
-    if (
-      isOnMediaArea
-      && (sidebarContent.isOpen || !isPresentationEnabled())
-      && (sidebarContent.sidebarContentPanel === PANELS.SHARED_NOTES || !isPresentationEnabled())
-    ) {
-      if (layoutType === LAYOUT_TYPE.VIDEO_FOCUS) {
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-          value: PANELS.CHAT,
-        });
-
-        layoutContextDispatch({
-          type: ACTIONS.SET_ID_CHAT_OPEN,
-          value: PUBLIC_CHAT_ID,
-        });
-      } else {
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-          value: false,
-        });
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-          value: PANELS.NONE,
-        });
-      }
-
-      layoutContextDispatch({
-        type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
-        value: {
-          content: PRESENTATION_AREA.PINNED_NOTES,
-          open: true,
-        },
-      });
-
-      return () => {
-        layoutContextDispatch({
-          type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
-          value: {
-            content: PRESENTATION_AREA.PINNED_NOTES,
-            open: false,
-          },
-        });
-      };
-    } if (shouldShowSharedNotesOnPresentationArea) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
-        value: {
-          content: PRESENTATION_AREA.PINNED_NOTES,
-          open: true,
-        },
-      });
-    }
-  }, []);
 
   const renderHeaderOnMedia = () => {
     return amIPresenter ? (

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-graphql/component.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useMutation, useSubscription } from '@apollo/client';
-import { Session } from 'meteor/session';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
 import NotesService from '/imports/ui/components/notes/notes-graphql/service';
 import PadContainer from '/imports/ui/components/pads/container';
 import browserInfo from '/imports/utils/browserInfo';
 import Header from '/imports/ui/components/common/control-header/component';
 import NotesDropdown from './notes-dropdown/component';
-import { PANELS, ACTIONS, LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
-import { isPresentationEnabled } from '/imports/ui/services/features';
+import {
+  PANELS, ACTIONS,
+} from '/imports/ui/components/layout/enums';
 import { layoutSelectInput, layoutDispatch, layoutSelectOutput } from '/imports/ui/components/layout/context';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import useHasPermission from './hooks/useHasPermission';
@@ -22,9 +22,7 @@ import {
   isScreenBroadcasting,
 } from '/imports/ui/components/screenshare/service';
 
-const CHAT_CONFIG = window.meetingClientSettings.public.chat;
 const NOTES_CONFIG = window.meetingClientSettings.public.notes;
-const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 const DELAY_UNMOUNT_SHARED_NOTES = window.meetingClientSettings.public.app.delayForUnmountOfSharedNote;
 
 const intlMessages = defineMessages({
@@ -44,7 +42,6 @@ const intlMessages = defineMessages({
 
 interface NotesContainerGraphqlProps {
   area: 'media' | undefined;
-  layoutType: string;
   isToSharedNotesBeShow: boolean;
 }
 
@@ -73,7 +70,6 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     layoutContextDispatch,
     isResizing,
     area,
-    layoutType,
     sidebarContent,
     sharedNotesOutput,
     amIPresenter,
@@ -113,64 +109,6 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     }
     return () => clearTimeout(timoutRef);
   }, [isToSharedNotesBeShow, sidebarContent.sidebarContentPanel]);
-  // eslint-disable-next-line consistent-return
-  useEffect(() => {
-    if (
-      isOnMediaArea
-      && (sidebarContent.isOpen || !isPresentationEnabled())
-      && (sidebarContent.sidebarContentPanel === PANELS.SHARED_NOTES || !isPresentationEnabled())
-    ) {
-      if (layoutType === LAYOUT_TYPE.VIDEO_FOCUS) {
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-          value: PANELS.CHAT,
-        });
-
-        layoutContextDispatch({
-          type: ACTIONS.SET_ID_CHAT_OPEN,
-          value: PUBLIC_CHAT_ID,
-        });
-      } else {
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-          value: false,
-        });
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-          value: PANELS.NONE,
-        });
-      }
-
-      layoutContextDispatch({
-        type: ACTIONS.SET_NOTES_IS_PINNED,
-        value: true,
-      });
-      layoutContextDispatch({
-        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-        value: true,
-      });
-
-      return () => {
-        layoutContextDispatch({
-          type: ACTIONS.SET_NOTES_IS_PINNED,
-          value: false,
-        });
-        layoutContextDispatch({
-          type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-          value: Session.get('presentationLastState'),
-        });
-      };
-    } if (shouldShowSharedNotesOnPresentationArea) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_NOTES_IS_PINNED,
-        value: true,
-      });
-      layoutContextDispatch({
-        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-        value: true,
-      });
-    }
-  }, []);
 
   const renderHeaderOnMedia = () => {
     return amIPresenter ? (
@@ -228,7 +166,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
 };
 
 const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
-  const { area, layoutType, isToSharedNotesBeShow } = props;
+  const { area, isToSharedNotesBeShow } = props;
 
   const hasPermission = useHasPermission();
   const { data: pinnedPadData } = useSubscription<PinnedPadSubscriptionResponse>(PINNED_PAD_SUBSCRIPTION);
@@ -272,7 +210,6 @@ const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
       amIPresenter={amIPresenter}
       shouldShowSharedNotesOnPresentationArea={shouldShowSharedNotesOnPresentationArea}
       isRTL={isRTL}
-      layoutType={layoutType}
       isToSharedNotesBeShow={isToSharedNotesBeShow}
       handlePinSharedNotes={handlePinSharedNotes}
     />

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
@@ -23,9 +23,6 @@ const SmartMediaShareContainer = (props) => {
       externalVideoUrl = Panopto.getSocialUrl(url);
     }
 
-    // Close Shared Notes if open.
-    NotesService.pinSharedNotes(false);
-
     startExternalVideo({ variables: { externalVideoUrl } });
   };
 

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -142,9 +142,6 @@ class ScreenshareComponent extends React.Component {
       intl,
       fullscreenContext,
       layoutContextDispatch,
-      toggleSwapLayout,
-      pinSharedNotes,
-      stopExternalVideoShare,
     } = this.props;
     screenshareHasEnded();
     window.removeEventListener('screensharePlayFailed', this.handlePlayElementFailed);
@@ -179,8 +176,6 @@ class ScreenshareComponent extends React.Component {
       type: ACTIONS.SET_PRESENTATION_IS_OPEN,
       value: Session.get('presentationLastState'),
     });
-
-    pinSharedNotes(Session.get('pinnedNotesLastState'), stopExternalVideoShare);
   }
 
   clearMediaFlowingMonitor() {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -16,7 +16,6 @@ import getFromUserSettings from '/imports/ui/services/users-settings';
 import AudioService from '/imports/ui/components/audio/service';
 import MediaService from '/imports/ui/components/media/service';
 import { defineMessages } from 'react-intl';
-import NotesService from '/imports/ui/components/notes/service';
 import { EXTERNAL_VIDEO_STOP } from '../external-video-player/mutations';
 
 const screenshareIntlMessages = defineMessages({
@@ -152,7 +151,5 @@ export default withTracker(() => {
     hidePresentationOnJoin: getFromUserSettings('bbb_hide_presentation_on_join', LAYOUT_CONFIG.hidePresentationOnJoin),
     enableVolumeControl: shouldEnableVolumeControl(),
     outputDeviceId: AudioService.outputDeviceId(),
-    isSharedNotesPinned: MediaService.shouldShowSharedNotes(),
-    pinSharedNotes: NotesService.pinSharedNotes,
   };
 })(ScreenshareContainer);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -5,11 +5,9 @@ import Settings from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import Auth from '/imports/ui/services/auth';
 import AudioService from '/imports/ui/components/audio/service';
-import { Meteor } from "meteor/meteor";
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 import browserInfo from '/imports/utils/browserInfo';
-import NotesService from '/imports/ui/components/notes/service';
 
 const VOLUME_CONTROL_ENABLED = window.meetingClientSettings.public.kurento.screenshare.enableVolumeControl;
 const SCREENSHARE_MEDIA_ELEMENT_NAME = 'screenshareVideo';
@@ -309,8 +307,6 @@ const shareScreen = async (stopWatching, isPresenter, onFail, options = {}) => {
       return;
     }
 
-    // Close Shared Notes if open.
-    NotesService.pinSharedNotes(false);
     // stop external video share if running
     stopWatching();
 


### PR DESCRIPTION
### What does this PR do?

It fixes a problem where pinned sharedNotes was not unmounting from the presentation area when another component, such as screenshare or external-video, requested to be rendered within the presentation area.

See error below:

https://github.com/bigbluebutton/bigbluebutton/assets/69865537/193defaf-9971-43f0-8385-b42dc9b3da2d

Now, the fix:

https://github.com/bigbluebutton/bigbluebutton/assets/69865537/262d323c-40d7-40ae-815a-8d79e6dc9ced

