### PR TITLE
build: Update logrotate rule to add date extension to archived logs files

### DIFF
--- a/build/packages-template/bbb-record-core/bbb-record-core.logrotate
+++ b/build/packages-template/bbb-record-core/bbb-record-core.logrotate
@@ -1,5 +1,5 @@
-/var/log/bigbluebutton/bbb-rap-worker.log 
-/var/log/bigbluebutton/sanity.log 
+/var/log/bigbluebutton/bbb-rap-worker.log
+/var/log/bigbluebutton/sanity.log
 {
         weekly
         missingok
@@ -9,4 +9,6 @@
         nocreate
         notifempty
         sharedscripts
+        dateext
+        dateformat -%Y-%m-%d
 }

--- a/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.logrotate
+++ b/build/packages-template/bbb-webrtc-sfu/bbb-webrtc-sfu.logrotate
@@ -5,5 +5,6 @@
         compress
         notifempty
         copytruncate
+        dateext
+        dateformat -%Y-%m-%d
 }
-


### PR DESCRIPTION
### What does this PR do?

Add date to archived log filename.

### Motivation

Better readability for system administrators.

### More

- [ ] Need to do so for all BBB services.
