### PR TITLE
docs: change order of mediasoup IP config

### DIFF
--- a/docs/docs/administration/configure-firewall.md
+++ b/docs/docs/administration/configure-firewall.md
@@ -167,9 +167,9 @@ Notice the `listenIps` key is an **array**. If you need mediasoup to work with *
 mediasoup:
   webrtc:
     listenIps:
+      - ip: 2001:db8::
       - ip: 0.0.0.0
         announcedIp: 192.0.2.0
-      - ip: 2001:db8::
 ```
 
 Restart BigBlueButton to apply the changes.


### PR DESCRIPTION
### What does this PR do?

- [docs: change order of mediasoup IP config](https://github.com/bigbluebutton/bigbluebutton/commit/c8dfa09feeaf285672a343efa64fbdb834ca677e) 
  - See https://github.com/bigbluebutton/bigbluebutton/issues/20966.
  - The order of the configured mediasoup listenIps influence the server's candidate priorities. 
  - There's not a big impact to this, but if we want to be friendly to RFC 8421 (and to Happy Eyeballs), we should suggest sorting IPv6 first.
  - Change docs so that the IPv6 config in mediasoup comes first.

### Closes Issue(s)

Closes #20966