### PR TITLE
fix(bbb-export-annotations): Handle text rendering issue

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -130,6 +130,7 @@ function escapeText(string) {
       .replace(/</g, '\\&lt;');
 }
 
+// Rasterizes text into an image. Returns true if successful, false otherwise.
 function render_textbox(textColor, font, fontSize, textAlign, text, id, textBoxWidth = null) {
   fontSize = to_pt(fontSize) * config.process.textScaleFactor;
   text = escapeText(text);
@@ -155,12 +156,15 @@ function render_textbox(textColor, font, fontSize, textAlign, text, id, textBoxW
         path.join(dropbox, `text${id}.png`),
       ]);
 
-  try {
-    cp.spawnSync(config.shared.imagemagick, commands, {shell: false});
-  } catch (error) {
+  const result = cp.spawnSync(config.shared.imagemagick, commands, {shell: false});
+
+  if (result.error || result.status !== 0) {
     logger.error(`ImageMagick failed to render textbox in job ${jobId}: ${error.message}`);
     statusUpdate.setError();
+    return false;
   }
+
+  return true;
 }
 
 function get_gap(dash, size) {
@@ -607,10 +611,10 @@ function overlay_shape_label(svg, annotation) {
   const label_center_x = shape_x + shape_width * x_offset;
   const label_center_y = shape_y + shape_height * y_offset;
 
-  render_textbox(fontColor, font, fontSize, textAlign, text, id);
+  const renderStatus = render_textbox(fontColor, font, fontSize, textAlign, text, id);
   const shape_label = path.join(dropbox, `text${id}.png`);
 
-  if (fs.existsSync(shape_label)) {
+  if (fs.existsSync(shape_label) && renderStatus) {
     // Poll results must fit inside shape, unlike other rectangle labels.
     // Linewrapping handled by client.
     const ref = `file://${dropbox}/text${id}.png`;
@@ -651,25 +655,27 @@ function overlay_sticky(svg, annotation) {
   const text = annotation.text;
   const id = sanitize(annotation.id);
 
-  render_textbox(textColor, font, fontSize, textAlign, text, id, textBoxWidth);
+  const renderStatus = render_textbox(textColor, font, fontSize, textAlign, text, id, textBoxWidth);
 
   // Overlay transparent text image over empty sticky note
-  svg.ele('g', {
-    transform: `rotate(${rotation}, ${textBox_x + (textBoxWidth / 2)}, ${textBox_y + (textBoxHeight / 2)})`,
-  }).ele('rect', {
-    x: textBox_x,
-    y: textBox_y,
-    width: textBoxWidth,
-    height: textBoxHeight,
-    fill: backgroundColor,
-  }).up()
-      .ele('image', {
-        'x': textBox_x,
-        'y': textBox_y,
-        'width': textBoxWidth,
-        'height': textBoxHeight,
-        'xlink:href': `file://${dropbox}/text${id}.png`,
-      }).up();
+  if (renderStatus) {
+    svg.ele('g', {
+      transform: `rotate(${rotation}, ${textBox_x + (textBoxWidth / 2)}, ${textBox_y + (textBoxHeight / 2)})`,
+    }).ele('rect', {
+      x: textBox_x,
+      y: textBox_y,
+      width: textBoxWidth,
+      height: textBoxHeight,
+      fill: backgroundColor,
+    }).up()
+        .ele('image', {
+          'x': textBox_x,
+          'y': textBox_y,
+          'width': textBoxWidth,
+          'height': textBoxHeight,
+          'xlink:href': `file://${dropbox}/text${id}.png`,
+        }).up();
+  }
 }
 
 function overlay_triangle(svg, annotation) {
@@ -719,20 +725,22 @@ function overlay_text(svg, annotation) {
   const rotation = rad_to_degree(annotation.rotation);
   const [textBox_x, textBox_y] = annotation.point;
 
-  render_textbox(fontColor, font, fontSize, textAlign, text, id);
+  const renderStatus = render_textbox(fontColor, font, fontSize, textAlign, text, id);
 
-  const rotation_x = textBox_x + (textBoxWidth / 2);
-  const rotation_y = textBox_y + (textBoxHeight / 2);
+  if (renderStatus) {
+    const rotation_x = textBox_x + (textBoxWidth / 2);
+    const rotation_y = textBox_y + (textBoxHeight / 2);
 
-  svg.ele('g', {
-    transform: `rotate(${rotation} ${rotation_x} ${rotation_y})`,
-  }).ele('image', {
-    'x': textBox_x,
-    'y': textBox_y,
-    'width': textBoxWidth,
-    'height': textBoxHeight,
-    'xlink:href': `file://${dropbox}/text${id}.png`,
-  }).up();
+    svg.ele('g', {
+      transform: `rotate(${rotation} ${rotation_x} ${rotation_y})`,
+    }).ele('image', {
+      'x': textBox_x,
+      'y': textBox_y,
+      'width': textBoxWidth,
+      'height': textBoxHeight,
+      'xlink:href': `file://${dropbox}/text${id}.png`,
+    }).up();
+  }
 }
 
 function overlay_annotation(svg, currentAnnotation) {

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -638,6 +638,8 @@ function overlay_shape_label(svg, annotation) {
       'height': labelHeight,
       'xlink:href': ref,
       }).up();
+    } else {
+      logger.warn(`Could not render status in overlay_shape_label for ${annotation}`);
     }
 }
 
@@ -675,9 +677,9 @@ function overlay_sticky(svg, annotation) {
           'height': textBoxHeight,
           'xlink:href': `file://${dropbox}/text${id}.png`,
         }).up();
+  } else {
+    logger.warn(`Could not render status in overlay_sticky for ${annotation}`);
   }
-} else {
-  logger.warn("Could not render status in overlay_sticky for JSON.stringify(annotation)");
 }
 
 function overlay_triangle(svg, annotation) {
@@ -742,9 +744,9 @@ function overlay_text(svg, annotation) {
       'height': textBoxHeight,
       'xlink:href': `file://${dropbox}/text${id}.png`,
     }).up();
+  } else {
+    logger.warn(`Could not render status in render_textbox for ${annotation}`);
   }
-} else {
-  logger.warn("Could not render status in render_textbox for JSON.stringify(annotation)");
 }
 
 function overlay_annotation(svg, currentAnnotation) {

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -741,6 +741,8 @@ function overlay_text(svg, annotation) {
       'xlink:href': `file://${dropbox}/text${id}.png`,
     }).up();
   }
+} else {
+  logger.warn("Could not render status in render_textbox for JSON.stringify(annotation)");
 }
 
 function overlay_annotation(svg, currentAnnotation) {

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -676,6 +676,8 @@ function overlay_sticky(svg, annotation) {
           'xlink:href': `file://${dropbox}/text${id}.png`,
         }).up();
   }
+} else {
+  logger.warn("Could not render status in overlay_sticky for JSON.stringify(annotation)");
 }
 
 function overlay_triangle(svg, annotation) {


### PR DESCRIPTION
### What does this PR do?
If ImageMagick fails to rasterize text for some reason so that it can be included in a PDF export, a corrupted image file was being generated that prevented subsequent shapes from appearing on the resulting PDF.

This PR proactively prevents the corrupted image file from being included in the SVG.

### Closes Issue(s)
Closes #20690

### How to test
I managed to reproduce the issue by adding very large amounts of text to the whiteboard (e.g., a 5000-word Lorem Ipsum).

### More
In BBB 3.0, we do not rely on ImageMagick to embed text in the exported PDF. Hence, it is not necessary to port this PR.