### PR TITLE
fix(audio): broken connection stats on Firefox >= 125

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1085,10 +1085,9 @@ class AudioManager {
       receivers[0] &&
       receivers[0].transport &&
       receivers[0].transport.iceTransport &&
-      receivers[0].transport.iceTransport
+      typeof receivers[0].transport.iceTransport.getSelectedCandidatePair === 'function'
     ) {
-      selectedPair =
-        receivers[0].transport.iceTransport.getSelectedCandidatePair();
+      selectedPair = receivers[0].transport.iceTransport.getSelectedCandidatePair();
     }
 
     return selectedPair;


### PR DESCRIPTION
### What does this PR do?

WebRTC-based stats generation in the connection status modal is broken on Firefox >= 125. A broken type check coupled with a new partially implemented RTCIceTransport dictionary causes an undefined function call when fetching the selected candidate pair. Since that error is unhandled, collection breaks.

Correctly check for the getSelectedCandidatePair method availability in RTCIceTransport so that it skips to pair inference from getStats if necessary.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/20117

