### PR TITLE
fix(bbb-html5): crash on video-provider unmount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -226,9 +226,11 @@ class VideoProvider extends Component {
     this._isMounted = false;
     VideoService.updatePeerDictionaryReference({});
 
-    this.ws.onmessage = null;
-    this.ws.onopen = null;
-    this.ws.onclose = null;
+    if (this.ws) {
+      this.ws.onmessage = null;
+      this.ws.onopen = null;
+      this.ws.onclose = null;
+    }
 
     window.removeEventListener('beforeunload', this.onBeforeUnload);
     VideoService.exitVideo(sendUserUnshareWebcam);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/component.tsx
@@ -229,9 +229,11 @@ class VideoProviderGraphql extends Component {
     this._isMounted = false;
     VideoService.updatePeerDictionaryReference({});
 
-    this.ws.onmessage = null;
-    this.ws.onopen = null;
-    this.ws.onclose = null;
+    if (this.ws) {
+      this.ws.onmessage = null;
+      this.ws.onopen = null;
+      this.ws.onclose = null;
+    }
 
     window.removeEventListener('beforeunload', this.onBeforeUnload);
     exitVideo();


### PR DESCRIPTION
### What does this PR do?

- [fix(bbb-html5): crash on video-provider unmount](https://github.com/bigbluebutton/bigbluebutton/commit/eccb06369b06c68022eab41bb93fa13181e54054)
  - There's a race condition that may cause a client crash whenever a
video-provider's unmount procedure is run, but its signalling websocket
is undefined. The WS's callback handlers are re-assigned without
checking for the socket's availability, causing an unhandled TypeError.
  - The WS may be undefined in a couple of scenarios, e.g.: unmouting before
the socket was successfully set up, unmounting while a reconnect is in
place etc.
  - Check whether the socket exists before accessing it in video-provider's
componentWillUnmount routine.

### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20008