### PR TITLE
fix(debounce): reset timeout when leading is true

### DIFF
--- a/bigbluebutton-html5/imports/utils/debounce.js
+++ b/bigbluebutton-html5/imports/utils/debounce.js
@@ -21,6 +21,19 @@ export function debounce(func, delay, options = {}) {
     lastThis = null;
   }
 
+  function scheduleTimeout() {
+    timeoutId = setTimeout(() => {
+      if (!trailing) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      } else {
+        invokeFunc();
+        timeoutId = null;
+      }
+      calledOnce = false;
+    }, delay);
+  }
+
   return function (...args) {
     lastArgs = args;
     lastThis = this;
@@ -31,22 +44,16 @@ export function debounce(func, delay, options = {}) {
         calledOnce = true;
       }
 
-      timeoutId = setTimeout(() => {
-        if (!trailing) {
-          clearTimeout(timeoutId);
-          timeoutId = null;
-        } else {
-          invokeFunc();
-          timeoutId = null;
-        }
-        calledOnce = false;
-      }, delay);
+      scheduleTimeout();
     } else if (trailing) {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
         invokeFunc();
         timeoutId = null;
       }, delay);
+    } else if (leading && calledOnce) {
+      clearTimeout(timeoutId);
+      scheduleTimeout();
     }
   };
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the debounce function to work properly when leading is true by adding a condition to reset and reschedule the timeout whenever a subsequent call happens whithin the delay timeframe.

### Closes Issue(s)
Closes #20509

