### PR TITLE
fix: Graphql Middleware logging bytes

### DIFF
--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -203,7 +203,7 @@ func parseGraphQLMutation(query string, variables map[string]interface{}) (strin
 			if len(paramParts) != 2 {
 				continue // Skip invalid params
 			}
-			paramName, paramValue := paramParts[0], paramParts[1]
+			paramName, paramValue := strings.Trim(paramParts[0], " \t"), paramParts[1]
 
 			// Handle variable substitution
 			if strings.HasPrefix(paramValue, "$") {

--- a/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
@@ -55,7 +55,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, fromHasuraToBrowserChan
 			continue
 		}
 
-		log.Tracef("received from hasura: %v", message)
+		log.Tracef("received from hasura: %s", string(message))
 
 		handleMessageReceivedFromHasura(hc, fromHasuraToBrowserChannel, fromBrowserToHasuraChannel, message)
 	}

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -205,7 +205,7 @@ RangeLoop:
 					continue
 				}
 
-				log.Tracef("sending to hasura: %v", fromBrowserMessage)
+				log.Tracef("sending to hasura: %s", string(fromBrowserMessage))
 				errWrite := hc.Websocket.Write(hc.Context, websocket.MessageText, fromBrowserMessage)
 				if errWrite != nil {
 					if !errors.Is(errWrite, context.Canceled) {

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -53,7 +53,7 @@ func BrowserConnectionReader(
 			return
 		}
 
-		log.Tracef("received from browser: %v", message)
+		log.Tracef("received from browser: %s", string(message))
 
 		if messageType != websocket.MessageText {
 			log.Warnf("received non-text message: %v", messageType)

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -113,7 +113,7 @@ func sendBbbCoreMsgToRedis(name string, body map[string]interface{}) {
 		return
 	}
 
-	log.Tracef("JSON message sent to channel %s:\n%s\n", channelName, messageJSON)
+	log.Tracef("JSON message sent to channel %s:\n%s\n", channelName, string(messageJSON))
 }
 
 func SendUserGraphqlReconnectionForcedEvtMsg(sessionToken string) {


### PR DESCRIPTION
- It also trim the input names before sending to Graphql-actions