### PR TITLE
fix(bbb-html5): validate before getting user-list element attribute

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/component.jsx
@@ -92,7 +92,7 @@ class UserParticipants extends Component {
 
   selectEl(el) {
     if (!el) return null;
-    if (el.getAttribute('tabindex')) return el?.focus();
+    if (typeof el.getAttribute === 'function' && el.getAttribute('tabindex')) return el?.focus();
     this.selectEl(el?.firstChild);
   }
 


### PR DESCRIPTION
### What does this PR do?

- [fix(user-list): validate before getting element attribute](https://github.com/bigbluebutton/bigbluebutton/commit/41c58d2466a489f98d5f49ce0bc08c6bc692cedf) 
  - Fixes a client crash
  - Implements check for getAttribute type before calling it.
  
### Closes Issue(s)

None
