### PR TITLE
refactor (gql-middlware): Refactored code to simplify channel handling and remove unnecessary routines

### DIFF
--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -58,13 +58,12 @@ type BrowserConnection struct {
 }
 
 type HasuraConnection struct {
-	Id                       string                // hasura connection id
-	BrowserConn              *BrowserConnection    // browser connection that originated this hasura connection
-	Websocket                *websocket.Conn       // websocket used to connect to Hasura
-	WebsocketCloseError      *websocket.CloseError // closeError received from Hasura
-	Context                  context.Context       // hasura connection context (child of browser connection context)
-	ContextCancelFunc        context.CancelFunc    // function to cancel the hasura context (and so, the hasura connection)
-	FreezeMsgFromBrowserChan *SafeChannel          // indicate that it's waiting for the return of mutations before closing connection
+	Id                  string                // hasura connection id
+	BrowserConn         *BrowserConnection    // browser connection that originated this hasura connection
+	Websocket           *websocket.Conn       // websocket used to connect to Hasura
+	WebsocketCloseError *websocket.CloseError // closeError received from Hasura
+	Context             context.Context       // hasura connection context (child of browser connection context)
+	ContextCancelFunc   context.CancelFunc    // function to cancel the hasura context (and so, the hasura connection)
 }
 
 type HasuraMessage struct {

--- a/bbb-graphql-middleware/internal/common/types.go
+++ b/bbb-graphql-middleware/internal/common/types.go
@@ -34,24 +34,27 @@ type GraphQlSubscription struct {
 }
 
 type BrowserConnection struct {
-	Id                          string             // browser connection id
-	Websocket                   *websocket.Conn    // websocket of browser connection
-	SessionToken                string             // session token of this connection
-	MeetingId                   string             // auth info provided by bbb-web
-	UserId                      string             // auth info provided by bbb-web
-	BBBWebSessionVariables      map[string]string  // graphql session variables provided by akka-apps
-	ClientSessionUUID           string             // self-generated unique id for this client
-	Context                     context.Context    // browser connection context
-	ContextCancelFunc           context.CancelFunc // function to cancel the browser context (and so, the browser connection)
-	BrowserRequestCookies       []*http.Cookie
-	ActiveSubscriptions         map[string]GraphQlSubscription // active subscriptions of this connection (start, but no stop)
-	ActiveSubscriptionsMutex    sync.RWMutex                   // mutex to control the map usage
-	ConnectionInitMessage       []byte                         // init message received in this connection (to be used on hasura reconnect)
-	HasuraConnection            *HasuraConnection              // associated hasura connection
-	Disconnected                bool                           // indicate if the connection is gone
-	ConnAckSentToBrowser        bool                           // indicate if `connection_ack` msg was already sent to the browser
-	GraphqlActionsContext       context.Context                // graphql actions context
-	GraphqlActionsContextCancel context.CancelFunc             // function to cancel the graphql actions context
+	Id                             string             // browser connection id
+	Websocket                      *websocket.Conn    // websocket of browser connection
+	SessionToken                   string             // session token of this connection
+	MeetingId                      string             // auth info provided by bbb-web
+	UserId                         string             // auth info provided by bbb-web
+	BBBWebSessionVariables         map[string]string  // graphql session variables provided by akka-apps
+	ClientSessionUUID              string             // self-generated unique id for this client
+	Context                        context.Context    // browser connection context
+	ContextCancelFunc              context.CancelFunc // function to cancel the browser context (and so, the browser connection)
+	BrowserRequestCookies          []*http.Cookie
+	ActiveSubscriptions            map[string]GraphQlSubscription // active subscriptions of this connection (start, but no stop)
+	ActiveSubscriptionsMutex       sync.RWMutex                   // mutex to control the map usage
+	ConnectionInitMessage          []byte                         // init message received in this connection (to be used on hasura reconnect)
+	HasuraConnection               *HasuraConnection              // associated hasura connection
+	Disconnected                   bool                           // indicate if the connection is gone
+	ConnAckSentToBrowser           bool                           // indicate if `connection_ack` msg was already sent to the browser
+	GraphqlActionsContext          context.Context                // graphql actions context
+	GraphqlActionsContextCancel    context.CancelFunc             // function to cancel the graphql actions context
+	FromBrowserToHasuraChannel     *SafeChannelByte               // channel to transmit messages from Browser to Hasura
+	FromBrowserToGqlActionsChannel *SafeChannelByte               // channel to transmit messages from Browser to Graphq-Actions
+	FromHasuraToBrowserChannel     *SafeChannelByte               // channel to transmit messages from Hasura/GqlActions to Browser
 }
 
 type HasuraConnection struct {

--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -17,9 +17,7 @@ import (
 var graphqlActionsUrl = os.Getenv("BBB_GRAPHQL_MIDDLEWARE_GRAPHQL_ACTIONS_URL")
 
 func GraphqlActionsClient(
-	browserConnection *common.BrowserConnection,
-	fromBrowserToGqlActionsChannel *common.SafeChannelByte,
-	fromHasuraToBrowserChannel *common.SafeChannelByte) error {
+	browserConnection *common.BrowserConnection) error {
 
 	log := log.WithField("_routine", "GraphqlActionsClient").WithField("browserConnectionId", browserConnection.Id)
 	log.Debug("Starting GraphqlActionsClient")
@@ -33,7 +31,7 @@ RangeLoop:
 		case <-browserConnection.GraphqlActionsContext.Done():
 			log.Debug("GraphqlActionsContext cancelled!")
 			break RangeLoop
-		case fromBrowserMessage := <-fromBrowserToGqlActionsChannel.ReceiveChannel():
+		case fromBrowserMessage := <-browserConnection.FromBrowserToGqlActionsChannel.ReceiveChannel():
 			{
 				if fromBrowserMessage == nil {
 					continue
@@ -76,7 +74,7 @@ RangeLoop:
 							},
 						}
 						jsonData, _ := json.Marshal(browserResponseData)
-						fromHasuraToBrowserChannel.Send(jsonData)
+						browserConnection.FromHasuraToBrowserChannel.Send(jsonData)
 					} else {
 						//Action sent successfully, return data msg to client
 						browserResponseData := map[string]interface{}{
@@ -89,7 +87,7 @@ RangeLoop:
 							},
 						}
 						jsonData, _ := json.Marshal(browserResponseData)
-						fromHasuraToBrowserChannel.Send(jsonData)
+						browserConnection.FromHasuraToBrowserChannel.Send(jsonData)
 					}
 
 					//Return complete msg to client
@@ -98,7 +96,7 @@ RangeLoop:
 						"type": "complete",
 					}
 					jsonData, _ := json.Marshal(browserResponseComplete)
-					fromHasuraToBrowserChannel.Send(jsonData)
+					browserConnection.FromHasuraToBrowserChannel.Send(jsonData)
 				}
 
 				//Fallback to Hasura was disabled (keeping the code temporarily)

