### PR TITLE
test: skipping test yt related

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -27,7 +27,7 @@ test.describe.parallel('Presentation', () => {
   });
 
   // https://docs.bigbluebutton.org/2.6/release-tests.html#start-youtube-video-sharing
-  test('Start external video', { tag: '@ci' }, async ({ browser, context, page }) => {
+  test('Start external video', { tag: '@flaky' }, async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.startExternalVideo();

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -13,7 +13,7 @@ test.describe.parallel('Screenshare', () => {
     await screenshare.startSharing();
   });
 
-  test('Start screenshare stops external video', { tag: '@ci' }, async ({ browser, page }) => {
+  test('Start screenshare stops external video', { tag: '@flaky' }, async ({ browser, page }) => {
     const screenshare = new ScreenShare(browser, page);
     await screenshare.init(true, true);
     await screenshare.screenshareStopsExternalVideo();


### PR DESCRIPTION
### What does this PR do?
Skip the tests related to the external video because youtube says that the tests are bots.
![Screenshot from 2024-08-09 09-10-18](https://github.com/user-attachments/assets/34cf5201-88a6-4520-83ed-c69a68202cf5)


Skipped tests:
* Start external video
* Start screen share stops external video
