### PR TITLE
fix(webcams): lower pageChangeDebounceTime to 1s

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -494,7 +494,7 @@ public:
       # user to enable/disable it
       paginationToggleEnabled: true
       # how long (in ms) the negotiation will be debounced after a page change.
-      pageChangeDebounceTime: 2500
+      pageChangeDebounceTime: 1000
       # video page sizes for DESKTOP endpoints. It stands for the number of SUBSCRIBER streams.
       # PUBLISHERS aren't accounted for .
       # A page size of 0 (zero) means that the page size is unlimited (disabled).


### PR DESCRIPTION
### What does this PR do?

- [fix(webcams): lower pageChangeDebounceTime to 1s](https://github.com/bigbluebutton/bigbluebutton/commit/36ec3e9f24d488078bb5c1aa7c35308604956c76) 
  * Webcam pagination has a timed camera negotiation debounce
after a page change is triggered. The goal is to avoid overlapping
negotiation requests on sequential page changes. That value is
configurable and set to 2.5 seconds by default, which is too
conservative for today's standards.
  * Lower the default pageChangeDebounceTime to 1s.

### Closes Issue(s)

n/a

### Motivation

Usage feedback.

### More

Backport to 2.7 (note to self)
