### PR TITLE
refactor: Simplifying ReactionEmoji Storage and Queries

### DIFF
--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -469,6 +469,13 @@ type Mutation {
 }
 
 type Mutation {
+  userSetCaptionLocale(
+    locale: String!
+    provider: String!
+  ): Boolean
+}
+
+type Mutation {
   userSetConnectionAlive(
     networkRttInMs: Float!
   ): Boolean
@@ -528,13 +535,6 @@ type Mutation {
 
 type Mutation {
   userSetSpeechLocale(
-    locale: String!
-    provider: String!
-  ): Boolean
-}
-
-type Mutation {
-  userSetCaptionLocale(
     locale: String!
     provider: String!
   ): Boolean

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -59,13 +59,13 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
-  - name: captionSubmitText
+  - name: captionAddLocale
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
-  - name: captionAddLocale
+  - name: captionSubmitText
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
@@ -421,6 +421,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: userSetCaptionLocale
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: userSetConnectionAlive
     definition:
       kind: synchronous
@@ -476,12 +482,6 @@ actions:
     permissions:
       - role: bbb_client
   - name: userSetSpeechLocale
-    definition:
-      kind: synchronous
-      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
-    permissions:
-      - role: bbb_client
-  - name: userSetCaptionLocale
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_activeLocales.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_activeLocales.yaml
@@ -11,8 +11,8 @@ object_relationships:
     using:
       manual_configuration:
         column_mapping:
-          meetingId: meetingId
           createdBy: userId
+          meetingId: meetingId
         insertion_order: null
         remote_table:
           name: v_user_ref

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -34,15 +34,6 @@ object_relationships:
         remote_table:
           name: v_meeting
           schema: public
-  - name: reaction
-    using:
-      manual_configuration:
-        column_mapping:
-          userId: userId
-        insertion_order: null
-        remote_table:
-          name: v_user_reaction_current
-          schema: public
   - name: voice
     using:
       manual_configuration:
@@ -81,6 +72,7 @@ select_permissions:
         - away
         - awayTime
         - banned
+        - captionLocale
         - clientType
         - color
         - disconnected
@@ -105,10 +97,10 @@ select_permissions:
         - presenter
         - raiseHand
         - raiseHandTime
+        - reactionEmoji
         - registeredOn
         - role
         - speechLocale
-        - captionLocale
         - userId
       filter:
         _and:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -52,15 +52,6 @@ object_relationships:
         remote_table:
           name: v_meeting
           schema: public
-  - name: reaction
-    using:
-      manual_configuration:
-        column_mapping:
-          userId: userId
-        insertion_order: null
-        remote_table:
-          name: v_user_reaction_current
-          schema: public
   - name: sharedNotesSession
     using:
       manual_configuration:
@@ -153,8 +144,8 @@ select_permissions:
         - avatar
         - away
         - banned
+        - captionLocale
         - clientType
-        - enforceLayout
         - color
         - disconnected
         - echoTestRunningAt
@@ -162,11 +153,14 @@ select_permissions:
         - ejectReasonCode
         - ejected
         - emoji
+        - enforceLayout
         - expired
         - extId
         - guest
         - guestStatus
         - hasDrawPermissionOnCurrentPage
+        - inactivityWarningDisplay
+        - inactivityWarningTimeoutSecs
         - isDialIn
         - isModerator
         - isOnline
@@ -182,13 +176,11 @@ select_permissions:
         - pinned
         - presenter
         - raiseHand
+        - reactionEmoji
         - registeredAt
         - registeredOn
         - role
         - speechLocale
-        - captionLocale
-        - inactivityWarningDisplay
-        - inactivityWarningTimeoutSecs
         - userId
       filter:
         _and:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
@@ -14,6 +14,7 @@ select_permissions:
         - avatar
         - away
         - banned
+        - captionLocale
         - clientType
         - color
         - disconnected
@@ -35,10 +36,10 @@ select_permissions:
         - pinned
         - presenter
         - raiseHand
+        - reactionEmoji
         - registeredOn
         - role
         - speechLocale
-        - captionLocale
         - userId
       filter:
         meetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -54,7 +54,6 @@
 - "!include public_v_user_customParameter.yaml"
 - "!include public_v_user_guest.yaml"
 - "!include public_v_user_reaction.yaml"
-- "!include public_v_user_reaction_current.yaml"
 - "!include public_v_user_ref.yaml"
 - "!include public_v_user_transcriptionError.yaml"
 - "!include public_v_user_typing_private.yaml"

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -45,10 +45,6 @@ export interface CustomParameter {
   value: string;
 }
 
-export interface Reaction {
-  reactionEmoji: string;
-}
-
 export interface BreakoutRooms {
   currentRoomJoined: boolean;
   assignedAt: string;
@@ -102,6 +98,7 @@ export interface User {
   color: string;
   avatar: string;
   emoji: string;
+  reactionEmoji: string;
   presenter?: boolean;
   pinned?: boolean;
   guest?: boolean;
@@ -127,7 +124,6 @@ export interface User {
   size: number;
   away: boolean;
   raiseHand: boolean;
-  reaction: Reaction;
   breakoutRooms: BreakoutRooms;
   customParameters: Array<CustomParameter>;
   userClientSettings: UserClientSettings;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
@@ -21,7 +21,7 @@ const ReactionsButtonContainer = ({ ...props }) => {
     raiseHand: user.raiseHand,
     away: user.away,
     voice: user.voice,
-    reaction: user.reaction,
+    reactionEmoji: user.reactionEmoji,
   }));
 
   const currentUser = {
@@ -36,7 +36,7 @@ const ReactionsButtonContainer = ({ ...props }) => {
 
   return (
     <ReactionsButton {...{
-      currentUserReaction: currentUserData?.reaction?.reactionEmoji ?? 'none',
+      currentUserReaction: currentUserData?.reactionEmoji ?? 'none',
       layoutContextDispatch,
       sidebarContentPanel,
       isMobile,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -160,7 +160,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
 
   const reactionsEnabled = isReactionsEnabled();
 
-  const userAvatarFiltered = (user.raiseHand === true || user.away === true || (user.reaction && user.reaction.reactionEmoji !== 'none')) ? '' : user.avatar;
+  const userAvatarFiltered = (user.raiseHand === true || user.away === true || (user.reactionEmoji && user.reactionEmoji !== 'none')) ? '' : user.avatar;
 
   const emojiIcons = [
     {
@@ -192,8 +192,8 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
     if (user.emoji !== 'none' && user.emoji !== 'notAway') {
       return <Icon iconName={normalizeEmojiName(user.emoji)} />;
     }
-    if (user.reaction && user.reaction.reactionEmoji !== 'none') {
-      return user.reaction.reactionEmoji;
+    if (user.reactionEmoji && user.reactionEmoji !== 'none') {
+      return user.reactionEmoji;
     }
     if (user.name && userAvatarFiltered.length === 0) {
       return user.name.toLowerCase().slice(0, 2);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -23,9 +23,7 @@ subscription getvideoData($userIds: [String]!) {
     userId
     raiseHand
     isModerator
-    reaction {
-      reactionEmoji
-    }
+    reactionEmoji
   }
 }
 `;
@@ -46,9 +44,7 @@ subscription getVideoDataGrid {
     clientType
     userId
     raiseHand
-    reaction {
-      reactionEmoji
-    }
+    reactionEmoji
   }
 }
 `;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-status/component.jsx
@@ -8,7 +8,7 @@ const UserStatus = (props) => {
   const listenOnly = voiceUser?.listenOnly;
   const muted = voiceUser?.muted;
   const voiceUserJoined = voiceUser?.joined;
-  const emoji = user?.reaction?.reactionEmoji;
+  const emoji = user?.reactionEmoji;
   const raiseHand = user?.raiseHand;
   const away = user?.away;
   return (

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/queries.ts
@@ -33,9 +33,7 @@ export interface VideoStreamsUsersResponse {
     clientType: string;
     raiseHand: boolean;
     isModerator: boolean;
-    reaction: {
-      reactionEmoji: string;
-    };
+    reactionEmoji: string;
   }[];
 }
 
@@ -118,9 +116,7 @@ export const GRID_USERS_SUBSCRIPTION = gql`
       userId
       raiseHand
       isModerator
-      reaction {
-        reactionEmoji
-      }
+      reactionEmoji
     }
   }
 `;
@@ -149,9 +145,7 @@ export const VIDEO_STREAMS_USERS_FILTERED_SUBSCRIPTION = gql`
       userId
       raiseHand
       isModerator
-      reaction {
-        reactionEmoji
-      }
+      reactionEmoji
     }
   }
 `;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-status/component.tsx
@@ -19,7 +19,7 @@ const UserStatus: React.FC<UserStatusProps> = (props) => {
   const listenOnly = voiceUser?.listenOnly;
   const muted = voiceUser?.muted;
   const voiceUserJoined = voiceUser?.joined;
-  const emoji = data?.reaction?.reactionEmoji;
+  const emoji = data?.reactionEmoji;
   const away = data?.away;
   return (
     <div>

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -16,6 +16,7 @@ subscription userCurrentSubscription {
     ejectReasonCode
     ejected
     emoji
+    reactionEmoji
     enforceLayout
     expired
     extId
@@ -48,9 +49,6 @@ subscription userCurrentSubscription {
     customParameters {
       parameter
       value
-    }
-    reaction {
-      reactionEmoji
     }
     breakoutRooms {
       currentRoomJoined

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -23,6 +23,7 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
     away
     raiseHand
     emoji
+    reactionEmoji
     avatar
     presenter
     pinned
@@ -53,9 +54,6 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
       sequence
       shortName
       currentlyInRoom
-    }
-    reaction {
-      reactionEmoji
     }
   }
 }`;


### PR DESCRIPTION
This PR introduces a change to store the user's `reactionEmoji` directly in the `user` table. This adjustment streamlines the process of fetching the current emoji, as it eliminates the need to compare the entire history of emojis to find the most recent one.

- Before: `user.reaction.reactionEmoji`
- Now: `user.reactionEmoji`

An Akka-apps routine is now in place to ensure that expired emojis are cleared from the `user` table. This makes the query more efficient since it no longer needs to filter out expired reactions.

This refactor is part of a series of improvements designed to make GraphQL queries faster and more efficient for the server.