### PR TITLE
test: removing temporally external video test from ci

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -20,7 +20,7 @@ test.describe.parallel('Presentation', () => {
   });
 
   // https://docs.bigbluebutton.org/2.7/testing/release-testing/#start-youtube-video-sharing
-  test('Start external video @ci', async ({ browser, context, page }) => {
+  test('Start external video', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.startExternalVideo();

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -20,7 +20,7 @@ test.describe.parallel('Presentation', () => {
   });
 
   // https://docs.bigbluebutton.org/2.7/testing/release-testing/#start-youtube-video-sharing
-  test('Start external video', async ({ browser, context, page }) => {
+  test('Start external video @ci @flaky', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.startExternalVideo();


### PR DESCRIPTION
### What does this PR do?
Adds the flaky flag to the external video test, and the test will be updated.