### PR TITLE
fix: auto hide whiteboard toolbars not working

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -24,7 +24,7 @@ import {
   toggleToolsAnimations,
   formatAnnotations,
 } from './service';
-import { SettingsService, getSettingsSingletonInstance } from '/imports/ui/services/settings';
+import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Auth from '/imports/ui/services/auth';
 import {
   layoutSelect,
@@ -338,8 +338,8 @@ const WhiteboardContainer = (props) => {
         zoomSlide,
         notifyNotAllowedChange,
         notifyShapeNumberExceeded,
-        whiteboardToolbarAutoHide: SettingsService?.application?.whiteboardToolbarAutoHide,
-        animations: SettingsService?.application?.animations,
+        whiteboardToolbarAutoHide: Settings?.application?.whiteboardToolbarAutoHide,
+        animations: Settings?.application?.animations,
         toggleToolsAnimations,
         isIphone,
         currentPresentationPage,
@@ -349,9 +349,9 @@ const WhiteboardContainer = (props) => {
         whiteboardWriters,
         zoomChanger,
         skipToSlide,
-        locale: SettingsService?.application?.locale,
-        darkTheme: SettingsService?.application?.darkTheme,
-        selectedLayout: SettingsService?.application?.selectedLayout,
+        locale: Settings?.application?.locale,
+        darkTheme: Settings?.application?.darkTheme,
+        selectedLayout: Settings?.application?.selectedLayout,
         isInfiniteWhiteboard,
       }}
       {...props}
@@ -362,6 +362,5 @@ const WhiteboardContainer = (props) => {
     />
   );
 };
-
 
 export default WhiteboardContainer;


### PR DESCRIPTION
### What does this PR do?

fix issue with settings not being passed correctly to whiteboard component

#### before

https://github.com/user-attachments/assets/27711425-418c-4f00-bdc1-e3e0a7d52f72

#### after

https://github.com/user-attachments/assets/44385e67-dd35-4b6b-95b8-500a4058ba64

### How to test
1. enable "Auto Hide Whiteboard Toolbars" in settings panel
2. move mouse cursor out of the presentation area
3. whiteboard toolbars should be hidden