### PR TITLE
fix: Warning message character limit exceeded is still showing up after being sent

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -312,6 +312,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
 
       setMessage('');
       updateUnreadMessages(chatId, '');
+      setError(null);
       setHasErrors(false);
       setShowEmojiPicker(false);
       const sentMessageEvent = new CustomEvent(ChatEvents.SENT_MESSAGE);


### PR DESCRIPTION
### What does this PR do?

removes chat error when a message is sent

### Closes Issue(s)
Closes #20142