### PR TITLE
chore: Avoid exceeding a secondary rate limit on workflows

### DIFF
--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -11,6 +11,9 @@ env:
 jobs:
   get-pr-data:
     runs-on: ubuntu-latest
+    concurrency:
+      group: github-api-request
+      cancel-in-progress: false
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     outputs:
       pr-number: ${{ steps.pr.outputs.result }}

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -316,7 +316,7 @@ jobs:
           find $HOME/.cache/ms-playwright -name libnssckbi.so -exec rm {} \; -exec ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so {} \;
           npm run test-firefox-ci -- --shard ${{ env.shard }}
           '
-      - if: always() && github.event_name == 'pull_request'
+      - if: always()
         name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -12,8 +12,11 @@ permissions:
 jobs:
   main:
     permissions:
-      pull-requests: write  # for eps1lon/actions-label-merge-conflict to label PRs
+      pull-requests: write # for eps1lon/actions-label-merge-conflict to label PRs
     runs-on: ubuntu-latest
+    concurrency:
+      group: github-api-request
+      cancel-in-progress: false
     steps:
       - name: Check for dirty pull requests
         uses: eps1lon/actions-label-merge-conflict@v3
@@ -21,6 +24,6 @@ jobs:
           dirtyLabel: "status: conflict"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           commentOnDirty: |
-              This pull request has conflicts ☹
-              Please resolve those so we can review the pull request.
-              Thanks.
+            This pull request has conflicts ☹
+            Please resolve those so we can review the pull request.
+            Thanks.


### PR DESCRIPTION
### What does this PR do?
We've noticed recently the `Merge conflict check` and `Automated tests - publish results` workflows not working properly when adding or deleting the bot comment. in the publish results workflow logs, I could see this error with status 403:
```
Error: Unhandled error: HttpError: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.
```
looks like we are exceeding the API requests due to both actions running at the same moment (every time a commit is pushed and right after the automated tests workflow starts - which is triggered by pushing a commit).

Adding the [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency#overview) field can avoid this behavior ([see here](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#avoid-concurrent-requests)) once it waits until the previous action ends



### More
- Also upload the automated tests report on push events (only for pull_request currently)
