### PR TITLE
UI: Selected tab's style indicating active

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/component.jsx
@@ -45,6 +45,7 @@ const BreakoutRoomItem = ({
             <Styled.ListItem
               role="button"
               tabIndex={0}
+              active={sidebarContentPanel === PANELS.BREAKOUT}
               onClick={toggleBreakoutPanel}
               data-test="breakoutRoomsItem"
               aria-label={intl.formatMessage(intlMessages.breakoutTitle)}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -129,10 +129,12 @@ const ListItem = styled(Styled.ListItem)`
     text-overflow: ellipsis;
   }
 
-  &:active {
-    background-color: ${listItemBgHover};
-    box-shadow: inset 0 0 0 ${borderSize} ${itemFocusBorder}, inset 1px 0 0 1px ${itemFocusBorder};
-  }
+  ${({ active }) => active && `
+  outline: transparent;
+  outline-style: dotted;
+  outline-width: ${borderSize};
+  background-color: ${listItemBgHover};
+`}
 `;
 
 const UnreadMessages = styled(FlexColumn)`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/styles.js
@@ -17,9 +17,8 @@ import {
   colorGrayDark,
   colorGrayLight,
   colorGrayLighter,
-  listItemBgHover,
-  itemFocusBorder,
   unreadMessagesBg,
+  colorGrayLightest,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { fontSizeSmall } from '/imports/ui/stylesheets/styled-components/typography';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
@@ -133,7 +132,7 @@ const ListItem = styled(Styled.ListItem)`
   outline: transparent;
   outline-style: dotted;
   outline-width: ${borderSize};
-  background-color: ${listItemBgHover};
+  background-color: ${colorGrayLightest};
 `}
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/timer/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/timer/component.jsx
@@ -56,6 +56,7 @@ class Timer extends PureComponent {
             <Styled.ListItem
               role="button"
               tabIndex={0}
+              active={sidebarContentPanel === PANELS.TIMER}
               onClick={() => {
                 layoutContextDispatch({
                   type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/styles.ts
@@ -184,7 +184,6 @@ const ChatListItem = styled.button<ChatListItemProps>`
     background-color: ${listItemBgHover};
   }
 
-  &:active,
   &:focus {
     outline: transparent;
     outline-width: ${borderSize};
@@ -213,6 +212,11 @@ const ChatListItem = styled.button<ChatListItemProps>`
     margin-left: 0;
     margin-right: ${borderSize};
   }
+  ${({ active }: ChatListItemProps) => active && `
+    outline: transparent;
+    outline-style: dotted;
+    outline-width: ${borderSize};
+    background-color: ${listItemBgHover};  `}
 `;
 
 const ChatThumbnail = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/styles.ts
@@ -16,6 +16,7 @@ import {
   colorSuccess,
   itemFocusBorder,
   unreadMessagesBg,
+  colorGrayLightest,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 interface UserAvatarProps {
@@ -216,7 +217,8 @@ const ChatListItem = styled.button<ChatListItemProps>`
     outline: transparent;
     outline-style: dotted;
     outline-width: ${borderSize};
-    background-color: ${listItemBgHover};  `}
+    background-color: ${colorGrayLightest};
+  `}
 `;
 
 const ChatThumbnail = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
@@ -49,6 +49,7 @@ const UserPolls = ({
             role="button"
             tabIndex={0}
             data-test="pollMenuButton"
+            active={sidebarContentPanel === PANELS.POLL}
             onClick={handleClickTogglePoll}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
@@ -138,6 +138,7 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
         aria-describedby="lockedNotes"
         role="button"
         tabIndex={0}
+        active={notesOpen}
         onClick={() => toggleNotesPanel(sidebarContentPanel, layoutContextDispatch)}
         // @ts-ignore
         onKeyDown={(e) => {


### PR DESCRIPTION
### What does this PR do?

This PR add styles on the list item styles, in order to show which tab is currently being used. (See example).

### Closes Issue(s)

#18314

### Example:

Before:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/0ee4785a-640e-4754-8d1b-46620a00cf3e)


![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/47e2a5a6-a30b-4dfa-bffa-c8c258241d93)


After:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/26d21c6f-1084-4e78-9eb3-54a776dfb423)


![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/9e2eeb0a-fed6-4fa0-a9ab-521c32133778)

