### PR TITLE
fix: Only receive user join/leave and guest join notifications if enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -11,6 +11,7 @@ import {
   userLeavePushAlert,
 } from './service';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
+import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 
 const Notifications: React.FC = () => {
   const [registeredAt, setRegisteredAt] = React.useState<string>(new Date().toISOString());
@@ -35,10 +36,31 @@ const Notifications: React.FC = () => {
     isModerator: u.isModerator,
   }));
 
+  const Settings = getSettingsSingletonInstance();
+  const {
+    userJoinPushAlerts,
+    userLeavePushAlerts,
+    guestWaitingPushAlerts,
+  } = Settings.application;
+
+  const excludedMessageIds = [];
+
+  if (!userJoinPushAlerts) {
+    excludedMessageIds.push('app.notification.userJoinPushAlert');
+  }
+
+  if (!userLeavePushAlerts) {
+    excludedMessageIds.push('app.notification.userLeavePushAlert');
+  }
+
+  if (!guestWaitingPushAlerts) {
+    excludedMessageIds.push('app.userList.guest.pendingGuestAlert');
+  }
+
   const {
     data: notificationsStream,
   } = useDeduplicatedSubscription<NotificationResponse>(getNotificationsStream, {
-    variables: { initialCursor: '2024-04-18' },
+    variables: { initialCursor: '2024-04-18', excludedMessageIds },
   });
 
   const notifier = (notification: Notification) => {

--- a/bigbluebutton-html5/imports/ui/components/notifications/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/queries.ts
@@ -16,8 +16,15 @@ export interface NotificationResponse {
 }
 
 export const getNotificationsStream = gql`
-  subscription getNotificationStream($initialCursor: timestamptz!){
-    notification_stream(batch_size: 10, cursor: {initial_value: {createdAt: $initialCursor}}) {
+  subscription getNotificationStream(
+    $initialCursor: timestamptz!,
+    $excludedMessageIds: [String!]!
+  ){
+    notification_stream(
+      batch_size: 10,
+      cursor: {initial_value: {createdAt: $initialCursor}},
+      where: {messageId: {_nin: $excludedMessageIds}}
+    ) {
       notificationType
       icon
       messageId


### PR DESCRIPTION
### What does this PR do?

This enhancement will allow the client to specify which notifications should be received, rather than the server sending all notifications regardless of whether the client uses them or not.

### Motivation

Improve performance