### PR TITLE
fix (build/gql-server): Hasura trying to apply metadata using wrong password

### DIFF
--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -39,10 +39,15 @@ case "$1" in
 
   echo "Postgresql configured"
 
-  echo "Set a random password to Hasura in case its using the default 'bigbluebutton'"
-  HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
-  sed -i "s/HASURA_GRAPHQL_ADMIN_SECRET=bigbluebutton/HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD/g" /etc/default/bbb-graphql-server
+  #Generate a random password to Hasura to improve security
   HASURA_ADM_PASSWORD=$(grep '^HASURA_GRAPHQL_ADMIN_SECRET=' /etc/default/bbb-graphql-server | cut -d '=' -f 2)
+  if [ "$HASURA_ADM_PASSWORD" = "bigbluebutton" ]; then
+    echo "Set a random password to Hasura replacing the default 'bigbluebutton'"
+    HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
+    sed -i "s/HASURA_GRAPHQL_ADMIN_SECRET=bigbluebutton/HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD/g" /etc/default/bbb-graphql-server
+    HASURA_ADM_PASSWORD="$HASURA_RANDOM_ADM_PASSWORD"
+  fi
+
   sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb-graphql-server/config.yaml
 
   if [ ! -f /.dockerenv ]; then

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -43,7 +43,7 @@ case "$1" in
   HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
   sed -i "s/HASURA_GRAPHQL_ADMIN_SECRET=bigbluebutton/HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD/g" /etc/default/bbb-graphql-server
   HASURA_ADM_PASSWORD=$(grep '^HASURA_GRAPHQL_ADMIN_SECRET=' /etc/default/bbb-graphql-server | cut -d '=' -f 2)
-  sed -i "s/admin_secret: bigbluebutton/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb-graphql-server/config.yaml
+  sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb-graphql-server/config.yaml
 
   if [ ! -f /.dockerenv ]; then
     systemctl enable bbb-graphql-server.service


### PR DESCRIPTION
### TL;DR
This PR fixes an issue where the `/usr/share/bbb-graphql-server/config.yaml` does not update correctly after a package update.

### Details
When some Hasura default config is changed, during a package update the file `/etc/default/bbb-graphql-server` is overwritten, resetting the `HASURA_GRAPHQL_ADMIN_SECRET` to `bigbluebutton`. 
A new random password is then generated for security.

The issue arises when `/usr/share/bbb-graphql-server/config.yaml` does not reset and thus doesn't receive the new password, causing a mismatch.

#### Fixes
- Ensure `/usr/share/bbb-graphql-server/config.yaml` updates with the new password.
- Print the new password message only after generation (not always as before).
