### PR TITLE
Fix: Even number of emoji clicks hide who the sender was

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -74,8 +74,7 @@ const ReactionsButton = (props) => {
   };
 
   const handleReactionSelect = (reaction) => {
-    const newReaction = currentUserReaction === reaction ? currentUserReaction : reaction;
-    setReactionEmoji({ variables: { reactionEmoji: newReaction } });
+    setReactionEmoji({ variables: { reactionEmoji: reaction } });
   };
 
   const handleRaiseHandButtonClick = () => {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -74,7 +74,7 @@ const ReactionsButton = (props) => {
   };
 
   const handleReactionSelect = (reaction) => {
-    const newReaction = currentUserReaction === reaction ? 'none' : reaction;
+    const newReaction = currentUserReaction === reaction ? currentUserReaction : reaction;
     setReactionEmoji({ variables: { reactionEmoji: newReaction } });
   };
 


### PR DESCRIPTION
### What does this PR do?

This PR keeps the emoji on the user list and reaction button until it times out or user changes emoji/reaction.

### Closes Issue(s)

#20817 