### PR TITLE
fix(users-context): phantom user

### DIFF
--- a/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
+++ b/bigbluebutton-html5/imports/api/users-persistent-data/server/publishers.js
@@ -34,7 +34,10 @@ async function usersPersistentData() {
       meetingId,
       $or: [
         {
-          'shouldPersist.hasMessages': true,
+          'shouldPersist.hasMessages.public': true,
+        },
+        {
+          'shouldPersist.hasMessages.private': true,
         },
         {
           loggedOut: false,

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/adapter.jsx
@@ -56,6 +56,7 @@ const Adapter = () => {
         });
       },
       changed: (obj) => {
+        ChatLogger.debug('usersAdapter::observe::changed', obj);
         dispatch({
           type: ACTIONS.CHANGED,
           value: {

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
@@ -63,16 +63,13 @@ const reducer = (state, action) => {
 
       const { user } = action.value;
       if (state[user.meetingId] && state[user.meetingId][user.userId]) {
-        if (state[user.meetingId][user.userId].loggedOut) {
-          const newState = { ...state };
-          newState[user.meetingId][user.userId] = {
-            ...state[user.meetingId][user.userId],
-            loggedOut: false,
-          };
-  
-          return newState;  
-        }
-        return state;
+        const newState = { ...state };
+        newState[user.meetingId][user.userId] = {
+          ...state[user.meetingId][user.userId],
+          ...user,
+        };
+
+        return newState;
       }
 
       const newState = { ...state };

--- a/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/users-context/context.jsx
@@ -27,6 +27,7 @@ const reducer = (state, action) => {
     case ACTIONS.ADDED:
     case ACTIONS.CHANGED: {
       ChatLogger.debug('UsersContextProvider::reducer::added', { ...action });
+
       const { user } = action.value;
 
       const newState = { ...state };
@@ -53,11 +54,13 @@ const reducer = (state, action) => {
 
         return newState;
       }
-      return state;    
+      return state;
     }
 
     // USER PERSISTENT DATA
     case ACTIONS.ADDED_USER_PERSISTENT_DATA: {
+      ChatLogger.debug('UsersContextProvider::reducer::added_user_persistent_data', { ...action });
+
       const { user } = action.value;
       if (state[user.meetingId] && state[user.meetingId][user.userId]) {
         if (state[user.meetingId][user.userId].loggedOut) {
@@ -83,6 +86,8 @@ const reducer = (state, action) => {
       return newState;
     }
     case ACTIONS.CHANGED_USER_PERSISTENT_DATA: {
+      ChatLogger.debug('UsersContextProvider::reducer::changed_user_persistent_data', { ...action });
+
       const { user } = action.value;
       const stateUser = state[user.meetingId][user.userId];
       if (stateUser) {


### PR DESCRIPTION
### What does this PR do?

Fixes phantom user bug by changing the logic of the context action 'add_user_persistent_data' that was not correctly handling the transition of user roles. Some users were left with wrong logged out status because the context logic only updated its state when the added user was logged out.


### Closes Issue(s)
Closes #20251