### PR TITLE
Add: Local history of rtt status changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -5,6 +5,7 @@ import { getStatus, startMonitoringNetwork } from '/imports/ui/components/connec
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 
 import getBaseUrl from '/imports/ui/core/utils/getBaseUrl';
+import useCurrentUser from '../../core/hooks/useCurrentUser';
 
 const ConnectionStatus = () => {
   const STATS_INTERVAL = window.meetingClientSettings.public.stats.interval;
@@ -12,6 +13,16 @@ const ConnectionStatus = () => {
   const timeoutRef = useRef(null);
 
   const [updateConnectionAliveAtM] = useMutation(UPDATE_CONNECTION_ALIVE_AT);
+
+  const {
+    data,
+  } = useCurrentUser((u) => ({
+    userId: u.userId,
+    avatar: u.avatar,
+    isModerator: u.isModerator,
+    color: u.color,
+    isOnline: u.isOnline,
+  }));
 
   const handleUpdateConnectionAliveAt = () => {
     const startTime = performance.now();
@@ -34,6 +45,14 @@ const ConnectionStatus = () => {
           connectionStatus.setRttValue(networkRtt);
           connectionStatus.setRttStatus(rttStatus);
           connectionStatus.setLastRttRequestSuccess(true);
+
+          if (Object.keys(rttLevels).includes(rttStatus)) {
+            connectionStatus.addUserNetworkHistory(
+              data,
+              rttStatus,
+              Date.now(),
+            );
+          }
         }
       })
       .catch(() => {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -336,7 +336,7 @@ class ConnectionStatusComponent extends PureComponent {
                   : (
                     <TooltipContainer
                       placement="top"
-                      title={`this is a message`}
+                      title={intl.formatMessage(intlMessages.noEvent)}
                     >
                       <CommonIcon iconName="close" rotate={false} />
                     </TooltipContainer>

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -35,6 +35,13 @@ class ConnectionStatus {
     video: {},
   });
 
+  private userNetworkHistory = makeVar<Array<{
+    user: Pick<User, 'userId' | 'avatar' | 'isModerator' | 'color' | 'isOnline' | 'name'>,
+    lastUnstableStatus: string,
+    lastUnstableStatusAt: Date | number,
+    clientNotResponding?: boolean,
+  }>>([]);
+
   private packetLossStatus = makeVar('normal');
 
   public setPacketLossStatus(value: string): void {
@@ -152,6 +159,32 @@ class ConnectionStatus {
 
   public getConnectedStatusVar() {
     return this.connected;
+  }
+
+  public addUserNetworkHistory(
+    user: User,
+    lastUnstableStatus: string,
+    lastUnstableStatusAt: Date | number,
+  ): void {
+    const userNetworkHistory = [...this.userNetworkHistory()];
+    userNetworkHistory.push({
+      user: {
+        userId: user.userId,
+        avatar: user.avatar,
+        isModerator: user.isModerator,
+        color: user.color,
+        isOnline: user.isOnline,
+        name: user.name,
+      },
+      lastUnstableStatus,
+      lastUnstableStatusAt,
+      clientNotResponding: false,
+    });
+    this.userNetworkHistory(userNetworkHistory);
+  }
+
+  public getUserNetworkHistory() {
+    return this.userNetworkHistory();
   }
 }
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1009,6 +1009,7 @@
     "app.connection-status.usingTurn": "Using TURN",
     "app.connection-status.yes": "Yes",
     "app.connection-status.connectionStats": "Connection Stats",
+    "app.connection-status.connectionStatusNoEvent": "No event generated for this status.",
     "app.connection-status.myLogs": "My Logs",
     "app.connection-status.sessionLogs": "Session Logs",
     "app.connection-status.next": "Next page",


### PR DESCRIPTION
### What does this PR do?
this PR creates a history of rtt events with bad status, also modifies the interface to not show the connections status when the client isn't responding for user not misundertand the message (before user not responding was being shown with good status) also add a icon for status without a event, that doesn't generates a timestamp.