### PR TITLE
UI: Raise hand and emoji showing at the same time.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
@@ -24,7 +24,7 @@ const UserStatus: React.FC<UserStatusProps> = (props) => {
   const away = data?.away;
   return (
     <div>
-      {away && !raiseHand && <span>⏰</span>}
+      {away && <span>⏰</span>}
       {(emoji && emoji !== 'none' && !away) && <span>{emoji}</span>}
       {(muted && !listenOnly) && <Styled.Muted iconName="unmute_filled" />}
       {listenOnly && <Styled.Voice iconName="listen" /> }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
@@ -25,7 +25,7 @@ const UserStatus: React.FC<UserStatusProps> = (props) => {
   return (
     <div>
       {away && !raiseHand && <span>⏰</span>}
-      {(emoji && emoji !== 'none' && !raiseHand && !away) && <span>{emoji}</span>}
+      {(emoji && emoji !== 'none' && !away) && <span>{emoji}</span>}
       {(muted && !listenOnly) && <Styled.Muted iconName="unmute_filled" />}
       {listenOnly && <Styled.Voice iconName="listen" /> }
       {(voiceUserJoined && !muted) && <Styled.Voice iconName="unmute" />}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
@@ -20,7 +20,6 @@ const UserStatus: React.FC<UserStatusProps> = (props) => {
   const muted = voiceUser?.muted;
   const voiceUserJoined = voiceUser?.joined;
   const emoji = data?.reaction?.reactionEmoji;
-  const raiseHand = data?.raiseHand;
   const away = data?.away;
   return (
     <div>


### PR DESCRIPTION
### What does this PR do?

This PR removes the code that limits the emojis to appear only when user has no raised hands on webcam item area.

### Before

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/f49b9309-34e5-4fa8-a913-ceb30b50606b)

### After

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/79779a49-0a56-4660-9d8e-cd021bcd4304)

### Closes Issue(s)

#20419