### PR TITLE
Fix: [3.0] Timer/stopwatch drifts back and forth on voice activity

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
@@ -16,7 +16,9 @@ import { Input } from '../../layout/layoutTypes';
 import { TIMER_START, TIMER_STOP } from '../mutations';
 import useTimer from '/imports/ui/core/hooks/useTImer';
 
-const useTimerLogic = (initialTime: number, isRunning: boolean, isStopwatch: boolean) => {
+const useTimerLogic = (
+  initialTime: number, isRunning: boolean, isStopwatch: boolean, startedOn: number, passedTime: number,
+) => {
   const [time, setTime] = useState(initialTime);
   const startTimeRef = useRef(Date.now());
   const animationFrameRef = useRef<number>();
@@ -41,6 +43,10 @@ const useTimerLogic = (initialTime: number, isRunning: boolean, isStopwatch: boo
         cancelAnimationFrame(animationFrameRef.current);
       }
       setTime(initialTime);
+    }
+
+    if (startedOn === 0) {
+      setTime(passedTime);
     }
 
     return () => {
@@ -72,14 +78,12 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
   isModerator,
   sidebarNavigationIsOpen,
   sidebarContentIsOpen,
-  // It is used in the container
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   startedOn,
 }) => {
   const [startTimerMutation] = useMutation(TIMER_START);
   const [stopTimerMutation] = useMutation(TIMER_STOP);
 
-  const time = useTimerLogic(passedTime, running, stopwatch);
+  const time = useTimerLogic(passedTime, running, stopwatch, startedOn, passedTime);
 
   const CDN = window.meetingClientSettings.public.app.cdn;
   const BASENAME = window.meetingClientSettings.public.app.basename;

--- a/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
@@ -16,9 +16,23 @@ import { Input } from '../../layout/layoutTypes';
 import { TIMER_START, TIMER_STOP } from '../mutations';
 import useTimer from '/imports/ui/core/hooks/useTImer';
 
-const useTimerLogic = (
-  initialTime: number, isRunning: boolean, isStopwatch: boolean, startedOn: number, passedTime: number,
-) => {
+interface TimerLogicProps {
+  initialTime: number;
+  isRunning: boolean;
+  isStopwatch: boolean;
+  startedOn: number;
+  passedTime: number;
+  children: (time: number) => React.ReactNode;
+}
+
+const TimerLogic: React.FC<TimerLogicProps> = ({
+  initialTime,
+  isRunning,
+  isStopwatch,
+  startedOn,
+  passedTime,
+  children,
+}) => {
   const [time, setTime] = useState(initialTime);
   const startTimeRef = useRef(Date.now());
   const animationFrameRef = useRef<number>();
@@ -56,7 +70,7 @@ const useTimerLogic = (
     };
   }, [initialTime, isRunning, isStopwatch]);
 
-  return time;
+  return <>{children(time)}</>;
 };
 
 interface TimerIndicatorProps {
@@ -82,8 +96,6 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
 }) => {
   const [startTimerMutation] = useMutation(TIMER_START);
   const [stopTimerMutation] = useMutation(TIMER_STOP);
-
-  const time = useTimerLogic(passedTime, running, stopwatch, startedOn, passedTime);
 
   const CDN = window.meetingClientSettings.public.app.cdn;
   const BASENAME = window.meetingClientSettings.public.app.basename;
@@ -124,31 +136,39 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
     }
   }, [isModerator, running, stopTimer, startTimer]);
 
