### PR TITLE
fix: remove recording indicator label in phone

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -164,6 +164,7 @@ class LeaveMeetingButton extends PureComponent {
           trigger={(
             <Styled.LeaveButton
               state={isDropdownOpen ? 'open' : 'closed'}
+              isMobile={isMobile}
               aria-label={intl.formatMessage(intlMessages.leaveMeetingBtnLabel)}
               label={intl.formatMessage(intlMessages.leaveMeetingBtnLabel)}
               tooltipLabel={intl.formatMessage(intlMessages.leaveMeetingBtnLabel)}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
@@ -8,9 +8,13 @@ const LeaveButton = styled(Button)`
       display: none;
     }
   `}
-  ${({ state }) => state === 'closed' && `
+
+  ${({ state, isMobile }) => state === 'closed' && !isMobile && `
     margin-left: 1.0rem;
     margin-right: 0.5rem;
+  `}
+
+  ${({ state }) => state === 'closed' && `
     border-radius: 1.1rem;
     font-size: 1rem;
     line-height: 1.1rem;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -136,7 +136,8 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
   }, [shouldNotify, recordingNotificationEnabled, recording]);
 
   const recordTitle = useMemo(() => {
-    if (!isPhone && !recording) {
+    if (isPhone) return '';
+    if (!recording) {
       return time > 0
         ? intl.formatMessage(intlMessages.resumeTitle)
         : intl.formatMessage(intlMessages.startTitle);
@@ -146,7 +147,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
 
   const recordingIndicatorIcon = useMemo(() => (
     <Styled.RecordingIndicatorIcon
-      titleMargin={!isPhone || recording}
+      titleMargin={!isPhone && recording}
       data-test="mainWhiteboard"
     >
       <svg


### PR DESCRIPTION
### What does this PR do?

Removes recording indicator label in phones

#### before

![Screenshot from 2024-07-01 10-02-04](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/2a7e9398-7f00-4916-88e8-e3952d360fa8)

#### after
![Screenshot from 2024-07-01 10-03-34](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/a0652925-9e41-4be1-990f-a4db5da6ba45)



### How to test

Join a meeting with recording enabled on a phone