### PR TITLE
feature: Add new API /create param `loginURL`

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -7,6 +7,14 @@ import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success }
 
+case class MeetingSystemColumnsDbModel(
+      loginUrl:                              Option[String],
+      logoutUrl:                             String,
+      customLogoUrl:                         Option[String],
+      bannerText:                            Option[String],
+      bannerColor:                           Option[String],
+)
+
 case class MeetingDbModel(
     meetingId:                             String,
     extId:                                 String,
@@ -19,10 +27,7 @@ case class MeetingDbModel(
     presentationUploadExternalDescription: String,
     presentationUploadExternalUrl:         String,
     learningDashboardAccessToken:          String,
-    logoutUrl:                             String,
-    customLogoUrl:                         Option[String],
-    bannerText:                            Option[String],
-    bannerColor:                           Option[String],
+    systemColumns:                         MeetingSystemColumnsDbModel,
     createdTime:                           Long,
     durationInSeconds:                     Int,
     endWhenNoModerator:                    Boolean,
@@ -45,10 +50,7 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
     presentationUploadExternalDescription,
     presentationUploadExternalUrl,
     learningDashboardAccessToken,
-    logoutUrl,
-    customLogoUrl,
-    bannerText,
-    bannerColor,
+    systemColumns,
     createdTime,
     durationInSeconds,
     endWhenNoModerator,
@@ -68,10 +70,12 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
   val presentationUploadExternalDescription = column[String]("presentationUploadExternalDescription")
   val presentationUploadExternalUrl = column[String]("presentationUploadExternalUrl")
   val learningDashboardAccessToken = column[String]("learningDashboardAccessToken")
+  val loginUrl = column[Option[String]]("loginUrl")
   val logoutUrl = column[String]("logoutUrl")
   val customLogoUrl = column[Option[String]]("customLogoUrl")
   val bannerText = column[Option[String]]("bannerText")
   val bannerColor = column[Option[String]]("bannerColor")
+  val systemColumns = (loginUrl, logoutUrl, customLogoUrl, bannerText, bannerColor) <> (MeetingSystemColumnsDbModel.tupled, MeetingSystemColumnsDbModel.unapply)
   val createdTime = column[Long]("createdTime")
   val durationInSeconds = column[Int]("durationInSeconds")
   val endWhenNoModerator = column[Boolean]("endWhenNoModerator")
@@ -97,19 +101,25 @@ object MeetingDAO {
           presentationUploadExternalDescription = meetingProps.meetingProp.presentationUploadExternalDescription,
           presentationUploadExternalUrl = meetingProps.meetingProp.presentationUploadExternalUrl,
           learningDashboardAccessToken = meetingProps.password.learningDashboardAccessToken,
-          logoutUrl = meetingProps.systemProps.logoutUrl,
-          customLogoUrl = meetingProps.systemProps.customLogoURL match {
-            case "" => None
-            case logoUrl => Some(logoUrl)
-          },
-          bannerText = meetingProps.systemProps.bannerText match {
-            case "" => None
-            case bannerText => Some(bannerText)
-          },
-          bannerColor = meetingProps.systemProps.bannerColor match {
-            case "" => None
-            case bannerColor => Some(bannerColor)
-          },
+          systemColumns = MeetingSystemColumnsDbModel(
+            loginUrl = meetingProps.systemProps.loginUrl match {
+              case "" => None
+              case loginUrl => Some(loginUrl)
+            },
+            logoutUrl = meetingProps.systemProps.logoutUrl,
+            customLogoUrl = meetingProps.systemProps.customLogoURL match {
+              case "" => None
+              case logoUrl => Some(logoUrl)
+            },
+            bannerText = meetingProps.systemProps.bannerText match {
+              case "" => None
+              case bannerText => Some(bannerText)
+            },
+            bannerColor = meetingProps.systemProps.bannerColor match {
+              case "" => None
+              case bannerColor => Some(bannerColor)
+            },
+          ),
           createdTime = meetingProps.durationProps.createdTime,
           durationInSeconds = meetingProps.durationProps.duration * 60,
           endWhenNoModerator = meetingProps.durationProps.endWhenNoModerator,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -9,7 +9,7 @@ import scala.util.{ Failure, Success }
 
 case class MeetingSystemColumnsDbModel(
       loginUrl:                              Option[String],
-      logoutUrl:                             String,
+      logoutUrl:                             Option[String],
       customLogoUrl:                         Option[String],
       bannerText:                            Option[String],
       bannerColor:                           Option[String],
@@ -71,7 +71,7 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
   val presentationUploadExternalUrl = column[String]("presentationUploadExternalUrl")
   val learningDashboardAccessToken = column[String]("learningDashboardAccessToken")
   val loginUrl = column[Option[String]]("loginUrl")
-  val logoutUrl = column[String]("logoutUrl")
+  val logoutUrl = column[Option[String]]("logoutUrl")
   val customLogoUrl = column[Option[String]]("customLogoUrl")
   val bannerText = column[Option[String]]("bannerText")
   val bannerColor = column[Option[String]]("bannerColor")
@@ -106,7 +106,10 @@ object MeetingDAO {
               case "" => None
               case loginUrl => Some(loginUrl)
             },
-            logoutUrl = meetingProps.systemProps.logoutUrl,
+            logoutUrl = meetingProps.systemProps.logoutUrl match {
+              case "" => None
+              case logoutUrl => Some(logoutUrl)
+            },
             customLogoUrl = meetingProps.systemProps.customLogoURL match {
               case "" => None
               case logoUrl => Some(logoUrl)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -69,6 +69,7 @@ case class LockSettingsProps(
 
 case class SystemProps(
     html5InstanceId: Int,
+    loginUrl: String,
     logoutUrl: String,
     customLogoURL: String,
     bannerText: String,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -37,6 +37,7 @@ public class ApiParams {
     public static final String IS_BREAKOUT = "isBreakout";
     public static final String LOGO = "logo";
     public static final String LOGOUT_TIMER = "logoutTimer";
+    public static final String LOGIN_URL = "loginURL";
     public static final String LOGOUT_URL = "logoutURL";
     public static final String MAX_PARTICIPANTS = "maxParticipants";
     public static final String MEETING_ID = "meetingID";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -452,7 +452,7 @@ public class MeetingService implements MessageListener {
             m.getUserInactivityInspectTimerInMinutes(), m.getUserInactivityThresholdInMinutes(),
             m.getUserActivitySignResponseDelayInMinutes(), m.getEndWhenNoModerator(), m.getEndWhenNoModeratorDelayInMinutes(),
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
-            m.breakoutRoomsParams, m.lockSettingsParams, m.getHtml5InstanceId(), m.getLogoutUrl(), m.getCustomLogoURL(),
+            m.breakoutRoomsParams, m.lockSettingsParams, m.getHtml5InstanceId(), m.getLoginUrl(), m.getLogoutUrl(), m.getCustomLogoURL(),
             m.getBannerText(), m.getBannerColor(), m.getGroups(), m.getDisabledFeatures(), m.getNotifyRecordingIsOn(),
             m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(),
             m.getOverrideClientSettings());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -454,6 +454,7 @@ public class ParamsProcessorUtil {
         // Get all the other relevant parameters and generate defaults if none
         // has been provided.
         String dialNumber = processDialNumber(params.get(ApiParams.DIAL_NUMBER));
+        String loginUrl = params.get(ApiParams.LOGIN_URL);
         String logoutUrl = processLogoutUrl(params.get(ApiParams.LOGOUT_URL));
         boolean record = processRecordMeeting(params.get(ApiParams.RECORD));
         int maxUsers = processMaxUser(params.get(ApiParams.MAX_PARTICIPANTS));
@@ -742,7 +743,9 @@ public class ParamsProcessorUtil {
                 internalMeetingId, createTime).withName(meetingName)
                 .withMaxUsers(maxUsers).withModeratorPass(modPass)
                 .withViewerPass(viewerPass).withRecording(record)
-                .withDuration(meetingDuration).withLogoutUrl(logoutUrl)
+                .withDuration(meetingDuration)
+                .withLoginUrl(loginUrl)
+                .withLogoutUrl(logoutUrl)
                 .withLogoutTimer(logoutTimer)
                 .withBannerText(bannerText).withBannerColor(bannerColor)
                 .withTelVoice(telVoice).withWebVoice(webVoice)

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -144,7 +144,7 @@ public class Meeting {
         maxUsers = builder.maxUsers;
         bannerColor = builder.bannerColor;
         bannerText = builder.bannerText;
-		loginUrl = builder.loginUrl;
+        loginUrl = builder.loginUrl;
         logoutUrl = builder.logoutUrl;
         logoutTimer = builder.logoutTimer;
         defaultAvatarURL = builder.defaultAvatarURL;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -1064,15 +1064,15 @@ public class Meeting {
     	  return this;
     	}
 
-		public Builder withLoginUrl(String l) {
-			loginUrl = l;
-			return this;
-		}
+    	public Builder withLoginUrl(String l) {
+    	  loginUrl = l;
+    	  return this;
+    	}
 
-		public Builder withLogoutUrl(String l) {
-			logoutUrl = l;
-			return this;
-		}
+    	public Builder withLogoutUrl(String l) {
+    	  logoutUrl = l;
+    	  return this;
+    	}
 
     	public Builder withLogoutTimer(int l) {
     		logoutTimer = l;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -60,6 +60,7 @@ public class Meeting {
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
 	private String modOnlyMessage = "";
+	private String loginUrl;
 	private String logoutUrl;
 	private int logoutTimer = 0;
 	private int maxUsers;
@@ -143,6 +144,7 @@ public class Meeting {
         maxUsers = builder.maxUsers;
         bannerColor = builder.bannerColor;
         bannerText = builder.bannerText;
+		loginUrl = builder.loginUrl;
         logoutUrl = builder.logoutUrl;
         logoutTimer = builder.logoutTimer;
         defaultAvatarURL = builder.defaultAvatarURL;
@@ -560,6 +562,10 @@ public class Meeting {
 	}
 
 
+	public String getLoginUrl() {
+		return loginUrl;
+	}
+
 	public String getLogoutUrl() {
 		return logoutUrl;
 	}
@@ -899,6 +905,7 @@ public class Meeting {
     	private String telVoice;
     	private String welcomeMsgTemplate;
     	private String welcomeMsg;
+    	private String loginUrl;
     	private String logoutUrl;
     	private String bannerColor;
     	private String bannerText;
@@ -1057,10 +1064,15 @@ public class Meeting {
     	  return this;
     	}
 
-    	public Builder withLogoutUrl(String l) {
-    		logoutUrl = l;
+    	public Builder withLoginUrl(String l) {
+    		loginUrl = l;
     		return this;
     	}
+
+		public Builder withLogoutUrl(String l) {
+			logoutUrl = l;
+			return this;
+		}
 
     	public Builder withLogoutTimer(int l) {
     		logoutTimer = l;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -1064,10 +1064,10 @@ public class Meeting {
     	  return this;
     	}
 
-    	public Builder withLoginUrl(String l) {
-    		loginUrl = l;
-    		return this;
-    	}
+		public Builder withLoginUrl(String l) {
+			loginUrl = l;
+			return this;
+		}
 
 		public Builder withLogoutUrl(String l) {
 			logoutUrl = l;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -42,6 +42,7 @@ public interface IBbbWebApiGWApp {
                      BreakoutRoomsParams breakoutParams,
                      LockSettingsParams lockSettingsParams,
                      Integer html5InstanceId,
+                     String loginUrl,
                      String logoutUrl,
                      String customLogoURL,
                      String bannerText,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -149,6 +149,7 @@ class BbbWebApiGWApp(
                     breakoutParams:                         BreakoutRoomsParams,
                     lockSettingsParams:                     LockSettingsParams,
                     html5InstanceId:                        java.lang.Integer,
+                    loginUrl:                               String,
                     logoutUrl:                              String,
                     customLogoURL:                          String,
                     bannerText:                             String,
@@ -235,6 +236,10 @@ class BbbWebApiGWApp(
 
     val systemProps = SystemProps(
       html5InstanceId,
+      loginUrl match {
+        case url: String => url
+        case _ => ""
+      },
       logoutUrl,
       customLogoURL,
       bannerText match {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -20,6 +20,7 @@ create table "meeting" (
 	"presentationUploadExternalUrl" varchar(500),
 	"learningDashboardAccessToken" varchar(100),
 	"html5InstanceId" varchar(100),
+	"loginUrl" varchar(500),
 	"logoutUrl" varchar(500),
 	"customLogoUrl" varchar(500),
 	"bannerText" text,

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -173,6 +173,7 @@ select_permissions:
         - extId
         - html5InstanceId
         - isBreakout
+        - loginUrl
         - logoutUrl
         - maxPinnedCameras
         - meetingCameraCap

--- a/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
+++ b/bigbluebutton-html5/imports/api/meetings/server/modifiers/addMeeting.js
@@ -129,6 +129,7 @@ export default async function addMeeting(meeting) {
     },
     systemProps: {
       html5InstanceId: Number,
+      loginUrl: String,
       logoutUrl: String,
       customLogoURL: String,
       bannerText: String,

--- a/bigbluebutton-html5/imports/ui/Types/meeting.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meeting.ts
@@ -129,6 +129,7 @@ export interface Meeting {
   componentsFlags: ComponentsFlags;
   endWhenNoModerator: boolean;
   endWhenNoModeratorDelayInMinutes: number;
+  loginUrl: string | null;
   metadata: Array<Metadata>;
   groups: Array<groups>;
 }

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
@@ -9,6 +9,7 @@ const MEETING_SUBSCRIPTION = gql`
         extId
         endWhenNoModerator
         endWhenNoModeratorDelayInMinutes
+        loginUrl
         lockSettings {
           disableCam
           disableMic

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -50,6 +50,12 @@ const createEndpointTableData = [
     "description": (<>Set the maximum number of users allowed to joined the conference at the same time.</>)
   },
   {
+    "name": "loginURL",
+    "required": false,
+    "type": "String",
+    "description": (<>Enables third-party applications to provide a URL that users can access during a meeting to join the session directly.</>)
+  },
+  {
     "name": "logoutURL",
     "required": false,
     "type": "String",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -109,8 +109,8 @@ Updated in 2.7:
 
 Updated in 3.0:
 
+- **create** - **Added:** `loginURL`.
 - **join** - **Added:** `userdata-bbb_default_layout`. **Removed:** `defaultLayout` (replaced by `userdata-bbb_default_layout`).
-
 
 ## API Data Types
 


### PR DESCRIPTION
This pull request adds a new parameter `loginURL` to the `/create` API endpoint. The purpose of this parameter is to allow third-party applications to specify a URL for users to access and join a live meeting.

This feature is particularly useful in hybrid settings. For example, a teacher can display a QR code within BigBlueButton (BBB), which students can scan to be taken directly to a site like Greenlight. There, they can enter their name and join the meeting to participate in activities like an online poll.

API /create param:
`loginURL=https://myserver.bbb//rooms/4h9-3s2-ffs-mam`

Graphql query:
```gql
subscription {
  meeting {
    loginUrl
  }
}
```