### PR TITLE
refactor (akka-apps): Routine to purge old meetings from Graphql database

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -58,6 +58,14 @@ class BigBlueButtonActor(
     }
   }
 
+  object BBBTasksExecutor
+  context.system.scheduler.schedule(
+    1 minute,
+    1 minute,
+    self,
+    BBBTasksExecutor
+  )
+
   override def preStart() {
     bbbMsgBus.subscribe(self, meetingManagerChannel)
     DatabaseConnection.initialize()
@@ -72,6 +80,7 @@ class BigBlueButtonActor(
 
   def receive = {
     // Internal messages
+    case BBBTasksExecutor               => handleMeetingTasksExecutor()
     case msg: DestroyMeetingInternalMsg => handleDestroyMeeting(msg)
 
     //Api messages
@@ -211,6 +220,12 @@ class BigBlueButtonActor(
     val event = MsgBuilder.buildCheckAlivePingSysMsg(msg.body.system, msg.body.bbbWebTimestamp, System.currentTimeMillis())
     healthzService.sendPubSubStatusMessage(msg.body.akkaAppsTimestamp, System.currentTimeMillis())
     outGW.send(event)
+  }
+
+  private def handleMeetingTasksExecutor(): Unit = {
+    // Delays meeting data for 1 hour post-meeting in case users request info after it ends.
+    // This routine ensures proper purging if akka-apps restart and the handleDestroyMeeting scheduler does not run.
+    MeetingDAO.deleteOldMeetings()
   }
 
   private def handleDestroyMeeting(msg: DestroyMeetingInternalMsg): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -166,6 +166,17 @@ object MeetingDAO {
     )
   }
 
+  def deleteOldMeetings() = {
+    val oneHourAgo = java.sql.Timestamp.from(java.time.Instant.now().minusSeconds(3600))
+
+    DatabaseConnection.enqueue(
+      TableQuery[MeetingDbTableDef]
+        .filter(_.endedAt < oneHourAgo)
+        .delete
+    )
+  }
+
+
   def setMeetingEnded(meetingId: String, endedReasonCode: String, endedBy: String) = {
 
     UserDAO.softDeleteAllFromMeeting(meetingId)


### PR DESCRIPTION
Currently, a scheduler is configured to remove all meeting data 1 hour after a meeting ends. The issue arises when the akka-apps service is restarted, causing the scheduler to be lost. 

This PR introduces a routine that runs every minute to identify and purge old meetings that were not removed properly from the database.