### PR TITLE
fix(sharedNotes): Fix pinned shared notes button border

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/styles.ts
@@ -15,6 +15,10 @@ const UnreadMessagesText = styled(StyledContent.UnreadMessagesText)``;
 
 const ListItem = styled(StyledContent.ListItem)`
   i{ left: 4px; }
+
+  :disabled {
+    border: none;
+  }
 `;
 
 const NotesTitle = styled.div`


### PR DESCRIPTION
When shared notes are pinned the button exhibits an improper black border, fixed it

![352654991-62296b5f-ccd8-45c7-97fe-a03c828f39c7](https://github.com/user-attachments/assets/833b1f2e-fa27-442b-80b9-78f6b4d2ff87)

