### PR TITLE
Fix: [2.7] Breakout room invitation option missing from user dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -430,7 +430,7 @@ class UserOptions extends PureComponent {
           }}
         />
         {this.renderModal(isCreateBreakoutRoomModalOpen, this.setCreateBreakoutRoomModalIsOpen, "medium",
-          CreateBreakoutRoomContainer, {isBreakoutRecordable, isInvitation})}
+          CreateBreakoutRoomContainer, {isBreakoutRecordable, isInvitation, isUpdate: isInvitation})}
         {this.renderModal(isGuestPolicyModalOpen, this.setGuestPolicyModalIsOpen, "low",
           GuestPolicyContainer)}
         {this.renderModal(isWriterMenuModalOpen, this.setWriterMenuModalIsOpen, "low",

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -133,7 +133,11 @@ const intlMessages = defineMessages({
   newTab: {
     id: 'app.modal.newTab',
     description: 'label used in aria description',
-  }
+  },
+  invitationItem: {
+    id: 'app.userList.userOptions.invitationItem',
+    description: 'Invitation item',
+  },
 });
 
 const USER_STATUS_ENABLED = Meteor.settings.public.userStatus.enabled;
@@ -225,6 +229,10 @@ class UserOptions extends PureComponent {
       && !meetingIsBreakout
       && !hasBreakoutRoom
       && isBreakoutRoomsEnabled();
+
+      const canInviteUsers = amIModerator
+      && !meetingIsBreakout
+      && hasBreakoutRoom
 
     const { locale } = intl;
 
@@ -318,6 +326,22 @@ class UserOptions extends PureComponent {
         });
       }
 
+      if (canInviteUsers && isMeteorConnected) {
+        this.menuItems.push({
+          key: this.createBreakoutId,
+          icon: 'rooms',
+          label: intl.formatMessage(intlMessages.invitationItem),
+          onClick: this.onInvitationUsers,
+          dataTest: 'inviteBreakoutRooms',
+        })
+        // <Dropdown.DropdownListItem
+        //   data-test="inviteBreakoutRooms"
+        //   icon="rooms"
+        //   label={intl.formatMessage(intlMessages.invitationItem)}
+        //   key={this.createBreakoutId}
+        //   onClick={this.onInvitationUsers}
+        // />
+}
       if (amIModerator && CaptionsService.isCaptionsEnabled()) {
         this.menuItems.push({
           icon: 'closed_caption',

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -135,7 +135,7 @@ const intlMessages = defineMessages({
     description: 'label used in aria description',
   },
   invitationItem: {
-    id: 'app.userList.userOptions.invitationItem',
+    id: 'app.userList.userOptions.breakoutRoomInvitationLabel',
     description: 'Invitation item',
   },
 });

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-options/component.jsx
@@ -134,7 +134,7 @@ const intlMessages = defineMessages({
     id: 'app.modal.newTab',
     description: 'label used in aria description',
   },
-  invitationItem: {
+  invitationLabel: {
     id: 'app.userList.userOptions.breakoutRoomInvitationLabel',
     description: 'Invitation item',
   },
@@ -330,17 +330,10 @@ class UserOptions extends PureComponent {
         this.menuItems.push({
           key: this.createBreakoutId,
           icon: 'rooms',
-          label: intl.formatMessage(intlMessages.invitationItem),
+          label: intl.formatMessage(intlMessages.invitationLabel),
           onClick: this.onInvitationUsers,
           dataTest: 'inviteBreakoutRooms',
         })
-        // <Dropdown.DropdownListItem
-        //   data-test="inviteBreakoutRooms"
-        //   icon="rooms"
-        //   label={intl.formatMessage(intlMessages.invitationItem)}
-        //   key={this.createBreakoutId}
-        //   onClick={this.onInvitationUsers}
-        // />
 }
       if (amIModerator && CaptionsService.isCaptionsEnabled()) {
         this.menuItems.push({

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -174,7 +174,7 @@
     "app.userList.userOptions.clearAllLabel": "Clear all status icons",
     "app.userList.userOptions.clearAllDesc": "Clears all status icons from users",
     "app.userList.userOptions.clearAllReactionsLabel": "Clear all reactions",
-    "app.userList.userOptions.invitationItem": "Breakout room invitation",
+    "app.userList.userOptions.breakoutRoomInvitationLabel": "Breakout room invitation",
     "app.userList.userOptions.clearAllReactionsDesc": "Clears all reaction emojis from users",
     "app.userList.userOptions.muteAllExceptPresenterLabel": "Mute all users except presenter",
     "app.userList.userOptions.muteAllExceptPresenterDesc": "Mutes all users in the meeting except the presenter",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -174,6 +174,7 @@
     "app.userList.userOptions.clearAllLabel": "Clear all status icons",
     "app.userList.userOptions.clearAllDesc": "Clears all status icons from users",
     "app.userList.userOptions.clearAllReactionsLabel": "Clear all reactions",
+    "app.userList.userOptions.invitationItem": "Breakout room invitation",
     "app.userList.userOptions.clearAllReactionsDesc": "Clears all reaction emojis from users",
     "app.userList.userOptions.muteAllExceptPresenterLabel": "Mute all users except presenter",
     "app.userList.userOptions.muteAllExceptPresenterDesc": "Mutes all users in the meeting except the presenter",


### PR DESCRIPTION
### What does this PR do?

This PR fixes the missing button with which the moderator could invite user to breakout rooms

### Closes Issue(s)

#19644 