### PR TITLE
chore: Replace tldraw with @bigbluebutton/tldraw

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -12,8 +12,8 @@ import {
   InstancePresenceRecordType,
   setDefaultUiAssetUrls,
   setDefaultEditorAssetUrls,
-} from "@tldraw/tldraw";
-import "@tldraw/tldraw/tldraw.css";
+} from "@bigbluebutton/tldraw";
+import "@bigbluebutton/tldraw/tldraw.css";
 import SlideCalcUtil from "/imports/utils/slideCalcUtils";
 import { HUNDRED_PERCENT } from "/imports/utils/slideCalcUtils";
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -8,7 +8,7 @@ import React, {
 import { useSubscription, useMutation, useQuery } from '@apollo/client';
 import {
   AssetRecordType,
-} from '@tldraw/tldraw';
+} from '@bigbluebutton/tldraw';
 import { throttle } from 'radash';
 import {
   CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-tools/noop-tool/component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable lines-between-class-members */
-import { StateNode } from '@tldraw/tldraw';
+import { StateNode } from '@bigbluebutton/tldraw';
 
 export default class NoopTool extends StateNode {
    static override id = 'noop';

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -862,6 +862,116 @@
         }
       }
     },
+    "@bigbluebutton/editor": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/editor/-/editor-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-6G3ZkyybttB6J/BaWWKjYShPs+tJ3bMB0+zbvKVCN5o1Zou4g+cqzvfOcMWHqPunhBiglfQ97JIAXXQ+jl7CeA==",
+      "requires": {
+        "@bigbluebutton/state": "2.0.0-alpha.19",
+        "@bigbluebutton/store": "2.0.0-alpha.19",
+        "@bigbluebutton/tlschema": "2.0.0-alpha.19",
+        "@bigbluebutton/utils": "2.0.0-alpha.19",
+        "@bigbluebutton/validate": "2.0.0-alpha.19",
+        "@types/core-js": "^2.5.5",
+        "@use-gesture/react": "^10.2.27",
+        "classnames": "^2.3.2",
+        "core-js": "^3.31.1",
+        "eventemitter3": "^4.0.7",
+        "idb": "^7.1.1",
+        "is-plain-object": "^5.0.0",
+        "lodash.throttle": "^4.1.1",
+        "lodash.uniq": "^4.5.0",
+        "nanoid": "4.0.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.37.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+          "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw=="
+        },
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        }
+      }
+    },
+    "@bigbluebutton/state": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/state/-/state-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-hSf13Ix1vEyQfF0xL5ttQpANHBN/ktRzX3h1l1OQ23ANjt+5PikCVDpuHruRB8bxWLIlS9m7QI7qa2iZWga1Sg=="
+    },
+    "@bigbluebutton/store": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/store/-/store-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-7ll1gJDf/MqIj8o9QyZbFBGtWNEziOFhJaWx8mlefH2OwIOT1A9qntm3kLtSpBMlXDR6JxtINwSmKjp4RXf84g==",
+      "requires": {
+        "@bigbluebutton/state": "2.0.0-alpha.19",
+        "@bigbluebutton/utils": "2.0.0-alpha.19",
+        "lodash.isequal": "^4.5.0",
+        "nanoid": "4.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        }
+      }
+    },
+    "@bigbluebutton/tldraw": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/tldraw/-/tldraw-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-17CBnRAXVhdlrk7m9fSvSzs/kdMjhUlt1DLwx2wq93cSuIoAi+lwmAeXfe2NY9dDw5N5pcBnHzLXbCwOOV904g==",
+      "requires": {
+        "@bigbluebutton/editor": "2.0.0-alpha.19",
+        "@radix-ui/react-alert-dialog": "^1.0.0",
+        "@radix-ui/react-context-menu": "^2.1.5",
+        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-popover": "^1.0.7",
+        "@radix-ui/react-select": "^1.2.0",
+        "@radix-ui/react-slider": "^1.1.0",
+        "@radix-ui/react-toast": "^1.1.1",
+        "canvas-size": "^1.2.6",
+        "classnames": "^2.3.2",
+        "downscale": "^1.0.6",
+        "hotkeys-js": "^3.11.2",
+        "lz-string": "^1.4.4"
+      }
+    },
+    "@bigbluebutton/tlschema": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/tlschema/-/tlschema-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-ZJFhu+XHvbLYUPJrMAJ/JyulC91PWPfJkIOpm/SRfjjoXb87tHlfcAjQ1qzMooiaV1lExcMwPb+2reGK/zUphw==",
+      "requires": {
+        "@bigbluebutton/state": "2.0.0-alpha.19",
+        "@bigbluebutton/store": "2.0.0-alpha.19",
+        "@bigbluebutton/utils": "2.0.0-alpha.19",
+        "@bigbluebutton/validate": "2.0.0-alpha.19",
+        "nanoid": "4.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
+        }
+      }
+    },
+    "@bigbluebutton/utils": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/utils/-/utils-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-ijGUTAPQyI2p/Op3HJyrAkk+9zpSy9bOJ8jBx/xHgbzMR9G+Mk6GyCg2uqHmHPgImWAqOQ1OvW8RTvV7vfoWyA=="
+    },
+    "@bigbluebutton/validate": {
+      "version": "2.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/validate/-/validate-2.0.0-alpha.19.tgz",
+      "integrity": "sha512-vlKptCiN1aE23fGcUuEIxm/Kq57TtnWEWfE8QmU1gYPKVeEx3hTdaZXp+eJzqEvHU0xDW4DzbgRmLRoV5ecjJQ==",
+      "requires": {
+        "@bigbluebutton/utils": "2.0.0-alpha.19"
+      }
+    },
     "@browser-bunyan/console-formatted-stream": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@browser-bunyan/console-formatted-stream/-/console-formatted-stream-1.8.0.tgz",
