### PR TITLE
refactor: add names to unnamed queries

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/queries.ts
@@ -6,7 +6,7 @@ export interface WelcomeMsgsResponse {
 }
 
 export const GET_WELCOME_MESSAGE = gql`
-  query {
+  query getWelcomeMessage{
     user_welcomeMsgs {
       welcomeMsg
       welcomeMsgForModerators

--- a/bigbluebutton-html5/imports/ui/components/screenreader-alert/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/screenreader-alert/queries.ts
@@ -11,7 +11,7 @@ export interface UnreadChatsSubscriptionResponse {
 }
 
 export const UNREAD_CHATS_SUBSCRIPTION = gql`
-  subscription {
+  subscription unreadChatsSubscription {
     chat(
       where: {
         totalUnread: { _gt: 0 },


### PR DESCRIPTION
### What does this PR do?

Add name to welcome message query and unread chats subscription.

### Motivation

You should define a name for every GraphQL operation in your application. Doing so provides the following benefits:

- You clarify the purpose of each operation for both yourself and your teammates.
- You avoid unexpected errors when combining multiple operations in a single query document (an anonymous operation can only appear alone).
- You improve debugging output in both client and server code, helping you identify exactly which operation is causing issues.

(https://www.apollographql.com/docs/react/data/operation-best-practices/)