### PR TITLE
fix(whiteboard): Focus wheel zoom towards mouse pointer

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -115,9 +115,14 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
         const ZOOM_IN_FACTOR = 0.1;
         const ZOOM_OUT_FACTOR = 0.1;
 
+        // Get the current mouse position
+        const mouseX = event.clientX;
+        const mouseY = event.clientY;
+
+        // Get the current camera position and zoom level
         const { x: cx, y: cy, z: cz } = tlEditorRef.current.getCamera();
 
-        let currentZoomLevel = tlEditorRef.current.getCamera().z / initialZoomRef.current;
+        let currentZoomLevel = cz / initialZoomRef.current;
         if (event.deltaY < 0) {
             currentZoomLevel = Math.min(currentZoomLevel + ZOOM_IN_FACTOR, MAX_ZOOM_FACTOR);
         } else {
@@ -131,19 +136,15 @@ const useMouseEvents = ({ whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoo
         // Calculate the new camera zoom factor
         const newCameraZoomFactor = currentZoomLevel * initialZoomRef.current;
 
-        // Break down the calculations for deltaX
-        const scaleAdjustmentX = cursorPosition.x / newCameraZoomFactor - cursorPosition.x;
-        const zoomAdjustmentX = cursorPosition.x / cz - cursorPosition.x;
-        const deltaX = scaleAdjustmentX - zoomAdjustmentX;
+        // Calculate the mouse position in canvas space using whiteboardRef
+        const rect = whiteboardRef.current.getBoundingClientRect();
+        const canvasMouseX = (mouseX - rect.left) / cz + cx;
+        const canvasMouseY = (mouseY - rect.top) / cz + cy;
 
-        // Break down the calculations for deltaY
-        const scaleAdjustmentY = cursorPosition.y / newCameraZoomFactor - cursorPosition.y;
-        const zoomAdjustmentY = cursorPosition.y / cz - cursorPosition.y;
-        const deltaY = scaleAdjustmentY - zoomAdjustmentY;
-
+        // Calculate the new camera position to keep the mouse position under the cursor
         const nextCamera = {
-            x: cx + deltaX,
-            y: cy + deltaY,
+            x: canvasMouseX - (canvasMouseX - cx) * (newCameraZoomFactor / cz),
+            y: canvasMouseY - (canvasMouseY - cy) * (newCameraZoomFactor / cz),
             z: newCameraZoomFactor,
         };
 


### PR DESCRIPTION
### What does this PR do?
This PR improves the zoom functionality on the whiteboard by modifying the wheel zoom behavior. It ensures that the zoom now follows the pointer location.

### Motivation
Previously, the zoom did not follow the pointer location. By updating the zoom functionality to center around the pointer, users can have more precise control over the zooming.


