### PR TITLE
fix: only send cursor updates of users with whiteboard access

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -343,7 +343,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         const { updated } = changes;
         const { "pointer:pointer": pointers } = updated;
 
-        if (pointers) {
+        if ((isPresenter || hasWBAccessRef.current) && pointers) {
           const [prevPointer, nextPointer] = pointers;
           updateCursorPosition(nextPointer?.x, nextPointer?.y);
         }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react';
 
 const useCursor = (publishCursorUpdate, whiteboardId) => {
-    const [cursorPosition, setCursorPosition] = useState({ x: -1, y: -1 });
+    const [cursorPosition, setCursorPosition] = useState({ x: '', y: '' });
 
     const updateCursorPosition = (newX, newY) => {
         setCursorPosition({ x: newX, y: newY });
     };
 
     useEffect(() => {
+        if (!cursorPosition || cursorPosition.x === '' || cursorPosition.y === '') {
+            return;
+        }
         publishCursorUpdate({
             whiteboardId,
             xPercent: cursorPosition?.x,


### PR DESCRIPTION
### What does this PR do?

Adjusts whiteboard cursor updates so it only sends data about users that have whiteboard access.