### PR TITLE
docs(fix): incorrect default value for bbb_display_branding_area in docs

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1379,7 +1379,7 @@ Useful tools for development:
 
 | Parameter                             | Description                                                                               | Default value |
 | ------------------------------------- | ----------------------------------------------------------------------------------------- | ------------- |
-| `userdata-bbb_display_branding_area=` | If set to `true`, the client will display the branding area in the upper left hand corner | `false`       |
+| `userdata-bbb_display_branding_area=` | If set to `true`, the client will display the branding area in the upper left hand corner | `true`       |
 
 #### Shortcut parameters
 


### PR DESCRIPTION
### What does this PR do?

Adjusts default value for bbb_display_branding_area parameter in docs

### More

https://github.com/bigbluebutton/bigbluebutton/commit/da8075e2ede5989b163643f2ed0b16de231ff15c