### PR TITLE
fix: locales issues

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlAdapter.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlAdapter.tsx
@@ -34,7 +34,7 @@ const IntlAdapter: React.FC<IntlAdapterProps> = ({
 
   useEffect(() => {
     intlHolder.setIntl(intl);
-  }, []);
+  }, [currentLocale]);
 
   const sendUiDataToPlugins = () => {
     window.dispatchEvent(new CustomEvent(PluginSdk.IntlLocaleUiDataNames.CURRENT_LOCALE, {

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -22,7 +22,9 @@ const updateSettings = (obj, msgDescriptor, mutation) => {
   }
 };
 
-const getAvailableLocales = () => fetch('./locales/').then(locales => locales.json());
+const getAvailableLocales = () => fetch('./locales/')
+  .then((locales) => locales.json())
+  .then((locales) => locales.filter((locale) => locale.name !== 'index.json'));
 
 const FALLBACK_LOCALES = {
   dv: {


### PR DESCRIPTION
### What does this PR do?

1. fix issue where an invalid `index` locale is displayed in the "application language" dropdown
2. fix issue where the notification displayed after saving settings is always in the default locale

### How to test

issue 1:
1. create / join a meeting
2. open the "options" menu (3-dots menu on top right of the client)
3. open application language dropdown
4. "index" value should not be displayed

issue 2:
1. create / join a meeting with the default locale (`en`)
2. open the "options" menu (3-dots menu on top right of the client)
3. open application language dropdown
4. select `Español - Spanish` 
5. save the changes (a notification should be displayed in **english** saying that the settings are saved)
6. repeat steps 2-3
7. select `Português - Portuguese`
8. save the changes (a notification should be displayed in **spanish** saying that the settings are saved)