### PR TITLE
Fix: Unable to focus chat when double clicking it

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -43,6 +43,7 @@ export const MessageList = styled(ScrollboxVertical)`
   padding-top: 0;
   outline-style: none;
   overflow-x: hidden;
+  user-select: none;
 
   [dir='rtl'] & {
     margin: 0 0 0 auto;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -33,6 +33,7 @@ export const ChatMessages = styled.div<ChatMessagesProps>`
   `}
 
   padding-bottom: ${smPaddingX};
+  user-select: text;
 `;
 
 export const MessageList = styled(ScrollboxVertical)`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -21,6 +21,24 @@ interface ChatProps {
 
 const Chat: React.FC<ChatProps> = ({ isRTL }) => {
   const { isChrome } = browserInfo;
+
+  React.useEffect(() => {
+    const handleMouseDown = () => {
+      if (window.getSelection) {
+        const selection = window.getSelection();
+        if (selection) {
+          selection.removeAllRanges();
+        }
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, []);
+
   return (
     <Styled.Chat isRTL={isRTL} isChrome={isChrome}>
       <ChatHeader />
@@ -30,7 +48,6 @@ const Chat: React.FC<ChatProps> = ({ isRTL }) => {
     </Styled.Chat>
   );
 };
-
 export const ChatLoading: React.FC<ChatProps> = ({ isRTL }) => {
   const { isChrome } = browserInfo;
   return (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
@@ -18,6 +18,7 @@ export const Chat = styled.div<ChatProps>`
   justify-content: space-around;
   overflow: hidden;
   height: 100%;
+  user-select: none;
 
   ${({ isRTL }) => isRTL && `
     padding-left: 0.1rem;
@@ -70,6 +71,8 @@ const ChatContent = styled.div`
   display: contents;
 `;
 
-const ChatMessages = styled.div``;
+const ChatMessages = styled.div`
+  user-select: text;
+`;
 
 export default { Chat, ChatMessages, ChatContent };


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where by double clicking the chat, the user would be unable to re-click it and resto focus on chat input.