### PR TITLE
fix(audio): ensure current I/O devices are flagged as selected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -169,16 +169,24 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
     let deviceList: MenuOptionItemType[] = [];
 
     if (listLength > 0) {
-      deviceList = list.map((device, index) => (
-        {
+      deviceList = list.map((device, index) => {
+        // If the device is the first in the list and there's no
+        // currentDeviceId, the user hasn't explicitly selected a device and we
+        // couldn't infer it. In this case, consider the first device as the
+        // system default - as specified in "Media Capture and Streams API",
+        // Section 9.2, enumerateDevices algorithm.
+        const isCurrentDevice = (device.deviceId === currentDeviceId)
+          || (!currentDeviceId && index === 0);
+
+        return {
           key: `${device.deviceId}-${deviceKind}`,
           dataTest: `${deviceKind}-${index + 1}`,
           label: truncateDeviceName(device.label || getFallbackLabel(device, index + 1)),
-          customStyles: (device.deviceId === currentDeviceId) ? Styled.SelectedLabel : null,
-          iconRight: (device.deviceId === currentDeviceId) ? 'check' : null,
+          customStyles: isCurrentDevice ? Styled.SelectedLabel : null,
+          iconRight: isCurrentDevice ? 'check' : null,
           onClick: () => onDeviceListClick(device.deviceId, deviceKind, callback),
-        } as MenuOptionItemType
-      ));
+        } as MenuOptionItemType;
+      });
     } else if (deviceKind === AUDIO_OUTPUT && !SET_SINK_ID_SUPPORTED && listLength === 0) {
       // If the browser doesn't support setSinkId, show the chosen output device
       // as a placeholder Default - like it's done in audio/device-selector


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): ensure current I/O devices are flagged as selected](https://github.com/bigbluebutton/bigbluebutton/commit/c055caf9156073eac45b8f18ea784a9bc81a2a33) 
  - There's a regression in 3.0's I/O device selector where default output
devices are not marked as selected in the input-stream-live-selector
component unless the user explicitly selects them. This issue can also affect
input devices, although less commonly than output due to the system's ability
to infer the selected input device ID after the user joins audio.
  - When a device is the first in the list and no currentDeviceId is set in
the client, treat the first device returned by enumerateDevices as the
system default and hence selected, in accordance with the "Media Capture
and Streams API", Section 9.2, enumerateDevices algorithm.

### Closes Issue(s)

None

### How to test

- Join audio in via private/incognito session
- Check the I/O device selector - both input and output devices should be marked as selected