### PR TITLE
fix(whiteboard): Slide Navigation Crash and Event Listener Update

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -385,15 +385,15 @@ const PresentationMenu = (props) => {
       },
     );
 
-    if (props.amIPresenter) {
-      menuItems.push({
-        key: 'list-item-load-shapes',
-        dataTest: 'loadShapes',
-        label: 'Load .tldr Data',
-        icon: 'pen_tool',
-        onClick: handleFileClick,
-      });
-    }
+    // if (props.amIPresenter) {
+    //   menuItems.push({
+    //     key: 'list-item-load-shapes',
+    //     dataTest: 'loadShapes',
+    //     label: 'Load .tldr Data',
+    //     icon: 'pen_tool',
+    //     onClick: handleFileClick,
+    //   });
+    // }
 
     presentationDropdownItems.forEach((item, index) => {
       switch (item.type) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -1,14 +1,14 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
-import PresentationToolbar from './component';
+import { useSubscription, useMutation } from '@apollo/client';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
 import { isPollingEnabled } from '/imports/ui/services/features';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
-import { useSubscription, useMutation } from '@apollo/client';
 import POLL_SUBSCRIPTION from '/imports/ui/core/graphql/queries/pollSubscription';
 import { POLL_CANCEL, POLL_CREATE } from '/imports/ui/components/poll/mutations';
 import { PRESENTATION_SET_PAGE } from '../mutations';
+import PresentationToolbar from './component';
 
 const PresentationToolbarContainer = (props) => {
   const pluginsContext = useContext(PluginsContext);
@@ -50,7 +50,7 @@ const PresentationToolbarContainer = (props) => {
   };
 
   const previousSlide = () => {
-    let prevSlideNum = currentSlideNum - 1;
+    const prevSlideNum = currentSlideNum - 1;
     if (prevSlideNum < 1) {
       return;
     }
@@ -58,7 +58,7 @@ const PresentationToolbarContainer = (props) => {
   };
 
   const nextSlide = () => {
-    let nextSlideNum = currentSlideNum + 1;
+    const nextSlideNum = currentSlideNum + 1;
     if (nextSlideNum > numberOfSlides) {
       return;
     }
@@ -107,18 +107,14 @@ const PresentationToolbarContainer = (props) => {
   return null;
 };
 
-export default withTracker(() => {
-  return {
-    isMeteorConnected: Meteor.status().connected,
-    isPollingEnabled: isPollingEnabled(),
-  };
-})(PresentationToolbarContainer);
+export default withTracker(() => ({
+  isMeteorConnected: Meteor.status().connected,
+  isPollingEnabled: isPollingEnabled(),
+}))(PresentationToolbarContainer);
 
 PresentationToolbarContainer.propTypes = {
   // Number of current slide being displayed
   currentSlideNum: PropTypes.number.isRequired,
-  zoom: PropTypes.number.isRequired,
-  zoomChanger: PropTypes.func.isRequired,
 
   // Total number of slides in this presentation
   numberOfSlides: PropTypes.number.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -19,6 +19,7 @@ const PresentationToolbarContainer = (props) => {
     layoutSwapped,
     currentSlideNum,
     presentationId,
+    numberOfSlides,
   } = props;
 
   const { data: pollData } = useSubscription(POLL_SUBSCRIPTION);
@@ -49,12 +50,18 @@ const PresentationToolbarContainer = (props) => {
   };
 
   const previousSlide = () => {
-    const prevSlideNum = currentSlideNum - 1;
+    let prevSlideNum = currentSlideNum - 1;
+    if (prevSlideNum < 1) {
+      return;
+    }
     skipToSlide(prevSlideNum);
   };
 
   const nextSlide = () => {
-    const nextSlideNum = currentSlideNum + 1;
+    let nextSlideNum = currentSlideNum + 1;
+    if (nextSlideNum > numberOfSlides) {
+      return;
+    }
     skipToSlide(nextSlideNum);
   };
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -632,7 +632,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
     const handleArrowPress = (event) => {
       const currPageNum = parseInt(curPageIdRef.current);
-      const shapeSelected = tlEditorRef.current.selectedShapes.length > 0;
+      const shapeSelected = tlEditorRef.current.getSelectedShapes()?.length > 0;
       const changeSlide = (direction) => {
         if (!currentPresentationPage) return;
         let newSlideNum = currPageNum + direction;
@@ -671,7 +671,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
       if (
         (undoCondition || redoCondition) &&
-        (isPresenter || hasWBAccessRef.current)
+        (isPresenterRef.current || hasWBAccessRef.current)
       ) {
         event.preventDefault();
         event.stopPropagation();
@@ -687,7 +687,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       if (
         (event.keyCode === KEY_CODES.ARROW_RIGHT ||
           event.keyCode === KEY_CODES.ARROW_LEFT) &&
-        isPresenter
+        isPresenterRef.current
       ) {
         handleArrowPress(event);
       }


### PR DESCRIPTION
### What does this PR do?
This PR fixes two issues (1) it prevents the whiteboard disappearing when using the left arrow key at the start of the slides or the right arrow key at the end, and (2) it ensures that the event listener for slide navigation via arrow keys works without needing to click the presentation toolbar.

### Closes Issue(s)
Closes #20278 