--- a/bbb-graphql-middleware/internal/hasura/client.go
+++ b/bbb-graphql-middleware/internal/hasura/client.go
@@ -73,11 +73,10 @@ func HasuraClient(
 	defer hasuraConnectionContextCancel()
 
 	var thisConnection = common.HasuraConnection{
-		Id:                       hasuraConnectionId,
-		BrowserConn:              browserConnection,
-		Context:                  hasuraConnectionContext,
-		ContextCancelFunc:        hasuraConnectionContextCancel,
-		FreezeMsgFromBrowserChan: common.NewSafeChannel(1),
+		Id:                hasuraConnectionId,
+		BrowserConn:       browserConnection,
+		Context:           hasuraConnectionContext,
+		ContextCancelFunc: hasuraConnectionContextCancel,
 	}
 
 	browserConnection.HasuraConnection = &thisConnection

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -15,7 +15,7 @@ import (
 
 // HasuraConnectionWriter
 // process messages (middleware to hasura)
-func HasuraConnectionWriter(hc *common.HasuraConnection, fromBrowserToHasuraChannel *common.SafeChannelByte, wg *sync.WaitGroup, initMessage []byte) {
+func HasuraConnectionWriter(hc *common.HasuraConnection, wg *sync.WaitGroup, initMessage []byte) {
 	log := log.WithField("_routine", "HasuraConnectionWriter")
 
 	browserConnection := hc.BrowserConn
@@ -45,13 +45,7 @@ RangeLoop:
 		select {
 		case <-hc.Context.Done():
 			break RangeLoop
-		case <-hc.FreezeMsgFromBrowserChan.ReceiveChannel():
-			if !fromBrowserToHasuraChannel.Frozen() {
-				log.Debug("freezing channel fromBrowserToHasuraChannel")
-				//Freeze channel once it's about to close Hasura connection
-				fromBrowserToHasuraChannel.FreezeChannel()
-			}
-		case fromBrowserMessage := <-fromBrowserToHasuraChannel.ReceiveChannel():
+		case fromBrowserMessage := <-hc.BrowserConn.FromBrowserToHasuraChannel.ReceiveChannel():
 			{
 				if fromBrowserMessage == nil {
 					continue

--- a/bbb-graphql-middleware/internal/hasura/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hasura/retransmiter/retransmiter.go
@@ -5,7 +5,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowserToHasuraChannel *common.SafeChannelByte) {
+func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection) {
 	log := log.WithField("_routine", "RetransmitSubscriptionStartMessages").WithField("browserConnectionId", hc.BrowserConn.Id).WithField("hasuraConnectionId", hc.Id)
 
 	hc.BrowserConn.ActiveSubscriptionsMutex.RLock()
@@ -21,9 +21,9 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection, fromBrowse
 			log.Tracef("retransmiting subscription start: %v", subscription.Message)
 
 			if subscription.Type == common.Streaming && subscription.StreamCursorCurrValue != nil {
-				fromBrowserToHasuraChannel.Send(common.PatchQuerySettingLastCursorValue(subscription))
+				hc.BrowserConn.FromBrowserToHasuraChannel.Send(common.PatchQuerySettingLastCursorValue(subscription))
 			} else {
-				fromBrowserToHasuraChannel.Send(subscription.Message)
+				hc.BrowserConn.FromBrowserToHasuraChannel.Send(subscription.Message)
 			}
 		}
 	}

--- a/bbb-graphql-middleware/internal/websrv/writer/writer.go
+++ b/bbb-graphql-middleware/internal/websrv/writer/writer.go
@@ -2,7 +2,6 @@ package writer
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"github.com/iMDT/bbb-graphql-middleware/internal/common"
 	log "github.com/sirupsen/logrus"
@@ -11,12 +10,9 @@ import (
 )
 
 func BrowserConnectionWriter(
-	browserConnectionId string,
-	ctx context.Context,
-	browserWsConn *websocket.Conn,
-	fromHasuraToBrowserChannel *common.SafeChannelByte,
+	browserConnection *common.BrowserConnection,
 	wg *sync.WaitGroup) {
-	log := log.WithField("_routine", "BrowserConnectionWriter").WithField("browserConnectionId", browserConnectionId)
+	log := log.WithField("_routine", "BrowserConnectionWriter").WithField("browserConnectionId", browserConnection.Id)
 	defer log.Debugf("finished")
 	log.Debugf("starting")
 	defer wg.Done()
@@ -24,20 +20,20 @@ func BrowserConnectionWriter(
 RangeLoop:
 	for {
 		select {
-		case <-ctx.Done():
+		case <-browserConnection.Context.Done():
 			log.Debug("Browser context cancelled.")
 			break RangeLoop
-		case toBrowserMessage := <-fromHasuraToBrowserChannel.ReceiveChannel():
+		case toBrowserMessage := <-browserConnection.FromHasuraToBrowserChannel.ReceiveChannel():
 			{
 				if toBrowserMessage == nil {
-					if fromHasuraToBrowserChannel.Closed() {
+					if browserConnection.FromHasuraToBrowserChannel.Closed() {
 						break RangeLoop
 					}
 					continue
 				}
 
 				log.Tracef("sending to browser: %s", string(toBrowserMessage))
-				err := browserWsConn.Write(ctx, websocket.MessageText, toBrowserMessage)
+				err := browserConnection.Websocket.Write(browserConnection.Context, websocket.MessageText, toBrowserMessage)
 				if err != nil {
 					log.Debugf("Browser is disconnected, skipping writing of ws message: %v", err)
 					return
@@ -52,7 +48,7 @@ RangeLoop:
 					var hasuraMessage HasuraMessage
 					_ = json.Unmarshal(toBrowserMessage, &hasuraMessage)
 					if hasuraMessage.Type == "connection_error" {
-						_ = browserWsConn.Close(websocket.StatusInternalError, string(toBrowserMessage))
+						_ = browserConnection.Websocket.Close(websocket.StatusInternalError, string(toBrowserMessage))
 					}
 				}
 			}


### PR DESCRIPTION
1. **Remove `fromBrowserToHasuraConnectionEstablishingChannel`:**
   - **Previous Setup:** 
     - `fromBrowserToHasura` worked in parallel with `fromBrowserToHasuraConnectionEstablishingChannel`.
     - `fromBrowserToHasuraConnectionEstablishingChannel` was only needed until receiving the `connection_init` message, after which it was closed.
   - **New Setup:** 
     - The code now first receives `connection_init`.
     - After `connection_init`, it initializes the routine to consume subsequent messages.
     - This removes the need for two separate channels. The initial routine handles messages until `connection_init`, then stops reading, while the subsequent routine handles messages from that point onward.

2. **Remove Routine Waiting for All Mutations to Finish Before Closing Hasura Connection:**
   - **Previous Setup:** 
     - A routine waited for all mutations to finish before closing the Hasura connection.
   - **New Setup:** 
     - Mutations now go to `graphql-actions` instead of Hasura.
     - Closing the Hasura connection no longer impacts the mutations.
     - The browser can still receive mutation returns even after the Hasura connection is closed.