### PR TITLE
fix(audio): review device selection in mobile endpoints

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -15,7 +15,7 @@ import {
   notify,
   truncateDeviceName,
 } from '../service';
-import Mutetoggle from './muteToggle';
+import MuteToggle from './muteToggle';
 import ListenOnly from './listenOnly';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 
@@ -250,26 +250,37 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
           aria-hidden="true"
         />
       ) : null}
+      {(!listenOnly && isMobile) && (
+        <MuteToggle
+          talking={talking}
+          muted={muted}
+          disabled={disabled || isAudioLocked}
+          isAudioLocked={isAudioLocked}
+          toggleMuteMicrophone={toggleMuteMicrophone}
+          away={away}
+        />
+      )}
       <BBBMenu
         customStyles={!isMobile ? customStyles : null}
         trigger={(
           <>
-            {listenOnly
+            {!listenOnly && !isMobile
               ? (
-                <ListenOnly
-                  listenOnly={listenOnly}
-                  handleLeaveAudio={handleLeaveAudio}
-                  meetingIsBreakout={meetingIsBreakout}
-                />
-              )
-              : (
-                <Mutetoggle
+                <MuteToggle
                   talking={talking}
                   muted={muted}
                   disabled={disabled || isAudioLocked}
                   isAudioLocked={isAudioLocked}
                   toggleMuteMicrophone={toggleMuteMicrophone}
                   away={away}
+                />
+              )
+              : (
+                <ListenOnly
+                  listenOnly={listenOnly}
+                  handleLeaveAudio={handleLeaveAudio}
+                  meetingIsBreakout={meetingIsBreakout}
+                  actAsDeviceSelector={isMobile}
                 />
               )}
             <Styled.AudioDropdown

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/listenOnly.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/listenOnly.tsx
@@ -8,18 +8,24 @@ const intlMessages = defineMessages({
     id: 'app.audio.leaveAudio',
     description: 'Leave audio dropdown item label',
   },
+  changeAudioDevice: {
+    id: 'app.audio.changeAudioDevice',
+    description: 'Change audio device button label',
+  },
 });
 
 interface ListenOnlyProps {
   listenOnly: boolean;
   handleLeaveAudio: (meetingIsBreakout: boolean) => void;
   meetingIsBreakout: boolean;
+  actAsDeviceSelector: boolean;
 }
 
 export const ListenOnly: React.FC<ListenOnlyProps> = ({
   listenOnly,
   handleLeaveAudio,
   meetingIsBreakout,
+  actAsDeviceSelector,
 }) => {
   const intl = useIntl();
   const leaveAudioShourtcut = useShortcut('leaveAudio');
@@ -27,7 +33,9 @@ export const ListenOnly: React.FC<ListenOnlyProps> = ({
     // eslint-disable-next-line jsx-a11y/no-access-key
     <Button
       aria-label={intl.formatMessage(intlMessages.leaveAudio)}
-      label={intl.formatMessage(intlMessages.leaveAudio)}
+      label={actAsDeviceSelector
+        ? intl.formatMessage(intlMessages.changeAudioDevice)
+        : intl.formatMessage(intlMessages.leaveAudio)}
       accessKey={leaveAudioShourtcut}
       data-test="leaveListenOnly"
       hideLabel
@@ -35,10 +43,12 @@ export const ListenOnly: React.FC<ListenOnlyProps> = ({
       icon={listenOnly ? 'listen' : 'volume_level_2'}
       size="lg"
       circle
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation();
-        handleLeaveAudio(meetingIsBreakout);
-      }}
+      onClick={actAsDeviceSelector
+        ? () => null
+        : (e: React.MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation();
+          handleLeaveAudio(meetingIsBreakout);
+        }}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -39,7 +39,7 @@ interface MuteToggleProps {
   away: boolean;
 }
 
-export const Mutetoggle: React.FC<MuteToggleProps> = ({
+export const MuteToggle: React.FC<MuteToggleProps> = ({
   talking,
   muted,
   disabled,
@@ -90,4 +90,4 @@ export const Mutetoggle: React.FC<MuteToggleProps> = ({
   );
 };
 
-export default Mutetoggle;
+export default MuteToggle;

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -16,7 +16,7 @@ import { Meeting } from '/imports/ui/Types/meeting';
 import logger from '/imports/startup/client/logger';
 import Auth from '/imports/ui/services/auth';
 import MutedAlert from '/imports/ui/components/muted-alert/component';
-import Mutetoggle from './buttons/muteToggle';
+import MuteToggle from './buttons/muteToggle';
 import ListenOnly from './buttons/listenOnly';
 import LiveSelection from './buttons/LiveSelection';
 
@@ -163,13 +163,13 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   }, [inputDeviceId]);
 
   useEffect(() => {
-    if (enableDynamicAudioDeviceSelection && !isMobile) {
+    if (enableDynamicAudioDeviceSelection) {
       updateDevices(inAudio);
     }
   }, [inAudio]);
 
   return (
-    <div>
+    <>
       {inAudio && inputStream && muteAlertEnabled && !listenOnly && muted && showMute ? (
         <MutedAlert
           {...{
@@ -180,7 +180,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
       ) : null}
       {
 
-        enableDynamicAudioDeviceSelection && !isMobile ? (
+        enableDynamicAudioDeviceSelection ? (
           <LiveSelection
             listenOnly={listenOnly}
             inputDevices={inputDevices}
@@ -198,7 +198,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
         ) : (
           <>
             {(isConnected && !listenOnly) && (
-              <Mutetoggle
+              <MuteToggle
                 talking={talking}
                 muted={muted}
                 disabled={disabled || isAudioLocked}
@@ -211,11 +211,12 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
               listenOnly={listenOnly}
               handleLeaveAudio={handleLeaveAudio}
               meetingIsBreakout={meetingIsBreakout}
+              actAsDeviceSelector={enableDynamicAudioDeviceSelection && isMobile}
             />
           </>
         )
       }
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): review device selection in mobile endpoints](https://github.com/bigbluebutton/bigbluebutton/commit/a21addfa1f62108692d328dd082339bc7d500cf4)
  - Mobile users have no way to change I/O devices after joining audio.
The removal of the audio options chevron in mobile browsers was supposed
to be replaced by something else - in this case, by the dedicated
leave/join audio button. That didn't happen, leave/join audio button
retained the old behavior.
  - Review device selection in mobile endpoints via two UI/UX changes:
    - Fix an styling issue where the mute and listen only buttons were
    crammed together
    - Restore the device selection chevron/icon in mobile endpoints
    - Override the leave/join button action in mobile endpoints so that it
    opens the device selection contextual menu, which also includes the
    "Leave audio" option. This retains the old behavior (leaving audio)
    while also providing a way for users to change devices mid-call in
    mobile browsers.

### Closes Issue(s)

None

### More

3.0 version of https://github.com/bigbluebutton/bigbluebutton/pull/20122