### PR TITLE
fix(whiteboard) Delete key removing text shape while editing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -354,7 +354,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       return;
     }
 
-    if (event.key === 'Delete' || event.key === 'Backspace') {
+    if (event.key === 'Delete') {
       handleCut(false);
       return;
     }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -349,13 +349,13 @@ const Whiteboard = React.memo(function Whiteboard(props) {
       return;
     }
 
-    if (event.key === 'Delete' || event.key === 'Backspace') {
-      handleCut(false);
+    const editingShape = tlEditorRef.current?.getEditingShape();
+    if (editingShape && (isPresenterRef.current || hasWBAccessRef.current)) {
       return;
     }
 
-    const editingShape = tlEditorRef.current?.getEditingShape();
-    if (editingShape && (isPresenterRef.current || hasWBAccessRef.current)) {
+    if (event.key === 'Delete' || event.key === 'Backspace') {
+      handleCut(false);
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where pressing the delete key while editing text within a shape would inadvertently delete the entire shape. The update ensures that the delete key functions correctly by only removing the text as intended without deleting the shape.

### Motivation
Delete key was removing text shapes while editing when it shouldn't.