### PR TITLE
fix: Enable download of the presentation not possible for temporarily presenters

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -143,7 +143,7 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
       && m.body.fileStateType == "Converted") {
       val reason = "Converted presentation download disabled for this meeting. (PDF format)"
       PermissionCheck.ejectUserForFailedPermission(meetingId, userId, reason, bus.outGW, liveMeeting)
-    } else if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, userId)) {
+    } else if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, userId)) {
       val reason = "No permission to download presentation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, userId, reason, bus.outGW, liveMeeting)
     } else if (currentPres.isEmpty) {


### PR DESCRIPTION
### What does this PR do?

Adjusts permission for download presentation to check for presenter status instead of moderator role.

### Closes Issue(s)
Closes #20029

### How to test

1. Create conference
2. Join as moderator
3. Join as guest
4. Give the presenter rights to guest 
5. Upload presentation as guest
6. Enable download of the presentation
7. Try to download the presentation

**before:** presentation download link is empty and does not work
**after:** presentation download link works