### PR TITLE
fix: crash at meeting-ended due to undefined access + incorrect meetingID

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.jsx
@@ -142,7 +142,8 @@ class MeetingEnded extends PureComponent {
       this.localUserRole = user.role;
     }
 
-    const meeting = Meetings.findOne({ id: user?.meetingID });
+    const meetingID = user?.meetingId || Auth.meetingID;
+    const meeting = Meetings.findOne({ id: meetingID });
     if (meeting) {
       this.endWhenNoModeratorMinutes = meeting.durationProps.endWhenNoModeratorDelayInMinutes;
 


### PR DESCRIPTION
### What does this PR do?

- [fix: crash at meeting-ended due to undefined access + incorrect meetingID](https://github.com/bigbluebutton/bigbluebutton/commit/5f59453548bb5aca23d016b14ab8af3f9b73fdc7) 
  - Fixes an undefined access crash at the meeting-ended component caused by
trying to access a property of a nullish user document.
Fixes incorrect access to the meetingId property of the user document -
currently fetched as meetingID, which doesn't exist.

### Closes Issue(s)

None