### PR TITLE
fix: adjust sharedNotesSetPinned action parameter type

### DIFF
--- a/bbb-graphql-actions/src/actions/sharedNotesSetPinned.ts
+++ b/bbb-graphql-actions/src/actions/sharedNotesSetPinned.ts
@@ -6,7 +6,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   throwErrorIfInvalidInput(input,
       [
         {name: 'sharedNotesExtId', type: 'string', required: true},
-        {name: 'pinned', type: 'string', required: true},
+        {name: 'pinned', type: 'boolean', required: true},
       ]
   )
 


### PR DESCRIPTION
### What does this PR do?

Fix error when a user tries to pin the shared noted to the whiteboard area