### PR TITLE
fix: only allow POST for insertDocument in UrlMappings.groovy

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
@@ -104,7 +104,7 @@ class UrlMappings {
     }
 
     "/bigbluebutton/api/insertDocument"(controller: "api") {
-      action = [GET: 'insertDocument', POST: 'insertDocument']
+      action = [POST: 'insertDocument']
     }
 
     "/bigbluebutton/api/getJoinUrl"(controller: "api") {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Dropping the GET url map for `insertDocument` as it's not supported
<!-- A brief description of each change being made with this pull request. -->

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none


### Motivation
We don't support GET for insertDocument
<!-- What inspired you to submit this pull request? -->

### More

