### PR TITLE
fix: Label of quick poll items up to 'I'

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -293,7 +293,7 @@ const QuickPollDropdown = (props) => {
       itemLabel = itemLabel?.replace(/\s+/g, '').toUpperCase();
 
       const numChars = {
-        1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G'
+        1: 'A', 2: 'B', 3: 'C', 4: 'D', 5: 'E', 6: 'F', 7: 'G', 8: 'H', 9: 'I',
       };
       itemLabel = itemLabel.split('').map((c) => {
         if (numChars[c]) return numChars[c];


### PR DESCRIPTION
### What does this PR do?

Ports #12712 changes to v3.0.x-release.

_With #12620 and #12692, the quick poll accepts up to 9 options, however the labeling of quick poll in the presentation tool bar still shows only A-G letters, such as "A/B/C/D/E/F/G/8/9". This patch fixes the problem._
