### PR TITLE
fix (gql-middleware): Prevents resending all subscriptions when a user leaves a meeting

### DIFF
--- a/bbb-graphql-middleware/internal/hasura/retransmiter/retransmiter.go
+++ b/bbb-graphql-middleware/internal/hasura/retransmiter/retransmiter.go
@@ -9,15 +9,30 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection) {
 	log := log.WithField("_routine", "RetransmitSubscriptionStartMessages").WithField("browserConnectionId", hc.BrowserConn.Id).WithField("hasuraConnectionId", hc.Id)
 
 	hc.BrowserConn.ActiveSubscriptionsMutex.RLock()
-	for _, subscription := range hc.BrowserConn.ActiveSubscriptions {
+	defer hc.BrowserConn.ActiveSubscriptionsMutex.RUnlock()
 
+	userIsInMeetingNow := false
+	if hasuraRole, exists := hc.BrowserConn.BBBWebSessionVariables["x-hasura-role"]; exists {
+		userIsInMeetingNow = hasuraRole == "bbb_client"
+	}
+
+	for _, subscription := range hc.BrowserConn.ActiveSubscriptions {
 		//Not retransmitting Mutations
 		if subscription.Type == common.Mutation {
 			continue
 		}
 
-		if subscription.LastSeenOnHasuraConnection != hc.Id {
+		//When user left the meeting, Retransmit only Presence Manager subscriptions
+		if !userIsInMeetingNow &&
+			subscription.OperationName != "getUserInfo" &&
+			subscription.OperationName != "getUserCurrent" {
+			log.Infof("Skipping retransmit %s because the user is offline", subscription.OperationName)
+			log.Debugf("Skipping retransmit %s because the user is offline", subscription.OperationName)
+			continue
+		}
 
+		if subscription.LastSeenOnHasuraConnection != hc.Id {
+			log.Infof("retransmiting subscription start: %v", string(subscription.Message))
 			log.Tracef("retransmiting subscription start: %v", string(subscription.Message))
 
 			if subscription.Type == common.Streaming && subscription.StreamCursorCurrValue != nil {
@@ -27,5 +42,5 @@ func RetransmitSubscriptionStartMessages(hc *common.HasuraConnection) {
 			}
 		}
 	}
-	hc.BrowserConn.ActiveSubscriptionsMutex.RUnlock()
+
 }


### PR DESCRIPTION
**TL;DR:** This PR prevents resending all subscriptions when a user leaves a meeting, allowing only the PresenceManager subscriptions to be re-sent.

**Details:**

Currently, when a user changes their role or another important status, the GraphQL-Middleware reconnects with Hasura and re-sends all subscriptions. This is expected behavior when a user remains in the meeting.

When a user leaves the meeting, this reconnection and retransmission still occur. 
The issue arises because after leaving, the user loses permission to query most Graphql Types (tables). As a result, re-sending these subscriptions cause permission errors.

This PR addresses the issue by filtering the subscriptions. When the `Hasura-Role` is different from `bbb_client`, only the PresenceManager subscriptions will be re-sent. PresenceManager queries are allowed for all users, including those with the `not_joined_bbb_client` role.

**Closes:** #21026