### PR TITLE
fix(audio): review device selection in mobile endpoints

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-controls/component.jsx
@@ -109,18 +109,14 @@ class AudioControls extends PureComponent {
       inAudio,
     } = this.props;
 
-    const { isMobile } = deviceInfo;
-
     let { enableDynamicAudioDeviceSelection } = Meteor.settings.public.app;
 
     if (typeof enableDynamicAudioDeviceSelection === 'undefined') {
       enableDynamicAudioDeviceSelection = true;
     }
 
-    const _enableDynamicDeviceSelection = enableDynamicAudioDeviceSelection && !isMobile;
-
     if (inAudio) {
-      return this.renderButtonsAndStreamSelector(_enableDynamicDeviceSelection);
+      return this.renderButtonsAndStreamSelector(enableDynamicAudioDeviceSelection);
     }
 
     return this.renderJoinButton();


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): review device selection in mobile endpoints](https://github.com/bigbluebutton/bigbluebutton/commit/141c553b170f51e3cc758d1e59232ed063ec410d) 
  - Mobile users have no way to change I/O devices after joining audio.
The removal of the audio options chevron in mobile browsers was supposed
to be replaced by something else - in this case, by the dedicated
leave/join audio button. That didn't happen, leave/join audio button
retained the old behavior.
  - Review device selection in mobile endpoints via two UI/UX changes:
    - Restore the device selection chevron/icon in mobile endpoints
    - Override the leave/join button action in mobile endpoints so that it
    opens the device selection contextual menu, which also includes the
    "Leave audio" option. This retains the old behavior (leaving audio)
    while also providing a way for users to change devices mid-call in
    mobile browsers.

### Closes Issue(s)

None