### PR TITLE
refactor: port layout button changes to v3.0.x

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -270,7 +270,7 @@ class ActionsDropdown extends PureComponent {
       && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
       && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
 
-    if (shouldShowManageLayoutButton && isLayoutsEnabled) {
+    if (shouldShowManageLayoutButton && isLayoutsEnabled && (amIModerator || amIPresenter)) {
       actions.push({
         icon: 'manage_layout',
         label: intl.formatMessage(intlMessages.layoutModal),

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import EndMeetingConfirmationContainer from '/imports/ui/components/end-meeting-confirmation/container';
 import AboutContainer from '/imports/ui/components/about/container';
 import MobileAppModal from '/imports/ui/components/mobile-app-modal/mobile-app-modal-graphql/component';
+import LayoutModalContainer from '/imports/ui/components/layout/modal/container';
 import OptionsMenuContainer from '/imports/ui/components/settings/container';
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import ShortcutHelpComponent from '/imports/ui/components/shortcut-help/component';
@@ -14,6 +15,8 @@ import Styled from './styles';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
 import Session from '/imports/ui/services/storage/in-memory';
+import { LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
+import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 
 const intlMessages = defineMessages({
   optionsLabel: {
@@ -96,6 +99,10 @@ const intlMessages = defineMessages({
     id: 'app.audio.captions.button.stop',
     description: 'Stop audio captions',
   },
+  layoutModal: {
+    id: 'app.actionsBar.actionsDropdown.layoutModal',
+    description: 'Label for layouts selection button',
+  },
 });
 
 const propTypes = {
@@ -144,6 +151,7 @@ class OptionsDropdown extends PureComponent {
       isEndMeetingConfirmationModalOpen: false,
       isMobileAppModalOpen: false,
       isFullscreen: false,
+      isLayoutModalOpen: false,
     };
 
     // Set the logout code to 680 because it's not a real code and can be matched on the other side
@@ -156,6 +164,7 @@ class OptionsDropdown extends PureComponent {
     this.setMobileAppModalIsOpen = this.setMobileAppModalIsOpen.bind(this);
     this.setAboutModalIsOpen = this.setAboutModalIsOpen.bind(this);
     this.setShortcutHelpModalIsOpen = this.setShortcutHelpModalIsOpen.bind(this);
+    this.setLayoutModalIsOpen = this.setLayoutModalIsOpen.bind(this);
   }
 
   componentDidMount() {
@@ -238,10 +247,15 @@ class OptionsDropdown extends PureComponent {
     this.setState({isMobileAppModalOpen: value})
   }
 
+  setLayoutModalIsOpen(value) {
+    this.setState({ isLayoutModalOpen: value });
+  }
+
   renderMenuItems() {
     const {
       intl, amIModerator, isBreakoutRoom, isMeteorConnected, audioCaptionsEnabled,
-      audioCaptionsActive, audioCaptionsSet, isMobile, optionsDropdownItems, isDirectLeaveButtonEnabled,
+      audioCaptionsActive, audioCaptionsSet, isMobile, optionsDropdownItems,
+      isDirectLeaveButtonEnabled, isLayoutsEnabled,
     } = this.props;
 
     const { isIos } = deviceInfo;
@@ -331,6 +345,23 @@ class OptionsDropdown extends PureComponent {
       },
     );
 
+    const Settings = getSettingsSingletonInstance();
+    const { selectedLayout } = Settings.application;
+    const shouldShowManageLayoutButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
+      && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
+      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
+
+    if (shouldShowManageLayoutButton && isLayoutsEnabled) {
+      this.menuItems.push(
+        {
+          key: 'list-item-layout-modal',
+          icon: 'manage_layout',
+          label: intl.formatMessage(intlMessages.layoutModal),
+          onClick: () => this.setLayoutModalIsOpen(true),
+        },
+      );
+    }
+
     optionsDropdownItems.forEach((item) => {
       switch (item.type) {
         case OptionsDropdownItemType.OPTION:
@@ -409,8 +440,10 @@ class OptionsDropdown extends PureComponent {
       isRTL,
     } = this.props;
 
-    const { isAboutModalOpen, isShortcutHelpModalOpen, isOptionsMenuModalOpen,
-      isEndMeetingConfirmationModalOpen, isMobileAppModalOpen, } = this.state;
+    const {
+      isAboutModalOpen, isShortcutHelpModalOpen, isOptionsMenuModalOpen,
+      isEndMeetingConfirmationModalOpen, isMobileAppModalOpen, isLayoutModalOpen,
+    } = this.state;
 
     const customStyles = { top: '1rem' };
 
@@ -456,6 +489,13 @@ class OptionsDropdown extends PureComponent {
           "low", EndMeetingConfirmationContainer)}
         {this.renderModal(isMobileAppModalOpen, this.setMobileAppModalIsOpen, "low", 
           MobileAppModal)}
+        {this.renderModal(
+          isLayoutModalOpen,
+          this.setLayoutModalIsOpen,
+          'low',
+          LayoutModalContainer,
+        )}
+
       </>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/container.jsx
@@ -11,6 +11,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import Session from '/imports/ui/services/storage/in-memory';
+import { useIsLayoutsEnabled } from '/imports/ui/services/features';
 
 const { isIphone } = deviceInfo;
 const { isSafari, isValidSafariVersion } = browserInfo;
@@ -43,6 +44,7 @@ const OptionsDropdownContainer = (props) => {
   const openOptions = useShortcut('openOptions');
   const audioCaptionsActive = useStorageKey('audioCaptions') || false;
   const isDropdownOpen = useStorageKey('dropdownOpen');
+  const isLayoutsEnabled = useIsLayoutsEnabled();
 
   return (
     <OptionsDropdown {...{
@@ -60,6 +62,7 @@ const OptionsDropdownContainer = (props) => {
       isBreakoutRoom: currentMeeting?.isBreakout,
       // TODO: Replace/Remove
       isMeteorConnected: true,
+      isLayoutsEnabled,
       ...props,
     }}
     />


### PR DESCRIPTION
### What does this PR do?

Ports #19078 and #20670 to v3.0.x-release:
- Adds a new menu item in the "options" menu, that opens the Manage Layouts modal.
- Removes the Manage Layouts menu item from the "+" menu for viewers, keeping it for moderators and presenter
- Do not display layout button in the three dots menu if layouts are disabled.