### PR TITLE
docs: Testing plan update (what's new features)

### DIFF
--- a/bigbluebutton-tests/playwright/audio/audio.spec.js
+++ b/bigbluebutton-tests/playwright/audio/audio.spec.js
@@ -14,12 +14,12 @@ test.describe('Audio', () => {
     await audio.initUserPage(true, context);
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#listen-only-mode-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#listen-only-mode-automated
   test('Join audio with Listen Only @ci', async () => {
     await audio.joinAudio();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#join-audio-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#join-audio-automated
   test('Join audio with Microphone @ci', async () => {
     await audio.joinMicrophone();
   });
@@ -28,23 +28,23 @@ test.describe('Audio', () => {
     await audio.changeAudioInput();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#muteunmute
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#muteunmute
   test('Mute yourself by clicking the mute button', async () => {
     await audio.muteYourselfByButton();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#choosing-different-sources
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#choosing-different-sources
   test('Keep the last mute state after rejoining audio @ci', async () => {
     await audio.keepMuteStateOnRejoin();
   });
 
   // Talking Indicator
-  // https://docs.bigbluebutton.org/testing/release-testing/#talking-indicator
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#talking-indicator
   test('Mute yourself by clicking the talking indicator', async () => {
     await audio.muteYourselfByTalkingIndicator();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#talking-indicator
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#talking-indicator
   test('Mute another user by clicking the talking indicator', async () => {
     await audio.muteAnotherUser();
   });

--- a/bigbluebutton-tests/playwright/audio/audio.spec.js
+++ b/bigbluebutton-tests/playwright/audio/audio.spec.js
@@ -14,12 +14,12 @@ test.describe('Audio', () => {
     await audio.initUserPage(true, context);
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#listen-only-mode-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#listen-only-mode-automated
   test('Join audio with Listen Only @ci', async () => {
     await audio.joinAudio();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#join-audio-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#join-audio-automated
   test('Join audio with Microphone @ci', async () => {
     await audio.joinMicrophone();
   });
@@ -28,23 +28,23 @@ test.describe('Audio', () => {
     await audio.changeAudioInput();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#muteunmute
+  // https://docs.bigbluebutton.org/testing/release-testing/#muteunmute
   test('Mute yourself by clicking the mute button', async () => {
     await audio.muteYourselfByButton();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#choosing-different-sources
+  // https://docs.bigbluebutton.org/testing/release-testing/#choosing-different-sources
   test('Keep the last mute state after rejoining audio @ci', async () => {
     await audio.keepMuteStateOnRejoin();
   });
 
   // Talking Indicator
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#talking-indicator
+  // https://docs.bigbluebutton.org/testing/release-testing/#talking-indicator
   test('Mute yourself by clicking the talking indicator', async () => {
     await audio.muteYourselfByTalkingIndicator();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#talking-indicator
+  // https://docs.bigbluebutton.org/testing/release-testing/#talking-indicator
   test('Mute another user by clicking the talking indicator', async () => {
     await audio.muteAnotherUser();
   });

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -42,7 +42,7 @@ test.describe.parallel('Breakout', () => {
   });
 
   test.describe.parallel('After creating', () => {
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#moderators-creating-breakout-rooms-and-assiging-users-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#moderators-creating-breakout-rooms-and-assiging-users-automated
     test('Join Breakout room @ci', async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -42,7 +42,7 @@ test.describe.parallel('Breakout', () => {
   });
 
   test.describe.parallel('After creating', () => {
-    // https://docs.bigbluebutton.org/testing/release-testing/#moderators-creating-breakout-rooms-and-assiging-users-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#moderators-creating-breakout-rooms-and-assiging-users-automated
     test('Join Breakout room @ci', async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -15,12 +15,12 @@ test.describe('Chat', () => {
     await chat.initUserPage(true, context);
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#public-message-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#public-message-automated
   test('Send public message @ci', async () => {
     await chat.sendPublicMessage();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#private-message-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#private-message-automated
   test('Send private message @ci', async () => {
     await chat.sendPrivateMessage();
   });
@@ -41,7 +41,7 @@ test.describe('Chat', () => {
     await chat.characterLimit();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#sending-empty-chat-message-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#sending-empty-chat-message-automated
   test('Not able to send an empty message @ci', async () => {
     await chat.emptyMessage();
   });

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -15,12 +15,12 @@ test.describe('Chat', () => {
     await chat.initUserPage(true, context);
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#public-message-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#public-message-automated
   test('Send public message @ci', async () => {
     await chat.sendPublicMessage();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#private-message-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#private-message-automated
   test('Send private message @ci', async () => {
     await chat.sendPrivateMessage();
   });
@@ -41,7 +41,7 @@ test.describe('Chat', () => {
     await chat.characterLimit();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#sending-empty-chat-message-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#sending-empty-chat-message-automated
   test('Not able to send an empty message @ci', async () => {
     await chat.emptyMessage();
   });

--- a/bigbluebutton-tests/playwright/connectionFailure/connectionFailure.spec.js
+++ b/bigbluebutton-tests/playwright/connectionFailure/connectionFailure.spec.js
@@ -7,7 +7,7 @@ const notificationsUtil = require('../notifications/util');
 const deepEqual = require('deep-equal');
 
 test.describe.parallel('Connection failure', () => {
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#sharing-screen-in-full-screen-mode-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
   test('Screen sharer', async ({ browser, browserName, page }) => {
     await checkRootPermission(); // check sudo permission before starting test
     test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,

--- a/bigbluebutton-tests/playwright/connectionFailure/connectionFailure.spec.js
+++ b/bigbluebutton-tests/playwright/connectionFailure/connectionFailure.spec.js
@@ -7,7 +7,7 @@ const notificationsUtil = require('../notifications/util');
 const deepEqual = require('deep-equal');
 
 test.describe.parallel('Connection failure', () => {
-  // https://docs.bigbluebutton.org/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
   test('Screen sharer', async ({ browser, browserName, page }) => {
     await checkRootPermission(); // check sudo permission before starting test
     test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -5,28 +5,28 @@ const { Presentation } = require('./presentation');
 const customStyleAvoidUploadingNotifications = encodeCustomParams(`userdata-bbb_custom_style=.presentationUploaderToast{display: none;}`);
 
 test.describe.parallel('Presentation', () => {
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#navigation-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#navigation-automated
   test('Skip slide @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.skipSlide();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#minimizerestore-presentation-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#minimizerestore-presentation-automated
   test('Hide/Restore presentation @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.hideAndRestorePresentation();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#start-youtube-video-sharing
+  // https://docs.bigbluebutton.org/testing/release-testing/#start-youtube-video-sharing
   test('Start external video @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.startExternalVideo();
   });
 
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#fit-to-width-option
+  // https://docs.bigbluebutton.org/testing/release-testing/#fit-to-width-option
   test('Presentation fit to width @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initModPage(page, true, { createParameter: customStyleAvoidUploadingNotifications });
@@ -65,7 +65,7 @@ test.describe.parallel('Presentation', () => {
   });
 
   test.describe.parallel('Manage', () => {
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#uploading-a-presentation-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#uploading-a-presentation-automated
     test('Upload single presentation @ci', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, true);
@@ -78,14 +78,14 @@ test.describe.parallel('Presentation', () => {
       await presentation.uploadOtherPresentationsFormat();
     });
 
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#uploading-multiple-presentations-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#uploading-multiple-presentations-automated
     test('Upload multiple presentations', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, true);
       await presentation.uploadMultiplePresentationsTest();
     });
 
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#enabling-and-disabling-presentation-download-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#enabling-and-disabling-presentation-download-automated
     test('Enable and disable original presentation download @ci', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -5,28 +5,28 @@ const { Presentation } = require('./presentation');
 const customStyleAvoidUploadingNotifications = encodeCustomParams(`userdata-bbb_custom_style=.presentationUploaderToast{display: none;}`);
 
 test.describe.parallel('Presentation', () => {
-  // https://docs.bigbluebutton.org/testing/release-testing/#navigation-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#navigation-automated
   test('Skip slide @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.skipSlide();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#minimizerestore-presentation-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#minimizerestore-presentation-automated
   test('Hide/Restore presentation @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.hideAndRestorePresentation();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#start-youtube-video-sharing
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#start-youtube-video-sharing
   test('Start external video @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.startExternalVideo();
   });
 
-  // https://docs.bigbluebutton.org/testing/release-testing/#fit-to-width-option
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#fit-to-width-option
   test('Presentation fit to width @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initModPage(page, true, { createParameter: customStyleAvoidUploadingNotifications });
@@ -65,7 +65,7 @@ test.describe.parallel('Presentation', () => {
   });
 
   test.describe.parallel('Manage', () => {
-    // https://docs.bigbluebutton.org/testing/release-testing/#uploading-a-presentation-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#uploading-a-presentation-automated
     test('Upload single presentation @ci', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, true);
@@ -78,14 +78,14 @@ test.describe.parallel('Presentation', () => {
       await presentation.uploadOtherPresentationsFormat();
     });
 
-    // https://docs.bigbluebutton.org/testing/release-testing/#uploading-multiple-presentations-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#uploading-multiple-presentations-automated
     test('Upload multiple presentations', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, true);
       await presentation.uploadMultiplePresentationsTest();
     });
 
-    // https://docs.bigbluebutton.org/testing/release-testing/#enabling-and-disabling-presentation-download-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#enabling-and-disabling-presentation-download-automated
     test('Enable and disable original presentation download @ci', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -2,7 +2,7 @@ const { test, devices } = require('@playwright/test');
 const { ScreenShare } = require('./screenshare');
 
 test.describe.parallel('Screenshare', () => {
-  // https://docs.bigbluebutton.org/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
   test('Share screen @ci', async ({ browser, browserName, page }) => {
     test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,
               "Screenshare tests not able in Firefox browser without desktop");

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -2,7 +2,7 @@ const { test, devices } = require('@playwright/test');
 const { ScreenShare } = require('./screenshare');
 
 test.describe.parallel('Screenshare', () => {
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#sharing-screen-in-full-screen-mode-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
   test('Share screen @ci', async ({ browser, browserName, page }) => {
     test.skip(browserName === 'firefox' && process.env.DISPLAY === undefined,
               "Screenshare tests not able in Firefox browser without desktop");

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -9,7 +9,7 @@ const iPhone11 = devices['iPhone 11'];
 
 test.describe.parallel('User', () => {
   test.describe.parallel('Actions', () => {
-    // https://docs.bigbluebutton.org/testing/release-testing/#set-status--raise-hand-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#set-status--raise-hand-automated
     test('Raise and lower Hand', async ({ browser, context, page }) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, true);
@@ -30,7 +30,7 @@ test.describe.parallel('User', () => {
   });
 
   test.describe.parallel('List', () => {
-    // https://docs.bigbluebutton.org/testing/release-testing/#set-status--raise-hand-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#set-status--raise-hand-automated
     test('Change user status @ci', async ({ browser, page }) => {
       const status = new Status(browser, page);
       await status.init(true, true);
@@ -43,14 +43,14 @@ test.describe.parallel('User', () => {
       await multiusers.userPresence();
     });
 
-    // https://docs.bigbluebutton.org/testing/release-testing/#make-viewer-a-presenter-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#make-viewer-a-presenter-automated
     test('Make presenter @ci', async ({ browser, context, page }) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initPages(page);
       await multiusers.makePresenter();
     });
 
-    // https://docs.bigbluebutton.org/testing/release-testing/#taking-presenter-status-back-automated
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#taking-presenter-status-back-automated
     test('Take presenter @ci', async ({ browser, context, page }) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page);
@@ -96,7 +96,7 @@ test.describe.parallel('User', () => {
   test.describe.parallel('Manage', () => {
     test.describe.parallel('Guest policy', () => {
       test.describe.parallel('ASK_MODERATOR @ci', () => {
-        // https://docs.bigbluebutton.org/testing/release-testing/#ask-moderator
+        // https://docs.bigbluebutton.org/2.7/testing/release-testing/#ask-moderator
         test('Message to guest lobby', async ({ browser, context, page }) => {
           const guestPolicy = new GuestPolicy(browser, context);
           await guestPolicy.initModPage(page);
@@ -145,7 +145,7 @@ test.describe.parallel('User', () => {
         await guestPolicy.initModPage(page);
         await guestPolicy.alwaysAccept();
       });
-      // https://docs.bigbluebutton.org/testing/release-testing/#always-deny
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#always-deny
       test('ALWAYS_DENY @ci', async ({ browser, context, page }) => {
         const guestPolicy = new GuestPolicy(browser, context);
         await guestPolicy.initModPage(page);
@@ -154,49 +154,49 @@ test.describe.parallel('User', () => {
     });
 
     test.describe.parallel('Lock viewers @ci', () => {
-      // https://docs.bigbluebutton.org/testing/release-testing/#webcam
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#webcam
       test('Lock Share webcam', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockShareWebcam();
       });
 
-      // https://docs.bigbluebutton.org/testing/release-testing/#see-other-viewers-webcams
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#see-other-viewers-webcams
       test('Lock See other viewers webcams', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSeeOtherViewersWebcams();
       });
 
-      // https://docs.bigbluebutton.org/testing/release-testing/#microphone
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#microphone
       test('Lock Share microphone', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockShareMicrophone();
       });
 
-      // https://docs.bigbluebutton.org/testing/release-testing/#public-chat
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#public-chat
       test('Lock Send public chat messages', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSendPublicChatMessages();
       });
 
-      // https://docs.bigbluebutton.org/testing/release-testing/#private-chat
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#private-chat
       test('Lock Send private chat messages', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSendPrivateChatMessages();
       });
 
-      // https://docs.bigbluebutton.org/testing/release-testing/#shared-notes-1
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#shared-notes-1
       test('Lock Edit Shared Notes', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockEditSharedNotes();
       });
 
-      // https://docs.bigbluebutton.org/testing/release-testing/#see-other-viewers-in-the-users-list
+      // https://docs.bigbluebutton.org/2.7/testing/release-testing/#see-other-viewers-in-the-users-list
       test('Lock See other viewers in the Users list', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
@@ -216,7 +216,7 @@ test.describe.parallel('User', () => {
       });
     });
 
-    // https://docs.bigbluebutton.org/testing/release-testing/#saving-usernames
+    // https://docs.bigbluebutton.org/2.7/testing/release-testing/#saving-usernames
     test('Save user names', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initPages(page);

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -9,7 +9,7 @@ const iPhone11 = devices['iPhone 11'];
 
 test.describe.parallel('User', () => {
   test.describe.parallel('Actions', () => {
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#set-status--raise-hand-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#set-status--raise-hand-automated
     test('Raise and lower Hand', async ({ browser, context, page }) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, true);
@@ -30,7 +30,7 @@ test.describe.parallel('User', () => {
   });
 
   test.describe.parallel('List', () => {
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#set-status--raise-hand-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#set-status--raise-hand-automated
     test('Change user status @ci', async ({ browser, page }) => {
       const status = new Status(browser, page);
       await status.init(true, true);
@@ -43,14 +43,14 @@ test.describe.parallel('User', () => {
       await multiusers.userPresence();
     });
 
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#make-viewer-a-presenter-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#make-viewer-a-presenter-automated
     test('Make presenter @ci', async ({ browser, context, page }) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initPages(page);
       await multiusers.makePresenter();
     });
 
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#taking-presenter-status-back-automated
+    // https://docs.bigbluebutton.org/testing/release-testing/#taking-presenter-status-back-automated
     test('Take presenter @ci', async ({ browser, context, page }) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page);
@@ -96,7 +96,7 @@ test.describe.parallel('User', () => {
   test.describe.parallel('Manage', () => {
     test.describe.parallel('Guest policy', () => {
       test.describe.parallel('ASK_MODERATOR @ci', () => {
-        // https://docs.bigbluebutton.org/2.6/release-tests.html#ask-moderator
+        // https://docs.bigbluebutton.org/testing/release-testing/#ask-moderator
         test('Message to guest lobby', async ({ browser, context, page }) => {
           const guestPolicy = new GuestPolicy(browser, context);
           await guestPolicy.initModPage(page);
@@ -145,7 +145,7 @@ test.describe.parallel('User', () => {
         await guestPolicy.initModPage(page);
         await guestPolicy.alwaysAccept();
       });
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#always-deny
+      // https://docs.bigbluebutton.org/testing/release-testing/#always-deny
       test('ALWAYS_DENY @ci', async ({ browser, context, page }) => {
         const guestPolicy = new GuestPolicy(browser, context);
         await guestPolicy.initModPage(page);
@@ -154,49 +154,49 @@ test.describe.parallel('User', () => {
     });
 
     test.describe.parallel('Lock viewers @ci', () => {
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#webcam
+      // https://docs.bigbluebutton.org/testing/release-testing/#webcam
       test('Lock Share webcam', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockShareWebcam();
       });
 
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#see-other-viewers-webcams
+      // https://docs.bigbluebutton.org/testing/release-testing/#see-other-viewers-webcams
       test('Lock See other viewers webcams', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSeeOtherViewersWebcams();
       });
 
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#microphone
+      // https://docs.bigbluebutton.org/testing/release-testing/#microphone
       test('Lock Share microphone', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockShareMicrophone();
       });
 
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#public-chat
+      // https://docs.bigbluebutton.org/testing/release-testing/#public-chat
       test('Lock Send public chat messages', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSendPublicChatMessages();
       });
 
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#private-chat
+      // https://docs.bigbluebutton.org/testing/release-testing/#private-chat
       test('Lock Send private chat messages', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSendPrivateChatMessages();
       });
 
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#shared-notes-1
+      // https://docs.bigbluebutton.org/testing/release-testing/#shared-notes-1
       test('Lock Edit Shared Notes', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockEditSharedNotes();
       });
 
-      // https://docs.bigbluebutton.org/2.6/release-tests.html#see-other-viewers-in-the-users-list
+      // https://docs.bigbluebutton.org/testing/release-testing/#see-other-viewers-in-the-users-list
       test('Lock See other viewers in the Users list', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
@@ -216,7 +216,7 @@ test.describe.parallel('User', () => {
       });
     });
 
-    // https://docs.bigbluebutton.org/2.6/release-tests.html#saving-usernames
+    // https://docs.bigbluebutton.org/testing/release-testing/#saving-usernames
     test('Save user names', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initPages(page);

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -3,7 +3,7 @@ const { MultiUsers } = require('../user/multiusers');
 const { Webcam } = require('./webcam');
 
 test.describe.parallel('Webcam', () => {
-  // https://docs.bigbluebutton.org/testing/release-testing/#joining-webcam-automated
+  // https://docs.bigbluebutton.org/2.7/testing/release-testing/#joining-webcam-automated
   test('Shares webcam @ci', async ({ browser, page }) => {
     const webcam = new Webcam(browser, page);
     await webcam.init(true, true);

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -3,7 +3,7 @@ const { MultiUsers } = require('../user/multiusers');
 const { Webcam } = require('./webcam');
 
 test.describe.parallel('Webcam', () => {
-  // https://docs.bigbluebutton.org/2.6/release-tests.html#joining-webcam-automated
+  // https://docs.bigbluebutton.org/testing/release-testing/#joining-webcam-automated
   test('Shares webcam @ci', async ({ browser, page }) => {
     const webcam = new Webcam(browser, page);
     await webcam.init(true, true);

--- a/docs/docs/testing/release-testing.md
+++ b/docs/docs/testing/release-testing.md
@@ -35,21 +35,46 @@ all of these tests.
 
 5. Presentation should appear on All Clients in sync with updates, and All Clients should see the notification with the new presentation name
 
-### Sending presentation download link to the chat [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Sending presentation download link in the chat - containing the annotations [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
-1. Join a meeting and draw some annotations on the slide.
+1. Join a meeting
 
-2. Select Moderator/Presenter Action menu
+2. Draw some annotations on the slide
 
-3. Choose "Manage presentations"
+3. Select Moderator/Presenter Action menu
 
-4. Click on "Send to chat" button.
+4. Click on "Upload/Manage presentations"
 
-5. Verify that the link was sent to the chat and the link works.
+5. Click on "Export options" button of the current presentation
 
-6. Draw some annotations on the whiteboard.
+6. Click on "Send out a download link for the presentation including whiteboard annotations" button
 
-7. Send the download link to the chat again. This time, the presentation downloaded through the link should include the annotation.
+    - You should see a notification with the upload progress displayed
+    - After the upload is done, every user should be able to see a public chat message with the name of the file + "(with whiteboard annotations)" and a downloadable link below
+    - This file should contain all presentation slides **including the annotations**
+
+### Enable/Disable presentation download [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+
+1. Join a meeting
+
+2. Wait for the presentation to be uploaded
+
+3. Select Moderator/Presenter Action menu
+
+4. Click on "Upload/Manage presentations"
+
+5. Click on "Export options" button of the current presentation
+
+6. Click on "Enable download of the presentation (pdf)" button
+
+    - A notification warning the presentation download is available should be displayed
+    - A download button should be displayed in the bottom left corner
+    - The downloaded file should be the original presentation, **not containing any annotations**
+    - This should be available to all users in the meeting, including the ones joining after its enabled
+
+7. Select the actions button -> click on "Upload/Manage presentations" -> "Export options" of the current presentation -> click on "Disable download of the original presentation (pdf)" button
+
+    - The presentation should not be available for download anymore
 
 ### Deleting Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
@@ -343,6 +368,34 @@ The webcams should be resized as per the size we want.
 
 8. That particular webcam should unpin.
 
+### Disable self-view
+
+1. Join in a meeting with 2 users sharing webcams.
+
+2. Select the webcam dropdown menu. Click on "Disable self-view"
+
+    - You shouldn't see this option in other users' webcam menu
+    - You should stop seeing your webcam video, replaced by a placeholder with the "Self-view disabled" label.
+    - Other users should keep seeing you normally.
+
+3. Select again the webcam dropdown menu. Click on "Enable self-view"
+
+    - You should be able to see you again after enabling it
+
+### Share camera as content
+
+1. Join in a meeting with 2 users.
+
+2. As the presenter, click on "Share camera as content" in the actions dropdown.
+
+    - You should see the same webcam settings modal as normal sharing webcam.
+
+3. Select a camera device and click on "Start sharing"
+
+    - "Minimize presentation" button icon should change to a webcam. Clicking on it should minimize the webcam content.
+    - Once it's shared, it should use the presentation area and not be affected by changes on presentations (e.g. delete, upload, enable download).
+    - To start a normal webcam sharing, you need to first stop sharing and then click on "Share webcam" and "Start sharing".
+
 ## Screenshare
 
 ### Sharing screen in Full Screen mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js)
@@ -505,6 +558,26 @@ The screen sharing stops, a sound effect of disconnection is heard and the prese
 2. Join a breakout room. Draw something on the whiteboard. End the breakout room.
 
 3. Breakout room's annotations should be converted to a pdf and that pdf should be available for uploading to the whiteboard.
+
+### Use different presentation in breakout rooms
+
+1. Join in a meeting with a moderator and an attendee
+
+2. As the moderator/presenter, click on the actions button, "Upload/Manage presentations" and upload a new presentation file
+
+3. Click on "Create breakout rooms" in the manage users dropdown
+
+    - In the "Manage rooms" section - where the assigned users are displayed - you should see a dropdown down below room's name
+
+4. Click on the presentation dropdown in any rooms
+    - you should see "current slide" option, which should set only the current slide as the breakouts' presentation
+    - you should see all the uploaded files options listed. the one selected should be set as the presentation, containing all slides provided
+
+5. Select different options for each room and click on "Create"
+
+6. Join each user in different rooms
+
+    - you should see the correct presentation selected displayed for each user/room
 
 ## Audio
 
@@ -1227,7 +1300,7 @@ Share notes should export and download in the chosen format.
 
 7. Locked user: should still see the features locked.
 
-## Chat (Public/Private)
+## Chat
 
 ### Public message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
 
@@ -1280,6 +1353,23 @@ Note :
 - As a Viewer(feature):
   "Save Chat/Copy Chat
   (if Private Chat) += Close Private Chat Tab"
+
+### Prevent specific user from sending public chat messages
+
+1. Join in a meeting with a mod and and attendee
+
+2. As the mod, click on the attendee's user list item
+
+3. Click on the "Lock public chat" button
+
+    - Attendee should not be able to send any new message in the public chat - textarea and send button should be disabled
+    - Other users should still be able to send messages
+
+4. Click on the locked attendee's user list item
+
+5. Click on the "Unlock public chat" button
+
+    - The user should get the permission back of sending messages in the public chat
 
 ## Polling
 
@@ -1387,23 +1477,15 @@ Note :
 
 ## User list settings
 
-### Set status / Raise hand [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
+### Clear all reactions
 
-1. Viewer: select your user icon from user list
+1. Click on the reactions bar and react with some of the available options
 
-2. From menu options choose set status
+2. Select manage users icon (cog wheel icon in users list)
 
-3. Set a status/raise hand.
+3. Choose clear all status icons.
 
-4. Icon in the users list should update to display emoticon chosen by the user, when status is set by a user the moderator will see their user icon move to the top of the list.
-
-### Clear status
-
-1. Select manage users icon (cog wheel icon in users list)
-
-2. choose clear all status icons.
-
-3. All status icons in the users list should clear.
+    - All the current reactions should be cleared
 
 ### Mute users
 
@@ -1448,20 +1530,6 @@ Note :
 2. Moderator: Choose save user names.
 
 3. Users list names will download as a TXT based document to local device.
-
-### Shared Notes
-
-1. Moderator: Select manage users icon (cog wheel in users list).
-
-2. Moderator: Choose lock viewers.
-
-3. Moderator: Lock shared notes.
-
-4. Moderator: exit menu.
-
-5. Viewer: Open shared notes panel.
-
-6. Viewer: Attempt to contribute to shared notes to confirm if it's locked.
 
 ## Options menu
 
@@ -1680,6 +1748,46 @@ Note :
 
 - Click "Deny" for the specific user in teh waiting users panel. That viewer should see the message "Guest denied of joining the meeting" and should soon be redirected to the home page.
 
+## Reactions bar
+
+### Use a reaction
+
+1. Join in a meeting with 2 users
+
+2. Click on the "Reactions bar" button below presentation
+
+    - You should be able to see a set of buttons with emojis and a "Raise your hand" button
+
+3. Click on any emoji
+
+    - The other user should see the emoji you reacted in your user avatar in the user list
+    - The reaction should keep displayed for a while
+    - The reaction should be removed once you click again in the emoji
+    - The reaction should be changed once you click in a different emoji
+    - if the `emojiRain` setting is enabled, all users should see an animated rain of emojis from their reactions button on every reaction 
+
+### Raise / Lower your hand
+
+1. Join in a meeting with 2 users
+
+2. Click on the "Reactions bar" button below presentation
+
+    - You should be able to see a set of buttons with emojis and a "Raise your hand" button
+
+3. Click on the "Raise your hand" button
+
+    - All users should see a notification saying that you raised your hand
+    - Your avatar should be changed for every users' user list
+    - The button label should be changed to "Lower your hand"
+
+4. Click on the reactions bar again and then click on "Lower your hand" button
+
+    - The avatar and notification should be removed
+    - The reaction bar button should return to its default icon
+    - Any moderator should be able to lower other users' hand
+
+
+
 ## Recording
 
 ### Start recording notification: not in audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
@@ -1718,24 +1826,197 @@ Note :
 
 Client should apply custom parameters according to the descriptions from [here](/administration/customize#application-parameters).
 
+### Override default presentation on CREATE meeting API call
+
+(for more information, see the documentation [here](/new-features/#override-default-presentation-on-create-via-url))
+
+1. When creating a meeting, use the following settings (required):
+```sh
+preUploadedPresentation=https://dagrs.berkeley.edu/sites/default/files/2020-01/sample.pdf
+preUploadedPresentationOverrideDefault=true
+preUploadedPresentationName=ScientificPaper.pdf
+```
+2. Create and join the meeting
+
+    - You should see the "ScientificPaper.pdf" file displayed as the default - or any other value you use in the `preUploadedPresentationName` parameter
+
+### Set a webcam background by passing a url
+
+1. When creating a meeting, use `webcamBackgroundURL=https://upload.wikimedia.org/wikipedia/commons/3/35/Spartan_apple.jpg` parameter (check [here](/development/api/#get-join) for more information)
+
+2. Join the meeting
+
+3. Click to "Share webcam"
+
+    - you should see the webcam settings dropdown displayed
+    - in the preview video, you should see the apples image (or any image you set in the parameter) automatically set as the default background
+    - you should be able to remove this background by clicking the "x" button in the background's top-right corner
+    - once you start sharing, all users should see correctly the background applied
+
+
 ## iFrame
+
+## Timer and stopwatch
+
+### Stopwatch
+
+1. Join in a meeting with 2 users (mod and attendee)
+
+2. As the mod/presenter, click on the actions button
+
+3. Click on "Activate timer/stopwatch"
+    - You should see a new sidebar content with a timer countdown stopped, "Stopwatch" and "Timer" buttons on below the timer and "Start" and "Reset" buttons below
+    - You should see a timer indicator in the top right corner of the meeting (below settings and connection status buttons) with the current time - initially zero
+    - A new user list item should be displayed to all moderator with the title "TIME" and a button with "Stopwatch" or "Timer" (the one selected) with a clock icon
+    - All moderators should be able to interact with this panel and indicator (starting, stopping, changing stopwatch <-> timer)
+
+4. Click on "Start" button
+
+    - The button should change its color to red and label to "Stop"
+    - The timer and timer indicator should start the countdown - it's expected 1-2 seconds of difference between them
+    - Timer indicator should change its color too
+
+5. Click on "Stop" button
+
+    - The timer should stop counting down - the indicator as well
+    - The button should change its color to blue and label to "Start"
+
+6. Click on "Start" button and then click on the timer indicator
+
+    - You should also be able to start and stop the counting by clicking on the timer indicator
+
+7. Click on the actions button and then click on "Deactivate timer/stopwatch"
+
+    - The user list item should not be displayed anymore
+    - Timer indicator should not be displayed anymore
+    - Any active stopwatch should stop immediately, not being displayed anymore
+
+
+### Timer
+
+1. Join in a meeting with 2 users (mod and attendee)
+
+2. As the mod/presenter, click on the actions button
+
+3. Click on "Activate timer/stopwatch"
+    - You should see a new sidebar content with a timer countdown stopped, "Stopwatch" and "Timer" buttons on below the timer and "Start" and "Reset" buttons below
+    - You should see a timer indicator in the top right corner of the meeting (below settings and connection status buttons) with the current time - initially zero
+    - A new user list item should be displayed to all moderator with the title "TIME" and a button with "Stopwatch" or "Timer" (the one selected) with a clock icon
+    - All moderators should be able to interact with this panel and indicator (starting, stopping, changing stopwatch <-> timer)
+
+4. Click on "Timer" button
+
+    - You should see 3 input fields for each hours, minutes and seconds
+    - The initial value should be "00:05:00"
+    - The timer indicator should be changed too
+
+5. Click on "Start" button
+
+    - The timer countdown should start
+    - The timer indicator should start too
+    - Both button background colors should be changed
+
+6. Click on "Stop" button
+
+    - Both button background colors should be changed
+    - The timer should stop and keep its counting
+
+7. Click on "Reset" button
+
+    - The timer should reset to its value set in the input fields
+    - If the timer is active, it should reset the values to the ones set in the input fields and it should **not** be stopped
+
+8. Click on "Start" button and then click on the timer indicator
+
+    - You should be able to start and stop the counting by clicking on the timer indicator
+
+7. Click on the actions button and then click on "Deactivate timer/stopwatch"
+
+    - The user list item should not be displayed anymore
+    - Timer indicator should not be displayed anymore
+    - Any active timer should stop immediately, not being displayed anymore
+
 
 ## Learning Dashboard
 
 ## Layout Manager
 
-### Choose a layout
+### Update everyone's layout [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/layouts/layouts.spec.js)
 
 1. Join a meeting with a webcam and at least 2 users.
 
-2. Choose "Layout Settings Modal" in the actions dropdown.
+2. Click on "Manage layout" in the actions dropdown.
 
-3. Enable "Keep pushing to everyone". Select a new layout. Press "Confirm".
+3. Select a new layout. Click on "Update".
 
-4. Verify that the layout changes for both you and another user.
+    - The layout should change only for you, but stays the same for another user.
 
-5. Choose "Layout Settings Modal" in the actions dropdown.
+4. Click on "Manage layout" in the actions dropdown.
 
-6. Disable "Keep pushing to everyone". Select a new layout. Press "Confirm".
+5. Select a new layout. Click on "Update everyone".
 
-7. Verify that the layout only changes for you, but stays the same for another user.
+    - The layout should change for both you and another user.
+
+### Focus on presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/layouts/layouts.spec.js)
+
+1. Join in a meeting with one user sharing webcam.
+
+2. Click on "Manage layout" in the actions dropdown.
+
+3. Select the "Focus on presentation" layout. Click on "Update".
+
+    - you should see the cameras positioned down below the chat and the presentation fills all the main area.
+
+    - Once you hide the public chat (or any sidebar content displayed), it's expected to hide the cameras as well.
+
+### Grid layout [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/layouts/layouts.spec.js)
+
+1. Join in a meeting with 3 users sharing webcams.
+
+2. Click on "Manage layout" in the actions dropdown.
+
+3. Select the "Grid layout". Click on "Update".
+
+    - The presentation should be positioned down below the chat (or any sidebar content displayed). The cameras should be displayed in the main area.
+
+4. Stop sharing webcam with a user.
+
+    - A placeholder should be displayed in its place containing the user avatar.
+
+### Smart layout [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/layouts/layouts.spec.js)
+
+1. Join in a meeting with 2 users.
+
+2. Click on "Manage layout" in the actions dropdown.
+
+3. Select the "Smart layout". Click on "Update".
+    - The elements should be displayed the same as the "Custom layout" if no webcams are being shared.
+
+4. Start sharing webcam with a user.
+
+    - In the full landscape viewport (1920xx1080), you should see the camera positioned between chat and presentation
+    - In a portrait viewport, you should see the camera position above presentation
+    - You should not be able to change the cameras' position by dragging and dropping
+    - Changing the window width, you should the the elements automatically re-positioning themselves to the better fit of the viewport space
+
+### Custom layout [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/layouts/layouts.spec.js)
+
+1. Join in a meeting sharing webcam.
+
+2. Click on "Manage layout" in the actions dropdown.
+
+3. Select the "Custom layout". Click on "Update".
+
+    - The webcam initially should be displayed above presentation
+
+4. Between camera and presentation, press and drag to resize the size proportion.
+
+    - You should see the size of presentation and webcams changing depending how much you set.
+
+5. Drag and drop webcams to a different position.
+
+    - You should be able to drop the cameras in the following positions:
+        - aside presentation;
+        - below presentation;
+        - above presentation;
+        - below chat (or any sidebar content displayed, e.g. shared notes, stopwatch, polling, etc)

--- a/docs/docs/testing/release-testing.md
+++ b/docs/docs/testing/release-testing.md
@@ -559,7 +559,8 @@ The screen sharing stops, a sound effect of disconnection is heard and the prese
 
 3. Breakout room's annotations should be converted to a pdf and that pdf should be available for uploading to the whiteboard.
 
-### Use different presentation in breakout rooms
+### Use a different presentation for each breakout room
+
 
 1. Join in a meeting with a moderator and an attendee
 

--- a/docs/docs/testing/release-testing.md
+++ b/docs/docs/testing/release-testing.md
@@ -14,13 +14,13 @@ This document is meant to be a combination of manual and (labeled so) automated 
 The <b>automated tests</b> are only a portion of the testing done before a release. Ideally they should be triggered often, for example when testing pull requests, or once a day automatically.
 
 The <b>manual tests</b> really help to ensure release quality. They should
-be performed by humans using different browsers. It is usefull to have multiple
+be performed by humans using different browsers. It is useful to have multiple
 humans performing these tests together. You should plan at least an hour to perform
 all of these tests.
 
 ## Presentation
 
-### Uploading a Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Uploading a Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. As a moderator, select Moderator/Presenter Action menu (+)
 
@@ -35,7 +35,7 @@ all of these tests.
 
 5. Presentation should appear on All Clients in sync with updates, and All Clients should see the notification with the new presentation name
 
-### Sending presentation download link to the chat [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Sending presentation download link to the chat [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. Join a meeting and draw some annotations on the slide.
 
@@ -51,7 +51,7 @@ all of these tests.
 
 7. Send the download link to the chat again. This time, the presentation downloaded through the link should include the annotation.
 
-### Deleting Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Deleting Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. Select Moderator/Presenter Action menu
 
@@ -61,7 +61,7 @@ all of these tests.
 
 4. Choose confirm
 
-### Uploading multiple presentations [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Uploading multiple presentations [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. Select Moderator/Presenter Action menu
 
@@ -89,7 +89,7 @@ all of these tests.
 
 6. New presenter: open "Manage presentations" modal, verify that there's only the default presentation name visible.
 
-### Navigation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Navigation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. Locate slide navigation bar
 
@@ -117,8 +117,7 @@ all of these tests.
 
 4. Hold down the space while moving mouse to pan.
 
-
-### Minimize/Restore Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
+### Minimize/Restore Presentation [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. Clicking on Share webcam.
 
@@ -170,7 +169,7 @@ all of these tests.
 
 4. Presentation should return to normal view
 
-### Make viewer a presenter [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
+### Make viewer a presenter [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
 
 1. Click viewer icon from users list
 
@@ -178,7 +177,7 @@ all of these tests.
 
 3. Viewer selected should have all presenter capabilities and presenter Icon should appear over user icon in the users list.
 
-### Taking presenter status back [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
+### Taking presenter status back [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
 
 1. In order to take back the presenter, can be done in following ways:
 
@@ -196,7 +195,7 @@ You should now have presenter capabilities and presenter icon should appear over
 
 ## Webcams
 
-### Joining Webcam [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/webcam/webcam.spec.js)
+### Joining Webcam [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/webcam/webcam.spec.js)
 
 1. Click on "Share webcam" icon
 
@@ -346,7 +345,7 @@ The webcams should be resized as per the size we want.
 
 ## Screenshare
 
-### Sharing screen in Full Screen mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js)
+### Sharing screen in Full Screen mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js)
 
 1. Clicking on share screen icon
 
@@ -387,7 +386,7 @@ The screen sharing stops, a sound effect of disconnection is heard and the prese
 
 ## Breakout rooms
 
-### Moderators creating breakout rooms and assiging users [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/breakout/breakout.spec.js)
+### Moderators creating breakout rooms and assiging users [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/breakout/breakout.spec.js)
 
 1. Click "Manage users" (cog wheel icon in the user list).
 
@@ -431,7 +430,7 @@ The screen sharing stops, a sound effect of disconnection is heard and the prese
 
 10. Public chats in all the breakout rooms should get the message highlighted by a special background color.
 
-### Viewers choosing the breakout rooms [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/breakout/breakout.spec.js)
+### Viewers choosing the breakout rooms [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/breakout/breakout.spec.js)
 
 1. Click "Manage users" (cog wheel icon in the user list).
 
@@ -509,7 +508,7 @@ The screen sharing stops, a sound effect of disconnection is heard and the prese
 
 ## Audio
 
-### Join audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/audio/audio.spec.js)
+### Join audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/audio/audio.spec.js)
 
 1. Join a meeting.
 
@@ -555,7 +554,7 @@ The screen sharing stops, a sound effect of disconnection is heard and the prese
 
 3. You should be redirected to the meeting and your microphone button should not be highlighted.
 
-### Listen Only Mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/audio/audio.spec.js)
+### Listen Only Mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/audio/audio.spec.js)
 
 1. Join a meeting.
 
@@ -716,7 +715,7 @@ Enable Microphone : This will cause a user name to appear on left top corner of 
 
 7. All clients should see the drawing and the drawing should be colored accordingly.
 
-### Use shape tools [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js)
+### Use shape tools [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js)
 
 1. Join meeting with two or more users.
 
@@ -770,7 +769,7 @@ Enable Microphone : This will cause a user name to appear on left top corner of 
 
 5. Both annotations should disappear for all clients.
 
-### Multi-user whiteboard [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js)
+### Multi-user whiteboard [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js)
 
 1. Join meeting with two or more users.
 
@@ -1230,7 +1229,7 @@ Share notes should export and download in the chosen format.
 
 ## Chat (Public/Private)
 
-### Public message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
+### Public message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
 
 1. Join meeting with viewers and moderators.
 
@@ -1242,7 +1241,7 @@ Share notes should export and download in the chosen format.
 
 5. All users should see the message.
 
-### Private message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
+### Private message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
 
 1. Join meeting with viewers and moderators.
 
@@ -1256,7 +1255,7 @@ Share notes should export and download in the chosen format.
 
 6. Another user should see the private chat message tab and a message counter notification. After clicking on the tab, user should see the private message.
 
-### Chat Character Limit [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
+### Chat Character Limit [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
 
 1. Join meeting.
 
@@ -1264,7 +1263,7 @@ Share notes should export and download in the chosen format.
 
 3. Warning should appear to inform about the character limit and you shouldn't be able to send the message.
 
-### Sending Empty chat message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
+### Sending Empty chat message [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/chat/chat.spec.js)
 
 1. Join meeting.
 
@@ -1284,7 +1283,7 @@ Note :
 
 ## Polling
 
-### Start a single-choice poll [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
+### Start a single-choice poll [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
 
 1. Join meeting
 
@@ -1322,7 +1321,7 @@ Note :
 
 9. Poll results will show up in public chat and presentation area for all users.
 
-### Start an anonymous poll [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
+### Start an anonymous poll [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
 
 1. Join meeting
 
@@ -1343,7 +1342,7 @@ Note :
 6. Poll results will show up in public chat and presentation area for all users.
 
 
-### Custom Poll [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
+### Custom Poll [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
 
 1. Click on the options (+) button in the bottom left corner of the whiteboard area.
 
@@ -1360,7 +1359,7 @@ Note :
   on it are available
 - A live Poll Results Tab will show up to the presenter.
 
-### Quick Poll Option [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
+### Quick Poll Option [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/polling/polling.spec.js)
 
 (Presenter feature : Choosing Quick Poll Options from the current Slide which is loaded from the Quick Poll file)
 
@@ -1388,7 +1387,7 @@ Note :
 
 ## User list settings
 
-### Set status / Raise hand [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
+### Set status / Raise hand [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/user/user.spec.js)
 
 1. Viewer: select your user icon from user list
 
@@ -1519,7 +1518,7 @@ Note :
 
 3. The Popup Alerts for Chat are now Disabled/Enabled.
 
-#### D. Application Language [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/options/options.spec.js)
+#### D. Application Language [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/options/options.spec.js)
 
 (Inside "Application" section of the Settings modal)
 
@@ -1531,7 +1530,7 @@ Note :
 
 4. The screen quickly reloads to apply the language change action
 
-#### D. Dark Mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/options/options.spec.js)
+#### D. Dark Mode [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/options/options.spec.js)
 
 (Inside "Application" section of the Settings modal)
 
@@ -1683,7 +1682,7 @@ Note :
 
 ## Recording
 
-### Start recording notification: not in audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
+### Start recording notification: not in audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
 
 1. Create a recorded meeting and join the meeting without joining audio.
 
@@ -1691,7 +1690,7 @@ Note :
 
 3. Verify that the toast notification about no active mic appears.
 
-### Start recording notification: in listen only [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
+### Start recording notification: in listen only [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
 
 1. Create a recorded meeting and join the meeting in listen only mode.
 
@@ -1699,7 +1698,7 @@ Note :
 
 3. Verify that the toast notification about no active mic appears.
 
-### No start recording notification: in audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
+### No start recording notification: in audio [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
 
 1. Create a recorded meeting and join the meeting with microphone.
 
@@ -1707,7 +1706,7 @@ Note :
 
 3. Verify that the toast notification about no active mic doesn't appear.
 
-### Start recording modal [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
+### Start recording modal [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/notifications/notifications.spec.js)
 
 1. Create a recorded meeting and join it.
 
@@ -1715,7 +1714,7 @@ Note :
 
 3. Verify that the start recording modal appears.
 
-## Custom Parameters [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.6.x-release/bigbluebutton-tests/playwright/customparameters/customparameters.spec.js)
+## Custom Parameters [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v2.7.x-release/bigbluebutton-tests/playwright/parameters/parameters.spec.js)
 
 Client should apply custom parameters according to the descriptions from [here](/administration/customize#application-parameters).
 


### PR DESCRIPTION
### What does this PR do?
- Fixes links on `.spec` test files
- Adds the following tests of new features:
  - disable self-view
  - share camera as content
  - use different presentation in breakout rooms
  - prevent specific user from sending public chat messages
  - reaction
  - override default presentation on CREATE meeting API call
  - set a webcam background by passing a url
  - timer and stopwatch
  - grid layout
- Updates the existing tests:
  - enable/disable presentation download
  - set status (removed)
  - clear status (removed)
  - raise / lower hand
  - update everyone's layout
  - all layout tests