### PR TITLE
Graphql-server: Add mutation `captionSetOwner`

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/caption/CaptionApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/caption/CaptionApp2x.scala
@@ -4,8 +4,9 @@ import org.apache.pekko.actor.ActorContext
 import org.apache.pekko.event.Logging
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.running.{ LiveMeeting }
+import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.db.{ CaptionLocaleDAO, CaptionTypes }
 
 class CaptionApp2x(implicit val context: ActorContext) extends RightsManagementTrait {
   val log = Logging(context.system, getClass)
@@ -84,6 +85,7 @@ class CaptionApp2x(implicit val context: ActorContext) extends RightsManagementT
       val event = UpdateCaptionOwnerEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)
+      CaptionLocaleDAO.insertOrUpdateCaptionLocale(liveMeeting.props.meetingProp.intId, locale, CaptionTypes.TYPED, newOwnerId)
     }
 
     if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/CaptionLangDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/CaptionLangDAO.scala
@@ -1,0 +1,41 @@
+package org.bigbluebutton.core.db
+
+import slick.jdbc.PostgresProfile.api._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{ Failure, Success }
+
+case class CaptionLocaleDbModel(
+    meetingId:   String,
+    locale:      String,
+    captionType: String,
+    ownerUserId: String,
+    updatedAt:   java.sql.Timestamp
+)
+
+class CaptionLocaleTableDef(tag: Tag) extends Table[CaptionLocaleDbModel](tag, None, "caption_locale") {
+  val meetingId = column[String]("meetingId", O.PrimaryKey)
+  val locale = column[String]("locale", O.PrimaryKey)
+  val captionType = column[String]("captionType", O.PrimaryKey)
+  val ownerUserId = column[String]("ownerUserId")
+  val updatedAt = column[java.sql.Timestamp]("updatedAt")
+  def * = (meetingId, locale, captionType, ownerUserId, updatedAt) <> (CaptionLocaleDbModel.tupled, CaptionLocaleDbModel.unapply)
+}
+
+object CaptionLocaleDAO {
+  def insertOrUpdateCaptionLocale(meetingId: String, locale: String, captionType: String, ownerUserId: String) = {
+    DatabaseConnection.db.run(
+      TableQuery[CaptionLocaleTableDef].insertOrUpdate(
+        CaptionLocaleDbModel(
+          meetingId = meetingId,
+          locale = locale,
+          captionType = captionType,
+          ownerUserId = ownerUserId,
+          updatedAt = new java.sql.Timestamp(System.currentTimeMillis())
+        )
+      )
+    ).onComplete {
+        case Success(_) => DatabaseConnection.logger.debug(s"Upserted caption with ID $meetingId-$locale on CaptionLocale table")
+        case Failure(e) => DatabaseConnection.logger.debug(s"Error upserting caption on CaptionLocale: $e")
+      }
+  }
+}

