### PR TITLE
fix(presentation): restore last state after sharing media

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -4,7 +4,12 @@ import { useMutation, useReactiveVar } from '@apollo/client';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import Auth from '/imports/ui/services/auth';
 import ActionsBar from './component';
-import { layoutSelectOutput, layoutDispatch } from '../layout/context';
+import {
+  layoutSelectOutput,
+  layoutSelectInput,
+  layoutDispatch,
+  layoutSelect,
+} from '../layout/context';
 import {
   useIsExternalVideoEnabled,
   useIsPollingEnabled,
@@ -41,6 +46,9 @@ const ActionsBarContainer = (props) => {
   );
   const presentationPage = presentationPageData?.pres_page_curr[0] || {};
   const isThereCurrentPresentation = !!presentationPage?.presentationId;
+
+  const genericMainContent = layoutSelectInput((i) => i.genericMainContent);
+  const isThereGenericMainContent = !!genericMainContent.genericContentId;
 
   const { data: currentMeeting } = useMeeting((m) => ({
     externalVideo: m.externalVideo,
@@ -113,6 +121,7 @@ const ActionsBarContainer = (props) => {
         isSharedNotesPinned,
         isTimerActive: currentMeeting.componentsFlags.hasTimer,
         isTimerEnabled: isTimerFeatureEnabled,
+        hasGenericContent: isThereGenericMainContent,
       }
     }
     />

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -55,6 +55,10 @@ const PresentationOptionsContainer = ({
   const isThereCurrentPresentation = hasExternalVideo || hasScreenshare
   || hasPresentation || hasPinnedSharedNotes
   || hasGenericContent || hasCameraAsContent;
+  const onlyPresentation = hasPresentation
+  && !hasExternalVideo && !hasScreenshare
+  && !hasPinnedSharedNotes && !hasGenericContent
+  && !hasCameraAsContent;
   return (
     <Button
       icon={`${buttonType}${!presentationIsOpen ? '_off' : ''}`}
@@ -68,7 +72,7 @@ const PresentationOptionsContainer = ({
       size="lg"
       onClick={() => {
         setPresentationIsOpen(layoutContextDispatch, !presentationIsOpen);
-        if (!hasExternalVideo && !hasScreenshare && !hasPinnedSharedNotes) {
+        if (onlyPresentation) {
           Session.setItem('presentationLastState', !presentationIsOpen);
         }
       }}

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -574,7 +574,6 @@ class App extends Component {
           shouldShowScreenshare
             ? (
               <ScreenshareContainer
-                isLayoutSwapped={!presentationIsOpen}
                 isPresenter={isPresenter}
               />
             )

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -223,27 +223,6 @@ const AppContainer = (props) => {
     );
   });
 
-  useEffect(() => {
-    if (isSharingVideo && !hasExternalVideoOnLayout) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
-        value: {
-          content: PRESENTATION_AREA.EXTERNAL_VIDEO,
-          open: true,
-        },
-      });
-      layoutContextDispatch({
-        type: ACTIONS.SET_HAS_EXTERNAL_VIDEO,
-        value: true,
-      });
-    } else if (hasExternalVideoOnLayout) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_HAS_EXTERNAL_VIDEO,
-        value: false,
-      });
-    }
-  }, [isSharingVideo]);
-
   const shouldShowExternalVideo = isExternalVideoEnabled && isSharingVideo;
 
   const shouldShowGenericMainContent = !!genericMainContent.genericContentId;

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -12,6 +12,7 @@ import useUpdatePresentationAreaContentForPlugin from '/imports/ui/components/pl
 import { useIsPresentationEnabled } from '/imports/ui/services/features';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
 import { usePrevious } from '../whiteboard/utils';
+import Session from '/imports/ui/services/storage/in-memory';
 
 // variable to debug in console log
 const debug = false;
@@ -1361,6 +1362,7 @@ const updatePresentationAreaContent = (
     previousPresentationAreaContentActions.current = currentPresentationAreaContentActions.slice(0);
     const lastIndex = currentPresentationAreaContentActions.length - 1;
     const lastPresentationContentInPile = currentPresentationAreaContentActions[lastIndex];
+    let shouldOpenPresentation = true;
     switch (lastPresentationContentInPile.value.content) {
       case PRESENTATION_AREA.GENERIC_CONTENT: {
         layoutContextDispatch({
@@ -1457,6 +1459,7 @@ const updatePresentationAreaContent = (
           type: ACTIONS.PINNED_NOTES,
           value: !lastPresentationContentInPile.value.open,
         });
+        shouldOpenPresentation = Session.getItem('presentationLastState');
         break;
       }
       default:
@@ -1464,7 +1467,7 @@ const updatePresentationAreaContent = (
     }
     layoutContextDispatch({
       type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-      value: true,
+      value: shouldOpenPresentation,
     });
   }
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -303,7 +303,7 @@ class Presentation extends PureComponent {
           },
         });
       }
-      const presentationChanged = presentationId !== currentPresentationId;
+      const presentationChanged = presentationId && presentationId !== currentPresentationId;
 
       if (
         !presentationIsOpen

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -147,12 +147,6 @@ class ScreenshareComponent extends React.Component {
       },
     });
 
-    if (isLayoutSwapped) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-        value: true,
-      });
-    }
     Session.setItem('pinnedNotesLastState', isSharedNotesPinned);
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR restores the presentation to its previous state after sharing media.
Before:
![before](https://github.com/user-attachments/assets/6916018b-9da6-47cb-975b-de238c1c0268)

After:
![after](https://github.com/user-attachments/assets/4384d2e8-6340-4646-b523-0f508238f733)




### Motivation
Presentation was always restored after sharing screen, sharing camera as content, sharing generic content or sharing external video.
