### PR TITLE
ci: Introduces "in progress" PR comment

### DIFF
--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -39,7 +39,7 @@ jobs:
     needs: get-pr-data
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v2
+        uses: peter-evans/find-comment@v3
         id: fc
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
@@ -47,7 +47,7 @@ jobs:
           body-includes: Automated tests Summary
       - name: Remove previous comment
         if: steps.fc.outputs.comment-id != ''
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.deleteComment({
@@ -65,7 +65,7 @@ jobs:
             <h3><strong>:construction:</strong> Tests are running...</h3>
       - name: Passing tests comment
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
           body: |
@@ -73,7 +73,7 @@ jobs:
             <h3><strong>:white_check_mark:</strong> All the CI tests have passed!</h3>
       - name: Failing tests comment
         if: ${{ github.event.workflow_run.conclusion != 'success' && fromJson(env.isCompleted) }}
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
           body: |

--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -5,44 +5,33 @@ on:
       - Automated tests
     types:
       - completed
-
+      - requested
+env:
+  isCompleted: ${{ github.event.workflow_run.status == 'completed' }}
 jobs:
   get-pr-data:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     outputs:
-      pr-number: ${{ steps.set-env.outputs.pr-number }}
-      workflow-id: ${{ steps.set-env.outputs.workflow-id }}
+      pr-number: ${{ steps.pr.outputs.result }}
+      workflow-id: ${{ github.event.workflow_run.id }}
     steps:
-      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
-      - name: Download artifact
-        uses: actions/github-script@v6
+      - name: Find associated pull request
+        id: pr
+        uses: actions/github-script@v7
         with:
           script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr-comment-data"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr-comment-data.zip`, Buffer.from(download.data));
-      - name: Unzip artifact
-        run: unzip pr-comment-data.zip
-      - name: Set env variables
-        id: set-env
-        run: |
-          echo "pr-number=$(cat ./pr_number)" >> $GITHUB_OUTPUT
-          echo "workflow-id=$(cat ./workflow_id)" >> $GITHUB_OUTPUT
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
+              per_page: 1,
+            })
+            const items = response.data.items
+            if (items.length < 1) {
+              console.error('No PRs found')
+              return
+            }
+            const pullRequestNumber = items[0].number
+            return pullRequestNumber
   comment-pr:
     runs-on: ubuntu-latest
     permissions:
@@ -66,6 +55,14 @@ jobs:
               repo: context.repo.repo,
               comment_id: ${{ steps.fc.outputs.comment-id }}
             })
+      - name: In progress tests comment
+        if: ${{ !fromJson(env.isCompleted) }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          body: |
+            <h1>Automated tests Summary</h1>
+            <h3><strong>:construction:</strong> Tests are running...</h3>
       - name: Passing tests comment
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: peter-evans/create-or-update-comment@v2
@@ -75,7 +72,7 @@ jobs:
             <h1>Automated tests Summary</h1>
             <h3><strong>:white_check_mark:</strong> All the CI tests have passed!</h3>
       - name: Failing tests comment
-        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        if: ${{ github.event.workflow_run.conclusion != 'success' && fromJson(env.isCompleted) }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}


### PR DESCRIPTION
### What does this PR do?
This PR adds the needed code for the publish results workflow to make a comment when the automated tests start to run. This will ease when the action has been re-ran - currently, the previous result comment is being kept.

![2024-07-15_17-31](https://github.com/user-attachments/assets/98dc16a4-f58e-4f88-a940-147a24fe5649)


### More
As this workflow runs based on the pushed file in the default branch for security reasons, the changes here will only be noticed after its merge