### PR TITLE
refactor: replace defaultProps on function components with default function parameters

### DIFF
--- a/bigbluebutton-html5/.eslintrc.js
+++ b/bigbluebutton-html5/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     'jsx-a11y/no-access-key': 0,
     'react/jsx-props-no-spreading': 'off',
     'max-classes-per-file': ['error', 2],
+    'react/require-default-props': 0,
   },
   globals: {
     browser: 'writable',
@@ -43,6 +44,7 @@ module.exports = {
         'import/extensions': [2, 'never'],
         'react/sort-comp': [0],
         'react/jsx-filename-extension': ['error', { extensions: ['.tsx', '.jsx'] }],
+        'react/require-default-props': 0,
         'max-len': [
           'error',
           {

--- a/bigbluebutton-html5/imports/startup/client/base.jsx
+++ b/bigbluebutton-html5/imports/startup/client/base.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
-import PropTypes from 'prop-types';
 import Auth from '/imports/ui/services/auth';
 import AppContainer from '/imports/ui/components/app/container';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
@@ -22,14 +21,6 @@ import { useStorageKey } from '/imports/ui/services/storage/hooks';
 const HTML = document.getElementsByTagName('html')[0];
 
 let checkedUserSettings = false;
-
-const propTypes = {
-  approved: PropTypes.bool,
-};
-
-const defaultProps = {
-  approved: false,
-};
 
 const fullscreenChangedEvents = [
   'fullscreenchange',
@@ -181,9 +172,6 @@ class Base extends Component {
     );
   }
 }
-
-Base.propTypes = propTypes;
-Base.defaultProps = defaultProps;
 
 const BaseContainer = (props) => {
   const codeError = useStorageKey('codeError');

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -227,17 +227,11 @@ const propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   userId: PropTypes.string.isRequired,
-  emoji: PropTypes.string,
   sidebarContentPanel: PropTypes.string.isRequired,
   layoutContextDispatch: PropTypes.func.isRequired,
   muted: PropTypes.bool.isRequired,
 };
 
-const defaultProps = {
-  emoji: '',
-};
-
 ReactionsButton.propTypes = propTypes;
-ReactionsButton.defaultProps = defaultProps;
 
 export default withShortcutHelper(ReactionsButton, ['raiseHand']);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -29,10 +29,6 @@ const propTypes = {
   screenshareDataSavingSetting: PropTypes.bool.isRequired,
 };
 
-const defaultProps = {
-  amIPresenter: false,
-};
-
 const intlMessages = defineMessages({
   desktopShareLabel: {
     id: 'app.actionsBar.actionsDropdown.desktopShareLabel',
@@ -121,7 +117,7 @@ const ScreenshareButton = ({
   intl,
   enabled,
   isScreenBroadcasting,
-  amIPresenter,
+  amIPresenter = false,
   isMeteorConnected,
 }) => {
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
@@ -218,5 +214,4 @@ const ScreenshareButton = ({
 };
 
 ScreenshareButton.propTypes = propTypes;
-ScreenshareButton.defaultProps = defaultProps;
 export default injectIntl(memo(ScreenshareButton));

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -125,10 +125,6 @@ const propTypes = {
   darkTheme: PropTypes.bool.isRequired,
 };
 
-const defaultProps = {
-  actionsbar: null,
-};
-
 const isLayeredView = window.matchMedia(`(max-width: ${SMALL_VIEWPORT_BREAKPOINT}px)`);
 
 class App extends Component {
@@ -650,6 +646,5 @@ class App extends Component {
 }
 
 App.propTypes = propTypes;
-App.defaultProps = defaultProps;
 
 export default injectIntl(App);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -69,14 +69,6 @@ const propTypes = {
   away: PropTypes.bool,
 };
 
-const defaultProps = {
-  inputDeviceId: null,
-  outputDeviceId: null,
-  resolve: null,
-  joinFullAudioImmediately: false,
-  away: false,
-};
-
 const intlMessages = defineMessages({
   microphoneLabel: {
     id: 'app.audioModal.microphoneLabel',
@@ -144,7 +136,47 @@ const intlMessages = defineMessages({
   },
 });
 
-const AudioModal = (props) => {
+const AudioModal = ({
+  forceListenOnlyAttendee,
+  joinFullAudioImmediately = false,
+  listenOnlyMode,
+  audioLocked,
+  isUsingAudio,
+  isListenOnly,
+  autoplayBlocked,
+  closeModal,
+  isEchoTest,
+  exitAudio,
+  resolve = null,
+  leaveEchoTest,
+  AudioError,
+  joinEchoTest,
+  isConnecting,
+  localEchoEnabled,
+  joinListenOnly,
+  changeInputStream,
+  joinMicrophone,
+  intl,
+  isMobileNative,
+  formattedDialNum,
+  isRTL,
+  isConnected,
+  inputDeviceId = null,
+  outputDeviceId = null,
+  changeInputDevice,
+  changeOutputDevice,
+  showVolumeMeter,
+  notify,
+  formattedTelVoice,
+  handleAllowAutoplay,
+  showPermissionsOvelay,
+  isIE,
+  isOpen,
+  priority,
+  setIsOpen,
+  getTroubleshootingLink,
+  away = false,
+}) => {
   const [content, setContent] = useState(null);
   const [hasError, setHasError] = useState(false);
   const [disableActions, setDisableActions] = useState(false);
@@ -152,48 +184,6 @@ const AudioModal = (props) => {
   const [autoplayChecked, setAutoplayChecked] = useState(false);
   const [setAway] = useMutation(SET_AWAY);
   const voiceToggle = useToggleVoice();
-
-  const {
-    forceListenOnlyAttendee,
-    joinFullAudioImmediately,
-    listenOnlyMode,
-    audioLocked,
-    isUsingAudio,
-    isListenOnly,
-    autoplayBlocked,
-    closeModal,
-    isEchoTest,
-    exitAudio,
-    resolve,
-    leaveEchoTest,
-    AudioError,
-    joinEchoTest,
-    isConnecting,
-    localEchoEnabled,
-    joinListenOnly,
-    changeInputStream,
-    joinMicrophone,
-    intl,
-    isMobileNative,
-    formattedDialNum,
-    isRTL,
-    isConnected,
-    inputDeviceId,
-    outputDeviceId,
-    changeInputDevice,
-    changeOutputDevice,
-    showVolumeMeter,
-    notify,
-    formattedTelVoice,
-    handleAllowAutoplay,
-    showPermissionsOvelay,
-    isIE,
-    isOpen,
-    priority,
-    setIsOpen,
-    getTroubleshootingLink,
-    away,
-  } = props;
 
   const prevAutoplayBlocked = usePreviousValue(autoplayBlocked);
 
@@ -588,6 +578,5 @@ const AudioModal = (props) => {
 };
 
 AudioModal.propTypes = propTypes;
-AudioModal.defaultProps = defaultProps;
 
 export default injectIntl(AudioModal);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-stream-volume/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-stream-volume/component.jsx
@@ -21,12 +21,12 @@ const propTypes = {
 };
 
 const AudioStreamVolume = ({
-  volumeFloor,
-  volumeRange,
-  low,
-  optimum,
-  high,
-  stream,
+  volumeFloor = VOL_FLOOR,
+  volumeRange = VOL_CEIL,
+  low = VOL_FLOOR,
+  optimum = Math.round(0.3 * VOL_CEIL),
+  high = Math.round(0.4 * VOL_CEIL),
+  stream = null,
 }) => {
   const harkObserver = useRef(null);
   const volumeRef = useRef(0);
@@ -86,13 +86,5 @@ const AudioStreamVolume = ({
 };
 
 AudioStreamVolume.propTypes = propTypes;
-AudioStreamVolume.defaultProps = {
-  volumeFloor: VOL_FLOOR,
-  volumeRange: VOL_CEIL,
-  low: VOL_FLOOR,
-  optimum: Math.round(0.3 * VOL_CEIL),
-  high: Math.round(0.4 * VOL_CEIL),
-  stream: null,
-};
 
 export default React.memo(AudioStreamVolume);

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -237,10 +237,6 @@ export default lockContextContainer(injectIntl(withTracker(({
   };
 })(AudioContainer)));
 
-AudioContainer.defaultProps = {
-  microphoneConstraints: undefined,
-};
-
 AudioContainer.propTypes = {
   hasBreakoutRooms: PropTypes.bool.isRequired,
   meetingIsBreakout: PropTypes.bool.isRequired,
@@ -255,5 +251,4 @@ AudioContainer.propTypes = {
   userLocks: PropTypes.shape({
     userMic: PropTypes.bool.isRequired,
   }).isRequired,
-  microphoneConstraints: PropTypes.shape({}),
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/component.jsx
@@ -16,11 +16,6 @@ const propTypes = {
   initialHearingState: PropTypes.bool,
 };
 
-const defaultProps = {
-  stream: null,
-  initialHearingState: false,
-};
-
 const intlMessages = defineMessages({
   stopAudioFeedbackLabel: {
     id: 'app.audio.stopAudioFeedback',
@@ -34,8 +29,8 @@ const intlMessages = defineMessages({
 
 const LocalEcho = ({
   intl,
-  stream,
-  initialHearingState,
+  stream = null,
+  initialHearingState = false,
 }) => {
   const loopbackAgent = useRef(null);
   const [hearing, setHearing] = useState(initialHearingState);
@@ -83,6 +78,5 @@ const LocalEcho = ({
 };
 
 LocalEcho.propTypes = propTypes;
-LocalEcho.defaultProps = defaultProps;
 
 export default injectIntl(React.memo(LocalEcho));

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -515,7 +515,7 @@ const CreateBreakoutRoomContainer: React.FC<CreateBreakoutRoomContainerProps> = 
   isOpen,
   setIsOpen,
   priority,
-  isUpdate,
+  isUpdate = false,
 }) => {
   const [fetchedBreakouts, setFetchedBreakouts] = React.useState(false);
   // isBreakoutRecordable - get from meeting breakout policies breakoutPolicies/record
@@ -575,14 +575,6 @@ const CreateBreakoutRoomContainer: React.FC<CreateBreakoutRoomContainerProps> = 
       runningRooms={breakoutsData?.breakoutRoom ?? []}
     />
   );
-};
-
-CreateBreakoutRoomContainer.defaultProps = {
-  isUpdate: false,
-};
-
-CreateBreakoutRoom.defaultProps = {
-  isUpdate: false,
 };
 
 export default CreateBreakoutRoomContainer;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -76,7 +76,7 @@ function assertAsMetadata(metadata: unknown): asserts metadata is Metadata {
 
 const ChatPollContent: React.FC<ChatPollContentProps> = ({
   metadata: string,
-  height,
+  height = undefined,
 }) => {
   const intl = useIntl();
 
@@ -112,10 +112,6 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
       </ResponsiveContainer>
     </div>
   );
-};
-
-ChatPollContent.defaultProps = {
-  height: undefined,
 };
 
 export default ChatPollContent;

--- a/bigbluebutton-html5/imports/ui/components/common/button/button-emoji/ButtonEmoji.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/button-emoji/ButtonEmoji.jsx
@@ -28,32 +28,22 @@ const propTypes = {
   rotate: PropTypes.bool,
 };
 
-const defaultProps = {
-  emoji: '',
-  label: '',
-  onKeyDown: null,
-  onFocus: null,
-  tabIndex: -1,
-  hideLabel: false,
-  onClick: null,
-  className: '',
-  rotate: false,
-};
-
 const ButtonEmoji = (props) => {
   const {
-    hideLabel,
-    className,
+    hideLabel = false,
+    className = '',
     hidden,
-    rotate,
+    rotate = false,
     ...newProps
   } = props;
 
   const {
-    emoji,
-    label,
-    tabIndex,
-    onClick,
+    emoji = '',
+    label = '',
+    tabIndex = -1,
+    onClick = null,
+    onKeyDown = null,
+    onFocus = null,
   } = newProps;
 
   const IconComponent = (<Styled.EmojiButtonIcon iconName={emoji} rotate={rotate} />);
@@ -68,6 +58,9 @@ const ButtonEmoji = (props) => {
           {...newProps}
           aria-label={label}
           onClick={onClick}
+          onKeyDown={onKeyDown}
+          onFocus={onFocus}
+          className={className}
         >
           <Styled.Label>
             { !hideLabel && label }
@@ -82,4 +75,3 @@ const ButtonEmoji = (props) => {
 export default ButtonEmoji;
 
 ButtonEmoji.propTypes = propTypes;
-ButtonEmoji.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/common/fallback-errors/fallback-view/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/fallback-errors/fallback-view/component.jsx
@@ -27,13 +27,14 @@ const propTypes = {
   }),
 };
 
-const defaultProps = {
-  error: {
-    message: '',
-  },
+const defaultError = {
+  message: '',
 };
 
-const FallbackView = ({ error, intl }) => (
+const FallbackView = ({
+  error = defaultError,
+  intl,
+}) => (
   <Styled.Background>
     <Styled.CodeError>
       {intl.formatMessage(intlMessages.title)}
@@ -57,6 +58,5 @@ const FallbackView = ({ error, intl }) => (
 );
 
 FallbackView.propTypes = propTypes;
-FallbackView.defaultProps = defaultProps;
 
 export default injectIntl(FallbackView);

--- a/bigbluebutton-html5/imports/ui/components/common/fullscreen-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/fullscreen-button/component.jsx
@@ -30,32 +30,21 @@ const propTypes = {
   fullScreenStyle: PropTypes.bool,
 };
 
-const defaultProps = {
-  dark: false,
-  bottom: false,
-  isIphone: false,
-  isFullscreen: false,
-  elementName: '',
-  color: 'default',
-  fullScreenStyle: true,
-  fullscreenRef: null,
-};
-
 const FullscreenButtonComponent = ({
   intl,
-  dark,
-  bottom,
-  elementName,
+  dark = false,
+  bottom = false,
+  elementName = '',
   elementId,
   elementGroup,
-  isIphone,
-  isFullscreen,
+  isIphone = false,
+  isFullscreen = false,
   layoutContextDispatch,
   currentElement,
   currentGroup,
-  color,
-  fullScreenStyle,
-  fullscreenRef,
+  color = 'default',
+  fullScreenStyle = true,
+  fullscreenRef = null,
   handleToggleFullScreen,
 }) => {
   if (isIphone) return null;
@@ -105,6 +94,5 @@ const FullscreenButtonComponent = ({
 };
 
 FullscreenButtonComponent.propTypes = propTypes;
-FullscreenButtonComponent.defaultProps = defaultProps;
 
 export default injectIntl(FullscreenButtonComponent);

--- a/bigbluebutton-html5/imports/ui/components/common/icon/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/icon/component.jsx
@@ -12,19 +12,12 @@ const propTypes = {
   color: PropTypes.string,
 };
 
-const defaultProps = {
-  prependIconName: 'icon-bbb-',
-  rotate: false,
-  className: '',
-  color: undefined,
-};
-
 const Icon = ({
-  className,
-  prependIconName,
+  className = '',
+  prependIconName = 'icon-bbb-',
   iconName,
-  rotate,
-  color,
+  rotate = false,
+  color = undefined,
   ...props
 }) => (
   <Styled.Icon
@@ -39,4 +32,3 @@ const Icon = ({
 export default memo(Icon);
 
 Icon.propTypes = propTypes;
-Icon.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/common/icon/icon-ts/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/icon/icon-ts/component.tsx
@@ -9,16 +9,10 @@ interface IconProps {
   className?: string;
 }
 
-const defaultProps = {
-  prependIconName: 'icon-bbb-',
-  rotate: false,
-  className: '',
-};
-
 const Icon: React.FC<IconProps> = ({
-  className,
-  prependIconName,
-  iconName,
+  className = '',
+  prependIconName = 'icon-bbb-',
+  iconName = '',
   rotate = false,
 }) => (
   <Styled.Icon
@@ -26,7 +20,5 @@ const Icon: React.FC<IconProps> = ({
     $rotate={rotate}
   />
 );
-
-Icon.defaultProps = defaultProps;
 
 export default memo(Icon);

--- a/bigbluebutton-html5/imports/ui/components/common/remaining-time/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/remaining-time/component.tsx
@@ -20,11 +20,6 @@ interface RemainingTimeProps {
   alertLabel?: intlMsg;
 }
 
-const defaultProps = {
-  endingLabel: undefined,
-  alertLabel: undefined,
-};
-
 let lastAlertTime: number | null = null;
 
 const RemainingTime: React.FC<RemainingTimeProps> = (props) => {
@@ -32,8 +27,8 @@ const RemainingTime: React.FC<RemainingTimeProps> = (props) => {
     referenceStartedTime,
     durationInSeconds,
     durationLabel,
-    endingLabel,
-    alertLabel,
+    endingLabel = undefined,
+    alertLabel = undefined,
     isBreakout,
     boldText,
   } = props;
@@ -125,7 +120,5 @@ const RemainingTime: React.FC<RemainingTimeProps> = (props) => {
     </span>
   );
 };
-
-RemainingTime.defaultProps = defaultProps;
 
 export default RemainingTime;

--- a/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
@@ -10,10 +10,6 @@ const propTypes = {
   type: PropTypes.oneOf(Object.values(toast.TYPE)).isRequired,
 };
 
-const defaultProps = {
-  icon: null,
-};
-
 const defaultIcons = {
   [toast.TYPE.INFO]: 'help',
   [toast.TYPE.SUCCESS]: 'checkmark',
@@ -23,7 +19,7 @@ const defaultIcons = {
 };
 
 const Toast = ({
-  icon,
+  icon = null,
   type,
   message,
   content,
@@ -53,4 +49,3 @@ const Toast = ({
 export default Toast;
 
 Toast.propTypes = propTypes;
-Toast.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/dropdown/list/separator/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/list/separator/component.jsx
@@ -2,16 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Styled from './styles';
 
-const DropdownListSeparator = ({ style }) => (
+const DropdownListSeparator = ({ style = null }) => (
   <Styled.Separator style={style} />
 );
 
 DropdownListSeparator.propTypes = {
   style: PropTypes.shape({}),
-};
-
-DropdownListSeparator.defaultProps = {
-  style: null,
 };
 
 export default DropdownListSeparator;

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -7,19 +7,17 @@ import deviceInfo from '/imports/utils/deviceInfo';
 import Button from '/imports/ui/components/common/button/component';
 import Styled from './styles';
 
-const LayoutModalComponent = (props) => {
-  const {
-    intl,
-    setIsOpen,
-    isModerator,
-    isPresenter,
-    application,
-    updateSettings,
-    onRequestClose,
-    isOpen,
-    setLocalSettings,
-  } = props;
-
+const LayoutModalComponent = ({
+  intl,
+  setIsOpen,
+  isModerator = false,
+  isPresenter,
+  application,
+  updateSettings,
+  onRequestClose,
+  isOpen,
+  setLocalSettings,
+}) => {
   const [selectedLayout, setSelectedLayout] = useState(application.selectedLayout);
   const [updateAllUsed, setUpdateAllUsed] = useState(false);
 
@@ -199,11 +197,6 @@ const propTypes = {
   setLocalSettings: PropTypes.func.isRequired,
 };
 
-const defaultProps = {
-  isModerator: false,
-};
-
 LayoutModalComponent.propTypes = propTypes;
-LayoutModalComponent.defaultProps = defaultProps;
 
 export default injectIntl(LayoutModalComponent);

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/component.jsx
@@ -11,17 +11,11 @@ const propTypes = {
   color: PropTypes.string,
 };
 
-const defaultProps = {
-  color: 'default',
-};
-
-const NotificationsBar = (props) => {
-  const {
-    color,
-    children,
-    alert,
-  } = props;
-
+const NotificationsBar = ({
+  color = 'default',
+  children,
+  alert,
+}) => {
   const hasColor = COLORS.includes(color);
 
   return (
@@ -42,6 +36,5 @@ const NotificationsBar = (props) => {
 };
 
 NotificationsBar.propTypes = propTypes;
-NotificationsBar.defaultProps = defaultProps;
 
 export default injectWbResizeEvent(NotificationsBar);

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -634,6 +634,7 @@ class Presentation extends PureComponent {
         multiUser={multiUser}
         whiteboardId={currentSlide?.id}
         numberOfSlides={totalPages}
+        layoutSwapped={false}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/download-presentation-button/component.jsx
@@ -18,14 +18,10 @@ const propTypes = {
   dark: PropTypes.bool,
 };
 
-const defaultProps = {
-  dark: false,
-};
-
 const DownloadPresentationButton = ({
   intl,
   handleDownloadPresentation,
-  dark,
+  dark = false,
 }) => (
   <Styled.ButtonWrapper theme={dark ? 'dark' : 'light'}>
     <Styled.DownloadButton
@@ -41,6 +37,5 @@ const DownloadPresentationButton = ({
 );
 
 DownloadPresentationButton.propTypes = propTypes;
-DownloadPresentationButton.defaultProps = defaultProps;
 
 export default injectIntl(DownloadPresentationButton);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -99,40 +99,25 @@ const propTypes = {
   })).isRequired,
 };
 
-const defaultProps = {
-  allowSnapshotOfCurrentSlide: false,
-  isIphone: false,
-  isFullscreen: false,
-  isRTL: false,
-  elementName: '',
-  meetingName: '',
-  fullscreenRef: null,
-  elementId: '',
-  elementGroup: '',
-  currentElement: '',
-  currentGroup: '',
-  tldrawAPI: null,
-};
-
 const PresentationMenu = (props) => {
   const {
     intl,
-    isFullscreen,
-    elementId,
-    elementName,
-    elementGroup,
-    currentElement,
-    currentGroup,
-    fullscreenRef,
-    tldrawAPI,
+    isFullscreen = false,
+    elementId = '',
+    elementName = '',
+    elementGroup = '',
+    currentElement = '',
+    currentGroup = '',
+    fullscreenRef = null,
+    tldrawAPI = null,
     handleToggleFullscreen,
     layoutContextDispatch,
-    meetingName,
-    isIphone,
-    isRTL,
+    meetingName = '',
+    isIphone = false,
+    isRTL = false,
     isToolbarVisible,
     setIsToolbarVisible,
-    allowSnapshotOfCurrentSlide,
+    allowSnapshotOfCurrentSlide = false,
     presentationDropdownItems,
     slideNum,
     currentUser,
@@ -541,6 +526,5 @@ const PresentationMenu = (props) => {
 };
 
 PresentationMenu.propTypes = propTypes;
-PresentationMenu.defaultProps = defaultProps;
 
 export default injectIntl(PresentationMenu);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -125,7 +125,3 @@ PresentationToolbarContainer.propTypes = {
   // Actions required for the presenter toolbar
   layoutSwapped: PropTypes.bool,
 };
-
-PresentationToolbarContainer.defaultProps = {
-  layoutSwapped: false,
-};

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
@@ -25,10 +25,13 @@ const createAction = (url, startWatching) => {
   }
 };
 
-export const SmartMediaShare = (props) => {
-  const {
-    currentSlide, intl, isMobile, isRTL, startWatching,
-  } = props;
+export const SmartMediaShare = ({
+  currentSlide = undefined,
+  intl,
+  isMobile,
+  isRTL,
+  startWatching,
+}) => {
   const linkPatt = /(https?:\/\/.*?)(?=\s|$)/g;
   const externalLinks = safeMatch(linkPatt, currentSlide?.content?.replace(/[\r\n]/g, '  '), false);
   if (!externalLinks) return null;
@@ -85,8 +88,4 @@ SmartMediaShare.propTypes = {
   }).isRequired,
   isMobile: PropTypes.bool.isRequired,
   isRTL: PropTypes.bool.isRequired,
-};
-
-SmartMediaShare.defaultProps = {
-  currentSlide: undefined,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/switch-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/switch-button/component.jsx
@@ -24,21 +24,13 @@ const propTypes = {
   switched: PropTypes.bool,
 };
 
-const defaultProps = {
-  dark: false,
-  bottom: false,
-  handleSwitch: () => {},
-  switched: false,
-};
-
-const SwitchButtonComponent = (props) => {
-  const {
-    intl,
-    dark,
-    bottom,
-    handleSwitch,
-    switched,
-  } = props;
+const SwitchButtonComponent = ({
+  intl,
+  dark = false,
+  bottom = false,
+  handleSwitch = () => {},
+  switched = false,
+}) => {
   const formattedLabel = intl.formatMessage(switched
     ? intlMessages.switchButtonShrink
     : intlMessages.switchButtonExpand);
@@ -59,6 +51,5 @@ const SwitchButtonComponent = (props) => {
 };
 
 SwitchButtonComponent.propTypes = propTypes;
-SwitchButtonComponent.defaultProps = defaultProps;
 
 export default injectIntl(SwitchButtonComponent);

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -269,12 +269,13 @@ const renderItemWhiteBoard = (func, key, alt) => {
   );
 }
 
-const ShortcutHelpComponent = (props) => {
-  const { intl, shortcuts,
-    isOpen,
-    onRequestClose,
-    priority,
-  } = props;
+const ShortcutHelpComponent = ({
+  intl = {},
+  shortcuts,
+  isOpen,
+  onRequestClose,
+  priority,
+}) => {
   const { browserName } = browserInfo;
   const { isIos, isMacos } = deviceInfo;
   const [ selectedTab, setSelectedTab] = React.useState(0);
@@ -442,10 +443,6 @@ const ShortcutHelpComponent = (props) => {
       </Styled.SettingsTabs>
     </ModalSimple>
   );
-};
-
-ShortcutHelpComponent.defaultProps = {
-  intl: {},
 };
 
 ShortcutHelpComponent.propTypes = {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -26,16 +26,11 @@ const propTypes = {
   contextDispatch: PropTypes.func.isRequired,
 };
 
-const defaultProps = {
-  left: null,
-  right: null,
-};
-
 const SidebarContent = (props) => {
   const {
     top,
-    left,
-    right,
+    left = null,
+    right = null,
     zIndex,
     minWidth,
     width,
@@ -162,5 +157,4 @@ const SidebarContent = (props) => {
 };
 
 SidebarContent.propTypes = propTypes;
-SidebarContent.defaultProps = defaultProps;
 export default SidebarContent;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.jsx
@@ -18,26 +18,19 @@ const propTypes = {
   contextDispatch: PropTypes.func.isRequired,
 };
 
-const defaultProps = {
-  left: null,
-  right: null,
-};
-
-const SidebarNavigation = (props) => {
-  const {
-    top,
-    left,
-    right,
-    zIndex,
-    minWidth,
-    width,
-    maxWidth,
-    height,
-    isResizable,
-    resizableEdge,
-    contextDispatch,
-  } = props;
-
+const SidebarNavigation = ({
+  top,
+  left = null,
+  right = null,
+  zIndex,
+  minWidth,
+  width,
+  maxWidth,
+  height,
+  isResizable,
+  resizableEdge,
+  contextDispatch,
+}) => {
   const [resizableWidth, setResizableWidth] = useState(width);
   const [isResizing, setIsResizing] = useState(false);
   const [resizeStartWidth, setResizeStartWidth] = useState(0);
@@ -106,5 +99,4 @@ const SidebarNavigation = (props) => {
 };
 
 SidebarNavigation.propTypes = propTypes;
-SidebarNavigation.defaultProps = defaultProps;
 export default SidebarNavigation;

--- a/bigbluebutton-html5/imports/ui/components/user-avatar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/component.jsx
@@ -20,39 +20,23 @@ const propTypes = {
   isSkeleton: PropTypes.bool,
 };
 
-const defaultProps = {
-  children: <></>,
-  moderator: false,
-  presenter: false,
-  talking: false,
-  muted: false,
-  listenOnly: false,
-  voice: false,
-  noVoice: false,
-  color: '#000',
-  emoji: false,
-  avatar: '',
-  className: '',
-  isSkeleton: false,
-};
-
 const { isChrome, isFirefox, isEdge } = browserInfo;
 
 const UserAvatar = ({
-  children,
-  moderator,
-  presenter,
-  className,
-  talking,
-  muted,
-  listenOnly,
-  color,
-  voice,
-  emoji,
-  avatar,
-  noVoice,
-  whiteboardAccess,
-  isSkeleton,
+  children = <></>,
+  moderator = false,
+  presenter = false,
+  className = '',
+  talking = false,
+  muted = false,
+  listenOnly = false,
+  color = '#000',
+  voice = false,
+  emoji = false,
+  avatar = '',
+  noVoice = false,
+  whiteboardAccess = false,
+  isSkeleton = false,
 }) => {
   const Settings = getSettingsSingletonInstance();
   const { animations } = Settings.application;
@@ -76,7 +60,6 @@ const UserAvatar = ({
           isChrome={isChrome}
           isFirefox={isFirefox}
           isEdge={isEdge}
-          className={className}
           style={{
             backgroundColor: color,
             color, // We need the same color on both for the border
@@ -105,6 +88,5 @@ const UserAvatar = ({
 };
 
 UserAvatar.propTypes = propTypes;
-UserAvatar.defaultProps = defaultProps;
 
 export default UserAvatar;

--- a/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/chat-list-item/component.jsx
@@ -47,26 +47,20 @@ const propTypes = {
   shortcuts: PropTypes.string,
 };
 
-const defaultProps = {
-  shortcuts: '',
-  tabIndex: -1,
-};
-
-const ChatListItem = (props) => {
-  const {
-    chat,
-    activeChatId,
-    idChatOpen,
-    compact,
-    intl,
-    tabIndex,
-    isPublicChat,
-    shortcuts: TOGGLE_CHAT_PUB_AK,
-    sidebarContentIsOpen,
-    sidebarContentPanel,
-    layoutContextDispatch,
-  } = props;
-
+const ChatListItem = ({
+  chat,
+  activeChatId,
+  idChatOpen,
+  compact,
+  intl,
+  tabIndex = -1,
+  isPublicChat,
+  shortcuts = '',
+  sidebarContentIsOpen,
+  sidebarContentPanel,
+  layoutContextDispatch,
+}) => {
+  const TOGGLE_CHAT_PUB_AK = shortcuts;
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_id;
 
@@ -201,6 +195,5 @@ const ChatListItem = (props) => {
 };
 
 ChatListItem.propTypes = propTypes;
-ChatListItem.defaultProps = defaultProps;
 
 export default withShortcutHelper(injectIntl(ChatListItem), 'togglePublicChat');

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/skeleton/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/skeleton/component.tsx
@@ -45,8 +45,4 @@ const SkeletonUserListItem: React.FC<SkeletonUserListItemProps> = ({
   );
 };
 
-SkeletonUserListItem.defaultProps = {
-  enableAnimation: true,
-};
-
 export default SkeletonUserListItem;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-polls/component.jsx
@@ -14,7 +14,7 @@ const intlMessages = defineMessages({
 
 const UserPolls = ({
   intl,
-  isPresenter,
+  isPresenter = false,
   pollIsOpen,
   forcePollOpen,
   sidebarContentPanel,
@@ -75,8 +75,4 @@ UserPolls.propTypes = {
   isPresenter: PropTypes.bool,
   pollIsOpen: PropTypes.bool.isRequired,
   forcePollOpen: PropTypes.bool.isRequired,
-};
-
-UserPolls.defaultProps = {
-  isPresenter: false,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -42,12 +42,16 @@ const shouldEnableBackgroundUpload = () => {
   return ENABLE_UPLOAD && isCustomVirtualBackgroundsEnabled();
 };
 
+const defaultInitialVirtualBgState = {
+  type: EFFECT_TYPES.NONE_TYPE,
+};
+
 const VirtualBgSelector = ({
   intl,
   handleVirtualBgSelected,
   locked,
-  showThumbnails,
-  initialVirtualBgState,
+  showThumbnails = false,
+  initialVirtualBgState = defaultInitialVirtualBgState,
   isVisualEffects,
   readFile,
 }) => {
@@ -517,11 +521,5 @@ const VirtualBgSelector = ({
 };
 
 VirtualBgSelector.propTypes = propTypes;
-VirtualBgSelector.defaultProps = {
-  showThumbnails: false,
-  initialVirtualBgState: {
-    type: EFFECT_TYPES.NONE_TYPE,
-  },
-};
 
 export default injectIntl(withFileReader(VirtualBgSelector, MIME_TYPES_ALLOWED, MAX_FILE_SIZE));

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.jsx
@@ -27,14 +27,28 @@ const intlMessages = defineMessages({
 
 const VIDEO_CONTAINER_WIDTH_BOUND = 125;
 
-const VideoListItem = (props) => {
-  const {
-    name, voiceUser, isFullscreenContext, layoutContextDispatch, user, onHandleVideoFocus,
-    cameraId, numOfStreams, focused, onVideoItemMount, onVideoItemUnmount,
-    makeDragOperations, dragging, draggingOver, isRTL, isStream, settingsSelfViewDisable,
-    disabledCams, amIModerator, stream,
-  } = props;
-
+const VideoListItem = ({
+  name,
+  voiceUser,
+  isFullscreenContext,
+  layoutContextDispatch,
+  user,
+  onHandleVideoFocus,
+  cameraId,
+  numOfStreams = 0,
+  focused,
+  onVideoItemMount = () => {},
+  onVideoItemUnmount = () => {},
+  makeDragOperations,
+  dragging,
+  draggingOver,
+  isRTL,
+  isStream,
+  settingsSelfViewDisable,
+  disabledCams,
+  amIModerator,
+  stream,
+}) => {
   const intl = useIntl();
 
   const [videoDataLoaded, setVideoDataLoaded] = useState(false);
@@ -283,13 +297,6 @@ const VideoListItem = (props) => {
 
 export default withDragAndDrop(injectIntl(VideoListItem));
 
-VideoListItem.defaultProps = {
-  numOfStreams: 0,
-  onVideoItemMount: () => { },
-  onVideoItemUnmount: () => { },
-  onVirtualBgDrop: () => { },
-};
-
 VideoListItem.propTypes = {
   cameraId: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
@@ -300,7 +307,6 @@ VideoListItem.propTypes = {
   onHandleVideoFocus: PropTypes.func.isRequired,
   onVideoItemMount: PropTypes.func,
   onVideoItemUnmount: PropTypes.func,
-  onVirtualBgDrop: PropTypes.func,
   isFullscreenContext: PropTypes.bool.isRequired,
   layoutContextDispatch: PropTypes.func.isRequired,
   user: PropTypes.shape({

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.jsx
@@ -73,13 +73,22 @@ const intlMessages = defineMessages({
   },
 });
 
-const UserActions = (props) => {
-  const {
-    name, cameraId, numOfStreams, onHandleVideoFocus, user, focused, onHandleMirror,
-    isVideoSqueezed, videoContainer, isRTL, isStream, isSelfViewDisabled, isMirrored,
-    amIModerator,
-  } = props;
-
+const UserActions = ({
+  name,
+  cameraId,
+  numOfStreams,
+  onHandleVideoFocus = () => {},
+  user,
+  focused = false,
+  onHandleMirror,
+  isVideoSqueezed = false,
+  videoContainer = () => {},
+  isRTL,
+  isStream,
+  isSelfViewDisabled,
+  isMirrored,
+  amIModerator,
+}) => {
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 
   let userCameraDropdownItems = [];
@@ -273,13 +282,6 @@ const UserActions = (props) => {
 };
 
 export default UserActions;
-
-UserActions.defaultProps = {
-  focused: false,
-  isVideoSqueezed: false,
-  videoContainer: () => { },
-  onHandleVideoFocus: () => {},
-};
 
 UserActions.propTypes = {
   name: PropTypes.string.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-avatar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-provider-graphql/video-list/video-list-item/user-avatar/component.tsx
@@ -24,17 +24,16 @@ const UserAvatarVideo: React.FC<UserAvatarVideoProps> = (props) => {
     name = '', color = '', avatar = '', emoji = '', isModerator,
   } = data;
   let {
-    presenter, clientType,
+    presenter = false, clientType,
   } = data;
 
   const { talking = false } = voiceUser;
 
   const handleUserIcon = () => {
     if (emoji !== 'none') {
-      // @ts-expect-error -> Untyped component.
       return <Icon iconName={UserListService.normalizeEmojiName(emoji)} />;
     }
-    return name.toLowerCase().slice(0, 2);
+    return <>{name.toLowerCase().slice(0, 2)}</>;
   };
 
   // hide icons when squeezed

--- a/bigbluebutton-html5/imports/ui/components/wake-lock/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/wake-lock/container.jsx
@@ -14,10 +14,6 @@ const propTypes = {
   autoJoin: PropTypes.bool.isRequired,
 };
 
-const defaultProps = {
-  areAudioModalsOpen: false,
-};
-
 function usePrevious(value) {
   const ref = useRef();
   useEffect(() => {
@@ -55,7 +51,6 @@ const WakeLockContainer = (props) => {
 };
 
 WakeLockContainer.propTypes = propTypes;
-WakeLockContainer.defaultProps = defaultProps;
 
 export default withTracker(() => {
   const APP_CONFIG = window.meetingClientSettings.public.app;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -62,15 +62,19 @@ const determineViewerFitToWidth = (currentPresentationPage) => {
   );
 };
 
+const defaultUser = {
+  userId: '',
+};
+
 const Whiteboard = React.memo(function Whiteboard(props) {
   const {
-    isPresenter,
+    isPresenter = false,
     removeShapes,
     persistShapeWrapper,
     shapes,
     assets,
-    currentUser,
-    whiteboardId,
+    currentUser = defaultUser,
+    whiteboardId = undefined,
     zoomSlide,
     curPageId,
     zoomChanger,
@@ -93,7 +97,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
     isToolbarVisible,
     isModerator,
     currentPresentationPage,
-    presentationId,
+    presentationId = undefined,
     hasWBAccess,
     bgShape,
     publishCursorUpdate,
@@ -1365,7 +1369,6 @@ Whiteboard.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
-  svgUri: PropTypes.string,
   maxStickyNoteLength: PropTypes.number.isRequired,
   fontFamily: PropTypes.string.isRequired,
   colorStyle: PropTypes.string.isRequired,
@@ -1385,22 +1388,6 @@ Whiteboard.propTypes = {
   isFullscreen: PropTypes.bool.isRequired,
   layoutContextDispatch: PropTypes.func.isRequired,
   fullscreenAction: PropTypes.string.isRequired,
-  fullscreenRef: PropTypes.instanceOf(Element),
   handleToggleFullScreen: PropTypes.func.isRequired,
-  numberOfPages: PropTypes.number,
-  sidebarNavigationWidth: PropTypes.number,
   presentationId: PropTypes.string,
-};
-
-Whiteboard.defaultProps = {
-  fullscreenRef: undefined,
-  svgUri: undefined,
-  whiteboardId: undefined,
-  sidebarNavigationWidth: 0,
-  presentationId: undefined,
-  currentUser: {
-    userId: "",
-  },
-  isPresenter: false,
-  numberOfPages: 0,
 };


### PR DESCRIPTION
### What does this PR do?

Fix warnings by replacing defaultProps with default function parameters and disabling defaultProps eslint rule.

![Screenshot from 2024-06-11 10-11-26](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/8d551c9f-55ff-41c7-85f0-589a85150e50)


### Motivation

Default props on function components are going to be deprecated in future release in favor of default function parameters

### More

https://github.com/facebook/react/pull/16210, https://github.com/facebook/react/pull/25699