### PR TITLE
Handling Validations and Error Reporting in bbb-graphql-actions (was in Hasura)

### DIFF
--- a/bbb-graphql-actions/src/actions/allUsersClearEmoji.ts
+++ b/bbb-graphql-actions/src/actions/allUsersClearEmoji.ts
@@ -17,7 +17,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   };
 
   const body = {
-    userId: input.userId
+    userId: routing.userId
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-actions/src/actions/allUsersClearReaction.ts
+++ b/bbb-graphql-actions/src/actions/allUsersClearReaction.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = `ClearAllUsersReactionCmdMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
@@ -1,9 +1,40 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
+import {ValidationError} from "../types/ValidationError";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
   const eventName = 'CreateBreakoutRoomsCmdMsg';
+
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'record', type: 'boolean', required: true},
+        {name: 'captureNotes', type: 'boolean', required: true},
+        {name: 'captureSlides', type: 'boolean', required: true},
+        {name: 'durationInMinutes', type: 'int', required: true},
+        {name: 'sendInviteToModerators', type: 'boolean', required: true},
+        {name: 'rooms', type: 'objectArray', required: true},
+      ]
+  )
+
+    const breakoutRooms = input['rooms'] as Array<Record<string, unknown>>;
+    if(breakoutRooms.length < 2) {
+        throw new ValidationError('It is required to set two or more rooms.', 400);
+    }
+
+  throwErrorIfInvalidInput(breakoutRooms[0],
+      [
+        {name: 'captureNotesFilename', type: 'string', required: true},
+        {name: 'captureSlidesFilename', type: 'string', required: true},
+        {name: 'freeJoin', type: 'boolean', required: true},
+        {name: 'isDefaultName', type: 'boolean', required: true},
+        {name: 'name', type: 'string', required: true},
+        {name: 'sequence', type: 'int', required: true},
+        {name: 'shortName', type: 'string', required: true},
+        {name: 'users', type: 'stringArray', required: true},
+      ]
+  )
+
 
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,

--- a/bbb-graphql-actions/src/actions/breakoutRoomEndAll.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomEndAll.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = 'EndAllBreakoutRoomsMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/breakoutRoomMoveUser.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomMoveUser.ts
@@ -1,8 +1,17 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'fromBreakoutRoomId', type: 'string', required: true},
+        {name: 'toBreakoutRoomId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'ChangeUserBreakoutReqMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/breakoutRoomRequestJoinUrl.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomRequestJoinUrl.ts
@@ -1,7 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   const eventName = 'RequestBreakoutJoinURLReqMsg';
+
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'breakoutRoomId', type: 'string', required: true},
+      ]
+  )
 
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,

--- a/bbb-graphql-actions/src/actions/breakoutRoomSendMessageToAll.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomSendMessageToAll.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'message', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'SendMessageToAllBreakoutRoomsReqMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/breakoutRoomSetTime.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomSetTime.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'timeInMinutes', type: 'int', required: true},
+      ]
+  )
+
   const eventName = 'UpdateBreakoutRoomsTimeReqMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/cameraBroadcastStart.ts
+++ b/bbb-graphql-actions/src/actions/cameraBroadcastStart.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'stream', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `UserBroadcastCamStartMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/cameraBroadcastStop.ts
+++ b/bbb-graphql-actions/src/actions/cameraBroadcastStop.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'stream', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `UserBroadcastCamStopMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/captionSetOwner.ts
+++ b/bbb-graphql-actions/src/actions/captionSetOwner.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'locale', type: 'string', required: true},
+        {name: 'ownerUserId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `UpdateCaptionOwnerPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/captionSubmitText.ts
+++ b/bbb-graphql-actions/src/actions/captionSubmitText.ts
@@ -1,6 +1,19 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'transcriptId', type: 'string', required: true},
+        {name: 'start', type: 'int', required: true},
+        {name: 'end', type: 'int', required: true},
+        {name: 'text', type: 'string', required: true},
+        {name: 'transcript', type: 'string', required: true},
+        {name: 'locale', type: 'string', required: true},
+        {name: 'isFinal', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `UpdateTranscriptPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/chatCreateWithUser.ts
+++ b/bbb-graphql-actions/src/actions/chatCreateWithUser.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `CreateGroupChatReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/chatPublicClearHistory.ts
+++ b/bbb-graphql-actions/src/actions/chatPublicClearHistory.ts
@@ -1,8 +1,9 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = `ClearPublicChatHistoryPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/chatRemove.ts
+++ b/bbb-graphql-actions/src/actions/chatRemove.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'chatId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `DestroyGroupChatReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/chatSendMessage.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessage.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
-  const eventName = `SendGroupChatMessageMsg`;
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'chatMessageInMarkdownFormat', type: 'string', required: true},
+        {name: 'chatId', type: 'string', required: true},
+      ]
+  )
 
