### PR TITLE
fix(bbb-html5): add specific logCodes for root error boundaries

### DIFF
--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -13,15 +13,18 @@ import StartupDataFetch from '/imports/ui/components/connection-manager/startup-
 
 import GraphqlToMiniMongoAdapterManager from '/imports/ui/components/components-data/graphqlToMiniMongoAdapterManager/component';
 
+const STARTUP_CRASH_METADATA = { logCode: 'app_startup_crash', logMessage: 'Possible startup crash' };
+const APP_CRASH_METADATA = { logCode: 'app_crash', logMessage: 'Possible app crash' };
+
 const Main: React.FC = () => {
   // Meteor.disconnect();
   return (
     <StartupDataFetch>
-      <ErrorBoundary Fallback={ErrorScreen}>
+      <ErrorBoundary Fallback={ErrorScreen} logMetadata={STARTUP_CRASH_METADATA}>
         <LoadingScreenHOC>
           <IntlLoaderContainer>
             {/* from there the error messages are located */}
-            <LocatedErrorBoundary Fallback={ErrorScreen}>
+            <LocatedErrorBoundary Fallback={ErrorScreen} logMetadata={APP_CRASH_METADATA}>
               <ConnectionManager>
                 <PresenceManager>
                   <GraphqlToMiniMongoAdapterManager>

--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
@@ -6,11 +6,19 @@ const propTypes = {
   children: PropTypes.element.isRequired,
   Fallback: PropTypes.element,
   errorMessage: PropTypes.string,
+  logMetadata: PropTypes.shape({
+    logCode: PropTypes.string,
+    logMessage: PropTypes.string,
+  }),
 };
 
 const defaultProps = {
   Fallback: null,
   errorMessage: 'Something went wrong',
+  logMetadata: {
+    logCode: 'Error_Boundary_wrapper',
+    logMessage: 'generic error boundary logger',
+  },
 };
 
 class ErrorBoundary extends Component {
@@ -30,13 +38,17 @@ class ErrorBoundary extends Component {
   }
 
   componentDidUpdate() {
-    const { code, error, errorInfo } = this.state;
-    const log = code === '403' ? 'warn' : 'error';
+    const { error, errorInfo } = this.state;
+    const { logMetadata: { logCode, logMessage } } = this.props;
     if (error || errorInfo) {
-      logger[log]({
-        logCode: 'Error_Boundary_wrapper',
-        extraInfo: { error, errorInfo },
-      }, 'generic error boundary logger');
+      logger.error({
+        logCode,
+        extraInfo: {
+          errorMessage: error?.message,
+          errorStack: error?.stack,
+          errorInfo,
+        },
+      }, logMessage);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

The ErrorBoundary component has a generic log message that is not overridable and will aggregate errors from different components. The ideal scenario is that log tags are configurable so that errors can be filtered in log post-processing.
  - Add the logMetadata: { logCode, logMessage } prop to the ErrorBoundary component so that log tags are configurable. Default tags are maintained.
  - Add specific log metadatas for the client startup error boundary (logCode: 'app_startup_crash') and the user connection error boundary (logCode: 'app_crash').

### Closes Issue(s)

None

### Motivation

Catching application crashes in production.
