### PR TITLE
feat(whiteboard): Reuse poll result diagram as a whiteboard shape

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -8,6 +8,7 @@ import Styled from './styles';
 
 interface ChatPollContentProps {
   metadata: string;
+  height?: number;
 }
 
 interface Metadata {
@@ -75,6 +76,7 @@ function assertAsMetadata(metadata: unknown): asserts metadata is Metadata {
 
 const ChatPollContent: React.FC<ChatPollContentProps> = ({
   metadata: string,
+  height,
 }) => {
   const intl = useIntl();
 
@@ -92,13 +94,13 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
     };
   });
 
-  const height = translatedAnswers.length * 50;
+  const useHeight = height || translatedAnswers.length * 50;
   return (
     <div data-test="chatPollMessageText">
       <Styled.PollText>
         {pollData.questionText}
       </Styled.PollText>
-      <ResponsiveContainer width="90%" height={height}>
+      <ResponsiveContainer width="90%" height={useHeight}>
         <BarChart
           data={translatedAnswers}
           layout="vertical"
@@ -110,6 +112,10 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
       </ResponsiveContainer>
     </div>
   );
+};
+
+ChatPollContent.defaultProps = {
+  height: null,
 };
 
 export default ChatPollContent;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -115,7 +115,7 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
 };
 
 ChatPollContent.defaultProps = {
-  height: null,
+  height: undefined,
 };
 
 export default ChatPollContent;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -31,6 +31,8 @@ import { notifyShapeNumberExceeded, getCustomEditorAssetUrls, getCustomAssetUrls
 
 import NoopTool from './custom-tools/noop-tool/component';
 
+import { PollShapeUtil } from './custom-shapes/poll/component';
+
 // Helper functions
 const deleteLocalStorageItemsWithPrefix = (prefix) => {
   const keysToRemove = Object.keys(localStorage).filter((key) =>
@@ -146,6 +148,9 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   const lastKnownWidth = React.useRef(presentationAreaWidth);
 
   const [shapesVersion, setShapesVersion] = React.useState(0);
+
+  const customShapeUtils = [PollShapeUtil];
+  const customTools = [NoopTool];
 
   const setIsMouseDown = (val) => {
     isMouseDownRef.current = val;
@@ -1306,8 +1311,6 @@ const Whiteboard = React.memo(function Whiteboard(props) {
           }
         }),[]
 
-  const customTools = [NoopTool];
-
   return (
     <div
       ref={whiteboardRef}
@@ -1320,6 +1323,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         forceMobile={true}
         hideUi={hasWBAccessRef.current || isPresenter ? false : true}
         onMount={handleTldrawMount}
+        shapeUtils={customShapeUtils}
         tools={customTools}
       />
       <Styled.TldrawV2GlobalStyle

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/component.tsx
@@ -42,6 +42,7 @@ export class PollShapeUtil extends ShapeUtil<IPollShape> {
     };
   }
 
+  // eslint-disable-next-line class-methods-use-this
   getGeometry(shape: IPollShape) {
     return new Rectangle2d({
       width: shape.props.w,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/component.tsx
@@ -33,6 +33,7 @@ export class PollShapeUtil extends ShapeUtil<IPollShape> {
       w: 300,
       h: 300,
       color: 'black',
+      fill: 'white',
       question: '',
       numRespondents: 0,
       numResponders: 0,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/component.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {
+  HTMLContainer,
+  Rectangle2d,
+  ShapeUtil,
+  TLOnResizeHandler,
+  getDefaultColorTheme,
+  resizeBox,
+} from '@bigbluebutton/tldraw';
+import { pollShapeMigrations } from './poll-shape-migrations';
+import { pollShapeProps } from './poll-shape-props';
+import { IPollShape } from './poll-shape-types';
+import ChatPollContent from '/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component';
+
+export class PollShapeUtil extends ShapeUtil<IPollShape> {
+  static override type = 'poll' as const;
+
+  static override props = pollShapeProps;
+
+  static override migrations = pollShapeMigrations;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override isAspectRatioLocked = (_shape: IPollShape) => false;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override canResize = (_shape: IPollShape) => true;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override canBind = (_shape: IPollShape) => true;
+
+  getDefaultProps(): IPollShape['props'] {
+    return {
+      w: 300,
+      h: 300,
+      color: 'black',
+      question: '',
+      numRespondents: 0,
+      numResponders: 0,
+      questionText: '',
+      questionType: '',
+      answers: [],
+    };
+  }
+
+  getGeometry(shape: IPollShape) {
+    return new Rectangle2d({
+      width: shape.props.w,
+      height: shape.props.h,
+      isFilled: true,
+    });
+  }
+
+  component(shape: IPollShape) {
+    const { bounds } = this.editor.getShapeGeometry(shape);
+    const theme = getDefaultColorTheme({
+      isDarkMode: this.editor.user.getIsDarkMode(),
+    });
+
+    const contentRef = React.useRef<HTMLDivElement>(null);
+    const pollMetadata = JSON.stringify({
+      id: shape.id,
+      question: shape.props.question,
+      numRespondents: shape.props.numRespondents,
+      numResponders: shape.props.numResponders,
+      questionText: shape.props.questionText,
+      questionType: shape.props.questionType,
+      answers: shape.props.answers,
+    });
+
+    const adjustedHeight = shape.props.questionText.length > 0 ? bounds.height - 75 : bounds.height;
+
+    return (
+      <HTMLContainer
+        id={shape.id}
+        style={{
+          border: '1px solid #8B9AA8',
+          borderRadius: '4px',
+          boxShadow: '0px 0px 4px 0px rgba(0, 0, 0, 0.20)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'all',
+          backgroundColor: theme[shape.props.color].semi,
+          color: theme[shape.props.color].solid,
+        }}
+      >
+        <div
+          ref={contentRef}
+          style={{
+            width: `${bounds.width}px`,
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
+          <ChatPollContent
+            metadata={pollMetadata}
+            height={adjustedHeight}
+          />
+        </div>
+      </HTMLContainer>
+    );
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  indicator(shape: IPollShape) {
+    return <rect width={shape.props.w} height={shape.props.h} />;
+  }
+
+  override onResize: TLOnResizeHandler<IPollShape> = (shape, info) => {
+    return resizeBox(shape, info);
+  }
+}
+
+export default PollShapeUtil;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-migrations.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-migrations.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+
+import { defineMigrations } from '@bigbluebutton/tldraw';
+
+// Migrations for the custom poll shape (optional but very helpful)
+export const pollShapeMigrations = defineMigrations({
+  currentVersion: 1,
+  migrators: {
+    1: {
+      // example, removing a property from the shape
+      up(shape) {
+        const migratedUpShape = { ...shape };
+        delete migratedUpShape.somePropertyToRemove;
+        return migratedUpShape;
+      },
+      down(shape) {
+        const migratedDownShape = { ...shape };
+        migratedDownShape.somePropertyToRemove = 'some value';
+        return migratedDownShape;
+      },
+    },
+  },
+});
+
+export default pollShapeMigrations;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-props.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-props.ts
@@ -1,7 +1,7 @@
 import { DefaultColorStyle, ShapeProps, T } from '@bigbluebutton/tldraw';
-import { ICardShape } from './poll-shape-types';
+import { IPollShape } from './poll-shape-types';
 
-export const pollShapeProps: ShapeProps<ICardShape> = {
+export const pollShapeProps: ShapeProps<IPollShape> = {
   w: T.number,
   h: T.number,
   color: DefaultColorStyle,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-props.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-props.ts
@@ -1,0 +1,17 @@
+import { DefaultColorStyle, ShapeProps, T } from '@bigbluebutton/tldraw';
+import { ICardShape } from './poll-shape-types';
+
+export const pollShapeProps: ShapeProps<ICardShape> = {
+  w: T.number,
+  h: T.number,
+  color: DefaultColorStyle,
+  fill: T.string,
+  question: T.string,
+  numRespondents: T.number,
+  numResponders: T.number,
+  questionText: T.string,
+  questionType: T.string,
+  answers: T.any,
+};
+
+export default pollShapeProps;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-types.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/custom-shapes/poll/poll-shape-types.ts
@@ -1,0 +1,21 @@
+import { TLBaseShape, TLDefaultColorStyle } from '@bigbluebutton/tldraw';
+
+export type IPollShape = TLBaseShape<
+  'poll',
+  {
+    w: number,
+    h: number,
+    color: TLDefaultColorStyle,
+    fill: string,
+    question: string,
+    numRespondents: number,
+    numResponders: number,
+    questionText: string,
+    questionType: string,
+    answers: Array<{
+      id: number,
+      key: string,
+      numVotes: number,
+    }>,
+  }
+>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -161,7 +161,6 @@ const formatAnnotations = (annotations, intl, curPageId, currentPresentationPage
     if (annotationInfo.questionType) {
       // poll result, convert it to text and create tldraw shape
       if (!annotationInfo.props) {
-        const { POLL_BAR_CHAR } = PollService;
         annotationInfo.answers = annotationInfo.answers.reduce(
           caseInsensitiveReducer, [],
         );
@@ -171,26 +170,18 @@ const formatAnnotations = (annotations, intl, curPageId, currentPresentationPage
         const lines = pollResult.split('\n');
         const longestLine = lines.reduce((a, b) => (a.length > b.length ? a : b), '').length;
 
-        // add empty spaces after last ∎ in each of the lines to make them all the same length
-        pollResult = lines.map((line) => {
-          if (!line.includes(POLL_BAR_CHAR) || line.length === longestLine) return line;
-
-          const splitLine = line.split(`${POLL_BAR_CHAR} `);
-          const spaces = ' '.repeat(longestLine - line.length);
-          return `${splitLine[0]} ${spaces} ${splitLine[1]}`;
-        }).join('\n');
-
         // Text measurement estimation
         const averageCharWidth = 14;
         const lineHeight = 32;
+        const padding = 2;
 
-        const annotationWidth = longestLine * averageCharWidth; // Estimate width
-        const annotationHeight = lines.length * lineHeight; // Estimate height
+        const annotationWidth = longestLine * averageCharWidth;
+        const annotationHeight = lines.length * lineHeight;
 
         const slideWidth = currentPresentationPage?.scaledWidth;
         const slideHeight = currentPresentationPage?.scaledHeight;
-        const xPosition = slideWidth - annotationWidth;
-        const yPosition = slideHeight - annotationHeight;
+        const xPosition = slideWidth - annotationWidth - padding;
+        const yPosition = slideHeight - annotationHeight - padding;
 
         annotationInfo = {
           x: xPosition,
@@ -203,22 +194,18 @@ const formatAnnotations = (annotations, intl, curPageId, currentPresentationPage
           index: 'a1',
           id: `${annotationInfo.id}`,
           meta: {},
-          type: 'geo',
+          type: 'poll',
           props: {
-            url: '',
-            text: `${pollResult}`,
             color: 'black',
-            font: 'mono',
             fill: 'semi',
-            dash: 'draw',
             w: annotationWidth,
             h: annotationHeight,
-            size: 'm',
-            growY: 0,
-            align: 'middle',
-            geo: 'rectangle',
-            verticalAlign: 'middle',
-            labelColor: 'black',
+            answers: annotationInfo.answers,
+            numRespondents: annotationInfo.numRespondents,
+            numResponders: annotationInfo.numResponders,
+            questionText: annotationInfo.questionText,
+            questionType: annotationInfo.questionType,
+            question: annotationInfo.question || "",
           },
         };
       } else {
@@ -233,22 +220,18 @@ const formatAnnotations = (annotations, intl, curPageId, currentPresentationPage
           index: annotationInfo.index,
           id: annotationInfo.id,
           meta: annotationInfo.meta,
-          type: 'geo',
+          type: 'poll',
           props: {
-            url: '',
-            text: annotationInfo.props.text,
-            color: annotationInfo.props.color,
-            font: annotationInfo.props.font,
-            fill: annotationInfo.props.fill,
-            dash: annotationInfo.props.dash,
+            color: 'black',
+            fill: 'semi',
             h: annotationInfo.props.h,
             w: annotationInfo.props.w,
-            size: annotationInfo.props.size,
-            growY: 0,
-            align: 'middle',
-            geo: annotationInfo.props.geo,
-            verticalAlign: 'middle',
-            labelColor: annotationInfo.props.labelColor,
+            answers: annotationInfo.answers,
+            numRespondents: annotationInfo.numRespondents,
+            numResponders: annotationInfo.numResponders,
+            questionText: annotationInfo.questionText,
+            questionType: annotationInfo.questionType,
+            question: annotationInfo.question || '',
           },
         };
       }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -124,6 +124,10 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     bottom: 9.5rem !important;
   }
 
+  [id*="shape:poll-result"] {
+    background-color: white !important;
+  }
+
   ${({ presentationHeight }) => {
     const minRange = { height: 345, top: 14 };
     const maxRange = { height: 1200, top: 384 };

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -463,6 +463,7 @@ exports.wbTextShape = 'button[data-testid="tools.text"]';
 exports.wbTypedText = 'div[data-shape="text"]';
 exports.wbTypedStickyNote = 'div[data-shape-type="note"]';
 exports.wbDrawnRectangle = 'div[data-shape-type="geo"]';
+exports.wbPollShape = 'div[data-shape-type="poll"]';
 exports.wbDrawnLine = 'div[data-shape="draw"]';
 exports.multiUsersWhiteboardOn = 'button[data-test="turnMultiUsersWhiteboardOn"]';
 exports.multiUsersWhiteboardOff = 'button[data-test="turnMultiUsersWhiteboardOff"]';

--- a/bigbluebutton-tests/playwright/polling/poll.js
+++ b/bigbluebutton-tests/playwright/polling/poll.js
@@ -65,8 +65,8 @@ class Polling extends MultiUsers {
     await this.modPage.waitAndClick(e.publishPollingLabel);
     await this.modPage.wasRemoved(e.pollingContainer);
 
-    await this.modPage.hasElement(e.wbDrawnRectangle, ELEMENT_WAIT_LONGER_TIME);
-    await this.userPage.hasElement(e.wbDrawnRectangle);
+    await this.modPage.hasElement(e.wbPollShape, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.hasElement(e.wbPollShape);
   }
 
   async stopPoll() {

--- a/bigbluebutton-tests/playwright/polling/poll.js
+++ b/bigbluebutton-tests/playwright/polling/poll.js
@@ -267,7 +267,7 @@ class Polling extends MultiUsers {
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
     await util.startPoll(this.modPage);
 
-    const wbDrawnRectangleLocator = await this.modPage.getLocator(e.wbDrawnRectangle);
+    const wbDrawnRectangleLocator = await this.modPage.getLocator(e.wbPollShape);
     const initialWbDrawnRectangleCount = await wbDrawnRectangleLocator.count();
 
     await this.modPage.hasElementDisabled(e.publishPollingLabel);
@@ -298,7 +298,7 @@ class Polling extends MultiUsers {
     await this.userPage.waitAndClick(e.zoomInButton);
     await this.userPage.waitAndClick(e.resetZoomButton);
 
-    const wbDrawnRectangleUserLocator = await this.userPage.getLocator(e.wbDrawnRectangle).last();
+    const wbDrawnRectangleUserLocator = await this.userPage.getLocator(e.wbPollShape).last();
     await wbDrawnRectangleUserLocator.dblclick({ timeout: ELEMENT_WAIT_TIME });
     await this.userPage.page.keyboard.type('testUser');
     await expect(wbDrawnRectangleUserLocator).toContainText('testUser');
@@ -315,7 +315,7 @@ class Polling extends MultiUsers {
     await this.modPage.hasElement(e.quickPoll, ELEMENT_WAIT_LONGER_TIME);
     await this.modPage.waitAndClick(e.publishPollingLabel);
     // Check poll results
-    await this.modPage.hasElement(e.wbDrawnRectangle);
+    await this.modPage.hasElement(e.wbPollShape);
   }
 
   async startNewPoll() {


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new shape to the whiteboard for polls. Previously, the poll shape was a regular rectangle with text added to the label. With tldraw v19, we can now create new shapes that can be any React component. So, we've updated the poll shape to unify with the component displayed in the chat panel.

Before:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/24a99626-0b71-4bbf-a73d-62bcffddcd32)

After:
![image](https://github.com/bigbluebutton/bigbluebutton/assets/22058534/a7644f6f-f599-4740-b749-8c84cc2d49ab)

### Closes
#20371 

### Motivation
The new poll shape uses the same component as the chat published poll, ensuring a consistent look across both the whiteboard and the chat panel. This unification helps in maintaining visual consistency and improves the overall user experience.