### PR TITLE
fix: missing whiteboardId error

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -142,6 +142,8 @@ const WhiteboardContainer = (props) => {
   const publishCursorUpdate = (payload) => {
     const { whiteboardId, xPercent, yPercent } = payload;
 
+    if (!whiteboardId || !xPercent || !yPercent) return;
+
     presentationPublishCursor({
       variables: {
         whiteboardId,


### PR DESCRIPTION
### What does this PR do?

Fix the error encountered when attempting to send updates for the whiteboard cursor when whiteboardId is unavailable.

![Screenshot from 2024-04-22 15-09-54](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/f36157cc-3502-44f4-83de-e5a1f1c2105e)