@@ -2476,103 +2586,6 @@
         "tslib": "^2.5.0"
       }
     },
-    "@tldraw/editor": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/editor/-/editor-2.0.2.tgz",
-      "integrity": "sha512-ik7JvBQv9AsvkGhBfNkPdM0m+cBiarfPLrzlgyB2dec4lWQOIIL/p9J+28FUWQ4bzDvD6JN0eGXnsGj754ypQg==",
-      "requires": {
-        "@tldraw/state": "2.0.2",
-        "@tldraw/store": "2.0.2",
-        "@tldraw/tlschema": "2.0.2",
-        "@tldraw/utils": "2.0.2",
-        "@tldraw/validate": "2.0.2",
-        "@types/core-js": "^2.5.5",
-        "@use-gesture/react": "^10.2.27",
-        "classnames": "^2.3.2",
-        "core-js": "^3.31.1",
-        "eventemitter3": "^4.0.7",
-        "idb": "^7.1.1",
-        "is-plain-object": "^5.0.0",
-        "lodash.throttle": "^4.1.1",
-        "lodash.uniq": "^4.5.0",
-        "nanoid": "4.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.36.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
-          "integrity": "sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA=="
-        },
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
-        }
-      }
-    },
-    "@tldraw/state": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/state/-/state-2.0.2.tgz",
-      "integrity": "sha512-8736faV/vTDipYa6xpTG2l3XJgwu1lR4wAwobW/AdiflWBoxiejK4GZyVhb1HtSvcb9EV/ZDOG9SAwG2cKUw9A=="
-    },
-    "@tldraw/store": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/store/-/store-2.0.2.tgz",
-      "integrity": "sha512-02Wg37GiVGoUXxpcyLaoyOMUXn62OxuwcN3Ij7nVxHs7XGJmeMdWKodFMSss1Jh7lzJJMS5r8BJ3knB/ENdcWA==",
-      "requires": {
-        "@tldraw/state": "2.0.2",
-        "@tldraw/utils": "2.0.2",
-        "lodash.isequal": "^4.5.0",
-        "nanoid": "4.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
-        }
-      }
-    },
-    "@tldraw/tldraw": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-2.0.2.tgz",
-      "integrity": "sha512-34GK/SjYMyvPSrO7D0DR0sg3qi0XtFhyNKS4ls4PNGNa24Ov4Etm3MVEmbOe+stqAi8FC4hlfSDd7eE/vIsU5w==",
-      "requires": {
-        "tldraw": "2.0.2"
-      }
-    },
-    "@tldraw/tlschema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/tlschema/-/tlschema-2.0.2.tgz",
-      "integrity": "sha512-gpSdyl7n5vMutgSX7+1dvZj6DGxQhCyDMhOmuWQGkTuQrbp/RmOIRwxAfLRIZCJstKKohy/skc3XzAhL5wEbHQ==",
-      "requires": {
-        "@tldraw/state": "2.0.2",
-        "@tldraw/store": "2.0.2",
-        "@tldraw/utils": "2.0.2",
-        "@tldraw/validate": "2.0.2",
-        "nanoid": "4.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
-        }
-      }
-    },
-    "@tldraw/utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/utils/-/utils-2.0.2.tgz",
-      "integrity": "sha512-oXqCF2fERXG7e30npML/zMGtyRWIfgUXVvgdXtWR/S7/mwVU0MeY9YJ7eAuY+iIFshpV9MM99tQxqUZKVJ6NNw=="
-    },
-    "@tldraw/validate": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@tldraw/validate/-/validate-2.0.2.tgz",
-      "integrity": "sha512-dc2WxVwDf4HKP0/5AXukv/gqjrEg2fNCbKTRrxGDgvXfsRe1Gg8o9cVYlzZLRmbvj1DL8ggw4DAvbyL1FZh5Gg==",
-      "requires": {
-        "@tldraw/utils": "2.0.2"
-      }
-    },
     "@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4079,6 +4092,11 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3"
       }
