### PR TITLE
fix(whiteboard): Correct scaling after layout changes and full-screen exits

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -174,7 +174,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
   const previousTool = React.useRef(null);
 
   const THRESHOLD = 0.1;
-  const CAMERA_UPDATE_DELAY = 500;
+  const CAMERA_UPDATE_DELAY = 650;
   const lastKnownHeight = React.useRef(presentationAreaHeight);
   const lastKnownWidth = React.useRef(presentationAreaWidth);
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the whiteboard failing to scale correctly after changing the layout or exiting a full-screen webcam view. The update slightly increases the timeout to allow the BBB layout to complete its calculations and position itself properly.

### Closes Issue(s)

Closes #20819 
