### PR TITLE
fix (akka-apps): Timer not resetting `accumulated` value properly

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
@@ -44,18 +44,36 @@ object TimerModel {
   }
 
   def setRunning(model: TimerModel, running: Boolean): Unit = {
+    val now = System.currentTimeMillis()
 
-    //If it is running and will stop, calculate new Accumulated
-    if(getRunning(model) && !running) {
-      val now = System.currentTimeMillis()
+    // If the timer is running and will stop, update accumulated time
+    if (isRunning(model) && !running) {
       val accumulated = getAccumulated(model) + Math.abs(now - getStartedAt(model)).toInt
-      this.setAccumulated(model, accumulated)
+      setAccumulated(model, accumulated)
     }
 
+    // If the timer is not running and will start, set the start time
+    if (!isRunning(model) && running) {
+      setStartedAt(model, now)
+    }
+
+    // Determine if the timer is finished
+    val isTimerFinished = running && !isStopwatch(model) && {
+      val currentTimerTime = model.startedAt + (model.time - model.accumulated)
+      currentTimerTime < now
+    }
+
+    // If the timer is finished, reset the accumulated time and start time if running
+    if (isTimerFinished) {
+      setAccumulated(model, 0)
+      if (running) setStartedAt(model, now)
+    }
+
+    // Update the running status of the model
     model.running = running
   }
 
-  def getRunning(model: TimerModel): Boolean = {
+  def isRunning(model: TimerModel): Boolean = {
     model.running
   }
 
@@ -63,7 +81,7 @@ object TimerModel {
     model.stopwatch = stopwatch
   }
 
-  def getStopwatch(model: TimerModel): Boolean = {
+  def isStopwatch(model: TimerModel): Boolean = {
     model.stopwatch
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StartTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StartTimerReqMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core.apps.timer
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.TimerModel.{ isRunning, isStopwatch }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait, TimerModel }
@@ -30,7 +31,11 @@ trait StartTimerReqMsgHdlr extends RightsManagementTrait {
       val reason = "You need to be the presenter or moderator to start timer"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      TimerModel.setStartedAt(liveMeeting.timerModel, System.currentTimeMillis())
+      //check if it is a resume or a new timer
+      //      if (isStopwatch(liveMeeting.timerModel)) {
+      //        if(isRunning(liveMeeting.timerModel))
+      //      }
+
       TimerModel.setRunning(liveMeeting.timerModel, running = true)
       TimerDAO.update(liveMeeting.props.meetingProp.intId, liveMeeting.timerModel)
       broadcastEvent()

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StartTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/StartTimerReqMsgHdlr.scala
@@ -31,11 +31,6 @@ trait StartTimerReqMsgHdlr extends RightsManagementTrait {
       val reason = "You need to be the presenter or moderator to start timer"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      //check if it is a resume or a new timer
-      //      if (isStopwatch(liveMeeting.timerModel)) {
-      //        if(isRunning(liveMeeting.timerModel))
-      //      }
-
       TimerModel.setRunning(liveMeeting.timerModel, running = true)
       TimerDAO.update(liveMeeting.props.meetingProp.intId, liveMeeting.timerModel)
       broadcastEvent()

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/SwitchTimerReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/timer/SwitchTimerReqMsgHdlr.scala
@@ -32,7 +32,7 @@ trait SwitchTimerReqMsgHdlr extends RightsManagementTrait {
       val reason = "You need to be the presenter or moderator to switch timer"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else {
-      if (TimerModel.getStopwatch(liveMeeting.timerModel) != msg.body.stopwatch) {
+      if (TimerModel.isStopwatch(liveMeeting.timerModel) != msg.body.stopwatch) {
         TimerModel.setStopwatch(liveMeeting.timerModel, msg.body.stopwatch)
         TimerModel.setRunning(liveMeeting.timerModel, running = false)
         TimerModel.reset(liveMeeting.timerModel) //Reset on switch Stopwatch/Timer

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -193,7 +193,7 @@ object BreakoutRoomDAO {
 //      TableQuery[BreakoutRoomDbTableDef]
 //        .filter(_.meetingId === meetingId)
 //        .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedAt, t.endedAt, t.songTrack))
-//        .update((getStopwatch(breakoutRoomModel), getRunning(breakoutRoomModel), getIsACtive(breakoutRoomModel), getTime(breakoutRoomModel), getAccumulated(breakoutRoomModel), getStartedAt(breakoutRoomModel), getEndedAt(breakoutRoomModel), getTrack(breakoutRoomModel))
+//        .update((isStopwatch(breakoutRoomModel), getRunning(breakoutRoomModel), getIsACtive(breakoutRoomModel), getTime(breakoutRoomModel), getAccumulated(breakoutRoomModel), getStartedAt(breakoutRoomModel), getEndedAt(breakoutRoomModel), getTrack(breakoutRoomModel))
 //        )
 //    ).onComplete {
 //      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on BreakoutRoom table!")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.db
 
 import org.bigbluebutton.core.apps.TimerModel
-import org.bigbluebutton.core.apps.TimerModel.{getAccumulated, getIsActive, getRunning, getStartedAt, getStopwatch, getTime, getTrack}
+import org.bigbluebutton.core.apps.TimerModel.{getAccumulated, getIsActive, isRunning, getStartedAt, isStopwatch, getTime, getTrack}
 import slick.jdbc.PostgresProfile.api._
 
 import scala.util.{Failure, Success}
@@ -36,8 +36,8 @@ object TimerDAO {
       TableQuery[TimerDbTableDef].insertOrUpdate(
         TimerDbModel(
           meetingId = meetingId,
-          stopwatch = getStopwatch(model),
-          running = getRunning(model),
+          stopwatch = isStopwatch(model),
+          running = isRunning(model),
           active = getIsActive(model),
           time = getTime(model),
           accumulated = getAccumulated(model),
@@ -57,7 +57,7 @@ object TimerDAO {
         .filter(_.meetingId === meetingId)
         .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedOn, t.songTrack))
         .update(
-          (getStopwatch(timerModel), getRunning(timerModel), getIsActive(timerModel), getTime(timerModel),
+          (isStopwatch(timerModel), isRunning(timerModel), getIsActive(timerModel), getTime(timerModel),
           getAccumulated(timerModel), getStartedAt(timerModel), getTrack(timerModel))
         )
     ).onComplete {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1568,7 +1568,8 @@ SELECT
      "stopwatch",
      case
         when "stopwatch" is true or "running" is false then "running"
-        when "startedAt" + (("time" - coalesce("accumulated",0)) * interval '1 milliseconds') >= current_timestamp then true else false
+        when "startedAt" + (("time" - coalesce("accumulated",0)) * interval '1 milliseconds') >= current_timestamp then true
+        else false
      end "running",
      "active",
      "time",


### PR DESCRIPTION
When the timer reaches the end, the `running` flag is set to `false`, but the `accumulated` time is not being reset correctly. This issue arises because the message indicating the end of the timer, which previously handled resetting the `accumulated` time, is no longer being sent.
Now `akka-apps` will check for this situation on the next "start" and reset it automatically.

Closes #20237