### PR TITLE
feat: add experimental support for ICE restart

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.14.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.15.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -32,6 +32,10 @@ const TRANSPARENT_LISTEN_ONLY = MEDIA.transparentListenOnly;
 const MEDIA_TAG = MEDIA.mediaTag.replace(/#/g, '');
 const CONNECTION_TIMEOUT_MS = MEDIA.listenOnlyCallTimeout || 15000;
 const { audio: NETWORK_PRIORITY } = MEDIA.networkPriorities || {};
+const {
+  enabled: RESTART_ICE = false,
+  retries: RESTART_ICE_RETRIES = 1,
+} = Meteor.settings.public.kurento?.restartIce?.audio || {};
 const SENDRECV_ROLE = 'sendrecv';
 const RECV_ROLE = 'recv';
 const BRIDGE_NAME = 'fullaudio';
@@ -346,6 +350,8 @@ export default class SFUAudioBridge extends BaseAudioBridge {
           mediaStreamFactory: this.mediaStreamFactory,
           gatheringTimeout: GATHERING_TIMEOUT,
           transparentListenOnly: isTransparentListenOnlyEnabled(),
+          restartIce: RESTART_ICE,
+          restartIceMaxRetries: RESTART_ICE_RETRIES,
         };
 
         this.broker = new AudioBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -15,6 +15,10 @@ const SIGNAL_CANDIDATES = Meteor.settings.public.kurento.signalCandidates;
 const TRACE_LOGS = Meteor.settings.public.kurento.traceLogs;
 const { screenshare: NETWORK_PRIORITY } = Meteor.settings.public.media.networkPriorities || {};
 const GATHERING_TIMEOUT = Meteor.settings.public.kurento.gatheringTimeout;
+const {
+  enabled: RESTART_ICE = false,
+  retries: RESTART_ICE_RETRIES = 3,
+} = Meteor.settings.public.kurento?.restartIce?.screenshare || {};
 
 const BRIDGE_NAME = 'kurento'
 const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
@@ -269,6 +273,8 @@ export default class KurentoScreenshareBridge {
       forceRelay: shouldForceRelay(),
       traceLogs: TRACE_LOGS,
       gatheringTimeout: GATHERING_TIMEOUT,
+      restartIce: RESTART_ICE,
+      restartIceMaxRetries: RESTART_ICE_RETRIES,
     };
 
     this.broker = new ScreenshareBroker(
@@ -341,6 +347,7 @@ export default class KurentoScreenshareBridge {
         traceLogs: TRACE_LOGS,
         networkPriority: NETWORK_PRIORITY,
         gatheringTimeout: GATHERING_TIMEOUT,
+        restartIce: RESTART_ICE,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -151,6 +151,9 @@ class AudioBroker extends BaseBroker {
         this.onstart(parsedMessage.success);
         this.started = true;
         break;
+      case 'restartIceResponse':
+        this.handleRestartIceResponse(parsedMessage);
+        break;
       case 'webRTCAudioError':
       case 'error':
         this.handleSFUError(parsedMessage);

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -41,6 +41,8 @@ class ScreenshareBroker extends BaseBroker {
     // traceLogs
     // networkPriority
     // gatheringTimeout
+    // restartIce
+    // restartIceMaxRetries
     Object.assign(this, options);
   }
 
@@ -96,6 +98,9 @@ class ScreenshareBroker extends BaseBroker {
         break;
       case 'iceCandidate':
         this.handleIceCandidate(parsedMessage.candidate);
+        break;
+      case 'restartIceResponse':
+        this.handleRestartIceResponse(parsedMessage);
         break;
       case 'error':
         this.handleSFUError(parsedMessage);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -319,6 +319,21 @@ public:
     # Controls whether ICE candidates should be signaled to bbb-webrtc-sfu.
     # Enable this if you want to use Kurento as the media server.
     signalCandidates: false
+    # restartIce: controls whether ICE restarts should be signaled to bbb-webrtc-sfu
+    #   whenever peers of the selected type (audio, video, screenshare) transition
+    #   to failure states. Disabled by default (experimental).
+    # restartIce.<mediaType>.retries: number of ICE restart retries before giving up
+    #   (i.e.: throwing an error). Default is 1 for audio, 3 for video and screenshare.
+    restartIce:
+      audio:
+        enabled: false
+        retries: 1
+      video:
+        enabled: false
+        retries: 3
+      screenshare:
+        enabled: false
+        retries: 3
     # traceLogs: <Boolean> - enable trace logs in SFU peers
     traceLogs: false
     cameraTimeouts:


### PR DESCRIPTION
### What does this PR do?

- [feat: add experimental support for ICE restart](https://github.com/bigbluebutton/bigbluebutton/commit/27d6bca5156c793f692d78d34171688f462bd609) 
  - We currently use full renegotiation for audio, video, and screen sharing
reconnections, which involves re-creating transports and signaling channels
from scratch. While effective in some scenarios, this approach is slow and,
especially with outbound cameras and screen sharing, prone to failures.
  - To counter that, WebRTC provides a mechanism to restart ICE without needing
to re-create the peer connection. This allows us to avoid full renegotiation
and bypass some server-side signaling limitations. Implementing ICE restart
should make outbound camera/screen sharing reconnections more reliable and
faster.
  - This commit implements the ICE restart procedure for all WebRTC components,
based on bbb-webrtc-sfu >= v2.15.0-beta.0, which added support for ICE restart
requests. This feature is off by default. To enable it, adjust the following
flags:
    - `/etc/bigbluebutton/bbb-webrtc-sfu/production.yml`: `allowIceRestart: true`
    - `/etc/bigbluebutton/bbb-html5.yml`: `public.kurento.restartIce`
      * Refer to the inline documentation; this can be enabled on the client side
    per media type.
      * Note: The default max retries for audio is lower than for cameras/screen
    sharing (1 vs 3). This is because the full renegotiation process for audio
    is more reliable, so ICE restart is attempted first, followed by full
    renegotiation if necessary. This approach is less suitable for cameras/
    screen sharing, where longer retry periods for ICE restart make sense
    since full renegotation there is... iffy.
- [build(bbb-webrtc-sfu): v2.15.0-beta.0](https://github.com/bigbluebutton/bigbluebutton/commit/5ab21c2146cf4a3fa206192dd8e0fdb7d053260e) 
  - feat: add restartIce support for video/screenshare modules

### Closes Issue(s)

None