### PR TITLE
fix(webcam): stopping a specific webcam will actually stop all

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/hooks/index.ts
@@ -22,6 +22,7 @@ import {
 } from '/imports/ui/components/video-provider/video-provider-graphql/stream-sorting';
 import {
   useVideoState,
+  getConnectingStream,
   setVideoState,
   useConnectingStream,
   streams,
@@ -487,11 +488,11 @@ export const useLockUser = () => {
 export const useStopVideo = () => {
   const [cameraBroadcastStop] = useMutation(CAMERA_BROADCAST_STOP);
   const [getOwnVideoStreams] = useOwnVideoStreamsQuery();
-  const exit = useExitVideo(true);
 
   return useCallback(async (cameraId?: string) => {
     const { data } = await getOwnVideoStreams();
     const streams = data?.user_camera ?? [];
+    const connectingStream = getConnectingStream();
     const hasTargetStream = streams.some((s) => s.streamId === cameraId);
     const hasOtherStream = streams.some((s) => s.streamId !== cameraId);
 
@@ -499,12 +500,10 @@ export const useStopVideo = () => {
       cameraBroadcastStop({ variables: { cameraId } });
     }
 
-    if (!hasOtherStream) {
+    if (!hasOtherStream && !connectingStream) {
       videoService.exitedVideo();
     } else {
-      exit().then(() => {
-        videoService.exitedVideo();
-      });
+      videoService.stopConnectingStream();
     }
   }, [cameraBroadcastStop]);
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/state.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/state.ts
@@ -17,9 +17,9 @@ export type ConnectingStream = {
   name: string;
   userId: string;
   type: 'connecting';
-} | null;
+};
 
-const connectingStream = makeVar<ConnectingStream>(null);
+const connectingStream = makeVar<ConnectingStream | null>(null);
 
 const useConnectingStream = (streams?: Stream[]) => {
   const connecting = useReactiveVar(connectingStream);
@@ -35,9 +35,11 @@ const useConnectingStream = (streams?: Stream[]) => {
   return connecting;
 };
 
-const setConnectingStream = (stream: ConnectingStream) => {
+const setConnectingStream = (stream: ConnectingStream | null) => {
   connectingStream(stream);
 };
+
+const getConnectingStream = () => connectingStream();
 
 export type Stream = {
   stream: string;
@@ -65,6 +67,7 @@ export {
   setVideoState,
   getVideoState,
   useConnectingStream,
+  getConnectingStream,
   setConnectingStream,
   setStreams,
   getStreams,
@@ -76,6 +79,7 @@ export default {
   setVideoState,
   getVideoState,
   useConnectingStream,
+  getConnectingStream,
   setConnectingStream,
   setStreams,
   getStreams,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/types.ts
@@ -2,6 +2,6 @@ import { VideoStreamsUsersResponse } from './queries';
 import { ConnectingStream, Stream } from './state';
 
 export type StreamUser = VideoStreamsUsersResponse['user'][number];
-export type StreamItem = Stream | NonNullable<ConnectingStream>;
+export type StreamItem = Stream | ConnectingStream;
 export type GridItem = StreamUser & { type: 'grid' };
 export type VideoItem = StreamItem | GridItem;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a bug where the client stops all webcams when stopping a specific webcam.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None