### PR TITLE
feat(plugin): userCameraDropdown enhancements, user-camera dom-element and screenshareHelper

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -138,7 +138,7 @@ class BBBMenu extends React.Component {
             $roundButtons={roundButtons}
             $isToggle={isToggle}
             onClick={(event) => {
-              onClick();
+              onClick(event);
               const close = !keepOpen && !key?.includes('setstatus') && !key?.includes('back');
               // prevent menu close for sub menu actions
               if (close) this.handleClose(event);

--- a/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/context.tsx
+++ b/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/context.tsx
@@ -10,6 +10,7 @@ export const PluginsContextProvider = ({ children, ...props }: any) => {
     {} as ExtensibleArea,
   );
   const [domElementManipulationMessageIds, setDomElementManipulationMessageIds] = useState<string[]>([]);
+  const [domElementManipulationStreamIds, setDomElementManipulationStreamIds] = useState<string[]>([]);
 
   return (
     <PluginsContext.Provider
@@ -19,6 +20,8 @@ export const PluginsContextProvider = ({ children, ...props }: any) => {
         pluginsExtensibleAreasAggregatedState,
         domElementManipulationMessageIds,
         setDomElementManipulationMessageIds,
+        domElementManipulationStreamIds,
+        setDomElementManipulationStreamIds,
       }}
     >
       {children}

--- a/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/components-data/plugin-context/types.ts
@@ -21,4 +21,7 @@ export interface PluginsContextType {
     domElementManipulationMessageIds: string[];
     setDomElementManipulationMessageIds: React.Dispatch<
         React.SetStateAction<string[]>>;
+    domElementManipulationStreamIds: string[];
+    setDomElementManipulationStreamIds: React.Dispatch<
+    React.SetStateAction<string[]>>;
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/dom-element-manipulation/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/dom-element-manipulation/manager.tsx
@@ -6,11 +6,13 @@ import { HookEventWrapper } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/ty
 import { DomElementManipulationHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/enums';
 
 import ChatMessageDomElementManipulationHookManager from './chat/message/hook-manager';
+import UserCameraDomElementManipulationHookManager from './user-camera/hook-manager';
 
 const hooksMap:{
   [key: string]: React.FunctionComponent
 } = {
   [DomElementManipulationHooks.CHAT_MESSAGE]: ChatMessageDomElementManipulationHookManager,
+  [DomElementManipulationHooks.USER_CAMERA]: UserCameraDomElementManipulationHookManager,
 };
 
 const PluginDomElementManipulationManager: React.FC = () => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/dom-element-manipulation/user-camera/hook-manager.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/dom-element-manipulation/user-camera/hook-manager.ts
@@ -1,0 +1,43 @@
+import { useContext, useEffect } from 'react';
+import { HookEventWrapper, SubscribedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
+import { HookEvents } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
+import { DomElementManipulationHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/enums';
+import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
+import { UserCameraDomElementsArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
+
+const UserCameraDomElementManipulationHookManager = () => {
+  const {
+    setDomElementManipulationStreamIds,
+  } = useContext(PluginsContext);
+
+  useEffect(() => {
+    const subscribeHandler: EventListener = (
+      (event: HookEventWrapper<void>) => {
+        let hookArguments: UserCameraDomElementsArguments | undefined;
+        if (event.detail.hook === DomElementManipulationHooks.USER_CAMERA) {
+          const detail = event.detail as SubscribedEventDetails;
+          hookArguments = detail.hookArguments as UserCameraDomElementsArguments;
+          setDomElementManipulationStreamIds(hookArguments.streamIds);
+        }
+      }) as EventListener;
+    const unsubscribeHandler: EventListener = (
+      (event: HookEventWrapper<void>) => {
+        let hookArguments: UserCameraDomElementsArguments | undefined;
+        if (event.detail.hook === DomElementManipulationHooks.USER_CAMERA) {
+          const detail = event.detail as SubscribedEventDetails;
+          hookArguments = detail.hookArguments as UserCameraDomElementsArguments;
+          setDomElementManipulationStreamIds(hookArguments.streamIds);
+        }
+      }) as EventListener;
+
+    window.addEventListener(HookEvents.SUBSCRIBED, subscribeHandler);
+    window.addEventListener(HookEvents.UNSUBSCRIBED, unsubscribeHandler);
+    return () => {
+      window.removeEventListener(HookEvents.SUBSCRIBED, subscribeHandler);
+      window.removeEventListener(HookEvents.UNSUBSCRIBED, unsubscribeHandler);
+    };
+  }, []);
+  return null;
+};
+
+export default UserCameraDomElementManipulationHookManager;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/screenshare-helper/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/screenshare-helper/manager.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState, useContext } from 'react';
+import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
+
+import {
+  ExtensibleAreaComponentManagerProps, ExtensibleArea,
+  ExtensibleAreaComponentManager,
+} from '../../types';
+import { PluginsContext } from '../../../../components-data/plugin-context/context';
+
+const ScreenshareHelperPluginStateContainer = ((
+  props: ExtensibleAreaComponentManagerProps,
+) => {
+  const {
+    uuid,
+    generateItemWithId,
+    extensibleAreaMap,
+    pluginApi,
+  } = props;
+  const [
+    screenshareHelperItems,
+    setScreenshareHelperItems,
+  ] = useState<PluginSdk.ScreenshareHelperInterface[]>([]);
+
+  const {
+    pluginsExtensibleAreasAggregatedState,
+    setPluginsExtensibleAreasAggregatedState,
+  } = useContext(PluginsContext);
+
+  useEffect(() => {
+    extensibleAreaMap[uuid].screenshareHelperItems = screenshareHelperItems;
+
+    const aggregatedScreenshareHelperItems = ([] as PluginSdk.ScreenshareHelperInterface[]).concat(
+      ...Object.values(extensibleAreaMap)
+        .map((extensibleArea: ExtensibleArea) => extensibleArea.screenshareHelperItems),
+    );
+
+    setPluginsExtensibleAreasAggregatedState(
+      {
+        ...pluginsExtensibleAreasAggregatedState,
+        screenshareHelperItems: aggregatedScreenshareHelperItems,
+      },
+    );
+  }, [screenshareHelperItems]);
+
+  pluginApi.setScreenshareHelperItems = (items: PluginSdk.ScreenshareHelperInterface[]) => {
+    const itemsWithId = items.map(generateItemWithId) as PluginSdk.ScreenshareHelperInterface[];
+    setScreenshareHelperItems(itemsWithId);
+    return itemsWithId.map((i) => i.id);
+  };
+  return null;
+}) as ExtensibleAreaComponentManager;
+
+export default ScreenshareHelperPluginStateContainer;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/manager.tsx
@@ -19,6 +19,7 @@ import {
 } from './types';
 import FloatingWindowPluginStateContainer from './components/floating-window/manager';
 import GenericContentPluginStateContainer from './components/generic-content/manager';
+import ScreenshareHelperPluginStateContainer from './components/screenshare-helper/manager';
 
 const extensibleAreaMap: ExtensibleAreaMap = {};
 
@@ -36,6 +37,7 @@ const extensibleAreaComponentManagers: ExtensibleAreaComponentManager[] = [
   UserListItemAdditionalInformationPluginStateContainer,
   FloatingWindowPluginStateContainer,
   GenericContentPluginStateContainer,
+  ScreenshareHelperPluginStateContainer,
 ];
 
 function generateItemWithId<T extends PluginProvidedUiItemDescriptor>(

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/types.ts
@@ -15,6 +15,7 @@ export interface ExtensibleArea {
   actionsBarItems: PluginSdk.ActionsBarInterface[];
   presentationDropdownItems: PluginSdk.PresentationDropdownInterface[];
   navBarItems: PluginSdk.NavBarInterface[];
+  screenshareHelperItems: PluginSdk.ScreenshareHelperInterface[];
   optionsDropdownItems: PluginSdk.OptionsDropdownInterface[];
   cameraSettingsDropdownItems: PluginSdk.CameraSettingsDropdownInterface[];
   userCameraDropdownItems: PluginSdk.UserCameraDropdownInterface[];

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -5,7 +5,9 @@ import { debounce } from '/imports/utils/debounce';
 import FullscreenButtonContainer from '/imports/ui/components/common/fullscreen-button/container';
 import SwitchButtonContainer from './switch-button/container';
 import Styled from './styles';
+import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import VolumeSlider from '../external-video-player/volume-slider/component';
+import PluginButtonContainer from './plugin-button/container';
 import AutoplayOverlay from '../media/autoplay-overlay/component';
 import logger from '/imports/startup/client/logger';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
@@ -37,6 +39,32 @@ import Session from '/imports/ui/services/storage/in-memory';
 const MOBILE_HOVER_TIMEOUT = 5000;
 const MEDIA_FLOW_PROBE_INTERVAL = 500;
 const SCREEN_SIZE_DISPATCH_INTERVAL = 500;
+
+const renderPluginItems = (pluginItems, bottom, right) => {
+  if (pluginItems !== undefined) {
+    return (
+      <>
+        {
+          pluginItems.map((pluginItem) => {
+            const returnComponent = (
+              <PluginButtonContainer
+                key={`${pluginItem.type}-${pluginItem.id}-${pluginItem.label}`}
+                dark
+                bottom={bottom}
+                right={right}
+                icon={pluginItem.icon}
+                label={pluginItem.label}
+                onClick={pluginItem.onClick}
+              />
+            );
+            return returnComponent;
+          })
+        }
+      </>
+    );
+  }
+  return (<></>);
+};
 
 class ScreenshareComponent extends React.Component {
   static renderScreenshareContainerInside(mainText) {
@@ -70,6 +98,8 @@ class ScreenshareComponent extends React.Component {
     this.dispatchScreenShareSize = this.dispatchScreenShareSize.bind(this);
     this.handleOnMuted = this.handleOnMuted.bind(this);
     this.dispatchScreenShareSize = this.dispatchScreenShareSize.bind(this);
+    this.renderScreenshareButtons = this.renderScreenshareButtons.bind(this);
+    this.splitPluginItems = this.splitPluginItems.bind(this);
     this.debouncedDispatchScreenShareSize = debounce(
       this.dispatchScreenShareSize,
       SCREEN_SIZE_DISPATCH_INTERVAL,
@@ -336,14 +366,16 @@ class ScreenshareComponent extends React.Component {
     if (!ALLOW_FULLSCREEN) return null;
 
     return (
-      <FullscreenButtonContainer
-        key={uniqueId('fullscreenButton-')}
-        elementName={intl.formatMessage(this.locales.label)}
-        fullscreenRef={this.screenshareContainer}
-        elementId={fullscreenElementId}
-        isFullscreen={fullscreenContext}
-        dark
-      />
+      <Styled.FullscreenButtonWrapperForScreenshare>
+        <FullscreenButtonContainer
+          key={uniqueId('fullscreenButton-')}
+          elementName={intl.formatMessage(this.locales.label)}
+          fullscreenRef={this.screenshareContainer}
+          elementId={fullscreenElementId}
+          isFullscreen={fullscreenContext}
+          dark
+        />
+      </Styled.FullscreenButtonWrapperForScreenshare>
     );
   }
 
@@ -410,7 +442,8 @@ class ScreenshareComponent extends React.Component {
     return [(
       <Styled.HoverToolbar
         toolbarStyle={toolbarStyle}
-        key='hover-toolbar-screenshare'>
+        key="hover-toolbar-screenshare"
+      >
         <VolumeSlider
           volume={getVolume()}
           muted={getVolume() === 0}
@@ -418,8 +451,8 @@ class ScreenshareComponent extends React.Component {
           onMuted={this.handleOnMuted}
         />
       </Styled.HoverToolbar>
-      ),
-      (deviceInfo.isMobile) && this.renderMobileVolumeControlOverlay(),
+    ),
+    (deviceInfo.isMobile) && this.renderMobileVolumeControlOverlay(),
     ];
   }
 
@@ -446,17 +479,41 @@ class ScreenshareComponent extends React.Component {
     );
   }
 
+  splitPluginItems() {
+    const { pluginScreenshareHelperItems } = this.props;
+
+    return pluginScreenshareHelperItems.reduce((result, item) => {
+      switch (item.position) {
+        case PluginSdk.ScreenshareHelperItemPosition.TOP_RIGHT:
+          result.topRightPluginItems.push(item);
+          break;
+        case PluginSdk.ScreenshareHelperItemPosition.TOP_LEFT:
+          result.topLeftPluginItems.push(item);
+          break;
+        case PluginSdk.ScreenshareHelperItemPosition.BOTTOM_RIGHT:
+          result.bottomRightPluginItems.push(item);
+          break;
+        case PluginSdk.ScreenshareHelperItemPosition.BOTTOM_LEFT:
+          result.bottomLeftPluginItems.push(item);
+          break;
+        default:
+          break;
+      }
+      return result;
+    }, {
+      topRightPluginItems: [],
+      topLeftPluginItems: [],
+      bottomRightPluginItems: [],
+      bottomLeftPluginItems: [],
+    });
+  }
+
   renderScreensharePresenter() {
     const { switched } = this.state;
     const { isGloballyBroadcasting, intl } = this.props;
 
     return (
-      <Styled.ScreenshareContainer
-        switched={switched}
-        key="screenshareContainer"
-        ref={(ref) => { this.screenshareContainer = ref; }}
-      >
-        {isGloballyBroadcasting && this.renderSwitchButton()}
+      <>
         {this.renderVideo(switched)}
 
         {
@@ -473,7 +530,7 @@ class ScreenshareComponent extends React.Component {
               intl.formatMessage(this.locales.presenterLoadingLabel),
             )
         }
-      </Styled.ScreenshareContainer>
+      </>
     );
   }
 
@@ -482,15 +539,7 @@ class ScreenshareComponent extends React.Component {
     const { loaded } = this.state;
 
     return (
-      <Styled.ScreenshareContainer
-        switched
-        key="screenshareContainer"
-        ref={(ref) => {
-          this.screenshareContainer = ref;
-        }}
-        id="screenshareContainer"
-      >
-        {loaded && this.renderFullscreenButton()}
+      <>
         {this.renderVideo(true)}
         {loaded && enableVolumeControl && this.renderVolumeSlider() }
 
@@ -503,12 +552,61 @@ class ScreenshareComponent extends React.Component {
               : null
           }
         </Styled.ScreenshareContainerDefault>
-      </Styled.ScreenshareContainer>
+      </>
+    );
+  }
+
+  renderScreenshareButtons() {
+    const { isPresenter, isGloballyBroadcasting } = this.props;
+    const { loaded } = this.state;
+    const {
+      topRightPluginItems,
+      topLeftPluginItems,
+      bottomRightPluginItems,
+      bottomLeftPluginItems,
+    } = this.splitPluginItems();
+    return (
+      <>
+        <Styled.ScreenshareButtonsContainterWrapper
+          positionYAxis="top"
+          positionXAxis="left"
+        >
+          {renderPluginItems(topLeftPluginItems, false, false)}
+        </Styled.ScreenshareButtonsContainterWrapper>
+        <Styled.ScreenshareButtonsContainterWrapper
+          positionYAxis="top"
+          positionXAxis="right"
+        >
+          {isPresenter
+            // Presenter button:
+            ? isGloballyBroadcasting && this.renderSwitchButton()
+            // Non-presenter button:
+            : loaded && this.renderFullscreenButton()}
+          {renderPluginItems(topRightPluginItems, false, true)}
+        </Styled.ScreenshareButtonsContainterWrapper>
+        <Styled.ScreenshareButtonsContainterWrapper
+          positionYAxis="bottom"
+          positionXAxis="left"
+        >
+          {renderPluginItems(bottomLeftPluginItems, true, false)}
+        </Styled.ScreenshareButtonsContainterWrapper>
+        <Styled.ScreenshareButtonsContainterWrapper
+          positionYAxis="bottom"
+          positionXAxis="right"
+        >
+          {renderPluginItems(bottomRightPluginItems, true, true)}
+        </Styled.ScreenshareButtonsContainterWrapper>
+      </>
     );
   }
 
   render() {
-    const { loaded, autoplayBlocked, mediaFlowing} = this.state;
+    const {
+      loaded,
+      autoplayBlocked,
+      mediaFlowing,
+      switched,
+    } = this.state;
     const {
       isPresenter,
       isGloballyBroadcasting,
@@ -565,7 +663,19 @@ class ScreenshareComponent extends React.Component {
             </Styled.SpinnerWrapper>
           )}
         {autoplayBlocked ? this.renderAutoplayOverlay() : null}
-        {isPresenter ? this.renderScreensharePresenter() : this.renderScreenshareDefault()}
+        <Styled.ScreenshareContainer
+          switched={isPresenter ? switched : true}
+          key="screenshareContainer"
+          ref={(ref) => {
+            this.screenshareContainer = ref;
+          }}
+          id="screenshareContainer"
+        >
+          {this.renderScreenshareButtons()}
+          {isPresenter
+            ? this.renderScreensharePresenter()
+            : this.renderScreenshareDefault()}
+        </Styled.ScreenshareContainer>
       </div>
     );
   }
@@ -577,6 +687,9 @@ ScreenshareComponent.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
+  pluginScreenshareHelperItems: PropTypes.arrayOf(PropTypes.objectOf({
+    position: PropTypes.string,
+  })).isRequired,
   isPresenter: PropTypes.bool.isRequired,
   layoutContextDispatch: PropTypes.func.isRequired,
   enableVolumeControl: PropTypes.bool.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import { defineMessages } from 'react-intl';
 import {
@@ -11,6 +11,7 @@ import {
   useScreenshareHasAudio,
   useBroadcastContentType,
 } from './service';
+import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import ScreenshareComponent from './component';
 import { layoutSelect, layoutSelectOutput, layoutDispatch } from '../layout/context';
 import getFromUserSettings from '/imports/ui/services/users-settings';
@@ -93,6 +94,7 @@ const ScreenshareContainer = (props) => {
   const screenShare = layoutSelectOutput((i) => i.screenShare);
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const layoutContextDispatch = layoutDispatch();
+  const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 
   const { element } = fullscreen;
   const fullscreenElementId = 'Screenshare';
@@ -137,11 +139,18 @@ const ScreenshareContainer = (props) => {
   const isCameraAsContentBroadcasting = useIsCameraAsContentBroadcasting();
   const hasAudio = useScreenshareHasAudio();
 
+  let pluginScreenshareHelperItems = [];
+  if (pluginsExtensibleAreasAggregatedState.screenshareHelperItems) {
+    pluginScreenshareHelperItems = [
+      ...pluginsExtensibleAreasAggregatedState.screenshareHelperItems,
+    ];
+  }
   if (isScreenBroadcasting || isCameraAsContentBroadcasting) {
     return (
       <ScreenshareComponent
         {
         ...{
+          pluginScreenshareHelperItems,
           layoutContextDispatch,
           ...props,
           ...screenShare,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/plugin-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/plugin-button/component.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Styled from './styles';
+
+interface PluginButtonComponentProps {
+  dark: boolean;
+  bottom: boolean;
+  right: boolean;
+  icon: string;
+  label: string;
+  onClick: () => void;
+}
+
+const PluginButtonComponent = ({
+  dark = false,
+  bottom = false,
+  onClick = () => {},
+  right,
+  icon,
+  label,
+}: PluginButtonComponentProps) => (
+  <Styled.PluginButtonWrapper
+    {...{
+      dark,
+      bottom,
+      right,
+    }}
+  >
+    <Styled.PluginButton
+      color="default"
+      icon={icon}
+      size="sm"
+      onClick={onClick}
+      hideLabel
+      label={label}
+      data-test="switchButton"
+    />
+  </Styled.PluginButtonWrapper>
+);
+
+export default PluginButtonComponent;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/plugin-button/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/plugin-button/container.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PluginButtonComponent from './component';
+
+interface PluginButtonContainerProps {
+  dark: boolean;
+  bottom: boolean;
+  right: boolean;
+  icon: string;
+  label: string;
+  onClick: () => void;
+}
+
+const PluginButtonContainer = (props: PluginButtonContainerProps) => {
+  const {
+    dark,
+    bottom,
+    right,
+    icon,
+    label,
+    onClick,
+  } = props;
+  return (
+    <PluginButtonComponent
+      dark={dark}
+      bottom={bottom}
+      right={right}
+      icon={icon}
+      label={label}
+      onClick={onClick}
+    />
+  );
+};
+
+export default PluginButtonContainer;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/plugin-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/plugin-button/styles.js
@@ -6,19 +6,21 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import Button from '/imports/ui/components/common/button/component';
 
-const SwitchButtonWrapper = styled.div`
-  position: relative;
-  right: 0;
-  left: auto;
+const PluginButtonWrapper = styled.div`
   background-color: ${colorTransparent};
   cursor: pointer;
   border: 0;
   z-index: 2;
   margin: 2px;
-
   [dir="rtl"] & {
     right: auto;
-    left: 1.75rem;
+    left: 0;
+    ${({ fullScreenEnabled }) => fullScreenEnabled && `
+      left: 1.75rem;
+    `}
+  }
+  [class*="presentationZoomControls"] & {
+    position: relative !important;
   }
 
   ${({ dark }) => dark && `
@@ -36,17 +38,9 @@ const SwitchButtonWrapper = styled.div`
       color: ${colorBlack};
     }
   `}
-
-  ${({ bottom }) => bottom && `
-    bottom: 0;
-  `}
-
-  ${({ bottom }) => !bottom && `
-    top: 0;
-  `}
 `;
 
-const SwitchButton = styled(Button)`
+const PluginButton = styled(Button)`
   padding: 5px;
 
   &,
@@ -65,6 +59,6 @@ const SwitchButton = styled(Button)`
 `;
 
 export default {
-  SwitchButtonWrapper,
-  SwitchButton,
+  PluginButtonWrapper,
+  PluginButton,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
@@ -90,7 +90,37 @@ const HoverToolbar = styled.div`
   `}
 `;
 
+const ScreenshareButtonsContainterWrapper = styled.div`
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  width: 50%;
+
+  ${({ positionXAxis }) => positionXAxis === 'right' && `
+    right: 0;
+    flex-direction: row-reverse;
+  `}
+  ${({ positionXAxis }) => positionXAxis === 'left' && `
+    left: 0;
+  `}
+
+  ${({ positionYAxis }) => positionYAxis === 'top' && `
+    top: 0;
+  `}
+  ${({ positionYAxis }) => positionYAxis === 'bottom' && `
+    bottom: 0;
+  `}
+`;
+
+const FullscreenButtonWrapperForScreenshare = styled.div`
+  & > * {
+    position: relative !important;
+  }
+`;
+
 export default {
+  FullscreenButtonWrapperForScreenshare,
+  ScreenshareButtonsContainterWrapper,
   ScreenshareContainerInside,
   MainText,
   ScreenshareVideo,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { IntlShape, defineMessages, injectIntl } from 'react-intl';
+import { UpdatedEventDetailsForUserCameraDomElement } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
 import { throttle } from '/imports/utils/throttle';
 import { range } from '/imports/utils/array-utils';
 import Styled from './styles';
@@ -76,6 +77,7 @@ interface VideoListProps {
   isGridEnabled: boolean;
   streams: VideoItem[];
   intl: IntlShape;
+  setUserCamerasRequestedFromPlugin: React.Dispatch<React.SetStateAction<UpdatedEventDetailsForUserCameraDomElement[]>>;
   onVideoItemMount: (stream: string, video: HTMLVideoElement) => void;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (stream: string, type: string, name: string, data: string) => Promise<unknown>;
@@ -345,6 +347,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       onVideoItemMount,
       onVideoItemUnmount,
       handleVideoFocus,
+      setUserCamerasRequestedFromPlugin,
       focusedId,
     } = this.props;
     const numOfStreams = streams.length;
@@ -369,6 +372,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
             name={name}
             focused={isFocused}
             isStream={isStream}
+            setUserCamerasRequestedFromPlugin={setUserCamerasRequestedFromPlugin}
             onHandleVideoFocus={isStream ? handleVideoFocus : null}
             onVideoItemMount={(videoRef) => {
               this.handleCanvasResize();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import VideoList from '/imports/ui/components/video-provider/video-list/component';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
 import { useNumberOfPages } from '/imports/ui/components/video-provider/hooks';
 import { VideoItem } from '/imports/ui/components/video-provider/types';
 import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
+import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
+import { UpdatedEventDetailsForUserCameraDomElement } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
+import { HookEvents } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
+import { DomElementManipulationHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/enums';
+import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 
 interface VideoListContainerProps {
   streams: VideoItem[];
@@ -33,12 +38,30 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
   } = props;
   const numberOfPages = useNumberOfPages();
 
+  const { domElementManipulationStreamIds } = useContext(PluginsContext);
+
+  const [userCamerasRequestedFromPlugin, setUserCamerasRequestedFromPlugin] = useState<
+    UpdatedEventDetailsForUserCameraDomElement[]>([]);
+  useEffect(() => {
+    const dataToSend = userCamerasRequestedFromPlugin.filter((
+      userCamera,
+    ) => domElementManipulationStreamIds.indexOf(userCamera.streamId) !== -1);
+    window.dispatchEvent(
+      new CustomEvent<UpdatedEventDetails<UpdatedEventDetailsForUserCameraDomElement[]>>(HookEvents.UPDATED, {
+        detail: {
+          hook: DomElementManipulationHooks.USER_CAMERA,
+          data: dataToSend,
+        },
+      }),
+    );
+  }, [domElementManipulationStreamIds]);
   return (
     !streams.length
       ? null
       : (
         <VideoList
           layoutType={layoutType}
+          setUserCamerasRequestedFromPlugin={setUserCamerasRequestedFromPlugin}
           layoutContextDispatch={layoutContextDispatch}
           numberOfPages={numberOfPages}
           currentVideoPageIndex={currentVideoPageIndex}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import { UpdatedEventDetailsForUserCameraDomElement } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
 import Session from '/imports/ui/services/storage/in-memory';
 import UserActions from '/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component';
 import UserStatus from '/imports/ui/components/video-provider/video-list/video-list-item/user-status/component';
@@ -29,6 +30,7 @@ const VIDEO_CONTAINER_WIDTH_BOUND = 125;
 
 interface VideoListItemProps {
   isFullscreenContext: boolean;
+  setUserCamerasRequestedFromPlugin: React.Dispatch<React.SetStateAction<UpdatedEventDetailsForUserCameraDomElement[]>>;
   layoutContextDispatch: (...args: unknown[]) => void;
   isRTL: boolean;
   amIModerator: boolean;
@@ -63,7 +65,7 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
     name, voiceUser, isFullscreenContext, layoutContextDispatch, onHandleVideoFocus,
     cameraId, numOfStreams, focused, onVideoItemMount, onVideoItemUnmount,
     makeDragOperations, dragging, draggingOver, isRTL, isStream, settingsSelfViewDisable,
-    disabledCams, amIModerator, stream,
+    disabledCams, amIModerator, stream, setUserCamerasRequestedFromPlugin,
   } = props;
 
   const intl = useIntl();
@@ -83,6 +85,18 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
 
   const videoTag = useRef<HTMLVideoElement | null>(null);
   const videoContainer = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setUserCamerasRequestedFromPlugin((userCamera) => {
+      if (videoContainer.current && !userCamera.some((uc) => uc.streamId === cameraId)) {
+        userCamera.push({
+          streamId: cameraId,
+          userCameraDomElement: videoContainer.current,
+        });
+      }
+      return userCamera;
+    });
+  }, [videoContainer]);
 
   const videoIsReady = isStreamHealthy && videoDataLoaded && !isSelfViewDisabled;
   const Settings = getSettingsSingletonInstance();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { UpdatedEventDetailsForUserCameraDomElement } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
+
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
 import VideoListItem from './component';
@@ -21,6 +23,7 @@ interface VideoListItemContainerProps {
   isStream: boolean;
   onHandleVideoFocus: ((id: string) => void) | null;
   stream: VideoItem;
+  setUserCamerasRequestedFromPlugin: React.Dispatch<React.SetStateAction<UpdatedEventDetailsForUserCameraDomElement[]>>;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (type: string, name: string, data: string) => void;
   onVideoItemMount: (ref: HTMLVideoElement) => void;
@@ -37,6 +40,7 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
     onVideoItemMount,
     onVideoItemUnmount,
     onVirtualBgDrop,
+    setUserCamerasRequestedFromPlugin,
     stream,
     userId,
   } = props;
@@ -72,6 +76,7 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
         isRTL,
         amIModerator,
       }}
+      setUserCamerasRequestedFromPlugin={setUserCamerasRequestedFromPlugin}
       cameraId={cameraId}
       disabledCams={disabledCams}
       focused={focused}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
@@ -2,7 +2,7 @@ import React, { MutableRefObject, useContext, useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useMutation } from '@apollo/client';
 import Session from '/imports/ui/services/storage/in-memory';
-import { UserCameraDropdownInterface } from 'bigbluebutton-html-plugin-sdk';
+import { UserCameraDropdownInterface, UserCameraDropdownOption } from 'bigbluebutton-html-plugin-sdk';
 import browserInfo from '/imports/utils/browserInfo';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
 import BBBMenu from '/imports/ui/components/common/menu/component';
@@ -243,19 +243,24 @@ const UserActions: React.FC<UserActionProps> = (props) => {
       );
     }
 
-    userCameraDropdownItems.forEach((pluginItem) => {
+    userCameraDropdownItems.filter(
+      (pluginItem) => (pluginItem.displayFunction?.({ userId, streamId: cameraId }) ?? true),
+    ).forEach((pluginItem) => {
       switch (pluginItem.type) {
-        case UserCameraDropdownItemType.OPTION:
+        case UserCameraDropdownItemType.OPTION: {
+          const optionItem = pluginItem as UserCameraDropdownOption;
           menuItems.push({
-            key: pluginItem.id,
-            // @ts-expect-error -> Plugin-related.
-            label: pluginItem.label,
-            // @ts-expect-error -> Plugin-related.
-            onClick: pluginItem.onClick,
-            // @ts-expect-error -> Plugin-related.
-            icon: pluginItem.icon,
+            key: optionItem.id,
+            label: optionItem.label,
+            onClick: (event: React.MouseEvent<HTMLElement>) => optionItem.onClick({
+              streamId: cameraId,
+              userId,
+              browserClickEvent: event,
+            }),
+            icon: optionItem.icon,
           });
           break;
+        }
         case UserCameraDropdownItemType.SEPARATOR:
           menuItems.push({
             key: pluginItem.id,


### PR DESCRIPTION
### What does this PR do?

This PR does 3 related things in general:
- Enhance user-camera-dropdown extensible area;
  - Add display function callback to decide in which cameras that dropdown will be shown;
  - Add onClick arguments for the dropdown option;  
- Create another extensible-area which is screenshare helper;
- Create another dom-element-manipulation hook: `useUserCameraDomElement`;

See some demo of the 2 first items:

User-camera-dropdown display funcion demo:

https://github.com/user-attachments/assets/53cad8c6-baf2-4768-8ce7-d215a3a3e5cd


Screenshare helper buttons
![image](https://github.com/user-attachments/assets/9fa1e7ae-c95e-43cb-8717-39dedc5613ce)


### More
Closely related to SDK's https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/106
