### PR TITLE
fix: Pinned notes disappears when changing layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -132,6 +132,13 @@ const AppContainer = (props) => {
     }
   }, [meetingLayout, layoutContextDispatch, layoutType]);
 
+  useEffect(() => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_LAYOUT_TYPE,
+      value: selectedLayout,
+    });
+  }, [selectedLayout]);
+
   const horizontalPosition = cameraDock.position === 'contentLeft' || cameraDock.position === 'contentRight';
   // this is not exactly right yet
   let presentationVideoRate;

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -11,6 +11,7 @@ import { INITIAL_INPUT_STATE, INITIAL_OUTPUT_STATE } from './initState';
 import useUpdatePresentationAreaContentForPlugin from '/imports/ui/components/plugins-engine/ui-data-hooks/layout/presentation-area/utils';
 import { isPresentationEnabled } from '/imports/ui/services/features';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
+import { usePrevious } from '../whiteboard/utils';
 
 // variable to debug in console log
 const debug = false;
@@ -1332,6 +1333,7 @@ const reducer = (state, action) => {
 
 const updatePresentationAreaContent = (
   layoutContextState,
+  previousLayoutType,
   previousPresentationAreaContentActions,
   layoutContextDispatch,
 ) => {
@@ -1343,7 +1345,7 @@ const updatePresentationAreaContent = (
   if (!equals(
     currentPresentationAreaContentActions,
     previousPresentationAreaContentActions.current,
-  )) {
+  ) || layoutType !== previousLayoutType) {
     const CHAT_CONFIG = window.meetingClientSettings.public.chat;
     const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 
@@ -1473,9 +1475,13 @@ const LayoutContextProvider = (props) => {
 
   const [layoutContextState, layoutContextDispatch] = useReducer(reducer, initState);
   const { children } = props;
+  const { layoutType } = layoutContextState;
+  const previousLayoutType = usePrevious(layoutType);
+
   useEffect(() => {
     updatePresentationAreaContent(
       layoutContextState,
+      previousLayoutType,
       previousPresentationAreaContentActions,
       layoutContextDispatch,
     );


### PR DESCRIPTION
### What does this PR do?

Adjusts layout checks so shared notes remain pinned if layout is changed

### Closes Issue(s)
Closes #20450
Closes #20442