### PR TITLE
fix: askForConfirmationOnLeave not working if user joined mic

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -96,6 +96,7 @@ export default {
   isConnecting: () => AudioManager.isConnecting,
   isListenOnly: () => AudioManager.isListenOnly,
   isEchoTest: () => AudioManager.isEchoTest,
+  isMuted: () => AudioManager.isMuted,
   autoplayBlocked: () => AudioManager.autoplayBlocked,
   handleAllowAutoplay: () => AudioManager.handleAllowAutoplay(),
   playAlertSound: (url) => AudioManager.playAlertSound(url),


### PR DESCRIPTION
### What does this PR do?

Confirmation popup was not showing when the user had joined audio, and also the mute function was not working, this PR fixes it

- Fix missing isMuted in Audio Service
- Fix muteMicrophone function not working on leave
  - The `onbeforeunload` event was not receiving the updated muteMicrophone function, so the function was not working

### How to test

1. Start a meeting with `askForConfirmationOnLeave` enabled
2. Join audio with microphone
3. Unmute own microphone
4. Try to close the tab/window

The confirmation dialog should appear and the microphone should be muted.