### PR TITLE
fix(html5): restore lint:file npm script

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -8,6 +8,7 @@
     "tscheck": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:file": "eslint",
     "test": "export WITH_RECORD=false;export REGRESSION_TESTING=false;env $(cat ../bigbluebutton-tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
     "test:recording": "export WITH_RECORD=true;export REGRESSION_TESTING=false;env $(cat ../bigbluebutton-tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",
     "test-visual-regression": "export REGRESSION_TESTING=true;env $(cat ../bigbluebutton-tests/puppeteer/.env | xargs)  jest all.test.js --color --detectOpenHandles --forceExit",


### PR DESCRIPTION
- [Restore](https://github.com/bigbluebutton/bigbluebutton/pull/20811/files#r1698682454) the `lint:file` npm script. Rationale outlined in
  - https://github.com/bigbluebutton/bigbluebutton/pull/13870

> The lint:fix hook fixes/alters things. The lint run script runs eslint over the whole root directory.
> I just want to check linting offenses on a per-file/directory basis without having files messed with or needing a fancy IDE.

If there's an alternative in place that doesn't require a globally installed eslint, please let me know + close this.
