### PR TITLE
test: fix breakout tests failing on CI

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -104,6 +104,7 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
           value={selectValue}
           onChange={handleSelectChange}
           disabled={waiting}
+          data-test="selectBreakoutRoomBtn"
         >
           {
             breakouts.sort((a, b) => a.sequence - b.sequence).map(({ shortName, breakoutRoomId }) => (

--- a/bigbluebutton-tests/playwright/breakout/create.js
+++ b/bigbluebutton-tests/playwright/breakout/create.js
@@ -34,7 +34,6 @@ class Create extends MultiUsers {
     await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
 
     await this.userPage.hasElement(e.modalConfirmButton);
-    await this.userPage.waitAndClick(e.modalDismissButton);
     await this.modPage.hasElement(e.breakoutRoomsItem);
   }
 

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -61,6 +61,7 @@ class Join extends Create {
     await breakoutUserPage.hasElement(e.presentationTitle);
 
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.hasElement(e.breakoutRemainingTime);
     await this.modPage.type(e.chatBox, "test");
     await this.modPage.waitAndClick(e.sendButton);
 

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -235,6 +235,8 @@ class Join extends Create {
   async userCanChooseRoom() {
     await this.userPage.bringToFront();
 
+    await this.userPage.hasElementEnabled(e.selectBreakoutRoomBtn);
+    await this.userPage.hasElementEnabled(e.modalConfirmButton);
     await this.userPage.checkElementCount(e.roomOption, 2);
 
     await this.userPage.getLocator(`${e.fullscreenModal} >> select`).selectOption({index: 1});

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -94,6 +94,7 @@ exports.warningNoUserAssigned = 'span[data-test="warningNoUserAssigned"]';
 exports.timeRemaining = 'span[data-test="timeRemaining"]';
 exports.captureBreakoutSharedNotes = 'input[id="captureNotesBreakoutCheckbox"]';
 exports.captureBreakoutWhiteboard = 'input[id="captureSlidesBreakoutCheckbox"]';
+exports.selectBreakoutRoomBtn = 'select[data-test="selectBreakoutRoomBtn"]';
 exports.roomOption = 'option[data-test="roomOption"]';
 
 // Chat


### PR DESCRIPTION
### What does this PR do?
- Fixes `Breakout › After creating › Message to all rooms` => failing due to the tooltip displayed in front of the button when performing click action;
- Fixes `Breakout › After creating › User can choose a room` => testing code with wrong steps, outcoming false positive