### PR TITLE
feat: add WebRTC stats information to client logs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
@@ -36,17 +36,21 @@ class ConnectionStatusButton extends PureComponent {
     );
   }
 
-  setModalIsOpen = (isOpen) => this.setState({ isModalOpen: isOpen }); 
+  setModalIsOpen = (isOpen) => this.setState({ isModalOpen: isOpen });
 
   renderModal(isModalOpen) {
+    const { logMediaStats, monitoringInterval } = this.props;
+
     return (
-      isModalOpen ?
-      <ConnectionStatusModalContainer
-        {...{
-          isModalOpen,
-          setModalIsOpen: this.setModalIsOpen
-        }}
-      /> : null
+      (isModalOpen || logMediaStats) ?
+        <ConnectionStatusModalContainer
+          {...{
+            isModalOpen,
+            setModalIsOpen: this.setModalIsOpen,
+            logMediaStats,
+            monitoringInterval,
+          }}
+        /> : null
     )
   }
 

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
@@ -12,5 +12,6 @@ export default withTracker(() => {
   return {
     connected,
     stats: ConnectionStatusService.getStats(),
+    logMediaStats: ConnectionStatusService.LOG_MEDIA_STATS,
   };
 })(connectionStatusButtonContainer);

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
@@ -7,4 +7,5 @@ const connectionStatusContainer = props => <ConnectionStatusComponent {...props}
 
 export default withTracker(() => ({
   connectionStatus: ConnectionStatusService.getConnectionStatus(),
+  logMonitoringInterval: ConnectionStatusService.LOG_MONITORING_INTERVAL,
 }))(connectionStatusContainer);

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -15,12 +15,6 @@ import NotesService from '/imports/ui/components/notes/service';
 
 const VOLUME_CONTROL_ENABLED = Meteor.settings.public.kurento.screenshare.enableVolumeControl;
 const SCREENSHARE_MEDIA_ELEMENT_NAME = 'screenshareVideo';
-
-const DEFAULT_SCREENSHARE_STATS_TYPES = [
-  'outbound-rtp',
-  'inbound-rtp',
-];
-
 const CONTENT_TYPE_CAMERA = "camera";
 const CONTENT_TYPE_SCREENSHARE = "screenshare";
 
@@ -355,9 +349,6 @@ const dataSavingSetting = () => Settings.dataSaving.viewScreenshare;
    * For more information see:
    *  - https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats
    *  - https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport
-
-   * @param {Array[String]} statsType - An array containing valid RTCStatsType
-   *                                    values to include in the return object
    *
    * @returns {Object} The information about each active screen sharing peer.
    *          The returned format follows the format returned by video's service
@@ -367,22 +358,7 @@ const dataSavingSetting = () => Settings.dataSaving.viewScreenshare;
    *            peerIdString: RTCStatsReport
    *          }
    */
