### PR TITLE
fix(bbb-html5): crash when stopping WebRTC peers

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
@@ -283,7 +283,9 @@ class BaseBroker {
       }
 
       if (connectionState === 'failed' || connectionState === 'closed') {
-        this.webRtcPeer.peerConnection.onconnectionstatechange = null;
+        if (this.webRtcPeer?.peerConnection) {
+          this.webRtcPeer.peerConnection.onconnectionstatechange = null;
+        }
         // 1307: "ICE_STATE_FAILED",
         const error = BaseBroker.assembleError(1307);
         this.onerror(error);
@@ -343,7 +345,7 @@ class BaseBroker {
     this.onerror = function(){};
     window.removeEventListener('beforeunload', this.onbeforeunload);
 
-    if (this.webRtcPeer) {
+    if (this.webRtcPeer?.peerConnection) {
       this.webRtcPeer.peerConnection.onconnectionstatechange = null;
     }
 


### PR DESCRIPTION
### What does this PR do?

- [fix(bbb-html5): crash when stopping WebRTC peers](https://github.com/bigbluebutton/bigbluebutton/commit/85cdc7cc2ac818672130ec0e528d07cfc2745592) 
  - There's a race condition that may cause a client crash whenever a
connectionstatechange callback is cleaned up in a peer without a
valid peer connection present in our custom RTCPeerConnection wrapper.
  - Check for peerConnection availability in the WebRtcPeer wrapper before
trying to clean up its connectionstatechange callback.

### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20009