### PR TITLE
fix(presentation): presentation snapshot overflowing the slide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -304,20 +304,14 @@ const PresentationMenu = (props) => {
             try {
               // filter shapes that are inside the slide
               const backgroundShape = tldrawAPI.getCurrentPageShapes().find((s) => s.id === `shape:BG-${slideNum}`);
-              const shapes = tldrawAPI.getCurrentPageShapes().filter(
-                (shape) => shape.x <= backgroundShape.props.w
-                  && shape.y <= backgroundShape.props.h
-                  && shape.x >= 0
-                  && shape.y >= 0,
-              );
+              const shapes = tldrawAPI.getCurrentPageShapes();
               const svgElem = await tldrawAPI.getSvg(shapes.map((shape) => shape.id));
+              svgElem.setAttribute('width', backgroundShape.props.w);
+              svgElem.setAttribute('height', backgroundShape.props.h);
+              svgElem.setAttribute('viewBox', `1 1 ${backgroundShape.props.w} ${backgroundShape.props.h}`);
 
               // workaround for ios
               if (isIos || isSafari) {
-                svgElem.setAttribute('width', backgroundShape.props.w);
-                svgElem.setAttribute('height', backgroundShape.props.h);
-                svgElem.setAttribute('viewBox', `1 1 ${backgroundShape.props.w} ${backgroundShape.props.h}`);
-
                 const svgString = new XMLSerializer().serializeToString(svgElem);
                 const blob = new Blob([svgString], { type: 'image/svg+xml' });
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes annotations overflowing the slide container in presentation snapshots, which adds a white margin. Some annotations gets lost.

#### Whiteboard:
![Screenshot from 2024-08-01 12-11-10](https://github.com/user-attachments/assets/6c4a75e7-c3ef-41ea-88d9-4770d916e719)

#### Generated snapshot:
![Presentation__2024-08-01T15_09_49 338Z](https://github.com/user-attachments/assets/07df4ff0-a08b-4216-8401-1660c2781b51)

#### Currently (lost star and added white margin):
![Presentation__2024-08-01T15_09_00 969Z](https://github.com/user-attachments/assets/48cc757b-b033-4eb2-971f-bc02b6259adc)