### PR TITLE
refactor (gql-middleware): Avoid sending msg GraphqlConnectionClosed when unnecessary

### DIFF
--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -81,7 +81,10 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 		if bcExists {
 			sessionTokenRemoved := BrowserConnections[browserConnectionId].SessionToken
 			delete(BrowserConnections, browserConnectionId)
-			go SendUserGraphqlConnectionClosedSysMsg(sessionTokenRemoved, browserConnectionId)
+
+			if sessionTokenRemoved != "" {
+				go SendUserGraphqlConnectionClosedSysMsg(sessionTokenRemoved, browserConnectionId)
+			}
 		}
 		BrowserConnectionsMutex.Unlock()
 


### PR DESCRIPTION
Avoid sending msg `UserGraphqlConnectionClosedSysMsg` to akka-apps when it didn't send the `UserGraphqlConnectionEstablishedSysMsg` previously.