### PR TITLE
test: Skip pin notes onto whiteboard to be updated

### DIFF
--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
@@ -1,6 +1,6 @@
 const { test } = require('../fixtures');
 const { SharedNotes } = require('./sharednotes');
-const { initializePages } = require('../core/helpers');
+const { linkIssue, initializePages } = require('../core/helpers');
 const { fullyParallel } = require('../playwright.config');
 
 test.describe('Shared Notes', () => {
@@ -39,7 +39,8 @@ test.describe('Shared Notes', () => {
     await sharedNotes.seeNotesWithoutEditPermission();
   });
 
-  test('Pin and unpin notes onto whiteboard', { tag: '@ci' }, async () => {
+  test('Pin and unpin notes onto whiteboard', { tag: '@flaky' }, async () => {
+    linkIssue('20892');
     await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });


### PR DESCRIPTION

### What does this PR do?
Skips the test pin notes onto whiteboard, which will be updated. 
See issue #20892 for more information.


