### PR TITLE
fix(connection-status): jitter causes false positive critical alerts

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -644,7 +644,6 @@ export interface Stats {
   timeout: number
   log: boolean
   notification: Notification
-  jitter: number[]
   loss: number[]
   rtt: number[]
   level: string[]

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
@@ -7,10 +7,9 @@ import { getWorstStatus } from '../service';
 const ConnectionStatusButtonContainer = (props) => {
   const connected = useReactiveVar(connectionStatus.getConnectedStatusVar());
   const rttStatus = useReactiveVar(connectionStatus.getRttStatusVar());
-  const jitterStatus = useReactiveVar(connectionStatus.getJitterStatusVar());
   const packetLossStatus = useReactiveVar(connectionStatus.getPacketLossStatusVar());
 
-  const myCurrentStatus = getWorstStatus([rttStatus, jitterStatus, packetLossStatus]);
+  const myCurrentStatus = getWorstStatus([rttStatus, packetLossStatus]);
 
   return (
     <ConnectionStatusButtonComponent

--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -453,9 +453,6 @@ export async function startMonitoringNetwork(getVideoStreamsStats) {
 
     connectionStatus.setNetworkData(networkData);
     connectionStatus
-      .setJitterStatus(getStatus(window.meetingClientSettings.public.stats.jitter, jitter));
-
-    connectionStatus
       .setPacketLossStatus(getStatus(window.meetingClientSettings.public.stats.loss, packetsLost));
   }, NETWORK_MONITORING_INTERVAL_MS);
 }

--- a/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
@@ -116,9 +116,8 @@ class ConnectionStatusIcon extends PureComponent {
 
 const WrapConnectionStatus = (props) => {
   const rttStatus = useReactiveVar(connectionStatus.getRttStatusVar());
-  const jitterStatus = useReactiveVar(connectionStatus.getJitterStatusVar());
   const packetLossStatus = useReactiveVar(connectionStatus.getPacketLossStatusVar());
-  const status = getWorstStatus([rttStatus, jitterStatus, packetLossStatus]);
+  const status = getWorstStatus([rttStatus, packetLossStatus]);
   return (
     <ConnectionStatusIcon
       {...props}

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -35,8 +35,6 @@ class ConnectionStatus {
     video: {},
   });
 
-  private jitterStatus = makeVar('normal');
-
   private packetLossStatus = makeVar('normal');
 
   public setPacketLossStatus(value: string): void {
@@ -52,21 +50,6 @@ class ConnectionStatus {
 
   public getPacketLossStatusVar() {
     return this.packetLossStatus;
-  }
-
-  public setJitterStatus(value: string): void {
-    if (value !== this.jitterStatus()) {
-      logger.info({ logCode: 'stats_jitter_status_state' }, `Jitter status changed to ${value} (jitter=${this.networkData()?.audio?.jitter})`);
-      this.jitterStatus(value);
-    }
-  }
-
-  public getJitterStatus() {
-    return this.jitterStatus();
-  }
-
-  public getJitterStatusVar() {
-    return this.jitterStatus;
   }
 
   public setNetworkData(data: NetworkData): void {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -680,11 +680,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         warning: false,
         error: true,
       },
-      jitter: [
-        10,
-        20,
-        30,
-      ],
       loss: [
         0.05,
         0.1,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -915,10 +915,6 @@ public:
     notification:
       warning: false
       error: true
-    jitter:
-      warning: 10
-      danger: 20
-      critical: 30
     loss:
       warning: 0.05
       danger: 0.1


### PR DESCRIPTION
### What does this PR do?

- [fix(connection-status): jitter causes false positive critical alerts](https://github.com/bigbluebutton/bigbluebutton/commit/24ae746a88dc490d3c37c279213261734d32aca0) 
  * Jitter evaluation, as an alert trigger, was changed in 3.0 to get the internal
average jitter used in the conn-status component data (which is total jitter
delay divided by jitterbuffer emit events). This was done accidentally and that
metric is _very_ different from the one used in 2.7 (point-in-time jitter from
remote-inbound-rtp/inbound-rtp, highest on the interval, gathered on
/utils/stats.js).  The alert thresholds were preserved, which makes it overly
sensitive in regards to jitter (and thus causes it to be critical whenever the
user is in audio).
  * Remove jitter as a connection status alert trigger, which fixes the
false positive. The implementation on <= 2.7 is also not ideal - if
anything, it generates false negatives. That's why I'm removing jitter for
the time being since it's ill-suited (at least in the way it's used)
for what we want to achieve.

### Closes Issue(s)

Might close https://github.com/bigbluebutton/bigbluebutton/issues/20800