### PR TITLE
feat (gql-middleware): Add an env var to choose to store raw data cache in memory or file

### DIFF
--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -45,6 +45,13 @@ func main() {
 		log.Infof("Json Patch Disabled!")
 	}
 
+	if rawDataCacheStorageMode := os.Getenv("BBB_GRAPHQL_MIDDLEWARE_RAW_DATA_CACHE_STORAGE_MODE"); rawDataCacheStorageMode == "memory" {
+		msgpatch.RawDataCacheStorageMode = "memory"
+	} else {
+		msgpatch.RawDataCacheStorageMode = "file"
+	}
+	log.Infof("Raw Data Cache Storage Mode: %s", msgpatch.RawDataCacheStorageMode)
+
 	// Websocket listener
 
 	//Define IP to listen

--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -26,6 +26,7 @@ type GraphQlSubscription struct {
 	StreamCursorField          string
 	StreamCursorVariableName   string
 	StreamCursorCurrValue      interface{}
+	LastReceivedData           []byte
 	LastReceivedDataChecksum   uint32
 	JsonPatchSupported         bool   // indicate if client support Json Patch for this subscription
 	LastSeenOnHasuraConnection string // id of the hasura connection that this query was active

--- a/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
@@ -138,9 +138,13 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, messageMap map[strin
 						}
 
 						lastDataChecksumWas := subscription.LastReceivedDataChecksum
+						lastDataAsJsonWas := subscription.LastReceivedData
 						cacheKey := fmt.Sprintf("%s-%s-%v-%v", string(subscription.Type), subscription.OperationName, subscription.LastReceivedDataChecksum, dataChecksum)
 
 						//Store LastReceivedData Checksum
+						if msgpatch.RawDataCacheStorageMode == "memory" {
+							subscription.LastReceivedData = dataAsJson
+						}
 						subscription.LastReceivedDataChecksum = dataChecksum
 						hc.BrowserConn.ActiveSubscriptionsMutex.Lock()
 						hc.BrowserConn.ActiveSubscriptions[queryId] = subscription
@@ -148,7 +152,7 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, messageMap map[strin
 
 						//Apply msg patch when it supports it
 						if subscription.JsonPatchSupported {
-							msgpatch.PatchMessage(&messageMap, queryId, dataKey, dataAsJson, hc.BrowserConn, cacheKey, lastDataChecksumWas, dataChecksum)
+							msgpatch.PatchMessage(&messageMap, queryId, dataKey, lastDataAsJsonWas, dataAsJson, hc.BrowserConn.Id, hc.BrowserConn.SessionToken, cacheKey, lastDataChecksumWas, dataChecksum)
 						}
 					}
 				}

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -168,7 +168,7 @@ RangeLoop:
 
 					browserConnection.ActiveSubscriptionsMutex.RUnlock()
 					if jsonPatchSupported {
-						msgpatch.RemoveConnSubscriptionCacheFile(browserConnection, queryId)
+						msgpatch.RemoveConnSubscriptionCacheFile(browserConnection.Id, browserConnection.SessionToken, queryId)
 					}
 					browserConnection.ActiveSubscriptionsMutex.Lock()
 					delete(browserConnection.ActiveSubscriptions, queryId)


### PR DESCRIPTION
To generate a JsonPatch, it's essential to retain the previously received data for comparison with the new data. Currently, this data is stored in files.

To improve the middleware's performance, this PR adds an option to store the previous data in memory instead of files.

#### Configuration
To enable this feature, you need to update `/etc/default/bbb-graphql-middleware` by adding one of the following lines:

- **Store in files (default)**
  ```
  BBB_GRAPHQL_MIDDLEWARE_RAW_DATA_CACHE_STORAGE_MODE=file
  ```
- **Store in memory**
  ```
  BBB_GRAPHQL_MIDDLEWARE_RAW_DATA_CACHE_STORAGE_MODE=memory
  ```

**Note:** This configuration option is intended for debugging purposes and may be changed or removed in the future. Therefore, it will not be documented or included as a sample in `/etc/default/bbb-graphql-middleware`.