### PR TITLE
fix(bbb-html5): filter poll users array before processing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/live-result/component.jsx
@@ -73,6 +73,7 @@ class LiveResult extends PureComponent {
       : [...users];
 
     userAnswers = userAnswers.map(id => usernames[id])
+      .filter((user) => user)
       .map((user) => {
         let answer = '';
 


### PR DESCRIPTION
### What does this PR do?

- [fix(poll): filter users array before processing](https://github.com/bigbluebutton/bigbluebutton/commit/8dad2db2e22720ac0a1ac1d17bc7b239cc8b50cd) 
  - Fix a crash in the polls live result by filtering out undefined users.
This scenario might happen when getting user information by an id that
is not present in the current usernames list by some inconsistency
between the user's information from the users context and poll
votes/responses.

### Closes Issue(s)

None