### PR TITLE
fix: Ensure size estimate is applied to text shapes while typing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -16,7 +16,7 @@ import {
 import Styled from './styles';
 import PanToolInjector from './pan-tool-injector/component';
 import {
-  findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, usePrevious, TextUtil
+  findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, usePrevious, TextUtil,
 } from './utils';
 import { isEqual } from 'radash';
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
@@ -275,11 +275,109 @@ const getTextSize = (text, style, padding) => {
   return [width + padding, height + padding];
 };
 
+const TextUtil = {
+  getBoundsEstimate(shape) {
+    const { text, style } = shape;
+    const div = document.createElement('div');
+    div.style.position = 'absolute';
+    div.style.visibility = 'hidden';
+    div.style.whiteSpace = 'pre';
+    div.style.fontSize = this.getFontSize(style.size);
+    div.style.fontFamily = this.getFontFamily(style.font);
+    div.style.letterSpacing = style.letterSpacing || 'normal';
+    div.style.lineHeight = style.lineHeight || 'normal';
+    div.textContent = text;
+    document.body.appendChild(div);
+
+    // Calculate the number of lines
+    const numberOfLines = text.split('\n').length;
+
+    // Get the bounding box dimensions
+    const { width } = div.getBoundingClientRect();
+    const lineHeight = parseFloat(getComputedStyle(div).lineHeight);
+    const height = lineHeight * numberOfLines;
+    document.body.removeChild(div);
+
+    // Dynamic padding adjustment based on font size
+    const paddingAdjustment = parseInt(div.style.fontSize, 10) * 0.3;
+    let finalWidth = width + paddingAdjustment;
+    let finalHeight = height + paddingAdjustment;
+
+    // Apply width and height multipliers based on font size and style
+    finalWidth *= this.getWidthMultiplier(style.size, style.font);
+    finalHeight *= this.getHeightMultiplier(style.size, style.font, numberOfLines);
+
+    return {
+      width: finalWidth,
+      height: finalHeight,
+    };
+  },
+
+  getFontSize(size) {
+    switch (size) {
+      case 'small': return '12px';
+      case 'medium': return '16px';
+      case 'large': return '20px';
+      default: return '16px';
+    }
+  },
+
+  getFontFamily(font) {
+    switch (font) {
+      case 'mono': return 'monospace';
+      case 'script': return 'Comic Sans MS, cursive, sans-serif';
+      case 'sans': return 'Arial, sans-serif';
+      case 'serif': return 'Times New Roman, serif';
+      default: return 'sans-serif';
+    }
+  },
+
+  getWidthMultiplier(size, font) {
+    const fontMultiplier = {
+      small: { mono: 3, default: 2 },
+      medium: { mono: 4, default: 3 },
+      large: { mono: 7, default: 4 },
+    };
+
+    if (font === 'mono') {
+      return fontMultiplier[size].mono;
+    } else if (['script', 'sans', 'serif'].includes(font)) {
+      return fontMultiplier[size].default;
+    }
+
+    return 1;
+  },
+
+  getHeightMultiplier(size, font, numberOfLines) {
+    const baseMultiplier = 1.5;
+
+    if (font === 'mono') {
+      return baseMultiplier + (numberOfLines > 1 ? 0.5 : 0);
+    } else if (['script', 'sans', 'serif'].includes(font)) {
+      return baseMultiplier + (numberOfLines > 1 ? 0.3 : 0);
+    }
+
+    return baseMultiplier;
+  }
+};
+
 const Utils = {
-  usePrevious, findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, getTextSize,
+  usePrevious,
+  findRemoved,
+  filterInvalidShapes,
+  mapLanguage,
+  sendShapeChanges,
+  getTextSize,
+  TextUtil
 };
 
 export default Utils;
 export {
-  usePrevious, findRemoved, filterInvalidShapes, mapLanguage, sendShapeChanges, getTextSize,
+  usePrevious,
+  findRemoved,
+  filterInvalidShapes,
+  mapLanguage,
+  sendShapeChanges,
+  getTextSize,
+  TextUtil
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/utils.js
@@ -275,6 +275,11 @@ const getTextSize = (text, style, padding) => {
   return [width + padding, height + padding];
 };
 
+
+// getBoundsEstimate here is a function inspired by implementations in tldraw-v1:
+// TextUtil: https://github.com/tldraw/tldraw-v1/blob/f786c38ac0fdce337c4405c11cbfa9223d2ee6dd/packages/tldraw/src/state/shapes/TextUtil/TextUtil.tsx#L24
+// getTextSize: https://github.com/tldraw/tldraw-v1/blob/f786c38ac0fdce337c4405c11cbfa9223d2ee6dd/packages/tldraw/src/state/shapes/shared/getTextSize.ts#L6
+// It calculates the estimated bounds of a text shape based on its content and style.
 const TextUtil = {
   getBoundsEstimate(shape) {
     const { text, style } = shape;


### PR DESCRIPTION
### What does this PR do?
This PR introduces calculations to estimate and apply the size of text shapes in `tldraw-v1` as users type. The implementation leverages a utility function, TextUtil, that calculates the dimensions of the text based on its content and style properties. This approach mirrors the functionality in tldraw v1, where similar calculations are handled internally. The key improvement is ensuring that text shapes always have a defined size, preventing issues where size attributes might be missing during the editing process.

### Motivation

The motivation for this PR is to address the issue where `tldraw-v1` did not dynamically apply a size to text shapes while typing. Previously, tldraw-v1 calculated the size of text shapes during the `onCommand` event, which occurs after typing is completed. This approach could lead to inconsistencies, as the size was not updated in real-time. This PR ensures that text shapes have a defined size throughout the editing process.

Related to #20690