### PR TITLE
fix: undefined accesses causes crashes in actions-bar breakout utils

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/service.js
@@ -22,15 +22,15 @@ const isMe = (intId) => intId === Auth.userID;
 export default {
   isMe,
   meetingName: () => Meetings.findOne({ meetingId: Auth.meetingID },
-    { fields: { name: 1 } }).name,
+    { fields: { name: 1 } })?.name,
   users: () => Users.find({
     meetingId: Auth.meetingID,
     clientType: { $ne: DIAL_IN_USER },
   }).fetch(),
   groups: () => Meetings.findOne({ meetingId: Auth.meetingID },
-    { fields: { groups: 1 } }).groups,
+    { fields: { groups: 1 } })?.groups,
   isBreakoutRecordable: () => Meetings.findOne({ meetingId: Auth.meetingID },
-    { fields: { 'breakoutProps.record': 1 } }).breakoutProps.record,
+    { fields: { 'breakoutProps.record': 1 } })?.breakoutProps?.record,
   breakoutJoinedUsers: () => Breakouts.find({
     joinedUsers: { $exists: true },
   }, { fields: { joinedUsers: 1, breakoutId: 1, sequence: 1 }, sort: { sequence: 1 } }).fetch(),


### PR DESCRIPTION
### What does this PR do?

- [fix: undefined accesses causes crashes in actions-bar breakout utils](https://github.com/bigbluebutton/bigbluebutton/commit/cea92631fac86db09a9dcc1ed427754f02ae2422)
  - Multiple undefined accesses in actions-bar's service, mainly related to
breakouts and general meeting info, cause crashes in production
environments - most likely in reconnection scenarios.

### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20123