### PR TITLE
fix: create breakout rooms button in userlist dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -303,7 +303,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
       {
         key: 'separator-02',
         isSeparator: true,
-        allow: true,
+        allow: canCreateBreakout,
       },
       {
         allow: isLearningDashboardEnabled(),
@@ -381,7 +381,7 @@ const UserTitleOptionsContainer: React.FC = () => {
   const { data: meetingInfo } = useMeeting((meeting: Partial<Meeting>) => ({
     voiceSettings: meeting?.voiceSettings,
     isBreakout: meeting?.isBreakout,
-    breakoutPolicies: meeting?.breakoutPolicies,
+    componentsFlags: meeting?.componentsFlags,
     name: meeting?.name,
   }));
 
@@ -392,14 +392,15 @@ const UserTitleOptionsContainer: React.FC = () => {
   // in case of current user isn't load yet
   if (!currentUser?.isModerator ?? true) return null;
 
+  const hasBreakoutRooms = meetingInfo?.componentsFlags?.hasBreakoutRoom ?? false;
+
   return (
     <UserTitleOptions
       isRTL={isRTL}
       isMeetingMuted={meetingInfo?.voiceSettings?.muteOnStart}
       isBreakout={meetingInfo?.isBreakout}
       isModerator={currentUser?.isModerator ?? false}
-      hasBreakoutRooms={meetingInfo?.breakoutPolicies?.breakoutRooms !== undefined
-        && meetingInfo.breakoutPolicies.breakoutRooms.length > 0}
+      hasBreakoutRooms={hasBreakoutRooms}
       meetingName={meetingInfo?.name}
     />
   );


### PR DESCRIPTION
### What does this PR do?

Fix "create breakout rooms" options appearing in manage users dropdown when breakouts are active

![2024-06-05_11-35](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/9600853d-b051-435d-a336-627121fa717b)