+  const eventName = `SendGroupChatMessageMsg`;
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,
     userId: sessionVariables['x-hasura-userid'] as String

--- a/bbb-graphql-actions/src/actions/chatSetTyping.ts
+++ b/bbb-graphql-actions/src/actions/chatSetTyping.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'chatId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `UserTypingPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/externalVideoStart.ts
+++ b/bbb-graphql-actions/src/actions/externalVideoStart.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'externalVideoUrl', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `StartExternalVideoPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/externalVideoStop.ts
+++ b/bbb-graphql-actions/src/actions/externalVideoStop.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+
   const eventName = `StopExternalVideoPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/externalVideoUpdate.ts
+++ b/bbb-graphql-actions/src/actions/externalVideoUpdate.ts
@@ -1,8 +1,17 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'status', type: 'string', required: true},
+        {name: 'rate', type: 'number', required: true},
+        {name: 'time', type: 'number', required: true},
+        {name: 'state', type: 'number', required: true},
+      ]
+  )
+
   const eventName = `UpdateExternalVideoPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/guestUsersSetLobbyMessage.ts
+++ b/bbb-graphql-actions/src/actions/guestUsersSetLobbyMessage.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'message', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'SetGuestLobbyMessageCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/guestUsersSetLobbyMessagePrivate.ts
+++ b/bbb-graphql-actions/src/actions/guestUsersSetLobbyMessagePrivate.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'guestId', type: 'string', required: true},
+        {name: 'message', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'SetPrivateGuestLobbyMessageCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/guestUsersSetPolicy.ts
+++ b/bbb-graphql-actions/src/actions/guestUsersSetPolicy.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'guestPolicy', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'SetGuestPolicyCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/guestUsersSubmitApprovalStatus.ts
+++ b/bbb-graphql-actions/src/actions/guestUsersSubmitApprovalStatus.ts
@@ -1,8 +1,24 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'guests', type: 'objectArray', required: true},
+      ]
+  )
+
+  const guests = input['guests'] as Array<Record<string, unknown>>;
+  if(guests.length > 0) {
+    throwErrorIfInvalidInput(guests[0],
+        [
+          {name: 'guest', type: 'string', required: true},
+          {name: 'status', type: 'string', required: true},
+        ]
+    )
+  }
+
   const eventName = 'GuestsWaitingApprovedMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/meetingEnd.ts
+++ b/bbb-graphql-actions/src/actions/meetingEnd.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = 'LogoutAndEndMeetingCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/meetingLayoutSetProps.ts
+++ b/bbb-graphql-actions/src/actions/meetingLayoutSetProps.ts
@@ -1,8 +1,20 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'layout', type: 'string', required: true},
+        {name: 'syncWithPresenterLayout', type: 'boolean', required: true},
+        {name: 'presentationIsOpen', type: 'boolean', required: true},
+        {name: 'isResizing', type: 'boolean', required: true},
+        {name: 'cameraPosition', type: 'string', required: false},
+        {name: 'focusedCamera', type: 'string', required: true},
+        {name: 'presentationVideoRate', type: 'number', required: true},
+      ]
+  )
+
   const eventName = 'BroadcastLayoutMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/meetingLayoutSetSyncWithPresenterLayout.ts
+++ b/bbb-graphql-actions/src/actions/meetingLayoutSetSyncWithPresenterLayout.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'syncWithPresenterLayout', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = 'BroadcastPushLayoutMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/meetingLockSettingsSetProps.ts
+++ b/bbb-graphql-actions/src/actions/meetingLockSettingsSetProps.ts
@@ -1,8 +1,23 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'disableCam', type: 'boolean', required: true},
+        {name: 'disableMic', type: 'boolean', required: true},
+        {name: 'disablePrivChat', type: 'boolean', required: true},
+        {name: 'disablePubChat', type: 'boolean', required: true},
+        {name: 'disableNotes', type: 'boolean', required: true},
+        {name: 'hideUserList', type: 'boolean', required: true},
+        {name: 'lockOnJoin', type: 'boolean', required: true},
+        {name: 'lockOnJoinConfigurable', type: 'boolean', required: true},
+        {name: 'hideViewersCursor', type: 'boolean', required: true},
+        {name: 'hideViewersAnnotation', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = 'ChangeLockSettingsInMeetingCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/meetingRecordingSetStatus.ts
+++ b/bbb-graphql-actions/src/actions/meetingRecordingSetStatus.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'recording', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = 'SetRecordingStatusCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/meetingSetMuted.ts
+++ b/bbb-graphql-actions/src/actions/meetingSetMuted.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'muted', type: 'boolean', required: true},
+        {name: 'exceptPresenter', type: 'boolean', required: false},
+      ]
+  )
+
   const eventName =
       (input.exceptPresenter || false) ?
       'MuteAllExceptPresentersCmdMsg' :

--- a/bbb-graphql-actions/src/actions/meetingSetWebcamOnlyForModerator.ts
+++ b/bbb-graphql-actions/src/actions/meetingSetWebcamOnlyForModerator.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'webcamsOnlyForModerator', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = 'UpdateWebcamsOnlyForModeratorCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pluginDataChannelDeleteEntry.ts
+++ b/bbb-graphql-actions/src/actions/pluginDataChannelDeleteEntry.ts
@@ -1,6 +1,16 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pluginName', type: 'string', required: true},
+        {name: 'channelName', type: 'string', required: true},
+        {name: 'subChannelName', type: 'string', required: true},
+        {name: 'entryId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `PluginDataChannelDeleteMessageMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pluginDataChannelPushEntry.ts
+++ b/bbb-graphql-actions/src/actions/pluginDataChannelPushEntry.ts
@@ -1,7 +1,19 @@
 import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+    throwErrorIfInvalidInput(input,
+        [
+            {name: 'pluginName', type: 'string', required: true},
+            {name: 'subChannelName', type: 'string', required: true},
+            {name: 'channelName', type: 'string', required: true},
+            {name: 'payloadJson', type: 'json', required: true},
+            {name: 'toRoles', type: 'stringArray', required: true},
+            {name: 'toUserIds', type: 'stringArray', required: true},
+        ]
+    )
+
   const eventName = `PluginDataChannelPushEntryMsg`;
 
   const routing = {
@@ -14,12 +26,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     meetingId: routing.meetingId,
     userId: routing.userId
   };
