### PR TITLE
ci: Add loglevel=trace for middleware during Automated tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -271,6 +271,7 @@ jobs:
             cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v jammy-30-dev -s bbb-ci.test -j -d /certs/
             bbb-conf --salt bbbci
             sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json
+            sudo sed -i "s/BBB_GRAPHQL_MIDDLEWARE_LOG_LEVEL=.*/BBB_GRAPHQL_MIDDLEWARE_LOG_LEVEL=TRACE/g" /etc/default/bbb-graphql-middleware
             bbb-conf --restart
             EOF
       - name: List systemctl services


### PR DESCRIPTION
Add `BBB_GRAPHQL_MIDDLEWARE_LOG_LEVEL=TRACE` for middleware during Automated tests

It will help to debug tests that are stuck in this screen:
![image](https://github.com/user-attachments/assets/df76de1b-8c1b-42d8-9318-12a5d914d0a1)
