### PR TITLE
refactor: add error boundary in whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -20,6 +20,8 @@ import browserInfo from '/imports/utils/browserInfo';
 import { addAlert } from '../screenreader-alert/service';
 import { debounce } from '/imports/utils/debounce';
 import { throttle } from '/imports/utils/throttle';
+import LocatedErrorBoundary from '/imports/ui/components/common/error-boundary/located-error-boundary/component';
+import FallbackView from '/imports/ui/components/common/fallback-errors/fallback-view/component';
 
 const intlMessages = defineMessages({
   presentationLabel: {
@@ -800,6 +802,8 @@ class Presentation extends PureComponent {
     const isVideoFocus = layoutType === LAYOUT_TYPE.VIDEO_FOCUS;
     const presentationZIndex = fullscreenContext ? presentationBounds.zIndex : undefined;
 
+    const APP_CRASH_METADATA = { logCode: 'whiteboard_crash', logMessage: 'Possible whiteboard crash' };
+
     return (
       <>
         <Styled.PresentationContainer
@@ -851,35 +855,37 @@ class Presentation extends PureComponent {
                 {!tldrawIsMounting
                   && currentSlide
                   && this.renderPresentationMenu()}
-                <WhiteboardContainer
-                  whiteboardId={currentSlide?.id}
-                  slidePosition={slidePosition}
-                  getSvgRef={this.getSvgRef}
-                  tldrawAPI={tldrawAPI}
-                  setTldrawAPI={this.setTldrawAPI}
-                  curPageId={currentSlide?.num.toString() || '0'}
-                  svgUri={currentSlide?.svgUri}
-                  intl={intl}
-                  presentationWidth={svgWidth}
-                  presentationHeight={svgHeight}
-                  presentationAreaHeight={presentationBounds?.height}
-                  presentationAreaWidth={presentationBounds?.width}
-                  isPanning={isPanning}
-                  zoomChanger={this.zoomChanger}
-                  fitToWidth={fitToWidth}
-                  zoomValue={zoom}
-                  setTldrawIsMounting={this.setTldrawIsMounting}
-                  setIsToolbarVisible={this.setIsToolbarVisible}
-                  isFullscreen={isFullscreen}
-                  fullscreenAction={ACTIONS.SET_FULLSCREEN_ELEMENT}
-                  fullscreenElementId={fullscreenElementId}
-                  layoutContextDispatch={layoutContextDispatch}
-                  fullscreenRef={this.refPresentationContainer}
-                  presentationId={currentPresentationId}
-                  darkTheme={darkTheme}
-                  isToolbarVisible={isToolbarVisible}
-                  isViewersAnnotationsLocked={isViewersAnnotationsLocked}
-                />
+                <LocatedErrorBoundary Fallback={FallbackView} logMetadata={APP_CRASH_METADATA}>
+                  <WhiteboardContainer
+                    whiteboardId={currentSlide?.id}
+                    slidePosition={slidePosition}
+                    getSvgRef={this.getSvgRef}
+                    tldrawAPI={tldrawAPI}
+                    setTldrawAPI={this.setTldrawAPI}
+                    curPageId={currentSlide?.num.toString() || '0'}
+                    svgUri={currentSlide?.svgUri}
+                    intl={intl}
+                    presentationWidth={svgWidth}
+                    presentationHeight={svgHeight}
+                    presentationAreaHeight={presentationBounds?.height}
+                    presentationAreaWidth={presentationBounds?.width}
+                    isPanning={isPanning}
+                    zoomChanger={this.zoomChanger}
+                    fitToWidth={fitToWidth}
+                    zoomValue={zoom}
+                    setTldrawIsMounting={this.setTldrawIsMounting}
+                    setIsToolbarVisible={this.setIsToolbarVisible}
+                    isFullscreen={isFullscreen}
+                    fullscreenAction={ACTIONS.SET_FULLSCREEN_ELEMENT}
+                    fullscreenElementId={fullscreenElementId}
+                    layoutContextDispatch={layoutContextDispatch}
+                    fullscreenRef={this.refPresentationContainer}
+                    presentationId={currentPresentationId}
+                    darkTheme={darkTheme}
+                    isToolbarVisible={isToolbarVisible}
+                    isViewersAnnotationsLocked={isViewersAnnotationsLocked}
+                  />
+                </LocatedErrorBoundary>
                 {isFullscreen && <PollingContainer />}
               </div>
               {!tldrawIsMounting && (


### PR DESCRIPTION
### What does this PR do?

Adds error boundary for the whiteboard component, so whiteboard component errors don't break the whole client.

#### before

![Screenshot from 2024-05-30 15-39-07](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/89ec7483-9919-4135-acfb-4b82a0ee0422)

#### after

![Screenshot from 2024-05-30 15-35-16](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/0d0d6d68-9a90-4293-a736-bfdbce60cf69)
