### PR TITLE
fix(whiteboard): Shapes Missing On Previous Slides For Late Joiners

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -14,7 +14,6 @@ import {
   CURRENT_PAGE_ANNOTATIONS_STREAM,
   CURRENT_PAGE_ANNOTATIONS_QUERY,
   CURRENT_PAGE_WRITERS_SUBSCRIPTION,
-  CURSOR_SUBSCRIPTION,
 } from './queries';
 import {
   initDefaultPages,
@@ -180,7 +179,7 @@ const WhiteboardContainer = (props) => {
     CURRENT_PAGE_ANNOTATIONS_QUERY,
     {
       skip: !curPageId,
-    }
+    },
   );
 
   React.useEffect(() => {
@@ -192,7 +191,7 @@ const WhiteboardContainer = (props) => {
   const processAnnotations = (data) => {
     const newAnnotations = [];
     const annotationsToBeRemoved = [];
-  
+
     data.forEach((item) => {
       if (item.annotationInfo === '') {
         annotationsToBeRemoved.push(item.annotationId);
@@ -200,13 +199,13 @@ const WhiteboardContainer = (props) => {
         newAnnotations.push(item);
       }
     });
-  
+
     const currentAnnotations = annotations.filter(
       (annotation) => !annotationsToBeRemoved.includes(annotation.annotationId),
     );
-  
+
     setAnnotations([...currentAnnotations, ...newAnnotations]);
-  }
+  };
 
   React.useEffect(() => {
     if (initialPageAnnotations && initialPageAnnotations.pres_annotation_curr) {
@@ -289,7 +288,7 @@ const WhiteboardContainer = (props) => {
     typeName: 'shape',
   });
 
-  if (!currentPresentationPage) return;
+  if (!currentPresentationPage) return null;
 
   return (
     <Whiteboard

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -4,7 +4,7 @@ import React, {
   useState,
   useMemo,
 } from 'react';
-import { useSubscription, useMutation } from '@apollo/client';
+import { useSubscription, useMutation, useQuery } from '@apollo/client';
 import {
   AssetRecordType,
 } from '@tldraw/tldraw';
@@ -12,6 +12,7 @@ import { throttle } from 'radash';
 import {
   CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
   CURRENT_PAGE_ANNOTATIONS_STREAM,
+  CURRENT_PAGE_ANNOTATIONS_QUERY,
   CURRENT_PAGE_WRITERS_SUBSCRIPTION,
   CURSOR_SUBSCRIPTION,
 } from './queries';
@@ -175,23 +176,48 @@ const WhiteboardContainer = (props) => {
     },
   );
 
+  const { data: initialPageAnnotations, refetch: refetchInitialPageAnnotations } = useQuery(
+    CURRENT_PAGE_ANNOTATIONS_QUERY,
+    {
+      skip: !curPageId,
+    }
+  );
+
+  React.useEffect(() => {
+    if (curPageIdRef.current) {
+      refetchInitialPageAnnotations();
+    }
+  }, [curPageIdRef.current]);
+
+  const processAnnotations = (data) => {
+    const newAnnotations = [];
+    const annotationsToBeRemoved = [];
+  
+    data.forEach((item) => {
+      if (item.annotationInfo === '') {
+        annotationsToBeRemoved.push(item.annotationId);
+      } else {
+        newAnnotations.push(item);
+      }
+    });
+  
+    const currentAnnotations = annotations.filter(
+      (annotation) => !annotationsToBeRemoved.includes(annotation.annotationId),
+    );
+  
+    setAnnotations([...currentAnnotations, ...newAnnotations]);
+  }
+
+  React.useEffect(() => {
+    if (initialPageAnnotations && initialPageAnnotations.pres_annotation_curr) {
+      processAnnotations(initialPageAnnotations.pres_annotation_curr);
+    }
+  }, [initialPageAnnotations]);
+
   useEffect(() => {
     const { pres_annotation_curr_stream: annotationStream } = annotationStreamData || {};
-
     if (annotationStream) {
-      const newAnnotations = [];
-      const annotationsToBeRemoved = [];
-      annotationStream.forEach((item) => {
-        if (item.annotationInfo === '') {
-          annotationsToBeRemoved.push(item.annotationId);
-        } else {
-          newAnnotations.push(item);
-        }
-      });
-      const currentAnnotations = annotations.filter(
-        (annotation) => !annotationsToBeRemoved.includes(annotation.annotationId),
-      );
-      setAnnotations([...currentAnnotations, ...newAnnotations]);
+      processAnnotations(annotationStream);
     }
   }, [annotationStreamData]);
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where late joiners to a whiteboard session were unable to see shapes drawn on previous slides before they joined. With these changes, late joiners will now be able to see all annotations made on all slides prior to their arrival in the session.


