### PR TITLE
fix(audio): moderators not able to mute users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/hooks/useToggleVoice.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/hooks/useToggleVoice.ts
@@ -14,9 +14,10 @@ const useToggleVoice = () => {
 
   const toggleVoice = async (userId?: string | null, muted?: boolean | null) => {
     let shouldMute = muted;
-    const userToMute = userId ?? Auth.userID;
+    let userToMute = userId ?? Auth.userID;
 
     if (muted === undefined || muted === null) {
+      userToMute = Auth.userID;
       const muted = currentUserData?.voice?.muted;
       shouldMute = !muted;
     }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/service.ts
@@ -9,10 +9,10 @@ export const muteUser = debounce(
     muted: boolean | undefined,
     isBreakout: boolean,
     isModerator: boolean,
-    toggleVoice: (userId?: string | null, muted?: string | null) => void,
+    toggleVoice: (userId?: string | null, muted?: boolean | null) => void,
   ) => {
     if (!isModerator || isBreakout || muted) return null;
-    toggleVoice(id);
+    toggleVoice(id, true);
     return null;
   },
 );


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a bug where moderators cannot mute users from talking indicators.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None


### Motivation

The bug:

1. Join 2 users, one of them as moderator.
2. Join audio for both users.
3. As the moderator, keep the mic muted.
4. As the moderator, try muting the other user.
5. The user does not get muted.