### PR TITLE
build: revert removal of gzip command in bbb-html5/build.sh

### DIFF
--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -41,6 +41,12 @@ node -v
 CI=true npm ci
 DISABLE_ESLINT_PLUGIN=true npm run build
 
+# Compress CSS, Javascript and tensorflow WASM binaries used for virtual backgrounds. Keep the
+# uncompressed versions as well so it works with mismatched nginx location blocks
+find dist -name '*.js' -exec gzip -k -f -9 '{}' \;
+find dist -name '*.css' -exec gzip -k -f -9 '{}' \;
+find dist -name '*.wasm' -exec gzip -k -f -9 '{}' \;
+
 cp -r dist/* staging/var/bigbluebutton/html5-client
 
 mkdir -p staging/etc/nginx/sites-available


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none
Related #20811 

### Motivation
<!-- What inspired you to submit this pull request? -->
In #20811 we removed the gzip commands from `build.sh` of `bbb-html5` package and the gzip flag from nginx. In https://github.com/bigbluebutton/bigbluebutton/pull/20899 we recovered the nginx portion and here we recover the gzip of the resources.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
The client should load fine, fonts, styles etc should appear fine. Ensure you clear cache prior to testing.
The largest file `bundle.xxxxxxxxx.js` used to be 5.9MB, now is 1.4MB.

before:
![Screenshot from 2024-08-13 19-48-33](https://github.com/user-attachments/assets/031d9cc3-63a5-4899-a533-a7f41444b03b)

after:
![Screenshot from 2024-08-13 19-48-11](https://github.com/user-attachments/assets/4770dcec-aff1-4861-95c3-9ef3ff818bb7)

Comparable with the ~1.6MB BBB 2.7.12 client's JS bundle.

### More
Credits to @prlanzarin for noting that we're removing it without cause in  #20811 and for following up with further analysis. I just tested locally and am sending the PR.
