### PR TITLE
feat(audio): dedicate mediasoup workers for audio streams

### DIFF
--- a/build/packages-template/bbb-webrtc-sfu/after-install.sh
+++ b/build/packages-template/bbb-webrtc-sfu/after-install.sh
@@ -10,7 +10,9 @@ case "$1" in
     chown bigbluebutton:bigbluebutton $TARGET
 
     # Set mediasoup IPs
+    # mediasoup.webrtc.listenIps[]: used for EXTERNAL comms (browser <-> ms)
     yq e -i ".mediasoup.webrtc.listenIps[0].announcedIp = \"$IP\"" $TARGET
+    # mediasoup.plainRtp.listenIp: used for INTERNAL comms (FreeSWITCH <-> ms)
     yq e -i ".mediasoup.plainRtp.listenIp.announcedIp = \"$IP\"" $TARGET
     # mediasoup.workerBalancing: defines the strategy to distribute mediasoup
     # elements (transports, producers, consumers) among workers.
@@ -18,6 +20,14 @@ case "$1" in
     # mediasoup.enableWorkerTransposing: whether to enable worker transposing
     # (ie: the ability to move a media stream from one worker to another).
     yq e -i '.mediasoup.enableWorkerTransposing = true' $TARGET
+    # mediasoup.dedicatedMediaTypeWorkers.audio: spin up #auto mediasoup workers
+    # dedicated to handling audio streams.
+    # auto = ceil((min(nproc,32) * 0.8) + (max(0, nproc - 32) / 2))
+    # The goal here is to try and preserve quality for audio streams via:
+    #   - reducing noise from video streams in these single threaded workers
+    #   - giving the possibility to specify different scheduling priorities for audio workers
+    yq e -i '.mediasoup.dedicatedMediaTypeWorkers.audio = "auto"' $TARGET
+
 
     FREESWITCH_IP=$(xmlstarlet sel -t -v '//X-PRE-PROCESS[@cmd="set" and starts-with(@data, "local_ip_v4=")]/@data' /opt/freeswitch/conf/vars.xml | sed 's/local_ip_v4=//g')
     if [ "$FREESWITCH_IP" != "" ]; then


### PR DESCRIPTION
### What does this PR do?

- [feat(audio): dedicate mediasoup workers for audio streams](https://github.com/bigbluebutton/bigbluebutton/commit/89209fc7ee3b945cae823bee07a7d027128fccf0) 
  - mediasoup workers are currently for general use,
regardless of stream type. This makes it difficult to give
different scheduling priorities for audio workers or prevent
noise from video streams, when our goal is to give higher
priority to audio in all ends of the system.
  - Set `mediasoup.dedicatedMediaTypeWorkers.audio` to `auto`. This will spin up 
`ceil((min(nproc, 32) * 0.8) + (max(0, nproc - 32))` mediasoup workers 
dedicated to handling audio streams.

### Closes Issue(s)

None

### Motivation

Follow up to #20822 