### PR TITLE
fix(api): Remove old enter endpoint validation logic

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1869,17 +1869,6 @@ class ApiController {
         log.error violation.getValue()
       }
 
-      if(apiCall == ValidationService.ApiCall.ENTER) {
-        //Check if error exist following an order (to avoid showing guestDeny when the meeting doesn't even exist)
-        String[] enterConstraintsKeys = new String[] {"missingSession","meetingForciblyEnded","notFound","guestDeny"}
-        for (String constraintKey : enterConstraintsKeys) {
-          if(violations.containsKey(constraintKey)) {
-            response = new AbstractMap.SimpleEntry<String, String>(constraintKey, violations.get(constraintKey))
-            break
-          }
-        }
-      }
-
       if(response == null) {
         for(Map.Entry<String, String> violation: violations.entrySet()) {
           response = new AbstractMap.SimpleEntry<String, String>(violation.getKey(), violation.getValue())


### PR DESCRIPTION
### What does this PR do?

Removes unused validation logic for the deprecated `enter` endpoint in `bbb-web`.


### Motivation

In the case that an API requested failed validation this code would try to run but would not be able to since the `enter` endpoint was removed. This resulted in the requests returning back a `500 Internal Server Error` instead of the proper validation failure response.
