### PR TITLE
fix: Breakouts' settings incorrect when going to Manage users modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -380,6 +380,8 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   }, [isBreakoutRecordable]);
 
   const form = useMemo(() => {
+    if (isUpdate) return null;
+
     return (
       <React.Fragment key="breakout-form">
         <Styled.BreakoutSettings>


### PR DESCRIPTION
### What does this PR do?

Do not display breakout settings when moving users

![Screenshot from 2024-05-17 10-33-31](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/07ae01eb-6d8b-445e-9f7b-e5f576b5f363)


### Closes Issue(s)
Closes #20266