### PR TITLE
test: adding test presentation snapshot to ci

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -47,7 +47,7 @@ test.describe.parallel('Presentation', () => {
     await presentation.presentationFullscreen();
   });
 
-  test('Presentation snapshot @ci @flaky', async ({ browser, context, page }, testInfo) => {
+  test('Presentation snapshot @ci', async ({ browser, context, page }, testInfo) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.presentationSnapshot(testInfo);


### PR DESCRIPTION

### What does this PR do?
Removes the flaky flag for the test presentation snapshot, so it will run again on CI.