### PR TITLE
Breakouts - do not allow slide/presentation change on breakout update

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/create-breakout-room/component.jsx
@@ -993,7 +993,7 @@ class BreakoutRoom extends PureComponent {
                   {intl.formatMessage(intlMessages.roomNameInputDesc)}
                 </div>
               </Styled.FreeJoinLabel>
-              { presentations.length > 0 ? (
+              { presentations.length > 0 && !isUpdate ? (
                 <Styled.BreakoutSlideLabel>
                   <Styled.InputRooms
                     value={this.getRoomPresentation(value)}


### PR DESCRIPTION
### What does this PR do?

Hides presentation dropdown on breakout update modal if breakouts are active

### Closes Issue(s)
Closes #20760

### How to test
1. join a meeting
2. create breakout rooms (presentation dropdown should be visible for each breakout room
3. select "manage users" in breakout panel dropdown
4. presentation dropdown should not appear
