### PR TITLE
fix (html5-dev-server): Prevent HEAD requests from crashing webpack-dev-server

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -110,6 +110,25 @@ if (env === prodEnv) {
       overlay: false,
       webSocketURL: 'auto://0.0.0.0:0/html5client/ws',
     },
+    setupMiddlewares: (middlewares, devServer) => {
+      if (!devServer) {
+        throw new Error('webpack-dev-server is not defined');
+      }
+
+      devServer.app.use((req, res, next) => {
+        // the server crashes when it receives HEAD requests, so we need to prevent it
+        if (req.method === 'HEAD') {
+          // console.log(`Request received: ${req.method} ${req.url}`);
+          res.setHeader('Content-Type', 'text/html');
+          res.setHeader('Content-Length', '0');
+          res.end();
+        } else {
+          next();
+        }
+      });
+
+      return middlewares;
+    },
   };
 }
 


### PR DESCRIPTION
As reported by @lfzawacki , a request using method `HEAD` to the html5client server such as `curl -I http://localhost:3000/` crashes the application.
![image](https://github.com/user-attachments/assets/38a4669c-1f2b-4aa0-acde-ec5bf29ca7c7)

It's not so easy to fix. As a workaround I included a handler specific for HEAD requests that will stop the regular flow and return hard-coded headers, avoiding the app from crashing.
Once it is only used for development, I think it can solve for now.

And rather than using `curl -I http://localhost:3000/` to get the headers (HEAD method request).
It's possible to use `curl -i -r 0-0 http://localhost:3000` instead (GET method request, but filtering only the headers).

