### PR TITLE
Fix: Focus on text input is lost after sending the message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -328,7 +328,6 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
           bubbles: true,
           cancelable: true,
         });
-
         handleSubmit(event);
       }
     };
@@ -436,7 +435,6 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
                   value: false,
                 },
               }));
-              setIsTextAreaFocused(false);
             }}
             onChange={handleMessageChange}
             onKeyDown={handleMessageKeyDown}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where the chat input would lose focus after sending messages. 

### Closes Issue(s)

#20399 
