### PR TITLE
Fix: Avatar is transparent in cc

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
@@ -35,7 +35,7 @@ const AudioCaptionsLive: React.FC<AudioCaptionsLiveProps> = ({
                       color={user.color}
                       moderator={user.isModerator}
                     >
-                      {user.avatar ? '' : user.name.toLowerCase().slice(0, 2)}
+                      {user.avatar ? '' : user.name.slice(0, 2)}
                     </Styled.UserAvatar>
                   </Styled.UserAvatarWrapper>
                 )}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
@@ -35,7 +35,7 @@ const AudioCaptionsLive: React.FC<AudioCaptionsLiveProps> = ({
                       color={user.color}
                       moderator={user.isModerator}
                     >
-                      {user.name.slice(0, 2)}
+                      {user.avatar ? '' : user.name.toLowerCase().slice(0, 2)}
                     </Styled.UserAvatar>
                   </Styled.UserAvatarWrapper>
                 )}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where the name initial would overlap the user's avatar.

### Closes Issue(s)

#20529 

### Before

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/9a9ffd25-29cf-4311-88c0-d722e7de020d)

### After

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/dd2e0844-5f6b-4e75-aa10-ac4940782f93)

