### PR TITLE
fix: optional chaining on isModerator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/container.jsx
@@ -26,7 +26,7 @@ const UserContentContainer = (props) => {
       {...{
         isGuestLobbyMessageEnabled,
         currentUser,
-        isTimerActive: currentMeeting?.componentsFlags?.hasTimer && currentUser.isModerator,
+        isTimerActive: currentMeeting?.componentsFlags?.hasTimer && currentUser?.isModerator,
         ...props,
       }}
     />


### PR DESCRIPTION
### What does this PR do?

Add optional chaining operator so an error does not occur in timer if currentUser is not available

### Motivation

![Screenshot from 2024-05-10 15-40-30](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/a2228919-2f7e-4a66-9e08-49e38f581412)
