### PR TITLE
fix(darkmode): fix avatar username color when dark mode is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -192,6 +192,7 @@ const Avatar = styled.div<AvatarProps>`
 
   ${({ moderator }) => moderator && `
     border-radius: 5px;
+    color: ${colorWhite} !important;
   `}
 
   ${({ presenter }) => presenter && `
@@ -324,7 +325,7 @@ const Avatar = styled.div<AvatarProps>`
   // ================ image ================
 
   // ================ content ================
-  color: ${colorWhite};
+  color: ${colorWhite} !important;
   font-size: 110%;
   text-transform: capitalize;
   display: flex;


### PR DESCRIPTION
### What does this PR do?
Puts the right color for the default user avatar when dark mode is enabled.

### Closes Issue(s)
None

### More
Before commit:
![image](https://github.com/user-attachments/assets/bedbb000-4d61-471d-ac0b-9d10fdb5cf33)
After commit:
![image](https://github.com/user-attachments/assets/9865d452-eb29-4112-9e6f-d69040e2a5c2)

