### PR TITLE
fix(whiteboard): Restore pan tool activation via spacebar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -145,6 +145,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   const isModeratorRef = React.useRef(isModerator);
   const currentPresentationPageRef = React.useRef(currentPresentationPage);
   const initialViewBoxWidthRef = React.useRef(null);
+  const previousTool = React.useRef(null);
 
   const THRESHOLD = 0.1;
   const CAMERA_UPDATE_DELAY = 650;
@@ -246,6 +247,12 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
     const editingShape = tlEditorRef.current?.getEditingShape();
     if (editingShape && (isPresenterRef.current || hasWBAccessRef.current)) {
+      return;
+    }
+
+    if (event.key === ' ' && tlEditorRef.current?.getCurrentToolId() !== 'hand') {
+      previousTool.current = tlEditorRef.current?.getCurrentToolId();
+      tlEditorRef.current?.setCurrentTool("hand");
       return;
     }
 
@@ -789,6 +796,13 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       if ((event.key === "z" || event.key === "Z") && undoRedoIntervalId) {
         clearInterval(undoRedoIntervalId);
         undoRedoIntervalId = null;
+      }
+
+      if (event.key === ' ') {
+        if (previousTool.current) {
+          tlEditorRef.current?.setCurrentTool(previousTool.current);
+          previousTool.current = null;
+        }
       }
     };
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -250,7 +250,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       return;
     }
 
-    if (event.key === ' ' && tlEditorRef.current?.getCurrentToolId() !== 'hand') {
+    if (event.key === ' ' && tlEditorRef.current?.getCurrentToolId() !== 'hand' && isPresenterRef.current) {
       previousTool.current = tlEditorRef.current?.getCurrentToolId();
       tlEditorRef.current?.setCurrentTool("hand");
       return;


### PR DESCRIPTION
### What does this PR do?
This PR restores the functionality of activating the pan tool when the spacebar is pressed and reverting to the previously selected tool when the spacebar is released.

### Motivation
The ability to switch to the pan tool using the spacebar is a common and expected behavior in many graphic and design applications. Restoring this functionality improves the user experience by making the whiteboard toolset more intuitive