### PR TITLE
fix: improve the hooks of voice activity

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
@@ -31,7 +31,7 @@ const ReactionsButtonContainer = ({ ...props }) => {
     emoji: currentUserData?.emoji,
     raiseHand: currentUserData?.raiseHand,
     away: currentUserData?.away,
-    muted: !unmutedUsers.has(Auth.userID),
+    muted: !unmutedUsers[Auth.userID],
   };
 
   const { autoCloseReactionsBar } = useSettings(SETTINGS.APPLICATION);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -240,7 +240,7 @@ const InputStreamLiveSelectorContainer: React.FC = () => {
   const { data: talkingUsers } = useWhoIsTalking();
   const { data: unmutedUsers } = useWhoIsUnmuted();
   const talking = Boolean(currentUser?.userId && talkingUsers[currentUser.userId]);
-  const muted = Boolean(currentUser?.userId && !unmutedUsers.has(currentUser.userId));
+  const muted = Boolean(currentUser?.userId && !unmutedUsers[currentUser.userId]);
 
   const { data: currentMeeting } = useMeeting((m: Partial<Meeting>) => {
     return {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/hooks/useMuteMicrophone.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/hooks/useMuteMicrophone.ts
@@ -11,7 +11,7 @@ const useMuteMicrophone = () => {
   }));
   const toggleVoice = useToggleVoice();
   const { data: unmutedUsers } = useWhoIsUnmuted();
-  const muted = currentUser?.userId && !unmutedUsers.has(currentUser?.userId);
+  const muted = currentUser?.userId && !unmutedUsers[currentUser?.userId];
   const userId = currentUser?.userId ?? '';
 
   return useCallback(() => {

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -176,7 +176,7 @@ const AudioContainer = (props) => {
 
   const { data: currentUser } = useCurrentUser((u) => ({ userId: u.userId }));
   const { data: unmutedUsers } = useWhoIsUnmuted();
-  const currentUserMuted = currentUser?.userId && !unmutedUsers.has(currentUser.userId);
+  const currentUserMuted = currentUser?.userId && !unmutedUsers[currentUser.userId];
 
   const joinAudio = () => {
     if (Service.isConnected()) return;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -199,18 +199,28 @@ const TalkingIndicatorContainer: React.FC = (() => {
         Object.values(talkingUsersData),
         (v: VoiceItem) => v.muted,
       ) as [VoiceItem[], VoiceItem[]];
+      const [talking, silent] = partition(
+        unmuted,
+        (v: VoiceItem) => v.talking,
+      ) as [VoiceItem[], VoiceItem[]];
       return [
-        ...unmuted.sort((v1, v2) => {
+        ...talking.sort((v1, v2) => {
           if (!v1.startTime && !v2.startTime) return 0;
           if (!v1.startTime) return 1;
           if (!v2.startTime) return -1;
           return v1.startTime - v2.startTime;
         }),
+        ...silent.sort((v1, v2) => {
+          if (!v1.endTime && !v2.endTime) return 0;
+          if (!v1.endTime) return 1;
+          if (!v2.endTime) return -1;
+          return v2.endTime - v1.endTime;
+        }),
         ...muted.sort((v1, v2) => {
           if (!v1.endTime && !v2.endTime) return 0;
           if (!v1.endTime) return 1;
           if (!v2.endTime) return -1;
-          return v1.endTime - v2.endTime;
+          return v2.endTime - v1.endTime;
         }),
       ].slice(0, TALKING_INDICATORS_MAX);
     }, [talkingUsersData]);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -107,7 +107,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
   const voiceUser = {
     ...user.voice,
     talking: talkingUsers[user.userId],
-    muted: !unmutedUsers.has(user.userId),
+    muted: !unmutedUsers[user.userId],
   };
   const subs = [];
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
@@ -67,7 +67,7 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
   const voiceData = useMemo(() => ({
     ...voiceUser,
     talking: talkingUsers[userId],
-    muted: !unmutedUsers.has(userId),
+    muted: !unmutedUsers[userId],
   }), [voiceUser, talkingUsers, unmutedUsers, userId]);
 
   return (

--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
@@ -16,54 +16,82 @@ const useTalkingUsers = () => {
     error,
   } = useVoiceActivity();
   const [record, setRecord] = useState<Record<string, VoiceItem>>({});
-  const timeoutRegistry = useRef<Record<string, NodeJS.Timeout>>({});
+  const mutedTimeoutRegistry = useRef<Record<string, NodeJS.Timeout | null>>({});
+  const spokeTimeoutRegistry = useRef<Record<string, NodeJS.Timeout | null>>({});
 
   useEffect(() => {
-    const talkingUsers: Record<string, VoiceItem> = {};
-    const [deleted] = partition(
-      Object.values(record),
-      (v: VoiceItem) => !voiceActivity[v.userId],
+    if (!voiceActivity) return;
+
+    const [muted, unmuted] = partition(
+      voiceActivity,
+      (v: VoiceItem) => v.muted,
     ) as [VoiceItem[], VoiceItem[]];
 
-    Object.values(voiceActivity).forEach((voice) => {
-      const { endTime, userId } = voice;
+    unmuted.forEach((voice) => {
+      const { endTime, startTime, userId } = voice;
+      const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
+      const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
 
-      talkingUsers[userId] = Object.assign(
-        talkingUsers[userId] || {},
-        voice,
-      );
+      // User has never talked
+      if (!(endTime || startTime)) return;
 
-      if (timeoutRegistry.current[userId]) {
-        clearTimeout(timeoutRegistry.current[userId]);
+      // Cancel any deletion
+      if (currentSpokeTimeout) {
+        clearTimeout(currentSpokeTimeout);
+        spokeTimeoutRegistry.current[userId] = null;
+      }
+      if (currentMutedTimeout) {
+        clearTimeout(currentMutedTimeout);
+        mutedTimeoutRegistry.current[userId] = null;
       }
 
-      if (endTime) {
-        timeoutRegistry.current[userId] = setTimeout(() => {
-          setRecord((prevRecord) => {
-            const newRecord = { ...prevRecord };
+      setRecord((previousRecord) => {
+        // User has stopped talking
+        if (endTime) {
+          spokeTimeoutRegistry.current[userId] = setTimeout(() => {
+            setRecord((previousRecord) => {
+              const newRecord = { ...previousRecord };
+              delete newRecord[userId];
+              return newRecord;
+            });
+          }, TALKING_INDICATOR_TIMEOUT);
+        }
+
+        return {
+          ...previousRecord,
+          [userId]: Object.assign(
+            previousRecord[userId] || {},
+            voice,
+          ),
+        };
+      });
+    });
+
+    muted.forEach((voice) => {
+      const { userId } = voice;
+      const currentTimeout = mutedTimeoutRegistry.current[userId];
+
+      if (currentTimeout) return;
+
+      setRecord((previousRecord) => {
+        mutedTimeoutRegistry.current[userId] = setTimeout(() => {
+          setRecord((previousRecord) => {
+            const newRecord = { ...previousRecord };
             delete newRecord[userId];
             return newRecord;
           });
+          mutedTimeoutRegistry.current[userId] = null;
         }, TALKING_INDICATOR_TIMEOUT);
-      }
-    });
 
-    deleted.forEach((voice) => {
-      const { userId } = voice;
-      const patchedVoice = voice;
-      patchedVoice.muted = true;
-      patchedVoice.talking = false;
-      timeoutRegistry.current[userId] = setTimeout(() => {
-        setRecord((prevRecord) => {
-          const newRecord = { ...prevRecord };
-          delete newRecord[userId];
-          return newRecord;
-        });
-      }, TALKING_INDICATOR_TIMEOUT);
-      talkingUsers[userId] = patchedVoice;
+        return {
+          ...previousRecord,
+          [userId]: Object.assign(
+            previousRecord[userId] || {},
+            voice,
+          ),
+        };
+      });
     });
-
-    setRecord(talkingUsers);
   }, [voiceActivity]);
 
   return {

--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
@@ -68,10 +68,13 @@ const useTalkingUsers = () => {
     });
 
     muted.forEach((voice) => {
-      const { userId } = voice;
+      const { userId, endTime, startTime } = voice;
       const currentTimeout = mutedTimeoutRegistry.current[userId];
 
       if (currentTimeout) return;
+
+      // User has never talked
+      if (!(endTime || startTime)) return;
 
       setRecord((previousRecord) => {
         mutedTimeoutRegistry.current[userId] = setTimeout(() => {

--- a/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
@@ -8,6 +8,7 @@ const useVoiceActivity = () => {
     loading,
     error,
   } = useDeduplicatedSubscription<VoiceActivityResponse>(VOICE_ACTIVITY);
+  console.log(data);
 
   if (error) {
     logger.error({

--- a/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
@@ -8,7 +8,6 @@ const useVoiceActivity = () => {
     loading,
     error,
   } = useDeduplicatedSubscription<VoiceActivityResponse>(VOICE_ACTIVITY);
-  console.log(data);
 
   if (error) {
     logger.error({

--- a/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
@@ -1,11 +1,6 @@
-import { useEffect, useState } from 'react';
 import logger from '/imports/startup/client/logger';
 import VOICE_ACTIVITY, { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/whoIsTalking';
 import useDeduplicatedSubscription from './useDeduplicatedSubscription';
-
-type VoiceItem = VoiceActivityResponse['user_voice_activity_stream'][number] & {
-  showTalkingIndicator: boolean | undefined;
-};
 
 const useVoiceActivity = () => {
   const {
@@ -13,7 +8,6 @@ const useVoiceActivity = () => {
     loading,
     error,
   } = useDeduplicatedSubscription<VoiceActivityResponse>(VOICE_ACTIVITY);
-  const [record, setRecord] = useState<Record<string, VoiceItem>>({});
 
   if (error) {
     logger.error({
@@ -25,32 +19,10 @@ const useVoiceActivity = () => {
     }, 'useVoiceActivity hook failed.');
   }
 
-  useEffect(() => {
-    const voiceActivity: Record<string, VoiceItem> = { ...record };
-
-    if (data) {
-      data.user_voice_activity_stream.forEach((voice) => {
-        const { userId, muted } = voice;
-
-        if (muted) {
-          delete voiceActivity[userId];
-          return;
-        }
-
-        voiceActivity[userId] = Object.assign(
-          voiceActivity[userId] || {},
-          voice,
-        );
-      });
-    }
-
-    setRecord(voiceActivity);
-  }, [data]);
-
   return {
     error,
     loading,
-    data: record,
+    data: data?.user_voice_activity_stream,
   };
 };
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalking.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalking.ts
@@ -6,20 +6,27 @@ const useWhoIsTalking = () => {
     data: voiceActivity,
     loading,
   } = useVoiceActivity();
-  const [record, setRecord] = useState<Record<string, boolean>>({});
+  const [talkingUsers, setTalkingUsers] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
-    const talkingUsers: Record<string, boolean> = {};
+    if (!voiceActivity) return;
 
-    Object.keys(voiceActivity).forEach((userId) => {
-      talkingUsers[userId] = voiceActivity[userId]?.talking;
+    const newTalkingUsers: Record<string, boolean> = { ...talkingUsers };
+
+    voiceActivity.forEach(({ userId, muted, talking }) => {
+      if (muted) {
+        delete newTalkingUsers[userId];
+        return;
+      }
+
+      newTalkingUsers[userId] = talking;
     });
 
-    setRecord(talkingUsers);
+    setTalkingUsers(newTalkingUsers);
   }, [voiceActivity]);
 
   return {
-    data: record,
+    data: talkingUsers,
     loading,
   };
 };

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmuted.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmuted.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import useVoiceActivity from './useVoiceActivity';
 
 const useWhoIsUnmuted = () => {
@@ -6,14 +6,29 @@ const useWhoIsUnmuted = () => {
     data: voiceActivity,
     loading,
   } = useVoiceActivity();
+  const [unmutedUsers, setUnmutedUsers] = useState<Record<string, boolean>>({});
 
-  const record = useMemo(() => {
-    const mutedUsers: Set<string> = new Set(Object.keys(voiceActivity));
-    return mutedUsers;
+  useEffect(() => {
+    if (!voiceActivity) return;
+
+    const newUnmutedUsers = { ...unmutedUsers };
+
+    voiceActivity.forEach((voice) => {
+      const { userId, muted } = voice;
+
+      if (muted) {
+        delete newUnmutedUsers[userId];
+        return;
+      }
+
+      newUnmutedUsers[userId] = true;
+    });
+
+    setUnmutedUsers(newUnmutedUsers);
   }, [voiceActivity]);
 
   return {
-    data: record,
+    data: unmutedUsers,
     loading,
   };
 };


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR includes fixes and improvements for the changes introduced in https://github.com/bigbluebutton/bigbluebutton/pull/20568.

- Use mapping object instead of `Set`.
- Call `setTimeout` only when the state update is invoked.
- `useVoiceActivity` no longer stores it own state. It leaves the duty of managing muted users to the callers.
- Improve talking indicator sorting.
- Improve timeout handling by splitting the registry into `spokeTimeoutRegistry` and `mutedTimeoutRegistry`. That way, we have more fine-grained control over timeouts.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None