### PR TITLE
docs: fix graphqlWebsocketUrl in cluster proxy setup docs

### DIFF
--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -103,7 +103,7 @@ Add these options to `/etc/bigbluebutton/bbb-web.properties`:
 defaultHTML5ClientUrl=https://bbb-proxy.example.com/bbb-01/html5client/join
 presentationBaseURL=https://bbb-01.example.com/bigbluebutton/presentation
 accessControlAllowOrigin=https://bbb-proxy.example.com
-graphqlWebsocketUrl=wss://bbb-01.example.com/v1/graphql
+graphqlWebsocketUrl=wss://bbb-01.example.com/graphql
 ```
 
 Add the following options to `/etc/bigbluebutton/bbb-html5.yml`:

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -104,6 +104,7 @@ defaultHTML5ClientUrl=https://bbb-proxy.example.com/bbb-01/html5client/join
 presentationBaseURL=https://bbb-01.example.com/bigbluebutton/presentation
 accessControlAllowOrigin=https://bbb-proxy.example.com
 graphqlWebsocketUrl=wss://bbb-01.example.com/graphql
+graphqlApiUrl=https://bbb-01.example.com/api/rest
 ```
 
 Add the following options to `/etc/bigbluebutton/bbb-html5.yml`:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes the graphqlWebsocketUrl in the 3.0 cluster proxy setup documentation, by removing the /v1 from the URL.  The client won't load when the URL is entered as suggested by the present docs.

### More
I noticed that https://github.com/bigbluebutton/bigbluebutton/pull/20647/files contains the same change, but the future of that PR is unclear to me.
Also I'm not sure how that https://github.com/bigbluebutton/bigbluebutton/pull/20664/files relates.

Furthermore, but not directly related: In my BBB 3.0 build with cluster proxy setup, in the browser console I still see CORS errors that I don't see in an equivalent 2.7 build or 3.0 without cluster proxy. I'm not sure what is missing, both GraphQL CORS options are set according to docs.