-
-  try {
-    JSON.parse(<string>input.payloadJson);
-  } catch (e) {
-    throw new ValidationError('Field `payloadJson` contains an invalid Json.', 400);
-  }
 
   const body = {
     pluginName: input.pluginName,

--- a/bbb-graphql-actions/src/actions/pluginDataChannelReset.ts
+++ b/bbb-graphql-actions/src/actions/pluginDataChannelReset.ts
@@ -1,6 +1,15 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pluginName', type: 'string', required: true},
+        {name: 'channelName', type: 'string', required: true},
+        {name: 'subChannelName', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `PluginDataChannelResetMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pollCancel.ts
+++ b/bbb-graphql-actions/src/actions/pollCancel.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+
   const eventName = `StopPollReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pollCreate.ts
+++ b/bbb-graphql-actions/src/actions/pollCreate.ts
@@ -1,9 +1,20 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 import {ValidationError} from "../types/ValidationError";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pollId', type: 'string', required: true},
+        {name: 'pollType', type: 'string', required: true},
+        {name: 'secretPoll', type: 'boolean', required: true},
+        {name: 'question', type: 'string', required: true},
+        {name: 'isMultipleResponse', type: 'boolean', required: true},
+        {name: 'answers', type: 'stringArray', required: false},
+      ]
+  )
+
   const eventName = input.pollType === 'CUSTOM' ? `StartCustomPollReqMsg` : `StartPollReqMsg`
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pollPublishResult.ts
+++ b/bbb-graphql-actions/src/actions/pollPublishResult.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pollId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `ShowPollResultReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pollSubmitUserTypedVote.ts
+++ b/bbb-graphql-actions/src/actions/pollSubmitUserTypedVote.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pollId', type: 'string', required: true},
+        {name: 'answer', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `RespondToTypedPollReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/pollSubmitUserVote.ts
+++ b/bbb-graphql-actions/src/actions/pollSubmitUserVote.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pollId', type: 'string', required: true},
+        {name: 'answerIds', type: 'intArray', required: true},
+      ]
+  )
+
   const eventName = `RespondToPollReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presAnnotationDelete.ts
+++ b/bbb-graphql-actions/src/actions/presAnnotationDelete.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pageId', type: 'string', required: true},
+        {name: 'annotationsIds', type: 'stringArray', required: true},
+      ]
+  )
+
   const eventName = `DeleteWhiteboardAnnotationsPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presAnnotationDeleteAll.ts
