### PR TITLE
refactor: enable warn logs; add a warning when we are skipping an ann…

### DIFF
--- a/bbb-export-annotations/lib/utils/logger.js
+++ b/bbb-export-annotations/lib/utils/logger.js
@@ -36,9 +36,7 @@ module.exports = class Logger {
   }
 
   warn(...messages) {
-    if (debug) {
-      console.log(date(), 'WARN\t', `[${this.context}]`, ...parse(messages));
-    }
+    console.log(date(), 'WARN\t', `[${this.context}]`, ...parse(messages));
   }
 
   error(...messages) {

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -704,6 +704,7 @@ function overlay_triangle(svg, annotation) {
 
 function overlay_text(svg, annotation) {
   if (annotation.size == null || annotation.size.length < 2) {
+    logger.warn("An annotation of type text had a missing or malformed property size and was excluded from the extraction. " + JSON.stringify(annotation));
     return
   }
   


### PR DESCRIPTION
…otation

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
* Enable logging warn messages -- they were grouped under debug
* Add a log for when we're skipping the export of an annotation due to missing `size`. Related https://github.com/bigbluebutton/bigbluebutton/issues/19668 and https://github.com/bigbluebutton/bigbluebutton/pull/19672

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none but it helps debug https://github.com/bigbluebutton/bigbluebutton/issues/20690

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
In a meeting draw some annotations and export the presentation+annotations. Even if we don't hit #20690 the test succeeds if we get an annotation without crashes.
If we do hit the issue, it would be visible via `/bigbluebutton/bbb-export-annotations$ npm start`

### More
<!-- Anything else we should know when reviewing? -->
