### PR TITLE
feat: Pass a different presentation to each breakout

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/BreakoutModel.scala
@@ -18,8 +18,11 @@ object BreakoutModel {
       captureSlides: Boolean,
       captureNotesFilename: String,
       captureSlidesFilename: String,
+      allPages: Boolean,
+      presId: String,
   ): BreakoutRoom2x = {
-    new BreakoutRoom2x(id, externalId, name, parentId, sequence, shortName, isDefaultName, freeJoin, voiceConf, assignedUsers, Vector(), Vector(), None, false, captureNotes, captureSlides, captureNotesFilename, captureSlidesFilename)
+    new BreakoutRoom2x(id, externalId, name, parentId, sequence, shortName, isDefaultName, freeJoin, voiceConf, assignedUsers, Vector(), Vector(), None, false,
+      captureNotes, captureSlides, captureNotesFilename, captureSlidesFilename, allPages, presId)
   }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/domain/BreakoutRoom2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/domain/BreakoutRoom2x.scala
@@ -19,6 +19,8 @@ case class BreakoutRoom2x(
     captureSlides:         Boolean,
     captureNotesFilename:  String,
     captureSlidesFilename: String,
+    allPages: Boolean,
+    presId: String,
 ) {
 
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -71,7 +71,7 @@ case class BreakoutRoomDetail(
 object CreateBreakoutRoomsCmdMsg { val NAME = "CreateBreakoutRoomsCmdMsg" }
 case class CreateBreakoutRoomsCmdMsg(header: BbbClientMsgHeader, body: CreateBreakoutRoomsCmdMsgBody) extends StandardMsg
 case class CreateBreakoutRoomsCmdMsgBody(meetingId: String, durationInMinutes: Int, record: Boolean, captureNotes: Boolean, captureSlides: Boolean, rooms: Vector[BreakoutRoomMsgBody], sendInviteToModerators: Boolean)
-case class BreakoutRoomMsgBody(name: String, sequence: Int, shortName: String, captureNotesFilename: String, captureSlidesFilename: String, isDefaultName: Boolean, freeJoin: Boolean, users: Vector[String])
+case class BreakoutRoomMsgBody(name: String, sequence: Int, shortName: String, captureNotesFilename: String, captureSlidesFilename: String, isDefaultName: Boolean, freeJoin: Boolean, users: Vector[String], allPages: Boolean, presId: String)
 
 // Sent by user to request ending all the breakout rooms
 object EndAllBreakoutRoomsMsg { val NAME = "EndAllBreakoutRoomsMsg" }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
@@ -94,6 +94,7 @@ public class PresentationUrlDownloadService {
                 }, 5, TimeUnit.SECONDS);
     }
 
+    // A negative presentationSlide indicates the entire presentation deck should be used.
     private void extractPage(final String sourceMeetingId, final String presentationId,
                              final Integer presentationSlide, final String destinationMeetingId) {
 
@@ -146,7 +147,7 @@ public class PresentationUrlDownloadService {
                 + newFilename;
         File newPresentation = new File(newFilePath);
 
-        if (sourcePresentationFile.getName().toLowerCase().endsWith("pdf")) {
+        if (sourcePresentationFile.getName().toLowerCase().endsWith("pdf") && presentationSlide >= 0) {
             pageExtractor.extractPage(sourcePresentationFile, new File(
                     newFilePath), presentationSlide);
         } else {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import ActionsBarService from '/imports/ui/components/actions-bar/service';
 import BreakoutRoomService from '/imports/ui/components/breakout-room/service';
 import CreateBreakoutRoomModal from './component';
+import Presentations from '/imports/api/presentations';
 import { isImportSharedNotesFromBreakoutRoomsEnabled, isImportPresentationWithAnnotationsFromBreakoutRoomsEnabled } from '/imports/ui/services/features';
 
 const METEOR_SETTINGS_APP = Meteor.settings.public.app;
@@ -46,4 +47,5 @@ export default withTracker(() => ({
   meetingName: ActionsBarService.meetingName(),
   amIModerator: ActionsBarService.amIModerator(),
   moveUser: ActionsBarService.moveUser,
+  presentations: Presentations.find({ 'conversion.done': true }).fetch(),
 }))(CreateBreakoutRoomContainer);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/styles.js
@@ -68,6 +68,15 @@ const FreeJoinLabel = styled.label`
   }
 `;
 
+const BreakoutSlideLabel = styled.label`
+  font-size: ${fontSizeSmall};
+  font-weight: bolder;
+  display: flex;
+  align-items: center;
+  font-size: ${fontSizeSmall};
+  margin-bottom: 0.2rem;
+`
+
 const BreakoutNameInput = styled.input`
   width: 100%;
   text-align: center;
@@ -377,4 +386,5 @@ export default {
   SubTitle,
   Content,
   ContentContainer,
+  BreakoutSlideLabel,
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1249,6 +1249,7 @@
     "app.createBreakoutRoom.setTimeHigherThanMeetingTimeError": "The breakout rooms duration can't exceed the meeting remaining time.",
     "app.createBreakoutRoom.roomNameInputDesc": "Updates breakout room name",
     "app.createBreakoutRoom.movedUserLabel": "Moved {0} to room {1}",
+    "app.createBreakoutRoom.currentSlideLabel": "Current slide",
     "app.updateBreakoutRoom.modalDesc": "To update or invite a user, simply drag them into the desired room.",
     "app.updateBreakoutRoom.cancelLabel": "Cancel",
     "app.updateBreakoutRoom.title": "Update Breakout Rooms",


### PR DESCRIPTION
### What does this PR do?
Introduces two new parameters to the `CreateBreakoutRoomsCmdMsg` call that controls which presentations and which slides appear in the breakout rooms.

### Closes Issue 
Closes #20626 

### Motivation

Provide the backend functionality for the client to build upon

### How to test

When the client creates the breakout room, each of them can individually specify the new `allPages` and `presId` parameters.

- When `allPages` is true, the presentation in the breakout room contains all slides of the specified presentation. If false, it uses the current slide or the one that the presentation showed last.

- `presId` is the identifier of the desired presentation. If left blank, it defaults to the current presentation.

The parameters interact as follows:

| All pages | Presentation | Breakout room shows                                                  |
| --------- | ------------ | -------------------------------------------------------------------- |
| false     | none         | current slide of the current presentation                            |
| false     | `presId`     | last shown slide of the specified presentation, first if never shown |
| true      | none         | all slides of the current presentation, starting from the first      |
| true      | `presId`     | all slides of the specified presentation, starting from the first    |

With a sample call from the client being:

```javascript
const rooms = range(1, numberOfRooms + 1).map((seq) => ({
	users, 
	name,
	captureNotesFilename,
	captureSlidesFilename,
	shortName,
	isDefaultName,
	freeJoin,
	sequence,
	allPages: true, // False for current slide in breakout, true for entire deck
	presId: 'abbeac32de1c32a803190231a239ba68f8805619-1661250031364'// The presentation ID used in the breakout room
}));
```

### More

The behavior of `allPages` matches the behavior of `ExportPresentationWithAnnotationReqMsg` and `MakePresentationWithAnnotationDownloadReqMsg` as specified by Richard in 2021, but they are distinct parameters and we are defaulting them to `true`. So all content is brought back from the breakout rooms (be it one or several slides) at the moment.