### PR TITLE
Fix: Whiteboard options button should not appear without the presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -756,6 +756,7 @@ class Presentation extends PureComponent {
       isPanning,
       tldrawAPI,
       isToolbarVisible,
+      presentationWidth,
     } = this.state;
 
     let viewBoxDimensions;
@@ -856,6 +857,7 @@ class Presentation extends PureComponent {
                   {slideContent}
                 </Styled.VisuallyHidden>
                 {!tldrawIsMounting
+                  && presentationWidth > 0
                   && currentSlide
                   && this.renderPresentationMenu()}
                 <LocatedErrorBoundary Fallback={FallbackView} logMetadata={APP_CRASH_METADATA}>
@@ -891,7 +893,7 @@ class Presentation extends PureComponent {
                 </LocatedErrorBoundary>
                 {isFullscreen && <PollingContainer />}
               </div>
-              {!tldrawIsMounting && (
+              {!tldrawIsMounting && presentationWidth > 0 && (
                 <Styled.PresentationToolbar
                   ref={(ref) => {
                     this.refPresentationToolbar = ref;


### PR DESCRIPTION
### What does this PR do?

This PR adds extra condition to make sure presentation is indeed rendered before showing buttons.

### Closes Issue(s)

#20610 

### After fix:

https://github.com/bigbluebutton/bigbluebutton/assets/36093456/fac892ac-27e9-4ae5-a67f-34d25aa42893



