### PR TITLE
fix(bbb-web and html5): removed .odi and .odc file-type supports (back-port)

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/FileTypeConstants.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/FileTypeConstants.java
@@ -31,6 +31,7 @@ public final class FileTypeConstants {
     public static final String RTF = "rtf";
     public static final String TXT = "txt";
     public static final String ODS = "ods";
+    public static final String ODG = "odg";
     public static final String ODP = "odp";
     public static final String AVI = "avi";
     public static final String MPG = "mpg";
@@ -38,6 +39,7 @@ public final class FileTypeConstants {
     public static final String PDF = "pdf";
     public static final String JPG = "jpg";
     public static final String JPEG = "jpeg";
+    public static final String WEBP = "webp";
     public static final String PNG = "png";
     public static final String SVG = "svg";
     private FileTypeConstants() {} // Prevent instantiation

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java
@@ -19,12 +19,17 @@ public class MimeTypeUtils {
     private  static final String RTF = "application/rtf";
     private  static final String TXT = "text/plain";
     private  static final String ODS = "application/vnd.oasis.opendocument.spreadsheet";
+    private static final String ODG = "application/vnd.oasis.opendocument.graphics";
     private  static final String ODP = "application/vnd.oasis.opendocument.presentation";
     private  static final String PDF = "application/pdf";
     private  static final String JPEG = "image/jpeg";
     private  static final String PNG = "image/png";
     private  static final String SVG = "image/svg+xml";
+    private static final String WEBP = "image/webp";
 
+    // If the following mime-types are changed, please, make sure to also change:
+    // bigbluebutton-html5/private/config/settings.yml: L827
+    // docs/docs/development/api.md: L1222
     private static final HashMap<String, List<String>> EXTENSIONS_MIME = new HashMap<String, List<String>>(16) {
         {
             put(FileTypeConstants.DOC, Arrays.asList(DOC, DOCX, TIKA_MSOFFICE, TIKA_MSOFFICE_X));
@@ -34,6 +39,7 @@ public class MimeTypeUtils {
             put(FileTypeConstants.PPTX, Arrays.asList(PPT, PPTX, TIKA_MSOFFICE, TIKA_MSOFFICE_X));
             put(FileTypeConstants.XLSX, Arrays.asList(XLS, XLSX, TIKA_MSOFFICE, TIKA_MSOFFICE_X));
             put(FileTypeConstants.ODT, Arrays.asList(ODT));
+            put(FileTypeConstants.ODG, Arrays.asList(ODG));
             put(FileTypeConstants.RTF, Arrays.asList(RTF));
             put(FileTypeConstants.TXT, Arrays.asList(TXT));
             put(FileTypeConstants.ODS, Arrays.asList(ODS));
@@ -43,6 +49,7 @@ public class MimeTypeUtils {
             put(FileTypeConstants.JPEG, Arrays.asList(JPEG));
             put(FileTypeConstants.PNG, Arrays.asList(PNG));
             put(FileTypeConstants.SVG, Arrays.asList(SVG));
+            put(FileTypeConstants.WEBP, Arrays.asList(WEBP));
         }
     };
 
@@ -71,8 +78,9 @@ public class MimeTypeUtils {
 
     public List<String> getValidMimeTypes() {
         List<String> validMimeTypes = Arrays.asList(XLS, XLSX,
-                DOC, DOCX, PPT, PPTX, ODT, RTF, TXT, ODS, ODP,
-                PDF, JPEG, PNG, SVG, TIKA_MSOFFICE, TIKA_MSOFFICE_X
+                DOC, DOCX, PPT, PPTX, ODT, RTF, TXT, ODS, ODP, ODG,
+                PDF, JPEG, PNG, SVG, TIKA_MSOFFICE, TIKA_MSOFFICE_X,
+                WEBP
         );
         return validMimeTypes;
     }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SupportedDocumentFilter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SupportedDocumentFilter.java
@@ -40,7 +40,7 @@ public class SupportedDocumentFilter {
 
     /* Get file extension - Perhaps try to rely on a more accurate method than an extension type ? */
     String extension = FilenameUtils.getExtension(presentationFile.getName());
-    boolean supported = SupportedFileTypes.isFileSupported(extension);
+    boolean supported = SupportedFileTypes.isPresentationMimeTypeValid(presentationFile, extension);
     notifyProgressListener(supported, pres);
     if (supported) {
       log.info("Received supported file {}", pres.getUploadedFile().getAbsolutePath());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SupportedFileTypes.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SupportedFileTypes.java
@@ -38,37 +38,21 @@ public final class SupportedFileTypes {
 
 	private static Logger log = LoggerFactory.getLogger(SupportedFileTypes.class);
 	private static MimeTypeUtils mimeTypeUtils = new MimeTypeUtils();
-
-	private static final List<String> SUPPORTED_FILE_LIST = Collections.unmodifiableList(new ArrayList<String>(15) {		
-		{				
-			// Add all the supported files				
-			add(XLS); add(XLSX);	add(DOC); add(DOCX); add(PPT); add(PPTX);				
-			add(ODT); add(RTF); add(TXT); add(ODS); add(ODP); add(PDF);
-			add(JPG); add(JPEG); add(PNG);
-		}
-	});
 		
 	private static final List<String> OFFICE_FILE_LIST = Collections.unmodifiableList(new ArrayList<String>(11) {		
 		{			
 			// Add all Offile file types
 			add(XLS); add(XLSX);	add(DOC); add(DOCX); add(PPT); add(PPTX);				
-			add(ODT); add(RTF); add(TXT); add(ODS); add(ODP); 
+			add(ODT); add(RTF); add(TXT); add(ODS); add(ODP); add(ODG);
 		}
 	});
 	
 	private static final List<String> IMAGE_FILE_LIST = Collections.unmodifiableList(new ArrayList<String>(3) {		
 		{	
 			// Add all image file types
-			add(JPEG); add(JPG); add(PNG);
+			add(JPEG); add(JPG); add(PNG); add(WEBP); add(SVG);
 		}
 	});
-
-	/*
-	 * Returns if the file with extension is supported.
-	 */
-	public static boolean isFileSupported(String fileExtension) {
-		return SUPPORTED_FILE_LIST.contains(fileExtension.toLowerCase());
-	}
 	
 	/*
 	 * Returns if the Office file is supported.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -821,6 +821,9 @@ public:
     mirroredFromBBBCore:
       uploadSizeMax: 30000000
       uploadPagesMax: 200
+    # If the following mime-types list is changed, please, make sure to also change:
+    # bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java: L34 (and related files.)
+    # docs/docs/development/api.md: L1222
     uploadValidMimeTypes:
       - extension: .pdf
         mime: application/pdf
@@ -848,10 +851,6 @@ public:
         mime: application/vnd.oasis.opendocument.presentation
       - extension: .odg
         mime: application/vnd.oasis.opendocument.graphics
-      - extension: .odc
-        mime: application/vnd.oasis.opendocument.chart
-      - extension: .odi
-        mime: application/vnd.oasis.opendocument.image
       - extension: .jpg
         mime: image/jpeg
       - extension: .jpeg
@@ -860,6 +859,8 @@ public:
         mime: image/png
       - extension: .webp
         mime: image/webp
+      - extension: .svg
+        mime: image/svg+xm
   selectRandomUser:
     enabled: true
     countdown: false

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -1217,31 +1217,44 @@ For example, the application may be able to register a URL that BigBlueButton wo
 
 ## Other Topics
 
-### Presentation Formats
+### Supported Document Types
 
-Valid presentation formats are listed down below:
+#### PDF Documents
 
-- Adobe Acrobat documents:
-  - extension: .pdf
-- Office documents:
-  - extension: .doc
-  - extension: .docx
-  - extension: .xls
-  - extension: .xlsx
-  - extension: .ppt
-  - extension: .pptx
-  - extension: .odt
-  - extension: .ods
-  - extension: .odp
-  - extension: .odg
-- Image:
-  - extension: .jpg
-  - extension: .jpeg
-  - extension: .png
-  - extension: .webp
-  - extension: .svg
-- Pure text:
-  - extension: .rtf
-  - extension: .txt
+- PDF:
+  - .pdf
+
+#### Office Documents
+
+- Microsoft Word:
+  - .doc
+  - .docx
+- Microsoft Excel:
+  - .xls
+  - .xlsx
+- Microsoft PowerPoint:
+  - .ppt
+  - .pptx
+- OpenDocument Formats:
+  - .odt (Text Document)
+  - .ods (Spreadsheet)
+  - .odp (Presentation)
+  - .odg (Graphics)
+
+#### Image Files
+
+- Common Image Formats:
+  - .jpg
+  - .jpeg
+  - .png
+  - .webp
+  - .svg
+
+#### Text Files
+
+- Rich Text Format:
+  - .rtf
+- Plain Text:
+  - .txt
 
 All these valid formats are also present in a list in the [back-end](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.10/bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java#L28-L47) and in the [front-end](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.10/bigbluebutton-html5/private/config/settings.yml#L824-L862) if more details are needed.

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -1219,7 +1219,7 @@ For example, the application may be able to register a URL that BigBlueButton wo
 
 ### Presentation Formats
 
-Valid formats of presentation is as described in the list ahead:
+Valid presentation formats are listed down below:
 
 - Adobe Acrobat documents:
   - extension: .pdf

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -509,7 +509,7 @@ See [Passing custom parameters to the client on join](/administration/customize/
 
 ### `POST` insertDocument
 
-This endpoint insert one or more documents into a running meeting via API call
+This endpoint insert one or more documents into a running meeting via API call.
 
 **Resource URL:**
 
@@ -1214,3 +1214,34 @@ For example, the application may be able to register a URL that BigBlueButton wo
 - http&#58;//third-party-app/bbb-integ.php?event=meetingEnded&meetingID=abcd
 - http&#58;//third-party-app/bbb-integ.php?event=userLeft&userID=1234
 - http&#58;//third-party-app/bbb-integ.php?event=meetingEnded&meetingID=abcd
+
+## Other Topics
+
+### Presentation Formats
+
+Valid formats of presentation is as described in the list ahead:
+
+- Adobe Acrobat documents:
+  - extension: .pdf
+- Office documents:
+  - extension: .doc
+  - extension: .docx
+  - extension: .xls
+  - extension: .xlsx
+  - extension: .ppt
+  - extension: .pptx
+  - extension: .odt
+  - extension: .ods
+  - extension: .odp
+  - extension: .odg
+- Image:
+  - extension: .jpg
+  - extension: .jpeg
+  - extension: .png
+  - extension: .webp
+  - extension: .svg
+- Pure text:
+  - extension: .rtf
+  - extension: .txt
+
+All these valid formats are also present in a list in the [back-end](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.10/bbb-common-web/src/main/java/org/bigbluebutton/presentation/MimeTypeUtils.java#L28-L47) and in the [front-end](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.10/bigbluebutton-html5/private/config/settings.yml#L824-L862) if more details are needed.


### PR DESCRIPTION
### What does this PR do?

It does a set of things related to file-type support:

- It removes support for `.odi` and `.odc`;
- It adds support for `.webp` files (even thought animated webp's aren't animated after the image processing in the back-end);
- It adds support for `.odg` files;
- It adds support for SVG files;
- It unifies file-type validation in the back-end document processing;
- It makes the list of supported file-types in the front-end equal to that of the back-end;
- And lastly, it adds a brief comment in the documentation pointing to the supported file-types.

Screenshots of the Doc comment down below:

![image](https://github.com/user-attachments/assets/aaa98e98-711b-45b0-a843-fbda8d361425)!

![image](https://github.com/user-attachments/assets/8ba99147-0eb5-4786-9c9c-ef737ad79b98)

### Closes Issue(s)

Closes #20346 and #20092

### How to test

- Build common-web;
- Run from source code bbb-web;
- Run html5 from source code as well;
- Now try to upload a .odi file, then a .odc file, see errors;
- Try to upload a .odg file and see that it happens normally;

### More

A minor note that is worth mentioning: To have a sample `.odi` and `.odc` files, they are rarely found these days, so, chatGPT can produce them if you ask.

This is a back-port from #20729.
