### PR TITLE
fix(screenshare): actions-bar loading state reacts to camera as content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -12,7 +12,6 @@ import {
   shareScreen,
   screenshareHasEnded,
   useIsCameraAsContentBroadcasting,
-  useIsSharing,
 } from '/imports/ui/components/screenshare/service';
 import { SCREENSHARING_ERRORS } from '/imports/api/screenshare/client/bridge/errors';
 import Button from '/imports/ui/components/common/button/component';
@@ -26,6 +25,7 @@ const propTypes = {
   enabled: PropTypes.bool.isRequired,
   amIPresenter: PropTypes.bool,
   isScreenBroadcasting: PropTypes.bool.isRequired,
+  isScreenGloballyBroadcasting: PropTypes.bool.isRequired,
   isMeteorConnected: PropTypes.bool.isRequired,
 };
 
@@ -117,6 +117,7 @@ const ScreenshareButton = ({
   intl,
   enabled,
   isScreenBroadcasting,
+  isScreenGloballyBroadcasting,
   amIPresenter = false,
   isMeteorConnected,
 }) => {
@@ -172,8 +173,7 @@ const ScreenshareButton = ({
     && amIPresenter;
 
   const dataTest = isScreenBroadcasting ? 'stopScreenShare' : 'startScreenShare';
-  const isSharing = useIsSharing();
-  const loading = isSharing && !isScreenBroadcasting;
+  const loading = isScreenBroadcasting && !isScreenGloballyBroadcasting;
 
   return (
     <>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import ScreenshareButton from './component';
 import { useIsScreenSharingEnabled } from '/imports/ui/services/features';
-import { useIsScreenBroadcasting } from '/imports/ui/components/screenshare/service';
+import { useIsScreenBroadcasting, useIsScreenGloballyBroadcasting } from '/imports/ui/components/screenshare/service';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 
 const ScreenshareButtonContainer = (props) => {
   const { viewScreenshare: screenshareDataSavingSetting } = useSettings(SETTINGS.DATA_SAVING);
   const screenIsBroadcasting = useIsScreenBroadcasting();
+  const { screenIsShared: isScreenGloballyBroadcasting } = useIsScreenGloballyBroadcasting();
   const enabled = useIsScreenSharingEnabled();
   return (
     <ScreenshareButton
       screenshareDataSavingSetting={screenshareDataSavingSetting}
       isScreenBroadcasting={screenIsBroadcasting}
+      isScreenGloballyBroadcasting={isScreenGloballyBroadcasting}
       enabled={enabled}
       {...props}
     />


### PR DESCRIPTION
### What does this PR do?

The isSharing var is content type agnostic, so it's picking up camera as content to flag the actions-bar button loading state.

Change the loading flag to track isScreenBroadcasting (contentType=screen, local || global) and isScreenGloballyBroadcasting (contentType=screen, global only). Fixes the camera as content false positive as well as the loading state itself.


### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/20941

### More

https://github.com/bigbluebutton/bigbluebutton/pull/20803#pullrequestreview-2210065106