### PR TITLE
fix(whiteboard): Properly handle line shape handles in akka

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -54,11 +54,21 @@ class WhiteboardModel extends SystemConfiguration {
 
     for (annotation <- annotations) {
       val oldAnnotation = wb.annotationsMap.get(annotation.id)
-      if (!oldAnnotation.isEmpty) {
+      if (oldAnnotation.isDefined) {
         val hasPermission = isPresenter || isModerator || oldAnnotation.get.userId == userId
         if (hasPermission) {
-          // Merge old and new annotation properties
-          val mergedAnnotationInfo = deepMerge(oldAnnotation.get.annotationInfo, annotation.annotationInfo)
+          // Determine if the annotation is a line shape
+          val isLineShape = annotation.annotationInfo.get("type").contains("line")
+
+          // Merge old and new annotation properties with special handling for line shape
+          val mergedAnnotationInfo = if (isLineShape) {
+            val newProps = annotation.annotationInfo.get("props").asInstanceOf[Option[Map[String, Any]]].getOrElse(Map.empty)
+            val oldProps = oldAnnotation.get.annotationInfo.get("props").asInstanceOf[Option[Map[String, Any]]].getOrElse(Map.empty)
+            val updatedProps = overwriteLineShapeHandles(oldProps, newProps)
+            annotation.annotationInfo + ("props" -> updatedProps)
+          } else {
+            deepMerge(oldAnnotation.get.annotationInfo, annotation.annotationInfo)
+          }
 
           // Apply cleaning if it's an arrow annotation
           val finalAnnotationInfo = if (annotation.annotationInfo.get("type").contains("arrow")) {
@@ -88,6 +98,15 @@ class WhiteboardModel extends SystemConfiguration {
     val newWb = wb.copy(annotationsMap = newAnnotationsMap)
     saveWhiteboard(newWb)
     annotationsAdded
+  }
+
+  private def overwriteLineShapeHandles(oldProps: Map[String, Any], newProps: Map[String, Any]): Map[String, Any] = {
+    val newHandles = newProps.get("handles")
+    val updatedProps = oldProps ++ newProps.filter {
+      case ("handles", _) => false // Remove the old handles
+      case _              => true
+    }
+    updatedProps ++ newHandles.map("handles" -> _)
   }
 
   private def cleanArrowAnnotationProps(annotationInfo: Map[String, _]): Map[String, _] = {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -138,7 +138,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   const initialViewBoxWidthRef = React.useRef(null);
 
   const THRESHOLD = 0.1;
-  const CAMERA_UPDATE_DELAY = 1000;
+  const CAMERA_UPDATE_DELAY = 650;
   const lastKnownHeight = React.useRef(presentationAreaHeight);
   const lastKnownWidth = React.useRef(presentationAreaWidth);
 
@@ -522,10 +522,12 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         const isCreatedByCurrentUser = remoteShapeMeta?.createdBy === currentUser?.userId;
         const isUpdatedByCurrentUser = remoteShapeMeta?.updatedBy === currentUser?.userId;
 
+        // System-level shapes (background image) lack createdBy and updatedBy metadata, which can cause false positives.
+        // These cases expect an early return and shouldn't be updated.
         if (
           remoteShapeMeta && (
             (isCreatedByCurrentUser && isUpdatedByCurrentUser)
-            || (isCreatedByCurrentUser && !isUpdatedByCurrentUser)
+            || (!isCreatedByCurrentUser && isUpdatedByCurrentUser)
           )
         ) {
           return;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -518,9 +518,15 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         delete remoteShape.questionType;
         toAdd.push(remoteShape);
       } else if (!isEqual(localShape, remoteShape) && prevShape) {
+        const remoteShapeMeta = remoteShape?.meta;
+        const isCreatedByCurrentUser = remoteShapeMeta?.createdBy === currentUser?.userId;
+        const isUpdatedByCurrentUser = remoteShapeMeta?.updatedBy === currentUser?.userId;
+
         if (
-          (remoteShape?.meta?.createdBy === currentUser?.userId && remoteShape?.meta?.updatedBy === currentUser?.userId)
-          || (remoteShape?.meta?.createdBy === currentUser?.userId && !remoteShape?.meta?.updatedBy)
+          remoteShapeMeta && (
+            (isCreatedByCurrentUser && isUpdatedByCurrentUser)
+            || (isCreatedByCurrentUser && !isUpdatedByCurrentUser)
+          )
         ) {
           return;
         }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -518,6 +518,13 @@ const Whiteboard = React.memo(function Whiteboard(props) {
         delete remoteShape.questionType;
         toAdd.push(remoteShape);
       } else if (!isEqual(localShape, remoteShape) && prevShape) {
+        if (
+          (remoteShape?.meta?.createdBy === currentUser?.userId && remoteShape?.meta?.updatedBy === currentUser?.userId)
+          || (remoteShape?.meta?.createdBy === currentUser?.userId && !remoteShape?.meta?.updatedBy)
+        ) {
+          return;
+        }
+
         const diff = {
           id: remoteShape.id,
           type: remoteShape.type,


### PR DESCRIPTION
### What does this PR do?
This PR adds functionality for handling line shape handles in akka. This ensures that the correct line shape data is transmitted to viewers, with the handles attribute properly overwritten instead of merged.

Additionally, it includes frontend checks to prevent unnecessary updates based on the meta properties of shapes. (related to #20070)

### Closes Issue(s)
Closes #20306,  #20340