+++ b/bbb-graphql-actions/src/actions/presAnnotationDeleteAll.ts
@@ -1,7 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
-    const eventName = `DeleteWhiteboardAnnotationsPubMsg`;
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pageId', type: 'string', required: true},
+      ]
+  )
+
+  const eventName = `DeleteWhiteboardAnnotationsPubMsg`;
 
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,

--- a/bbb-graphql-actions/src/actions/presAnnotationSubmit.ts
+++ b/bbb-graphql-actions/src/actions/presAnnotationSubmit.ts
@@ -1,7 +1,15 @@
 import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pageId', type: 'string', required: true},
+        {name: 'annotations', type: 'jsonArray', required: true},
+      ]
+  )
+
   const eventName = `SendWhiteboardAnnotationsPubMsg`;
 
   const routing = {
@@ -14,10 +22,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     meetingId: routing.meetingId,
     userId: routing.userId
   };
-
-  if(typeof input.annotations !== 'object' || !Array.isArray(input.annotations)) {
-    throw new ValidationError('Field `annotations` contains an invalid Json Array.', 400);
-  }
 
   const body = {
     whiteboardId: input.pageId,

--- a/bbb-graphql-actions/src/actions/presentationExport.ts
+++ b/bbb-graphql-actions/src/actions/presentationExport.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+        {name: 'fileStateType', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `MakePresentationDownloadReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationPublishCursor.ts
+++ b/bbb-graphql-actions/src/actions/presentationPublishCursor.ts
@@ -1,6 +1,15 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'whiteboardId', type: 'string', required: true},
+        {name: 'xPercent', type: 'number', required: true},
+        {name: 'yPercent', type: 'number', required: true},
+      ]
+  )
+
   const eventName = `SendCursorPositionPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationRemove.ts
+++ b/bbb-graphql-actions/src/actions/presentationRemove.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+      ]
+  )
+
   throwErrorIfNotPresenter(sessionVariables);
   const eventName = `RemovePresentationPubMsg`;
 

--- a/bbb-graphql-actions/src/actions/presentationRequestUploadToken.ts
+++ b/bbb-graphql-actions/src/actions/presentationRequestUploadToken.ts
@@ -1,9 +1,16 @@
 import { RedisMessage } from '../types';