-const getStats = async (statsTypes = DEFAULT_SCREENSHARE_STATS_TYPES) => {
-  const screenshareStats = {};
-  const peer = KurentoBridge.getPeerConnection();
-
-  if (!peer) return null;
-
-  const peerStats = await peer.getStats();
-
-  peerStats.forEach((stat) => {
-    if (statsTypes.includes(stat.type)) {
-      screenshareStats[stat.type] = stat;
-    }
-  });
-
-  return { screenshareStats };
-};
+const getStats = () => KurentoBridge.getStats();
 
 // This method may throw errors
 const isMediaFlowing = (previousStats, currentStats) => {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -8,7 +8,10 @@ import logger from '/imports/startup/client/logger';
 import { notify } from '/imports/ui/services/notification';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
 import iosWebviewAudioPolyfills from '/imports/utils/ios-webview-audio-polyfills';
-import { monitorAudioConnection } from '/imports/utils/stats';
+import {
+  monitorAudioConnection,
+  getRTCStatsLogMetadata,
+} from '/imports/utils/stats';
 import AudioErrors from './error-codes';
 import { Meteor } from 'meteor/meteor';
 import browserInfo from '/imports/utils/browserInfo';
@@ -46,17 +49,6 @@ const BREAKOUT_AUDIO_TRANSFER_STATES = {
   DISCONNECTED: 'disconnected',
   RETURNING: 'returning',
 };
-
-/**
- * Audio status to be filtered in getStats()
- */
-const FILTER_AUDIO_STATS = [
-  'outbound-rtp',
-  'inbound-rtp',
-  'candidate-pair',
-  'local-candidate',
-  'transport',
-];
 
 class AudioManager {
   constructor() {
@@ -539,15 +531,19 @@ class AudioManager {
 
     if (!this.isEchoTest) {
       this.notify(this.intl.formatMessage(this.messages.info.JOINED_AUDIO));
-      logger.info({
-        logCode: 'audio_joined',
-        extraInfo: {
-          secondsToActivateAudio,
-          inputDeviceId: this.inputDeviceId,
-          outputDeviceId: this.outputDeviceId,
-          isListenOnly: this.isListenOnly,
-        },
-      }, 'Audio Joined');
+      this.getStats().then((stats) => {
+        logger.info({
+          logCode: 'audio_joined',
+          extraInfo: {
+            secondsToActivateAudio,
+            inputDeviceId: this.inputDeviceId,
+            outputDeviceId: this.outputDeviceId,
+            isListenOnly: this.isListenOnly,
+            stats: getRTCStatsLogMetadata(stats),
+            clientSessionNumber: this.bridge.clientSessionNumber,
+          },
+        }, 'Audio Joined');
+      });
       if (STATS.enabled) this.monitor();
       this.audioEventHandler({
         name: 'started',
@@ -597,11 +593,15 @@ class AudioManager {
 
   callStateCallback(response) {
     return new Promise((resolve) => {
-      const { STARTED, ENDED, FAILED, RECONNECTING, AUTOPLAY_BLOCKED } =
-        CALL_STATES;
-
-      const { status, error, bridgeError, silenceNotifications, bridge } =
-        response;
+      const { STARTED, ENDED, FAILED, RECONNECTING, AUTOPLAY_BLOCKED } = CALL_STATES;
+      const {
+        status,
+        error,
+        bridgeError,
+        silenceNotifications,
+        bridge,
+        stats = {},
+      } = response;
 
       if (status === STARTED) {
         this.isReconnecting = false;
@@ -613,8 +613,15 @@ class AudioManager {
           breakoutMeetingId: '',
           status: BREAKOUT_AUDIO_TRANSFER_STATES.DISCONNECTED,
         });
-        logger.info({ logCode: 'audio_ended' }, 'Audio ended without issue');
         this.onAudioExit();
+        logger.info({
+          logCode: 'audio_ended',
+          extraInfo: {
+            inputDeviceId: this.inputDeviceId,
+            outputDeviceId: this.outputDeviceId,
+            isListenOnly: this.isListenOnly,
+          },
+        }, 'Audio ended without issue');
       } else if (status === FAILED) {
         this.isReconnecting = false;
         this.setBreakoutAudioTransferStatus({
@@ -635,6 +642,7 @@ class AudioManager {
               inputDeviceId: this.inputDeviceId,
               outputDeviceId: this.outputDeviceId,
               isListenOnly: this.isListenOnly,
+              stats,
             },
           },
           `Audio error - errorCode=${error}, cause=${bridgeError}`
@@ -650,10 +658,16 @@ class AudioManager {
           breakoutMeetingId: '',
           status: BREAKOUT_AUDIO_TRANSFER_STATES.DISCONNECTED,
         });
-        logger.info(
-          { logCode: 'audio_reconnecting' },
-          'Attempting to reconnect audio'
-        );
+        logger.info({
+          logCode: 'audio_reconnecting',
+          extraInfo: {
+            bridge,
+            inputDeviceId: this.inputDeviceId,
+            outputDeviceId: this.outputDeviceId,
+            isListenOnly: this.isListenOnly,
+            stats,
+          },
+        }, 'Attempting to reconnect audio');
         this.notify(
           this.intl.formatMessage(this.messages.info.RECONNECTING_AUDIO),
           true
@@ -972,171 +986,11 @@ class AudioManager {
   }
 
   /**
-   * Get the info about candidate-pair that is being used by the current peer.
-   * For firefox, or any other browser that doesn't support iceTransport
-   * property of RTCDtlsTransport, we retrieve the selected local candidate
-   * by looking into stats returned from getStats() api. For other browsers,
-   * we should use getSelectedCandidatePairFromPeer instead, because it has
-   * relatedAddress and relatedPort information about local candidate.
-   *
-   * @param {Object} stats object returned by getStats() api
-   * @returns An Object of type RTCIceCandidatePairStats containing information
-   *          about the candidate-pair being used by the peer.
-   *
-   * For firefox, we can use the 'selected' flag to find the candidate pair
-   * being used, while in chrome we can retrieved the selected pair
-   * by looking for the corresponding transport of the active peer.
-   * For more information see:
-   * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats
-   * and
-   * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/selected#value
-   */
-  static getSelectedCandidatePairFromStats(stats) {
-    if (!stats || typeof stats !== 'object') return null;
-
-    const transport =
-      Object.values(stats).find((stat) => stat.type === 'transport') || {};
-
-    return Object.values(stats).find(
-      (stat) =>
-        stat.type === 'candidate-pair' &&
-        stat.nominated &&
-        (stat.selected || stat.id === transport.selectedCandidatePairId)
-    );
-  }
-
-  /**
-   * Get the info about candidate-pair that is being used by the current peer.
-   * This function's return value (RTCIceCandidatePair object ) is different
-   * from getSelectedCandidatePairFromStats (RTCIceCandidatePairStats object).
-   * The information returned here contains the relatedAddress and relatedPort
-   * fields (only for candidates that are derived from another candidate, for
-   * host candidates, these fields are null). These field can be helpful for
-   * debugging network issues. For all the browsers that support iceTransport
-   * field of RTCDtlsTransport, we use this function as default to retrieve
-   * information about current selected-pair. For other browsers we retrieve it
-   * from getSelectedCandidatePairFromStats
-   *
-   * @returns {Object} An RTCIceCandidatePair represented the selected
-   *                   candidate-pair of the active peer.
-   *
-   * For more info see:
-   * https://www.w3.org/TR/webrtc/#dom-rtcicecandidatepair
-   * and
-   * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePair
-   * and
-   * https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport
-   */
-  getSelectedCandidatePairFromPeer() {
-    if (!this.bridge) return null;
-
-    const peer = this.bridge.getPeerConnection();
-
-    if (!peer) return null;
-
-    let selectedPair = null;
-
-    const receivers = peer.getReceivers();
-    if (
-      receivers &&
-      receivers[0] &&
-      receivers[0].transport &&
-      receivers[0].transport.iceTransport &&
-      typeof receivers[0].transport.iceTransport.getSelectedCandidatePair === 'function'
-    ) {
-      selectedPair = receivers[0].transport.iceTransport.getSelectedCandidatePair();
-    }
-
-    return selectedPair;
-  }
-
-  /**
-   * Gets the selected local-candidate information. For browsers that support
-   * iceTransport property (see getSelectedCandidatePairFromPeer) we get this
-   * info from peer, otherwise we retrieve this information from getStats() api
-   *
-   * @param {Object} [stats] The status object returned from getStats() api
-   * @returns {Object} An Object containing the information about the
-   *                   local-candidate. For browsers that support iceTransport
-   *                   property, the object's type is RCIceCandidate. A
-   *                   RTCIceCandidateStats is returned, otherwise.
-   *
-   * For more info see:
-   * https://www.w3.org/TR/webrtc/#dom-rtcicecandidate
-   * and
-   * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatestats
-   *
-   */
-  getSelectedLocalCandidate(stats) {
-    let selectedPair = this.getSelectedCandidatePairFromPeer();
-
-    if (selectedPair) return selectedPair.local;
-
-    if (!stats) return null;
-
-    selectedPair = AudioManager.getSelectedCandidatePairFromStats(stats);
-
-    if (selectedPair) return stats[selectedPair.localCandidateId];
-
-    return null;
-  }
-
-  /**
-   * Gets the information about private/public ip address from peer
-   * stats. The information retrieved from selected pair from the current
-   * RTCIceTransport and returned in a new Object with format:
-   * {
-   *   address: String,
-   *   relatedAddress: String,
-   *   port: Number,
-   *   relatedPort: Number,
-   *   candidateType: String,
-   *   selectedLocalCandidate: Object,
-   * }
-   *
-   * If users isn't behind NAT, relatedAddress and relatedPort may be null.
-   *
-   * @returns An Object containing the information about private/public IP
-   *          addresses and ports.
-   *
-   * For more information see:
-   * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats
-   * and
-   * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatestats
-   * and
-   * https://www.w3.org/TR/webrtc/#rtcicecandidatetype-enum
-   */
-  async getInternalExternalIpAddresses(stats) {
-    let transports = {};
-
-    if (stats) {
-      const selectedLocalCandidate = this.getSelectedLocalCandidate(stats);
-
-      if (!selectedLocalCandidate) return transports;
-
-      const candidateType =
-        selectedLocalCandidate.candidateType || selectedLocalCandidate.type;
-
-      transports = {
-        isUsingTurn: candidateType === 'relay',
-        address: selectedLocalCandidate.address,
-        relatedAddress: selectedLocalCandidate.relatedAddress,
-        port: selectedLocalCandidate.port,
-        relatedPort: selectedLocalCandidate.relatedPort,
-        candidateType,
-        selectedLocalCandidate,
-      };
-    }
-
-    return transports;
-  }
-
-  /**
    * Get stats about active audio peer.
    * We filter the status based on FILTER_AUDIO_STATS constant.
    * We also append to the returned object the information about peer's
    * transport. This transport information is retrieved by
-   * getInternalExternalIpAddressesFromPeer().
+   * getTransportStatsFromPeer().
    *
    * @returns An Object containing the status about the active audio peer.
    *
@@ -1145,28 +999,23 @@ class AudioManager {
    * and
    * https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport
    */
-  async getStats() {
+  async getStats(stats) {
     if (!this.bridge) return null;
 
-    const peer = this.bridge.getPeerConnection();
+    try {
+      const processedStats = await this.bridge.getStats(stats);
 
-    if (!peer) return null;
-
-    const peerStats = await peer.getStats();
-
-    const audioStats = {};
-
-    peerStats.forEach((stat) => {
-      if (FILTER_AUDIO_STATS.includes(stat.type)) {
-        audioStats[stat.id] = stat;
-      }
-    });
-
-    const transportStats = await this.getInternalExternalIpAddresses(
-      audioStats
-    );
-
-    return { transportStats, ...audioStats };
+      return processedStats;
+    } catch (error) {
+      logger.debug({
+        logCode: 'audiomanager_get_stats_failed',
+        extraInfo: {
+          errorName: error.name,
+          errorMessage: error.message,
+        },
+      }, `Failed to get audio stats: ${error.message}`);
+      return null;
+    }
   }
 }
 

--- a/bigbluebutton-html5/imports/utils/stats.js
+++ b/bigbluebutton-html5/imports/utils/stats.js
@@ -190,6 +190,349 @@ const monitorAudioConnection = conn => {
   });
 };
 
+/**
+ * Calculates the jitter buffer average.
+ * For more information see:
+ * https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay
+ * @param {Object} inboundRtpData The RTCInboundRtpStreamStats object retrieved
+ *                                in getStats() call.
+ * @returns The jitter buffer average in ms
+ */
+const calculateJitterBufferAverage = (inboundRtpData) => {
+  if (!inboundRtpData) return 0;
+
+  const {
+    jitterBufferDelay,
+    jitterBufferEmittedCount,
+  } = inboundRtpData;
+
+  if (!jitterBufferDelay || !jitterBufferEmittedCount) return '--';
+
+  return Math.round((jitterBufferDelay / jitterBufferEmittedCount) * 1000);
+};
+
+/**
+ * Given the data returned from getStats(), returns an array containing all the
+ * the stats of the given type.
+ * For more information see:
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsReport
+ * and
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCStatsType
+ * @param {Object} data - RTCStatsReport object returned from getStats() API
+ * @param {String} type - The string type corresponding to RTCStatsType object
+ * @returns {Array[Object]} An array containing all occurrences of the given
+ *                          type in the data Object.
+ */
+const getDataType = (data, type) => {
+  if (!data || typeof data !== 'object' || !type) return [];
+
+  return Object.values(data).filter((stat) => stat.type === type);
+};
+
+/**
+ * Returns a new Object containing extra parameters calculated from inbound
+ * data. The input data is also appended in the returned Object.
+ * @param {Object} currentData - The object returned from getStats / service's
+ *                               getNetworkData()
+ * @returns {Object} the currentData object with the extra inbound network
+ *                    added to it.
+ */
+const addExtraInboundNetworkParameters = (data) => {
+  if (!data) return data;
+
+  const inboundRtpData = getDataType(data, 'inbound-rtp')[0];
+
+  if (!inboundRtpData) return data;
+
+  const extraParameters = {
+    jitterBufferAverage: calculateJitterBufferAverage(inboundRtpData),
+    packetsLost: inboundRtpData.packetsLost,
+  };
+
+  return Object.assign(inboundRtpData, extraParameters);
+};
+
+/**
+ * Get the info about candidate-pair that is being used by the current peer.
+ * For firefox, or any other browser that doesn't support iceTransport
+ * property of RTCDtlsTransport, we retrieve the selected local candidate
+ * by looking into stats returned from getStats() api. For other browsers,
+ * we should use getSelectedCandidatePairFromPeer instead, because it has
+ * relatedAddress and relatedPort information about local candidate.
+ *
+ * @param {Object} stats object returned by getStats() api
+ * @returns An Object of type RTCIceCandidatePairStats containing information
+ *          about the candidate-pair being used by the peer.
+ *
+ * For firefox, we can use the 'selected' flag to find the candidate pair
+ * being used, while in chrome we can retrieved the selected pair
+ * by looking for the corresponding transport of the active peer.
+ * For more information see:
+ * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats
+ * and
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePairStats/selected#value
+ */
+const getSelectedCandidatePairFromStats = (stats) => {
+  if (!stats || typeof stats !== 'object') return null;
+
+  const transport = Object.values(stats).find((stat) => stat.type === 'transport') || {};
+
+  return Object.values(stats).find((stat) => stat.type === 'candidate-pair'
+    && stat.nominated
+    && (stat.selected || stat.id === transport.selectedCandidatePairId));
+};
+
+/**
+ * Get the info about candidate-pair that is being used by the current peer.
+ * This function's return value (RTCIceCandidatePair object ) is different
+ * from getSelectedCandidatePairFromStats (RTCIceCandidatePairStats object).
+ * The information returned here contains the relatedAddress and relatedPort
+ * fields (only for candidates that are derived from another candidate, for
+ * host candidates, these fields are null). These field can be helpful for
+ * debugging network issues. For all the browsers that support iceTransport
+ * field of RTCDtlsTransport, we use this function as default to retrieve
+ * information about current selected-pair. For other browsers we retrieve it
+ * from getSelectedCandidatePairFromStats
+ *
+ * @returns {Object} An RTCIceCandidatePair represented the selected
+ *                   candidate-pair of the active peer.
+ *
+ * For more info see:
+ * https://www.w3.org/TR/webrtc/#dom-rtcicecandidatepair
+ * and
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidatePair
+ * and
+ * https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport
+ */
+const getSelectedCandidatePairFromPeer = (peer) => {
+  if (!peer) return null;
+
+  let selectedPair = null;
+
+  const receivers = peer.getReceivers();
+  if (receivers
+    && receivers[0]
+    && receivers[0]?.transport?.iceTransport
+    && typeof receivers[0].transport.iceTransport.getSelectedCandidatePair === 'function') {
+    selectedPair = receivers[0].transport.iceTransport.getSelectedCandidatePair();
+  }
+
+  return selectedPair;
+};
+
+/**
+ * Gets the selected candidates (local and remote) information.
+ * For browsers that support iceTransport property (see
+ * getSelectedCandidatePairFromPeer) we get this info from peer, otherwise
+ * we retrieve this information from getStats() api
+ *
+ * @param {Object}   An object {peer?, stats?} containing the peer connection
+ *                   object and/or the stats
+ * @returns {Object} An Object {local, remote} containing the information about
+ *                   the selected candidates. For browsers that support the
+ *                   iceTransport property, the object attribute's type is RTCIceCandidate.
+ *                   A RTCIceCandidateStats is returned, otherwise.
+ *
+ * For more info see:
+ * https://www.w3.org/TR/webrtc/#dom-rtcicecandidate
+ * and
+ * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatestats
+ *
+ */
+const getSelectedCandidates = ({ peer, stats }) => {
+  let selectedPair = getSelectedCandidatePairFromPeer(peer);
+
+  if (selectedPair) return selectedPair;
+
+  if (!stats) return null;
+
+  selectedPair = getSelectedCandidatePairFromStats(stats);
+
+  if (selectedPair) {
+    return {
+      local: stats[selectedPair?.localCandidateId],
+      remote: stats[selectedPair?.remoteCandidateId],
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Gets the information about private/public ip address from peer
+ * stats. The information retrieved from selected pair from the current
+ * RTCIceTransport and returned in a new Object with format:
+ * {
+ *   isUsingTurn: Boolean,
+ *   address: String,
+ *   relatedAddress: String,
+ *   port: Number,
+ *   relatedPort: Number,
+ *   protocol: String,
+ *   candidateType: String,
+ *   ufrag: String,
+ *   remoteAddress: String,
+ *   remotePort: Number,
+ *   remoteCandidateType: String,
+ *   remoteProtocol: String,
+ *   remoteUfrag: String,
+ *   dtlsRole: String,
+ *   dtlsState: String,
+ *   iceRole: String,
+ *   iceState: String,
+ *   selectedCandidatePairChanges: Number
+ *   relayProtocol: String
+ * }
+ *
+ * If users isn't behind NAT, relatedAddress and relatedPort may be null.
+ *
+ * @returns An Object containing the information about the peer's transport.
+ *
+ * For more information see:
+ * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatepairstats
+ * and
+ * https://www.w3.org/TR/webrtc-stats/#dom-rtcicecandidatestats
+ * and
+ * https://www.w3.org/TR/webrtc/#rtcicecandidatetype-enum
+ */
+const getTransportStats = async (peer, stats) => {
+  let transports = {};
+
+  if (stats) {
+    const selectedCandidates = getSelectedCandidates({ peer, stats }) || {};
+    const {
+      local: selectedLocalCandidate = {},
+      remote: selectedRemoteCandidate = {},
+    } = selectedCandidates;
+    const candidateType = selectedLocalCandidate?.candidateType || selectedLocalCandidate?.type;
+    const remoteCandidateType = selectedRemoteCandidate?.candidateType
+      || selectedRemoteCandidate?.type;
+    const isUsingTurn = candidateType ? candidateType === 'relay' : null;
+    // 1 transport per peer connection - we can safely get the first one
+    const transportData = getDataType(stats, 'transport')[0];
+
+    transports = {
+      isUsingTurn,
+      address: selectedLocalCandidate?.address,
+      relatedAddress: selectedLocalCandidate?.relatedAddress,
+      port: selectedLocalCandidate?.port,
+      relatedPort: selectedLocalCandidate?.relatedPort,
+      protocol: selectedLocalCandidate?.protocol,
+      candidateType,
+      ufrag: selectedLocalCandidate?.usernameFragment,
+      remoteAddress: selectedRemoteCandidate?.address,
+      remotePort: selectedRemoteCandidate?.port,
+      remoteCandidateType,
+      remoteProtocol: selectedRemoteCandidate?.protocol,
+      remoteUfrag: selectedRemoteCandidate?.usernameFragment,
+      dtlsRole: transportData?.dtlsRole,
+      dtlsState: transportData?.dtlsState,
+      iceRole: transportData?.iceRole,
+      iceState: transportData?.iceState,
+      selectedCandidatePairChanges: transportData?.selectedCandidatePairChanges,
+
+    };
+
+    if (isUsingTurn) transports.relayProtocol = selectedLocalCandidate.relayProtocol;
+  }
+
+  return transports;
+};
+
+const buildInboundRtpData = (inbound) => {
+  if (!inbound) return {};
+
+  const inboundRtp = {
+    kind: inbound.kind,
+    jitterBufferAverage: inbound.jitterBufferAverage,
+    lastPacketReceivedTimestamp: inbound.lastPacketReceivedTimestamp,
+    packetsLost: inbound.packetsLost,
+    packetsReceived: inbound.packetsReceived,
+    packetsDiscarded: inbound.packetsDiscarded,
+  };
+
+  if (inbound.kind === 'audio') {
+    inboundRtp.totalAudioEnergy = inbound.totalAudioEnergy;
+  } else if (inbound.kind === 'video') {
+    inboundRtp.framesDecoded = inbound.framesDecoded;
+    inboundRtp.framesDropped = inbound.framesDropped;
+    inboundRtp.framesReceived = inbound.framesReceived;
+    inboundRtp.hugeFramesSent = inbound.hugeFramesSent;
+    inboundRtp.keyFramesDecoded = inbound.keyFramesDecoded;
+    inboundRtp.keyFramesReceived = inbound.keyFramesReceived;
+    inboundRtp.totalDecodeTime = inbound.totalDecodeTime;
+    inboundRtp.totalInterFrameDelay = inbound.totalInterFrameDelay;
+    inboundRtp.totalSquaredInterFrameDelay = inbound.totalSquaredInterFrameDelay;
+  }
+
+  return inboundRtp;
+};
+
+const buildOutboundRtpData = (outbound) => {
+  if (!outbound) return {};
+
+  const outboundRtp = {
+    kind: outbound.kind,
+    packetsSent: outbound.packetsSent,
+    nackCount: outbound.nackCount,
+    targetBitrate: outbound.targetBitrate,
+    totalPacketSendDelay: outbound.totalPacketSendDelay,
+  };
+
+  if (outbound.kind === 'audio') {
+    outboundRtp.totalAudioEnergy = outbound.totalAudioEnergy;
+  } else if (outbound.kind === 'video') {
+    outboundRtp.framesEncoded = outbound.framesEncoded;
+    outboundRtp.framesSent = outbound.framesSent;
+    outboundRtp.hugeFramesSent = outbound.hugeFramesSent;
+    outboundRtp.keyFramesEncoded = outbound.keyFramesEncoded;
+    outboundRtp.totalEncodeTime = outbound.totalEncodeTime;
+    outboundRtp.totalPacketSendDelay = outbound.totalPacketSendDelay;
+    outboundRtp.firCount = outbound.firCount;
+    outboundRtp.pliCount = outbound.pliCount;
+    outboundRtp.nackCount = outbound.nackCount;
+    outboundRtp.qpsFE = outbound.qpSum / outbound.framesEncoded;
+  }
+
+  return outboundRtp;
+};
+
+const getRTCStatsLogMetadata = (stats) => {
+  if (!stats) return {};
+
+  const { transportStats = {} } = stats;
+
+  addExtraInboundNetworkParameters(stats);
+  const selectedPair = getSelectedCandidatePairFromStats(stats);
+  const inbound = getDataType(stats, 'inbound-rtp')[0];
+  const outbound = getDataType(stats, 'outbound-rtp')[0];
+
+  return {
+    inboundRtp: buildInboundRtpData(inbound),
+    outbound: buildOutboundRtpData(outbound),
+    selectedPair: {
+      state: selectedPair?.state,
+      nominated: selectedPair?.nominated,
+      totalRoundTripTime: selectedPair?.totalRoundTripTime,
+      requestsSent: selectedPair?.requestsSent,
+      responsesReceived: selectedPair?.responsesReceived,
+      availableOutgoingBitrate: selectedPair?.availableOutgoingBitrate,
+      availableIncomingBitrate: selectedPair?.availableIncomingBitrate,
+      lastPacketSentTimestamp: selectedPair?.lastPacketSentTimestamp,
+      lastPacketReceivedTimestamp: selectedPair?.lastPacketReceivedTimestamp,
+    },
+    transport: transportStats,
+  };
+};
+
 export {
+  addExtraInboundNetworkParameters,
+  calculateJitterBufferAverage,
+  getDataType,
+  getTransportStats,
+  getSelectedCandidates,
+  getSelectedCandidatePairFromPeer,
+  getSelectedCandidatePairFromStats,
+  getRTCStatsLogMetadata,
   monitorAudioConnection,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -789,7 +789,16 @@ public:
     enabled: true
     interval: 10000
     timeout: 30000
+    # Server-side stats event logging. Everytime a connection status event update
+    # is received by Meteor, it'll be logged *by the server*.
     log: true
+    # Client-side WebRTC stats logging. If enabled, the client will log periodic
+    # WebRTC stats information to the configured logging transports.
+    # Disabled by default. This log is verbose and may incur in additional network
+    # usage if external logging targets are configured.
+    logMediaStats:
+      enabled: false
+      interval: 30000
     notification:
       warning: false
       error: true


### PR DESCRIPTION
### What does this PR do?

- [feat: add WebRTC stats information to client logs](https://github.com/bigbluebutton/bigbluebutton/commit/3c4e3de2869254cdc52d2434227a03476849cf7d) 
  - We should be able to capture  WebRTC stats in some form for post-processing
  so that it helps on debugging support requests (and other use cases, e.g.:
  improving field trial analysis on test servers).
  Although much of WebRTC stats information can be gathered via server side
  components, none have logs as structured for proper post-processing as
  the client logs - so we're going the client route for now.
  - Capture WebRTC stats information for audio and screen sharing via:
    - Audio logCodes: new `stats` extraInfo field
      - `audio_joined`
      - `audio_failure`
      - `sfuaudio_error_retry_through_relay`
      - `sfuaudio_error_try_to_reconnect`
    - Screen share logCodes: new `stats` extraInfo field
      - screenshare_presenter_start_success
      - screenshare_viewer_start_success
      - screenshare_broker_failure
  - Additionally, add an option to periodically capture WebRTC stats information
  for all relevant peers. This is disabled by default since the log can be
  verbose (and, consequentially, network or storage taxing when using external
  logging targets). It can be enabled via `public.stats.logMediaStats` in
  settings.yml. The default interval is 30s. The periodic log format is as
  follows:
    - logCode: `mediaStats`
    - extraInfo.stats: an aggregated stats object of all peers (equivalent
      to the `Copy` function in the Connection Status modal).


### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/20951

### How to test

- settings.yml: `public.stats.logMediaStats: true`
- Enable one of the remote logging targets as documented in https://docs.bigbluebutton.org/administration/configuration-files/#logs-sent-directly-from-the-client

### More

- `logCode: media_stats` sample:
```json
{"logCode":"media_stats","logDescription":"Media stats","connectionId":"ZHYJ4gi382KdoiJcv","extraInfo":{"audio":{"audioCurrentUploadRate":0,"audioCurrentDownloadRate":0,"jitter":59,"packetsLost":0,"transportStats":{"isUsingTurn":false,"address":"192.0.2.1","relatedAddress":"192.168.2.111","port":3549,"relatedPort":46907,"protocol":"udp","candidateType":"prflx","ufrag":"WbaJ","remoteAddress":"192.0.2.2","remotePort":9727,"remoteCandidateType":"host","remoteProtocol":"udp","remoteUfrag":"y9mfczvjeojqghf5vev0504gzlwf92s6","dtlsRole":"server","dtlsState":"connected","iceRole":"controlling","iceState":"connected","selectedCandidatePairChanges":1}},"video":{"videoCurrentUploadRate":0,"videoCurrentDownloadRate":0,"screenshareTransportStats":{"isUsingTurn":false,"address":"192.0.2.1","relatedAddress":"192.168.2.111","port":3886,"relatedPort":44700,"protocol":"udp","candidateType":"prflx","ufrag":"UPNn","remoteAddress":"192.0.2.2","remotePort":8181,"remoteCandidateType":"host","remoteProtocol":"udp","remoteUfrag":"wxydpl4ytsurlvtgla36qqljm5zseg6h","dtlsRole":"server","dtlsState":"connected","iceRole":"controlling","iceState":"connected","selectedCandidatePairChanges":1}},"clientURL":"https://milton.dev/html5client/join?sessionToken=xqmygx1sle5fvhoy"},"userInfo":{"sessionToken":"xqmygx1sle5fvhoy","meetingId":"79e035f2b64c72f12d9c4bde41d794a140aab4e8-1724763884981","requesterUserId":"w_jitxsty0oqfh","fullname":"User 41807","confname":"random-8704967","externUserID":"w_jitxsty0oqfh","uniqueClientSession":"xqmygx1sle5fvhoy-ut44ki"}}
```

- `logCode: audio_joined` sample:
```json
{"logCode":"audio_joined","logDescription":"Audio Joined","connectionId":"ZHYJ4gi382KdoiJcv","extraInfo":{"secondsToActivateAudio":0.49,"inputDeviceId":"default","outputDeviceId":"","isListenOnly":false,"stats":{"inboundRtp":{"kind":"audio","jitterBufferAverage":"--","packetsLost":0,"packetsReceived":0,"packetsDiscarded":0,"totalAudioEnergy":0},"outbound":{"kind":"audio","packetsSent":12,"nackCount":0,"targetBitrate":128000,"totalPacketSendDelay":0.000002},"selectedPair":{"state":"succeeded","nominated":true,"totalRoundTripTime":0.046,"requestsSent":2,"responsesReceived":2,"availableOutgoingBitrate":300000,"lastPacketSentTimestamp":1724779552089,"lastPacketReceivedTimestamp":1724779552055},"transport":{"isUsingTurn":false,"address":"192.0.2.1","relatedAddress":"192.168.2.111","port":3549,"relatedPort":46907,"protocol":"udp","candidateType":"prflx","ufrag":"WbaJ","remoteAddress":"192.0.2.2","remotePort":9727,"remoteCandidateType":"host","remoteProtocol":"udp","remoteUfrag":"y9mfczvjeojqghf5vev0504gzlwf92s6","dtlsRole":"server","dtlsState":"connected","iceRole":"controlling","iceState":"connected","selectedCandidatePairChanges":1}},"clientSessionNumber":30,"clientURL":"https://milton.dev/html5client/join?sessionToken=xqmygx1sle5fvhoy"},"userInfo":{"sessionToken":"xqmygx1sle5fvhoy","meetingId":"79e035f2b64c72f12d9c4bde41d794a140aab4e8-1724763884981","requesterUserId":"w_jitxsty0oqfh","fullname":"User 41807","confname":"random-8704967","externUserID":"w_jitxsty0oqfh","uniqueClientSession":"xqmygx1sle5fvhoy-ut44ki"}}
```

