### PR TITLE
Allow additional parameters in content type headers

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/ContentTypeValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/validator/ContentTypeValidator.java
@@ -31,7 +31,12 @@ public class ContentTypeValidator implements ConstraintValidator<ContentTypeCons
         if (requestBodyPresent) {
             if (contentType == null || contentTypeHeader == null) return false;
             else {
-                return request.getSupportedContentTypes().contains(contentType);
+                String[] contentTypeParts = contentType.split(";");
+                for (Object o: request.getSupportedContentTypes()) {
+                    String supportedContentType = (String) o;
+                    if (contentTypeParts[0].equals(supportedContentType)) return true;
+                }
+                return false;
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

Relaxes the content type validation constraints to allow additional parameters to passed along with the `Content-Type` header instead of forcing the content type to exactly match the predefined supported content types.

### Closes Issue(s)
Closes #20384
