### PR TITLE
fix: only allow POST for insertDocument in UrlMappings.groovy [2.7]

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
@@ -104,7 +104,7 @@ class UrlMappings {
     }
 
     "/bigbluebutton/api/insertDocument"(controller: "api") {
-      action = [GET: 'insertDocument', POST: 'insertDocument']
+      action = [POST: 'insertDocument']
     }
 
     "/bigbluebutton/api/getJoinUrl"(controller: "api") {


### PR DESCRIPTION
Backport of #20431 to BBB 2.7