### PR TITLE
fix(webcam): grid layout not activating in some cases

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
@@ -26,6 +26,15 @@ const useDeduplicatedSubscription = <T = any>(
   }, []);
 
   useEffect(() => {
+    if (options?.skip) {
+      subscriptionHashRef.current = '';
+      if (subscriptionRef.current && optionsRef.current) {
+        GrahqlSubscriptionStore.unsubscribe(subscriptionRef.current, optionsRef.current?.variables);
+        subscriptionRef.current = null;
+        optionsRef.current = undefined;
+      }
+      return;
+    }
     if (subscriptionHashRef.current !== subscriptionHash) {
       subscriptionHashRef.current = subscriptionHash;
       if (subscriptionRef.current && optionsRef.current) {
@@ -48,7 +57,7 @@ const useDeduplicatedSubscription = <T = any>(
       });
     }
     return GrahqlSubscriptionStore.makeSubscription<T>(subscription, options?.variables);
-  }, [subscriptionHash, options?.skip]);
+  }, [subscriptionHash]);
   return useReactiveVar(sub);
 };
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

It tweaks the `useDeduplicatedSubscription` hook to handle the `skip` option properly by doing the cleanup when the option is `true`. That fixes a bug where the grid layout is not being activated if the user is already sharing webcam before grid layout activation.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none

### More

Related to https://github.com/bigbluebutton/bigbluebutton/pull/20447.
