### PR TITLE
fix(video): webcam fails to be loaded on preview when changing profiles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -646,7 +646,7 @@ class VideoPreview extends Component {
 
     if (!actualDeviceId && this.currentVideoStream) {
       actualDeviceId = MediaStreamUtils.extractDeviceIdFromStream(
-        this.currentVideoStream.mediaStream,
+        this.currentVideoStream.originalStream,
         'video',
       );
     }
@@ -660,9 +660,7 @@ class VideoPreview extends Component {
       ? PreviewService.getDefaultProfile()
       : PreviewService.getCameraAsContentProfile();
 
-    return this.getCameraStream(deviceId, defaultProfile).then(() => {
-      this.updateDeviceId(deviceId);
-    });
+    return this.getCameraStream(deviceId, defaultProfile);
   }
 
   async startEffects(deviceId) {


### PR DESCRIPTION
### What does this PR do?

- [fix(video): webcam fails to be loaded on preview when changing profiles](https://github.com/bigbluebutton/bigbluebutton/commit/2c6de02f1ca1b1e0bbf0a2883bc729723b732493) 
  - There's an issue where permission-less sessions of video-preview
fail to change video profiles. Whenever gUM is on prompt mode,
deviceIds are obfuscated, which means getInitialCamera will need to
infer the deviceId based on the current media stream.
Since the virtual bg worker is now called synchronously (https://github.com/bigbluebutton/bigbluebutton/commit/e28a595b525f6ff6c472ac3a00b13e455d7cea4a),
it'll be extracted incorrectly from the virtual effect MediaStream
(rather  than the original stream) - which causes getInitialCamera to
use the effect's deviceId rather than the original stream's deviceId.
  - Guarantee that deviceId inference via MediaStreamTrack uses
BBBVideoStream's originalStream (so that virtual effect streams are
bypassed). Also remove the call to updateDeviceId in getInitialCamera
since it's redundant since commit https://github.com/bigbluebutton/bigbluebutton/commit/e28a595b525f6ff6c472ac3a00b13e455d7cea4a.

### Closes Issue(s)

None (reported internally)