### PR TITLE
fix(darkmode): fix avatar username color in chat when dark mode is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -164,7 +164,7 @@ export const ChatAvatar = styled.div<ChatAvatarProps>`
   // ================ image ================
 
   // ================ content ================
-  color: ${colorWhite};
+  color: ${colorWhite} !important;
   font-size: 110%;
   text-transform: capitalize;
   display: flex;


### PR DESCRIPTION
### What does this PR do?
 Puts the right color for the default user avatar in chat when dark mode is enabled.


### Closes Issue(s)
None

### More
Before:
![Captura de tela de 2024-08-21 16-39-05](https://github.com/user-attachments/assets/ea37f00b-4b5a-43b8-80a0-a0c7ebdc14e2)

After:
![Captura de tela de 2024-08-21 17-13-39](https://github.com/user-attachments/assets/4936b50c-5026-49d4-b8c0-4df0e96f34e5)

