### PR TITLE
fix(webcam): fetch user data of webcam users only

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/hooks/index.ts
@@ -24,6 +24,7 @@ import {
 } from '../state';
 import {
   OWN_VIDEO_STREAMS_QUERY,
+  VIDEO_STREAMS_USERS_FILTERED_SUBSCRIPTION,
   VIDEO_STREAMS_USERS_SUBSCRIPTION,
   VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION,
   VideoStreamsUsersResponse,
@@ -327,9 +328,17 @@ export const useStreams = () => {
   return { streams: videoStreams };
 };
 
-export const useStreamUsers = () => {
+export const useStreamUsers = (isGridEnabled: boolean) => {
+  const { streams } = useStreams();
+  const subscription = isGridEnabled
+    ? VIDEO_STREAMS_USERS_SUBSCRIPTION
+    : VIDEO_STREAMS_USERS_FILTERED_SUBSCRIPTION;
+  const variables = isGridEnabled
+    ? {}
+    : { userIds: streams.map((s) => s.userId) }
   const { data, loading, error } = useSubscription<VideoStreamsUsersResponse>(
-    VIDEO_STREAMS_USERS_SUBSCRIPTION,
+    subscription,
+    { variables },
   );
   const users = useMemo(
     () => (data
@@ -433,7 +442,7 @@ export const useVideoStreams = (
 ) => {
   const [state] = useVideoState();
   const { currentVideoPageIndex, numberOfPages } = state;
-  const { users } = useStreamUsers();
+  const { users } = useStreamUsers(isGridEnabled);
   const { streams: videoStreams} = useStreams();
   const connectingStream = useConnectingStream(videoStreams);
   const gridSize = useGridSize();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/queries.ts
@@ -109,6 +109,38 @@ export const VIDEO_STREAMS_USERS_SUBSCRIPTION = gql`
   }
 `;
 
+export const VIDEO_STREAMS_USERS_FILTERED_SUBSCRIPTION = gql`
+  subscription FilteredVideoStreamsUsers($userIds: [String]!) {
+    user(
+      where: {
+        userId: {
+          _in: $userIds
+        }
+      }
+    ) {
+      name
+      userId
+      nameSortable
+      pinned
+      loggedOut
+      away
+      disconnected
+      emoji
+      role
+      avatar
+      color
+      presenter
+      clientType
+      userId
+      raiseHand
+      isModerator
+      reaction {
+        reactionEmoji
+      }
+    }
+  }
+`;
+
 export default {
   VIDEO_STREAMS_SUBSCRIPTION,
   VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION,


### PR DESCRIPTION
### What does this PR do?

- Do not fetch user data of users who are not in webcam.
- Except when grid layout is active. In this situation we need to know about all users.