### PR TITLE
refactor: reduce useMemo use

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -182,7 +182,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
       : intlMessages.recordingIndicatorOff,
   ), [recording]);
 
-  const recordMeetingButton = useMemo(() => (
+  const recordMeetingButton = (
     <Styled.RecordingControl
       aria-label={recordTitle}
       aria-describedby="recording-description"
@@ -209,13 +209,13 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
         )}
       </Styled.PresentationTitle>
     </Styled.RecordingControl>
-  ), [recording, micUser, time]);
+  );
 
-  const recordMeetingButtonWithTooltip = useMemo(() => (
+  const recordMeetingButtonWithTooltip = (
     <Tooltip title={intl.formatMessage(intlMessages.stopTitle)}>
       {recordMeetingButton}
     </Tooltip>
-  ), [recording, micUser, time]);
+  );
 
   const recordingButton = recording ? recordMeetingButtonWithTooltip : recordMeetingButton;
   const showButton = isModerator && allowStartStopRecording;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -71,7 +71,8 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
       setTalkingIndicatorList([]);
     };
   }, []);
-  const talkingElements = useMemo(() => talkingUsers.map((talkingUser) => {
+
+  const filteredTalkingUsers = talkingUsers.map((talkingUser) => {
     const {
       talking,
       muted,
@@ -80,6 +81,26 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
         speechLocale,
         name,
       },
+      userId,
+    } = talkingUser;
+    return {
+      talking,
+      muted,
+      color,
+      speechLocale,
+      name,
+      userId,
+    };
+  });
+
+  const talkingElements = useMemo(() => filteredTalkingUsers.map((talkingUser) => {
+    const {
+      talking,
+      muted,
+      color,
+      speechLocale,
+      name,
+      userId,
     } = talkingUser;
 
     const ariaLabel = intl.formatMessage(talking
@@ -90,7 +111,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
     icon = muted ? 'mute' : icon;
     return (
       <Styled.TalkingIndicatorWrapper
-        key={uniqueId(`${name}-`)}
+        key={userId}
         talking={talking}
         muted={muted}
       >
@@ -105,11 +126,11 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
           $spoke={!talking || undefined}
           $muted={muted || undefined}
           $isViewer={!isModerator || undefined}
-          key={uniqueId(`${name}-`)}
+          key={userId}
           onClick={() => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore - call signature is misse due the function being wrapped
-            muteUser(talkingUser.userId, muted, isBreakout, isModerator, toggleVoice);
+            muteUser(userId, muted, isBreakout, isModerator, toggleVoice);
           }}
           label={name}
           tooltipLabel={!muted && isModerator
@@ -134,18 +155,18 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
         </Styled.TalkingIndicatorButton>
       </Styled.TalkingIndicatorWrapper>
     );
-  }), [talkingUsers]);
+  }), [filteredTalkingUsers]);
 
   const maxIndicator = () => {
     if (!moreThanMaxIndicators) return null;
 
-    const nobodyTalking = talkingUsers.every((user) => !user.talking);
+    const nobodyTalking = filteredTalkingUsers.every((user) => !user.talking);
 
     const { moreThanMaxIndicatorsTalking, moreThanMaxIndicatorsWereTalking } = intlMessages;
 
     const ariaLabel = intl.formatMessage(nobodyTalking
       ? moreThanMaxIndicatorsWereTalking : moreThanMaxIndicatorsTalking, {
-      0: talkingUsers.length,
+      0: filteredTalkingUsers.length,
     });
 
     return (

--- a/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
@@ -45,7 +45,7 @@ const SettingsLoader: React.FC = () => {
           method: 'get',
           credentials: 'include',
           headers: {
-            'x-session-token': sessionToken,
+            'x-session-token': sessionToken ?? '',
           },
         })
           .then((resp) => resp.json())

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useMemo,
   useState,
 } from 'react';
 import {
@@ -243,7 +242,8 @@ export const useStreamUsers = (isGridEnabled: boolean) => {
   const { streams } = useStreams();
   const gridSize = useGridSize();
   const [gridUsers, setGridUsers] = useState<GridItem[]>([]);
-  const userIds = useMemo(() => streams.map((s) => s.user.userId), [streams]);
+  const userIds = streams.map((s) => s.user.userId);
+
   const streamCount = streams.length;
   const {
     data: gridData,


### PR DESCRIPTION
### What does this PR do?

- removes useMemo in record indicator component that had time as dependency
- removes unused and unique data from talking indicator useMemo
- removes useStreamUsers hook useMemo

### Motivation

increase client-side performance by removing useMemo from components that do not benefit from it