### PR TITLE
Fix: Emoji animations are not being turned off by using the slider in settings.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/emoji-rain/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-rain/component.jsx
@@ -85,7 +85,7 @@ const EmojiRain = ({ reactions }) => {
   }, [EMOJI_RAIN_ENABLED, animations, isAnimating]);
 
   useEffect(() => {
-    if (isAnimating) {
+    if (isAnimating && animations !== false) {
       reactions.forEach((reaction) => {
         const currentTime = new Date().getTime();
         const secondsSinceCreated = (currentTime - reaction.creationDate.getTime()) / 1000;


### PR DESCRIPTION
### What does this PR do?

This PR  adjust the verifications to make sure that emoji rain only happens when animations are on.

### Closes Issue(s)

#19354 