### PR TITLE
style: adjust connection status modal padding

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.js
@@ -17,7 +17,6 @@ import {
   titlePositionLeft,
   mdPaddingX,
   borderSizeLarge,
-  jumboPaddingY,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
   fontSizeSmall,
@@ -81,7 +80,6 @@ const ClientNotRespondingText = styled.div`
     width: 100%;
   }
 `;
-
 
 const Text = styled.div`
   padding-left: .5rem;
@@ -165,7 +163,7 @@ const CopyContainer = styled.div`
   justify-content: flex-end;
   border: none;
   border-top: 1px solid ${colorOffWhite};
-  padding: ${jumboPaddingY} 0 0;
+  padding: ${mdPaddingX} 0 0 0;
 `;
 
 const ConnectionStatusModal = styled(ModalSimple)`


### PR DESCRIPTION
### What does this PR do?

Adjusts connection status modal padding

#### before
![bef](https://github.com/user-attachments/assets/877e83f0-19ff-49ff-8422-efbb806cd1f1)

#### after

![aft](https://github.com/user-attachments/assets/45940777-2ab8-4487-92b5-ff3e7571e23d)
