### PR TITLE
fix(connection-status): stop RTT calculation on meeting end

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -84,6 +84,10 @@ const ConnectionStatus = () => {
       if (STATS_ENABLED) {
         window.removeEventListener('audiostats', handleAudioStatsEvent);
       }
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
     };
   }, []);
 


### PR DESCRIPTION
### What does this PR do?

Does the right cleanup so the RTT calculation stops when the meeting ends.