### PR TITLE
feat(logout): Add option to send userId and meetingId to logoutURL

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -268,7 +268,11 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
   const confirmRedirect = (isBreakout: boolean, allowRedirect: boolean) => {
     if (isBreakout) window.close();
     if (allowRedirect) {
-      window.location.href = logoutUrl;
+      let redirectTo = logoutUrl;
+      redirectTo = redirectTo.replaceAll('%%USERID%%', userId);
+      redirectTo = redirectTo.replaceAll('%%USERNAME%%', userName);
+      redirectTo = redirectTo.replaceAll('%%MEETINGID%%', meetingId);
+      window.location.href = redirectTo;
     }
   };
 


### PR DESCRIPTION
This is used by the upcoming custom feedback app together with the logoutURL functionality.

Here's an example of the logoutURL we'd configure in `bigbluebutton-web/grails-app/conf/bigbluebutton.properties`:

    bigbluebutton.web.logoutURL=${bigbluebutton.web.serverURL}/feedback?meetingID=%%MEETINGID%%&userID=%%USERID%%

The `%%MEETINGID%%` and `%%USERID%%` parameters can be used as templates that will be substituted by the time the user is redirected after they leave the meeting. The currently implemented parameters are:

**%%MEETINGID%%** : The current meeting's internal meeting ID

**%%USERID%%** : The current user's internal user ID

**%%USERNAME%%** : The current user's name

These parameters might change or be updated in the future.