### PR TITLE
fix(bbb-html5): correct parameter type for wake lock log codes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/wake-lock/service.js
+++ b/bigbluebutton-html5/imports/ui/components/wake-lock/service.js
@@ -11,8 +11,8 @@ const WAKELOCK_ERRORS = {
   REQUEST_FAILED: {
     locale: 'wakeLockAcquireFailed',
     error: 'wake_lock_request_error',
-  }
-}
+  },
+};
 
 class WakeLock {
   constructor() {
@@ -52,7 +52,7 @@ class WakeLock {
   async request() {
     if (!this.isSupported()) {
       logger.warn({
-        logCode: WAKELOCK_ERRORS.NOT_SUPPORTED,
+        logCode: WAKELOCK_ERRORS.NOT_SUPPORTED.error,
       }, 'Wake lock API not supported');
       return {
         ...WAKELOCK_ERRORS.NOT_SUPPORTED,
@@ -67,7 +67,7 @@ class WakeLock {
       document.addEventListener('fullscreenchange', this.handleVisibilityChanged.bind(this));
     } catch (err) {
       logger.warn({
-        logCode: WAKELOCK_ERRORS.REQUEST_FAILED,
+        logCode: WAKELOCK_ERRORS.REQUEST_FAILED.error,
         extraInfo: {
           errorName: err.name,
           errorMessage: err.message,


### PR DESCRIPTION
### What does this PR do?

- [fix(wake-lock): correct parameter type for log code](https://github.com/bigbluebutton/bigbluebutton/commit/31a6527cca14ecd516e87da60ab6d17d4d0aa9e0)
  - Previously, an object was incorrectly passed as the log code parameter.
  - Fixes it by ensuring that a string is passed instead.
  
### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20152