-import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'podId', type: 'string', required: true},
+        {name: 'filename', type: 'string', required: true},
+        {name: 'uploadTemporaryId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `PresentationUploadTokenReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationSetCurrent.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetCurrent.ts
@@ -1,9 +1,15 @@
 import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `SetCurrentPresentationPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationSetDownloadable.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetDownloadable.ts
@@ -1,8 +1,16 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+        {name: 'downloadable', type: 'boolean', required: true},
+        {name: 'fileStateType', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `SetPresentationDownloadablePubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationSetPage.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetPage.ts
@@ -1,9 +1,16 @@
 import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+        {name: 'pageId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `SetCurrentPagePubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationSetRenderedInToast.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetRenderedInToast.ts
@@ -1,9 +1,14 @@
 import { RedisMessage } from '../types';
-import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `SetPresentationRenderedInToastPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationSetWriters.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetWriters.ts
@@ -1,9 +1,16 @@
 import { RedisMessage } from '../types';
 import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'pageId', type: 'string', required: true},
+        {name: 'usersIds', type: 'stringArray', required: true},
+      ]
+  )
+
   const eventName = `ModifyWhiteboardAccessPubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/presentationSetZoom.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetZoom.ts
@@ -1,9 +1,20 @@
 import { RedisMessage } from '../types';
-import { ValidationError } from '../types/ValidationError';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'presentationId', type: 'string', required: true},
+        {name: 'pageId', type: 'string', required: true},
+        {name: 'pageNum', type: 'int', required: true},
+        {name: 'xOffset', type: 'number', required: true},
+        {name: 'yOffset', type: 'number', required: true},
+        {name: 'widthRatio', type: 'number', required: true},
+        {name: 'heightRatio', type: 'number', required: true},
+      ]
+  )
+
   const eventName = `ResizeAndMovePagePubMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/sharedNotesCreateSession.ts
+++ b/bbb-graphql-actions/src/actions/sharedNotesCreateSession.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'sharedNotesExtId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `PadCreateSessionReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/sharedNotesSetPinned.ts
+++ b/bbb-graphql-actions/src/actions/sharedNotesSetPinned.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotPresenter} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'sharedNotesExtId', type: 'string', required: true},
+        {name: 'pinned', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `PadPinnedReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerActivate.ts
+++ b/bbb-graphql-actions/src/actions/timerActivate.ts
@@ -1,8 +1,17 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'stopwatch', type: 'boolean', required: true},
+        {name: 'running', type: 'boolean', required: true},
+        {name: 'time', type: 'int', required: true},
+        {name: 'track', type: 'string', required: false},
+      ]
+  )
+
   const eventName = `ActivateTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerDeactivate.ts
+++ b/bbb-graphql-actions/src/actions/timerDeactivate.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = `DeactivateTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerReset.ts
+++ b/bbb-graphql-actions/src/actions/timerReset.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = `ResetTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerSetSongTrack.ts
+++ b/bbb-graphql-actions/src/actions/timerSetSongTrack.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'track', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `SetTrackReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerSetTime.ts
+++ b/bbb-graphql-actions/src/actions/timerSetTime.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'time', type: 'int', required: true},
+      ]
+  )
+
   const eventName = `SetTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerStart.ts
+++ b/bbb-graphql-actions/src/actions/timerStart.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = `StartTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerStop.ts
+++ b/bbb-graphql-actions/src/actions/timerStop.ts
@@ -3,6 +3,7 @@ import {throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+
   const eventName = `StopTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/timerSwitchMode.ts
+++ b/bbb-graphql-actions/src/actions/timerSwitchMode.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'stopwatch', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `SwitchTimerReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userEjectCameras.ts
+++ b/bbb-graphql-actions/src/actions/userEjectCameras.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'EjectUserCamerasCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userEjectFromMeeting.ts
+++ b/bbb-graphql-actions/src/actions/userEjectFromMeeting.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'banUser', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `EjectUserFromMeetingCmdMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userEjectFromVoice.ts
+++ b/bbb-graphql-actions/src/actions/userEjectFromVoice.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'banUser', type: 'boolean', required: false},
+      ]
+  )
+
   const eventName = 'EjectUserFromVoiceCmdMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userJoinMeeting.ts
