### PR TITLE
Fix: ensure API calls are headed towards the BBB Server

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -878,6 +878,10 @@ public class ParamsProcessorUtil {
         return graphqlWebsocketUrl;
     }
 
+    public String getServerUrl() {
+        return defaultServerUrl;
+    }
+
 	public String getDefaultGuestWaitURL() {
 		return defaultGuestWaitURL;
         }

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -53,7 +53,10 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
   const [graphqlUrl, setGraphqlUrl] = React.useState<string>('');
   const loadingContextInfo = useContext(LoadingContext);
   useEffect(() => {
-    fetch(`https://${window.location.hostname}/bigbluebutton/api`, {
+    const urlParams = new URLSearchParams(window.location.search);
+    const bbbHost = urlParams.get('bbb-host');
+    fetch(`${bbbHost}/bigbluebutton/api`, {
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/startup-data-fetch/component.tsx
@@ -61,8 +61,9 @@ const StartupDataFetch: React.FC<StartupDataFetchProps> = ({
       return;
     }
     const clientStartupSettings = `/api/rest/clientStartupSettings/?sessionToken=${sessionToken}`;
-    const url = new URL(`${window.location.origin}${clientStartupSettings}`);
-    fetch(url, { method: 'get' })
+    const bbbHost = urlParams.get('bbb-host');
+    const url = new URL(`${bbbHost}${clientStartupSettings}`);
+    fetch(url, { method: 'get', credentials: 'include' })
       .then((resp) => resp.json())
       .then((data: Response) => {
         const settings = data.meeting_clientSettings[0];

--- a/bigbluebutton-html5/imports/ui/components/mobile-app-modal/mobile-app-modal-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/mobile-app-modal/mobile-app-modal-graphql/component.tsx
@@ -69,9 +69,12 @@ const MobileAppModalGraphql: React.FC<MobileAppModalGraphqlProps> = (props) => {
   const intl = useIntl();
 
   useEffect(() => {
-    const url = `/bigbluebutton/api/getJoinUrl?sessionToken=${sessionToken}`;
+    const urlParams = new URLSearchParams(window.location.search);
+    const bbbHost = urlParams.get('bbb-host');
+    const url = `${bbbHost}/bigbluebutton/api/getJoinUrl?sessionToken=${sessionToken}`;
     const options = {
       method: 'GET',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
@@ -29,9 +29,10 @@ const SettingsLoader: React.FC = () => {
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const sessionToken = urlParams.get('sessionToken');
+    const bbbHost = urlParams.get('bbb-host');
     const clientStartupSettings = `/api/rest/clientSettings/?sessionToken=${sessionToken}`;
-    const url = new URL(`${window.location.origin}${clientStartupSettings}`);
-    fetch(url, { method: 'get' })
+    const url = new URL(`${bbbHost}${clientStartupSettings}`);
+    fetch(url, { method: 'get', credentials: 'include' })
       .then((resp) => resp.json())
       .then((data: Response) => {
         const settings = data?.meeting_clientSettings[0].clientSettingsJson;

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -268,6 +268,7 @@ class ApiController {
     //check if exists the param redirect
     boolean redirectClient = REDIRECT_RESPONSE
     String clientURL = paramsProcessorUtil.getDefaultHTML5ClientUrl();
+    String serverURL = paramsProcessorUtil.getServerUrl();
 
     if (!StringUtils.isEmpty(params.redirect)) {
       try {
@@ -494,7 +495,7 @@ class ApiController {
     // Keep track of the client url in case this needs to wait for
     // approval as guest. We need to be able to send the user to the
     // client after being approved by moderator.
-    us.clientUrl = clientURL + "?sessionToken=" + sessionToken
+    us.clientUrl = clientURL + "?sessionToken=" + sessionToken + '&bbb-host=' + serverURL;
 
     session[sessionToken] = sessionToken
     meetingService.addUserSession(sessionToken, us)
@@ -507,7 +508,7 @@ class ApiController {
 
     // Process if we send the user directly to the client or
     // have it wait for approval.
-    String destUrl = clientURL + "?sessionToken=" + sessionToken
+    String destUrl = clientURL + "?sessionToken=" + sessionToken + '&bbb-host=' + serverURL;
     if (guestStatusVal.equals(GuestPolicy.WAIT)) {
       String guestWaitUrl = paramsProcessorUtil.getDefaultGuestWaitURL();
       destUrl = guestWaitUrl + "?sessionToken=" + sessionToken

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -124,9 +124,9 @@ public:
     url: 'https://bbb-01.example.com/pad'
 ```
 
-Create (or edit if it already exists) these unit file overrides:
+Create (or edit if it already exists) this unit file overrides:
 
-* `/usr/lib/systemd/system/bbb-html5.service`
+* `/etc/systemd/system/bbb-html5.service.d/cluster.conf`
 
 It should have the following content:
 
@@ -189,10 +189,19 @@ BBB_GRAPHQL_MIDDLEWARE_ORIGIN=bbb-proxy.example.org
 Pay attention that this one is without protocol, just the hostname.
 
 
-Restart BigBlueButton:
+Adjust the CORS setting in `/etc/default/bbb-graphql-server`:
 
 ```shell
-$ bbb-conf --restart
+HASURA_GRAPHQL_CORS_DOMAIN="https://bbb-proxy.example.org"
+```
+
+This one includes the protocol.
+
+Reload systemd and restart BigBlueButton:
+
+```shell
+# systemctl daemon-reload
+# bbb-conf --restart
 ```
 
 Now, opening a new session should show


### PR DESCRIPTION


### What does this PR do?

In BBB 3.0 the cluster setup was broken because the HTML5 client made API requests to the proxy instead of the BBB server.

The idea of this patch is that the API passes the BBB Host URL as query parameter to the HTML5 client. The client can use this information to

* fetch settings
* connect to graphql
* make calls to the BBB API

It also contains a docs update to ensure that the GraphQL API can be used (CORS related).