### PR TITLE
bbb-web: Introduce config `apiUrl` for cluster setup

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -76,6 +76,7 @@ public class ParamsProcessorUtil {
     private int defaultNumDigitsForTelVoice;
     private String defaultHTML5ClientUrl;
 
+    private String apiUrl;
     private String graphqlWebsocketUrl;
     private String graphqlApiUrl;
     private Boolean allowRequestsWithoutSession = false;
@@ -891,6 +892,10 @@ public class ParamsProcessorUtil {
         return graphqlApiUrl;
     }
 
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
 	public Boolean getUseDefaultLogo() {
 		return useDefaultLogo;
 	}
@@ -1256,6 +1261,10 @@ public class ParamsProcessorUtil {
 
     public void setGraphqlApiUrl(String graphqlApiUrl) {
         this.graphqlApiUrl = graphqlApiUrl;
+    }
+
+    public void setApiUrl(String apiUrl) {
+        this.apiUrl = apiUrl;
     }
 
 	public void setUseDefaultLogo(Boolean value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/ResponseBuilder.java
@@ -52,7 +52,12 @@ public class ResponseBuilder {
         return new Date(timestamp).toString();
     }
 
-    public String buildMeetingVersion(String apiVersion, String bbbVersion, String graphqlWebsocketUrl, String graphqlApiUrl, String returnCode) {
+    public String buildMeetingVersion(String apiVersion,
+                                      String bbbVersion,
+                                      String apiUrl,
+                                      String graphqlWebsocketUrl,
+                                      String graphqlApiUrl,
+                                      String returnCode) {
         StringWriter xmlText = new StringWriter();
 
         Map<String, Object> data = new HashMap<String, Object>();
@@ -60,6 +65,7 @@ public class ResponseBuilder {
         data.put("version", apiVersion);
         data.put("apiVersion", apiVersion);
         data.put("bbbVersion", bbbVersion);
+        data.put("apiUrl", apiUrl);
         data.put("graphqlWebsocketUrl", graphqlWebsocketUrl);
         data.put("graphqlApiUrl", graphqlApiUrl);
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -304,6 +304,9 @@ bigbluebutton.web.logoutURL=default
 # successfully joining the meeting.
 defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/join
 
+# API url (it's necessary to change for cluster setup)
+apiUrl=${bigbluebutton.web.serverURL}/bigbluebutton
+
 # Graphql websocket url (it's necessary to change for cluster setup)
 # Using `serverURL` as default, so `https` will be automatically replaced by `wss`
 graphqlWebsocketUrl=${bigbluebutton.web.serverURL}/graphql

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -141,6 +141,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultServerUrl" value="${bigbluebutton.web.serverURL}"/>
         <property name="defaultNumDigitsForTelVoice" value="${defaultNumDigitsForTelVoice}"/>
         <property name="defaultHTML5ClientUrl" value="${defaultHTML5ClientUrl}"/>
+        <property name="apiUrl" value="${apiUrl}"/>
         <property name="graphqlWebsocketUrl" value="${graphqlWebsocketUrl}"/>
         <property name="graphqlApiUrl" value="${graphqlApiUrl}"/>
         <property name="useDefaultLogo" value="${useDefaultLogo}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -98,6 +98,7 @@ class ApiController {
             version paramsProcessorUtil.getApiVersion()
             apiVersion paramsProcessorUtil.getApiVersion()
             bbbVersion paramsProcessorUtil.getBbbVersion()
+            apiUrl paramsProcessorUtil.getApiUrl()
             graphqlWebsocketUrl paramsProcessorUtil.getGraphqlWebsocketUrl()
             graphqlApiUrl paramsProcessorUtil.getGraphqlApiUrl()
           }
@@ -110,6 +111,7 @@ class ApiController {
           render(text: responseBuilder.buildMeetingVersion(
                   paramsProcessorUtil.getApiVersion(),
                   paramsProcessorUtil.getBbbVersion(),
+                  paramsProcessorUtil.getApiUrl(),
                   paramsProcessorUtil.getGraphqlWebsocketUrl(),
                   paramsProcessorUtil.getGraphqlApiUrl(),
                   RESP_CODE_SUCCESS),

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/api-version.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/api-version.ftlx
@@ -6,6 +6,7 @@
     <version>${apiVersion}</version>
     <apiVersion>${apiVersion}</apiVersion>
     <bbbVersion>${bbbVersion}</bbbVersion>
+    <apiUrl>${apiUrl}</apiUrl>
     <graphqlWebsocketUrl>${graphqlWebsocketUrl}</graphqlWebsocketUrl>
     <graphqlApiUrl>${graphqlApiUrl}</graphqlApiUrl>
 </response>

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -103,7 +103,9 @@ Add these options to `/etc/bigbluebutton/bbb-web.properties`:
 defaultHTML5ClientUrl=https://bbb-proxy.example.com/bbb-01/html5client/join
 presentationBaseURL=https://bbb-01.example.com/bigbluebutton/presentation
 accessControlAllowOrigin=https://bbb-proxy.example.com
-graphqlWebsocketUrl=wss://bbb-01.example.com/v1/graphql
+apiUrl=https://bbb-01.example.com/bigbluebutton
+graphqlWebsocketUrl=wss://bbb-01.example.com/graphql
+graphqlApiUrl=https://bbb-01.example.com/api/rest
 ```
 
 Add the following options to `/etc/bigbluebutton/bbb-html5.yml`:


### PR DESCRIPTION
Sometimes the client needs to send some request to the API and it is better to send it directly to the current BBB server instead of sending it to the cluster.
This PR will introduce a new config that will be provided through a request to API root:

<table><tr><td>

![image](https://github.com/bigbluebutton/bigbluebutton/assets/5660191/5622e5d3-f2c9-4e06-ac2a-826eca2bd6ef)

</td></tr></table>

This way the Client can store this URL and always use it when necessary.

@Tainan404 will send a subsequent PR making the Client benefit from it to request `/ping` and `/feedback`.

Related: #20439