### PR TITLE
fix(html5): connection status picking wrong status

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -381,20 +381,20 @@ const calculateBitsPerSecondFromMultipleData = (currentData, previousData) => {
 const sortConnectionData = (connectionData) => connectionData.sort(sortLevel).sort(sortOnline);
 
 export function getStatus(levels, value) {
-  const sortedLevels = Object.keys(levels)
-    .map(Number)
-    .sort((a, b) => a - b);
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0; i < sortedLevels.length; i++) {
-    if (value < sortedLevels[i]) {
-      return i === 0 ? 'normal' : levels[sortedLevels[i - 1]];
+  const sortedLevels = Object.entries(levels)
+    .map((entry) => [entry[0], Number(entry[1])])
+    .sort((a, b) => a[1] - b[1]);
+
+  for (let i = 0; i < sortedLevels.length; i += 1) {
+    if (value < sortedLevels[i][1]) {
+      return i === 0 ? 'normal' : sortedLevels[i - 1][0];
     }
     if (i === sortedLevels.length - 1) {
-      return levels[sortedLevels[i]];
+      return sortedLevels[i][0];
     }
   }
 
-  return levels[sortedLevels[sortedLevels.length - 1]];
+  return sortedLevels[sortedLevels.length - 1][0];
 }
 
 /**


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes connection status picking wrong status due to not considering config value format properly.

<img width="911" alt="Untitled" src="https://github.com/user-attachments/assets/c1d51d12-bf56-4aeb-a4de-9463a28f4ab1">

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None