### PR TITLE
fix: sidebar in integration layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -113,7 +113,6 @@ const CamerasOnlyLayout = (props) => {
       sidebarNavWidth.width,
       sidebarContentWidth.width,
     );
-    console.log({ mediaAreaBounds });
     const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
     const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -7,7 +7,7 @@ import {
 } from '/imports/ui/components/layout/context';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
-import { ACTIONS } from '/imports/ui/components/layout/enums';
+import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
@@ -113,7 +113,7 @@ const CamerasOnlyLayout = (props) => {
       sidebarNavWidth.width,
       sidebarContentWidth.width,
     );
-    console.log({mediaAreaBounds})
+    console.log({ mediaAreaBounds });
     const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);
     const actionbarBounds = calculatesActionbarBounds(mediaAreaBounds);
     const sidebarSize = sidebarContentWidth.width + sidebarNavWidth.width;
@@ -321,6 +321,21 @@ const CamerasOnlyLayout = (props) => {
         left: mediaBounds.left,
         right: isRTL ? mediaBounds.right : null,
       },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+      value: false,
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: false,
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: PANELS.NONE,
     });
   };
 

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -5,6 +5,7 @@ import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import {
   ACTIONS,
+  PANELS,
   CAMERADOCK_POSITION,
 } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
@@ -311,6 +312,21 @@ const PresentationOnlyLayout = (props) => {
         left: mediaBounds.left,
         right: mediaBounds.right,
       },
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+      value: false,
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: false,
+    });
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: PANELS.NONE,
     });
   };
 


### PR DESCRIPTION
### What does this PR do?

Fix sidebar content appearing in integration layouts

### How to test

join a meeting with one of the integration layouts that should not display a sidebar (custom join parameter `enforceLayout=CAMERAS_ONLY` or `enforceLayout=PRESENTATION_ONLY`

#### Before
media area is not using all available space

![Screenshot from 2024-07-08 14-04-21](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/e30a4304-abde-4cd1-88d2-36382d8e7187)


#### After
media area should use all available space

![Screenshot from 2024-07-08 14-03-59](https://github.com/bigbluebutton/bigbluebutton/assets/3728706/401119f7-0368-4e84-b165-243d7f0be843)
