### PR TITLE
Fix: external video skipping

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -515,10 +515,10 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const playerPlaybackRate = currentMeeting.externalVideo?.playerPlaybackRate ?? 1;
   const playerUpdatedAt = currentMeeting.externalVideo?.updatedAt ?? Date.now();
   const playerUpdatedAtDate = new Date(playerUpdatedAt);
-  const currentDate = new Date(Date.now() + timeSync);
+  const currentDate = new Date(Date.now() + (timeSync ?? 0));
   const isPaused = !currentMeeting.externalVideo?.playerPlaying ?? false;
-  const currentTime = isPaused ? playerCurrentTime : (((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
-    + playerCurrentTime) * playerPlaybackRate;
+  const currentTime = isPaused ? playerCurrentTime : ((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
+   + (playerCurrentTime) * playerPlaybackRate;
   const isPresenter = currentUser.presenter ?? false;
   const isGridLayout = currentMeeting.layout?.currentLayoutType === 'VIDEO_FOCUS';
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -333,7 +333,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     return true;
   };
 
-  const handleOnReady= () => {
+  const handleOnReady = () => {
     currentTime = -1;
   };
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -318,7 +318,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     setPlayed(state.played);
     setLoaded(state.loaded);
 
-    if (playing) {
+    if (playing && isPresenter) {
       currentTime = playerRef.current?.getCurrentTime() || 0;
     }
   };

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -333,6 +333,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     return true;
   };
 
+  const handleOnReady= () => {
+    currentTime = 0;
+    console.log('IM REEEEAAAAADY');
+  };
+
   return (
     <Styled.Container
       style={{
@@ -372,6 +377,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           width="100%"
           ref={playerRef}
           volume={volume}
+          onReady={handleOnReady}
           onPlay={handleOnPlay}
           onDuration={handleDuration}
           onProgress={(state: OnProgressProps) => {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -310,6 +310,19 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   };
 
+  const handleOnReady = () => {
+    currentTime = -1;
+  };
+
+  const handleProgress = (state: OnProgressProps) => {
+    setPlayed(state.played);
+    setLoaded(state.loaded);
+
+    if (playing) {
+      currentTime = playerRef.current?.getCurrentTime() || 0;
+    }
+  };
+
   const isMinimized = width === 0 && height === 0;
 
   // @ts-ignore accessing lib private property
@@ -331,10 +344,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       return false;
     }
     return true;
-  };
-
-  const handleOnReady = () => {
-    currentTime = -1;
   };
 
   return (
@@ -379,10 +388,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           onReady={handleOnReady}
           onPlay={handleOnPlay}
           onDuration={handleDuration}
-          onProgress={(state: OnProgressProps) => {
-            setPlayed(state.played);
-            setLoaded(state.loaded);
-          }}
+          onProgress={handleProgress}
           onPause={handleOnStop}
           onEnded={handleOnStop}
           muted={mute || isEchoTest}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -334,8 +334,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   };
 
   const handleOnReady= () => {
-    currentTime = 0;
-    console.log('IM REEEEAAAAADY');
+    currentTime = -1;
   };
 
   return (


### PR DESCRIPTION
### What does this PR do?

This PR fixes an error with the external video, where as soon as the user started and external video session, the video would skip forward, the amount of time the video would skip depends on the latency.

## Before fix:

[Screencast from 2024-05-15 10-25-50.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/3c538763-da1d-4437-8f5c-2a0d93cf72b8)

## After fix:

[Screencast from 2024-05-15 10-18-48.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/dcf9f2a8-f1e1-48e9-a2cf-c0999fb718b6)



