### PR TITLE
config: Warn when .dpkg-dist files detected in /etc/default

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1197,7 +1197,8 @@ check_state() {
     dpkg_dist_files=$(find /etc/default -type f -name "*.dpkg-dist")
     if [ -n "$dpkg_dist_files" ]; then
       echo "# Warning: found the following configuration files which were ignored when installing."
-      echo "# Please inspect those files and consider applying the differences to the similarly named configuration file in the same directory."
+      echo "# Please inspect those files and consider applying the differences to the similarly"
+      echo "# named configuration file in the same directory."
       echo "# When done, please restart BigBlueButton."
       echo "#"
       echo "$dpkg_dist_files"

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1193,6 +1193,15 @@ check_state() {
 			echo "#"
 		fi
 
+    # check for any maintainer configuration files being ignored
+    dpkg_dist_files=$(find /etc/default -type f -name "*.dpkg-dist")
+    if [ -n "$dpkg_dist_files" ]; then
+      echo "# Warning: found the following configuration files which were ignored when installing."
+      echo "# Please inspect those files and consider applying the differences to the similarly named configuration file in the same directory."
+      echo "# When done, please restart BigBlueButton."
+      echo "#"
+      echo "$dpkg_dist_files"
+    fi
 
     exit 0
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Warn when a file like `/etc/default/bbb-graphql-server.dpkg-dist` is detected.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none

### Motivation
<!-- What inspired you to submit this pull request? -->
When upgrading BBB 3.0 servers, frequently there are files kept during the installation.
Most often they are the config files for `bbb-graphql-server` and `bbb-graphql-middleware`.

**Note**: when upgrading a 3.0.0-alpha.7 server to 3.0.0-beta.1+ BBB server, such a configuration being withheld means that users cannot join the session, resulting in "error 300 something went wrong".



### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->


### More
<!-- Anything else we should know when reviewing? -->
The most common problem is that we actually change the value for `HASURA_GRAPHQL_ADMIN_SECRET` in`/etc/default/bbb-graphql-server` but that means any newer `/etc/default/bbb-graphql-server` from packaging is put aside.

Sample run:

```
# Warning: found the following configuration files which were ignored when installing.
# Please inspect those files and consider applying the differences to the similarly named configuration file in the same directory.
# When done, please restart BigBlueButton.
#
/etc/default/bbb-graphql-server.dpkg-dist
```