### PR TITLE
fix: Refactor Userlist Ordering

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -98,6 +98,7 @@ select_permissions:
         - raiseHand
         - raiseHandTime
         - reactionEmoji
+        - registeredAt
         - registeredOn
         - role
         - speechLocale

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -11,7 +11,7 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
                   {isDialIn: desc},
                   {hasDrawPermissionOnCurrentPage: desc},
                   {nameSortable: asc},
-                  {registeredAt: asc}
+                  {registeredAt: asc},
                   {userId: asc}
                 ]) {
     isDialIn

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -4,14 +4,16 @@ export const USER_LIST_SUBSCRIPTION = gql`
 subscription UserListSubscription($offset: Int!, $limit: Int!) {
   user(limit:$limit, offset: $offset, 
                 order_by: [
+                  {presenter: desc},
                   {role: asc},
                   {raiseHandTime: asc_nulls_last},
                   {emojiTime: asc_nulls_last},
                   {isDialIn: desc},
                   {hasDrawPermissionOnCurrentPage: desc},
                   {nameSortable: asc},
+                  {registeredAt: asc}
                   {userId: asc}
-                ]) {     
+                ]) {
     isDialIn
     userId
     extId


### PR DESCRIPTION
This PR refactors the userlist ordering and improves database indexing. Key changes include:

- Ensuring the presenter is always placed at the top of the userlist (currently presenter is like a normal user in the ordering when multi-whiteboard is enabled).
- Ignoring emojis when sorting names.
- Adding `registeredOn` as a sort column above `userId` for cases where two or more users have the same name.
- Updating the database index to align with the client's sorting criteria.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>

![presenter-not-above](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/c02126aa-3ea7-444c-8093-f21fd9083b83)


</td>
<td>

![presenter-not-above-after](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/c9857ed1-297f-4bba-82ac-9d080243dab5)

</td>
</tr>
<tr>
<td>

![user-emoji-last](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/ca6cb1dd-0115-4f07-b8e9-a96fbb09c14b)

</td>
<td>

![user-emoji-last-after](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/11e7f738-5a0a-476b-8ef8-ee23afcbb9ff)

</td>
</tr>

