### PR TITLE
Fix: Input losing focus on wb mount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1153,6 +1153,16 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
   const customTools = [NoopTool];
 
+  React.useEffect(() => {
+    const chatInput = document.querySelector("#message-input");
+    const wasChatInputFocused = chatInput?.contains(document.activeElement);
+    if (!isPresenter && wasChatInputFocused) {
+      setTimeout(() => {
+      chatInput.focus();
+      }, 1500);
+    }
+  }, [isMounting]);
+
   return (
     <div
       ref={whiteboardRef}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where all users with the chat input as active element would lose its focus when TLDraw/WB remounts.

### Closes Issue(s)

#19636 and also #20047