### PR TITLE
feat: make guest policy configurable for dial-in endpoints

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -48,6 +48,7 @@ trait SystemConfiguration {
   lazy val toggleListenOnlyAfterMuteTimer = Try(config.getInt("voiceConf.toggleListenOnlyAfterMuteTimer")).getOrElse(4)
   lazy val transparentListenOnlyThreshold = Try(config.getInt("voiceConf.transparentListenOnlyThreshold")).getOrElse(0)
   lazy val muteOnStartThreshold = Try(config.getInt("voiceConf.muteOnStartThreshold")).getOrElse(0)
+  lazy val dialInEnforceGuestPolicy = Try(config.getBoolean("voiceConf.dialInEnforceGuestPolicy")).getOrElse(true)
 
   lazy val recordingChapterBreakLengthInMinutes = Try(config.getInt("recording.chapterBreakLengthInMinutes")).getOrElse(0)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -111,14 +111,18 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
       if (isDialInUser) {
         registerUserInRegisteredUsers()
         registerUserInUsers2x()
-        guestPolicy match {
-          case GuestPolicy(policy, setBy) => {
-            policy match {
-              case GuestPolicyType.ALWAYS_ACCEPT => letUserEnter()
-              case GuestPolicyType.ALWAYS_DENY   => VoiceApp.removeUserFromVoiceConf(liveMeeting, outGW, msg.body.voiceUserId)
-              case GuestPolicyType.ASK_MODERATOR => registerUserAsGuest()
+        if (dialInEnforceGuestPolicy) {
+          guestPolicy match {
+            case GuestPolicy(policy, setBy) => {
+              policy match {
+                case GuestPolicyType.ALWAYS_ACCEPT => letUserEnter()
+                case GuestPolicyType.ALWAYS_DENY   => VoiceApp.removeUserFromVoiceConf(liveMeeting, outGW, msg.body.voiceUserId)
+                case GuestPolicyType.ASK_MODERATOR => registerUserAsGuest()
+              }
             }
           }
+        } else {
+          letUserEnter()
         }
       } else {
         // Regular users reach this point after beeing

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -9,7 +9,7 @@ pekko {
   }
   loggers = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
   loglevel = "DEBUG"
-  
+
   redis-publish-worker-dispatcher {
       mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
       # Throughput defines the maximum number of messages to be
@@ -17,7 +17,7 @@ pekko {
       # Set to 1 for as fair as possible.
       throughput = 512
     }
-    
+
   redis-subscriber-worker-dispatcher {
       mailbox-type = "org.apache.pekko.dispatch.SingleConsumerOnlyUnboundedMailbox"
       # Throughput defines the maximum number of messages to be
@@ -129,6 +129,9 @@ voiceConf {
   # Overrides any existing muteOnStart directive (bbb-web, API and the client).
   # 0 = disabled.
   muteOnStartThreshold = 0
+
+  # Whether guest policy should be enforced on dial-in endpoints
+  dialInEnforceGuestPolicy = true
 }
 
 recording {


### PR DESCRIPTION
### What does this PR do?

- [feat: make guest policy optional for dial-in in akka-apps](https://github.com/bigbluebutton/bigbluebutton/commit/dd1cf00dd25ba48e5c3a480115c77725b928ea33) 
  - Dial-in endpoints currently follow the same guest approval process as regular
users. While this is correct for default installations, it complicates the join
procedure in setups where approval is managed externally, such as with pre-
configured conference PIN codes. Another relevant scenario is when call
origination is done from BBB, rather than as an inbound call.
  - This commit makes the enforcement of the guest policy for dial-in/external
endpoints optional in akka-apps. **The default behavior remains unchanged
(enforce)**. This provides more flexibility for the dial-in mechanism, allowing
for smoother handling of the scenarios mentioned above.

### Closes Issue(s)

None