### PR TITLE
refactor(bbb-web): Add message key to insertDocument responses

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
@@ -218,12 +218,13 @@ public class ResponseBuilder {
         return xmlText.toString();
     }
 
-    public String buildInsertDocumentResponse(String message, String returnCode) {
+    public String buildInsertDocumentResponse(String messageKey, String message, String returnCode) {
 
         StringWriter xmlText = new StringWriter();
 
         Map<String, Object> data = new HashMap<String, Object>();
         data.put("returnCode", returnCode);
+        data.put("messageKey", messageKey);
         data.put("message", message);
 
         processData(getTemplate("insert-document.ftlx"), data, xmlText);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1129,14 +1129,14 @@ class ApiController {
       if (uploadDocuments(meeting, true)) {
         withFormat {
           xml {
-            render(text: responseBuilder.buildInsertDocumentResponse("Presentation is being uploaded", RESP_CODE_SUCCESS)
+            render(text: responseBuilder.buildInsertDocumentResponse("documentInserted", "Presentation is being uploaded", RESP_CODE_SUCCESS)
                     , contentType: "text/xml")
           }
         }
-      } else if (meetingService.isMeetingWithDisabledPresentation(meetingId)) {
+      } else if (meetingService.isMeetingWithDisabledPresentation(meeting.getInternalId())) {
         withFormat {
           xml {
-            render(text: responseBuilder.buildInsertDocumentResponse("Presentation feature is disabled, ignoring.",
+            render(text: responseBuilder.buildInsertDocumentResponse("presentationDisabled", "Presentation feature is disabled, ignoring.",
                     RESP_CODE_FAILED), contentType: "text/xml")
           }
         }
@@ -1145,7 +1145,7 @@ class ApiController {
       log.warn("Meeting with externalID ${externalMeetingId} doesn't exist.")
       withFormat {
         xml {
-          render(text: responseBuilder.buildInsertDocumentResponse(
+          render(text: responseBuilder.buildInsertDocumentResponse("notFound",
                   "Meeting with id [${externalMeetingId}] not found.", RESP_CODE_FAILED),
                   contentType: "text/xml")
         }

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/insert-document.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/insert-document.ftlx
@@ -3,6 +3,7 @@
 <response>
   <#-- Where code is a 'SUCCESS' or 'FAILED' String -->
   <returncode>${returnCode}</returncode>
+  <messageKey>${messageKey}</messageKey>
   <message>${message}</message>
 </response>
 </#compress>


### PR DESCRIPTION
### What does this PR do?

Adds a `messageKey` field to responses from the `insertDocument` endpoint to help identify the result of the API call.

### Closes Issue(s)
Closes #20109


### Motivation

The purpose of this is to make the responses of this endpoint consistent with the pattern used by the other endpoints for structuring their responses.
