### PR TITLE
refactor: BreakoutRoom storage and handlers

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -2,7 +2,6 @@ package org.bigbluebutton.core.db
 
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
 import org.bigbluebutton.core.domain.BreakoutRoom2x
-import org.bigbluebutton.core.models.{RegisteredUsers, Roles}
 import org.bigbluebutton.core.running.LiveMeeting
 import slick.jdbc.PostgresProfile.api._
 
@@ -14,7 +13,6 @@ case class BreakoutRoomUserDbModel(
       meetingId:          String,
       userId:             String,
       joinURL:            String,
-      joinedAt:           Option[java.sql.Timestamp],
       assignedAt:         Option[java.sql.Timestamp],
 )
 
@@ -23,27 +21,28 @@ class BreakoutRoomUserDbTableDef(tag: Tag) extends Table[BreakoutRoomUserDbModel
   val meetingId = column[String]("meetingId", O.PrimaryKey)
   val userId = column[String]("userId", O.PrimaryKey)
   val joinURL = column[String]("joinURL")
-  val joinedAt = column[Option[java.sql.Timestamp]]("joinedAt")
   val assignedAt = column[Option[java.sql.Timestamp]]("assignedAt")
-  override def * = (breakoutRoomId, meetingId, userId, joinURL, joinedAt, assignedAt) <> (BreakoutRoomUserDbModel.tupled, BreakoutRoomUserDbModel.unapply)
+  override def * = (breakoutRoomId, meetingId, userId, joinURL, assignedAt) <> (BreakoutRoomUserDbModel.tupled, BreakoutRoomUserDbModel.unapply)
 }
 
 object BreakoutRoomUserDAO {
 
-  def prepareInsert(breakoutRoomId: String, meetingId: String, userId: String, joinURL: String) = {
+  def prepareInsert(breakoutRoomId: String, meetingId: String, userId: String, joinURL: String, wasAssignedByMod: Boolean) = {
     TableQuery[BreakoutRoomUserDbTableDef].insertOrUpdate(
       BreakoutRoomUserDbModel(
         breakoutRoomId = breakoutRoomId,
         meetingId = meetingId,
         userId = userId,
         joinURL = joinURL,
-        joinedAt = None,
-        assignedAt = Some(new java.sql.Timestamp(System.currentTimeMillis())),
+        assignedAt = wasAssignedByMod match {
+          case true => Some(new java.sql.Timestamp(System.currentTimeMillis()))
+          case false => None
+        },
       )
     )
   }
 
-  def prepareDelete(breakoutRoomId: String, meetingId: String, userId: String) = {
+  def prepareDelete(breakoutRoomId: String, meetingId: String, userId: String, exceptBreakoutRooomId: String) = {
     var query = TableQuery[BreakoutRoomUserDbTableDef]
                 .filter(_.meetingId === meetingId)
                 .filter(_.userId === userId)
@@ -52,14 +51,27 @@ object BreakoutRoomUserDAO {
     if (breakoutRoomId.nonEmpty) {
       query = query.filter(_.breakoutRoomId === breakoutRoomId)
     }
+
+    if (exceptBreakoutRooomId.nonEmpty) {
+      query = query.filter(_.breakoutRoomId =!= exceptBreakoutRooomId)
+    }
+
     query.delete
   }
 
-  def updateRoomChanged(meetingId: String, userId: String, fromBreakoutRoomId: String, toBreakoutRoomId: String, joinUrl: String) = {
-    DatabaseConnection.db.run(DBIO.seq(
-      BreakoutRoomUserDAO.prepareDelete(fromBreakoutRoomId, meetingId, userId),
-      BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl)
-    ).transactionally)
+  def updateRoomChanged(meetingId: String, userId: String, fromBreakoutRoomId: String,
+                        toBreakoutRoomId: String, joinUrl: String, removePreviousRoom: Boolean) = {
+    DatabaseConnection.db.run(
+      if (removePreviousRoom) {
+        DBIO.seq(
+          BreakoutRoomUserDAO.prepareDelete(fromBreakoutRoomId, meetingId, userId, exceptBreakoutRooomId = toBreakoutRoomId),
+          BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)
+        )
+      } else {
+        DBIO.seq(
+          BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)
+        )
+      }.transactionally)
       .onComplete {
         case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) changed on breakoutRoom_user table!")
         case Failure(e) => DatabaseConnection.logger.debug(s"Error changing breakoutRoom_user: $e")
@@ -68,34 +80,23 @@ object BreakoutRoomUserDAO {
 
   def updateUserJoined(meetingId: String, usersInRoom: Vector[String], breakoutRoom: BreakoutRoom2x) = {
     DatabaseConnection.db.run(
-      TableQuery[BreakoutRoomUserDbTableDef]
-        .filter(_.meetingId === meetingId)
-        .filter(_.userId inSet usersInRoom)
-        .filter(_.breakoutRoomId === breakoutRoom.id)
-        .filter(_.joinedAt.isEmpty)
-        .map(u_bk => u_bk.joinedAt)
-        .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
+      sqlu"""UPDATE "breakoutRoom_user" SET
+                "joinedAt" = current_timestamp
+                WHERE "meetingId" = ${meetingId}
+                AND "userId" in (${usersInRoom.mkString(",")})
+                AND "breakoutRoomId" = ${breakoutRoom.id}
+                AND "joinedAt" is null"""
     ).onComplete {
       case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated joinedAt=now() on breakoutRoom_user table!")
       case Failure(e) => DatabaseConnection.logger.error(s"Error updating joinedAt=now() on breakoutRoom_user: $e")
     }
   }
 
-  def updateUserEjected(meetingId: String, userId: String, breakoutRoomId: String) = {
-    DatabaseConnection.db.run(DBIO.seq(
-      BreakoutRoomUserDAO.prepareDelete(meetingId, userId, breakoutRoomId),
-    ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) deleted on breakoutRoom_user table!")
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error deleting breakoutRoom_user: $e")
-      }
-  }
-
   def insertBreakoutRoom(userId: String, room: BreakoutRoom2x, liveMeeting: LiveMeeting) = {
       for {
         (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString)
       } yield {
-        DatabaseConnection.db.run(BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL))
+        DatabaseConnection.db.run(BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = false))
           .onComplete {
             case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on breakoutRoom_user table!")
             case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting breakoutRoom_user: $e")

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -309,7 +309,6 @@ COMMENT ON COLUMN "user"."disconnected" IS 'This column is set true when the use
 COMMENT ON COLUMN "user"."expired" IS 'This column is set true after 10 seconds with disconnected=true';
 COMMENT ON COLUMN "user"."loggedOut" IS 'This column is set to true when the user click the button to Leave meeting';
 
-
 --Virtual columns isDialIn, isModerator, isOnline, isWaiting, isAllowed, isDenied
 ALTER TABLE "user" ADD COLUMN "isDialIn" boolean GENERATED ALWAYS AS ("clientType" = 'dial-in-user') STORED;
 ALTER TABLE "user" ADD COLUMN "isWaiting" boolean GENERATED ALWAYS AS ("guestStatus" = 'WAIT') STORED;
@@ -323,8 +322,16 @@ ALTER TABLE "user" ADD COLUMN "nameSortable" varchar(255) GENERATED ALWAYS AS (i
 
 CREATE INDEX "idx_user_waiting" ON "user"("meetingId") where "isWaiting" is true;
 
---ALTER TABLE "user" ADD COLUMN "isModerator" boolean GENERATED ALWAYS AS (CASE WHEN "role" = 'MODERATOR' THEN true ELSE false END) STORED;
---ALTER TABLE "user" ADD COLUMN "isOnline" boolean GENERATED ALWAYS AS (CASE WHEN "joined" IS true AND "loggedOut" IS false THEN true ELSE false END) STORED;
+ALTER TABLE "user" ADD COLUMN "isModerator" boolean GENERATED ALWAYS AS (CASE WHEN "role" = 'MODERATOR' THEN true ELSE false END) STORED;
+ALTER TABLE "user" ADD COLUMN "isOnline" boolean GENERATED ALWAYS AS (
+    CASE WHEN
+            "user"."joined" IS true
+            AND "user"."expired" IS false
+            AND "user"."loggedOut" IS false
+            AND "user"."ejected" IS NOT true
+        THEN true
+        ELSE false
+        END) STORED;
 
 -- user (on update emoji, raiseHand or away: set new time)
 CREATE OR REPLACE FUNCTION update_user_emoji_time_trigger_func()
@@ -397,8 +404,8 @@ AS SELECT "user"."userId",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     "user"."hasDrawPermissionOnCurrentPage",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
-    CASE WHEN "user"."joined" IS true AND "user"."expired" IS false AND "user"."loggedOut" IS false AND "user"."ejected" IS NOT TRUE THEN true ELSE false END "isOnline"
-   FROM "user"
+    "user"."isOnline"
+  FROM "user"
   WHERE "user"."loggedOut" IS FALSE
   AND "user"."expired" IS FALSE
   AND "user"."ejected" IS NOT TRUE
@@ -458,7 +465,7 @@ AS SELECT "user"."userId",
     "user"."echoTestRunningAt",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
-    CASE WHEN "user"."joined" IS true AND "user"."expired" IS false AND "user"."loggedOut" IS false AND "user"."ejected" IS NOT TRUE THEN true ELSE false END "isOnline",
+    "user"."isOnline",
     "user"."inactivityWarningDisplay",
     "user"."inactivityWarningTimeoutSecs"
    FROM "user";
@@ -523,7 +530,7 @@ AS SELECT
     "user"."captionLocale",
     "user"."hasDrawPermissionOnCurrentPage",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
-    CASE WHEN "user"."joined" IS true AND "user"."expired" IS false AND "user"."loggedOut" IS false AND "user"."ejected" IS NOT TRUE THEN true ELSE false END "isOnline"
+    "user"."isOnline"
    FROM "user";
 
 create table "user_customParameter"(
@@ -1624,52 +1631,141 @@ CREATE TABLE "breakoutRoom_user" (
 	"assignedAt" timestamp with time zone,
 	"joinedAt" timestamp with time zone,
 	"inviteDismissedAt" timestamp with time zone,
+	"userJoinedSomeRoomAt" timestamp with time zone,
+	"isLastAssignedRoom" boolean,
+	"isLastJoinedRoom" boolean,
+	"isUserCurrentlyInRoom" boolean,
 	CONSTRAINT "breakoutRoom_user_pkey" PRIMARY KEY ("breakoutRoomId", "meetingId", "userId"),
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 create index "idx_breakoutRoom_user_meeting_user" on "breakoutRoom_user" ("meetingId", "userId");
 create index "idx_breakoutRoom_user_user_meeting" on "breakoutRoom_user" ("userId", "meetingId");
 
+ALTER TABLE "breakoutRoom_user" ADD COLUMN "showInvitation" boolean GENERATED ALWAYS AS (
+    CASE WHEN
+            "isLastAssignedRoom" IS true
+            and "isUserCurrentlyInRoom" is null
+            AND ("joinedAt" is null or "assignedAt" > "joinedAt")
+            AND ("userJoinedSomeRoomAt" is null or "assignedAt" > "userJoinedSomeRoomAt")
+            AND ("inviteDismissedAt" is null or "assignedAt" > "inviteDismissedAt")
+        THEN true
+        ELSE false
+        END) STORED;
+       --AND ("isModerator" is false OR "sendInvitationToModerators")
+
+--Trigger to populate `isLastAssignedRoom` and `isLastJoinedRoom`
+CREATE OR REPLACE FUNCTION "ins_upd_del_breakoutRoom_user_trigger_func"() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        -- Determine the latest assigned room and latest joined room for the remaining rows
+        PERFORM
+            set_last_room(OLD."meetingId", OLD."userId");
+    ELSE
+        -- For INSERT or UPDATE
+        PERFORM
+            set_last_room(NEW."meetingId", NEW."userId");
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION set_last_room(meetingId varchar(100), userId varchar(50)) RETURNS VOID AS $$
+DECLARE
+    "latestAssignedRoomId" varchar(100);
+    "latestJoinedRoomId" varchar(100);
+    "latestJoinedAt" timestamp with time zone;
+BEGIN
+    SELECT "breakoutRoomId"
+    INTO "latestAssignedRoomId"
+    FROM "breakoutRoom_user"
+    WHERE "meetingId" = meetingId
+      AND "userId" = userId
+      AND "assignedAt" IS NOT NULL
+    ORDER BY "assignedAt" DESC NULLS LAST
+    LIMIT 1;
+
+    SELECT "breakoutRoomId"
+    INTO "latestJoinedRoomId"
+    FROM "breakoutRoom_user"
+    WHERE "meetingId" = meetingId
+      AND "userId" = userId
+      AND "joinedAt" IS NOT NULL
+    ORDER BY "joinedAt" DESC NULLS LAST
+    LIMIT 1;
+
+    UPDATE "breakoutRoom_user" bu
+    SET "isLastAssignedRoom" = CASE
+            WHEN "latestAssignedRoomId" IS NOT NULL AND bu."breakoutRoomId" = "latestAssignedRoomId" THEN TRUE
+            ELSE FALSE
+        END,
+        "isLastJoinedRoom" = CASE
+            WHEN "latestJoinedRoomId" IS NOT NULL AND bu."breakoutRoomId" = "latestJoinedRoomId" THEN TRUE
+            ELSE FALSE
+        END
+    WHERE bu."meetingId" = meetingId
+      AND bu."userId" = userId
+      AND (bu."isLastAssignedRoom" IS DISTINCT FROM (CASE WHEN "latestAssignedRoomId" IS NOT NULL AND bu."breakoutRoomId" = "latestAssignedRoomId" THEN TRUE ELSE FALSE END)
+       OR bu."isLastJoinedRoom" IS DISTINCT FROM (CASE WHEN "latestJoinedRoomId" IS NOT NULL AND bu."breakoutRoomId" = "latestJoinedRoomId" THEN TRUE ELSE FALSE END));
+
+       --userJoinedSomeRoomAt
+       SELECT max("joinedAt")
+           INTO "latestJoinedAt"
+           from "breakoutRoom_user" bru
+           where bru."meetingId" = meetingId
+           and bru."userId" = userId;
+
+       update "breakoutRoom_user" set "userJoinedSomeRoomAt" = "latestJoinedAt"
+          where "breakoutRoom_user"."meetingId" = meetingId
+          and "breakoutRoom_user"."userId" = userId
+          and "breakoutRoom_user"."userJoinedSomeRoomAt" != "latestJoinedAt";
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "ins_upd_del_breakoutRoom_user_trigger"
+AFTER INSERT OR UPDATE OR DELETE ON "breakoutRoom_user"
+FOR EACH ROW EXECUTE FUNCTION "ins_upd_del_breakoutRoom_user_trigger_func"();
+
+
+CREATE OR REPLACE FUNCTION "update_bkroom_isUserCurrentlyInRoom_trigger_func"()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW."isOnline" <> OLD."isOnline" THEN
+        update "breakoutRoom_user" set "isUserCurrentlyInRoom" = a."isOnline"
+	   from (
+		   select
+		   bru."breakoutRoomId", bru."userId", bkroom_user."isOnline"
+		   from "user" bkroom_user
+		   join meeting_breakout mb on mb."meetingId" = bkroom_user."meetingId"
+		   join "breakoutRoom" br on br."parentMeetingId" = mb."parentId" and mb."sequence" = br."sequence"
+		   join "user" u on u."meetingId" = br."parentMeetingId"  and bkroom_user."extId" = u."extId" || '-' || br."sequence"
+		   join "breakoutRoom_user" bru on bru."userId" = u."userId" and bru."breakoutRoomId" = br."breakoutRoomId"
+		   where bkroom_user."userId" = NEW."userId"
+	   ) a
+		where "breakoutRoom_user"."breakoutRoomId" = a."breakoutRoomId"
+		and "breakoutRoom_user"."userId" = a."userId";
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_bkroom_isUserCurrentlyInRoom_trigger" AFTER UPDATE OF "isOnline" ON "user"
+    FOR EACH ROW EXECUTE FUNCTION "update_bkroom_isUserCurrentlyInRoom_trigger_func"();
 
 CREATE OR REPLACE VIEW "v_breakoutRoom" AS
-SELECT *,
-    --showInvitation flag
-    case WHEN 1=1
-    	--this is not the last room the user joined
-    	-- AND "lastRoomJoinedId" != "breakoutRoomId" --the next condition turn this one useless
-    	--user didn't joined some room after assigned
-    	AND ("lastRoomJoinedAt" IS NULL OR "lastRoomJoinedAt" < "assignedAt")
-    	--user didn't close the invitation already
-    	and ("inviteDismissedAt" is NULL OR "assignedAt" > "inviteDismissedAt")
-    	--user is not online in other room
-    	AND "lastRoomIsOnline" IS FALSE
-    	--this is this the last assignment?
-    	AND "currentRoomPriority" = 1
-    	--user is not moderator or sendInviteToMod flag is true
-    	AND ("isModerator" is false OR "sendInvitationToModerators")
-    	THEN TRUE ELSE FALSE END "showInvitation"
-from (
-    SELECT u."meetingId" as "userMeetingId", u."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin", b."sequence", b."name", b."isDefaultName",
+SELECT u."meetingId" as "userMeetingId", u."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin",
+            b."sequence", b."name", b."isDefaultName",
             b."shortName", b."startedAt", b."endedAt", b."durationInSeconds", b."sendInvitationToModerators",
-                bu."assignedAt", bu."joinURL", bu."inviteDismissedAt", u."role" = 'MODERATOR' as "isModerator",
-                --CASE WHEN b."durationInSeconds" = 0 THEN NULL ELSE b."startedAt" + b."durationInSeconds" * '1 second'::INTERVAL END AS "willEndAt",
-                ub."isOnline" AS "currentRoomIsOnline",
-                ub."registeredAt" AS "currentRoomRegisteredAt",
-                ub."joined" AS "currentRoomJoined",
-                rank() OVER (partition BY u."meetingId", u."userId" order by "assignedAt" desc nulls last) as "currentRoomPriority",
-                max(bu."joinedAt") OVER (partition BY u."meetingId", u."userId") AS "lastRoomJoinedAt",
-                max(bu."breakoutRoomId") OVER (partition BY u."meetingId", u."userId" ORDER BY bu."joinedAt") AS "lastRoomJoinedId",
-                sum(CASE WHEN ub."isOnline" THEN 1 ELSE 0 END) OVER (partition BY u."meetingId", u."userId") > 0 as "lastRoomIsOnline"
+            bu."assignedAt", bu."joinURL", bu."inviteDismissedAt", u."role" = 'MODERATOR' as "isModerator",
+            bu."isLastAssignedRoom", bu."isLastJoinedRoom", bu."isUserCurrentlyInRoom", bu."showInvitation",
+            bu."joinedAt" is not null as "hasJoined"
     FROM "user" u
     JOIN "breakoutRoom" b ON b."parentMeetingId" = u."meetingId"
     LEFT JOIN "breakoutRoom_user" bu ON bu."meetingId" = u."meetingId" AND bu."userId" = u."userId" AND bu."breakoutRoomId" = b."breakoutRoomId"
-    LEFT JOIN "meeting" mb ON mb."extId" = b."externalId"
-    LEFT JOIN "v_user" ub ON ub."meetingId" = mb."meetingId" and ub."extId" = u."extId" || '-' || b."sequence"
     WHERE (bu."assignedAt" IS NOT NULL
             OR b."freeJoin" IS TRUE
             OR u."role" = 'MODERATOR')
-    AND b."endedAt" IS NULL
-) a;
+    AND b."endedAt" IS NULL;
 
 CREATE OR REPLACE VIEW "v_breakoutRoom_assignedUser" AS
 SELECT "parentMeetingId", "breakoutRoomId", "userMeetingId", "userId"
@@ -1685,7 +1781,7 @@ SELECT DISTINCT
         "userId",
         false as "isAudioOnly"
 FROM "v_breakoutRoom"
-WHERE "currentRoomIsOnline" IS TRUE
+WHERE "isUserCurrentlyInRoom" IS TRUE
 union --include users that joined only with audio
 select parent_user."meetingId" as "parentMeetingId",
         bk_user."meetingId" as "breakoutRoomId",

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
@@ -31,19 +31,15 @@ select_permissions:
       columns:
         - assignedAt
         - breakoutRoomId
-        - currentRoomIsOnline
-        - currentRoomJoined
-        - currentRoomPriority
-        - currentRoomRegisteredAt
+        - isUserCurrentlyInRoom
+        - hasJoined
+        - isLastAssignedRoom
         - durationInSeconds
         - endedAt
         - freeJoin
         - inviteDismissedAt
         - isDefaultName
         - joinURL
-        - lastRoomIsOnline
-        - lastRoomJoinedAt
-        - lastRoomJoinedId
         - name
         - sendInvitationToModerators
         - sequence

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -46,21 +46,17 @@ export interface CustomParameter {
 }
 
 export interface BreakoutRooms {
-  currentRoomJoined: boolean;
+  hasJoined: boolean;
   assignedAt: string;
   breakoutRoomId: string;
-  currentRoomIsOnline: boolean | null;
-  currentRoomPriority: number;
-  currentRoomRegisteredAt: string | null;
+  isUserCurrentlyInRoom: boolean | null;
+  isLastAssignedRoom: boolean | null;
   durationInSeconds: number;
   endedAt: string | null;
   freeJoin: boolean;
   inviteDismissedAt: string | null;
   isDefaultName: boolean;
   joinURL: string;
-  lastRoomIsOnline: boolean;
-  lastRoomJoinedAt: string;
-  lastRoomJoinedId: string;
   name: string;
   sendInvitationToModerators: boolean;
   sequence: number;

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -85,7 +85,7 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   const [waiting, setWaiting] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const defaultSelectedBreakoutId = breakouts.find(({ showInvitation }) => showInvitation)?.breakoutRoomId
+  const defaultSelectedBreakoutId = breakouts.find(({ isLastAssignedRoom }) => isLastAssignedRoom)?.breakoutRoomId
     || firstBreakoutId;
 
   const [selectValue, setSelectValue] = React.useState(defaultSelectedBreakoutId);
@@ -248,7 +248,7 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
     <BreakoutJoinConfirmation
       freeJoin={freeJoin}
       breakouts={breakoutData.breakoutRoom}
-      currentUserJoined={currentUser?.breakoutRooms?.currentRoomJoined ?? false}
+      currentUserJoined={currentUser?.breakoutRooms?.isUserCurrentlyInRoom ?? false}
       firstBreakoutId={breakoutRoomId}
       isUsingAudio={isUsingAudio}
       exitVideo={exitVideo}

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/queries.ts
@@ -6,6 +6,8 @@ export interface BreakoutRoom {
   sendInvitationToModerators: boolean;
   sequence: number;
   showInvitation: boolean;
+  isLastAssignedRoom: boolean;
+  isUserCurrentlyInRoom: boolean;
   joinURL: string | null;
   breakoutRoomId: string;
 }
@@ -50,6 +52,8 @@ export const getBreakoutData = gql`
       sendInvitationToModerators
       sequence
       showInvitation
+      isLastAssignedRoom
+      isUserCurrentlyInRoom
       joinURL
       breakoutRoomId
     }

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
@@ -228,7 +228,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
                   ) : (
                     <Styled.BreakoutActions>
                       {
-                        breakout.currentRoomJoined
+                        breakout.isUserCurrentlyInRoom
                           ? (
                             <Styled.AlreadyConnected data-test="alreadyConnected">
                               {intl.formatMessage(intlMessages.alreadyConnected)}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/queries.ts
@@ -9,7 +9,8 @@ export interface BreakoutRoom {
   joinURL: string | null;
   breakoutRoomId: string;
   isDefaultName: boolean;
-  currentRoomJoined: boolean;
+  hasJoined: boolean;
+  isUserCurrentlyInRoom: boolean;
   participants: Array<{
     userId: string;
     isAudioOnly: string;
@@ -43,7 +44,8 @@ export const getBreakoutData = gql`
       joinURL
       breakoutRoomId
       isDefaultName
-      currentRoomJoined
+      hasJoined
+      isUserCurrentlyInRoom
       participants {
         userId
         isAudioOnly
@@ -58,7 +60,7 @@ export const getBreakoutData = gql`
 
 export const getIfUserJoinedBreakoutRoom = gql`
   subscription getIdUserJoinedABreakout {
-    breakoutRoom_aggregate(where: {currentRoomJoined: {_eq: true}}) {
+    breakoutRoom_aggregate(where: {hasJoined: {_eq: true}}) {
       aggregate {
         count
       }

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -40,27 +40,23 @@ subscription userCurrentSubscription {
     captionLocale
     userId
     breakoutRooms {
-      currentRoomJoined
+      hasJoined
       assignedAt
       breakoutRoomId
-      currentRoomPriority
-      currentRoomRegisteredAt
+      isLastAssignedRoom
       durationInSeconds
       endedAt
       freeJoin
       inviteDismissedAt
       isDefaultName
       joinURL
-      lastRoomIsOnline
-      lastRoomJoinedAt
-      lastRoomJoinedId
       name
       sendInvitationToModerators
       sequence
       shortName
       showInvitation
       startedAt
-      currentRoomIsOnline
+      isUserCurrentlyInRoom
     }
     lastBreakoutRoom {
       currentlyInRoom


### PR DESCRIPTION
- Add the following columns to the `breakoutRoom_user` table: `userJoinedSomeRoomAt`, `isLastAssignedRoom`, `isLastJoinedRoom`, `isUserCurrentlyInRoom`, and `showInvitation`. These additions will precompute the necessary data and flags, eliminating the need to generate them for each query. This change will reduce the load on the queries, especially those relying on PostgreSQL window functions, which were making the queries very resource-intensive.
- Fix the button  "Already in room" / "Ask to join" (that was using wrong condition)
- Fix invitation showing wrong pre-selected room (closes #20453)
- Fix problems when moving users to another room