### PR TITLE
Fix: External video re-starting when changing presenters

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -240,16 +240,10 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   }, []);
 
   useEffect(() => {
-    if (playerRef.current && !isPresenter) {
-      playerRef.current.seekTo(currentTime, 'seconds');
-    }
-  }, [currentTime]);
-
-  useEffect(() => {
     if (playerRef.current) {
       playerRef.current.seekTo(currentTime, 'seconds');
     }
-  }, [playerRef.current]);
+  }, [playerRef.current, playing]);
 
   // --- Plugin related code ---;
   const internalPlayer = playerRef.current?.getInternalPlayer ? playerRef.current?.getInternalPlayer() : null;
@@ -507,8 +501,6 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const currentTime = isPaused ? playerCurrentTime : (((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
     + playerCurrentTime) * playerPlaybackRate;
   const isPresenter = currentUser.presenter ?? false;
-
-  console.log('currentTime', currentTime);
 
   return (
     <ExternalVideoPlayer

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -508,6 +508,8 @@ const ExternalVideoPlayerContainer: React.FC = () => {
     + playerCurrentTime) * playerPlaybackRate;
   const isPresenter = currentUser.presenter ?? false;
 
+  console.log('currentTime', currentTime);
+
   return (
     <ExternalVideoPlayer
       currentVolume={currentVolume}
@@ -520,7 +522,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
       isResizing={isResizing}
       fullscreenContext={fullscreenContext}
       externalVideo={externalVideo}
-      currentTime={isPresenter ? playerCurrentTime : currentTime}
+      currentTime={currentTime}
       key={key}
       setKey={setKey}
     />


### PR DESCRIPTION
### What does this PR do?

This PR fixes the presenter change re-starting the external video by removing the previous condition in charge of setting the value in which the video would play on component's mounting.

The 'playerCurrentTime' is updated by the DB and the DB does not recieve this value each second, this value is only used to do calculations on the videos actual current time and because of that this value should not be used to decide in which duration the video is at.

The value was set like that because of past experiences of the video skipping on start, I did some testing and it does't seem to occur anymore.

### Testing after the fix:

https://github.com/bigbluebutton/bigbluebutton/assets/36093456/7726e272-f07c-4ec9-8724-76b9df732eb5

### Closes Issue(s)

#20032

