### PR TITLE
fix: save region specific language does not work

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -280,7 +280,7 @@ class Settings extends Component {
 
             if (saved.application.locale !== current.application.locale) {
               const { language } = formatLocaleCode(saved.application.locale);
-              const { language: newLanguage } = formatLocaleCode(current.application.locale);
+              const newLanguage = current.application.locale;
               setUseCurrentLocale(newLanguage);
               document.body.classList.remove(`lang-${language}`);
             }


### PR DESCRIPTION
### What does this PR do?

Fix: switching to a region specific locale does not work. If the user changes locale to `pr-BR`, `pt` messages will be displayed instead.

#### before

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/4ee7b26a-8e51-40ce-8c33-c13b67e700ff

#### after

https://github.com/bigbluebutton/bigbluebutton/assets/3728706/eff7c1ad-7fd0-4602-b923-cede5d95ab0f
