### PR TITLE
fix (build): bypass docker error: toomanyrequests: You have reached your pull rate limit.

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -51,13 +51,36 @@ kill_docker() {
 
 trap 'kill_docker' SIGINT SIGTERM
 
+# Try to pull Docker Image 5 times (to bypass "toomanyrequests: You have reached your pull rate limit." error)
+retry_count=0
+max_retries=5
+retry_wait=300  # wait time in seconds (5 minutes)
+
+while [[ $retry_count -lt $max_retries ]]; do
+    if sudo docker pull "$DOCKER_IMAGE"; then
+        echo "Docker image pulled successfully."
+        break
+    else
+        echo "Failed to pull Docker image, attempt $((retry_count+1))/$max_retries."
+        ((retry_count++))
+        if [[ $retry_count -lt $max_retries ]]; then
+            echo "Waiting for $retry_wait seconds before retrying..."
+            sleep $retry_wait
+        else
+            echo "Exceeded maximum retry attempts. Exiting."
+            exit 1
+        fi
+    fi
+done
+
+
 # -v "$CACHE_DIR/dev":/root/dev
 sudo docker run --rm --detach --cidfile $DOCKER_CONTAINER_ID_FILE \
         --env GIT_REV=$GIT_REV --env COMMIT_DATE=$COMMIT_DATE --env LOCAL_BUILD=$LOCAL_BUILD \
         --mount type=bind,src="$PWD",dst=/mnt \
         --mount type=bind,src="${PWD}/artifacts,dst=/artifacts" \
         -t "$DOCKER_IMAGE" /mnt/build/setup-inside-docker.sh "$PACKAGE_TO_BUILD"
-        
+
 #        -v "$CACHE_DIR/$DISTRO/.gradle:/root/.gradle" \
 #        -v "$CACHE_DIR/$DISTRO/.grails:/root/.grails" \
 #        -v "$CACHE_DIR/$DISTRO/.ivy2:/root/.ivy2" \


### PR DESCRIPTION
The tests are often failing on "Generate artifacts" step because of the error `docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading`.

![image](https://github.com/user-attachments/assets/c3dbeded-d922-4b69-ba98-440e10e5f149)

Once it seems Authenticating is not an option.
I tweaked the build script to retry pulling the Docker Image after 5 minutes. I will re-try 5 times.
