### PR TITLE
Change: improve connection status to work when network is down

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -10,7 +10,6 @@ import logger from '/imports/startup/client/logger';
 import apolloContextHolder from '../../core/graphql/apolloContextHolder/apolloContextHolder';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import deviceInfo from '/imports/utils/deviceInfo';
-import { NetworkError } from '@apollo/client/errors';
 
 interface ConnectionManagerProps {
   children: React.ReactNode;


### PR DESCRIPTION
### What does this PR do?
The first implementation was considering when server is down, but after a few field test was noticed a issue when a network was down causing the issue of the client not being notified about it, it happens because our network layer (graphql-ws) doesn't automatic notify connection issues, we should make it manually