### PR TITLE
fix: Client crash on load when media.webspeech.synth.enabled = false

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -52,6 +52,8 @@ export const getSpeechVoices = () => {
   const LANGUAGES = window.meetingClientSettings.public.app.audioCaptions.language.available;
   if (!isWebSpeechApi()) return LANGUAGES;
 
+  if (!window.speechSynthesis) return null;
+
   return unique(
     window
       .speechSynthesis


### PR DESCRIPTION
### What does this PR do?

fix crash on Firefox if speech synthesis is not enabled

### Closes Issue(s)
Closes #20747

### How to test
1. Set `media.webspeech.synth.enabled` to `false` in Firefox about:config
2. Join Session