### PR TITLE
fix: Blank space when removing all presentations when external video is playing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -187,6 +187,11 @@ class Presentation extends PureComponent {
         type: ACTIONS.SET_PRESENTATION_SLIDES_LENGTH,
         value: totalPages,
       });
+    } else {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_SLIDES_LENGTH,
+        value: 0,
+      });
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Fix a case where the media area would get empty if all the presentations are removed while an external video is being shared.

### How to test
1. Join in a meeting with 2 users;
2. Share external video;
4. As the presenter: `Actions button > manage presentations > delete all > confirm`;
5. Stop sharing external video;
