### PR TITLE
fix(whiteboard): Increase duplicated shape distance from original

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -387,7 +387,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
           tlEditorRef.current?.setCurrentTool("select");
         },
         'd': () => {
-          tlEditorRef.current?.duplicateShapes(tlEditorRef.current?.getSelectedShapes(), { x: 10, y: 10 });
+          tlEditorRef.current?.duplicateShapes(tlEditorRef.current?.getSelectedShapes(), { x: 35, y: 35 });
           tlEditorRef.current?.selectNone();
         },
         'x': () => {


### PR DESCRIPTION
### What does this PR do?
This PR increases the offset of the duplicated shape using Ctrl + d.

Pasting with Ctrl + v after copying with Ctrl + (c | x) will overlay on top of the existing shape instead of having it offset. This is the default behavior for tldraw.