### PR TITLE
Fix: Message to all style not matching 2.7

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -12,7 +12,6 @@ import {
   ChatAvatar,
 } from './styles';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
-import { truncate } from 'fs/promises';
 
 interface ChatMessageProps {
   message: Message;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -12,6 +12,7 @@ import {
   ChatAvatar,
 } from './styles';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
+import { truncate } from 'fs/promises';
 
 interface ChatMessageProps {
   message: Message;
@@ -168,7 +169,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
           isSystemSender: true,
           component: (
             <ChatMessageTextContent
-              systemMsg
+              systemMsg={false}
               emphasizedMessage
               text={message.message}
             />


### PR DESCRIPTION
### What does this PR do?

This PR fixes the breakout room message so it matches the 2.7 version.

### After fix: 

![image](https://github.com/bigbluebutton/bigbluebutton/assets/36093456/7b5e5096-06de-440e-b5b0-084ccc1e99a3)
