### PR TITLE
fix: "send feedback" button styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -342,23 +342,25 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
             ) : null}
           </div>
         ) : null}
-        {noRating ? (
-          <Styled.MeetingEndedButton
-            color="primary"
-            onClick={() => setDispatched(true)}
-            aria-description={intl.formatMessage(intlMessage.confirmDesc)}
-          >
-            {intl.formatMessage(intlMessage.buttonOkay)}
-          </Styled.MeetingEndedButton>
-        ) : null}
-        {!noRating ? (
-          <Styled.MeetingEndedButton
-            onClick={sendFeedback}
-            aria-description={intl.formatMessage(intlMessage.sendDesc)}
-          >
-            {intl.formatMessage(intlMessage.sendLabel)}
-          </Styled.MeetingEndedButton>
-        ) : null}
+        <Styled.Wrapper>
+          {noRating ? (
+            <Styled.MeetingEndedButton
+              color="primary"
+              onClick={() => setDispatched(true)}
+              aria-description={intl.formatMessage(intlMessage.confirmDesc)}
+            >
+              {intl.formatMessage(intlMessage.buttonOkay)}
+            </Styled.MeetingEndedButton>
+          ) : null}
+          {!noRating ? (
+            <Styled.MeetingEndedButton
+              onClick={sendFeedback}
+              aria-description={intl.formatMessage(intlMessage.sendDesc)}
+            >
+              {intl.formatMessage(intlMessage.sendLabel)}
+            </Styled.MeetingEndedButton>
+          ) : null}
+        </Styled.Wrapper>
       </>
     );
   }, [askForFeedbackOnLogout, dispatched, selectedStars]);

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/styles.ts
@@ -75,7 +75,6 @@ const MeetingEndedButton = styled.button`
   cursor: pointer;
   user-select: none;
   height: 3rem;
-  width: 3rem;
   display: flex !important;
   align-items: center;
   box-align: center;


### PR DESCRIPTION
### What does this PR do?

Adjusts size and position for the "send feedback" button

#### before

![feedback-before](https://github.com/user-attachments/assets/49416a3c-7196-409c-8e1b-7959e1c67e45)


#### after

![feedback-after](https://github.com/user-attachments/assets/2662ac9b-7edd-41ba-8c50-f9f79f9a20b3)


### How to test
1. join a meeting with the parameter `userdata-bbb_ask_for_feedback_on_logout=true`
2. leave/end meeting
3. select any number of stars in feedback rating area