### PR TITLE
fix(plugin): current locale not being sent when client reloads

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlAdapter.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlAdapter.tsx
@@ -88,6 +88,14 @@ const IntlAdapter: React.FC<IntlAdapterProps> = ({
   const runOnCurrentLocaleUpdate = () => {
     setUp();
     sendUiDataToPlugins();
+    window.removeEventListener(
+      `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.IntlLocaleUiDataNames.CURRENT_LOCALE}`,
+      sendUiDataToPlugins,
+    );
+    window.addEventListener(
+      `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.IntlLocaleUiDataNames.CURRENT_LOCALE}`,
+      sendUiDataToPlugins,
+    );
   };
 
   useEffect(runOnMountAndUnmount, []);


### PR DESCRIPTION
### What does this PR do?

Fixes wrong locale being sent to plugins with useUiData in some cases:

- If the user change the language and then refreshes the page, the plugins were still receving the original language locale.
