### PR TITLE
fix(video): camera cannot be shared as content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -735,7 +735,13 @@ class VideoPreview extends Component {
       this.currentVideoStream = bbbVideoStream;
       this.updateDeviceId(deviceId);
 
-      if (cameraAsContent) return Promise.resolve(true);
+      if (cameraAsContent) {
+        this.setState({
+          isStartSharingDisabled: false,
+        });
+
+        return Promise.resolve(true);
+      }
 
       return this.startEffects(deviceId)
         .catch((error) => {


### PR DESCRIPTION
### What does this PR do?

- [fix(video): camera cannot be shared as content](https://github.com/bigbluebutton/bigbluebutton/commit/6ec1272a2bef2d8a4fb301358be6e183d353107a) 
  * A change in e28a595 introduced an issue where the "Share camera as
content" modal always has it's "share" action flagged as disabled. This
is due to a short-circuit introduced in the initial gUM procedure that
does not clear the "disabled" state before exiting.
  * Properly reset the "disabled" sharing state after the initial gUM in
video-preview when "Share camera as content" is used, thus fixing the
aforementioned issue.

### Closes Issue(s)

n/a