### PR TITLE
fix(whiteboard): Prevent Overlap Of Presentation Toolbar And Tldraw Context Menu

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -92,6 +92,7 @@ class Dropdown extends Component {
     this.handleToggle = this.handleToggle.bind(this);
     this.handleWindowClick = this.handleWindowClick.bind(this);
     this.updateOrientation = this.updateOrientation.bind(this);
+    this.updateZIndex = this.updateZIndex.bind(this);
   }
 
   componentDidMount() {
@@ -127,18 +128,9 @@ class Dropdown extends Component {
     window.removeEventListener('resize', this.updateOrientation);
   }
 
-  handleHide() {
-    Session.set('dropdownOpen', false);
-    const { onHide } = this.props;
-    this.setState({ isOpen: false }, () => {
-      const { removeEventListener } = window;
-      onHide();
-      removeEventListener('click', this.handleWindowClick, true);
-    });
-  }
-
   handleShow() {
     Session.set('dropdownOpen', true);
+    this.updateZIndex(0);
     const {
       onShow,
     } = this.props;
@@ -146,6 +138,17 @@ class Dropdown extends Component {
       const { addEventListener } = window;
       onShow();
       addEventListener('click', this.handleWindowClick, true);
+    });
+  }
+
+  handleHide() {
+    Session.set('dropdownOpen', false);
+    this.updateZIndex(1);
+    const { onHide } = this.props;
+    this.setState({ isOpen: false }, () => {
+      const { removeEventListener } = window;
+      onHide();
+      removeEventListener('click', this.handleWindowClick, true);
     });
   }
 
@@ -192,6 +195,15 @@ class Dropdown extends Component {
 
   updateOrientation() {
     this.setState({ isPortrait: deviceInfo.isPortrait() });
+  }
+
+  updateZIndex(zIndex) {
+    if (this) {
+      const presentationInnerWrapper = document.getElementById('presentationInnerWrapper');
+      if (presentationInnerWrapper) {
+        presentationInnerWrapper.style.zIndex = zIndex;
+      }
+    }
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -91,12 +91,14 @@ class Dropdown extends Component {
     this.handleHide = this.handleHide.bind(this);
     this.handleToggle = this.handleToggle.bind(this);
     this.handleWindowClick = this.handleWindowClick.bind(this);
+    this.handleContextMenu = this.handleContextMenu.bind(this);
     this.updateOrientation = this.updateOrientation.bind(this);
     this.updateZIndex = this.updateZIndex.bind(this);
   }
 
   componentDidMount() {
     window.addEventListener('resize', this.updateOrientation);
+    window.addEventListener('contextmenu', this.handleContextMenu);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -126,6 +128,12 @@ class Dropdown extends Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateOrientation);
+    window.removeEventListener('contextmenu', this.handleContextMenu);
+  }
+
+  handleContextMenu(event) {
+    event.preventDefault();
+    this.handleHide();
   }
 
   handleShow() {

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.js
@@ -160,7 +160,7 @@ const PresentationToolbar = styled.div`
   order: 2;
   position: absolute;
   bottom: 0;
-  z-index: 2;
+  z-index: 0;
 `;
 
 const ToastSeparator = styled(ToastStyled.Separator)``;


### PR DESCRIPTION
### What does this PR do?
This PR fixes the overlap issue between the presentation toolbar and the tldraw context menu when opened with a right-click.

### Closes Issue(s)

Closes #20281 