### PR TITLE
fix(connection-status): user report sorting

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -75,14 +75,16 @@ const startStatsTimeout = () => {
 };
 
 const sortLevel = (a, b) => {
-  const STATS = window.meetingClientSettings.public.stats;
+  const RTT = window.meetingClientSettings.public.stats.rtt;
 
-  const indexOfA = STATS.level.indexOf(a.level);
-  const indexOfB = STATS.level.indexOf(b.level);
+  if (!a.lastUnstableStatus && !b.lastUnstableStatus) return 0;
+  if (!a.lastUnstableStatus) return 1;
+  if (!b.lastUnstableStatus) return -1;
 
-  if (indexOfA < indexOfB) return 1;
-  if (indexOfA === indexOfB) return 0;
-  if (indexOfA > indexOfB) return -1;
+  const rttOfA = RTT[a.lastUnstableStatus];
+  const rttOfB = RTT[b.lastUnstableStatus];
+
+  return rttOfB - rttOfA;
 };
 
 const sortOnline = (a, b) => {

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -30,7 +30,10 @@ class ConnectionStatus {
   private rttValue = makeVar(0);
 
   // @ts-ignore
-  private networkData: ReactiveVar<NetworkData> = makeVar({});
+  private networkData: ReactiveVar<NetworkData> = makeVar({
+    audio: {},
+    video: {},
+  });
 
   private jitterStatus = makeVar('normal');
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes the sorting of connection status reports. Sorting is carried out by `lastUnstableStatus`.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None, but fixes a crash when openning the connection status modal.

![Screenshot from 2024-07-09 15-18-56](https://github.com/bigbluebutton/bigbluebutton/assets/62393923/9c19e8f9-4e63-400d-99f4-060e2e99225d)