### PR TITLE
fix(screen-reader): add safeguards for adding alerts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenreader-alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/screenreader-alert/component.tsx
@@ -14,7 +14,9 @@ const ScreenReaderAlert: React.FC<Props> = ({ olderAlert }) => {
     if (olderAlert) setTimeout(() => shiftAlert(), ARIA_ALERT_EXT_TIMEOUT);
   }, [olderAlert?.id]);
 
-  return olderAlert
+  const ariaAlertsElement = document.getElementById('aria-polite-alert');
+
+  return (olderAlert && olderAlert.text && ariaAlertsElement !== null)
     ? createPortal(olderAlert.text, document.getElementById('aria-polite-alert') as HTMLElement)
     : null;
 };


### PR DESCRIPTION
### What does this PR do?

Credits to @Arthurk12 

- [fix(screen-reader): add safeguards for adding alerts](https://github.com/bigbluebutton/bigbluebutton/commit/9947aa451e72c3277c8ed4edc97cfcd2b2467efc)
  - Adds checks for the alert's text and DOM element before adding screen
reader alerts.
  - Fixes a potential client crash

### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20012