### PR TITLE
refactor: change enforceLayout to match defaultMeetingLayout format

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -179,7 +179,7 @@ const AppContainer = (props) => {
   const shouldShowGenericComponent = !!genericComponent.genericComponentId;
 
   const validateEnforceLayout = (currentUser) => {
-    const layoutTypes = Object.values(LAYOUT_TYPE);
+    const layoutTypes = Object.keys(LAYOUT_TYPE);
     const enforceLayout = currentUser?.enforceLayout;
     return enforceLayout && layoutTypes.includes(enforceLayout) ? enforceLayout : null;
   };

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -72,8 +72,9 @@ class PushLayoutEngine extends React.Component {
 
     const changeLayout = LAYOUT_TYPE[getFromUserSettings('bbb_change_layout', null)];
     const defaultLayout = LAYOUT_TYPE[getFromUserSettings('bbb_default_layout', null)];
+    const enforcedLayout = LAYOUT_TYPE[enforceLayout] || null;
 
-    Settings.application.selectedLayout = enforceLayout
+    Settings.application.selectedLayout = enforcedLayout
       || changeLayout
       || defaultLayout
       || meetingLayout;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -162,7 +162,8 @@ authenticatedGuest=true
 
 #---------------------------------------------------
 # Default Meeting Layout
-# Valid values are CUSTOM_LAYOUT, SMART_LAYOUT, PRESENTATION_FOCUS, VIDEO_FOCUS
+# Accepted values are the standard layouts: CUSTOM_LAYOUT, SMART_LAYOUT, PRESENTATION_FOCUS, VIDEO_FOCUS
+# but also several layouts which are not meant to be selectable via UI: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY
 defaultMeetingLayout=CUSTOM_LAYOUT
 
 #


### PR DESCRIPTION
### What does this PR do?

Changes enforceLayout join parameter value format so it matches other layout-related parameters

#### previously accepted values:
  `custom`, `smart`, `presentationFocus`, `videoFocus`, `camerasOnly`, `presentationOnly`, `participantsAndChatOnly`

#### accepted values after this pr changes:
`CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`,`CAMERAS_ONLY`,`PRESENTATION_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`

