### PR TITLE
fix(webcam): client failing to apply virtual background effect

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -74,6 +74,8 @@ const deleteStream = (deviceId) => {
   return VIDEO_STREAM_STORAGE.delete(deviceId);
 }
 
+const clearStreams = () => VIDEO_STREAM_STORAGE.clear();
+
 const promiseTimeout = (ms, promise) => {
   const timeout = new Promise((resolve, reject) => {
     const id = setTimeout(() => {
@@ -246,4 +248,5 @@ export default {
   getCameraProfile,
   doGUM,
   terminateCameraStream,
+  clearStreams,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -149,7 +149,7 @@ const VirtualBgSelector = ({
     });
 
     const webcamBackgroundURL = webcamBackground?.webcamBackground;
-    if (webcamBackgroundURL !== '') {
+    if (webcamBackgroundURL !== '' && !backgrounds.webcamBackgroundURL) {
       dispatch({
         type: 'update',
         background: {
@@ -158,6 +158,7 @@ const VirtualBgSelector = ({
           data: webcamBackgroundURL,
           lastActivityDate: Date.now(),
           custom: true,
+          sessionOnly: true,
         },
       });
       handleVirtualBgSelected(

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/context.jsx
@@ -39,7 +39,7 @@ const reducer = (state, action) => {
       };
     }
     case 'update': {
-      if (action.background.custom) update(action.background);
+      if (action.background.custom && !action.background.sessionOnly) update(action.background);
       return {
         ...state,
         backgrounds: {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.jsx
@@ -11,6 +11,7 @@ import { isVirtualBackgroundsEnabled } from '/imports/ui/services/features';
 import Button from '/imports/ui/components/common/button/component';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
 import Settings from '/imports/ui/services/settings';
+import PreviewService from '/imports/ui/components/video-preview/service';
 
 const ENABLE_WEBCAM_SELECTOR_BUTTON = Meteor.settings.public.app.enableWebcamSelectorButton;
 const ENABLE_CAMERA_BRIGHTNESS = Meteor.settings.public.app.enableCameraBrightness;
@@ -108,6 +109,7 @@ const JoinVideoButton = ({
       default:
         if (exitVideo()) {
           VideoService.exitVideo();
+          PreviewService.clearStreams();
         } else {
           setForceOpen(isMobileSharingCamera);
           setVideoPreviewModalIsOpen(true);

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
@@ -388,42 +388,8 @@ export async function createVirtualBackgroundService(parameters = null) {
     } else {
         parameters.virtualSource = virtualBackgroundImagePath + parameters.backgroundFilename;
 
-        if (parameters.customParams) {
-            if (parameters.customParams.file) {
-                parameters.virtualSource = parameters.customParams.file;
-            } else {
-                const imageUrl = parameters.customParams.url;
-
-                // Function to convert image URL to a File object
-                async function getFileFromUrl(url) {
-                    try {
-                        const response = await fetch(url, {
-                            credentials: 'omit',
-                            mode: 'cors',
-                            headers: {
-                                'Accept': 'image/*',
-                            }
-                        });                
-                        if (!response.ok) {
-                            throw new Error(`HTTP error! status: ${response.status}`);
-                        }
-                        const blob = await response.blob();
-                        const file = new File([blob], 'fetchedWebcamBackground', { type: blob.type });
-                        return file;
-                    } catch (error) {
-                        logger.error('Fetch error:', error);
-                        return null;
-                    }
-                }
-
-                let fetchedWebcamBackground = await getFileFromUrl(imageUrl);
-
-                if (fetchedWebcamBackground) {
-                    parameters.virtualSource = URL.createObjectURL(fetchedWebcamBackground);
-                } else {
-                    logger.error('Failed to fetch custom webcam background image. Using fallback image.');
-                }
-            }
+        if (parameters?.customParams?.file) {
+            parameters.virtualSource = parameters.customParams.file;
         }
     }
 

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -66,9 +66,12 @@ const getVirtualBackgroundThumbnail = (name) => {
 //   type: <EFFECT_TYPES>,
 //   name: effect filename, if any
 // }
-const setSessionVirtualBackgroundInfo = (type, name, deviceId) => {
-  return Session.set(`VirtualBackgroundInfo_${deviceId}`, { type, name });
-}
+const setSessionVirtualBackgroundInfo = (
+  type,
+  name,
+  deviceId,
+  customParams,
+) => Session.set(`VirtualBackgroundInfo_${deviceId}`, { type, name, customParams });
 
 const getSessionVirtualBackgroundInfo = (deviceId) => {
   return Session.get(`VirtualBackgroundInfo_${deviceId}`) || {

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -69,15 +69,14 @@ const getVirtualBackgroundThumbnail = (name) => {
 const setSessionVirtualBackgroundInfo = (
   type,
   name,
-  deviceId,
   customParams,
+  deviceId,
 ) => Session.set(`VirtualBackgroundInfo_${deviceId}`, { type, name, customParams });
 
-const getSessionVirtualBackgroundInfo = (deviceId) => {
-  return Session.get(`VirtualBackgroundInfo_${deviceId}`) || {
-    type: EFFECT_TYPES.NONE_TYPE,
-  };
-}
+const getSessionVirtualBackgroundInfo = (deviceId) => Session.get(`VirtualBackgroundInfo_${deviceId}`) || {
+  type: EFFECT_TYPES.NONE_TYPE,
+  name: '',
+};
 
 const getSessionVirtualBackgroundInfoWithDefault = (deviceId) => {
   return Session.get(`VirtualBackgroundInfo_${deviceId}`) || {

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/bbb-video-stream.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/bbb-video-stream.js
@@ -90,6 +90,7 @@ export default class BBBVideoStream extends EventEmitter2 {
       });
       this.virtualBgType = type;
       this.virtualBgName = name;
+      this.customParams = customParams;
       return Promise.resolve();
     } catch (error) {
       return Promise.reject(error);
@@ -109,6 +110,7 @@ export default class BBBVideoStream extends EventEmitter2 {
       this.virtualBgService = service;
       this.virtualBgType = type;
       this.virtualBgName = name;
+      this.customParams = customParams;
       this.originalStream = this.mediaStream;
       this.mediaStream = effect;
       this.isVirtualBackgroundEnabled = true;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR fixes two bugs in the video preview:

- Client dropping the virtual background when the webcam profile changes.
- If webcam is shared with virtual background applied, stopped, and then re-shared the video preview fails to apply the virtual background effect, causing a blank webcam.

![Screenshot from 2024-07-24 11-01-03](https://github.com/user-attachments/assets/c7f65ca8-590a-47b7-9608-76196f5ad830)

Plus:

- Show the virtual background image provided by `webcamBackgroundURL` param in the virtual background selector.

`webcamBackgroundURL=https://content.r9cdn.net/rimg/dimg/63/30/85cee65b-city-46053-1673284fa31.jpg`:

![Screenshot from 2024-07-25 10-04-17](https://github.com/user-attachments/assets/cd534422-4c1c-48fc-8701-fefd6380784f).



