### PR TITLE
Fix: showing two message at same time on notification bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -71,7 +71,7 @@ const NotificationsBarContainer = () => {
         {!connected && intl.formatMessage(intlMessages.reconnectingMessage)}
         {(connected && !serverIsResponding && lastRttRequestSuccess)
           && intl.formatMessage(intlMessages.serverIsNotResponding)}
-        {(connected && (!pingIsComing || !lastRttRequestSuccess))
+        {(connected && serverIsResponding && !pingIsComing && lastRttRequestSuccess)
           && intl.formatMessage(intlMessages.serverIsSlow)}
       </>
     );


### PR DESCRIPTION
### What does this PR do?
Fix a small issue introduced in the PR #20630, that was showing two messages at same time on the notification bar
