### PR TITLE
Fix: timer panel remains open when the feature is deactivated

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -456,7 +456,6 @@ const TimerPanelContaier: React.FC = () => {
       accumulated={timer.accumulated}
       active={timer.active ?? false}
       time={timer.time}
-      endedOn={timer.endedOn}
       startedOn={timer.startedOn}
       startedAt={timer.startedAt}
     />

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -114,6 +114,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
   running,
   timePassed,
   startedOn,
+  active,
 }) => {
   const [timerReset] = useMutation(TIMER_RESET);
   const [timerStart] = useMutation(TIMER_START);
@@ -240,6 +241,12 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
       return prev;
     });
   }, [timePassed, stopwatch, startedOn]);
+
+  useEffect(() => {
+    if (!active) {
+      closePanel();
+    }
+  }, [active]);
 
   const timerControls = useMemo(() => {
     const timeFormatedString = humanizeSeconds(Math.floor(time / 1000));

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/timer.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/timer.ts
@@ -8,7 +8,6 @@ export interface TimerData {
   stopwatch: boolean;
   running: boolean;
   startedOn: number;
-  endedOn: number;
   startedAt: string;
 }
 
@@ -27,7 +26,6 @@ export const GET_TIMER = gql`
       running
       startedOn
       startedAt
-      endedOn
     }
   }
 `;


### PR DESCRIPTION
### What does this PR do?

Removes obsolete property `endedOn` and closes timer panel when feature is deactivated.

### Closes Issue(s)
Closes #20259