### PR TITLE
fix(whiteboard): Ensure duplicate shape shortcut does not trigger bookmark

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -224,6 +224,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   );
 
   const handleKeyDown = (event) => {
+    // Restrict certain actions when not a presenter and without whiteboard access
     if (!isPresenterRef.current) {
       if (
         !hasWBAccessRef.current ||
@@ -233,6 +234,51 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         event.stopPropagation();
         return;
       }
+    }
+
+    // Mapping of simple key shortcuts to tldraw functions
+    const simpleKeyMap = {
+      'v': () => tlEditorRef.current?.setCurrentTool("select"),
+      'd': () => tlEditorRef.current?.setCurrentTool("draw"),
+      'e': () => tlEditorRef.current?.setCurrentTool("eraser"),
+      'h': () => tlEditorRef.current?.setCurrentTool("hand"),
+      'r': () => tlEditorRef.current?.setCurrentTool("rectangle"),
+      'o': () => tlEditorRef.current?.setCurrentTool("ellipse"),
+      'a': () => tlEditorRef.current?.setCurrentTool("arrow"),
+      'l': () => tlEditorRef.current?.setCurrentTool("line"),
+      't': () => tlEditorRef.current?.setCurrentTool("text"),
+      'f': () => tlEditorRef.current?.setCurrentTool("frame"),
+      'n': () => tlEditorRef.current?.setCurrentTool("note"),
+    };
+
+    if (event.ctrlKey) {
+      const ctrlKeyMap = {
+        'a': () => {
+          tlEditorRef.current?.selectAll();
+          tlEditorRef.current?.setCurrentTool("select");
+        },
+        'd': () => {
+          tlEditorRef.current?.duplicateShapes(tlEditorRef.current?.getSelectedShapes(), { x: 10, y: 10 });
+          tlEditorRef.current?.selectNone();
+        },
+      };
+      if (ctrlKeyMap[event.key]) {
+        event.preventDefault();
+        event.stopPropagation();
+        ctrlKeyMap[event.key]();
+        return;
+      }
+    }
+
+    if (simpleKeyMap[event.key]) {
+      event.preventDefault();
+      event.stopPropagation();
+      simpleKeyMap[event.key]();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      tlEditorRef.current?.deselect(tlEditorRef.current?.getSelectedShapes());
     }
   };
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with the duplicate shape shortcut key where it was activating the browser bookmark. Now the shortcut key only duplicates the selected shape without activating bookmarks.

It also re-enables the shortcuts for selecting tools on the toolbar.

### Closes Issue(s)

Closes #20288 
