### PR TITLE
fix(whiteboard): Update bigbluebutton/tldraw package version

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -797,18 +797,6 @@
         "lodash.throttle": "^4.1.1",
         "lodash.uniq": "^4.5.0",
         "nanoid": "4.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.37.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-          "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw=="
-        },
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
-        }
       }
     },
     "@bigbluebutton/state": {
@@ -825,19 +813,12 @@
         "@bigbluebutton/utils": "2.0.0-alpha.20",
         "lodash.isequal": "^4.5.0",
         "nanoid": "4.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
-        }
       }
     },
     "@bigbluebutton/tldraw": {
-      "version": "2.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/tldraw/-/tldraw-2.0.0-alpha.20.tgz",
-      "integrity": "sha512-9UWnTuJnUJpeyvczd3Gj944xC4BmSli/GNKm1Gy9rFfB+DRVDLEO4zSc7NqV1pwBnSG2T2fFjVFFdtn6u40aSQ==",
+      "version": "2.0.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/tldraw/-/tldraw-2.0.0-alpha.21.tgz",
+      "integrity": "sha512-9SWI0Hj5VC+0IMqkqrU51qyMRxzOMu1i2f/q/a4PsSwie0Mgg7IbTEDIwWicmivsYr69Ti3rrSyC2IN9XvjQ3Q==",
       "requires": {
         "@bigbluebutton/editor": "2.0.0-alpha.20",
         "@radix-ui/react-alert-dialog": "^1.0.0",
@@ -865,13 +846,6 @@
         "@bigbluebutton/utils": "2.0.0-alpha.20",
         "@bigbluebutton/validate": "2.0.0-alpha.20",
         "nanoid": "4.0.2"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
-        }
       }
     },
     "@bigbluebutton/utils": {
@@ -3674,6 +3648,11 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "core-js": {
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw=="
     },
     "cosmiconfig": {
       "version": "7.1.0",
@@ -7277,6 +7256,11 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "nanoid": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@apollo/client": "^3.10.4",
     "@babel/runtime": "^7.17.9",
-    "@bigbluebutton/tldraw": "^2.0.0-alpha.20",
+    "@bigbluebutton/tldraw": "^2.0.0-alpha.21",
     "@browser-bunyan/server-stream": "^1.8.0",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",


### PR DESCRIPTION
### What does this PR do?
This PR updates the `@bigbluebutton/tldraw` to the latest version.

### Motivation
Some fixes for tldraw were lost when we moved from @tldraw/tldraw@v2.0.0-alpha.19 to @bigbluebutton/tldraw@^2.0.0-alpha.20. Updating to the latest version @bigbluebutton/tldraw@^2.0.0-alpha.21 should restore these fixes.

#19598, #20459
