### PR TITLE
fix: presenter could not change slide after external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -520,7 +520,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const { element } = fullscreen;
   const fullscreenContext = (element === fullscreenElementId);
   const [key, setKey] = React.useState(uniqueId('react-player'));
-  if (!currentUser || !currentMeeting) return null;
+  if (!currentUser || !currentMeeting?.externalVideo) return null;
   if (!hasExternalVideoOnLayout) return null;
   const playerCurrentTime = currentMeeting.externalVideo?.playerCurrentTime ?? 0;
   const playerPlaybackRate = currentMeeting.externalVideo?.playerPlaybackRate ?? 1;


### PR DESCRIPTION
### What does this PR do?

Fix condition that would cause external video area to remain in place after the presenter ends sharing a video.

### How to test

- Join a meeting
- Start sharing external video
- Stop sharing external video

#### before
- Presenter can't click "next slide" button

#### after
- Presenter is able to pass the slide by clicking "next slide" button