### PR TITLE
refactor (akka-apps): Make all inserts into the database thought batches instead of individual inserts

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -49,80 +49,60 @@ class BreakoutRoomDbTableDef(tag: Tag) extends Table[BreakoutRoomDbModel](tag, N
 }
 
 object BreakoutRoomDAO {
-
   def insert(breakout: BreakoutModel, liveMeeting: LiveMeeting) = {
-    DatabaseConnection.db.run(DBIO.sequence(
+    DatabaseConnection.enqueue(DBIO.sequence(
       for {
         (_, room) <- breakout.rooms
       } yield {
         prepareInsertOrUpdate(room, breakout.durationInSeconds, breakout.sendInviteToModerators)
       }
     ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on BreakoutRoom table!")
 
-          //Insert assigned users
-          DatabaseConnection.db.run(DBIO.sequence(
-            for {
-              (_, room) <- breakout.rooms
-              userId <- room.assignedUsers
-              (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString())
-            } yield {
-              BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = true)
-            }
-          ).transactionally)
-            .onComplete {
-              case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on breakoutRoom_user table!")
-              case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting breakoutRoom_user: $e")
-            }
+    //Insert assigned users
+    DatabaseConnection.enqueue(DBIO.sequence(
+      for {
+        (_, room) <- breakout.rooms
+        userId <- room.assignedUsers
+        (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString())
+      } yield {
+        BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = true)
+      }
+    ).transactionally)
 
+    //Assign left users to a random room in case it is freeJoin
+    val freeJoin = breakout.rooms.exists(r => r._2.freeJoin)
+    if(freeJoin) {
+      val assignedUsers = (for {
+        (_, room) <- breakout.rooms
+        userId <- room.assignedUsers
+      } yield {
+        userId
+      }).toVector
 
+      val nonAssignedUsers = Users2x.findAll(liveMeeting.users2x)
+        .filterNot(user => assignedUsers.contains(user.intId))
+        .filterNot(user => user.role == Roles.MODERATOR_ROLE)
+        .map(_.intId)
 
-          //Assign left users to a random room in case it is freeJoin
-          val freeJoin = breakout.rooms.exists(r => r._2.freeJoin)
-          if(freeJoin) {
-            val assignedUsers = (for {
-              (_, room) <- breakout.rooms
-              userId <- room.assignedUsers
-            } yield {
-              userId
-            }).toVector
+      val roomsSeq = breakout.rooms.values.toSeq
 
-            val nonAssignedUsers = Users2x.findAll(liveMeeting.users2x)
-              .filterNot(user => assignedUsers.contains(user.intId))
-              .filterNot(user => user.role == Roles.MODERATOR_ROLE)
-              .map(_.intId)
-
-            val roomsSeq = breakout.rooms.values.toSeq
-
-            DatabaseConnection.db.run(DBIO.sequence(
-                for {
-                  userId <- nonAssignedUsers
-                  randomIndex = Random.nextInt(roomsSeq.length)
-                  room <- Some(roomsSeq(randomIndex))
-                  (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString())
-                } yield {
-                  BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = true)
-                }
-              ).transactionally)
-              .onComplete {
-                case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on breakoutRoom_user table!")
-                case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting breakoutRoom_user: $e")
-              }
+      DatabaseConnection.enqueue(DBIO.sequence(
+          for {
+            userId <- nonAssignedUsers
+            randomIndex = Random.nextInt(roomsSeq.length)
+            room <- Some(roomsSeq(randomIndex))
+            (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString())
+          } yield {
+            BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = true)
           }
-        }
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting BreakoutRoom: $e")
+        ).transactionally)
       }
   }
 
 //  def update(room: BreakoutRoom2x) = {
-//    DatabaseConnection.db.run(
+//    DatabaseConnection.enqueue(
 //      prepareInsertOrUpdate(room)
-//    ).onComplete {
-//      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on BreakoutRoom table!")
-//      case Failure(e) => DatabaseConnection.logger.error(s"Error updating BreakoutRoom: $e")
-//    }
+//    )
 //  }
 
   def prepareInsertOrUpdate(room: BreakoutRoom2x, durationInSeconds: Int, sendInvitationToModerators: Boolean) = {
@@ -177,52 +157,40 @@ object BreakoutRoomDAO {
 //  }
 
   def deletePermanently(meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[BreakoutRoomDbTableDef]
         .filter(_.parentMeetingId === meetingId)
         .delete
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) delete of meeting ${meetingId} on BreakoutRooms table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error deleting BreakoutRoom of meeting ${meetingId}: $e")
-    }
+    )
   }
 
   def updateRoomsStarted(meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[BreakoutRoomDbTableDef]
         .filter(_.parentMeetingId === meetingId)
 //        .filter(_.breakoutRoomId === breakoutRoomId)
         .map(u => u.startedAt)
         .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated startedAt on BreakoutRoom table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating startedAt BreakoutRoom: $e")
-    }
+    )
   }
 
   def updateRoomsEnded(meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[BreakoutRoomDbTableDef]
         .filter(_.parentMeetingId === meetingId)
         .map(u => u.endedAt)
         .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated endedAt on BreakoutRoom table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating endedAt BreakoutRoom: $e")
-    }
+    )
   }
 
   def updateRoomsDuration(parentMeetingId: String, newDurationInSeconds: Int) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[BreakoutRoomDbTableDef]
         .filter(_.parentMeetingId === parentMeetingId)
         .filter(_.endedAt.isEmpty)
         .map(u => u.durationInSeconds)
         .update(newDurationInSeconds)
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated endedAt on BreakoutRoom table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating endedAt BreakoutRoom: $e")
-    }
+    )
   }
 
 //  def update(meetingId: String, breakoutRoomModel: BreakoutRoomModel) = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -61,7 +61,7 @@ object BreakoutRoomUserDAO {
 
   def updateRoomChanged(meetingId: String, userId: String, fromBreakoutRoomId: String,
                         toBreakoutRoomId: String, joinUrl: String, removePreviousRoom: Boolean) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       if (removePreviousRoom) {
         DBIO.seq(
           BreakoutRoomUserDAO.prepareDelete(fromBreakoutRoomId, meetingId, userId, exceptBreakoutRooomId = toBreakoutRoomId),
@@ -71,36 +71,26 @@ object BreakoutRoomUserDAO {
         DBIO.seq(
           BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)
         )
-      }.transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) changed on breakoutRoom_user table!")
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error changing breakoutRoom_user: $e")
       }
+    )
   }
 
   def updateUserJoined(meetingId: String, usersInRoom: Vector[String], breakoutRoom: BreakoutRoom2x) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       sqlu"""UPDATE "breakoutRoom_user" SET
                 "joinedAt" = current_timestamp
                 WHERE "meetingId" = ${meetingId}
                 AND "userId" in (${usersInRoom.mkString(",")})
                 AND "breakoutRoomId" = ${breakoutRoom.id}
                 AND "joinedAt" is null"""
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated joinedAt=now() on breakoutRoom_user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating joinedAt=now() on breakoutRoom_user: $e")
-    }
+    )
   }
 
   def insertBreakoutRoom(userId: String, room: BreakoutRoom2x, liveMeeting: LiveMeeting) = {
       for {
         (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString)
       } yield {
-        DatabaseConnection.db.run(BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = false))
-          .onComplete {
-            case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on breakoutRoom_user table!")
-            case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting breakoutRoom_user: $e")
-          }
+        DatabaseConnection.enqueue(BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = false))
       }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/CaptionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/CaptionDAO.scala
