### PR TITLE
fix(plugins): layout content pile hook improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -226,13 +226,6 @@ const AppContainer = (props) => {
   useEffect(() => {
     if (isSharingVideo && !hasExternalVideoOnLayout) {
       layoutContextDispatch({
-        type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
-        value: {
-          content: PRESENTATION_AREA.EXTERNAL_VIDEO,
-          open: true,
-        },
-      });
-      layoutContextDispatch({
         type: ACTIONS.SET_HAS_EXTERNAL_VIDEO,
         value: true,
       });

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -854,6 +854,8 @@ const reducer = (state, action) => {
       if (presentation.isOpen === action.value) {
         return state;
       }
+      const { presentationAreaContentActions } = state;
+      presentationAreaContentActions[presentationAreaContentActions.length - 1].value.open = action.value;
       return {
         ...state,
         input: {
@@ -863,6 +865,7 @@ const reducer = (state, action) => {
             isOpen: action.value,
           },
         },
+        presentationAreaContentActions,
       };
     }
     case ACTIONS.SET_PRESENTATION_SLIDES_LENGTH: {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-data-hooks/layout/presentation-area/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-data-hooks/layout/presentation-area/utils.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import { LayoutPresentatioAreaUiDataNames, UiLayouts } from 'bigbluebutton-html-plugin-sdk';
 import { LayoutPresentationAreaUiDataPayloads } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/layout/presentation-area/types';
+import { UI_DATA_LISTENER_SUBSCRIBED } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/consts';
 import { PRESENTATION_AREA } from '/imports/ui/components/layout/enums';
 
 const useUpdatePresentationAreaContentForPluginForPlugin = (layoutContextState: Layout) => {
@@ -10,8 +11,8 @@ const useUpdatePresentationAreaContentForPluginForPlugin = (layoutContextState: 
   ]>();
   const { presentationAreaContentActions: presentationAreaContentPile } = layoutContextState;
 
-  useEffect(() => {
-    setPresentationAreaContent(presentationAreaContentPile.map((p) => {
+  const generateNewContentInfo = () => {
+    return presentationAreaContentPile.map((p) => {
       let currentElement;
       let genericContentId;
       switch (p.value.content) {
@@ -37,12 +38,40 @@ const useUpdatePresentationAreaContentForPluginForPlugin = (layoutContextState: 
         currentElement,
         genericContentId,
       };
-    }));
-  }, [layoutContextState]);
-  useEffect(() => {
+    })
+  }
+
+  // Define function to first inform ui data hooks that subscribe to this event
+  const updateUiDataHookLayoutPresentatioAreaChangedForPlugin = () => {
+    const content = presentationAreaContent || generateNewContentInfo();
     window.dispatchEvent(new CustomEvent(LayoutPresentatioAreaUiDataNames.CURRENT_ELEMENT, {
-      detail: presentationAreaContent,
+      detail: content,
     }));
+  };
+
+  useEffect(() => {
+    // When component mount, add event listener to send first information
+    // about this ui data hooks to plugin
+    window.addEventListener(
+      `${UI_DATA_LISTENER_SUBSCRIBED}-${LayoutPresentatioAreaUiDataNames.CURRENT_ELEMENT}`,
+      updateUiDataHookLayoutPresentatioAreaChangedForPlugin,
+    );
+
+    // Before component unmount, remove event listeners for plugin ui data hooks
+    return () => {
+      window.removeEventListener(
+        `${UI_DATA_LISTENER_SUBSCRIBED}-${LayoutPresentatioAreaUiDataNames.CURRENT_ELEMENT}`,
+        updateUiDataHookLayoutPresentatioAreaChangedForPlugin,
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    setPresentationAreaContent(generateNewContentInfo())
+  }, [layoutContextState]);
+  
+  useEffect(() => {
+    updateUiDataHookLayoutPresentatioAreaChangedForPlugin();
   }, [presentationAreaContent]);
 };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -55,7 +55,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
 
   // --- Plugin related code ---
   useEffect(() => {
-    const updateUiDataHookCurrentVolumeForPlugin = () => {
+    const updateUiDataHookUserListForPlugin = () => {
       window.dispatchEvent(new CustomEvent(PluginSdk.UserListUiDataNames.USER_LIST_IS_OPEN, {
         detail: {
           value: true,
@@ -69,13 +69,13 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
       } as UserListUiDataPayloads[PluginSdk.UserListUiDataNames.USER_LIST_IS_OPEN],
     }));
     window.addEventListener(
-      `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.ExternalVideoVolumeUiDataNames.IS_VOLUME_MUTED}`,
-      updateUiDataHookCurrentVolumeForPlugin,
+      `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.UserListUiDataNames.USER_LIST_IS_OPEN}`,
+      updateUiDataHookUserListForPlugin,
     );
     return () => {
       window.removeEventListener(
-        `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.ExternalVideoVolumeUiDataNames.CURRENT_VOLUME_VALUE}`,
-        updateUiDataHookCurrentVolumeForPlugin,
+        `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.UserListUiDataNames.USER_LIST_IS_OPEN}`,
+        updateUiDataHookUserListForPlugin,
       );
       window.dispatchEvent(new CustomEvent(PluginSdk.UserListUiDataNames.USER_LIST_IS_OPEN, {
         detail: {


### PR DESCRIPTION
### What does this PR do?

- The isOpen property of the content was not being updated when the minimize button was pressed, so plugins couldn't know if it was open or not. 

- Also, plugins were not receiving the initial state when subscribing to the hook, they only received subsequent changes.

- fix duplicated external video event and user list event with wrong names.
