### PR TITLE
build: Update bbb-presentation-video to 5.0.0-beta.1 for Tldraw v2 shape support

### DIFF
--- a/bbb-presentation-video.placeholder.sh
+++ b/bbb-presentation-video.placeholder.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -ex
-RELEASE=4.0.4
+RELEASE=5.0.0-beta.1
 cat <<MSG
 This tool downloads prebuilt packages built on Github Actions
 The corresponding source can be browsed at https://github.com/bigbluebutton/bbb-presentation-video/tree/${RELEASE}


### PR DESCRIPTION
## What's Changed
* https://github.com/bigbluebutton/bbb-presentation-video/pull/49 by @danielpetri1

**Full Changelog**: https://github.com/bigbluebutton/bbb-presentation-video/compare/4.0.4...5.0.0-beta.1

Note that despite BigBlueButton 3.0 being based on Ubuntu 22.04, the bbb-presentation-video package is still being built on Ubuntu 20.04. This is not an issue, the package remains compatible with the newer Ubuntu version.