### PR TITLE
fix (graphql-middleware): After returning a Mutation data, it should send a `complete` message

### DIFF
--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -67,8 +67,15 @@ RangeLoop:
 										},
 									},
 								}
-
 								fromHasuraToBrowserChannel.Send(browserResponseData)
+
+								//Return complete msg to client
+								browserResponseComplete := map[string]interface{}{
+									"id":   queryId,
+									"type": "complete",
+								}
+								fromHasuraToBrowserChannel.Send(browserResponseComplete)
+
 								continue
 							} else {
 								log.Error("It was not able to send the request to Graphql Actions", err)


### PR DESCRIPTION
Apollo client expects to receive a `complete` message in order to consider a mutation finished.
This PR include this message following the `data` message.