### PR TITLE
fix: After locale change some menus show in the old locale

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -320,7 +320,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'learningDashboard',
       },
     ].filter(({ allow }) => allow);
-  }, [isModerator, hasBreakoutRooms, isMeetingMuted, locale]);
+  }, [isModerator, hasBreakoutRooms, isMeetingMuted, locale, intl]);
 
   const newLocal = 'true';
   return (


### PR DESCRIPTION
### What does this PR do?

Adjusts userlist options dropdown useMemo dependency array so it does not display incorrect locale when language is changed.

### Closes Issue(s)
Closes #20262