### PR TITLE
fix: external video can be seen through sidebar on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/component.jsx
@@ -580,6 +580,7 @@ class VideoPlayer extends Component {
       width,
       fullscreenContext,
       isResizing,
+      zIndex,
     } = this.props;
 
     const {
@@ -614,6 +615,8 @@ class VideoPlayer extends Component {
           pointerEvents: isResizing ? 'none' : 'inherit',
           display: isMinimized && 'none',
           background: 'var(--color-black)',
+          overflow: 'hidden',
+          zIndex,
         }}
       >
         <Styled.VideoPlayerWrapper


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a bug where the external video autoplay warning can be seen through the sidebar panel on mobile devices.

[Screencast from 09-07-2024 08:32:41.webm](https://github.com/bigbluebutton/bigbluebutton/assets/62393923/acfbe6f3-e703-4ec1-aba4-4f5a603f5117)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #20654