### PR TITLE
fix(audio): prevent permission check loop in Safari

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -633,10 +633,9 @@ const AudioModal = ({
               handleJoinMicrophone();
             });
         } else {
-          checkMicrophonePermission({ doGUM: false, permissionStatus }).then((hasPermission) => {
-            if (hasPermission === false) return;
-            handleGoToEchoTest();
-          });
+          // No need to check for permission here since the AudioSettings
+          // component will handle it
+          handleGoToEchoTest();
         }
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -69,8 +69,8 @@ const useIsUsingAudio = () => {
   const isConnected = useReactiveVar(AudioManager._isConnected.value);
   const isConnecting = useReactiveVar(AudioManager._isConnecting.value);
   const isHangingUp = useReactiveVar(AudioManager._isHangingUp.value);
-  const isEchoTest = useReactiveVar(AudioManager._isEchoTest.value);
-  return Boolean(isConnected || isConnecting || isHangingUp || isEchoTest);
+
+  return Boolean(isConnected || isConnecting || isHangingUp);
 };
 
 /**

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -673,7 +673,7 @@ class AudioManager {
   }
 
   isUsingAudio() {
-    return Boolean(this.isConnected || this.isConnecting || this.isHangingUp || this.isEchoTest);
+    return Boolean(this.isConnected || this.isConnecting || this.isHangingUp);
   }
 
   changeInputDevice(deviceId) {


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): prevent permission check loop in Safari](https://github.com/bigbluebutton/bigbluebutton/commit/1e53140a00dcb568ab50517aafa90815791ebe10) 
  - Safari may enter a microphone permission check loop due to buggy behavior
in the Permissions API. When permission isn't permanently denied, gUM
requests fail with a NotAllowedError for a few seconds. During this time,
the permission state remains 'prompt' instead of transitioning to 'denied'
and back to 'prompt' after the timeout.
  - This leads to an issue where, on retrying while in 'prompt' + blocked,
the client loops through gUM checks via: 
    1) checking permission in the API,
    2) receiving 'prompt', so trying gUM, 
    3) gUM fails, 
    4) returning to the modal and checking permission again because the API 
       still says 'prompt' =)
  -  Additionally, the `isUsingAudio` flag incorrectly counts the local echo
test/audio settings modal as "using audio," which toggles the flag on/off,
triggering the useEffect that causes the loop more frequently.
  - Remove the unnecessary AudioModal permission check that
causes the loop. Also, exclude "isEchoTest" from the `isUsingAudio` flag.

### Closes Issue(s)

None