### PR TITLE
fix(audio): ensure correct audio device labels in Firefox

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -279,6 +279,9 @@ class AudioSettings extends React.Component {
       // Only generate input streams if they're going to be used with something
       // In this case, the volume meter or local echo test.
       if (produceStreams) {
+        this.setState({
+          producingStreams: true,
+        });
         this.generateInputStream(deviceId).then((stream) => {
           // Extract the deviceId again from the stream to guarantee consistency
           // between stream DID vs chosen DID. That's necessary in scenarios where,
@@ -301,8 +304,13 @@ class AudioSettings extends React.Component {
           this.setState({
             inputDeviceId: extractedDeviceId,
             stream,
-            producingStreams: false,
           });
+
+          // Update the device list after the stream has been generated.
+          // This is necessary to guarantee the device list is up-to-date, mainly
+          // in Firefox as it omit labels if no active stream is present (even if
+          // gUM permission is flagged as granted).
+          this.updateDeviceList();
         }).catch((error) => {
           logger.warn({
             logCode: 'audiosettings_gum_failed',
@@ -313,6 +321,13 @@ class AudioSettings extends React.Component {
             },
           }, `Audio settings gUM failed: ${error.name}`);
           handleGUMFailure(error);
+        }).finally(() => {
+          // Component unmounted after gUM resolution -> skip echo rendering
+          if (!this._isMounted) return;
+
+          this.setState({
+            producingStreams: false,
+          });
         });
       } else {
         this.setState({
@@ -377,6 +392,15 @@ class AudioSettings extends React.Component {
           audioInputDevices,
           audioOutputDevices,
         });
+      })
+      .catch((error) => {
+        logger.warn({
+          logCode: 'audiosettings_enumerate_devices_error',
+          extraInfo: {
+            errorName: error.name,
+            errorMessage: error.message,
+          },
+        }, `Audio settings: error enumerating devices - {${error.name}: ${error.message}}`);
       });
   }
 


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): ensure correct audio device labels in Firefox](https://github.com/bigbluebutton/bigbluebutton/commit/b9f66c2a1002a565b4293b39a05123c5cff5d06c) 
  - Firefox incorretly displays placeholder audio device labels in the audio
settings/echo test modal when audio is disconnected. This issue arises
due to two quirks:
    - Firefox does not support the 'microphone' query from the Permissions
    API, causing a fallback gUM permission check.
    - Firefox omits device labels from `enumerateDevices` if no streams
    are active, even if gUM permission is granted. This behavior differs
    from other browsers and causes our `enumerateDevices` handling to
    assume that granted permission implies labels are present. This
    failed since we clear streams before resolving the fallback gUM.
  - We now run an additional `enumerateDevices` call in `AudioSettings` when
  a selected input device is defined. This ensures `enumerateDevices` is
  re-run when a new stream is active, adding the correct device labels in
  Firefox and improving device listings in all browsers. We've also
  enhanced error handling in the enumeration process and fixed a false
  positive in `hasMicrophonePermission`.

### Closes Issue(s)

None

### How to test

1. In a Firefox private session: join a room where audio settings/echo test isn't skipped, choose "Microphone"
2. See device labels in the audio settings modal