### PR TITLE
fix: Layout VIDEO_FOCUS shows empty tiles for other participants when see other viewers is locked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.js
@@ -454,8 +454,16 @@ class VideoService {
     let users = [];
 
     if (isGridEnabled) {
+      const selector = {
+        meetingId: Auth.meetingID,
+      };
+
+      if (this.hideUserlist() && this.getMyRole() === ROLE_VIEWER) {
+        selector.role = { $ne: ROLE_VIEWER };
+      }
+
       users = Users.find(
-        { meetingId: Auth.meetingID },
+        selector,
         { fields: { loggedOut: 1, left: 1, ...neededDataTypes} },
       ).fetch();
     }
@@ -631,6 +639,12 @@ class VideoService {
       return meeting.usersProp.webcamsOnlyForModerator;
     }
     return false;
+  }
+
+  hideUserlist() {
+    const meeting = Meetings.findOne({ meetingId: Auth.meetingID },
+      { fields: { 'lockSettingsProps.hideUserList': 1 } });
+    return meeting.lockSettingsProps ? meeting.lockSettingsProps.hideUserList : false;
   }
 
   hasCapReached() {


### PR DESCRIPTION
### What does this PR do?

fix grid mode displaying viewers when "See other viewers in the Users list" is locked

### Closes Issue(s)
Closes #20569

### How to test

1. Create a room
2. Click on three dots in the upper right corner
3. Click on "Choose Layout"
4. Select 'Grid layout'
5. Click on 'Update'
6. Click on 'Gear' Icon next to 'Users' in left bar.
7. Click on 'lock viewers'
8. Set 'See other Viewers webcams' to 'locked'
9. Set 'See other viewers in the Users list' to 'locked'
10. Open the room in two other browser incognito tabs and log in with usernames 'participant 1' and 'participant 2'
11. Set the video mode to 'Grid layout' in the participant tabs as welll (steps 2-5 above!)

**before**: viewers see other viewers' in cameras area
**after**: viewers should only see moderators tiles
