### PR TITLE
feat(config): introduce allowPresentationManagementInBreakouts to be able to block breakouts pres uploads

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -186,7 +186,7 @@ class ActionsDropdown extends PureComponent {
       hasCameraAsContent,
       isCameraAsContentEnabled,
       isTimerFeatureEnabled,
-      isPresentationUploadDisabled,
+      isPresentationManagementDisabled,
     } = this.props;
 
     const { pollBtnLabel, presentationLabel, takePresenter } = intlMessages;
@@ -195,7 +195,7 @@ class ActionsDropdown extends PureComponent {
 
     const actions = [];
 
-    if (amIPresenter && !isPresentationUploadDisabled && isPresentationEnabled()) {
+    if (amIPresenter && !isPresentationManagementDisabled && isPresentationEnabled()) {
       actions.push({
         icon: 'upload',
         dataTest: 'managePresentations',

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -186,6 +186,7 @@ class ActionsDropdown extends PureComponent {
       hasCameraAsContent,
       isCameraAsContentEnabled,
       isTimerFeatureEnabled,
+      isPresentationUploadDisabled,
     } = this.props;
 
     const { pollBtnLabel, presentationLabel, takePresenter } = intlMessages;
@@ -194,7 +195,7 @@ class ActionsDropdown extends PureComponent {
 
     const actions = [];
 
-    if (amIPresenter && isPresentationEnabled()) {
+    if (amIPresenter && !isPresentationUploadDisabled && isPresentationEnabled()) {
       actions.push({
         icon: 'upload',
         dataTest: 'managePresentations',

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -3,6 +3,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import Presentations from '/imports/api/presentations';
 import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
 import PresentationPodService from '/imports/ui/components/presentation-pod/service';
+import AppService from '/imports/ui/components/app/service';
 import ActionsDropdown from './component';
 import { layoutSelectInput, layoutDispatch, layoutSelect } from '../../layout/context';
 import { SMALL_VIEWPORT_BREAKPOINT } from '../../layout/enums';
@@ -32,6 +33,10 @@ const ActionsDropdownContainer = (props) => {
 
 export default withTracker(() => {
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
+  const { allowUploadNewDocsInBreakouts } = Meteor.settings.public.app.breakouts;
+  const isPresentationUploadDisabled = AppService.meetingIsBreakout()
+    && !allowUploadNewDocsInBreakouts;
+
   return {
     presentations,
     isTimerFeatureEnabled: isTimerFeatureEnabled(),
@@ -39,5 +44,6 @@ export default withTracker(() => {
     setPresentation: PresentationUploaderService.setPresentation,
     podIds: PresentationPodService.getPresentationPodIds(),
     isCameraAsContentEnabled: isCameraAsContentEnabled(),
+    isPresentationUploadDisabled,
   };
 })(ActionsDropdownContainer);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -33,9 +33,9 @@ const ActionsDropdownContainer = (props) => {
 
 export default withTracker(() => {
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
-  const { allowUploadNewDocsInBreakouts } = Meteor.settings.public.app.breakouts;
-  const isPresentationUploadDisabled = AppService.meetingIsBreakout()
-    && !allowUploadNewDocsInBreakouts;
+  const { allowDocsManagementInBreakouts } = Meteor.settings.public.app.breakouts;
+  const isPresentationManagementDisabled = AppService.meetingIsBreakout()
+    && !allowDocsManagementInBreakouts;
 
   return {
     presentations,
@@ -44,6 +44,6 @@ export default withTracker(() => {
     setPresentation: PresentationUploaderService.setPresentation,
     podIds: PresentationPodService.getPresentationPodIds(),
     isCameraAsContentEnabled: isCameraAsContentEnabled(),
-    isPresentationUploadDisabled,
+    isPresentationManagementDisabled,
   };
 })(ActionsDropdownContainer);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -33,9 +33,9 @@ const ActionsDropdownContainer = (props) => {
 
 export default withTracker(() => {
   const presentations = Presentations.find({ 'conversion.done': true }).fetch();
-  const { allowDocsManagementInBreakouts } = Meteor.settings.public.app.breakouts;
+  const { allowPresentationManagementInBreakouts } = Meteor.settings.public.app.breakouts;
   const isPresentationManagementDisabled = AppService.meetingIsBreakout()
-    && !allowDocsManagementInBreakouts;
+    && !allowPresentationManagementInBreakouts;
 
   return {
     presentations,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -138,7 +138,7 @@ public:
       captureSharedNotesByDefault: false
       sendInvitationToAssignedModeratorsByDefault: false
       breakoutRoomLimit: 16
-      allowUploadNewDocsInBreakouts: false
+      allowDocsManagementInBreakouts: false
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: false
     customHeartbeatUseDataFrames: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -138,6 +138,7 @@ public:
       captureSharedNotesByDefault: false
       sendInvitationToAssignedModeratorsByDefault: false
       breakoutRoomLimit: 16
+      allowUploadNewDocsInBreakouts: false
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: false
     customHeartbeatUseDataFrames: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -138,7 +138,7 @@ public:
       captureSharedNotesByDefault: false
       sendInvitationToAssignedModeratorsByDefault: false
       breakoutRoomLimit: 16
-      allowDocsManagementInBreakouts: false
+      allowPresentationManagementInBreakouts: true
     # https://github.com/bigbluebutton/bigbluebutton/pull/10826
     customHeartbeat: false
     customHeartbeatUseDataFrames: true


### PR DESCRIPTION
### What does this PR do?

introduces allowDocsManagementInBreakouts property in settings.yml

### Closes Issue(s)
Closes #20759

### How to test
1. join a meeting
2. create breakout rooms
3. join a breakout room
4. if `allowDocsManagementInBreakouts: false` (default), the presenter should not see `Upload/Manage presentations` on the + button