### PR TITLE
fix(whiteboard): Correct Viewer Canvas Position on Slide Change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -867,41 +867,39 @@ const Whiteboard = React.memo(function Whiteboard(props) {
           );
           let adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
           if (isPresenter) {
-            setTimeout(() => {
-              const container = document.querySelector(
-                '[data-test="presentationContainer"]'
+            const container = document.querySelector(
+              '[data-test="presentationContainer"]'
+            );
+            const innerWrapper = document.getElementById(
+              "presentationInnerWrapper"
+            );
+            const containerWidth = container ? container.offsetWidth : 0;
+            const innerWrapperWidth = innerWrapper
+              ? innerWrapper.offsetWidth
+              : 0;
+            const widthGap = Math.max(containerWidth - innerWrapperWidth, 0);
+            const camera = tlEditorRef.current.getCamera();
+
+            let adjustedZoom;
+            if (widthGap > 0) {
+              adjustedZoom = calculateZoomWithGapValue(
+                currentPresentationPage.scaledWidth,
+                currentPresentationPage.scaledHeight,
+                false,
+                widthGap
               );
-              const innerWrapper = document.getElementById(
-                "presentationInnerWrapper"
-              );
-              const containerWidth = container ? container.offsetWidth : 0;
-              const innerWrapperWidth = innerWrapper
-                ? innerWrapper.offsetWidth
-                : 0;
-              const widthGap = Math.max(containerWidth - innerWrapperWidth, 0);
-              const camera = tlEditorRef.current.getCamera();
 
-              let adjustedZoom;
-              if (widthGap > 0) {
-                adjustedZoom = calculateZoomWithGapValue(
-                  currentPresentationPage.scaledWidth,
-                  currentPresentationPage.scaledHeight,
-                  false,
-                  widthGap
-                );
+              adjustedZoom *= currentZoom / HUNDRED_PERCENT;
+            } else {
+              adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
+            }
 
-                adjustedZoom *= currentZoom / HUNDRED_PERCENT;
-              } else {
-                adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
-              }
+            const zoomToApply =
+              widthGap > 0
+                ? adjustedZoom
+                : baseZoom * (currentZoom / HUNDRED_PERCENT);
 
-              const zoomToApply =
-                widthGap > 0
-                  ? adjustedZoom
-                  : baseZoom * (currentZoom / HUNDRED_PERCENT);
-
-              setCamera(zoomToApply, camera.x, camera.y);
-            }, 50);
+            setCamera(zoomToApply, camera.x, camera.y);
           } else {
             // Viewer logic
             const effectiveZoom = calculateEffectiveZoom(
@@ -1090,6 +1088,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
             ? presentationAreaHeight - 40
             : presentationAreaHeight;
 
+          let effectiveZoom;
           let baseZoom;
           if (isPresenter) {
             // For presenters, use the full area minus any UI components like toolbars
@@ -1101,7 +1100,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
                 );
           } else {
             // For viewers
-            const effectiveZoom = calculateEffectiveZoom(
+            effectiveZoom = calculateEffectiveZoom(
               initialViewBoxWidthRef.current,
               currentPresentationPageRef.current.scaledViewBoxWidth
             );


### PR DESCRIPTION
### What does this PR do?
This PR fixes a `ReferenceError` that occurs when changing slides in the viewer. The issue was caused by an undefined variable `effectiveZoom`, which affects the canvas position, resulting in incorrect display alignment for the viewers when the presenter switches slides.

before:
![viewer-canvas-slide-change-bug](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/30edc556-7485-4c33-bbd5-830e360345af)


after:
![viewer-canvas-slide-change-fix](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/702b3d13-b1d3-49b8-80b2-d6fc610e54bf)


### Motivation
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/3bb3f4b4-56cd-410e-ae8a-3ac5026b9dbb)