-  const displayTime = useMemo(() => humanizeSeconds(Math.floor(time / 1000)), [time]);
-
   return (
-    <Styled.TimerWrapper>
-      <Styled.Timer>
-        <Styled.TimerButton
-          running={running}
-          disabled={!isModerator}
-          hide={sidebarNavigationIsOpen && sidebarContentIsOpen}
-          role="button"
-          tabIndex={0}
-          onClick={onClick}
-          data-test="timeIndicator"
-        >
-          <Styled.TimerContent>
-            <Styled.TimerIcon>
-              <Icon iconName="time" />
-            </Styled.TimerIcon>
-            <Styled.TimerTime aria-hidden>
-              {displayTime}
-            </Styled.TimerTime>
-          </Styled.TimerContent>
-        </Styled.TimerButton>
-      </Styled.Timer>
-    </Styled.TimerWrapper>
+    <TimerLogic
+      initialTime={passedTime}
+      isRunning={running}
+      isStopwatch={stopwatch}
+      startedOn={startedOn}
+      passedTime={passedTime}
+    >
+      {(time) => (
+        <Styled.TimerWrapper>
+          <Styled.Timer>
+            <Styled.TimerButton
+              running={running}
+              disabled={!isModerator}
+              hide={sidebarNavigationIsOpen && sidebarContentIsOpen}
+              role="button"
+              tabIndex={0}
+              onClick={onClick}
+              data-test="timeIndicator"
+            >
+              <Styled.TimerContent>
+                <Styled.TimerIcon>
+                  <Icon iconName="time" />
+                </Styled.TimerIcon>
+                <Styled.TimerTime aria-hidden>
+                  {humanizeSeconds(Math.floor(time / 1000))}
+                </Styled.TimerTime>
+              </Styled.TimerContent>
+            </Styled.TimerButton>
+          </Styled.Timer>
+        </Styled.TimerWrapper>
+      )}
+    </TimerLogic>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
@@ -16,7 +16,6 @@ import { Input } from '../../layout/layoutTypes';
 import { TIMER_START, TIMER_STOP } from '../mutations';
 import useTimer from '/imports/ui/core/hooks/useTImer';
 
-// Custom hook for timer logic
 const useTimerLogic = (initialTime: number, isRunning: boolean, isStopwatch: boolean) => {
   const [time, setTime] = useState(initialTime);
   const startTimeRef = useRef(Date.now());

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -106,7 +106,7 @@ interface TimerPanelProps extends TimerData {
   timePassed: number;
 }
 
-const TimerPanel: React.FC<TimerPanelProps> = React.memo(({
+const TimerPanel: React.FC<TimerPanelProps> = ({
   // eslint-disable-next-line react/prop-types
   stopwatch, songTrack, time, running, timePassed, startedOn, active,
 }) => {
@@ -406,7 +406,7 @@ const TimerPanel: React.FC<TimerPanelProps> = React.memo(({
       </Styled.TimerContent>
     </Styled.TimerSidebarContent>
   );
-});
+};
 
 const TimerPanelContaier: React.FC = () => {
   const [timeSync] = useTimeSync();

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -411,7 +411,7 @@ const TimerPanel: React.FC<TimerPanelProps> = React.memo(({
       </Styled.TimerContent>
     </Styled.TimerSidebarContent>
   );
-};
+});
 
 const TimerPanelContaier: React.FC = () => {
   const [timeSync] = useTimeSync();

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-// Prop types disabled due to false-positive bug
 import React, {
   useCallback,
   useEffect,
@@ -109,6 +107,7 @@ interface TimerPanelProps extends TimerData {
 }
 
 const TimerPanel: React.FC<TimerPanelProps> = React.memo(({
+  // eslint-disable-next-line react/prop-types
   stopwatch, songTrack, time, running, timePassed, startedOn, active,
 }) => {
   const [timerReset] = useMutation(TIMER_RESET);

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+// Prop types disabled due to false-positive bug
 import React, {
   useCallback,
   useEffect,
@@ -107,13 +109,7 @@ interface TimerPanelProps extends TimerData {
 }
 
 const TimerPanel: React.FC<TimerPanelProps> = React.memo(({
-  stopwatch,
-  songTrack,
-  time,
-  running,
-  timePassed,
-  startedOn,
-  active,
+  stopwatch, songTrack, time, running, timePassed, startedOn, active,
 }) => {
   const [timerReset] = useMutation(TIMER_RESET);
   const [timerStart] = useMutation(TIMER_START);


### PR DESCRIPTION
### What does this PR do?

This PR fixes the bug where the time on stopwatch would skip when UI changes cause re-rendering of the timer.

### Closes Issue(s)

#20858 
