### PR TITLE
feat(plugin): Verify plugin integrity with 'checksum' option

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/loader/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/loader/manager.tsx
@@ -32,6 +32,9 @@ const PluginLoaderManager = (props: PluginLoaderManagerProps) => {
     script.src = plugin.url;
     script.setAttribute('uuid', div.id);
     script.setAttribute('pluginName', plugin.name);
+    if (plugin.checksum) {
+      script.setAttribute('integrity', plugin.checksum);
+    }
     document.head.appendChild(script);
   }, [plugin, containerRef]);
   return null;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/types.ts
@@ -7,6 +7,7 @@ export interface PluginsEngineComponentProps {
 export interface PluginConfig {
     name: string;
     url: string;
+    checksum?: string;
 }
 
 export interface EffectivePluginConfig extends PluginConfig {


### PR DESCRIPTION
This will make use of the integrity attribute present in script tags to prevent supply chain attacks if plugins are loaded from external domains. The checksum should be added as follows in the plugin config:

    plugins:
      - name: GenericComponentPlugin
        url: https://lucas.elos.dev/plugins/GenericComponentPlugin.js
        checksum: "sha384-6eedeb944134dfea9b0395bc4eb312c7b77747e7834e46b83e05becf19aad6f1"
     ...


If the file has changed on the server the javascript will not load in the client. The script tag supports many hashing functions, here's an exemple of how the checksum can be calculated:

    openssl dgst -sha384 -binary GenericComponentPlugin.js | base64


If the plugin does not include the `checksum` setting the check is skipped and thus the default behavior for all plugins is not changed. This is an option for securing plugins in production.