### PR TITLE
fix(external-video): player starting at an advanced point

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -248,7 +248,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   useEffect(() => {
     if (playerRef.current) {
-      playerRef.current.seekTo(currentTime, 'seconds');
+      const truncatedTime = currentTime < 1 ? 0 : currentTime;
+      playerRef.current.seekTo(truncatedTime, 'seconds');
     }
   }, [playerRef.current, playing]);
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Sometimes, when sharing an YouTube video, the external video player starts at an advanced point, which harms the user experience. This happens when `currentTime` is between 0 and 1, making the player consider it as percentage. This PR truncates that value when it's less than `1`, making `0` the minimum value possible.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Partially closes (maybe) https://github.com/bigbluebutton/bigbluebutton/issues/19981 (not sure)
Closes (maybe) https://github.com/bigbluebutton/bigbluebutton/issues/19862 (not sure)