### PR TITLE
fix(whiteboard): Deactivate Drawing Tool On Access Change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -25,6 +25,8 @@ import {
 import { useMouseEvents, useCursor } from "./hooks";
 import { notifyShapeNumberExceeded } from "./service";
 
+import { NoopTool } from './custom-tools/noop-tool/component';
+
 // Helper functions
 const deleteLocalStorageItemsWithPrefix = (prefix) => {
   const keysToRemove = Object.keys(localStorage).filter((key) =>
@@ -166,21 +168,17 @@ const Whiteboard = React.memo(function Whiteboard(props) {
     hasWBAccessRef.current = hasWBAccess;
 
     if (!hasWBAccess && !isPresenter) {
-      tlEditorRef?.current?.setCurrentTool("select");
+      tlEditorRef?.current?.setCurrentTool("noop");
     }
   }, [hasWBAccess]);
 
   React.useEffect(() => {
-    if (!isEqual(isPresenterRef.current, isPresenter)) {
       isPresenterRef.current = isPresenter;
-    }
-  }, [isPresenter]);
 
-  React.useEffect(() => {
-    if (!isEqual(hasWBAccessRef.current, hasWBAccess)) {
-      hasWBAccessRef.current = hasWBAccess;
-    }
-  }, [hasWBAccess]);
+      if (!hasWBAccessRef.current && !isPresenter) {
+        tlEditorRef?.current?.setCurrentTool("noop");
+      }
+  }, [isPresenter]);
 
   React.useEffect(() => {
     if (!isEqual(prevShapesRef.current, shapes)) {
@@ -1147,6 +1145,8 @@ const Whiteboard = React.memo(function Whiteboard(props) {
     presentationAreaHeight,
   ]);
 
+  const customTools = [NoopTool];
+
   return (
     <div
       ref={whiteboardRef}
@@ -1158,6 +1158,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         forceMobile={true}
         hideUi={hasWBAccessRef.current || isPresenter ? false : true}
         onMount={handleTldrawMount}
+        tools={customTools}
       />
       <Styled.TldrawV2GlobalStyle
         {...{

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -25,7 +25,7 @@ import {
 import { useMouseEvents, useCursor } from "./hooks";
 import { notifyShapeNumberExceeded } from "./service";
 
-import { NoopTool } from './custom-tools/noop-tool/component';
+import NoopTool from './custom-tools/noop-tool/component';
 
 // Helper functions
 const deleteLocalStorageItemsWithPrefix = (prefix) => {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
@@ -1,14 +1,14 @@
-import { StateNode } from 'tldraw'
+import { StateNode } from '@tldraw/tldraw'
 
 export class NoopTool extends StateNode {
-	static override id = 'noop'
-	static override initial = 'idle'
+   static override id = 'noop';
+   static override initial = 'idle';
 
-	override onEnter = () => {
-		this.editor.setCursor({ type: 'default', rotation: 0 });
-	}
+   override onEnter = () => {
+      this.editor.setCursor({ type: 'default', rotation: 0 });
+   }
 
-	override onExit = () => {
-		this.editor.setCursor({ type: 'default', rotation: 0 });
-	}
+   override onExit = () => {
+      this.editor.setCursor({ type: 'default', rotation: 0 });
+   }
 }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
@@ -5,10 +5,10 @@ export class NoopTool extends StateNode {
 	static override initial = 'idle'
 
 	override onEnter = () => {
-		this.editor.setCursor({ type: 'default', rotation: 0 })
+		this.editor.setCursor({ type: 'default', rotation: 0 });
 	}
 
 	override onExit = () => {
-		this.editor.setCursor({ type: 'default', rotation: 0 })
+		this.editor.setCursor({ type: 'default', rotation: 0 });
 	}
 }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
@@ -1,0 +1,14 @@
+import { StateNode } from 'tldraw'
+
+export class NoopTool extends StateNode {
+	static override id = 'noop'
+	static override initial = 'idle'
+
+	override onEnter = () => {
+		this.editor.setCursor({ type: 'default', rotation: 0 })
+	}
+
+	override onExit = () => {
+		this.editor.setCursor({ type: 'default', rotation: 0 })
+	}
+}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
@@ -1,14 +1,15 @@
-import { StateNode } from '@tldraw/tldraw'
+/* eslint-disable lines-between-class-members */
+import { StateNode } from '@tldraw/tldraw';
 
-export class NoopTool extends StateNode {
+export default class NoopTool extends StateNode {
    static override id = 'noop';
    static override initial = 'idle';
 
    override onEnter = () => {
-      this.editor.setCursor({ type: 'default', rotation: 0 });
+     this.editor.setCursor({ type: 'default', rotation: 0 });
    }
 
    override onExit = () => {
-      this.editor.setCursor({ type: 'default', rotation: 0 });
+     this.editor.setCursor({ type: 'default', rotation: 0 });
    }
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds a `No Operation` tool to fix the issue where the presenter retained drawing capabilities after losing presenter status in a whiteboard session. By assigning the `No Operation` tool to users without whiteboard access, it effectively nullifies any drawing actions. 

### Closes Issue(s)
Closes #19985 