### PR TITLE
fix: snapshot of current slide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -316,8 +316,8 @@ const PresentationMenu = (props) => {
 
             try {
               // filter shapes that are inside the slide
-              const backgroundShape = tldrawAPI.currentPageShapes.find((s) => s.id === `shape:BG-${slideNum}`);
-              const shapes = tldrawAPI.currentPageShapes.filter(
+              const backgroundShape = tldrawAPI.getCurrentPageShapes().find((s) => s.id === `shape:BG-${slideNum}`);
+              const shapes = tldrawAPI.getCurrentPageShapes().filter(
                 (shape) => shape.x <= backgroundShape.props.w
                   && shape.y <= backgroundShape.props.h
                   && shape.x >= 0


### PR DESCRIPTION
### What does this PR do?

Adjusts the way to get current slide shapes in the snapshot feature after tldraw upgrade to v2.0.0-alpha.19