### PR TITLE
fix(audio): minimize redundant audio exit toasts

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -492,6 +492,7 @@ class AudioManager {
   }
 
   forceExitAudio() {
+    this.notifyAudioExit();
     this.isConnected = false;
     this.isConnecting = false;
     this.isHangingUp = false;
@@ -601,7 +602,21 @@ class AudioManager {
     this.isConnecting = true;
   }
 
+  // Must be called before the call is actually torn down (this.isConnected = true)
+  notifyAudioExit() {
+    try {
+      if (!this.error && (this.isConnected && !this.isEchoTest)) {
+        this.notify(
+          this.intl.formatMessage(this.messages.info.LEFT_AUDIO),
+          false,
+          'no_audio',
+        );
+      }
+    } catch {}
+  }
+
   onAudioExit() {
+    this.notifyAudioExit();
     this.isConnected = false;
     this.isConnecting = false;
     this.isHangingUp = false;
@@ -613,9 +628,6 @@ class AudioManager {
       this.inputStream = null;
     }
 
-    if (!this.error && !this.isEchoTest) {
-      this.notify(this.intl.formatMessage(this.messages.info.LEFT_AUDIO), false, 'no_audio');
-    }
     if (!this.isEchoTest) {
       this.playHangUpSound();
     }


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): minimize redundant audio exit toasts](https://github.com/bigbluebutton/bigbluebutton/commit/d658d81148da53a1695c09cac9e57710b55b8c95)
  - Audio exit toasts are fired in some redundant situations, e.g.: when the
error help screen is render.
  - Change the logic a bit so that it's only fired when the audio help modal
won't be shown, i.e.: when audio had successfully connected beforehand.

### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20004