### PR TITLE
fix: Timer stops updating if you select music

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
@@ -6,7 +6,7 @@ object TimerModel {
       stopwatch:      Boolean = true,
       time:           Int = 0,
       accumulated:    Int = 0,
-      track:          String = "track",
+      track:          String = "noTrack",
   ): Unit = {
     model.stopwatch = stopwatch
     model.time = time

--- a/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
@@ -77,7 +77,6 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
     }
 
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
       if (music.current) music.current.pause();
     };
   }, [songTrack]);
@@ -110,6 +109,10 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
     } else if (!running) {
       clearInterval(intervalRef.current);
     }
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
   }, [running]);
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

- Adjusts default value for timer music
- Fix issue with timer indicator stopping when timer music is changed

### Closes Issue(s)
Closes #20258