### PR TITLE
refactor (gql-actions): Make error messages show more details

### DIFF
--- a/bbb-graphql-actions/deploy.sh
+++ b/bbb-graphql-actions/deploy.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-if [ "$EUID" -ne 0 ]; then
-	echo "Please run this script as root ( or with sudo )" ;
-	exit 1;
-fi;
-
 
 cd "$(dirname "$0")"
 
@@ -11,15 +6,15 @@ for var in "$@"
 do
     if [[ $var == --reset ]] ; then
     	echo "Performing a full reset..."
-      rm -rf node_modules
+      sudo rm -rf node_modules
     fi
 done
 
 if [ ! -d ./node_modules ] ; then
-  npm ci --no-progress
+  sudo npm ci --no-progress
 fi
 
-npm run build
+sudo npm run build
 
 # handle renaming circa dec 2023
 if [[ -d /usr/local/bigbluebutton/bbb-graphql-actions-adapter-server ]] ; then
@@ -29,7 +24,7 @@ if [[ -d /usr/local/bigbluebutton/bbb-graphql-actions-adapter-server ]] ; then
     sudo rm -rf /usr/local/bigbluebutton/bbb-graphql-actions-adapter-server
 fi
 
-mv -f dist/index.js dist/bbb-graphql-actions.js
+sudo mv -f dist/index.js dist/bbb-graphql-actions.js
 sudo cp -rf dist/* /usr/local/bigbluebutton/bbb-graphql-actions
 sudo systemctl restart bbb-graphql-actions
 echo ''

--- a/bbb-graphql-actions/src/imports/validation.ts
+++ b/bbb-graphql-actions/src/imports/validation.ts
@@ -2,13 +2,13 @@ import {ValidationError} from "../types/ValidationError";
 
 export const throwErrorIfNotModerator = (sessionVariables: Record<string, unknown>) => {
     if(sessionVariables['x-hasura-moderatorinmeeting'] == "") {
-        throw new ValidationError('Permission Denied.', 403);
+        throw new ValidationError('Permission Denied (not moderator).', 403);
     }
 };
 
 export const throwErrorIfNotPresenter = (sessionVariables: Record<string, unknown>) => {
     if(sessionVariables['x-hasura-presenterinmeeting'] == "") {
-        throw new ValidationError('Permission Denied.', 403);
+        throw new ValidationError('Permission Denied (not presenter).', 403);
     }
 };
 

--- a/bbb-graphql-actions/src/index.ts
+++ b/bbb-graphql-actions/src/index.ts
@@ -65,7 +65,9 @@ app.post('/', async (req: Request, res: Response) => {
 
   } catch (error) {
     if (error instanceof ValidationError) {
-      res.status(error.status).send({message: error.message});
+      const actionName = req.body?.action?.name || 'Unidentified Action';
+
+      res.status(error.status).send({message: `${actionName}: ${error.message}`});
     } else {
       console.error(error);
       res.status(400).send({message: 'Internal Server Error'});

--- a/bbb-graphql-actions/src/index.ts
+++ b/bbb-graphql-actions/src/index.ts
@@ -64,13 +64,13 @@ app.post('/', async (req: Request, res: Response) => {
     res.status(200).json(true);
 
   } catch (error) {
-    if (error instanceof ValidationError) {
-      const actionName = req.body?.action?.name || 'Unidentified Action';
+    const actionName = req.body?.action?.name || 'Unidentified Action';
 
+    if (error instanceof ValidationError) {
       res.status(error.status).send({message: `${actionName}: ${error.message}`});
     } else {
       console.error(error);
-      res.status(400).send({message: 'Internal Server Error'});
+      res.status(400).send({message: `${actionName}: Internal Server Error`});
     }
   }
 });


### PR DESCRIPTION
Return more useful information in the error messages of Graphql Actions.
Now it will show the `actionName` and the missing permission (`not moderator` for instance).

Example of the message logged in the browser console after some error:

Before:
```
ERROR: clientLogger: [Network error]: ApolloError: graphql actions request failed: Permission Denied.
```

After:
```
ERROR: clientLogger: [Network error]: ApolloError: graphql actions request failed: meetingEnd: Permission Denied (not moderator).
```
