### PR TITLE
refactor: add voice activity adapter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -50,6 +50,7 @@ import BreakoutJoinConfirmationContainerGraphQL from '../breakout-join-confirmat
 import FloatingWindowContainer from '/imports/ui/components/floating-window/container';
 import ChatAlertContainerGraphql from '../chat/chat-graphql/alert/component';
 import { notify } from '/imports/ui/services/notification';
+import VoiceActivityAdapter from '../../core/adapters/voice-activity';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 
@@ -638,6 +639,7 @@ class App extends Component {
           <WakeLockContainer />
           {this.renderActionsBar()}
           <EmojiRainContainer />
+          <VoiceActivityAdapter />
           {customStyleUrl ? <link rel="stylesheet" type="text/css" href={customStyleUrl} /> : null}
           {customStyle ? <link rel="stylesheet" type="text/css" href={`data:text/css;charset=UTF-8,${encodeURIComponent(customStyle)}`} /> : null}
         </Styled.Layout>

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -193,7 +193,7 @@ const TalkingIndicatorContainer: React.FC = (() => {
     } = useDeduplicatedSubscription<IsBreakoutSubscriptionData>(MEETING_ISBREAKOUT_SUBSCRIPTION);
 
     const toggleVoice = useToggleVoice();
-    const { data: talkingUsersData, loading: talkingUsersLoading, error: talkingUsersError } = useTalkingUsers();
+    const { data: talkingUsersData, loading: talkingUsersLoading } = useTalkingUsers();
     const talkingUsers = useMemo(() => {
       const [muted, unmuted] = partition(
         Object.values(talkingUsersData),
@@ -227,11 +227,11 @@ const TalkingIndicatorContainer: React.FC = (() => {
 
     if (talkingUsersLoading || isBreakoutLoading) return null;
 
-    if (talkingUsersError || isBreakoutError) {
+    if (isBreakoutError) {
       return (
         <div>
           error:
-          { JSON.stringify(talkingUsersError || isBreakoutError) }
+          { JSON.stringify(isBreakoutError) }
         </div>
       );
     }

--- a/bigbluebutton-html5/imports/ui/core/adapters/voice-activity.tsx
+++ b/bigbluebutton-html5/imports/ui/core/adapters/voice-activity.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import useVoiceActivity from '/imports/ui/core/hooks/useVoiceActivity';
+import {
+  setWhoIsUnmutedLoading,
+  useWhoIsUnmutedConsumersCount,
+  dispatchWhoIsUnmutedUpdate,
+} from '/imports/ui/core/hooks/useWhoIsUnmuted';
+import {
+  setWhoIsTalkingLoading,
+  useWhoIsTalkingConsumersCount,
+  dispatchWhoIsTalkingUpdate,
+} from '/imports/ui/core/hooks/useWhoIsTalking';
+import {
+  dispatchTalkingUserUpdate,
+  setTalkingUserLoading,
+  useTalkingUserConsumersCount,
+} from '/imports/ui/core/hooks/useTalkingUsers';
+
+const VoiceActivityAdapter = () => {
+  const whoIsUnmutedConsumersCount = useWhoIsUnmutedConsumersCount();
+  const whoIsTalkingConsumersCount = useWhoIsTalkingConsumersCount();
+  const talkingUserConsumersCount = useTalkingUserConsumersCount();
+  const skip = !(
+    whoIsUnmutedConsumersCount
+    + whoIsTalkingConsumersCount
+    + talkingUserConsumersCount > 0
+  );
+  const { data: voiceActivity, loading } = useVoiceActivity(skip);
+
+  useEffect(() => {
+    dispatchWhoIsUnmutedUpdate(voiceActivity);
+    dispatchWhoIsTalkingUpdate(voiceActivity);
+    dispatchTalkingUserUpdate(voiceActivity);
+  }, [voiceActivity]);
+
+  useEffect(() => {
+    setWhoIsUnmutedLoading(loading);
+    setWhoIsTalkingLoading(loading);
+    setTalkingUserLoading(loading);
+  }, [loading]);
+
+  return null;
+};
+
+export default VoiceActivityAdapter;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { makeVar, useReactiveVar } from '@apollo/client';
 import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/whoIsTalking';
-import useVoiceActivity from './useVoiceActivity';
 import { partition } from '/imports/utils/array-utils';
 
 type VoiceItem = VoiceActivityResponse['user_voice_activity_stream'][number] & {
@@ -9,99 +9,155 @@ type VoiceItem = VoiceActivityResponse['user_voice_activity_stream'][number] & {
 
 const TALKING_INDICATOR_TIMEOUT = 5000;
 
-const useTalkingUsers = () => {
-  const {
-    data: voiceActivity,
-    loading,
-    error,
-  } = useVoiceActivity();
-  const [record, setRecord] = useState<Record<string, VoiceItem>>({});
-  const mutedTimeoutRegistry = useRef<Record<string, NodeJS.Timeout | null>>({});
-  const spokeTimeoutRegistry = useRef<Record<string, NodeJS.Timeout | null>>({});
+const createUseTalkingUsers = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<VoiceActivityResponse['user_voice_activity_stream'] | undefined>([]);
+  const loadingVar = makeVar(true);
 
-  useEffect(() => {
-    if (!voiceActivity) return;
+  const dispatchTalkingUserUpdate = (data?: VoiceActivityResponse['user_voice_activity_stream']) => stateVar(data);
 
-    const [muted, unmuted] = partition(
-      voiceActivity,
-      (v: VoiceItem) => v.muted,
-    ) as [VoiceItem[], VoiceItem[]];
+  const setTalkingUserLoading = (loading: boolean) => loadingVar(loading);
 
-    unmuted.forEach((voice) => {
-      const { endTime, startTime, userId } = voice;
-      const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
-      const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
+  const useTalkingUserConsumersCount = () => useReactiveVar(countVar);
 
-      // User has never talked
-      if (!(endTime || startTime)) return;
+  const useTalkingUsers = () => {
+    const voiceActivity = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+    const mutedTimeoutRegistry = useRef<Record<string, NodeJS.Timeout | null>>({});
+    const spokeTimeoutRegistry = useRef<Record<string, NodeJS.Timeout | null>>({});
+    const [record, setRecord] = useState<Record<string, VoiceItem>>({});
 
-      // Cancel any deletion
-      if (currentSpokeTimeout) {
-        clearTimeout(currentSpokeTimeout);
-        spokeTimeoutRegistry.current[userId] = null;
-      }
-      if (currentMutedTimeout) {
-        clearTimeout(currentMutedTimeout);
-        mutedTimeoutRegistry.current[userId] = null;
+    useEffect(() => {
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+      };
+    }, []);
+
+    useEffect(() => {
+      if (!voiceActivity) {
+        setRecord({});
+        return;
       }
 
-      setRecord((previousRecord) => {
-        // User has stopped talking
-        if (endTime) {
-          spokeTimeoutRegistry.current[userId] = setTimeout(() => {
-            setRecord((previousRecord) => {
-              const newRecord = { ...previousRecord };
-              delete newRecord[userId];
-              return newRecord;
-            });
-          }, TALKING_INDICATOR_TIMEOUT);
-        }
+      const [muted, unmuted] = partition(
+        voiceActivity,
+        (v: VoiceItem) => v.muted,
+      ) as [VoiceItem[], VoiceItem[]];
 
-        return {
-          ...previousRecord,
-          [userId]: Object.assign(
-            previousRecord[userId] || {},
-            voice,
-          ),
-        };
+      unmuted.forEach((voice) => {
+        const {
+          endTime, startTime, talking, userId,
+        } = voice;
+        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
+        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
+
+        // User has never talked
+        if (!(endTime || startTime)) return;
+
+        setRecord((previousRecord) => {
+          const previousIndicator = previousRecord[userId];
+
+          if (!previousIndicator && !talking) {
+            return previousRecord;
+          }
+
+          // Cancel any deletion if user has started talking
+          if (talking) {
+            if (currentSpokeTimeout) {
+              clearTimeout(currentSpokeTimeout);
+              spokeTimeoutRegistry.current[userId] = null;
+            }
+            if (currentMutedTimeout) {
+              clearTimeout(currentMutedTimeout);
+              mutedTimeoutRegistry.current[userId] = null;
+            }
+          }
+
+          // User has stopped talking
+          if (endTime && !currentSpokeTimeout) {
+            spokeTimeoutRegistry.current[userId] = setTimeout(() => {
+              setRecord((previousRecord) => {
+                const newRecord = { ...previousRecord };
+                delete newRecord[userId];
+                return newRecord;
+              });
+            }, TALKING_INDICATOR_TIMEOUT);
+          }
+
+          return {
+            ...previousRecord,
+            [userId]: Object.assign(
+              previousRecord[userId] || {},
+              voice,
+            ),
+          };
+        });
       });
-    });
 
-    muted.forEach((voice) => {
-      const { userId, endTime, startTime } = voice;
-      const currentTimeout = mutedTimeoutRegistry.current[userId];
+      muted.forEach((voice) => {
+        const { userId, endTime, startTime } = voice;
+        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
+        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
 
-      if (currentTimeout) return;
+        // User has never talked
+        if (!(endTime || startTime)) return;
 
-      // User has never talked
-      if (!(endTime || startTime)) return;
+        setRecord((previousRecord) => {
+          const previousIndicator = previousRecord[userId];
 
-      setRecord((previousRecord) => {
-        mutedTimeoutRegistry.current[userId] = setTimeout(() => {
-          setRecord((previousRecord) => {
-            const newRecord = { ...previousRecord };
-            delete newRecord[userId];
-            return newRecord;
-          });
-          mutedTimeoutRegistry.current[userId] = null;
-        }, TALKING_INDICATOR_TIMEOUT);
+          if (!previousIndicator) {
+            return previousRecord;
+          }
 
-        return {
-          ...previousRecord,
-          [userId]: Object.assign(
-            previousRecord[userId] || {},
-            voice,
-          ),
-        };
+          if (!currentMutedTimeout && !currentSpokeTimeout) {
+            mutedTimeoutRegistry.current[userId] = setTimeout(() => {
+              setRecord((previousRecord) => {
+                const newRecord = { ...previousRecord };
+                delete newRecord[userId];
+                return newRecord;
+              });
+              mutedTimeoutRegistry.current[userId] = null;
+            }, TALKING_INDICATOR_TIMEOUT);
+          }
+
+          return {
+            ...previousRecord,
+            [userId]: Object.assign(
+              previousRecord[userId] || {},
+              voice,
+            ),
+          };
+        });
       });
-    });
-  }, [voiceActivity]);
+    }, [voiceActivity]);
 
-  return {
-    error,
-    loading,
-    data: record,
+    return {
+      error: undefined,
+      loading,
+      data: record,
+    };
   };
+
+  return [
+    useTalkingUsers,
+    useTalkingUserConsumersCount,
+    dispatchTalkingUserUpdate,
+    setTalkingUserLoading,
+  ] as const;
+};
+
+const [
+  useTalkingUsers,
+  useTalkingUserConsumersCount,
+  dispatchTalkingUserUpdate,
+  setTalkingUserLoading,
+] = createUseTalkingUsers();
+
+export {
+  useTalkingUserConsumersCount,
+  dispatchTalkingUserUpdate,
+  setTalkingUserLoading,
 };
 
 export default useTalkingUsers;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useVoiceActivity.ts
@@ -2,12 +2,12 @@ import logger from '/imports/startup/client/logger';
 import VOICE_ACTIVITY, { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/whoIsTalking';
 import useDeduplicatedSubscription from './useDeduplicatedSubscription';
 
-const useVoiceActivity = () => {
+const useVoiceActivity = (skip = false) => {
   const {
     data,
     loading,
     error,
-  } = useDeduplicatedSubscription<VoiceActivityResponse>(VOICE_ACTIVITY);
+  } = useDeduplicatedSubscription<VoiceActivityResponse>(VOICE_ACTIVITY, { skip });
 
   if (error) {
     logger.error({

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalking.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalking.ts
@@ -1,19 +1,31 @@
-import { useEffect, useState } from 'react';
-import useVoiceActivity from './useVoiceActivity';
+import { useEffect } from 'react';
+import { makeVar, useReactiveVar } from '@apollo/client';
+import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/whoIsTalking';
 
-const useWhoIsTalking = () => {
-  const {
-    data: voiceActivity,
-    loading,
-  } = useVoiceActivity();
-  const [talkingUsers, setTalkingUsers] = useState<Record<string, boolean>>({});
+const createUseWhoIsTalking = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<Record<string, boolean>>({});
+  const loadingVar = makeVar(true);
 
-  useEffect(() => {
-    if (!voiceActivity) return;
+  const setWhoIsTalkingState = (newState: Record<string, boolean>) => stateVar(newState);
 
-    const newTalkingUsers: Record<string, boolean> = { ...talkingUsers };
+  const setWhoIsTalkingLoading = (loading: boolean) => loadingVar(loading);
 
-    voiceActivity.forEach(({ userId, muted, talking }) => {
+  const getWhoIsTalking = () => stateVar();
+
+  const dispatchWhoIsTalkingUpdate = (data?: VoiceActivityResponse['user_voice_activity_stream']) => {
+    if (countVar() === 0) return;
+
+    if (!data) {
+      stateVar({});
+      return;
+    }
+
+    const newTalkingUsers: Record<string, boolean> = { ...getWhoIsTalking() };
+
+    data.forEach((voice) => {
+      const { userId, muted, talking } = voice;
+
       if (muted) {
         delete newTalkingUsers[userId];
         return;
@@ -22,13 +34,51 @@ const useWhoIsTalking = () => {
       newTalkingUsers[userId] = talking;
     });
 
-    setTalkingUsers(newTalkingUsers);
-  }, [voiceActivity]);
-
-  return {
-    data: talkingUsers,
-    loading,
+    setWhoIsTalkingState(newTalkingUsers);
   };
+
+  const useWhoIsTalkingConsumersCount = () => useReactiveVar(countVar);
+
+  const useWhoIsTalking = () => {
+    const talkingUsers = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+
+    useEffect(() => {
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+        if (countVar() === 0) {
+          setWhoIsTalkingState({});
+        }
+      };
+    }, []);
+
+    return {
+      data: talkingUsers,
+      loading,
+    };
+  };
+
+  return [
+    useWhoIsTalking,
+    useWhoIsTalkingConsumersCount,
+    setWhoIsTalkingLoading,
+    dispatchWhoIsTalkingUpdate,
+  ] as const;
+};
+
+const [
+  useWhoIsTalking,
+  useWhoIsTalkingConsumersCount,
+  setWhoIsTalkingLoading,
+  dispatchWhoIsTalkingUpdate,
+] = createUseWhoIsTalking();
+
+export {
+  useWhoIsTalking,
+  useWhoIsTalkingConsumersCount,
+  setWhoIsTalkingLoading,
+  dispatchWhoIsTalkingUpdate,
 };
 
 export default useWhoIsTalking;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmuted.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmuted.ts
@@ -1,19 +1,29 @@
-import { useEffect, useState } from 'react';
-import useVoiceActivity from './useVoiceActivity';
+import { useEffect } from 'react';
+import { makeVar, useReactiveVar } from '@apollo/client';
+import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/whoIsTalking';
 
-const useWhoIsUnmuted = () => {
-  const {
-    data: voiceActivity,
-    loading,
-  } = useVoiceActivity();
-  const [unmutedUsers, setUnmutedUsers] = useState<Record<string, boolean>>({});
+const createUseWhoIsUnmuted = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<Record<string, boolean>>({});
+  const loadingVar = makeVar(true);
 
-  useEffect(() => {
-    if (!voiceActivity) return;
+  const setWhoIsUnmutedState = (newState: Record<string, boolean>) => stateVar(newState);
 
-    const newUnmutedUsers = { ...unmutedUsers };
+  const setWhoIsUnmutedLoading = (loading: boolean) => loadingVar(loading);
 
-    voiceActivity.forEach((voice) => {
+  const getWhoIsUnmuted = () => stateVar();
+
+  const dispatchWhoIsUnmutedUpdate = (data?: VoiceActivityResponse['user_voice_activity_stream']) => {
+    if (countVar() === 0) return;
+
+    if (!data) {
+      stateVar({});
+      return;
+    }
+
+    const newUnmutedUsers = { ...getWhoIsUnmuted() };
+
+    data.forEach((voice) => {
       const { userId, muted } = voice;
 
       if (muted) {
@@ -24,13 +34,51 @@ const useWhoIsUnmuted = () => {
       newUnmutedUsers[userId] = true;
     });
 
-    setUnmutedUsers(newUnmutedUsers);
-  }, [voiceActivity]);
-
-  return {
-    data: unmutedUsers,
-    loading,
+    setWhoIsUnmutedState(newUnmutedUsers);
   };
+
+  const useWhoIsUnmutedConsumersCount = () => useReactiveVar(countVar);
+
+  const useWhoIsUnmuted = () => {
+    const unmutedUsers = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+
+    useEffect(() => {
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+        if (countVar() === 0) {
+          setWhoIsUnmutedState({});
+        }
+      };
+    }, []);
+
+    return {
+      data: unmutedUsers,
+      loading,
+    };
+  };
+
+  return [
+    useWhoIsUnmuted,
+    useWhoIsUnmutedConsumersCount,
+    setWhoIsUnmutedLoading,
+    dispatchWhoIsUnmutedUpdate,
+  ] as const;
+};
+
+const [
+  useWhoIsUnmuted,
+  useWhoIsUnmutedConsumersCount,
+  setWhoIsUnmutedLoading,
+  dispatchWhoIsUnmutedUpdate,
+] = createUseWhoIsUnmuted();
+
+export {
+  useWhoIsUnmuted,
+  useWhoIsUnmutedConsumersCount,
+  setWhoIsUnmutedLoading,
+  dispatchWhoIsUnmutedUpdate,
 };
 
 export default useWhoIsUnmuted;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Adds a voice activity adapter in order to make just one `VoiceActivity` subscription. That adapter will dispatch stream data to the hook state of `useWhoIsTalking`, `useWhoIsUnmuted` and `useTalkingUsers`. Those hooks will consolidate the stream data and make it available through one single `makeVar`, making the state shared across all hook calls.

The subscription will start if at least one of these hooks is being called. If none of these hooks is being called the subscription will stop.

The hook state will be cleared when the hook is not being called.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None

### Motivation

Currently the client doesn't support deduplicated streams, so we need a way of consolidating the data we want in order to avoid making several subscriptions.