### PR TITLE
Refactor: migrate screenshare to graphql using a adapter

### DIFF
--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -13,6 +13,7 @@ import StartupDataFetch from '/imports/ui/components/connection-manager/startup-
 import UserGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/userGrapQlMiniMongoAdapter/component';
 import VoiceUserGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/voiceUserGraphQlMiniMongoAdapter/component';
 import MeetingGrapQlMiniMongoAdapter from '/imports/ui/components/components-data/meetingGrapQlMiniMongoAdapter/component';
+import ScreenShareGraphQlMiniMongoAdapterContainer from '/imports/ui/components/components-data/screenshareGraphQlMiniMongoAdapter/component';
 
 const Main: React.FC = () => {
   // Meteor.disconnect();
@@ -29,6 +30,7 @@ const Main: React.FC = () => {
                   <UserGrapQlMiniMongoAdapter />
                   <VoiceUserGrapQlMiniMongoAdapter />
                   <MeetingGrapQlMiniMongoAdapter />
+                  <ScreenShareGraphQlMiniMongoAdapterContainer />
                 </PresenceManager>
               </ConnectionManager>
             </LocatedErrorBoundary>

--- a/bigbluebutton-html5/imports/ui/components/components-data/screenshareGraphQlMiniMongoAdapter/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/screenshareGraphQlMiniMongoAdapter/component.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import Screenshare from '/imports/api/screenshare';
+import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
+import { ScreenshareType, getScreenShareData } from './queries';
+
+interface ScreenShareGraphQlMiniMongoAdapterProps {
+  meetingId: string;
+}
+
+const ScreenShareGraphQlMiniMongoAdapter: React.FC<ScreenShareGraphQlMiniMongoAdapterProps> = ({
+  meetingId,
+}) => {
+  const screenshareSubscription = useCreateUseSubscription<ScreenshareType>(getScreenShareData, {}, true);
+  const {
+    data: screenshareData,
+  } = screenshareSubscription();
+
+  useEffect(() => {
+    if (screenshareData) {
+      const screenshare = JSON.parse(JSON.stringify(screenshareData[0] || '{}'));
+      const { screenshareId } = screenshare;
+      Screenshare.upsert({ screenshareId }, {
+        meetingId,
+        screenshare: {
+          ...screenshare,
+        },
+        screenshareId,
+      });
+    }
+    return () => {
+      Screenshare.remove({ meetingId });
+    };
+  }, [screenshareData]);
+  return null;
+};
+
+const ScreenShareGraphQlMiniMongoAdapterContainer: React.FC = () => {
+  const {
+    data: currentMeeting,
+  } = useMeeting((m) => ({
+    componentsFlags: m.componentsFlags,
+    meetingId: m.meetingId,
+  }));
+  const hasCurrentscreenshare = currentMeeting?.componentsFlags?.hasScreenshare ?? false;
+  return hasCurrentscreenshare ? (
+    <ScreenShareGraphQlMiniMongoAdapter
+      meetingId={currentMeeting?.meetingId ?? ''}
+    />
+  ) : null;
+};
+
+export default ScreenShareGraphQlMiniMongoAdapterContainer;

--- a/bigbluebutton-html5/imports/ui/components/components-data/screenshareGraphQlMiniMongoAdapter/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/components-data/screenshareGraphQlMiniMongoAdapter/queries.ts
@@ -1,0 +1,41 @@
+import { gql } from '@apollo/client';
+
+export interface GetPresentationUploadTokenSubscriptionResponse {
+  data: {
+    screenshare: ScreenshareType[];
+  };
+}
+
+export interface ScreenshareType {
+  contentType: string;
+  hasAudio: boolean;
+  screenshareConf: string;
+  screenshareId: string;
+  startedAt: string;
+  stoppedAt: string | null;
+  stream: string;
+  vidHeight: number;
+  vidWidth: number;
+  voiceConf: string;
+}
+
+export const getScreenShareData = gql`
+  subscription getPresentationUploadToken {
+    screenshare {
+      contentType
+      hasAudio
+      screenshareConf
+      screenshareId
+      startedAt
+      stoppedAt
+      stream
+      vidHeight
+      vidWidth
+      voiceConf
+    }
+  }
+`;
+
+export default {
+  getScreenShareData,
+};

--- a/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/subscriptions/component.jsx
@@ -16,7 +16,7 @@ const SUBSCRIPTIONS = [
   // 'meetings',
   // 'captions',
   // 'voiceUsers',
-  'screenshare',
+  // 'screenshare',
   'users-settings',
   'users-infos',
   'meeting-time-remaining',


### PR DESCRIPTION
### What does this PR do?

Remove screenshare subscription to meteor and make it implementing a graphql adapter
