### PR TITLE
Fix: Make useDeduplicatedSubscription stop subscription with old parameters

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
@@ -44,7 +44,7 @@ function createUseSubscription<T>(
   ): GraphqlDataHookSubscriptionResponse<Array<Partial<T>>> {
     const subscriptionHashRef = useRef<string>('');
     const subscriptionRef = useRef <DocumentNode | TypedQueryDocumentNode | null>(null);
-    const optionsRef = useRef();
+    const optionsRef = useRef({});
     const subHash = stringToHash(
       JSON.stringify({ subscription: newSubscriptionGQL, variables: queryVariables }),
     );
@@ -211,11 +211,6 @@ export const useCreateUseSubscription = <T>(
   queryVariables = {},
   usePatchedSubscription = false,
 ) => {
-  const subscriptionHash = stringToHash(JSON.stringify({ subscription: query, variables: queryVariables }));
-  const subscriptionHashRef = useRef<string>('');
-  const subscriptionRef = useRef<DocumentNode | TypedQueryDocumentNode | null>(null);
-  const queryVariablesRef = useRef(queryVariables);
-
   const queryString = JSON.stringify(query);
   const queryVariablesString = JSON.stringify(queryVariables);
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import GrahqlSubscriptionStore, { stringToHash } from '/imports/ui/core/singletons/subscriptionStore';
 import { DocumentNode, TypedQueryDocumentNode } from 'graphql';
 import { OperationVariables, SubscriptionHookOptions, useReactiveVar } from '@apollo/client';
@@ -8,6 +8,9 @@ const useDeduplicatedSubscription = <T = any>(
   subscription: DocumentNode | TypedQueryDocumentNode,
   options?: SubscriptionHookOptions<NoInfer<T>, NoInfer<OperationVariables>>,
 ) => {
+  const subscriptionHashRef = useRef<string>('');
+  const subscriptionRef = useRef <DocumentNode | TypedQueryDocumentNode | null>(null);
+  const optionsRef = useRef(options);
   const subscriptionHash = stringToHash(JSON.stringify({ subscription, variables: options?.variables }));
 
   useEffect(() => {
@@ -15,6 +18,18 @@ const useDeduplicatedSubscription = <T = any>(
       GrahqlSubscriptionStore.unsubscribe(subscription, options?.variables);
     };
   }, []);
+
+  useEffect(() => {
+    if (subscriptionHashRef.current !== subscriptionHash) {
+      subscriptionHashRef.current = subscriptionHash;
+      if (subscriptionRef.current && optionsRef.current) {
+        GrahqlSubscriptionStore.unsubscribe(subscriptionRef.current, optionsRef.current?.variables);
+      }
+
+      subscriptionRef.current = subscription;
+      optionsRef.current = options;
+    }
+  }, [subscriptionHash]);
 
   const sub = useMemo(() => {
     return GrahqlSubscriptionStore.makeSubscription<T>(subscription, options?.variables);


### PR DESCRIPTION

### What does this PR do?
Change the logic of stop subscription to also includes the parameters changes and stop with the old parameters