### PR TITLE
Fix: Wrong position of audio arrow

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
@@ -70,7 +70,7 @@ export const DangerColor = {
 export const AudioDropdown = styled(ButtonEmoji)`
   span {
     i {
-      width: 0px !important;
+      width: 10px !important;
       bottom: 1px;
     }
   }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the arrow in the 'mute' button.

### Before the fix

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/adcc917b-a58b-46bd-8825-adb4d0dbfdaa)

### After the fix

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/f620939e-4b6d-441e-a54f-d3c1b1e59670)
