### PR TITLE
feat (gql-middleware): Add env var to deny certain subscriptions

### DIFF
--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -91,6 +91,23 @@ RangeLoop:
 								}
 							}
 
+							//Validate if subscription is allowed
+							if deniedSubscriptions := os.Getenv("BBB_GRAPHQL_MIDDLEWARE_DENIED_SUBSCRIPTIONS"); deniedSubscriptions != "" {
+								deniedSubscriptionsSlice := strings.Split(deniedSubscriptions, ",")
+								subscriptionAllowed := true
+								for _, s := range deniedSubscriptionsSlice {
+									if s == operationName {
+										subscriptionAllowed = false
+										break
+									}
+								}
+
+								if !subscriptionAllowed {
+									log.Infof("Subscription %s not allowed!", operationName)
+									continue
+								}
+							}
+
 							messageType = common.Subscription
 
 							browserConnection.ActiveSubscriptionsMutex.RLock()


### PR DESCRIPTION
Introduces a new env var `BBB_GRAPHQL_MIDDLEWARE_DENIED_SUBSCRIPTIONS` that allow to block some subscriptions by informing the list of subscriptions `operationName` to ignore.

For instance, to block all streaming subscriptions set this param at `/etc/default/bbb-graphql-middleware`.
```
BBB_GRAPHQL_MIDDLEWARE_DENIED_SUBSCRIPTIONS=voiceUserStream,getCursorCoordinatesStream,getNotificationStream,annotationsStream,getEmojisToRain
```

_It will not be included on docs or as sample in `/etc/default/bbb-graphql-middleware` because it is a debugging var that might be changed or removed._