### PR TITLE
fix(screenshare): use local state as well for rendering

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -26,6 +26,7 @@ import useSettings from '../../services/settings/hooks/useSettings';
 import { SETTINGS } from '../../services/settings/enums';
 import { useStorageKey } from '../../services/storage/hooks';
 import { useVideoStreamsCount } from '../video-provider/hooks';
+import { useIsRTCContentBridgeBroadcasting } from '/imports/ui/components/screenshare/service';
 
 const currentUserEmoji = (currentUser) => (currentUser
   ? {
@@ -131,6 +132,7 @@ const AppContainer = (props) => {
   const isScreenSharingEnabled = useIsScreenSharingEnabled();
   const isExternalVideoEnabled = useIsExternalVideoEnabled();
   const isPresentationEnabled = useIsPresentationEnabled();
+  const isRTCContentBridgeBroadcasting = useIsRTCContentBridgeBroadcasting();
 
   const { data: currentUserData } = useCurrentUser((user) => ({
     enforceLayout: user.enforceLayout,
@@ -231,9 +233,10 @@ const AppContainer = (props) => {
     return enforceLayout && layoutTypes.includes(enforceLayout) ? enforceLayout : null;
   };
 
+  // This is a trigger for showing both screenshare and "camera as content" since
+  // the later uses the screenshare bridge to broadcast cameras (with CONTENT_TYPE_CAMERA)
   const shouldShowScreenshare = (viewScreenshare || isPresenter)
-    && (currentMeeting?.componentsFlags?.hasScreenshare
-      || currentMeeting?.componentsFlags?.hasCameraAsContent);
+    && isRTCContentBridgeBroadcasting;
   const shouldShowPresentation = (!shouldShowScreenshare && !isSharedNotesPinned
     && !shouldShowExternalVideo && !shouldShowGenericMainContent
     && (presentationIsOpen || presentationRestoreOnUpdate)) && isPresentationEnabled;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -155,6 +155,17 @@ export const useBroadcastContentType = () => {
   return data[0].contentType;
 };
 
+// This hook is used to check if the WebRTC content bridge (ie.: screensharing
+// or camera as content) is broadcasting. It uses both the local and remote
+// states - for remote-only checks, use useIsScreenGloballyBroadcasting or
+// useIsCameraAsContentGloballyBroadcasting.
+export const useIsRTCContentBridgeBroadcasting = () => {
+  const isScreenBroadcasting = useIsScreenBroadcasting();
+  const isCameraAsContentBroadcasting = useIsCameraAsContentBroadcasting();
+
+  return isScreenBroadcasting || isCameraAsContentBroadcasting;
+}
+
 export const screenshareHasEnded = () => {
   if (isSharingVar()) {
     setIsSharing(false);
@@ -382,4 +393,5 @@ export default {
   useIsCameraAsContentBroadcasting,
   useScreenshareHasAudio,
   useBroadcastContentType,
+  useIsRTCContentBridgeBroadcasting,
 };


### PR DESCRIPTION
### What does this PR do?

- [fix(screenshare): use local state as well for rendering](https://github.com/bigbluebutton/bigbluebutton/pull/20828/commits/7ea8de15dbe3afb1b6219432a46ba59e287a76aa) 
  * BBB <= 2.7 uses both the local and remote states for loading the
screen-sharing container in the content area - with proper tracking of
connecting/connected states to speed up UI responsiveness for presenters
and properly reflect the current media state.
    That behavior was reverted in 3.0 to only use the remote state, which
regresses the client by causing the UI to be idle (thus not reflect any
state) while screen is being negotiated.
  * Use both local and remote states for rendering the screen sharing
component, which fixes the aforementioned regression.

### Closes Issue(s)

None

### More

Comparison (with artificial latency to make it clearer):

#### 2.7

https://github.com/user-attachments/assets/4986fdbf-4fb1-4c84-bf2e-b0b788aeea63

#### Current 3.0

https://github.com/user-attachments/assets/1e307ae7-cad5-41ad-bebb-3720598a9bd4

#### This PR


https://github.com/user-attachments/assets/4478b5f7-7e00-4ef2-beb8-ee5c29801850


