### PR TITLE
fix: Improve screen reader accessibility for polling modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/polling/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/polling/styles.js
@@ -33,11 +33,14 @@ import {
 import { hasPhoneDimentions } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import Button from '/imports/ui/components/common/button/component';
 
-const PollingTitle = styled.div`
+const PollingTitle = styled.h1`
   white-space: nowrap;
   padding-bottom: ${mdPaddingY};
   padding-top: ${mdPaddingY};
   font-size: ${fontSizeSmall};
+  margin: 0;
+  padding: 0;
+  font-weight: 600;
 `;
 
 const PollButtonWrapper = styled.div`
@@ -131,8 +134,11 @@ const QHeader = styled.span`
   left: ${smPaddingY};
 `;
 
-const QTitle = styled.div`
+const QTitle = styled.h1`
   font-size: ${fontSizeSmall};
+  margin: 0;
+  padding: 0;
+  font-weight: 600;
 `;
 
 const QText = styled.div`


### PR DESCRIPTION
### What does this PR do?
This PR improves accessibility for screen reader users by updating the polling question and options to use heading elements (`<h1>`). This makes it easier for users to find the poll using heading navigation shortcuts.


### Motivation
Issue #20621 pointed out that screen reader users had trouble finding the polling modal. We added headings so users can jump to the poll with screen reader shortcuts. The modal stays in the complementary landmark region, so users can also find it quickly using NVDA's d or JAWS' r keys, instead of moving it to the end of the DOM.