### PR TITLE
nginx/html5: Introduce endpoint `/bigbluebutton/ping` for RTT calc

### DIFF
--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -149,6 +149,14 @@
             proxy_set_header        X-Original-URI $request_uri;
         }
 
+        location /bigbluebutton/ping {
+            default_type text/plain;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+            add_header Pragma "no-cache";
+            add_header Expires "0";
+            return 200 "";
+        }
+
 	}
 
 	location @error403 {

--- a/build/packages-template/bbb-html5/bbb-html5.nginx
+++ b/build/packages-template/bbb-html5/bbb-html5.nginx
@@ -52,11 +52,3 @@ location /html5client/sockjs {
   try_files $uri @html5client;
   limit_conn ws_zone 3;
 }
-
-location /html5client/ping {
-    default_type text/plain;
-    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-    add_header Pragma "no-cache";
-    add_header Expires "0";
-    return 200 "Ping successful";
-}

--- a/build/packages-template/bbb-html5/bbb-html5.nginx
+++ b/build/packages-template/bbb-html5/bbb-html5.nginx
@@ -52,3 +52,11 @@ location /html5client/sockjs {
   try_files $uri @html5client;
   limit_conn ws_zone 3;
 }
+
+location /html5client/ping {
+    default_type text/plain;
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+    add_header Pragma "no-cache";
+    add_header Expires "0";
+    return 200 "Ping successful";
+}


### PR DESCRIPTION
Currently, the RTT measurement relies on responses from `gql-middleware` and `gql-actions`. This dependency can cause delays on the server side, which may result in a high RTT. Users might mistakenly think the issue lies with their connection when it's actually a server-side problem.

To accurately measure RTT and diagnose client connection issues, it's better to have an endpoint that isn't affected by any application delays. 

This PR introduces a new endpoint at `/bigbluebutton/ping` in Nginx. The endpoint will simply return `200 ""`, allowing us to measure RTT solely based on the server network without any influence from application-level delays.

