### PR TITLE
add config flag to mute audio output on away mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -611,6 +611,7 @@ export interface Media {
   sdpSemantics: string
   localEchoTest: LocalEchoTest
   showVolumeMeter: boolean
+  muteSpeakerIfAway: boolean
 }
 
 export interface Audio2 {

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -611,7 +611,7 @@ export interface Media {
   sdpSemantics: string
   localEchoTest: LocalEchoTest
   showVolumeMeter: boolean
-  muteSpeakerIfAway: boolean
+  muteAudioOutputWhenAway: boolean
 }
 
 export interface Audio2 {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
@@ -123,11 +123,15 @@ export const muteAway = (
   }
 
   // mute/unmute speaker
-  if (away) {
-    setSpeakerLevel(Number(prevSpeakerLevelValue));
-  } else {
-    Storage.setItem('prevSpeakerLevel', getSpeakerLevel());
-    setSpeakerLevel(0);
+  const MUTE_SPEAKER = window.meetingClientSettings.public.media.muteSpeakerIfAway;
+
+  if (MUTE_SPEAKER) {
+    if (away) {
+      setSpeakerLevel(Number(prevSpeakerLevelValue));
+    } else {
+      Storage.setItem('prevSpeakerLevel', getSpeakerLevel());
+      setSpeakerLevel(0);
+    }
   }
 
   // enable/disable video

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
@@ -123,7 +123,7 @@ export const muteAway = (
   }
 
   // mute/unmute speaker
-  const MUTE_SPEAKER = window.meetingClientSettings.public.media.muteSpeakerIfAway;
+  const MUTE_SPEAKER = window.meetingClientSettings.public.media.muteAudioOutputWhenAway;
 
   if (MUTE_SPEAKER) {
     if (away) {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -670,7 +670,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         },
       },
       showVolumeMeter: true,
-      muteSpeakerIfAway: false,
+      muteAudioOutputWhenAway: false,
     },
     stats: {
       enabled: true,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -670,6 +670,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         },
       },
       showVolumeMeter: true,
+      muteSpeakerIfAway: false,
     },
     stats: {
       enabled: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -907,8 +907,8 @@ public:
     #audioTroubleshootingLinks:
     #  7: 'https://link.bigbluebutton.org/perm'
     #  0: 'https://link.bigbluebutton.org/unk'
-    # muteSpeakerIfAway: mute output audio if user is in away mode
-    muteSpeakerIfAway: false
+    # muteAudioOutputWhenAway: mute output audio if user is in away mode
+    muteAudioOutputWhenAway: false
   stats:
     enabled: true
     interval: 10000

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -907,6 +907,8 @@ public:
     #audioTroubleshootingLinks:
     #  7: 'https://link.bigbluebutton.org/perm'
     #  0: 'https://link.bigbluebutton.org/unk'
+    # muteSpeakerIfAway: mute output audio if user is in away mode
+    muteSpeakerIfAway: false
   stats:
     enabled: true
     interval: 10000


### PR DESCRIPTION
### What does this PR do?

Adds a flag `muteAudioOutputWhenAway` to control if output audio should be disabled when a user is in away mode (default: `false`).

Before this change, output audio is always muted when a user is away.

### Motivation

Feedback on #20076
