### PR TITLE
refactor (akka-apps): Routine to reset finished Timers

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/TimerModel.scala
@@ -44,6 +44,8 @@ object TimerModel {
   }
 
   def setRunning(model: TimerModel, running: Boolean): Unit = {
+    resetTimerIfFinished(model)
+
     val now = System.currentTimeMillis()
 
     // If the timer is running and will stop, update accumulated time
@@ -57,20 +59,21 @@ object TimerModel {
       setStartedAt(model, now)
     }
 
-    // Determine if the timer is finished
-    val isTimerFinished = running && !isStopwatch(model) && {
-      val currentTimerTime = model.startedAt + (model.time - model.accumulated)
-      currentTimerTime < now
-    }
-
-    // If the timer is finished, reset the accumulated time and start time if running
-    if (isTimerFinished) {
-      setAccumulated(model, 0)
-      if (running) setStartedAt(model, now)
-    }
-
     // Update the running status of the model
     model.running = running
+  }
+
+  def resetTimerIfFinished(model: TimerModel) = {
+    // If the timer is finished, reset the accumulated time and start time if running
+    if (isRunning(model)
+      && !isStopwatch(model)
+      && (model.startedAt + (model.time - model.accumulated)) < System.currentTimeMillis()) {
+      model.running = false
+      reset(model)
+      true
+    } else {
+      false
+    }
   }
 
   def isRunning(model: TimerModel): Boolean = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -793,6 +793,7 @@ class MeetingActor(
 
   private def handleMeetingTasksExecutor(): Unit = {
     clearExpiredReactionEmojis()
+    stopFinishedTimer()
   }
 
   private def clearExpiredReactionEmojis(): Unit = {
@@ -807,6 +808,12 @@ class MeetingActor(
           Users2x.setReactionEmoji(liveMeeting.users2x, user.intId, "none", 0)
         }
       }
+    }
+  }
+
+  private def stopFinishedTimer(): Unit = {
+    if (TimerModel.resetTimerIfFinished(liveMeeting.timerModel)) {
+      TimerDAO.update(liveMeeting.props.meetingProp.intId, liveMeeting.timerModel)
     }
   }
 


### PR DESCRIPTION
Previously, the Timer properties were only reset when a new timer was started. This caused inconsistencies in the GraphQL database as the values were not properly updated.

To address this, we have introduced a routine that runs every 5 seconds. This routine checks for finished timers and resets their values if they are found to be completed. This ensures that the database remains consistent and accurate.