### PR TITLE
fix: remove spurious getUserMedia in ErrorScreen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -93,11 +93,6 @@ class ErrorScreen extends PureComponent {
   componentDidMount() {
     const { code, callback, endedReason } = this.props;
     // stop audio
-    document.querySelector('audio').pause();
-    navigator
-      .mediaDevices
-      .getUserMedia({ audio: true, video: true })
-      .then((m) => m.getTracks().forEach((t) => t.stop()));
     window.dispatchEvent(new Event('StopAudioTracks'));
     callback(endedReason, () => {});
     console.error({ logCode: 'startup_client_usercouldnotlogin_error' }, `User could not log in HTML5, hit ${code}`);


### PR DESCRIPTION
### What does this PR do?

- [fix: remove spurious getUserMedia in ErrorScreen](https://github.com/bigbluebutton/bigbluebutton/commit/4dcc77968b3ad6c3d53a73dde32e549a03e9a656) 
  * There's a very odd getUserMedia call tucked into the base ErrorScreen.
There's no rationale in either the commit or PR that added them, but the
intention seems to be stopping audio on client crash.
Using getUserMedia like that will have no effect other than an odd
permission prompt on iframe-based environments or a webcam activation
flash after the client crashes.
  * Remove ErrorScreen's getUserMedia call as well as the HTMLMedia pause
call - both should be handled gracefully by AudioManager's forceExitAudio
triggered by the StopAudioTracks event (also ErrorScreen). If there's an
edge case where it isn't properly stopped, we'll have to tackle it
there.

### Closes Issue(s)

None

