### PR TITLE
fix (build): Force to always restart Hasura service after package upgrade

### DIFF
--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -53,7 +53,7 @@ case "$1" in
   if [ ! -f /.dockerenv ]; then
     systemctl enable bbb-graphql-server.service
     systemctl daemon-reload
-    startService bbb-graphql-server || echo "bbb-graphql-server service could not be registered or started"
+    restartService bbb-graphql-server || echo "bbb-graphql-server service could not be registered or started"
 
     #Check if Hasura is ready before applying metadata
     HASURA_PORT=8085


### PR DESCRIPTION
There are situations where the Hasura password is reset. In such cases, it is crucial to restart the Hasura service to ensure it recognizes and applies the new password. 
Without a restart, the service will fail to apply the metadata successfully, leading to an upgrade failure. 
This failure can also impact other services, such as GraphQL Middleware, preventing them from completing their own upgrades. 
This PR addresses this issue by restarting Hasura service when the package is upgraded.