### PR TITLE
remove (gql-server): Removes old postgresql user/tables created for Meteor auth

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -449,13 +449,6 @@ AS SELECT "user"."userId",
     "user"."inactivityWarningTimeoutSecs"
    FROM "user";
 
---This view will be used by Meteor to validate if the provided authToken is valid
---It is temporary while Meteor is not removed
-create view "v_user_connection_auth" as
-select "meetingId", "userId", "authToken"
-from "v_user_current"
-where "isOnline" is true;
-
 CREATE OR REPLACE VIEW "v_user_guest" AS
 SELECT u."meetingId", u."userId",
 u."guestStatus",

--- a/bbb-graphql-server/deploy.sh
+++ b/bbb-graphql-server/deploy.sh
@@ -25,22 +25,6 @@ sudo runuser -u postgres -- psql -q -c "alter database bbb_graphql set timezone 
 echo "Creating tables in bbb_graphql"
 sudo runuser -u postgres -- psql -U postgres -d bbb_graphql -q -f bbb_schema.sql --set ON_ERROR_STOP=on
 
-echo "Creating frontend in bbb_graphql"
-DATABASE_FRONTEND_USER="bbb_frontend"
-FRONT_USER_EXISTS=$(sudo -u postgres psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '$DATABASE_FRONTEND_USER'")
-if [ "$FRONT_USER_EXISTS" = '1' ]
-then
-    echo "User $DATABASE_FRONTEND_USER already exists"
-else
-    sudo -u postgres psql -q -c "CREATE USER $DATABASE_FRONTEND_USER WITH PASSWORD '$DATABASE_FRONTEND_USER'"
-    sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
-    sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
-    sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
-    echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
-fi
-
-sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
-
 echo "Starting Hasura"
 sudo systemctl start bbb-graphql-server
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1122,13 +1122,6 @@ public:
       - coffeeshop.jpg
       - board.jpg
 private:
-  postgresql:
-    host: localhost
-    port: 5432
-    database: bbb_graphql
-    user: bbb_frontend
-    password: bbb_frontend
-    timeout: 30000
   analytics:
     includeChat: true
   app:

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -21,22 +21,6 @@ case "$1" in
       echo "Database $DATABASE_NAME created"
   fi
 
-  # Create a readonly user that will be used by Meteor to check authToken (while Meteor not removed from the project)
-  DATABASE_FRONTEND_USER="bbb_frontend"
-  FRONT_USER_EXISTS=$(sudo -u postgres psql -U postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = '$DATABASE_FRONTEND_USER'")
-  if [ "$FRONT_USER_EXISTS" = '1' ]
-  then
-      echo "User $DATABASE_FRONTEND_USER already exists"
-  else
-      sudo -u postgres psql -q -c "CREATE USER $DATABASE_FRONTEND_USER WITH PASSWORD '$DATABASE_FRONTEND_USER'"
-      sudo -u postgres psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO $DATABASE_FRONTEND_USER"
-      sudo -u postgres psql -q -d bbb_graphql -c "REVOKE ALL ON ALL TABLES IN SCHEMA public FROM $DATABASE_FRONTEND_USER"
-      sudo -u postgres psql -q -d bbb_graphql -c "GRANT USAGE ON SCHEMA public TO $DATABASE_FRONTEND_USER"
-      echo "User $DATABASE_FRONTEND_USER created on database bbb_graphql"
-  fi
-
-  sudo -u postgres psql -q -d bbb_graphql -c "GRANT SELECT ON v_user_connection_auth TO $DATABASE_FRONTEND_USER"
-
   echo "Postgresql configured"
 
   #Generate a random password to Hasura to improve security


### PR DESCRIPTION
A temporary user and view was created to allow Meteor perform user validation.
It is no longer used so this PR removes this part.

- Remove view `v_user_connection_auth`
- Remove user `bbb_frontend`