+++ b/bbb-graphql-actions/src/actions/userJoinMeeting.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'authToken', type: 'string', required: true},
+        {name: 'clientType', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `UserJoinMeetingReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetAway.ts
+++ b/bbb-graphql-actions/src/actions/userSetAway.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'away', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserAwayReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetCameraPinned.ts
+++ b/bbb-graphql-actions/src/actions/userSetCameraPinned.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'pinned', type: 'boolean', required: true},
+      ]
+  )
 
   const eventName = `ChangeUserPinStateReqMsg`;
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetConnectionAlive.ts
+++ b/bbb-graphql-actions/src/actions/userSetConnectionAlive.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'networkRttInMs', type: 'number', required: true},
+      ]
+  )
+
   const eventName = `UserConnectionAliveReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetEmojiStatus.ts
+++ b/bbb-graphql-actions/src/actions/userSetEmojiStatus.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'emoji', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserEmojiCmdMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetExitReason.ts
+++ b/bbb-graphql-actions/src/actions/userSetExitReason.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'exitReason', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserExitReasonCmdMsg`;
   //TODO Akka does not expect to receive this message
 

--- a/bbb-graphql-actions/src/actions/userSetLocked.ts
+++ b/bbb-graphql-actions/src/actions/userSetLocked.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'locked', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `LockUserInMeetingCmdMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetMobileFlag.ts
+++ b/bbb-graphql-actions/src/actions/userSetMobileFlag.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'mobile', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserMobileFlagReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetMuted.ts
+++ b/bbb-graphql-actions/src/actions/userSetMuted.ts
@@ -1,7 +1,14 @@
 import { RedisMessage } from '../types';
-import {isModerator} from "../imports/validation";
+import {isModerator, throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: false},
+        {name: 'muted', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `MuteUserCmdMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetPresenter.ts
+++ b/bbb-graphql-actions/src/actions/userSetPresenter.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `AssignPresenterReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetRaiseHand.ts
+++ b/bbb-graphql-actions/src/actions/userSetRaiseHand.ts
@@ -1,7 +1,14 @@
 import { RedisMessage } from '../types';
-import {isModerator, throwErrorIfNotModerator} from "../imports/validation";
+import {isModerator, throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: false},
+        {name: 'raiseHand', type: 'boolean', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserRaiseHandReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
+++ b/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
@@ -1,6 +1,13 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'reactionEmoji', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserReactionEmojiReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetRole.ts
+++ b/bbb-graphql-actions/src/actions/userSetRole.ts
@@ -1,8 +1,15 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'role', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `ChangeUserRoleCmdMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetSpeechLocale.ts
+++ b/bbb-graphql-actions/src/actions/userSetSpeechLocale.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'locale', type: 'string', required: true},
+        {name: 'provider', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `SetUserSpeechLocaleReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userThirdPartyInfoResquest.ts
+++ b/bbb-graphql-actions/src/actions/userThirdPartyInfoResquest.ts
@@ -1,8 +1,14 @@
 import { RedisMessage } from '../types';
-import {throwErrorIfNotModerator} from "../imports/validation";
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'externalUserId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = `LookUpUserReqMsg`;
 
   const routing = {

--- a/bbb-graphql-actions/src/actions/userTransferVoiceToMeeting.ts
+++ b/bbb-graphql-actions/src/actions/userTransferVoiceToMeeting.ts
@@ -1,6 +1,14 @@
 import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'fromMeetingId', type: 'string', required: true},
+        {name: 'toMeetingId', type: 'string', required: true},
+      ]
+  )
+
   const eventName = 'TransferUserToMeetingRequestMsg';
 
   const routing = {

--- a/bbb-graphql-actions/src/imports/validation.ts
+++ b/bbb-graphql-actions/src/imports/validation.ts
@@ -15,3 +15,109 @@ export const throwErrorIfNotPresenter = (sessionVariables: Record<string, unknow
 export const isModerator = (sessionVariables: Record<string, unknown>) => {
     return (sessionVariables['x-hasura-moderatorinmeeting'] !== "");
 };
+
+
+export type InputParam = {
+    name: string;
+    type: 'string' | 'number' | 'int' | 'boolean' | 'json' | 'jsonArray' | 'stringArray' | 'numberArray' | 'intArray' | 'objectArray';
+    required: boolean;
+};
+
+export const throwErrorIfInvalidInput = (input: Record<string, unknown>, expectedParams: InputParam[]) => {
+    for (const param of expectedParams) {
+        if (param.required && !(param.name in input)) {
+            throw new ValidationError(`Missing required parameter: '${param.name}'`, 403);
+        }
+
+        if (param.name in input) {
+            const value = input[param.name];
+
+            if (!param.required && value == null) {
+                //Param is null and it is not required
+                continue;
+            }
+
+            switch (param.type) {
+                case 'string':
+                    if (typeof value !== 'string') {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    break;
+                case 'number':
+                    if (typeof value !== 'number') {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    break;
+                case 'int':
+                    if (typeof value !== 'number' || !Number.isInteger(value)) {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    break;
+                case 'boolean':
+                    if (typeof value !== 'boolean') {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    break;
+                case 'json':
+                    if (typeof value !== 'object') {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    try {
+                        const jsonString = JSON.stringify(value);
+                        JSON.parse(jsonString);
+                    } catch (e) {
+                        throw new ValidationError(`Parameter '${param.name}' contains an invalid Json.`, 400);
+                    }
+                    break;
+                case 'jsonArray':
+                    if (typeof value !== 'object' || !Array.isArray(value)) {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    break;
+                case 'stringArray':
+                    if (typeof value !== 'object' || !Array.isArray(value)) {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    if(value.length > 0) {
+                        if (typeof value[0] !== 'string') {
+                            throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                        }
+                    }
+                    break;
+                case 'numberArray':
+                    if (typeof value !== 'object' || !Array.isArray(value)) {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    if(value.length > 0) {
+                        if (typeof value[0] !== 'number') {
+                            throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                        }
+                    }
+                    break;
+                case 'intArray':
+                    if (typeof value !== 'object' || !Array.isArray(value)) {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    if(value.length > 0) {
+                        if (typeof value[0] !== 'number' || !Number.isInteger(value[0])) {
+                            throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                        }
+                    }
+                    break;
+                case 'objectArray':
+                    if (typeof value !== 'object' || !Array.isArray(value)) {
+                        throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                    }
+                    if(value.length > 0) {
+                        if (typeof value[0] !== 'object') {
+                            throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
+                        }
+                    }
+                    break;
+                default:
+                    throw new ValidationError(`Unknown type for parameter '${param.name}'`, 400);
+            }
+        }
+    }
+    return true;
+}

--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -145,7 +145,7 @@ func SendGqlActionsRequest(funcName string, inputs map[string]interface{}, sessi
 	if response.StatusCode != 200 {
 		body, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			fmt.Println("Erro ao ler o corpo da resposta:", err)
+			fmt.Println("Error reading response body:", err)
 		}
 
 		var result map[string]interface{}

--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -143,8 +143,6 @@ func SendGqlActionsRequest(funcName string, inputs map[string]interface{}, sessi
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
-
-		// Lendo o corpo da resposta
 		body, err := ioutil.ReadAll(response.Body)
 		if err != nil {
 			fmt.Println("Erro ao ler o corpo da resposta:", err)
@@ -153,7 +151,6 @@ func SendGqlActionsRequest(funcName string, inputs map[string]interface{}, sessi
 		var result map[string]interface{}
 		err = json.Unmarshal(body, &result)
 		if err == nil {
-			// Verificando se a resposta contém a propriedade `message` e imprimindo-a, se existir
 			if message, ok := result["message"].(string); ok {
 				fmt.Println(message, err)
 				return fmt.Errorf("graphql actions request failed: %s", message)
@@ -161,7 +158,6 @@ func SendGqlActionsRequest(funcName string, inputs map[string]interface{}, sessi
 		}
 
 		return fmt.Errorf("graphql actions request failed: %s", response.Status)
-		//return fmt.Errorf("graphql actions request failed: %s", response.Body)
 	}
 
 	return nil

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -37,6 +37,7 @@ import Storage from '/imports/ui/services/storage/session';
 import { indexOf, without } from '/imports/utils/array-utils';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { throttle } from '/imports/utils/throttle';
+import logger from '/imports/startup/client/logger';
 
 // @ts-ignore - temporary, while meteor exists in the project
 const CHAT_CONFIG = window.meetingClientSettings.public.chat;
@@ -81,6 +82,9 @@ const messages = defineMessages({
   },
   errorMaxMessageLength: {
     id: 'app.chat.errorMaxMessageLength',
+  },
+  errorOnSendMessage: {
+    id: 'app.chat.errorOnSendMessage',
   },
   errorServerDisconnected: {
     id: 'app.chat.disconnected',
@@ -388,7 +392,12 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
       }
     });
 
-    if (chatSendMessageError) { return <div>something went wrong</div>; }
+    useEffect(() => {
+      if (chatSendMessageError && error == null) {
+        logger.debug('Error on sending chat message: ', chatSendMessageError?.message);
+        setError(intl.formatMessage(messages.errorOnSendMessage));
+      }
+    }, [chatSendMessageError]);
 
     return (
       <Styled.Form

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/container.jsx
@@ -28,7 +28,7 @@ const BreakoutRoomContainer = ({ breakoutRoom }) => {
   const {
     data: currentUser,
   } = useCurrentUser((u) => ({
-    isModerator: u.isModerator,
+    isModerator: u?.isModerator,
   }));
 
   if (userIsInvitedError) {
@@ -60,7 +60,7 @@ const BreakoutRoomContainer = ({ breakoutRoom }) => {
       layoutContextDispatch,
       sidebarContentPanel,
       hasBreakoutRoom: hasBreakoutRoom
-      && (userIsInvitedData.breakoutRoom.length > 0 || currentUser.isModerator),
+      && (userIsInvitedData.breakoutRoom.length > 0 || currentUser?.isModerator),
       breakoutRoom,
     }}
     />

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -4,6 +4,7 @@
     "app.chat.loading": "Chat messages loaded: {0}%",
     "app.chat.errorMaxMessageLength": "The message is too long, exceeded the maximum of {0} characters",
     "app.chat.errorMinMessageLength": "The message did not reach the minimum of {0} characters",
+    "app.chat.errorOnSendMessage": "Error on sending chat message",
     "app.chat.disconnected": "You are disconnected, messages can't be sent",
     "app.chat.locked": "Chat is locked, messages can't be sent",
     "app.chat.inputLabel": "Message input for chat {0}",


### PR DESCRIPTION
Since issue #20145, `mutation` requests no longer pass through Hasura. Consequently, `bbb-graphql-actions` is now responsible for performing all the validations (such as parameter types and required fields) that were previously handled by Hasura.

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/85dbc582-271b-4d7c-b5d8-5a5b46ee9aa5)

In case of an error, `bbb-graphql-actions` will return a message with the type `error`:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/dd2adb9a-a165-44b4-967a-7a5875885d95)

Additionally:
Errors when sending chat messages no longer block new messages. Instead, a generic error message will be displayed in the UI, and a detailed error message will be logged in the console:

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/05e122d4-b792-46a6-a564-dddff6c3d0db)
