### PR TITLE
Fix: Null label for emoji setting toast

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -239,10 +239,9 @@ class App extends Component {
         && currentUserEmoji.status !== 'raiseHand'
         && currentUserEmoji.status !== 'away'
     ) {
-      const formattedEmojiStatus = intl.formatMessage({ id: `app.actionsBar.emojiMenu.${currentUserEmoji.status}Label` })
-        || currentUserEmoji.status;
+      const formattedEmojiStatus = currentUserEmoji.status;
 
-      if (currentUserEmoji.status === 'none') {
+      if (currentUserEmoji.status === null) {
         notify(
           intl.formatMessage(intlMessages.clearedEmoji),
           'info',


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where the notifications regarding the user status/reactions would show the translation id instead of the proper message.

### Closes Issue(s)

#20539 

### Before

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/8b019064-21fc-43e2-883f-b47af5bf5e2c)

### After

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/7bdc7062-7668-4028-909a-c6d535a06fd5)





