### PR TITLE
fix: Manage Layouts ignores disabledFeatures

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/settings-dropdown/component.jsx
@@ -15,6 +15,7 @@ import { colorDanger, colorWhite } from '/imports/ui/stylesheets/styled-componen
 import Styled from './styles';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { isLayoutsEnabled } from '/imports/ui/services/features';
 
 const intlMessages = defineMessages({
   optionsLabel: {
@@ -322,6 +323,8 @@ class SettingsDropdown extends PureComponent {
       );
     }
 
+    const enableLayoutButton = isLayoutsEnabled();
+
     this.menuItems.push(
       {
         key: 'list-item-shortcuts',
@@ -329,18 +332,21 @@ class SettingsDropdown extends PureComponent {
         label: intl.formatMessage(intlMessages.hotkeysLabel),
         description: intl.formatMessage(intlMessages.hotkeysDesc),
         onClick: () => this.setShortcutHelpModalIsOpen(true),
+        divider: !isDirectLeaveButtonEnabled && !enableLayoutButton,
       },
     );
 
-    this.menuItems.push(
-      {
-        key: 'list-item-layout-modal',
-        icon: 'manage_layout',
-        label: intl.formatMessage(intlMessages.layoutModal),
-        onClick: () => this.setLayoutModalIsOpen(true),
-        divider: isDirectLeaveButtonEnabled ? false : true,
-      },
-    );
+    if (enableLayoutButton) {
+      this.menuItems.push(
+        {
+          key: 'list-item-layout-modal',
+          icon: 'manage_layout',
+          label: intl.formatMessage(intlMessages.layoutModal),
+          onClick: () => this.setLayoutModalIsOpen(true),
+          divider: !isDirectLeaveButtonEnabled,
+        },
+      );
+    }
 
     if (allowLogoutSetting && isMeteorConnected && !isDirectLeaveButtonEnabled) {
       this.menuItems.push(


### PR DESCRIPTION
### What does this PR do?

Do not display layout button in the three dots menu if layouts are disabled.

### Closes Issue(s)
Closes #20667

### How to test
Join a meeting with the custom parameter `disabledFeatures=layouts`

#### before
Manage layout option appears in the three dots menu

#### after
Manage layout does not appear in the three dots menu