### PR TITLE
fix: restore timer icon

### DIFF
--- a/bigbluebutton-html5/client/stylesheets/bbb-icons.css
+++ b/bigbluebutton-html5/client/stylesheets/bbb-icons.css
@@ -194,6 +194,10 @@
   content: "\e963";
 }
 
+.icon-bbb-time:before {
+  content: "\e908";
+}
+
 .icon-bbb-hand:before {
   content: "\e90f";
 }


### PR DESCRIPTION
### What does this PR do?

Restores timer feature icon

#### before
![Screenshot from 2024-07-25 14-18-47](https://github.com/user-attachments/assets/c44fbd1a-982d-4d8c-8742-36fa4c005c68)


#### after
![Screenshot from 2024-07-25 14-18-17](https://github.com/user-attachments/assets/3f8374d1-da4e-42db-bddd-b134bc79e298)
