### PR TITLE
fix (gql-server): not treat users who left the meeting as having a connection problem

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -828,8 +828,12 @@ CREATE OR REPLACE VIEW "v_user_connectionStatusReport" AS
 SELECT u."meetingId", u."userId",
 max(cs."connectionAliveAt") AS "connectionAliveAt",
 max(cs."status") AS "currentStatus",
---COALESCE(max(cs."applicationRttInMs"),(EXTRACT(EPOCH FROM (current_timestamp - max(cs."connectionAliveAt"))) * 1000)) AS "applicationRttInMs",
-CASE WHEN max(cs."connectionAliveAt") < current_timestamp - INTERVAL '1 millisecond' * max(cs."connectionAliveAtMaxIntervalMs") THEN TRUE ELSE FALSE END AS "clientNotResponding",
+CASE WHEN
+    u."isOnline"
+    AND max(cs."connectionAliveAt") < current_timestamp - INTERVAL '1 millisecond' * max(cs."connectionAliveAtMaxIntervalMs")
+    THEN TRUE
+    ELSE FALSE
+END AS "clientNotResponding",
 (array_agg(csm."status" ORDER BY csm."lastOccurrenceAt" DESC))[1] as "lastUnstableStatus",
 max(csm."lastOccurrenceAt") AS "lastUnstableStatusAt"
 FROM "user" u


### PR DESCRIPTION
When a user leaves the meeting, they receive the status `clientNotResponding` after a few seconds, which is then displayed in the connection report:

![client_not_responding-offline](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/e9eefe3e-9e15-4f34-ac18-47c44672ab2a)

The correct behavior should not treat users who left the meeting as having a connection problem.

Addresses one issue of #20486