### PR TITLE
fix(html5): Fix captionLocale logic to fetch correct captions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
@@ -68,7 +68,7 @@ const AudioCaptionsLiveContainer: React.FC = () => {
     loading: AudioCaptionsLiveLoading,
     error: AudioCaptionsLiveError,
   } = useDeduplicatedSubscription<getCaptions>(GET_CAPTIONS, {
-    variables: { locale: currentUser?.speechLocale ?? 'en-US' },
+    variables: { locale: currentUser?.captionLocale ?? 'en-US' },
   });
 
   const [audioCaptionsEnable] = useAudioCaptionEnable();


### PR DESCRIPTION
### What does this PR do?

As detected in the last dev-call, captions with languages other than English were not being displayed. This PR fixes it, now, any language the user chooses to see captions from, they will see it correctly.