### PR TITLE
chore: Bump requirement for safari versions

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1039,9 +1039,9 @@ private:
     - browser: ie
       version: Infinity
     - browser: safari
-      version: [12, 1]
+      version: [13, 1]
     - browser: mobileSafari
-      version: [12, 1]
+      version: [13, 4]
     - browser: opera
       version: 50
     - browser: electron


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Increases the minimum version requirement for Safari browser on mobile and desktop.
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
@prlanzarin / @Arthurk12  reported that since Safari Mobile < 13.4 and Safari Desktop < 13.1 do not have access to the ResizeObserver API, some odd behaviours are observed in our client.
<!-- What inspired you to submit this pull request? -->

### More

<!-- Anything else we should know when reviewing? -->