--- a/bbb-graphql-actions/src/actions/captionSetOwner.ts
+++ b/bbb-graphql-actions/src/actions/captionSetOwner.ts
@@ -1,0 +1,24 @@
+import { RedisMessage } from '../types';
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  const eventName = `UpdateCaptionOwnerPubMsg`;
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = { 
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    name: '',
+    locale: input.locale,
+    ownerId: input.ownerUserId,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1742,21 +1742,51 @@ SELECT
 	FLOOR(EXTRACT(EPOCH FROM current_timestamp) * 1000)::bigint AS "currentTimeMillis";
 
 ------------------------------------
-----audioCaption
+----audioCaption or typedCaption
+
+CREATE TABLE "caption_locale" (
+    "meetingId" varchar(100) NOT NULL REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
+    "locale" varchar(15) NOT NULL,
+    "captionType" varchar(100) NOT NULL, --Audio Transcription or Typed Caption
+    "ownerUserId" varchar(50),
+    "createdAt" timestamp with time zone default current_timestamp,
+    "updatedAt" timestamp with time zone,
+    CONSTRAINT "caption_locale_pk" primary key ("meetingId","locale","captionType"),
+    FOREIGN KEY ("meetingId", "ownerUserId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
+);
 
 CREATE TABLE "caption" (
     "captionId" varchar(100) NOT NULL PRIMARY KEY,
     "meetingId" varchar(100) NOT NULL REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
     "captionType" varchar(100) NOT NULL, --Audio Transcription or Typed Caption
     "userId" varchar(50),
-    "lang" varchar(15),
+    "locale" varchar(15),
     "captionText" text,
     "createdAt" timestamp with time zone,
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 
-create index idx_caption on caption("meetingId","lang","createdAt");
-create index idx_caption_captionType on caption("meetingId","lang","captionType","createdAt");
+CREATE OR REPLACE FUNCTION "update_caption_locale_owner_func"() RETURNS TRIGGER AS $$
+BEGIN
+    WITH upsert AS (
+        UPDATE "caption_locale" SET
+        "ownerUserId" = NEW.userId,
+        "updatedAt" = current_timestamp
+        WHERE "meetingId"=NEW."meetingId" AND "locale"=NEW."locale" AND "captionType"= NEW."captionType"
+    RETURNING *)
+    INSERT INTO "user_connectionStatusMetrics"("meetingId","locale","captionType","ownerUserId")
+    SELECT NEW."meetingId", NEW."locale", NEW."captionType", NEW."userId"
+    WHERE NOT EXISTS (SELECT * FROM upsert);
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "insert_caption_trigger" BEFORE INSERT ON "caption" FOR EACH ROW
+EXECUTE FUNCTION "update_caption_locale_owner_func"();
+
+create index idx_caption on caption("meetingId","locale","createdAt");
+create index idx_caption_captionType on caption("meetingId","locale","captionType","createdAt");
 
 CREATE OR REPLACE VIEW "v_caption" AS
 SELECT *
@@ -1764,11 +1794,11 @@ FROM "caption"
 WHERE "createdAt" > current_timestamp - INTERVAL '5 seconds';
 
 CREATE OR REPLACE VIEW "v_caption_typed_activeLocales" AS
-select distinct "meetingId", "lang", "userId"
-from "caption"
+select distinct "meetingId", "locale", "ownerUserId"
+from "caption_locale"
 where "captionType" = 'TYPED';
 
-create index "idx_caption_typed_activeLocales" on caption("meetingId","lang","userId") where "captionType" = 'TYPED';
+create index "idx_caption_typed_activeLocales" on caption("meetingId","locale","userId") where "captionType" = 'TYPED';
 
 ------------------------------------
 ----
@@ -1800,7 +1830,7 @@ CREATE TABLE "notification" (
 	"messageDescription"    varchar(100),
 	"messageValues"         jsonb,
 	"role"                  varchar(100), --MODERATOR, PRESENTER, VIEWER
-	"userMeetingId"         varchar(50),
+	"userMeetingId"         varchar(100),
 	"userId"                varchar(50),
 	"createdAt"             timestamp with time zone DEFAULT current_timestamp,
 	FOREIGN KEY ("userMeetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -559,3 +559,11 @@ input GuestUserApprovalStatus {
   status: String!
 }
 
+type Mutation {
+  captionSetOwner(
+    locale: String!
+    ownerUserId: String!
+  ): Boolean
+}
+
+

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -493,6 +493,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: captionSetOwner
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
 custom_types:
   enums: []
   input_objects:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption.yaml
@@ -26,7 +26,7 @@ select_permissions:
         - captionId
         - userId
         - captionType
-        - lang
+        - locale
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_typed_activeLocales.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_typed_activeLocales.yaml
@@ -12,7 +12,7 @@ object_relationships:
       manual_configuration:
         column_mapping:
           meetingId: meetingId
-          userId: userId
+          ownerUserId: userId
         insertion_order: null
         remote_table:
           name: v_user_ref
@@ -21,7 +21,7 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
-        - lang
+        - locale
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId


### PR DESCRIPTION
Add graphql action to set caption owner!

```gql
mutation {
  captionSetOwner(locale: "en", ownerUserId: "w_xxlfoz5hifpv")
}
```

Once it is called, the Type `caption_typed_activeLocales` will return the caption locale and its owner.