### PR TITLE
refactor: Introduce a new Graphql type to consume user `muted` and `talking` statuses

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserVoiceDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserVoiceDAO.scala
@@ -119,19 +119,6 @@ object UserVoiceDAO {
     }
   }
 
-  def delete(meetingId: String, userId: String) = {
-    DatabaseConnection.db.run(
-      TableQuery[UserDbTableDef]
-        .filter(_.meetingId === meetingId)
-        .filter(_.userId === userId)
-        .map(u => (u.loggedOut))
-        .update((true))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated loggedOut=true on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating loggedOut=true user: $e")
-    }
-  }
-
   def deleteUserVoice(meetingId: String,userId: String) = {
     //Meteor sets this props instead of removing
     //    muted: false
@@ -145,7 +132,7 @@ object UserVoiceDAO {
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .map(u => (u.muted, u.talking, u.listenOnly, u.joined, u.spoke, u.startTime, u.endTime))
-        .update((false, false, false, false, false, None, None))
+        .update((true, false, false, false, false, None, None))
     ).onComplete {
       case Success(rowsAffected) => DatabaseConnection.logger.debug(s"Voice of user ${userId} deleted (joined=false)")
       case Failure(e) => DatabaseConnection.logger.error(s"Error deleting voice user: $e")

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -487,13 +487,6 @@ type Mutation {
 }
 
 type Mutation {
-  userSetSpeechOptions(
-    partialUtterances: Boolean!
-    minUtteranceLength: Float!
-  ): Boolean
-}
-
-type Mutation {
   userSetCaptionLocale(
     locale: String!
     provider: String!
@@ -566,6 +559,13 @@ type Mutation {
 }
 
 type Mutation {
+  userSetSpeechOptions(
+    partialUtterances: Boolean!
+    minUtteranceLength: Float!
+  ): Boolean
+}
+
+type Mutation {
   userThirdPartyInfoResquest(
     externalUserId: String!
   ): Boolean
@@ -593,3 +593,4 @@ input GuestUserApprovalStatus {
   guest: String!
   status: String!
 }
+

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -439,12 +439,6 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
-  - name: userSetSpeechOptions
-    definition:
-      kind: synchronous
-      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
-    permissions:
-      - role: bbb_client
   - name: userSetConnectionAlive
     definition:
       kind: synchronous
@@ -500,6 +494,12 @@ actions:
     permissions:
       - role: bbb_client
   - name: userSetSpeechLocale
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: userSetSpeechOptions
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_voice_activity.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_voice_activity.yaml
@@ -1,0 +1,17 @@
+table:
+  name: v_user_voice_activity
+  schema: public
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - endTime
+        - muted
+        - startTime
+        - talking
+        - userId
+        - voiceActivityAt
+      filter:
+        voiceActivityAt:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -59,5 +59,6 @@
 - "!include public_v_user_typing_private.yaml"
 - "!include public_v_user_typing_public.yaml"
 - "!include public_v_user_voice.yaml"
+- "!include public_v_user_voice_activity.yaml"
 - "!include public_v_user_voice_mongodb_adapter.yaml"
 - "!include public_v_user_welcomeMsgs.yaml"


### PR DESCRIPTION
Currently, updating user `muted` and `talking` statuses involves multiple subscriptions, causing each subscription to update whenever any user talks. This redundancy increases latency and data traffic.

To address this, we will:
1. Use stream subscriptions to consume `muted` and `talking` data, reducing update latency.
2. Detach `muted` and `talking` properties from multiple subscriptions, centralizing them into a single subscription.

@JoVictorNunes will develop a specialized hook to provide `whoIsTalking` and `whoIsUnmuted` data, removing this information from other subscriptions.

This PR introduces:
- A new PostgreSQL view.
- A new GraphQL type.

These additions will help João implement the centralized hook and reduce data traffic for the GraphQL server.

```gql
subscription {
  user_voice_activity_stream(cursor: {initial_value: {voiceActivityAt: "2020-01-01"}}, batch_size: 10) {
    meetingId
    muted
    startTime
    endTime
    talking
    userId
  }
}
```