### PR TITLE
refactor (akka-apps): Show progress while importing whiteboard and sharedNotes from breakoutRoom

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
@@ -1,10 +1,11 @@
 package org.bigbluebutton.core.apps.breakout
 
-import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, BbbCoreHeaderWithMeetingId, ExportJob, MessageTypes, PresentationConversionUpdateEvtMsg, PresentationConversionUpdateEvtMsgBody, PresentationConversionUpdateSysPubMsg, PresentationUploadTokenSysPubMsg, PresentationUploadTokenSysPubMsgBody, Routing, StoreExportJobInRedisSysMsg, StoreExportJobInRedisSysMsgBody }
+import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, BbbCoreHeaderWithMeetingId, ExportJob, MessageTypes, PresentationConversionUpdateEvtMsg, PresentationConversionUpdateEvtMsgBody, PresentationConversionUpdateSysPubMsg, PresentationPageForExport, PresentationUploadTokenSysPubMsg, PresentationUploadTokenSysPubMsgBody, Routing, StoreExportJobInRedisSysMsg, StoreExportJobInRedisSysMsgBody, StoredAnnotations }
 import org.bigbluebutton.core.api.{ CapturePresentationReqInternalMsg, EndBreakoutRoomInternalMsg }
 import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
 import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
-import org.bigbluebutton.core.models.Pads
+import org.bigbluebutton.core.db.{ PresPresentationDAO }
+import org.bigbluebutton.core.models.{ Pads, PresentationInPod, PresentationPage, PresentationPod }
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 
 trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
@@ -22,32 +23,44 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
     }
 
     if (liveMeeting.props.breakoutProps.captureNotes) {
-      for {
-        group <- Pads.getGroup(liveMeeting.pads, "notes")
-      } yield {
-        val filename = liveMeeting.props.breakoutProps.captureNotesFilename
-        val userId: String = "system"
-        val jobId: String = s"${msg.breakoutId}-notes" // Used as the temporaryPresentationId upon upload
-        val presentationId = PresentationPodsApp.generatePresentationId(filename)
-
-        if (group.rev > 0) {
-          //Request upload of the sharedNotes of breakoutRoom
-          val presentationUploadToken: String = PresentationPodsApp.generateToken("DEFAULT_PRESENTATION_POD", userId)
-          outGW.send(buildPresentationUploadTokenSysPubMsg(msg.parentId, userId, presentationUploadToken, filename, presentationId))
-
-          val exportJob = ExportJob(jobId, "PadCaptureJob", filename, filename, group.padId, "", allPages = true, List(), msg.parentId, presentationUploadToken)
-          val job = buildStoreExportJobInRedisSysMsg(exportJob, liveMeeting)
-          outGW.send(job)
-        } else {
-          // Notify that no content is available
-          val event = buildPresentationConversionUpdateEvtMsg(msg.parentId, presentationId, filename, jobId)
-          outGW.send(event)
-        }
-      }
+      handleCaptureNotes(msg)
     }
 
     log.info("Breakout room {} ended by parent meeting {}.", msg.breakoutId, msg.parentId)
     sendEndMeetingDueToExpiry(msg.reason, eventBus, outGW, liveMeeting, "system")
+  }
+
+  def handleCaptureNotes(msg: EndBreakoutRoomInternalMsg) {
+    for {
+      group <- Pads.getGroup(liveMeeting.pads, "notes")
+    } yield {
+      val filename = liveMeeting.props.breakoutProps.captureNotesFilename
+      val userId: String = "system"
+      val jobId: String = s"${msg.breakoutId}-notes" // Used as the temporaryPresentationId upon upload
+      val presentationId = PresentationPodsApp.generatePresentationId(filename)
+
+      var pres = new PresentationInPod(presentationId, default = false, current = false, name = filename,
+        pages = Map.empty, downloadable = false, downloadFileExtension = "", removable = true, filenameConverted = filename,
+        uploadCompleted = false, numPages = 0, errorMsgKey = "", errorDetails = Map.empty)
+
+      if (group.rev > 0) {
+        //Request upload of the sharedNotes of breakoutRoom
+        val presentationUploadToken: String = PresentationPodsApp.generateToken("DEFAULT_PRESENTATION_POD", userId)
+        outGW.send(buildPresentationUploadTokenSysPubMsg(msg.parentId, userId, presentationUploadToken, filename, presentationId))
+
+        val exportJob = ExportJob(jobId, "PadCaptureJob", filename, filename, group.padId, "", allPages = true, List(), msg.parentId, presentationUploadToken)
+        val job = buildStoreExportJobInRedisSysMsg(exportJob, liveMeeting)
+        outGW.send(job)
+      } else {
+        pres = pres.copy(errorMsgKey = "204")
+
+        val event = buildPresentationConversionUpdateEvtMsg(msg.parentId, presentationId, filename, jobId)
+        outGW.send(event)
+      }
+
+      PresPresentationDAO.updateConversionStarted(msg.parentId, pres)
+
+    }
   }
 
   def buildStoreExportJobInRedisSysMsg(exportJob: ExportJob, liveMeeting: LiveMeeting): BbbCommonEnvCoreMsg = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -210,10 +210,15 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
     // Informs bbb-web about the token so that when we use it to upload the presentation, it is able to look it up in the list of tokens
     bus.outGW.send(buildPresentationUploadTokenSysPubMsg(parentMeetingId, userId, presentationUploadToken, filename, presentationId))
 
