### PR TITLE
fix(webcam): wrong VirtualBackground storage info

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -147,18 +147,6 @@ const VirtualBgSelector = ({
     }
   }, [isCustomVirtualBackgroundsEnabled]);
 
-  useEffect(() => {
-    const virtualBgData = {
-      name: currentVirtualBg.name,
-      type: currentVirtualBg.type,
-    };
-
-    const virtualBgArray = [virtualBgData];
-
-    const BBBStorage = getStorageSingletonInstance();
-    BBBStorage.setItem('WebcamBackground', virtualBgArray);
-  }, [currentVirtualBg]);
-
   const _virtualBgSelected = (type, name, index, customParams) => handleVirtualBgSelected(type, name, customParams)
     .then((switched) => {
       // Reset to the base NONE_TYPE effect if it failed because the expected

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -1,7 +1,7 @@
 import deviceInfo from '/imports/utils/deviceInfo';
 import browserInfo from '/imports/utils/browserInfo';
 import { createVirtualBackgroundService } from '/imports/ui/services/virtual-background';
-import Session from '/imports/ui/services/storage/in-memory';
+import { getStorageSingletonInstance } from '/imports/ui/services/storage';
 
 const BLUR_FILENAME = 'blur.jpg';
 const EFFECT_TYPES = {
@@ -87,21 +87,21 @@ const getVirtualBackgroundThumbnail = (name) => {
 //   name: effect filename, if any
 // }
 const setSessionVirtualBackgroundInfo = (deviceId, type, name, uniqueId = null) => {
-  Session.setItem(`VirtualBackgroundInfo_${deviceId}`, { type, name, uniqueId });
+  getStorageSingletonInstance().setItem(`VirtualBackgroundInfo_${deviceId}`, { type, name, uniqueId });
 };
 
-const getSessionVirtualBackgroundInfo = (deviceId) => Session
+const getSessionVirtualBackgroundInfo = (deviceId) => getStorageSingletonInstance()
   .getItem(`VirtualBackgroundInfo_${deviceId}`) || {
   type: EFFECT_TYPES.NONE_TYPE,
 };
 
-const getSessionVirtualBackgroundInfoWithDefault = (deviceId) => Session
+const getSessionVirtualBackgroundInfoWithDefault = (deviceId) => getStorageSingletonInstance()
   .getItem(`VirtualBackgroundInfo_${deviceId}`) || {
   type: EFFECT_TYPES.BLUR_TYPE,
   name: BLUR_FILENAME,
 };
 
-const removeSessionVirtualBackgroundInfo = (deviceId) => Session
+const removeSessionVirtualBackgroundInfo = (deviceId) => getStorageSingletonInstance()
   .removeItem(`VirtualBackgroundInfo_${deviceId}`);
 
 const isVirtualBackgroundSupported = () => !(deviceInfo.isIos || browserInfo.isSafari);


### PR DESCRIPTION
### What does this PR do?

- Use StorageSingleton to correct save and restore webcam background. 
- Remove unused storage set.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #20765

