### PR TITLE
feat(plugins): add open and close presentation area command support

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import PluginChatUiCommandsHandler from './chat/handler';
 import PluginSidekickOptionsContainerUiCommandsHandler from './sidekick-options-container/handler';
+import PluginPresentationAreaUiCommandsHandler from './presentation/handler';
 
 const PluginUiCommandsHandler = () => (
   <>
     <PluginChatUiCommandsHandler />
     <PluginSidekickOptionsContainerUiCommandsHandler />
+    <PluginPresentationAreaUiCommandsHandler />
   </>
 );
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/presentation/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/presentation/handler.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import {
+  PresentationAreaEnum,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/presentation-area/enums';
+import { layoutDispatch } from '../../../layout/context';
+import { ACTIONS } from '../../../layout/enums';
+
+const PluginPresentationAreaUiCommandsHandler = () => {
+  const layoutContextDispatch = layoutDispatch();
+
+  const handlePresentationAreaOpen = () => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+      value: true,
+    });
+  };
+
+  const handlePresentationAreaClose = () => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+      value: false,
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener(PresentationAreaEnum.OPEN, handlePresentationAreaOpen);
+    window.addEventListener(PresentationAreaEnum.CLOSE, handlePresentationAreaClose);
+
+    return () => {
+      window.addEventListener(PresentationAreaEnum.OPEN, handlePresentationAreaOpen);
+      window.addEventListener(PresentationAreaEnum.OPEN, handlePresentationAreaClose);
+    };
+  }, []);
+  return null;
+};
+
+export default PluginPresentationAreaUiCommandsHandler;

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -3322,9 +3322,9 @@
       "dev": true
     },
     "bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.54.tgz",
-      "integrity": "sha512-4dcu3ipM4cPDCcgQc1X8X8kM5vQ6z0nh+bKvCxsrD9i5NFF+8cl/cojektJE0Em50m1j8qnQ7fHmmu+9MtGPEA==",
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.55.tgz",
+      "integrity": "sha512-TsWHh8hQElGbBfgLcOb0bqWDArA6TSK86kP3920/W5HeoYvZSNG4Q3NHMR3Np/X29cFruV9YAfjTu0Id2VaUyw==",
       "requires": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -49,7 +49,7 @@
     "autoprefixer": "^10.4.4",
     "axios": "^1.6.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.54",
+    "bigbluebutton-html-plugin-sdk": "0.0.55",
     "bowser": "^2.11.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
What does this PR do?
Allows plugins to open and close the presentation area component via commands.

Needs https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/95