+    },
+    "downscale": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/downscale/-/downscale-1.0.6.tgz",
+      "integrity": "sha512-Arh9ftj+wo3CkFoT48SgT/crMyqmgZtNaaV/etjzHaUqNAaS36GS38ECURnfl7X/XvXN5uZNigGF7Vhffrm/pg=="
     },
     "electron-to-chromium": {
       "version": "1.4.598",
@@ -8850,26 +8868,6 @@
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "requires": {
         "@popperjs/core": "^2.9.0"
-      }
-    },
-    "tldraw": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/tldraw/-/tldraw-2.0.2.tgz",
-      "integrity": "sha512-qWIbsZkbCVcexGHtUBBjT28+upgzwSu3yImtQXRbfwDj8wbVadxxczAK9Uh6gSsRqlEx8WaQRu3Nkv/3QJSTQQ==",
-      "requires": {
-        "@radix-ui/react-alert-dialog": "^1.0.5",
-        "@radix-ui/react-context-menu": "^2.1.5",
-        "@radix-ui/react-dialog": "^1.0.5",
-        "@radix-ui/react-dropdown-menu": "^2.0.6",
-        "@radix-ui/react-popover": "^1.0.7",
-        "@radix-ui/react-select": "^1.2.0",
-        "@radix-ui/react-slider": "^1.1.0",
-        "@radix-ui/react-toast": "^1.1.1",
-        "@tldraw/editor": "2.0.2",
-        "canvas-size": "^1.2.6",
-        "classnames": "^2.3.2",
-        "hotkeys-js": "^3.11.2",
-        "lz-string": "^1.4.4"
       }
     },
     "to-fast-properties": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -40,7 +40,7 @@
     "@mconf/bbb-diff": "^1.2.0",
     "@mui/material": "^5.12.2",
     "@mui/system": "^5.12.3",
-    "@tldraw/tldraw": "^2.0.0-alpha.19",
+    "@bigbluebutton/tldraw": "^2.0.0-alpha.19",
     "@types/node": "^20.5.7",
     "@types/ramda": "^0.29.2",
     "@types/react": "^18.2.18",


### PR DESCRIPTION
### What does this PR do?

Previous versions of Tldraw's SDK were released under the permissive Apache-2.0 license.

However, on On December 20th, 2023, Tldraw announced a change in which only non-commercial uses of Tldraw are permitted without purchasing a commercial license.

This PR replaces the tldraw packages used by the client with the last 2.x pre-release version that remains licensed under Apache-2.0, i.e., v2.0.0-alpha.19.

The source code for the packages hosted on npm is available [here](https://github.com/bigbluebutton/tldraw).