### PR TITLE
build(bbb-webrtc-sfu): v2.15.0-beta.0

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.14.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.15.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webrtc-sfu): v2.15.0-beta.0](https://github.com/bigbluebutton/bigbluebutton/commit/c38f8aa41dedf425a9ec398a4299340e8d11e864) 
  - feat: add restartIce support for video/screenshare modules

### Closes Issue(s)

None

### Motivation

To be further contextualized with client side changes.
