### PR TITLE
fix: talking indicator getting stuck on audio exit

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
@@ -100,8 +100,15 @@ const createUseTalkingUsers = () => {
         const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
         const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
 
-        // User has never talked
-        if (!(endTime || startTime)) return;
+        // User has never talked or exited audio
+        if (!(endTime || startTime)) {
+          setRecord((previousRecord) => {
+            const newRecord = { ...previousRecord };
+            delete newRecord[userId];
+            return newRecord;
+          });
+          return;
+        }
 
         setRecord((previousRecord) => {
           const previousIndicator = previousRecord[userId];

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -479,8 +479,8 @@ class AudioManager {
       window.addEventListener('graphqlSubscription', (e) => {
         const { subscriptionHash, response } = e.detail;
         if (subscriptionHash === subHash) {
-          const { data } = response;
-          if (data) {
+          if (response) {
+            const { data } = response;
             const voiceUser = data.user_voice_activity_stream.find((v) => v.userId === Auth.userID);
             this.onVoiceUserChanges(voiceUser);
           }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes talking indicator getting stuck when the user exits audio while he's talking.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None

### More

How to reproduce the bug:
1. Join audio.
2. Keep talking.
3. Exit audio.
4. See your talking indicator stuck on the navbar.
