### PR TITLE
refactor (gql-middleware): Change Graphql endpoint to `/graphql`

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -302,7 +302,7 @@ defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join
 
 # Graphql websocket url (it's necessary to change for cluster setup)
 # Using `serverURL` as default, so `https` will be automatically replaced by `wss`
-graphqlWebsocketUrl=${bigbluebutton.web.serverURL}/v1/graphql
+graphqlWebsocketUrl=${bigbluebutton.web.serverURL}/graphql
 
 # This parameter defines the duration (in minutes) to wait before removing user sessions after a meeting has ended.
 # During this delay, users can still access information indicating that the "Meeting has ended".

--- a/build/packages-template/bbb-graphql-middleware/graphql.nginx
+++ b/build/packages-template/bbb-graphql-middleware/graphql.nginx
@@ -6,7 +6,7 @@ location /graphql-test {
 }
 
 # Websocket connection
-location /v1/graphql {
+location /graphql {
 	proxy_http_version 1.1;
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
**Background**
The current GraphQL endpoint is set to `/v1/graphql`, a path originally chosen due to Hasura's usage. 
However, the BBB client now interacts with the GraphQL middleware rather than directly with Hasura.

**Proposed Changes**
This PR changes the GraphQL endpoint to `/graphql` without versioning, for the following reasons:

1. Middleware Alignment: Since the client accesses the GraphQL middleware instead of Hasura, changing the path clarifies that requests are directed to the middleware layer.
2. Future Versioning: The new path also leaves room for possible versioning of the middleware in the future.