### PR TITLE
Remove: user list local state storing previous users list data

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -96,12 +96,6 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   const { roving } = Service;
 
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
-  const [previousUsersData, setPreviousUsersData] = React.useState(users);
-  useEffect(() => {
-    if (users?.length) {
-      setPreviousUsersData(users);
-    }
-  }, [users]);
 
   React.useEffect(() => {
     const firstChild = (selectedUser as HTMLElement)?.firstChild;
@@ -162,7 +156,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
               (props: RowRendererProps) => rowRenderer(
                 {
                   ...props,
-                  users: users || previousUsersData,
+                  users: users || [],
                   validCurrentUser,
                   offset,
                   meeting,


### PR DESCRIPTION
### What does this PR do?
In the first implementation we made store precious data users to not handle the loading stage, It's causing a bug where the old data it's being shown in the use list instead of the new one.
