### PR TITLE
fix(audio): prevent spurious mute toggle due to AudioSettings remount

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -497,8 +497,8 @@ class AudioManager {
   }
 
   onAudioJoin() {
-    this.isConnecting = false;
     this.isConnected = true;
+    this.isConnecting = false;
 
     const STATS = window.meetingClientSettings.public.stats;
 


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): prevent spurious mute toggle due to AudioSettings remount](https://github.com/bigbluebutton/bigbluebutton/commit/9040cb86cb89cd65ad19197b5f941ce466eb24fb) 
  - When listen only mode is deactivated and an user joins audio, an incorrect
remount of AudioSettings can trigger a spurious mute toggle. This happens
because AudioManager clears the `isConnecting` flag before setting the
`isConnected` flag. This creates a brief period where audio is flagged as
"disconnected," leading to a remount and unmount cycle that causes unwanted
mute/unmute actions due to AudioSettings' logic of muting/unmuting
active devices.
  - Ensure the `isConnected` flag is set before clearing the
`isConnecting` flag, preventing audio from being incorrectly flagged as
disconnected.

### Closes Issue(s)

None

### Motivation

See https://github.com/bigbluebutton/bigbluebutton/pull/20782#issuecomment-2292321802
Follow up to #20782