+    var pres = new PresentationInPod(presentationId, default = false, current = false, name = filename,
+      pages = Map.empty, downloadable = false, downloadFileExtension = "", removable = true, filenameConverted = filename,
+      uploadCompleted = false, numPages = 0, errorMsgKey = "", errorDetails = Map.empty)
+
     if (liveMeeting.props.meetingProp.disabledFeatures.contains("importPresentationWithAnnotationsFromBreakoutRooms")) {
       log.error(s"Capturing breakout rooms slides disabled in meeting ${meetingId}.")
     } else if (currentPres.isEmpty) {
       log.error(s"No presentation set in meeting ${meetingId}")
+      pres = pres.copy(errorMsgKey = "204")
       bus.outGW.send(buildBroadcastPresentationConversionUpdateEvtMsg(parentMeetingId, "204", jobId, filename, presentationUploadToken))
     } else {
       val allPages: Boolean = m.allPages
@@ -239,9 +244,13 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
         val annotations = new StoredAnnotations(jobId, presId, storeAnnotationPages)
         bus.outGW.send(buildStoreAnnotationsInRedisSysMsg(annotations, liveMeeting))
       } else {
+        pres = pres.copy(errorMsgKey = "204")
+
         // Notify that no content is available to capture
         bus.outGW.send(buildBroadcastPresentationConversionUpdateEvtMsg(parentMeetingId, "204", jobId, filename, presentationUploadToken))
       }
+
+      PresPresentationDAO.updateConversionStarted(parentMeetingId, pres)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionUpdatePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionUpdatePubMsgHdlr.scala
@@ -13,7 +13,12 @@ trait PresentationConversionUpdatePubMsgHdlr {
   def handle(msg: PresentationConversionUpdateSysPubMsg, state: MeetingState2x,
              liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
 
-    //    broadcastEvent(msg)
+    val presentationId = msg.body.presentationId
+    val pres = new PresentationInPod(presentationId, msg.body.presName, default = false, current = false, Map.empty, downloadable = false,
+      "", removable = true, filenameConverted = msg.body.presName, uploadCompleted = false, numPages = 0, errorDetails = Map.empty)
+
+    PresPresentationDAO.updateConversionStarted(liveMeeting.props.meetingProp.intId, pres)
+
     state
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
@@ -135,7 +135,9 @@ object PresPresentationDAO {
             p.removable,
             p.uploadInProgress,
             p.uploadCompleted,
-            p.totalPages))
+            p.totalPages,
+            p.uploadErrorMsgKey,
+            p.uploadErrorDetailsJson))
           .update(
             (presentation.name,
               presentation.filenameConverted,
@@ -148,7 +150,15 @@ object PresPresentationDAO {
               presentation.removable,
               !presentation.uploadCompleted,
               presentation.uploadCompleted,
-              presentation.numPages
+              presentation.numPages,
+              presentation.errorMsgKey match {
+                case "" => None
+                case error => Some(error)
+              },
+              presentation.errorDetails match {
+                case m if m.isEmpty => None
+                case m => Some(m.toJson)
+              },
             ))
       )
     }.onComplete {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
@@ -176,7 +176,7 @@ function renderPresentationItemStatus(item, intl) {
     return intl.formatMessage(errorMessage, constraint);
   }
 
-  if (('uploadErrorMsgKey' in item) && (item.uploadInProgress && item.uploadErrorMsgKey)) {
+  if (('uploadErrorMsgKey' in item) && item.uploadErrorMsgKey) {
     const errorMessage = intlMessages[item.uploadErrorMsgKey]
       || intlMessages.genericConversionStatus;
 


### PR DESCRIPTION
Following the refactor to shift several responsibilities from Meteor to Akka-apps, this PR introduces the following changes:

1. Presentations imported from breakout rooms, such as whiteboard or shared notes, will now be inserted into the database sooner. This allows for better tracking of the presentation's progress.

3. Presentations with errors, like "No content to capture," will also be inserted into the database. This provides presenters with clear feedback on why a presentation may not be available in a given room.

Future idea: Improve the error reporting mechanism during content import. Currently, inserting a placeholder presentation with an error message is a temporary solution copied from Meteor. This approach should be refined for better error handling in the future.