### PR TITLE
Refactor: useUserCurrentData to use subscription

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
@@ -1,12 +1,15 @@
-import { useContext } from 'react';
+
 import { User } from '../../Types/user';
-import { CurrentUserContext } from '../providers/current-user';
+import { useCreateUseSubscription } from './createUseSubscription';
+import CURRENT_USER_SUBSCRIPTION from '../graphql/queries/currentUserSubscription';
 
 const useCurrentUser = (fn: (c: Partial<User>) => Partial<User> = (u) => u) => {
-  const response = useContext(CurrentUserContext);
+  const currenUserSubscription = useCreateUseSubscription<User>(CURRENT_USER_SUBSCRIPTION, {}, true);
+  const response = currenUserSubscription(fn);
   const returnObject = {
     ...response,
-    data: response.data ? response.data.map(fn)[0] : null,
+    data: response.data ? response.data[0] : null,
+    rawData: response.data ?? null,
   };
   return returnObject;
 };

--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
@@ -1,4 +1,3 @@
-
 import { User } from '../../Types/user';
 import { useCreateUseSubscription } from './createUseSubscription';
 import CURRENT_USER_SUBSCRIPTION from '../graphql/queries/currentUserSubscription';

--- a/bigbluebutton-html5/imports/ui/core/providers/current-user.tsx
+++ b/bigbluebutton-html5/imports/ui/core/providers/current-user.tsx
@@ -1,10 +1,9 @@
 import React, { createContext } from 'react';
-import CURRENT_USER_SUBSCRIPTION from '../graphql/queries/currentUserSubscription';
-import { useSubscription } from '../hooks/createUseSubscription';
 import { User } from '../../Types/user';
 import { GraphqlDataHookSubscriptionResponse } from '../../Types/hook';
+import useCurrentUser from '../hooks/useCurrentUser';
 
-type CurrentUserContext = GraphqlDataHookSubscriptionResponse<Partial<User>[]>
+type CurrentUserContext = GraphqlDataHookSubscriptionResponse<Partial<User>[]>;
 
 export const CurrentUserContext = createContext<CurrentUserContext>({ loading: true });
 
@@ -13,9 +12,14 @@ interface CurrentUserProviderProps {
 }
 
 const CurrentUserProvider: React.FC<CurrentUserProviderProps> = (({ children }) => {
-  const response = useSubscription<User>(CURRENT_USER_SUBSCRIPTION, {}, true);
+  const response = useCurrentUser();
   return (
-    <CurrentUserContext.Provider value={response}>
+    <CurrentUserContext.Provider value={{
+      loading: response.loading,
+      data: response.rawData,
+      errors: response.errors,
+    }}
+    >
       {children}
     </CurrentUserContext.Provider>
   );


### PR DESCRIPTION

### What does this PR do?

This PR reimplements useCurrentUser to use a useSubscription, we must use the premise of never making a data hook depend on a provider, but rather the opposite.
