### PR TITLE
fix (gql-middlware): error when Retransmitting streaming subscription

### DIFF
--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -114,6 +114,9 @@ RangeLoop:
 							browserConnection.ActiveSubscriptionsMutex.RUnlock()
 							if queryIdExists {
 								lastReceivedDataChecksum = existingSubscriptionData.LastReceivedDataChecksum
+								streamCursorField = existingSubscriptionData.StreamCursorField
+								streamCursorVariableName = existingSubscriptionData.StreamCursorVariableName
+								streamCursorInitialValue = existingSubscriptionData.StreamCursorCurrValue
 							}
 
 							if strings.Contains(query, "_stream(") && strings.Contains(query, "cursor: {") {

--- a/bbb-graphql-middleware/internal/hasura/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hasura/retransmiter/retransmiter.go
@@ -18,7 +18,7 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection) {
 
 		if subscription.LastSeenOnHasuraConnection != hc.Id {
 
-			log.Tracef("retransmiting subscription start: %v", subscription.Message)
+			log.Tracef("retransmiting subscription start: %v", string(subscription.Message))
 
 			if subscription.Type == common.Streaming && subscription.StreamCursorCurrValue != nil {
 				hc.BrowserConn.FromBrowserToHasuraChannel.Send(common.PatchQuerySettingLastCursorValue(subscription))


### PR DESCRIPTION
When a user is promoted to mod or presenter, all the subscriptions are recreated to fetch it with refreshed permissions.
Gqlphql-middlware is not sending the cursor properly which cause an error and it stop receiving new data.

Error:
```
{
    "type": "error",
    "id": "f6f8a6ec-d30d-45f0-a044-635fc419197f",
    "payload": [
        {
            "message": "not a valid graphql query",
            "extensions": {
                "path": "$.query",
                "code": "validation-failed"
            }
        }
    ]
}
```

Reported by @antonbsa (also investigated by @JoVictorNunes )