### PR TITLE
refactor: Add TRACE logs for graphql-actions

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -57,10 +57,13 @@ object DatabaseConnection {
     }
 
     if (batch.nonEmpty) {
+      val startTime = System.nanoTime()
       val combinedAction = DBIO.sequence(batch.toList)
       db.run(combinedAction).onComplete {
         case scala.util.Success(_) =>
-          logger.debug(s"${batch.size} actions executed.")
+          val endTime = System.nanoTime()
+          val duration = (endTime - startTime) / 1e6 // convert to milliseconds
+          logger.debug(s"${batch.size} actions executed in the database in $duration ms.")
           isProcessing.set(false)
           if (!queue.isEmpty) tryProcessBatch()
         case scala.util.Failure(e) =>


### PR DESCRIPTION
This logs will be useful for analysis of @TiagoJacobs .

- Add a log to `akka-apps` to inform how long each batch took to exec:
```
9 actions executed in the database in 11.877587 ms
```

- Add a TRACE log to `gql-middleware` to inform how long each request to `gql-actions` took to finish:
```json
{"_routine":"GraphqlActionsClient","browserConnectionId":"BC0000000081","duration":"10 ms","funcName":"userSetConnectionAlive","inputs":{"networkRttInMs":5.300000000745058},"level":"info","msg":"Executed!","statusCode":200,"time":"2024-06-30T14:07:38-03:00"}
```

- Add an INFO log to `gql-middleware` to inform how long slow requests to `gql-actions` took to finish:
```json
{"_routine":"GraphqlActionsClient","browserConnectionId":"BC0000000081","duration":"150 ms","funcName":"userSetConnectionAlive","inputs":{"networkRttInMs":5.300000000745058},"level":"info","msg":"Took too long to execute!","statusCode":200,"time":"2024-06-30T14:07:38-03:00"}
```

_It includes the msg "Took too long to execute!"._
