### PR TITLE
fix: user can't join default selected breakout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -53,12 +53,14 @@ interface BreakoutJoinConfirmationProps {
   freeJoin: boolean;
   breakouts: BreakoutRoom[];
   currentUserJoined: boolean,
+  firstBreakoutId: string;
 }
 
 const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   freeJoin,
   breakouts,
   currentUserJoined,
+  firstBreakoutId,
 }) => {
   const [breakoutRoomRequestJoinURL] = useMutation(BREAKOUT_ROOM_REQUEST_JOIN_URL);
   const [callHandleinviteDismissedAt] = useMutation(handleinviteDismissedAt);
@@ -67,12 +69,23 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   const [waiting, setWaiting] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const defaultSelectedBreakoutId = breakouts.find(({ showInvitation }) => showInvitation)?.breakoutRoomId;
+  const defaultSelectedBreakoutId = breakouts.find(({ showInvitation }) => showInvitation)?.breakoutRoomId || firstBreakoutId;
+
   const [selectValue, setSelectValue] = React.useState(defaultSelectedBreakoutId);
 
   const requestJoinURL = (breakoutRoomId: string) => {
     breakoutRoomRequestJoinURL({ variables: { breakoutRoomId } });
   };
+
+  // request join url if free join is enabled and user is not assigned to any room
+  if (defaultSelectedBreakoutId === firstBreakoutId) {
+    const selectedBreakout = breakouts.find(({ breakoutRoomId }) => breakoutRoomId === defaultSelectedBreakoutId);
+    if (!selectedBreakout?.joinURL && !waiting) {
+      requestJoinURL(defaultSelectedBreakoutId);
+      setWaiting(true);
+    }
+  }
+
   const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectValue(event.target.value);
     const selectedBreakout = breakouts.find(({ breakoutRoomId }) => breakoutRoomId === event.target.value);
@@ -189,6 +202,7 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
   const {
     freeJoin,
     sendInvitationToModerators,
+    breakoutRoomId,
   } = firstBreakout;
   if (!sendInvitationToModerators && currentUser?.isModerator) return null;
   return (
@@ -196,6 +210,7 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
       freeJoin={freeJoin}
       breakouts={breakoutData.breakoutRoom}
       currentUserJoined={currentUser?.breakoutRooms?.currentRoomJoined ?? false}
+      firstBreakoutId={breakoutRoomId}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -66,7 +66,9 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   const intl = useIntl();
   const [waiting, setWaiting] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
-  const [selectValue, setSelectValue] = React.useState('');
+
+  const defaultSelectedBreakoutId = breakouts.find(({ showInvitation }) => showInvitation)?.breakoutRoomId;
+  const [selectValue, setSelectValue] = React.useState(defaultSelectedBreakoutId);
 
   const requestJoinURL = (breakoutRoomId: string) => {
     breakoutRoomRequestJoinURL({ variables: { breakoutRoomId } });

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -69,7 +69,8 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   const [waiting, setWaiting] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const defaultSelectedBreakoutId = breakouts.find(({ showInvitation }) => showInvitation)?.breakoutRoomId || firstBreakoutId;
+  const defaultSelectedBreakoutId = breakouts.find(({ showInvitation }) => showInvitation)?.breakoutRoomId
+    || firstBreakoutId;
 
   const [selectValue, setSelectValue] = React.useState(defaultSelectedBreakoutId);
 


### PR DESCRIPTION
### What does this PR do?

Fix issue with user not being able to join the default selected breakout form the invitation modal when "Allow users to choose rooms" option is checked.

