### PR TITLE
fix(bbb-html5): potential crash in Youtube captions toggle

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -252,10 +252,14 @@ class VideoPlayer extends Component {
     }, () => {
       const { subtitlesOn } = this.state;
       const { isPresenter } = this.props;
+      const internalPlayer = this?.player?.getInternalPlayer();
+      if (!internalPlayer) return;
       if (!isPresenter && subtitlesOn) {
-        this?.player?.getInternalPlayer()?.setOption('captions', 'reload', true);
-      } else {
-        this?.player?.getInternalPlayer()?.unloadModule('captions');
+        if (typeof internalPlayer.setOption === 'function') {
+          internalPlayer.setOption('captions', 'reload', true);
+        }
+      } else if (typeof internalPlayer.unloadModule === 'function') {
+        internalPlayer.unloadModule('captions');
       }
     });
   }


### PR DESCRIPTION
### What does this PR do?

- [fix(external-video): Youtube captions toggle](https://github.com/bigbluebutton/bigbluebutton/commit/eb29634a876a2a4d952a75dd01a1751b8af1802a) 
  - Ensures setOption and unloadModule are functions before calling.
  - Potentially fixes a crash caught in production logs
  
### Closes Issue(s)

None