@@ -34,7 +34,7 @@ object CaptionDAO {
 
   def insertOrUpdateCaption(captionId: String, meetingId: String, userId: String, transcript: String,
                             locale: String, captionType: String = CaptionTypes.AUDIO_TRANSCRIPTION) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[CaptionTableDef].insertOrUpdate(
         CaptionDbModel(
           captionId = captionId,
@@ -46,10 +46,7 @@ object CaptionDAO {
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
-    ).onComplete {
-        case Success(_) => DatabaseConnection.logger.debug(s"Upserted caption with ID $captionId on Caption table")
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error upserting caption on Caption: $e")
-      }
+    )
   }
 
   def insertOrUpdatePadCaption(meetingId: String, locale: String, userId: String, text: String) = {
@@ -94,12 +91,6 @@ object CaptionDAO {
                   )"""
     }
 
-    DatabaseConnection.db.run(DBIO.sequence(actions).transactionally).onComplete {
-      case Success(rowsAffected) =>
-        val total = rowsAffected.sum
-        DatabaseConnection.logger.debug(s"$total row(s) affected in caption table!")
-      case Failure(e) =>
-        DatabaseConnection.logger.error(s"Error executing action: ", e)
-    }
+    DatabaseConnection.enqueue(DBIO.sequence(actions).transactionally)
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/CaptionLocaleDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/CaptionLocaleDAO.scala
@@ -23,7 +23,7 @@ class CaptionLocaleTableDef(tag: Tag) extends Table[CaptionLocaleDbModel](tag, N
 
 object CaptionLocaleDAO {
   def insertOrUpdateCaptionLocale(meetingId: String, locale: String, captionType: String, userId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[CaptionLocaleTableDef].insertOrUpdate(
         CaptionLocaleDbModel(
           meetingId = meetingId,
@@ -33,9 +33,6 @@ object CaptionLocaleDAO {
           updatedAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
-    ).onComplete {
-        case Success(_) => DatabaseConnection.logger.debug(s"Upserted caption with ID $meetingId-$locale on CaptionLocale table")
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error upserting caption on CaptionLocale: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
@@ -42,7 +42,7 @@ class ChatMessageDbTableDef(tag: Tag) extends Table[ChatMessageDbModel](tag, Non
 
 object ChatMessageDAO {
   def insert(meetingId: String, chatId: String, groupChatMessage: GroupChatMessage) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ChatMessageDbTableDef].insertOrUpdate(
         ChatMessageDbModel(
           messageId = groupChatMessage.id,
@@ -59,19 +59,38 @@ object ChatMessageDAO {
           senderRole = Some(groupChatMessage.sender.role),
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on ChatMessage table!")
+    )
 
-          //Set chat visible for all participant users
-          ChatUserDAO.updateChatVisible(meetingId, chatId)
-        }
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting ChatMessage: $e")
-      }
+//        if(groupChatMessage.message.contains("MYMSG")) {
+//          DatabaseConnection.logger.info("INSERTED MSG: " + groupChatMessage.message)
+//        }
+
+        //Set chat visible for all participant users
+        ChatUserDAO.updateChatVisible(meetingId, chatId)
   }
 
+//  def insert(meetingId: String, chatId: String, groupChatMessage: GroupChatMessage): Unit = {
+//    val chatMessage = ChatMessageDbModel(
+//      messageId = groupChatMessage.id,
+//      chatId = chatId,
+//      meetingId = meetingId,
+//      correlationId = groupChatMessage.correlationId,
+//      createdAt = new java.sql.Timestamp(System.currentTimeMillis()),
+//      chatEmphasizedText = groupChatMessage.chatEmphasizedText,
+//      message = groupChatMessage.message,
+//      messageType = "default",
+//      messageMetadata = None,
+//      senderId = Some(groupChatMessage.sender.id),
+//      senderName = groupChatMessage.sender.name,
+//      senderRole = Some(groupChatMessage.sender.role),
+//    )
+//
+//    val insertAction = TableQuery[ChatMessageDbTableDef].insertOrUpdate(chatMessage)
+//    DatabaseConnection.enqueue(insertAction)
+//  }
+
   def insertSystemMsg(meetingId: String, chatId: String, message: String, messageType: String, messageMetadata: Map[String,Any], senderName: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ChatMessageDbTableDef].insertOrUpdate(
         ChatMessageDbModel(
           messageId = GroupChatFactory.genId(),
@@ -88,27 +107,19 @@ object ChatMessageDAO {
           senderRole = None
         )
       )
-    ).onComplete {
-      case Success(rowsAffected) => {
-        DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on ChatMessage(system) table!")
+    )
 
-        //Set chat visible for all participant users
-        ChatUserDAO.updateChatVisible(meetingId, chatId)
-      }
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting ChatMessage(system): $e")
-    }
+    //Set chat visible for all participant users
+    ChatUserDAO.updateChatVisible(meetingId, chatId)
   }
 
   def deleteAllFromChat(meetingId: String, chatId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ChatMessageDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.chatId === chatId)
         .delete
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) deleted from ChatMessage meetingId=${meetingId} chatId=${chatId}")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error deleting from ChatMessage meetingId=${meetingId} chatId=${chatId}: $e")
-    }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -2,13 +2,22 @@ package org.bigbluebutton.core.db
 
 import org.slf4j.LoggerFactory
 import slick.jdbc.PostgresProfile.api._
-
+import scala.concurrent.duration._
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object DatabaseConnection {
   val db = Database.forConfig("postgres")
-  //  implicit val session: Session = db.createSession()
   val logger = LoggerFactory.getLogger(this.getClass)
+
+  val queue = new ConcurrentLinkedQueue[DBIO[_]]()
+
+  // Initialize the scheduler for batch processing
+  val system = org.apache.pekko.actor.ActorSystem("DBActionBatchSystem")
+  system.scheduler.scheduleWithFixedDelay(50.millis, 50.millis)(new Runnable {
+    def run(): Unit = processBatch()
+  })
 
   def initialize(): Unit = {
     db.run(sql"SELECT current_timestamp".as[java.sql.Timestamp]).map { timestamp =>
@@ -16,6 +25,27 @@ object DatabaseConnection {
     }.recover {
       case ex: Exception =>
         logger.error(s"Failed to initialize database: ${ex.getMessage}")
+    }
+  }
+
+  def enqueue(action: DBIO[_]): Unit = {
+    queue.add(action)
+  }
+
+  private def processBatch(): Unit = {
+    if (!queue.isEmpty) {
+      val batch = queue.iterator().asScala.toSeq
+      queue.clear() // Clear the queue
+      val combinedAction = DBIO.sequence(batch)
+      db.run(combinedAction).onComplete {
+        case scala.util.Success(_) => {
+          logger.debug(s"${batch.size} actions executed.")
+          if (!queue.isEmpty) {
+            processBatch()
+          }
+        }
+        case scala.util.Failure(e) => logger.error(s"Error executing batch actions: $e")
+      }
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -2,21 +2,25 @@ package org.bigbluebutton.core.db
 
 import org.slf4j.LoggerFactory
 import slick.jdbc.PostgresProfile.api._
+
 import scala.concurrent.duration._
 import java.util.concurrent.ConcurrentLinkedQueue
-import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.util.control.Breaks.break
 
 object DatabaseConnection {
   val db = Database.forConfig("postgres")
   val logger = LoggerFactory.getLogger(this.getClass)
 
   val queue = new ConcurrentLinkedQueue[DBIO[_]]()
+  val isProcessing = new AtomicBoolean(false)
+  val batchSizeLimit = 500
 
   // Initialize the scheduler for batch processing
   val system = org.apache.pekko.actor.ActorSystem("DBActionBatchSystem")
   system.scheduler.scheduleWithFixedDelay(50.millis, 50.millis)(new Runnable {
-    def run(): Unit = processBatch()
+    def run(): Unit = tryProcessBatch()
   })
 
   def initialize(): Unit = {
@@ -30,22 +34,41 @@ object DatabaseConnection {
 
   def enqueue(action: DBIO[_]): Unit = {
     queue.add(action)
+    tryProcessBatch()
+  }
+
+  private def tryProcessBatch(): Unit = {
+    if (isProcessing.compareAndSet(false, true)) {
+      processBatch()
+    }
   }
 
   private def processBatch(): Unit = {
-    if (!queue.isEmpty) {
-      val batch = queue.iterator().asScala.toSeq
-      queue.clear() // Clear the queue
-      val combinedAction = DBIO.sequence(batch)
-      db.run(combinedAction).onComplete {
-        case scala.util.Success(_) => {
-          logger.debug(s"${batch.size} actions executed.")
-          if (!queue.isEmpty) {
-            processBatch()
-          }
-        }
-        case scala.util.Failure(e) => logger.error(s"Error executing batch actions: $e")
+    val batch = collection.mutable.ListBuffer[DBIO[_]]()
+    var action = queue.poll()
+    while (action != null) {
+      batch += action
+      if (batch.size >= batchSizeLimit) {
+        break()
       }
+
+      action = queue.poll()
+    }
+
+    if (batch.nonEmpty) {
+      val combinedAction = DBIO.sequence(batch.toList)
+      db.run(combinedAction).onComplete {
+        case scala.util.Success(_) =>
+          logger.debug(s"${batch.size} actions executed.")
+          isProcessing.set(false)
+          if (!queue.isEmpty) tryProcessBatch()
+        case scala.util.Failure(e) =>
+          logger.error(s"Error executing batch actions: $e")
+          isProcessing.set(false)
+          if (!queue.isEmpty) tryProcessBatch()
+      }
+    } else {
+      isProcessing.set(false)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ExternalVideoDAO.scala
@@ -34,7 +34,7 @@ class ExternalVideoDbTableDef(tag: Tag) extends Table[ExternalVideoDbModel](tag,
 
 object ExternalVideoDAO {
   def insert(meetingId: String, externalVideoUrl: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ExternalVideoDbTableDef].forceInsert(
         ExternalVideoDbModel(
           externalVideoId = System.currentTimeMillis() + "-" + RandomStringGenerator.randomAlphanumericString(8),
@@ -48,14 +48,11 @@ object ExternalVideoDAO {
           playerPlaying = true
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in ExternalVideo table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error inserting ExternalVideo: $e")
-      }
+    )
   }
 
   def update(meetingId: String, status: String, rate: Double, time: Double, state: Int) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ExternalVideoDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.stoppedSharingAt.isEmpty)
@@ -73,23 +70,17 @@ object ExternalVideoDAO {
           },
           new java.sql.Timestamp(System.currentTimeMillis())
         ))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on ExternalVideo table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating ExternalVideo: $e")
-      }
+    )
   }
 
   def updateStoppedSharing(meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ExternalVideoDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.stoppedSharingAt.isEmpty)
         .map(ev => (ev.stoppedSharingAt, ev.playerPlaying))
         .update(Some(new java.sql.Timestamp(System.currentTimeMillis())), false)
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated stoppedSharingAt on ExternalVideo table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating stoppedSharingAt on ExternalVideo: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/LayoutDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/LayoutDAO.scala
@@ -41,7 +41,7 @@ object LayoutDAO {
   }
 
   def insertOrUpdate(meetingId: String, layout: Layouts) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[LayoutDbTableDef].insertOrUpdate(
         LayoutDbModel(
           meetingId = meetingId,
@@ -55,9 +55,6 @@ object LayoutDAO {
           updatedAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted/updated on Layout table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting/updating Layout: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingBreakoutDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingBreakoutDAO.scala
@@ -41,7 +41,7 @@ class MeetingBreakoutDbTableDef(tag: Tag) extends Table[MeetingBreakoutDbModel](
 
 object MeetingBreakoutDAO {
   def insert(meetingId: String, breakoutProps: BreakoutProps) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingBreakoutDbTableDef].forceInsert(
         MeetingBreakoutDbModel(
           meetingId = meetingId,
@@ -58,11 +58,6 @@ object MeetingBreakoutDAO {
           captureSlidesFilename = breakoutProps.captureSlidesFilename
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingBreakout table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingBreakout: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingClientSettingsDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingClientSettingsDAO.scala
@@ -20,19 +20,14 @@ class MeetingClientSettingsDbTableDef(tag: Tag) extends Table[MeetingClientSetti
 
 object MeetingClientSettingsDAO {
   def insert(meetingId: String, clientSettingsJson: JsValue) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingClientSettingsDbTableDef].forceInsert(
         MeetingClientSettingsDbModel(
           meetingId = meetingId,
           clientSettingsJson = clientSettingsJson
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingClientSettings table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingClientSettings: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingGroupDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingGroupDAO.scala
@@ -27,7 +27,7 @@ class MeetingGroupDbTableDef(tag: Tag) extends Table[MeetingGroupDbModel](tag, N
 
 object MeetingGroupDAO {
   def insert(meetingId: String, groups: Vector[GroupProps]) = {
-    DatabaseConnection.db.run(DBIO.sequence(
+    DatabaseConnection.enqueue(DBIO.sequence(
       for {
         group <- groups
       } yield {
@@ -41,9 +41,5 @@ object MeetingGroupDAO {
         )
       }
     ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on MeetingGroup table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting MeetingGroup: $e")
-      }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingLockSettingsDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingLockSettingsDAO.scala
@@ -42,7 +42,7 @@ class MeetingLockSettingsDbTableDef(tag: Tag) extends Table[MeetingLockSettingsD
 
 object MeetingLockSettingsDAO {
   def insert(meetingId: String, lockSettingsProps: LockSettingsProps) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingLockSettingsDbTableDef].forceInsert(
         MeetingLockSettingsDbModel(
           meetingId = meetingId,
@@ -58,16 +58,11 @@ object MeetingLockSettingsDAO {
           hideViewersAnnotation = lockSettingsProps.hideViewersAnnotation,
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingLockSettings table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingLockSettings: $e")
-      }
+    )
   }
 
   def update(meetingId: String, permissions: Permissions) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingLockSettingsDbTableDef].insertOrUpdate(
         MeetingLockSettingsDbModel(
           meetingId = meetingId,
@@ -83,12 +78,7 @@ object MeetingLockSettingsDAO {
           hideViewersAnnotation = permissions.hideViewersAnnotation,
         ),
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated in MeetingLockSettings table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error updating MeetingLockSettings: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingMetadataDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingMetadataDAO.scala
@@ -27,7 +27,7 @@ class MeetingMetadataDbTableDef(tag: Tag) extends Table[MeetingMetadataDbModel](
 object MeetingMetadataDAO {
   def insert(meetingId: String, metadataProp: MetadataProp) = {
 
-    DatabaseConnection.db.run(DBIO.sequence(
+    DatabaseConnection.enqueue(DBIO.sequence(
       for {
         metadata <- metadataProp.metadata
       } yield {
@@ -40,9 +40,5 @@ object MeetingMetadataDAO {
         )
       }
     ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on MeetingMetadata table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting MeetingMetadata: $e")
-      }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingRecordingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingRecordingDAO.scala
@@ -32,7 +32,7 @@ object MeetingRecordingDAO {
     //Stop any previous recoding for this meeting before starting a new one
     updateStopped(meetingId, startedBy)
 
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingRecordingDbTableDef].forceInsert(
         MeetingRecordingDbModel(
           meetingId = meetingId,
@@ -42,25 +42,17 @@ object MeetingRecordingDAO {
           stoppedBy = None,
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingRecording table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingRecording: $e")
-      }
+    )
   }
 
   def updateStopped(meetingId: String, stoppedBy: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingRecordingDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.stoppedAt.isEmpty)
         .map(r => (r.stoppedAt, r.stoppedBy))
         .update(Some(new java.sql.Timestamp(System.currentTimeMillis())), Some(stoppedBy))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated stoppedAt on MeetingRecording table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating stoppedAt on MeetingRecording: $e")
-    }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingRecordingPoliciesDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingRecordingPoliciesDAO.scala
@@ -28,7 +28,7 @@ class MeetingRecordingPoliciesDbTableDef(tag: Tag) extends Table[MeetingRecordin
 
 object MeetingRecordingPoliciesDAO {
   def insert(meetingId: String, recordProp: RecordProp) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingRecordingPoliciesDbTableDef].forceInsert(
         MeetingRecordingPoliciesDbModel(
           meetingId = meetingId,
@@ -38,12 +38,7 @@ object MeetingRecordingPoliciesDAO {
           keepEvents = recordProp.keepEvents
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingRecordingPolicies table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingRecordingPolicies: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingUsersPoliciesDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingUsersPoliciesDAO.scala
@@ -44,7 +44,7 @@ class MeetingUsersPoliciesDbTableDef(tag: Tag) extends Table[MeetingUsersPolicie
 
 object MeetingUsersPoliciesDAO {
   def insert(meetingId:String, usersProp: UsersProp) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingUsersPoliciesDbTableDef].forceInsert(
         MeetingUsersPoliciesDbModel(
           meetingId = meetingId,
@@ -61,28 +61,20 @@ object MeetingUsersPoliciesDAO {
           allowPromoteGuestToModerator = usersProp.allowPromoteGuestToModerator,
         )
       )
-    ).onComplete {
-      case Success(rowsAffected) => {
-        DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingUsersPolicies table!")
-      }
-      case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingUsersPolicies: $e")
-    }
+    )
   }
 
   def update(meetingId: String, policy: GuestPolicy) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingUsersPoliciesDbTableDef]
         .filter(_.meetingId === meetingId)
         .map(u => u.guestPolicy)
         .update(policy.policy)
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated guestPolicy on meeting_usersPolicies table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating guestPolicy on meeting_usersPolicies: $e")
-    }
+    )
   }
 
   def updateGuestLobbyMessage(meetingId: String, guestLobbyMessage: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingUsersPoliciesDbTableDef]
         .filter(_.meetingId === meetingId)
         .map(u => u.guestLobbyMessage)
@@ -92,22 +84,16 @@ object MeetingUsersPoliciesDAO {
             case m => Some(m)
           }
         )
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated guestLobbyMessage on meeting_usersPolicies table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating guestLobbyMessage on meeting_usersPolicies: $e")
-    }
+    )
   }
 
   def updateWebcamsOnlyForModerator(meetingId: String, webcamsOnlyForModerator: Boolean) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingUsersPoliciesDbTableDef]
         .filter(_.meetingId === meetingId)
         .map(u => u.webcamsOnlyForModerator)
         .update(webcamsOnlyForModerator)
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated webcamsOnlyForModerator on meeting_usersPolicies table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating webcamsOnlyForModerator on meeting_usersPolicies: $e")
-    }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingVoiceDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingVoiceDAO.scala
@@ -29,7 +29,7 @@ class MeetingVoiceDbTableDef(tag: Tag) extends Table[MeetingVoiceDbModel](tag, "
 
 object MeetingVoiceDAO {
   def insert(meetingId: String, voiceProp: VoiceProp) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingVoiceDbTableDef].forceInsert(
         MeetingVoiceDbModel(
           meetingId = meetingId,
@@ -39,11 +39,6 @@ object MeetingVoiceDAO {
           muteOnStart = voiceProp.muteOnStart
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingVoice table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingVoice: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingWelcomeDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingWelcomeDAO.scala
@@ -25,7 +25,7 @@ class MeetingWelcomeDbTableDef(tag: Tag) extends Table[MeetingWelcomeDbModel](ta
 
 object MeetingWelcomeDAO {
   def insert(meetingId: String, welcomeProp: WelcomeProp) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[MeetingWelcomeDbTableDef].forceInsert(
         MeetingWelcomeDbModel(
           meetingId = meetingId,
@@ -39,11 +39,6 @@ object MeetingWelcomeDAO {
           }
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in MeetingWelcome table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting MeetingWelcome: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/NotificationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/NotificationDAO.scala
@@ -49,7 +49,7 @@ object NotificationDAO {
     }
 
     if (notificationType != "") {
-      DatabaseConnection.db.run(
+      DatabaseConnection.enqueue(
         TableQuery[NotificationDbTableDef].forceInsert(
           NotificationDbModel(
             meetingId,
@@ -67,10 +67,7 @@ object NotificationDAO {
             createdAt = new java.sql.Timestamp(System.currentTimeMillis())
           )
         )
-      ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted/updated on Notification table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting/updating Notification: $e")
-      }
+      )
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PollDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PollDAO.scala
@@ -39,7 +39,7 @@ object PollDAO {
     for {
       question <- poll.questions
     } yield {
-      DatabaseConnection.db.run(
+      DatabaseConnection.enqueue(
         TableQuery[PollDbTableDef].insertOrUpdate(
           PollDbModel(
             pollId = poll.id,
@@ -54,62 +54,42 @@ object PollDAO {
             publishedAt = None
           )
         )
-      ).onComplete {
-          case Success(rowsAffected) => {
-            DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on Poll table!")
-
-            DatabaseConnection.db.run(DBIO.sequence(
-              for {
-                answer <- question.answers.toList
-              } yield {
-                PollOptionDAO.prepareOptionInsert(poll.id, answer)
-              }
-            ).transactionally)
-              .onComplete {
-                case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on PollOption table!")
-                case Failure(e)            => DatabaseConnection.logger.error(s"Error inserting PollOption: $e")
-              }
-          }
-          case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting Poll: $e")
+      )
+      DatabaseConnection.enqueue(DBIO.sequence(
+        for {
+          answer <- question.answers.toList
+        } yield {
+          PollOptionDAO.prepareOptionInsert(poll.id, answer)
         }
+      ).transactionally)
     }
   }
 
   def updateOptions(poll: SimplePollResultOutVO) = {
-    DatabaseConnection.db.run(DBIO.sequence(
+    DatabaseConnection.enqueue(DBIO.sequence(
       for {
         answer <- poll.answers.toList
       } yield {
         PollOptionDAO.prepareOptionInsertOrUpdate(poll.id, answer)
       }
     ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on PollOption table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error inserting PollOption: $e")
-      }
   }
 
   def updatePublished(pollId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PollDbTableDef]
         .filter(_.pollId === pollId)
         .map(p => (p.published, p.publishedAt))
         .update(true, Some(new java.sql.Timestamp(System.currentTimeMillis())))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated published=true on Poll table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error updating published=true Poll: $e")
-      }
+    )
   }
 
   def updateEnded(pollId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PollDbTableDef]
         .filter(_.pollId === pollId)
         .map(p => p.ended)
         .update(true)
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated awaitingResponses=false on Poll table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error updating awaitingResponses=false Poll: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PollResponseDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PollResponseDAO.scala
@@ -26,54 +26,45 @@ object PollResponseDAO {
   def insert(poll: Poll, meetingId: String, userId: String, seqOptionIds: Seq[Int]) = {
 
     //Clear previous responses of the user and add all
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PollResponseDbTableDef]
         .filter(_.pollId === poll.id)
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .delete
-    ).onComplete {
-        case Success(rowsAffected) => {
-          for {
-            optionId <- seqOptionIds
-          } yield {
-            DatabaseConnection.db.run(
-              TableQuery[PollResponseDbTableDef].forceInsert(
-                PollResponseDbModel(
-                  pollId = poll.id,
-                  optionId = Some(optionId),
-                  meetingId = {
-                    if (poll.isSecret) None else Some(meetingId)
-                  },
-                  userId = {
-                    if (poll.isSecret) None else Some(userId)
-                  }
-                )
-              )
-            ).onComplete {
-                case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on PollResponse table!")
-                case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting PollResponse: $e")
-              }
-          }
+    )
 
-          //When Secret, insert the user in a different row just to inform the he answered already
-          if (poll.isSecret) {
-            DatabaseConnection.db.run(
-              TableQuery[PollResponseDbTableDef].forceInsert(
-                PollResponseDbModel(
-                  pollId = poll.id,
-                  optionId = None,
-                  meetingId = Some(meetingId),
-                  userId = Some(userId)
-                )
-              )
-            ).onComplete {
-                case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on PollResponse(secret) table!")
-                case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting PollResponse(secret): $e")
-              }
-          }
-        }
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error deleting poll  ${poll.id} for user ${userId}: $e")
-      }
+    for {
+      optionId <- seqOptionIds
+    } yield {
+      DatabaseConnection.enqueue(
+        TableQuery[PollResponseDbTableDef].forceInsert(
+          PollResponseDbModel(
+            pollId = poll.id,
+            optionId = Some(optionId),
+            meetingId = {
+              if (poll.isSecret) None else Some(meetingId)
+            },
+            userId = {
+              if (poll.isSecret) None else Some(userId)
+            }
+          )
+        )
+      )
+    }
+
+    //When Secret, insert the user in a different row just to inform the he answered already
+    if (poll.isSecret) {
+      DatabaseConnection.enqueue(
+        TableQuery[PollResponseDbTableDef].forceInsert(
+          PollResponseDbModel(
+            pollId = poll.id,
+            optionId = None,
+            meetingId = Some(meetingId),
+            userId = Some(userId)
+          )
+        )
+      )
+    }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresAnnotationHistoryDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresAnnotationHistoryDAO.scala
@@ -29,6 +29,7 @@ object PresAnnotationHistoryDAO {
 
   def insert(meetingId: String, annotationDiff: AnnotationVO) = {
     DatabaseConnection.db.run(
+      //TODO not being used for now
       TableQuery[PresAnnotationHistoryDbTableDef].returning(
         TableQuery[PresAnnotationHistoryDbTableDef].map(_.sequence)
       ) += PresAnnotationHistoryDbModel(
@@ -44,6 +45,7 @@ object PresAnnotationHistoryDAO {
 
   def delete(wbId: String, meetingId: String, userId: String, annotationId: String) = {
     DatabaseConnection.db.run(
+      //TODO not being used for now
       TableQuery[PresAnnotationHistoryDbTableDef].returning(
         TableQuery[PresAnnotationHistoryDbTableDef].map(_.sequence)
       ) += PresAnnotationHistoryDbModel(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageCursorDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageCursorDAO.scala
@@ -30,7 +30,7 @@ class PresPageCursorDbTableDef(tag: Tag) extends Table[PresPageCursorDbModel](ta
 object PresPageCursorDAO {
 
   def insertOrUpdate(pageId: String, meetingId: String, userId: String, xPercent: Double, yPercent: Double) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPageCursorDbTableDef].insertOrUpdate(
         PresPageCursorDbModel(
           pageId = pageId,
@@ -38,13 +38,10 @@ object PresPageCursorDAO {
           userId = userId,
           xPercent = xPercent,
           yPercent = yPercent,
-          lastUpdatedAt = new java.sql.Timestamp(System.currentTimeMillis(),
+          lastUpdatedAt = new java.sql.Timestamp(System.currentTimeMillis()),
         )
       )
-    )).onComplete {
-      case Success(rowsAffected) => // DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on pres_page_cursor table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error inserting pres_page_cursor: $e")
-    }
+    )
   }
 
   def clearUnusedCursors(meetingId: String, pageId: String, enabledUsers: Array[String]): Unit = {
@@ -56,10 +53,7 @@ object PresPageCursorDAO {
       deleteQuery.filterNot(_.userId inSet enabledUsers)
     }
 
-    DatabaseConnection.db.run(deleteQuery.delete).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"Users deleted from pres_page_cursor ${pageId}")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error deleting users from pres_page_cursor: $e")
-    }
+    DatabaseConnection.enqueue(deleteQuery.delete)
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageDAO.scala
@@ -59,7 +59,7 @@ object PresPageDAO {
     }
   }
   def insert(presentationId: String, page: PresentationPage) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPageDbTableDef].insertOrUpdate(
         PresPageDbModel(
           pageId = page.id,
@@ -82,46 +82,34 @@ object PresPageDAO {
           uploadCompleted = page.converted
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on PresentationPage table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting PresentationPage: $e")
-      }
+    )
   }
 
   def setCurrentPage(presentation: PresentationInPod, pageId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       sqlu"""UPDATE pres_page SET
                 "current" = (case when "pageId" = ${pageId} then true else false end),
                 "slideRevealed" = (case when "pageId" = ${pageId} then true else "slideRevealed" end)
                 WHERE "presentationId" = ${presentation.id}"""
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated current on PresPage table")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating current on PresPage: $e")
-      }
+    )
   }
 
   def resizeAndMovePage(presentation: PresentationPage) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPageDbTableDef]
         .filter(_.pageId === presentation.id)
         .map(p => (p.xOffset, p.yOffset, p.widthRatio, p.heightRatio))
         .update((presentation.xOffset, presentation.yOffset, presentation.widthRatio, presentation.heightRatio))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated size on PresPage table")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating size on PresPage: $e")
-      }
+    )
   }
 
   def updateSlidePosition(pageId: String, width: Double, height: Double, xOffset: Double, yOffset: Double,
                           widthRatio: Double, heightRatio: Double) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPageDbTableDef]
         .filter(_.pageId === pageId)
         .map(p => (p.width, p.height, p.xOffset, p.yOffset, p.viewBoxWidth, p.viewBoxHeight))
         .update((width, height, xOffset, yOffset, widthRatio, heightRatio))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated slide position on PresPage table")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating slide position on PresPage: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageWritersDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageWritersDAO.scala
@@ -34,17 +34,14 @@ object PresPageWritersDAO {
       deleteQuery.filterNot(_.userId inSet whiteboard.multiUser)
     }
 
-    DatabaseConnection.db.run(deleteQuery.delete).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"Users deleted from pres_page_writers ${whiteboard.id}")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error deleting users from pres_page_writers: $e")
-    }
+    DatabaseConnection.enqueue(deleteQuery.delete)
 
     PresPageCursorDAO.clearUnusedCursors(meetingId, whiteboard.id, whiteboard.multiUser)
 
     for {
       userId <- whiteboard.multiUser
     } yield {
-      DatabaseConnection.db.run(
+      DatabaseConnection.enqueue(
         TableQuery[PresPageWritersDbTableDef].insertOrUpdate(
           PresPageWritersDbModel(
             pageId = whiteboard.id,
@@ -53,12 +50,7 @@ object PresPageWritersDAO {
             changedModeOn = whiteboard.changedModeOn
           )
         )
-      ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on pres_page_writers table!")
-        }
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting pres_page_writers: $e")
-      }
+      )
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
@@ -4,12 +4,8 @@ import PostgresProfile.api._
 import org.bigbluebutton.core.models.PresentationInPod
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
 import spray.json._
-
 import scala.concurrent.Future
-
-
 
 case class PresPresentationDbModel(
     presentationId:         String,
@@ -75,7 +71,7 @@ object PresPresentationDAO {
   }
 
   def insertToken(meetingId: String, userId: String, temporaryId: String, presentationId: String, uploadToken: String, filename: String) = {
-    val dbRun = DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef].forceInsert(
         PresPresentationDbModel(
           presentationId = presentationId,
@@ -102,74 +98,48 @@ object PresPresentationDAO {
         )
       )
     )
-
-    dbRun.onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on Presentation table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error inserting Presentation: $e")
-    }
-
-    dbRun
   }
 
   def updateConversionStarted(meetingId: String, presentation: PresentationInPod) = {
-    val checkAndInsert = DatabaseConnection.db.run(
-      TableQuery[PresPresentationDbTableDef]
-        .filter(_.presentationId === presentation.id).exists.result).flatMap { exists =>
-      if (!exists) {
-        insertToken(meetingId, "", "", presentation.id, "", presentation.name)
-      } else {
-        Future.successful(0)
-      }
-    }
+    val presentationQuery = TableQuery[PresPresentationDbTableDef].filter(_.presentationId === presentation.id)
+      DatabaseConnection.db.run(presentationQuery.exists.result).map { exists =>
+        if (!exists) {
+          insertToken(meetingId, "", "", presentation.id, "", presentation.name)
+        }
 
-    checkAndInsert.flatMap { _ =>
-      DatabaseConnection.db.run(
-        TableQuery[PresPresentationDbTableDef]
-          .filter(_.presentationId === presentation.id)
-          .map(p => (
-            p.name,
-            p.filenameConverted,
-            p.isDefault,
-            p.downloadable,
-            p.downloadFileExtension,
-            p.removable,
-            p.uploadInProgress,
-            p.uploadCompleted,
-            p.totalPages,
-            p.uploadErrorMsgKey,
-            p.uploadErrorDetailsJson))
-          .update(
-            (presentation.name,
-              presentation.filenameConverted,
-              presentation.default,
-              presentation.downloadable,
-              presentation.downloadFileExtension match {
-                case "" => None
-                case downloadFileExtension => Some(downloadFileExtension)
-              },
-              presentation.removable,
-              !presentation.uploadCompleted,
-              presentation.uploadCompleted,
-              presentation.numPages,
-              presentation.errorMsgKey match {
-                case "" => None
-                case error => Some(error)
-              },
-              presentation.errorDetails match {
-                case m if m.isEmpty => None
-                case m => Some(m.toJson)
-              },
-            ))
-      )
-    }.onComplete {
-      case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated basicData on PresPresentation table")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating basicData on PresPresentation: $e")
+        DatabaseConnection.enqueue(
+          presentationQuery.map(p => (
+          p.name,
+          p.filenameConverted,
+          p.isDefault,
+          p.downloadable,
+          p.downloadFileExtension,
+          p.removable,
+          p.uploadInProgress,
+          p.uploadCompleted,
+          p.totalPages,
+          p.uploadErrorMsgKey,
+          p.uploadErrorDetailsJson
+        ))
+        .update(
+          presentation.name,
+          presentation.filenameConverted,
+          presentation.default,
+          presentation.downloadable,
+          if (presentation.downloadFileExtension.isEmpty) None else Some(presentation.downloadFileExtension),
+          presentation.removable,
+          !presentation.uploadCompleted,
+          presentation.uploadCompleted,
+          presentation.numPages,
+          if (presentation.errorMsgKey.isEmpty) None else Some(presentation.errorMsgKey),
+          if (presentation.errorDetails.isEmpty) None else Some(presentation.errorDetails.toJson)
+        ))
     }
   }
 
 
   def updatePages(presentation: PresentationInPod) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentation.id)
         .map(p => (p.downloadFileExtension, p.uploadInProgress, p.uploadCompleted, p.totalPages))
@@ -182,134 +152,103 @@ object PresPresentationDAO {
           presentation.uploadCompleted,
           presentation.numPages,
         ))
-    ).onComplete {
-      case Success(rowsAffected) => {
-        DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on PresPresentation table!")
+    )
 
-        DatabaseConnection.db.run(DBIO.sequence(
-            for {
-              page <- presentation.pages
-            } yield {
-              TableQuery[PresPageDbTableDef].insertOrUpdate(
-                PresPageDbModel(
-                  pageId = page._2.id,
-                  presentationId = presentation.id,
-                  num = page._2.num,
-                  urlsJson = page._2.urls.toJson,
-                  content = page._2.content,
-                  slideRevealed = page._2.current,
-                  current = page._2.current,
-                  xOffset = page._2.xOffset,
-                  yOffset = page._2.yOffset,
-                  widthRatio = page._2.widthRatio,
-                  heightRatio = page._2.heightRatio,
-                  width = page._2.width,
-                  height = page._2.height,
-                  viewBoxWidth = 1,
-                  viewBoxHeight = 1,
-                  maxImageWidth = 1440,
-                  maxImageHeight = 1080,
-                  uploadCompleted = page._2.converted
-                )
-              )
-            }
-          ).transactionally)
-          .onComplete {
-            case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on PresentationPage table!")
-            case Failure(e) => DatabaseConnection.logger.debug(s"Error updating PresentationPage: $e")
-          }
-
-        //Set current
-        if (presentation.current) {
-          setCurrentPres(presentation.id)
+    DatabaseConnection.enqueue(DBIO.sequence(
+        for {
+          page <- presentation.pages
+        } yield {
+          TableQuery[PresPageDbTableDef].insertOrUpdate(
+            PresPageDbModel(
+              pageId = page._2.id,
+              presentationId = presentation.id,
+              num = page._2.num,
+              urlsJson = page._2.urls.toJson,
+              content = page._2.content,
+              slideRevealed = page._2.current,
+              current = page._2.current,
+              xOffset = page._2.xOffset,
+              yOffset = page._2.yOffset,
+              widthRatio = page._2.widthRatio,
+              heightRatio = page._2.heightRatio,
+              width = page._2.width,
+              height = page._2.height,
+              viewBoxWidth = 1,
+              viewBoxHeight = 1,
+              maxImageWidth = 1440,
+              maxImageHeight = 1080,
+              uploadCompleted = page._2.converted
+            )
+          )
         }
+      ).transactionally)
 
-      }
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating user: $e")
+    //Set current
+    if (presentation.current) {
+      setCurrentPres(presentation.id)
     }
   }
 
   def setCurrentPres(presentationId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       sqlu"""UPDATE pres_presentation SET
                 "current" = (case when "presentationId" = ${presentationId} then true else false end)
                 WHERE "meetingId" = (select "meetingId" from pres_presentation where "presentationId" = ${presentationId})
                 AND exists (select 1 from pres_page where "presentationId" = ${presentationId} AND "current" IS true)"""
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated current on PresPresentation table")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error updating current on PresPresentation: $e")
-      }
+    )
   }
 
   def updateDownloadable(presentationId: String, downloadable : Boolean, downloadableExtension: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
         .map(p => (p.downloadable, p.downloadFileExtension))
         .update((downloadable, Some(downloadableExtension)))
-    ).onComplete {
-      case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated downloadable on PresPresentation table")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating downloadable on PresPresentation: $e")
-    }
+    )
   }
 
   def updateDownloadUri(presentationId: String, downloadFileUri: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
         .map(p => p.downloadFileUri)
         .update(Some(downloadFileUri))
-    ).onComplete {
-        case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated originalFileURI on PresPresentation table")
-        case Failure(e)           => DatabaseConnection.logger.error(s"Error updating originalFileURI on PresPresentation: $e")
-      }
+    )
   }
 
   def updateErrors(presentationId: String, errorMsgKey: String, errorDetails: scala.collection.immutable.Map[String, String]) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
         .map(p => (p.uploadErrorMsgKey, p.uploadErrorDetailsJson))
         .update(Some(errorMsgKey), Some(errorDetails.toJson))
-    ).onComplete {
-        case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated errorMsgKey on PresPresentation table")
-        case Failure(e)           => DatabaseConnection.logger.error(s"Error updating errorMsgKey on PresPresentation: $e")
-      }
+    )
   }
 
   def updateExportToChat(presentationId: String, exportToChatStatus: String, exportToChatCurrentPage: Int, exportToChatHasError: Boolean) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
         .map(p => (p.exportToChatStatus, p.exportToChatCurrentPage, p.exportToChatHasError))
         .update(Some(exportToChatStatus), Some(exportToChatCurrentPage), Some(exportToChatHasError))
-    ).onComplete {
-      case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated exportToChat on PresPresentation table")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating exportToChat on PresPresentation: $e")
-    }
+    )
   }
 
   def updateExportToChatStatus(presentationId: String, exportToChatStatus: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
         .map(p => p.exportToChatStatus)
         .update(Some(exportToChatStatus))
-    ).onComplete {
-      case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) updated exportToChatStatus on PresPresentation table")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating exportToChatStatus on PresPresentation: $e")
-    }
+    )
   }
 
   def delete(presentationId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[PresPresentationDbTableDef]
         .filter(_.presentationId === presentationId)
         .delete
-    ).onComplete {
-        case Success(rowAffected) => DatabaseConnection.logger.debug(s"$rowAffected row(s) deleted presentation on PresPresentation table")
-        case Failure(e)           => DatabaseConnection.logger.error(s"Error deleting presentation on PresPresentation: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
@@ -40,7 +40,7 @@ class ScreenshareDbTableDef(tag: Tag) extends Table[ScreenshareDbModel](tag, "sc
 
 object ScreenshareDAO {
   def insert(meetingId: String, screenshareModel: ScreenshareModel) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ScreenshareDbTableDef].forceInsert(
         ScreenshareDbModel(
           screenshareId = System.currentTimeMillis() + "-" + RandomStringGenerator.randomAlphanumericString(8),
@@ -56,24 +56,18 @@ object ScreenshareDAO {
           stoppedAt = None
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in Screenshare table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error inserting Screenshare: $e")
-      }
+    )
   }
 
   def updateStopped(meetingId: String, stream: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[ScreenshareDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.stream === stream)
         .filter(_.stoppedAt.isEmpty)
         .map(ev => ev.stoppedAt)
         .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated stoppedAt on Screenshare table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating stoppedAt on Screenshare: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesDAO.scala
@@ -28,7 +28,7 @@ class SharedNotesDbTableDef(tag: Tag) extends Table[SharedNotesDbModel](tag, Non
 
 object SharedNotesDAO {
   def insert(meetingId: String, group: PadGroup, padId: String, name: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[SharedNotesDbTableDef].insertOrUpdate(
         SharedNotesDbModel(
           meetingId = meetingId,
@@ -39,22 +39,16 @@ object SharedNotesDAO {
           pinned = false
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on SharedNotes table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting SharedNotes: $e")
-      }
+    )
   }
 
   def updatePinned(meetingId: String, sharedNotesExtId: String, pinned: Boolean) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[SharedNotesDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.sharedNotesExtId === sharedNotesExtId)
         .map(n => n.pinned)
         .update(pinned)
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated pinned on SharedNotes table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error updating pinned SharedNotes: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
@@ -32,7 +32,7 @@ class SharedNotesRevDbTableDef(tag: Tag) extends Table[SharedNotesRevDbModel](ta
 
 object SharedNotesRevDAO {
   def insert(meetingId: String, sharedNotesExtId: String, revId: Int, userId: String, changeset: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[SharedNotesRevDbTableDef].insertOrUpdate(
         SharedNotesRevDbModel(
           meetingId = meetingId,
@@ -46,23 +46,17 @@ object SharedNotesRevDAO {
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on SharedNotesRev table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting SharedNotesRev: $e")
-      }
+    )
   }
 
   def update(meetingId: String, sharedNotesExtId: String, revId: Int, start: Int, end: Int, text: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[SharedNotesRevDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.sharedNotesExtId === sharedNotesExtId)
         .filter(_.rev === revId)
         .map(n => (n.start, n.end, n.diff))
         .update((Some(start), Some(end), Some(text)))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated Rev on SharedNotes table!")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error updating Rev SharedNotes: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesSessionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesSessionDAO.scala
@@ -20,7 +20,7 @@ class SharedNotesSessionDbTableDef(tag: Tag) extends Table[SharedNotesSessionDbM
 
 object SharedNotesSessionDAO {
   def insert(meetingId: String, sharedNotesExtId: String, userId: String, sessionId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[SharedNotesSessionDbTableDef].insertOrUpdate(
         SharedNotesSessionDbModel(
           meetingId = meetingId,
@@ -29,22 +29,16 @@ object SharedNotesSessionDAO {
           sessionId = sessionId
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on SharedNotesSession table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting SharedNotesSession: $e")
-      }
+    )
   }
 
   def delete(meetingId: String, userId: String, sessionId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[SharedNotesSessionDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .filter(_.sessionId === sessionId)
         .delete
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"SharedNotesSession ${sessionId} deleted")
-        case Failure(e)            => DatabaseConnection.logger.error(s"Error deleting SharedNotesSession ${sessionId}: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/TimerDAO.scala
@@ -32,7 +32,7 @@ class TimerDbTableDef(tag: Tag) extends Table[TimerDbModel](tag, None, "timer") 
 
 object TimerDAO {
   def insert(meetingId: String, model: TimerModel) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[TimerDbTableDef].insertOrUpdate(
         TimerDbModel(
           meetingId = meetingId,
@@ -45,14 +45,11 @@ object TimerDAO {
           songTrack = getTrack(model),
         )
       )
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on Timer table!")
-      case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting Timer: $e")
-    }
+    )
   }
 
   def update(meetingId: String, timerModel: TimerModel) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[TimerDbTableDef]
         .filter(_.meetingId === meetingId)
         .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedOn, t.songTrack))
@@ -60,9 +57,6 @@ object TimerDAO {
           (isStopwatch(timerModel), isRunning(timerModel), getIsActive(timerModel), getTime(timerModel),
           getAccumulated(timerModel), getStartedAt(timerModel), getTrack(timerModel))
         )
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on Timer table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating Timer: $e")
-    }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserBreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserBreakoutRoomDAO.scala
@@ -31,7 +31,7 @@ class UserBreakoutRoomDbTableDef(tag: Tag) extends Table[UserBreakoutRoomDbModel
 object UserBreakoutRoomDAO {
 
   def updateLastBreakoutRoom(meetingId: String, userId: String, breakoutRoom: BreakoutRoom2x) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserBreakoutRoomDbTableDef].insertOrUpdate(
         UserBreakoutRoomDbModel(
           meetingId = meetingId,
@@ -43,29 +43,21 @@ object UserBreakoutRoomDAO {
           currentlyInRoom = true
         )
       )
-    ).onComplete {
-      case Success(rowsAffected) => {
-        DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_breakoutRoom table!")
-      }
-      case Failure(e) => DatabaseConnection.logger.error(s"Error inserting user_breakoutRoom: $e")
-    }
+    )
   }
 
   def updateLastBreakoutRoom(meetingId:String, usersInRoom: Vector[String], breakoutRoom: BreakoutRoom2x) = {
 
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserBreakoutRoomDbTableDef]
         .filter(_.meetingId === meetingId)
         .filterNot(_.userId inSet usersInRoom)
         .filter(_.breakoutRoomId === breakoutRoom.id)
         .map(u_bk => u_bk.currentlyInRoom)
         .update(false)
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated currentlyInRoom=false on user_breakoutRoom table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating currentlyInRoom=false on user_breakoutRoom: $e")
-    }
+    )
 
-    DatabaseConnection.db.run(DBIO.sequence(
+    DatabaseConnection.enqueue(DBIO.sequence(
       for {
         userId <- usersInRoom
       } yield {
@@ -82,9 +74,5 @@ object UserBreakoutRoomDAO {
         )
       }
     ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_breakoutRoom table!")
-        case Failure(e) => DatabaseConnection.logger.error(s"Error inserting user_breakoutRoom: $e")
-      }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCameraDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCameraDAO.scala
@@ -23,7 +23,7 @@ class UserCameraDbTableDef(tag: Tag) extends Table[UserCameraDbModel](tag, None,
 object UserCameraDAO {
 
   def insert(meetingId: String, webcam: WebcamStream) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserCameraDbTableDef].forceInsert(
         UserCameraDbModel(
           streamId = webcam.streamId,
@@ -31,23 +31,15 @@ object UserCameraDAO {
           userId = webcam.userId,
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_webcam table!")
-        }
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting webcam: $e")
-      }
+    )
   }
 
   def delete(streamId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserCameraDbTableDef]
         .filter(_.streamId === streamId)
         .delete
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"Webcam ${streamId} deleted")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error deleting webcam: $e")
-      }
+    )
   }
 
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserClientSettingsDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserClientSettingsDAO.scala
@@ -3,8 +3,6 @@ package org.bigbluebutton.core.db
 import PostgresProfile.api._
 import slick.lifted.ProvenShape
 import spray.json.JsValue
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{ Failure, Success }
 
 case class UserClientSettingsDbModel(
     userId:                 String,
@@ -22,7 +20,7 @@ class UserClientSettingsDbTableDef(tag: Tag) extends Table[UserClientSettingsDbM
 
 object UserClientSettingsDAO {
   def insert(userId: String, meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserClientSettingsDbTableDef].insertOrUpdate(
         UserClientSettingsDbModel(
           userId = userId,
@@ -30,9 +28,6 @@ object UserClientSettingsDAO {
           userClientSettingsJson = JsonUtils.stringToJson("{}")
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on UserClientSettings table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting UserClientSettings: $e")
-      }
+    )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserConnectionStatusDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserConnectionStatusDAO.scala
@@ -28,7 +28,7 @@ class UserConnectionStatusDbTableDef(tag: Tag) extends Table[UserConnectionStatu
 object UserConnectionStatusDAO {
 
   def insert(meetingId: String, userId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserConnectionStatusDbTableDef].insertOrUpdate(
         UserConnectionStatusDbModel(
           userId = userId,
@@ -39,14 +39,11 @@ object UserConnectionStatusDAO {
           statusUpdatedAt = None
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on UserConnectionStatus table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting UserConnectionStatus: $e")
-      }
+    )
   }
 
   def updateUserAlive(meetingId: String, userId: String, rtt: Option[Double], status: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserConnectionStatusDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
@@ -59,10 +56,7 @@ object UserConnectionStatusDAO {
             Some(new java.sql.Timestamp(System.currentTimeMillis())),
           )
         )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated connectionAliveAt on UserConnectionStatus table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating connectionAliveAt on UserConnectionStatus: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCustomParameter.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCustomParameter.scala
@@ -24,7 +24,7 @@ class UserCustomParameterDbTableDef(tag: Tag) extends Table[UserCustomParameterD
 
 object UserCustomParameterDAO {
   def insert(meetingId: String, userId: String, customParameters: Map[String, String]) = {
-    DatabaseConnection.db.run(DBIO.sequence(
+    DatabaseConnection.enqueue(DBIO.sequence(
       for {
         parameter <- customParameters
       } yield {
@@ -38,9 +38,5 @@ object UserCustomParameterDAO {
         )
       }
     ).transactionally)
-      .onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on UserCustomParameter table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting UserCustomParameter: $e")
-      }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -58,7 +58,7 @@ class UserDbTableDef(tag: Tag) extends Table[UserDbModel](tag, None, "user") {
 
 object UserDAO {
   def insert(meetingId: String, regUser: RegisteredUser) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef].forceInsert(
         UserDbModel(
           userId = regUser.id,
@@ -86,89 +86,69 @@ object UserDAO {
           }
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in User table!")
-          UserConnectionStatusDAO.insert(meetingId, regUser.id)
-          UserCustomParameterDAO.insert(meetingId, regUser.id, regUser.customParameters)
-          UserClientSettingsDAO.insert(regUser.id, meetingId)
-          ChatUserDAO.insertUserPublicChat(meetingId, regUser.id)
-        }
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting user: $e")
-      }
+    )
+
+    UserConnectionStatusDAO.insert(meetingId, regUser.id)
+    UserCustomParameterDAO.insert(meetingId, regUser.id, regUser.customParameters)
+    UserClientSettingsDAO.insert(regUser.id, meetingId)
+    ChatUserDAO.insertUserPublicChat(meetingId, regUser.id)
   }
 
   def update(regUser: RegisteredUser) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === regUser.meetingId)
         .filter(_.userId === regUser.id)
         .map(u => (u.guest, u.guestStatus, u.role, u.authed, u.joined, u.banned, u.loggedOut))
         .update((regUser.guest, regUser.guestStatus, regUser.role, regUser.authed, regUser.joined, regUser.banned, regUser.loggedOut))
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on user table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating user: $e")
-      }
+    )
   }
 
   def updateVoiceUserJoined(voiceUserState: VoiceUserState) = {
-
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === voiceUserState.meetingId)
         .filter(_.userId === voiceUserState.intId)
         .map(u => (u.guest, u.guestStatus, u.authed, u.joined))
         .update((false, "ALLOW", true, true))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on user table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating user table: $e")
-    }
+    )
   }
 
   def updateJoinError(meetingId: String, userId: String, joinErrorCode: String, joinErrorMessage: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .map(u => (u.joined, u.joinErrorCode, u.joinErrorMessage))
         .update((false, Some(joinErrorCode), Some(joinErrorMessage)))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on user (Joined) table!")
-      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating user (Joined): $e")
-    }
+    )
   }
 
   def softDelete(meetingId: String, userId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .filter(_.loggedOut =!= true)
         .map(u => (u.loggedOut))
         .update((true))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated loggedOut=true on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating loggedOut=true user: $e")
-    }
+    )
   }
 
   def softDeleteAllFromMeeting(meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === meetingId)
         .map(u => (u.loggedOut))
         .update((true))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated loggedOut=true on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating loggedOut=true user: $e")
-    }
+    )
   }
 
   def transferUserToBreakoutRoomAsAudioOnly(userId: String, meetingIdFrom: String, meetingIdTo: String) = {
 
     //Create a copy of the user using the same userId, but with the meetingId of the breakoutRoom
     //The user will be flagged by `transferredFromParentMeeting=true`
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       sqlu"""
         WITH upsert AS (
             UPDATE "user"
@@ -201,34 +181,25 @@ object UserDAO {
               and "meetingId" = ${meetingIdFrom}
               and NOT EXISTS (SELECT * FROM upsert)
           """
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted in user (transferredFromParentMeeting) table")
-      case Failure(e)            => DatabaseConnection.logger.error(s"Error inserting user (transferredFromParentMeeting): $e")
-    }
+    )
 
     //Set user as loggedOut in the old meeting (if it is from transferred origin)
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       sqlu"""update "user"
              set "loggedOut" = true
               where "userId" = ${userId}
               and "meetingId" = ${meetingIdFrom}
               and "transferredFromParentMeeting" is true
               """
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated in user (transferredFromParentMeeting) table")
-      case Failure(e)            => DatabaseConnection.logger.error(s"Error updating user (transferredFromParentMeeting): $e")
-    }
+    )
   }
 
   def permanentlyDeleteAllFromMeeting(meetingId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserDbTableDef]
         .filter(_.meetingId === meetingId)
         .delete
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"User from meeting ${meetingId} deleted")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error deleting user from meeting ${meetingId}: $e")
-    }
+    )
   }
 
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserGraphqlConnectionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserGraphqlConnectionDAO.scala
@@ -41,7 +41,7 @@ object UserGraphqlConnectionDAO {
              clientIsMobile: Boolean,
              middlewareUID:String,
              middlewareConnectionId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserGraphqlConnectionDbTableDef].insertOrUpdate(
         UserGraphqlConnectionDbModel(
           graphqlConnectionId = None,
@@ -55,16 +55,11 @@ object UserGraphqlConnectionDAO {
           closedAt = None
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) =>
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_graphqlConnection table!")
-        case Failure(e) =>
-          DatabaseConnection.logger.debug(s"Error inserting user_graphqlConnection: $e")
-      }
+    )
   }
 
   def updateClosed(sessionToken: String, middlewareUID: String, middlewareConnectionId: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserGraphqlConnectionDbTableDef]
         .filter(_.sessionToken === sessionToken)
         .filter(_.middlewareConnectionId === middlewareConnectionId)
@@ -72,10 +67,7 @@ object UserGraphqlConnectionDAO {
         .filter(_.closedAt.isEmpty)
         .map(u => u.closedAt)
         .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on user_graphqlConnection table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating user_graphqlConnection: $e")
-    }
+    )
   }
 
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserReactionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserReactionDAO.scala
@@ -26,7 +26,7 @@ class UserReactionDbTableDef(tag: Tag) extends Table[UserReactionDbModel](tag, "
 
 object UserReactionDAO {
   def insert(meetingId: String, userId: String, reactionEmoji: String, durationInSeconds: Int) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserReactionDbTableDef].forceInsert(
         UserReactionDbModel(
           meetingId = meetingId,
@@ -36,10 +36,7 @@ object UserReactionDAO {
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on UserReaction table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting UserReaction: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserStateDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserStateDAO.scala
@@ -69,7 +69,7 @@ class UserStateDbTableDef(tag: Tag) extends Table[UserStateDbModel](tag, None, "
 
 object UserStateDAO {
   def update(userState: UserState) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserStateDbTableDef]
         .filter(_.meetingId === userState.meetingId)
         .filter(_.userId === userState.intId)
@@ -87,40 +87,31 @@ object UserStateDAO {
           userState.clientType,
           userState.userLeftFlag.left
         ))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating user: $e")
-    }
+    )
   }
 
   def updateEjected(meetingId: String, userId: String, ejectReason: String, ejectReasonCode: String, ejectedByModerator: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserStateDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .map(u => (u.ejected, u.ejectReason, u.ejectReasonCode, u.ejectedByModerator))
         .update((true, Some(ejectReason), Some(ejectReasonCode), Some(ejectedByModerator)))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated ejected=true on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating ejected=true user: $e")
-    }
+    )
   }
 
   def updateExpired(meetingId: String, userId: String, expired: Boolean) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserStateDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .map(u => (u.expired))
         .update((expired))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated expired=true on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating expired=true user: $e")
-    }
+    )
   }
 
   def updateGuestStatus(meetingId: String, userId: String, guestStatus: String, guestStatusSetByModerator: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserStateDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
@@ -132,27 +123,21 @@ object UserStateDAO {
             case _ => None
           }
         ))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated guestStatus on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating guestStatus user: $e")
-    }
+    )
   }
 
   def updateGuestLobbyMessage(meetingId: String, userId: String, guestLobbyMessage: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserStateDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .map(u => u.guestLobbyMessage)
         .update(Some(guestLobbyMessage))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated guestLobbyMessage on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating guestLobbyMessage user: $e")
-    }
+    )
   }
 
   def updateInactivityWarning(meetingId: String, userId: String, inactivityWarningDisplay: Boolean, inactivityWarningTimeoutSecs: Long) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserStateDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
@@ -163,10 +148,7 @@ object UserStateDAO {
             case timeout: Long => Some(timeout)
             case _ => None
         }))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated inactivityWarningDisplay on user table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating inactivityWarningDisplay user: $e")
-    }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserTranscriptionErrorDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserTranscriptionErrorDAO.scala
@@ -27,7 +27,7 @@ class UserTranscriptionErrorDbTableDef(tag: Tag) extends Table[UserTranscription
 
 object UserTranscriptionErrorDAO {
   def insert(userId: String, meetingId: String, errorCode: String, errorMessage: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserTranscriptionErrorDbTableDef].insertOrUpdate(
         UserTranscriptionErrorDbModel(
           meetingId = meetingId,
@@ -37,10 +37,7 @@ object UserTranscriptionErrorDAO {
           lastUpdatedAt = new java.sql.Timestamp(System.currentTimeMillis()),
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_transcriptionError table!")
-        case Failure(e) => DatabaseConnection.logger.debug(s"Error inserting user_transcriptionError: $e")
-      }
+    )
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserVoiceConfStateDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserVoiceConfStateDAO.scala
@@ -29,7 +29,7 @@ class UserVoiceConfStateDbTableDef(tag: Tag) extends Table[UserVoiceConfStateDbM
 
 object UserVoiceConfStateDAO {
   def insertOrUpdate(meetingId: String, userId: String, voiceConf: String, voiceConfCallSession: String, clientSession: String, callState: String) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserVoiceConfStateDbTableDef].insertOrUpdate(
         UserVoiceConfStateDbModel(
           meetingId = meetingId,
@@ -40,10 +40,7 @@ object UserVoiceConfStateDAO {
           voiceConfCallState = callState,
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_voice table!")
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting voice: $e")
-      }
+    )
   }
 
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserVoiceDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserVoiceDAO.scala
@@ -53,7 +53,7 @@ class UserVoiceDbTableDef(tag: Tag) extends Table[UserVoiceDbModel](tag, None, "
 
 object UserVoiceDAO {
   def insert(voiceUserState: VoiceUserState) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserVoiceDbTableDef].insertOrUpdate(
         UserVoiceDbModel(
           meetingId = voiceUserState.meetingId,
@@ -73,24 +73,16 @@ object UserVoiceDAO {
           endTime = None
         )
       )
-    ).onComplete {
-        case Success(rowsAffected) => {
-          DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on user_voice table!")
-        }
-        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting voice: $e")
-      }
+    )
   }
 
   def update(voiceUserState: VoiceUserState) = {
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserVoiceDbTableDef]
         .filter(_.userId === voiceUserState.intId)
         .map(u => (u.listenOnly, u.muted, u.floor, u.lastFloorTime))
         .update((voiceUserState.listenOnly, voiceUserState.muted, voiceUserState.floor, voiceUserState.lastFloorTime))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on user_voice table!")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating user_voice: $e")
-    }
+    )
   }
 
   def updateTalking(voiceUserState: VoiceUserState) = {
@@ -113,10 +105,7 @@ object UserVoiceDAO {
             AND "userId" = ${voiceUserState.intId}"""
     }
 
-    DatabaseConnection.db.run(updateSql).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated with talking: ${voiceUserState.talking}")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error updating voice talking: $e")
-    }
+    DatabaseConnection.enqueue(updateSql)
   }
 
   def deleteUserVoice(meetingId: String,userId: String) = {
@@ -127,17 +116,12 @@ object UserVoiceDAO {
     //    joined: false
     //    spoke: false
 
-    DatabaseConnection.db.run(
+    DatabaseConnection.enqueue(
       TableQuery[UserVoiceDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.userId === userId)
         .map(u => (u.muted, u.talking, u.listenOnly, u.joined, u.spoke, u.startTime, u.endTime))
         .update((true, false, false, false, false, None, None))
-    ).onComplete {
-      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"Voice of user ${userId} deleted (joined=false)")
-      case Failure(e) => DatabaseConnection.logger.error(s"Error deleting voice user: $e")
-    }
+    )
   }
-
-
 }


### PR DESCRIPTION
After conducting several tests in meetings with over 500 users, we observed that chat messages sometimes experienced significant delays before appearing in the chat component. Upon tracking the message path, I discovered that the `akka-apps` component was slow to insert messages into the database. 

This delay occurs because `akka-apps` uses a single connection to PostgreSQL, which is intentional to ensure the command order is maintained.

To address this issue, this PR introduces a queue for database commands in `akka-apps`. All functions will now insert commands into the queue instead of directly into the database. This approach allows us to batch insert the queued items, significantly improving performance.

Below are the results from my test tracking a message (BEFORE THIS PR):

- Jun 27 10:42:28 Graphql-Actions sent to Redis
- **Jun 27 10:42:28 Akka-Apps received it from Redis**
- **Jun 27 10:43:05 Akka inserted into the database**
- Jun 27 10:43:05 Hasura queried the new info from the database
- Jun 27 10:43:05 Middleware received the message from WS connection with Hasura
- Jun 27 10:43:05 Middleware sent the message to the browser

The highlighted step indicates where the delay occurs.