### PR TITLE
fix(audio): close dialog when "Cancel" is clicked with listenOnlyMode=false

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -335,7 +335,6 @@ const AudioModal = ({
 
   const handleGoToAudioOptions = () => {
     setContent(null);
-    setHasError(true);
     setDisableActions(false);
   };
 
@@ -408,9 +407,11 @@ const AudioModal = ({
     }
   }, [changeInputStream, isConnected]);
 
-  const skipAudioOptions = () => (isConnecting || (forceListenOnlyAttendee && !autoplayChecked))
-    && !content
-    && !hasError;
+  const skipAudioOptions = useCallback(
+    // eslint-disable-next-line max-len
+    () => !hasError && (isConnecting || (forceListenOnlyAttendee && !autoplayChecked) || !listenOnlyMode),
+    [hasError, isConnecting, forceListenOnlyAttendee, autoplayChecked, listenOnlyMode],
+  );
 
   const renderAudioOptions = () => {
     const hideMicrophone = forceListenOnlyAttendee || audioLocked;
@@ -481,12 +482,17 @@ const AudioModal = ({
   );
 
   const handleBack = useCallback(() => {
-    if (isConnecting || isConnected || skipAudioOptions()) {
+    // If audio is active, audio options are flagged to be skipped (see skipAudioOptions)
+    // or listen only mode is deactivated (which means there are no actual options
+    // in the base modal), clicking back on any of the sub-modals should close the base modal
+    if (isConnecting
+      || isConnected
+      || skipAudioOptions()) {
       closeModal();
     } else {
       handleGoToAudioOptions();
     }
-  }, [isConnecting, isConnected, skipAudioOptions]);
+  }, [isConnecting, isConnected, skipAudioOptions, listenOnlyMode]);
 
   const renderAudioSettings = () => {
     const { animations } = getSettingsSingletonInstance().application;
@@ -521,6 +527,7 @@ const AudioModal = ({
         toggleVoice={voiceToggle}
         permissionStatus={permissionStatus}
         isTranscriptionEnabled={isTranscriptionEnabled}
+        skipAudioOptions={skipAudioOptions}
       />
     );
   };
@@ -592,26 +599,28 @@ const AudioModal = ({
   const renderContent = () => {
     const { animations } = getSettingsSingletonInstance().application;
 
-    if (findingDevices && content === null) {
-      return (
-        <Styled.Connecting role="alert">
-          <span data-test="findingDevicesLabel">
-            {intl.formatMessage(intlMessages.findingDevicesTitle)}
-          </span>
-          <Styled.ConnectingAnimation animations={animations} />
-        </Styled.Connecting>
-      );
-    }
+    if (content == null) {
+      if (findingDevices) {
+        return (
+          <Styled.Connecting role="alert">
+            <span data-test="findingDevicesLabel">
+              {intl.formatMessage(intlMessages.findingDevicesTitle)}
+            </span>
+            <Styled.ConnectingAnimation animations={animations} />
+          </Styled.Connecting>
+        );
+      }
 
-    if (skipAudioOptions()) {
-      return (
-        <Styled.Connecting role="alert">
-          <span data-test={!isEchoTest ? 'establishingAudioLabel' : 'connectingToEchoTest'}>
-            {intl.formatMessage(intlMessages.connecting)}
-          </span>
-          <Styled.ConnectingAnimation animations={animations} />
-        </Styled.Connecting>
-      );
+      if (skipAudioOptions()) {
+        return (
+          <Styled.Connecting role="alert">
+            <span data-test={!isEchoTest ? 'establishingAudioLabel' : 'connectingToEchoTest'}>
+              {intl.formatMessage(intlMessages.connecting)}
+            </span>
+            <Styled.ConnectingAnimation animations={animations} />
+          </Styled.Connecting>
+        );
+      }
     }
 
     return content ? contents[content].component() : renderAudioOptions();
@@ -667,7 +676,7 @@ const AudioModal = ({
   let title = content
     ? intl.formatMessage(contents[content].title)
     : intl.formatMessage(intlMessages.audioChoiceLabel);
-  title = !skipAudioOptions() && (!findingDevices || content)
+  title = (!skipAudioOptions() && !findingDevices) || content
     ? title
     : null;
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -41,6 +41,7 @@ const propTypes = {
   toggleVoice: PropTypes.func.isRequired,
   permissionStatus: PropTypes.string,
   isTranscriptionEnabled: PropTypes.bool.isRequired,
+  skipAudioOptions: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -520,6 +521,7 @@ class AudioSettings extends React.Component {
     const {
       isConnecting,
       isConnected,
+      skipAudioOptions,
       intl,
     } = this.props;
 
@@ -532,7 +534,7 @@ class AudioSettings extends React.Component {
         <Styled.BottomSeparator />
         <Styled.EnterAudio>
           <Styled.BackButton
-            label={isConnected
+            label={(isConnected || skipAudioOptions())
               ? intl.formatMessage(intlMessages.cancelLabel)
               : intl.formatMessage(intlMessages.backLabel)}
             color="secondary"


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): close dialog when "Cancel" is clicked with listenOnlyMode=false](https://github.com/bigbluebutton/bigbluebutton/commit/135350b6dc1a0e03b497805ad2e73ea0079221f3) 
  - When `listenOnlyMode` is `false` and the audio dialog's "Cancel" action is
clicked, the modal incorrectly re-renders instead of closing. Additionally,
the "Cancel" action is mislabeled as "Back."
  - This fix ensures the audio dialog closes properly when there are no options
to select (i.e., `listenOnlyMode=false`). The `skipAudioOptions` method is
revised to consider `listenOnlyMode` and ignore the "content" state.
  - Ignoring the "content" state allows options to be skipped even if a subscreen
is rendered (e.g., returning from the AudioSettings modal). The check for
`content == null` combined with `skipAudioOptions` is only necessary when
rendering the main modal. The `content == null` check has been moved to
the relevant section.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/20952

### How to test

Follow the instructions in https://github.com/bigbluebutton/bigbluebutton/issues/20952