### PR TITLE
fix: "Show Welcome Message" button always disabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -99,7 +99,11 @@ subscription userCurrentSubscription {
       changedModeOn
       pageId
       presentationId
-    } 
+    }
+    welcomeMsgs {
+      welcomeMsg
+      welcomeMsgForModerators
+    }
   }
 }
 `;


### PR DESCRIPTION
### What does this PR do?

Adjusts current user subscription info to correctly display "show welcome message" option in chat dropdown

### Closes Issue(s)
Closes #20342