### PR TITLE
Fix: Webcam display of emoji can trigger elements rearrangement

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/styles.ts
@@ -80,7 +80,7 @@ const Dropdown = styled.div<{
 `;
 
 const MenuWrapper = styled.div`
-  max-width: 75%;
+  max-width: 60%;
 `;
 
 const MenuWrapperSqueezed = styled.div`


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where the emoji in the webcam would trigger elements rearrangement.

### Closes Issue(s)

#20538 

### Before

[341111925-91bc0d2a-2f15-4ce4-901e-433d3b651964.webm](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/9841057a-0e41-4bd8-a6db-bf57184a86e0)

### After

https://github.com/bigbluebutton/bigbluebutton/assets/36093456/3f0c7fbb-5b0f-4169-9e24-a1dcbf54fa74



