### PR TITLE
fix: Blank space when removing all presentations after sharing an external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -1304,21 +1304,28 @@ const reducer = (state, action) => {
       if (action.value.open) {
         presentationAreaContentActions.push(action);
       } else {
-        const indexOfOpenedContent = presentationAreaContentActions.findIndex((p) => {
+        let indexesOfOpenedContent = presentationAreaContentActions.reduce((indexes, p, index) => {
           if (action.value.content === PRESENTATION_AREA.GENERIC_CONTENT) {
-            return (
+            if (
               p.value.content === action.value.content
-                && p.value.open
-                && p.value.genericContentId === action.value.genericContentId
-            );
+              && p.value.open
+              && p.value.genericContentId === action.value.genericContentId
+            ) {
+              indexes.push(index);
+            }
+          } else if (p.value.content === action.value.content && p.value.open) {
+            indexes.push(index);
           }
-          return (
-            p.value.content === action.value.content && p.value.open
-          );
-        });
+          return indexes;
+        }, []);
+        indexesOfOpenedContent = indexesOfOpenedContent.length > 0 ? indexesOfOpenedContent : -1;
         if (
-          indexOfOpenedContent !== -1
-        ) presentationAreaContentActions.splice(indexOfOpenedContent, 1);
+          indexesOfOpenedContent !== -1
+        ) {
+          indexesOfOpenedContent.reverse().forEach((index) => {
+            presentationAreaContentActions.splice(index, 1);
+          });
+        }
       }
       return {
         ...state,


### PR DESCRIPTION
### What does this PR do?

fix blank space in media area after sharing external video

### Closes Issue(s)
Closes #20728

### How to test
1. Join in a meeting with 2 users;
2. Share a video;
3. Stop sharing video;
4. As the presenter: `Actions button > manage presentations > delete all > confirm`;