### PR TITLE
Fix emoji picker icon and width on 3.0

### DIFF
--- a/bigbluebutton-html5/client/stylesheets/bbb-icons.css
+++ b/bigbluebutton-html5/client/stylesheets/bbb-icons.css
@@ -201,6 +201,9 @@
 .icon-bbb-hand:before {
   content: "\e90f";
 }
+.icon-bbb-happy:before {
+  content: "\e90e";
+}
 .icon-bbb-send:before {
   content: "\e934";
 }

--- a/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import data from '@emoji-mart/data';
@@ -50,6 +50,13 @@ const EmojiPicker = (props) => {
   const emojisToExclude = [
     ...DISABLE_EMOJIS,
   ];
+
+  // HACK: the library sets the width after it renders
+  //       this code fixes that, but is kinda ugly and only works if
+  //       we never render more than one emoji-picker at the same time
+  useEffect(() => {
+    document.getElementsByTagName('em-emoji-picker')[0].style.width = 'auto';
+  });
 
   return (
     <Picker


### PR DESCRIPTION
The icon used for emoji picker was removed in 3.0 because it was the same as the deprecated reaction icons. However it's still present in the woff file and thus I've only restored the css style and brought the button back since we still need it.

Also I've added a small hack to fix the emoji picker width. A better fix would probably involve a rewrite of the code and should be done at some point. 