### PR TITLE
fix: use logger convention in plugin startup logs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/loader/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/loader/manager.tsx
@@ -20,14 +20,22 @@ const PluginLoaderManager = (props: PluginLoaderManagerProps) => {
     div.id = uuid;
     containerRef.current?.appendChild(div);
 
-    const script = document.createElement('script');
+    const script: HTMLScriptElement = document.createElement('script');
     script.onload = () => {
       loadedPlugins.current += 1;
       setLastLoadedPlugin(script);
-      logger.info(`Loaded plugin ${plugin.name}`);
+      logger.info({
+        logCode: 'plugin_loaded',
+      }, `Loaded plugin ${plugin.name}`);
     };
-    script.onerror = (err) => {
-      logger.error(`Error when loading plugin ${plugin.name}, error: `, err);
+    script.onerror = () => {
+      logger.error({
+        logCode: 'plugin_load_error',
+        extraInfo: {
+          pluginName: plugin.name,
+          pluginUrl: plugin.url,
+        },
+      }, `Error when loading plugin ${plugin.name}`);
     };
     script.src = plugin.url;
     script.setAttribute('uuid', div.id);


### PR DESCRIPTION
### What does this PR do?

- [fix: use logger convention in plugin startup logs](https://github.com/bigbluebutton/bigbluebutton/commit/abd6f7fea1aefa0b1a97feafb82515951c7d4e5e) 
  - The plugin loader startup logs aren't following the logger convention,
which makes them hard to work with when post-processing logs.
The appended error message is also not useful since we're logging a
Event variant raw (which either outputs {} or nonsense like { isTrusted:
etc }).
  - Make the plugin "loaded" and "error" logs adhere to logger conventions.
In the future, the error log could use some tuning - there's no useful
info about root cause here.
### Closes Issue(s)

None

### Motivation

Stumbled upon this when debugging a broken dev plugin.
