### PR TITLE
fix(whiteboard): Restore cut, copy and paste functionality via keyboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -324,6 +324,10 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   }, [tlEditorRef]);
 
   const handleKeyDown = useCallback((event) => {
+    const debouncedUndo = debounce({ delay: 150 }, () => {
+      tlEditorRef.current?.undo();
+    });
+
     if (event.key === 'Escape') {
       tlEditorRef.current?.deselect(...tlEditorRef.current?.getSelectedShapes());
       return;
@@ -381,6 +385,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
             handlePaste();
           }
         },
+        'z': debouncedUndo,
       };
       if (ctrlKeyMap[event.key]) {
         event.preventDefault();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -253,12 +253,14 @@ const Whiteboard = React.memo(function Whiteboard(props) {
     });
   };
 
-  const handleCut = useCallback(() => {
+  const handleCut = useCallback((shouldCopy) => {
     const selectedShapes = tlEditorRef.current?.getSelectedShapes();
     if (!selectedShapes || selectedShapes.length === 0) {
       return;
     }
-    handleCopy();
+    if (shouldCopy) {
+      handleCopy();
+    }
     tlEditorRef.current?.deleteShapes(selectedShapes.map(shape => shape.id));
   }, [tlEditorRef]);
 
@@ -327,6 +329,11 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       return;
     }
 
+    if (event.key === 'Delete') {
+      handleCut(false);
+      return;
+    }
+
     const editingShape = tlEditorRef.current?.getEditingShape();
     if (editingShape && (isPresenterRef.current || hasWBAccessRef.current)) {
       return;
@@ -364,7 +371,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
           tlEditorRef.current?.selectNone();
         },
         'x': () => {
-          handleCut();
+          handleCut(true);
         },
         'c': () => {
           handleCopy();


### PR DESCRIPTION
### What does this PR do?
This PR restores the cut, copy, and paste functionality on the whiteboard via keyboard shortcuts.


### Motivation
The shortcut keys for cut (Ctrl+X), copy (Ctrl+C), and paste (Ctrl+V) were not working.