### PR TITLE
refactor: only send disable away mutation if user is away

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -58,7 +58,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
   const onClickCallback = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
 
-    if (muted) {
+    if (muted && away) {
       muteAway(muted, true, toggleVoice);
       VideoService.setTrackEnabled(true);
       setAway({

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -66,6 +66,7 @@ const propTypes = {
     NO_SSL: PropTypes.number.isRequired,
   }).isRequired,
   getTroubleshootingLink: PropTypes.func.isRequired,
+  away: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -73,6 +74,7 @@ const defaultProps = {
   outputDeviceId: null,
   resolve: null,
   joinFullAudioImmediately: false,
+  away: false,
 };
 
 const intlMessages = defineMessages({
@@ -190,6 +192,7 @@ const AudioModal = (props) => {
     priority,
     setIsOpen,
     getTroubleshootingLink,
+    away,
   } = props;
 
   const prevAutoplayBlocked = usePreviousValue(autoplayBlocked);
@@ -280,6 +283,8 @@ const AudioModal = (props) => {
   };
 
   const disableAwayMode = () => {
+    if (!away) return;
+
     muteAway(false, true, voiceToggle);
     setAway({
       variables: {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -17,8 +17,17 @@ import {
 import Storage from '/imports/ui/services/storage/session';
 import Service from '../service';
 import AudioModalService from '/imports/ui/components/audio/audio-modal/service';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
-const AudioModalContainer = (props) => <AudioModal {...props} />;
+const AudioModalContainer = (props) => {
+  const { data: currentUserData } = useCurrentUser((user) => ({
+    away: user.away,
+  }));
+
+  const away = currentUserData?.away;
+
+  return <AudioModal away={away} {...props} />;
+};
 
 const APP_CONFIG = window.meetingClientSettings.public.app;
 


### PR DESCRIPTION
### What does this PR do?

This pull request ensures that mutation calls for disabling away mode are only made when away mode is enabled.

### Motivation

Reduce workload on the server