### PR TITLE
build(fix): File permissions in packages should not depend on umask of build system

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -57,6 +57,7 @@ cp -r CHANGELOG.md CONTRIBUTING.md LICENSE README.md bin doc src tests var node_
 
 cp settings.json staging/usr/share/etherpad-lite
 git clone https://github.com/alangecker/bbb-etherpad-skin.git staging/usr/share/etherpad-lite/src/static/skins/bigbluebutton
+chmod -R a+rX staging/usr/share/etherpad-lite
 
 mkdir -p staging/usr/lib/systemd/system
 cp etherpad.service staging/usr/lib/systemd/system

--- a/build/packages-template/bbb-export-annotations/build.sh
+++ b/build/packages-template/bbb-export-annotations/build.sh
@@ -22,6 +22,7 @@ find -maxdepth 1 ! -path . ! -name staging $(printf "! -name %s " $(cat .build-f
 pushd .
 cd staging/usr/local/bigbluebutton/bbb-export-annotations/
 npm install --production
+chmod -R a+rX .
 popd
 
 mkdir -p staging/usr/lib/systemd/system
@@ -30,6 +31,7 @@ cp bbb-export-annotations.service staging/usr/lib/systemd/system
 #
 # Install fonts
 cp fonts/* staging/usr/local/share/fonts/
+chmod -R a+rX staging/usr/local/share/fonts/
 
 ##
 

--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -78,18 +78,18 @@ mkdir -p staging/usr/share/meteor/bundle/programs/web.browser/app/files
 cp node_modules/@fontsource/*/files/*.woff[2] staging/usr/share/meteor/bundle/programs/web.browser/app/files/
 
 cp systemd_start.sh staging/usr/share/meteor/bundle
-chmod +x staging/usr/share/meteor/bundle/systemd_start.sh
+chmod +rx staging/usr/share/meteor/bundle/systemd_start.sh
 
 cp systemd_start_frontend.sh staging/usr/share/meteor/bundle
-chmod +x staging/usr/share/meteor/bundle/systemd_start_frontend.sh
+chmod +rx staging/usr/share/meteor/bundle/systemd_start_frontend.sh
 
 cp workers-start.sh staging/usr/share/meteor/bundle
-chmod +x staging/usr/share/meteor/bundle/workers-start.sh
+chmod +rx staging/usr/share/meteor/bundle/workers-start.sh
 
 cp bbb-html5-with-roles.conf staging/usr/share/meteor/bundle
 
 cp mongod_start_pre.sh staging/usr/share/meteor/bundle
-chmod +x staging/usr/share/meteor/bundle/mongod_start_pre.sh
+chmod +rx staging/usr/share/meteor/bundle/mongod_start_pre.sh
 
 cp mongo-ramdisk.conf staging/usr/share/meteor/bundle
 

--- a/build/packages-template/bbb-pads/build.sh
+++ b/build/packages-template/bbb-pads/build.sh
@@ -21,6 +21,7 @@ find -maxdepth 1 ! -path . ! -name staging $(printf "! -name %s " $(cat .build-f
 pushd .
 cd staging/usr/local/bigbluebutton/bbb-pads/
 npm install --production
+chmod -R a+rX .
 popd
 
 mkdir -p staging/usr/lib/systemd/system

--- a/build/packages-template/bbb-record-core/build.sh
+++ b/build/packages-template/bbb-record-core/build.sh
@@ -34,6 +34,7 @@ pushd staging/usr/local/bigbluebutton/core
   bundle clean
   rm -r vendor/bundle/ruby/*/cache
   find vendor/bundle -name '*.o' -delete
+  chmod -R a+rX .
   find vendor/bundle/ruby/*/gems/resque-*/lib/resque/server/public -type f -name "*.png" -execdir chmod 0644 {} \;
   find vendor/bundle/ruby/*/gems/resque-*/bin -type f -execdir chmod 0755 {} \;
 popd


### PR DESCRIPTION
### What does this PR do?

Fixes permissions in packages. Makes build process less dependant on the umask of the package build system.

If the build system for packages has a umask of `0077`, cloned repositories will have no permissions for group and other. As the build scripts for some packages just copy from clone git repos, this will preserve the permissions in the package and prevent the following services from startup:

* `bbb-html5`
* `etherpad`
* `bbb-pads`
* `bbb-export-annotations`
* `bbb-rap-*`

This patch grants everyone read permissions to the code in the packages.

### Motivation

I recently changed the umask on my system to `0077`. The packages built on this system no longer work. I need BBB :smile: 
