### PR TITLE
Fix: Improve performance in webpack hmr and build

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -3,8 +3,8 @@
   "description": "BigBlueButton HTML5 Client",
   "license": "LGPL-3.0",
   "scripts": {
-    "start": "webpack serve --open",
-    "build": "webpack --config webpack.config.js --mode production",
+    "start": "NODE_ENV=development webpack serve --open --config webpack.config.js",
+    "build": "NODE_ENV=production webpack --config webpack.config.js --mode production",
     "tscheck": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -4,7 +4,12 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
-module.exports = {
+const env = process.env.NODE_ENV || 'development';
+
+const prodEnv = 'production';
+const devEnv = 'development';
+
+const config = {
   entry: './client/main.tsx',
   mode: 'development',
   output: {
@@ -12,20 +17,11 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     publicPath: '',
   },
-  optimization: {
-    minimize: true,
-    minimizer: [new TerserPlugin()],
+  cache: {
+    type: 'filesystem',
+    allowCollectingMemory: true,
   },
   devtool: 'source-map',
-  devServer: {
-    port: 3000,
-    hot: true,
-    allowedHosts: 'all',
-    client: {
-      overlay: false,
-      webSocketURL: 'auto://0.0.0.0:0/html5client/ws',
-    },
-  },
   plugins: [
     new HtmlWebpackPlugin({
       template: './client/main.html',
@@ -93,3 +89,27 @@ module.exports = {
     ],
   },
 };
+
+if (env === prodEnv) {
+  config.mode = prodEnv;
+  config.optimization = {
+    minimize: true,
+    minimizer: [new TerserPlugin()],
+  };
+  config.performance = {
+    hints: false,
+  };
+} else {
+  config.mode = devEnv;
+  config.devServer = {
+    port: 3000,
+    hot: true,
+    allowedHosts: 'all',
+    client: {
+      overlay: false,
+      webSocketURL: 'auto://0.0.0.0:0/html5client/ws',
+    },
+  };
+}
+
+module.exports = config;

--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -11,7 +11,6 @@ const devEnv = 'development';
 
 const config = {
   entry: './client/main.tsx',
-  mode: 'development',
   output: {
     filename: 'bundle.[fullhash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -97,7 +96,9 @@ if (env === prodEnv) {
     minimizer: [new TerserPlugin()],
   };
   config.performance = {
-    hints: false,
+    hints: 'warning',
+    maxAssetSize: 6000000,
+    maxEntrypointSize: 6000000,
   };
 } else {
   config.mode = devEnv;


### PR DESCRIPTION
### What does this PR do?
This PR split the dev and prod configs in webpack, it was made to improve dx expirence, because the hmr was taking 30s to build, disabling the minifier made the hmr compiler 10x faster, but the minifier is essential for the prod code, so I splitted adding it only in prod config.