### PR TITLE
feat(bbb-webrtc-sfu): enable new mediasoup balancing strategies

### DIFF
--- a/build/packages-template/bbb-webrtc-sfu/after-install.sh
+++ b/build/packages-template/bbb-webrtc-sfu/after-install.sh
@@ -12,6 +12,12 @@ case "$1" in
     # Set mediasoup IPs
     yq e -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
     yq e -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
+    # mediasoup.workerBalancing: defines the strategy to distribute mediasoup
+    # elements (transports, producers, consumers) among workers.
+    yq e -i '.mediasoup.workerBalancing.strategy = "least-loaded"' $TARGET
+    # mediasoup.enableWorkerTransposing: whether to enable worker transposing
+    # (ie: the ability to move a media stream from one worker to another).
+    yq e -i '.mediasoup.enableWorkerTransposing = true' $TARGET
 
     FREESWITCH_IP=$(xmlstarlet sel -t -v '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "local_ip_v4=")]/@data' /opt/freeswitch/conf/vars.xml | sed 's/local_ip_v4=//g')
     if [ "$FREESWITCH_IP" != "" ]; then


### PR DESCRIPTION
### What does this PR do?

- [feat(bbb-webrtc-sfu): enable new mediasoup balancing strategies](https://github.com/bigbluebutton/bigbluebutton/pull/20822/commits/936363b31077ce10905381767743db35378521b9)
  - We currently use a simple producer round-robin algorithm to distribute
elements between mediasoup workers. This works for most scenarios but
fails in some edge cases, such as:
    - 1-to-N scenarios where N >= ~600-800 (sample number, varies by
  single-core performance). This is due to subscribers being pinned to a
  producer's worker.
    - Poor distribution results from round-robin.
  - Enable the following new features in bbb-webrtc-sfu via after-install by
default:
    - `mediasoup.workerBalancing.strategy: least-loaded`: Replaces
  round-robin with load scoring. Workers are selected based on which is
  least loaded.
    - `mediasoup.enableWorkerTransposing: true`: Allows media streams to be
  bridged between workers through internal RTP pipes. This, along with a
  per-worker stream limit, enables seamless offloading of streams between
  workers (whether publishers or subscribers). The per-worker stream limit
  is still under review.
  - These changes should address the issues mentioned. They are enabled via
after-install because the SFU version is shared with previous BBB versions
where these features are not desirable yet.

### Closes Issue(s)

None