### PR TITLE
refactor (gql-server): Introduce flag `currentlyInMeeting` (replacing `isOnline`)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -110,7 +110,7 @@ class BigBlueButtonActor(
               "internalUserID" -> sessionTokenInfo._2,
               "externMeetingID" -> "",
               "externUserID" -> "",
-              "online" -> false,
+              "currentlyInMeeting" -> false,
               "authToken" -> "",
               "role" -> Roles.VIEWER_ROLE,
               "guest" -> "false",

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetUserApiMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetUserApiMsgHdlr.scala
@@ -28,7 +28,7 @@ trait GetUserApiMsgHdlr extends HandlerHelpers {
     val isLocked = Users2x.findWithIntId(liveMeeting.users2x, regUser.id).exists(u => u.locked)
     val userStateExists = Users2x.findWithIntId(liveMeeting.users2x, regUser.id).nonEmpty
 
-    val userIsOnline = regUser.joined && !regUser.loggedOut && !regUser.ejected && userStateExists
+    val currentlyInMeeting = regUser.joined && !regUser.loggedOut && !regUser.ejected && userStateExists
 
     val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
 
@@ -38,7 +38,7 @@ trait GetUserApiMsgHdlr extends HandlerHelpers {
     userInfos += ("externMeetingID" -> liveMeeting.props.meetingProp.extId)
     userInfos += ("externUserID" -> regUser.externId)
     userInfos += ("internalUserID" -> regUser.id)
-    userInfos += ("online" -> userIsOnline)
+    userInfos += ("currentlyInMeeting" -> currentlyInMeeting)
     userInfos += ("authToken" -> regUser.authToken)
     userInfos += ("sessionToken" -> regUser.sessionToken)
     userInfos += ("role" -> regUser.role)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/UserInfoService.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/UserInfoService.scala
@@ -41,7 +41,7 @@ class UserInfoService(system: ActorSystem, bbbActor: ActorRef) {
       }
     }
 
-    if (conditionalValue("online", "true", "false") == "true") {
+    if (conditionalValue("currentlyInMeeting", "true", "false") == "true") {
       Map(
         "response" -> "authorized",
         "X-Hasura-Role" -> "bbb_client",
@@ -60,7 +60,7 @@ class UserInfoService(system: ActorSystem, bbbActor: ActorRef) {
     } else {
       Map(
         "response" -> "authorized",
-        "X-Hasura-Role" -> "not_joined_bbb_client",
+        "X-Hasura-Role" -> "bbb_client_not_in_meeting",
         "X-Hasura-ModeratorInMeeting" -> conditionalValue("moderator", meetingID, ""),
         "X-Hasura-PresenterInMeeting" -> conditionalValue("presenter", meetingID, ""),
         "X-Hasura-UserId" -> userId,

--- a/bbb-graphql-client-test/src/Auth.js
+++ b/bbb-graphql-client-test/src/Auth.js
@@ -1,12 +1,12 @@
-import {gql, useMutation, useSubscription} from '@apollo/client';
+import { gql, useMutation, useSubscription } from "@apollo/client";
 import React from "react";
-import UserList from './UserList';
-import MeetingInfo from './MeetingInfo';
-import TotalOfUsers from './TotalOfUsers';
-import TotalOfModerators from './TotalOfModerators';
-import TotalOfViewers from './TotalOfViewers';
-import TotalOfUsersTalking from './TotalOfUsersTalking';
-import TotalOfUniqueNames from './TotalOfUniqueNames';
+import UserList from "./UserList";
+import MeetingInfo from "./MeetingInfo";
+import TotalOfUsers from "./TotalOfUsers";
+import TotalOfModerators from "./TotalOfModerators";
+import TotalOfViewers from "./TotalOfViewers";
+import TotalOfUsersTalking from "./TotalOfUsersTalking";
+import TotalOfUniqueNames from "./TotalOfUniqueNames";
 import ChatMessages from "./ChatMessages";
 import ChatsInfo from "./ChatsInfo";
 import ChatPublicMessages from "./ChatPublicMessages";
@@ -23,61 +23,53 @@ import UserConnectionStatusReport from "./UserConnectionStatusReport";
 import PresPresentationUploadToken from "./PresPresentationUploadToken";
 
 export default function Auth() {
-
-    //where is not necessary once user can update only its own status
-    //Hasura accepts "now()" as value to timestamp fields
-    const [updateUserClientEchoTestRunningAtMeAsNow] = useMutation(gql`
-      mutation UpdateUserClientEchoTestRunningAt {
-        update_user_current(
-            where: {}
-            _set: { echoTestRunningAt: "now()" }
-          ) {
-            affected_rows
-          }
+  //where is not necessary once user can update only its own status
+  //Hasura accepts "now()" as value to timestamp fields
+  const [updateUserClientEchoTestRunningAtMeAsNow] = useMutation(gql`
+    mutation UpdateUserClientEchoTestRunningAt {
+      update_user_current(where: {}, _set: { echoTestRunningAt: "now()" }) {
+        affected_rows
       }
-    `);
+    }
+  `);
 
-    const handleUpdateUserEchoTestRunningAt = () => {
-        updateUserClientEchoTestRunningAtMeAsNow();
-    };
+  const handleUpdateUserEchoTestRunningAt = () => {
+    updateUserClientEchoTestRunningAtMeAsNow();
+  };
 
-    const [dispatchUserJoin] = useMutation(gql`
-      mutation UserJoin($authToken: String!, $clientType: String!) {
-        userJoinMeeting(
-          authToken: $authToken,
-          clientType: $clientType,
-        )
-      }
-    `);
+  const [dispatchUserJoin] = useMutation(gql`
+    mutation UserJoin($authToken: String!, $clientType: String!) {
+      userJoinMeeting(authToken: $authToken, clientType: $clientType)
+    }
+  `);
 
-    const handleDispatchUserJoin = (authToken) => {
-        dispatchUserJoin({
-            variables: {
-                authToken: authToken,
-                clientType: 'HTML5',
-            },
-        });
-    };
+  const handleDispatchUserJoin = (authToken) => {
+    dispatchUserJoin({
+      variables: {
+        authToken: authToken,
+        clientType: "HTML5",
+      },
+    });
+  };
 
-    const [dispatchUserLeave] = useMutation(gql`
-      mutation UserLeaveMeeting {
-        userLeaveMeeting
-      }
-    `);
-    const handleDispatchUserLeave = (authToken) => {
-        dispatchUserLeave();
-    };
+  const [dispatchUserLeave] = useMutation(gql`
+    mutation UserLeaveMeeting {
+      userLeaveMeeting
+    }
+  `);
+  const handleDispatchUserLeave = (authToken) => {
+    dispatchUserLeave();
+  };
 
-
-  const { loading, error, data } = useSubscription(
-    gql`subscription {
+  const { loading, error, data } = useSubscription(gql`
+    subscription {
       user_current {
         userId
         authToken
         name
         loggedOut
         ejected
-        isOnline
+        currentlyInMeeting
         isModerator
         joined
         joinErrorCode
@@ -88,122 +80,155 @@ export default function Auth() {
           positionInWaitingQueue
         }
         meeting {
-            name
-            ended
-            learningDashboard {
-              learningDashboardAccessToken
-            }
+          name
+          ended
+          learningDashboard {
+            learningDashboardAccessToken
+          }
         }
       }
-    }`
-  );
+    }
+  `);
 
-  if(!loading && !error) {
+  if (!loading && !error) {
+    if (!data.hasOwnProperty("user_current") || data.user_current.length == 0) {
+      return (
+        <div>
+          <br />
+          Error: User not found
+        </div>
+      );
+    }
 
-      if(!data.hasOwnProperty('user_current') ||
-          data.user_current.length == 0
-      ) {
-          return <div><br />Error: User not found</div>;
-      }
-
-    return (<div>
+    return (
+      <div>
         <br />
         {data.user_current.map((curr) => {
-            console.log('user_current', curr);
+          console.log("user_current", curr);
 
-            if(curr.meeting.ended) {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    Meeting has ended.</div>
-            } else if(curr.ejected) {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    You left the meeting.</div>
-            } else if(curr.ejected) {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    You were ejected from the meeting.</div>
-            } else if(curr.guestStatus !== 'ALLOW') {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    <span>You are waiting for approval.</span>
-                    <span>{curr.guestStatusDetails.guestLobbyMessage}</span>
-                    <span>Your position is: {curr.guestStatusDetails.positionInWaitingQueue}</span>
-                </div>
-            } else if(curr.loggedOut) {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    <span>You left the meeting.</span>
-                </div>
-            } else if(!curr.joined) {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    <span>You didn't join yet.</span>
-                    <button onClick={() => handleDispatchUserJoin(curr.authToken)}>Join Now!</button>
-                </div>
-            } else if(curr.isOnline) {
-                return <div>
-                    {curr.meeting.name}
-                    <br/><br/>
-                    <span>You are online, welcome {curr.name} ({curr.userId})</span>
-                    <button onClick={() => handleDispatchUserLeave()}>Leave Now!</button>
+          if (curr.meeting.ended) {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                Meeting has ended.
+              </div>
+            );
+          } else if (curr.ejected) {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                You left the meeting.
+              </div>
+            );
+          } else if (curr.ejected) {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                You were ejected from the meeting.
+              </div>
+            );
+          } else if (curr.guestStatus !== "ALLOW") {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                <span>You are waiting for approval.</span>
+                <span>{curr.guestStatusDetails.guestLobbyMessage}</span>
+                <span>
+                  Your position is:{" "}
+                  {curr.guestStatusDetails.positionInWaitingQueue}
+                </span>
+              </div>
+            );
+          } else if (curr.loggedOut) {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                <span>You left the meeting.</span>
+              </div>
+            );
+          } else if (!curr.joined) {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                <span>You didn't join yet.</span>
+                <button onClick={() => handleDispatchUserJoin(curr.authToken)}>
+                  Join Now!
+                </button>
+              </div>
+            );
+          } else if (curr.currentlyInMeeting) {
+            return (
+              <div>
+                {curr.meeting.name}
+                <br />
+                <br />
+                <span>
+                  You are online, welcome {curr.name} ({curr.userId})
+                </span>
+                <button onClick={() => handleDispatchUserLeave()}>
+                  Leave Now!
+                </button>
 
-                    <MyInfo userAuthToken={curr.authToken} />
-                    <br />
+                <MyInfo userAuthToken={curr.authToken} />
+                <br />
 
-                    <MeetingInfo />
-                    <br />
+                <MeetingInfo />
+                <br />
 
-                    <TotalOfUsers />
-                    <TotalOfModerators />
-                    <TotalOfViewers />
-                    <TotalOfUsersTalking />
-                    <TotalOfUniqueNames />
-                    <br />
-                    <UserList user={curr} />
+                <TotalOfUsers />
+                <TotalOfModerators />
+                <TotalOfViewers />
+                <TotalOfUsersTalking />
+                <TotalOfUniqueNames />
+                <br />
+                <UserList user={curr} />
 
-                    <br />
-                    <UserConnectionStatus />
-                    <br />
-                    <UserConnectionStatusReport />
-                    <br />
-                    <UserClientSettings userId={curr.userId} />
-                    <br />
-                    <ChatsInfo />
-                    <br />
-                    <ChatMessages userId={curr.userId} />
-                    <br />
-                    <ChatPublicMessages userId={curr.userId} />
-                    <br />
-                    <CursorsAll />
-                    <br />
-                    <TalkingStream />
-                    <br />
-                    <CursorsStream />
-                    <br />
-                    <Annotations />
-                    <br />
-                    <AnnotationsHistory />
-                    <br />
+                <br />
+                <UserConnectionStatus />
+                <br />
+                <UserConnectionStatusReport />
+                <br />
+                <UserClientSettings userId={curr.userId} />
+                <br />
+                <ChatsInfo />
+                <br />
+                <ChatMessages userId={curr.userId} />
+                <br />
+                <ChatPublicMessages userId={curr.userId} />
+                <br />
+                <CursorsAll />
+                <br />
+                <TalkingStream />
+                <br />
+                <CursorsStream />
+                <br />
+                <Annotations />
+                <br />
+                <AnnotationsHistory />
+                <br />
 
-                    <PluginDataChannel userId={curr.userId} />
-                    <br />
+                <PluginDataChannel userId={curr.userId} />
+                <br />
 
-                    <PresPresentationUploadToken />
-                    <br />
-
-                </div>
-            }
-
-
+                <PresPresentationUploadToken />
+                <br />
+              </div>
+            );
+          }
         })}
-    </div>)
+      </div>
+    );
   }
 }
-

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -322,7 +322,7 @@ COMMENT ON COLUMN "user"."disconnected" IS 'This column is set true when the use
 COMMENT ON COLUMN "user"."expired" IS 'This column is set true after 10 seconds with disconnected=true';
 COMMENT ON COLUMN "user"."loggedOut" IS 'This column is set to true when the user click the button to Leave meeting';
 
---Virtual columns isDialIn, isModerator, isOnline, isWaiting, isAllowed, isDenied
+--Virtual columns isDialIn, isModerator, currentlyInMeeting, isWaiting, isAllowed, isDenied
 ALTER TABLE "user" ADD COLUMN "isDialIn" boolean GENERATED ALWAYS AS ("clientType" = 'dial-in-user') STORED;
 ALTER TABLE "user" ADD COLUMN "isWaiting" boolean GENERATED ALWAYS AS ("guestStatus" = 'WAIT') STORED;
 ALTER TABLE "user" ADD COLUMN "isAllowed" boolean GENERATED ALWAYS AS ("guestStatus" = 'ALLOW') STORED;
@@ -336,7 +336,7 @@ ALTER TABLE "user" ADD COLUMN "nameSortable" varchar(255) GENERATED ALWAYS AS (t
 CREATE INDEX "idx_user_waiting" ON "user"("meetingId") where "isWaiting" is true;
 
 ALTER TABLE "user" ADD COLUMN "isModerator" boolean GENERATED ALWAYS AS (CASE WHEN "role" = 'MODERATOR' THEN true ELSE false END) STORED;
-ALTER TABLE "user" ADD COLUMN "isOnline" boolean GENERATED ALWAYS AS (
+ALTER TABLE "user" ADD COLUMN "currentlyInMeeting" boolean GENERATED ALWAYS AS (
     CASE WHEN
             "user"."joined" IS true
             AND "user"."expired" IS false
@@ -382,9 +382,9 @@ AS SELECT "user"."userId",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     "user"."hasDrawPermissionOnCurrentPage",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
-    "user"."isOnline"
+    "user"."currentlyInMeeting"
   FROM "user"
-  WHERE "user"."isOnline" is true;
+  WHERE "user"."currentlyInMeeting" is true;
 
 CREATE INDEX "idx_v_user_meetingId" ON "user"("meetingId") 
                 where "user"."loggedOut" IS FALSE
@@ -403,7 +403,7 @@ CREATE INDEX "idx_v_user_meetingId_orderByColumns" ON "user"(
                         "registeredAt",
                         "userId"
                         )
-                where "user"."isOnline" is true;
+                where "user"."currentlyInMeeting" is true;
 
 CREATE OR REPLACE VIEW "v_user_current"
 AS SELECT "user"."userId",
@@ -447,7 +447,7 @@ AS SELECT "user"."userId",
     "user"."echoTestRunningAt",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
-    "user"."isOnline",
+    "user"."currentlyInMeeting",
     "user"."inactivityWarningDisplay",
     "user"."inactivityWarningTimeoutSecs"
    FROM "user";
@@ -504,7 +504,7 @@ AS SELECT
     "user"."captionLocale",
     "user"."hasDrawPermissionOnCurrentPage",
     CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
-    "user"."isOnline"
+    "user"."currentlyInMeeting"
    FROM "user";
 
 create table "user_metadata"(
@@ -747,7 +747,7 @@ SELECT u."meetingId", u."userId",
 max(cs."connectionAliveAt") AS "connectionAliveAt",
 max(cs."status") AS "currentStatus",
 CASE WHEN
-    u."isOnline"
+    u."currentlyInMeeting"
     AND max(cs."connectionAliveAt") < current_timestamp - INTERVAL '1 millisecond' * max(cs."connectionAliveAtMaxIntervalMs")
     THEN TRUE
     ELSE FALSE
@@ -1677,11 +1677,11 @@ FOR EACH ROW EXECUTE FUNCTION "ins_upd_del_breakoutRoom_user_trigger_func"();
 CREATE OR REPLACE FUNCTION "update_bkroom_isUserCurrentlyInRoom_trigger_func"()
 RETURNS TRIGGER AS $$
 BEGIN
-    IF NEW."isOnline" <> OLD."isOnline" THEN
-        update "breakoutRoom_user" set "isUserCurrentlyInRoom" = a."isOnline"
+    IF NEW."currentlyInMeeting" <> OLD."currentlyInMeeting" THEN
+        update "breakoutRoom_user" set "isUserCurrentlyInRoom" = a."currentlyInMeeting"
 	   from (
 		   select
-		   bru."breakoutRoomId", bru."userId", bkroom_user."isOnline"
+		   bru."breakoutRoomId", bru."userId", bkroom_user."currentlyInMeeting"
 		   from "user" bkroom_user
 		   join meeting_breakout mb on mb."meetingId" = bkroom_user."meetingId"
 		   join "breakoutRoom" br on br."parentMeetingId" = mb."parentId" and mb."sequence" = br."sequence"
@@ -1696,7 +1696,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER "update_bkroom_isUserCurrentlyInRoom_trigger" AFTER UPDATE OF "isOnline" ON "user"
+CREATE TRIGGER "update_bkroom_isUserCurrentlyInRoom_trigger" AFTER UPDATE OF "currentlyInMeeting" ON "user"
     FOR EACH ROW EXECUTE FUNCTION "update_bkroom_isUserCurrentlyInRoom_trigger_func"();
 
 CREATE OR REPLACE VIEW "v_breakoutRoom" AS

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -443,7 +443,7 @@ actions:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
-      - role: not_joined_bbb_client
+      - role: bbb_client_not_in_meeting
       - role: bbb_client
   - name: userLeaveMeeting
     definition:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -185,7 +185,7 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
-  - role: not_joined_bbb_client
+  - role: bbb_client_not_in_meeting
     permission:
       columns:
         - bannerColor

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientSettings.yaml
@@ -15,7 +15,7 @@ select_permissions:
         meetingId:
           _eq: X-Hasura-MeetingId
     comment: ""
-  - role: not_joined_bbb_client
+  - role: bbb_client_not_in_meeting
     permission:
       columns:
         - clientSettingsJson

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_learningDashboard.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_learningDashboard.yaml
@@ -10,7 +10,7 @@ select_permissions:
         meetingId:
           _eq: X-Hasura-ModeratorInMeeting
     comment: ""
-  - role: not_joined_bbb_client
+  - role: bbb_client_not_in_meeting
     permission:
       columns:
         - learningDashboardAccessToken

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -83,7 +83,7 @@ select_permissions:
         - hasDrawPermissionOnCurrentPage
         - isDialIn
         - isModerator
-        - isOnline
+        - currentlyInMeeting
         - isRunningEchoTest
         - joined
         - locked

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -163,7 +163,7 @@ select_permissions:
         - inactivityWarningTimeoutSecs
         - isDialIn
         - isModerator
-        - isOnline
+        - currentlyInMeeting
         - isRunningEchoTest
         - joinErrorCode
         - joinErrorMessage
@@ -188,7 +188,7 @@ select_permissions:
               _eq: X-Hasura-MeetingId
           - userId:
               _eq: X-Hasura-UserId
-  - role: not_joined_bbb_client
+  - role: bbb_client_not_in_meeting
     permission:
       columns:
         - authToken
@@ -200,7 +200,7 @@ select_permissions:
         - ejectReasonCode
         - ejected
         - expired
-        - isOnline
+        - currentlyInMeeting
         - isModerator
         - extId
         - guest

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_guest.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_guest.yaml
@@ -37,7 +37,7 @@ select_permissions:
           - meetingId:
               _eq: X-Hasura-ModeratorInMeeting
       allow_aggregations: true
-  - role: not_joined_bbb_client
+  - role: bbb_client_not_in_meeting
     permission:
       columns:
         - guestLobbyMessage

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
@@ -25,7 +25,7 @@ select_permissions:
         - hasDrawPermissionOnCurrentPage
         - isDialIn
         - isModerator
-        - isOnline
+        - currentlyInMeeting
         - joined
         - locked
         - loggedOut

--- a/bbb-learning-dashboard/src/components/UserDetails/component.jsx
+++ b/bbb-learning-dashboard/src/components/UserDetails/component.jsx
@@ -57,12 +57,12 @@ const UserDatailsComponent = (props) => {
   const leftTimes = Object.values(user.intIds).map((intId) => intId.leftOn);
   const joinTime = Math.min(...registeredTimes);
   const leftTime = Math.max(...leftTimes);
-  const isOnline = Object.values(user.intIds).some((intId) => intId.leftOn === 0);
+  const currentlyInMeeting = Object.values(user.intIds).some((intId) => intId.leftOn === 0);
 
   // Used in the calculation of the online loader.
   const sessionDuration = (endedOn || currTime()) - createdOn;
   const userStartOffsetTime = ((joinTime - createdOn) * 100) / sessionDuration;
-  const userEndOffsetTime = isOnline
+  const userEndOffsetTime = currentlyInMeeting
     ? 0
     : (((endedOn || currTime()) - leftTime) * 100) / sessionDuration;
 
@@ -400,7 +400,7 @@ const UserDatailsComponent = (props) => {
             </div>
             <div>
               <div className="font-medium">
-                { isOnline ? (
+                { currentlyInMeeting ? (
                   <span className="px-2 py-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full">
                     <FormattedMessage id="app.learningDashboard.indicators.userStatusOnline" defaultMessage="Online" />
                   </span>

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -73,7 +73,7 @@ export interface User {
   isModerator: boolean;
   clientType: string;
   disconnected: boolean;
-  isOnline: boolean;
+  currentlyInMeeting: boolean;
   ejectReason: string;
   ejectReasonCode: string;
   ejected: boolean;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -539,7 +539,7 @@ const ChatMessageFormContainer: React.FC = ({
     }
   }
 
-  if (chat?.participant && !chat.participant.isOnline) {
+  if (chat?.participant && !chat.participant.currentlyInMeeting) {
     return <ChatOfflineIndicator participantName={chat.participant.name} />;
   }
 
@@ -557,7 +557,7 @@ const ChatMessageFormContainer: React.FC = ({
         title,
         isRTL,
         // if participant is not defined, it means that the chat is public
-        partnerIsLoggedOut: chat?.participant ? !chat?.participant?.isOnline : false,
+        partnerIsLoggedOut: chat?.participant ? !chat?.participant?.currentlyInMeeting : false,
         locked: locked ?? false,
       }}
     />

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -287,7 +287,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
             <ChatMessageHeader
               sameSender={message?.user ? sameSender : false}
               name={messageContent.name}
-              isOnline={message.user?.isOnline ?? true}
+              currentlyInMeeting={message.user?.currentlyInMeeting ?? true}
               dateTime={dateTime}
             />
           )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
@@ -11,7 +11,7 @@ const intlMessages = defineMessages({
 
 interface ChatMessageHeaderProps {
   name: string;
-  isOnline: boolean;
+  currentlyInMeeting: boolean;
   dateTime: Date;
   sameSender: boolean;
 }
@@ -19,7 +19,7 @@ interface ChatMessageHeaderProps {
 const ChatMessageHeader: React.FC<ChatMessageHeaderProps> = ({
   sameSender,
   name,
-  isOnline,
+  currentlyInMeeting,
   dateTime,
 }) => {
   const intl = useIntl();
@@ -28,11 +28,11 @@ const ChatMessageHeader: React.FC<ChatMessageHeaderProps> = ({
   return (
     <Styled.HeaderContent>
       <Styled.ChatHeaderText>
-        <Styled.ChatUserName isOnline={isOnline}>
+        <Styled.ChatUserName currentlyInMeeting={currentlyInMeeting}>
           {name}
         </Styled.ChatUserName>
         {
-          isOnline ? null : (
+          currentlyInMeeting ? null : (
             <Styled.ChatUserOffline>
               {`(${intl.formatMessage(intlMessages.offline)})`}
             </Styled.ChatUserOffline>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/styles.ts
@@ -8,7 +8,7 @@ import {
 import { lineHeightComputed } from '/imports/ui/stylesheets/styled-components/typography';
 
 interface ChatUserNameProps {
-  isOnline: boolean;
+  currentlyInMeeting: boolean;
 }
 
 export const HeaderContent = styled.div`
@@ -31,11 +31,11 @@ export const ChatUserName = styled.div<ChatUserNameProps>`
   overflow: hidden;
   text-overflow: ellipsis;
 
-  ${({ isOnline }) => isOnline && `
+  ${({ currentlyInMeeting }) => currentlyInMeeting && `
     color: ${colorHeading};
   `}
 
-  ${({ isOnline }) => !isOnline && `
+  ${({ currentlyInMeeting }) => !currentlyInMeeting && `
     text-transform: capitalize;
     font-style: italic;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
@@ -8,7 +8,7 @@ export const CHAT_MESSAGE_PUBLIC_SUBSCRIPTION = gql`
         name
         userId
         avatar
-        isOnline
+        currentlyInMeeting
         isModerator
         color
       }
@@ -37,7 +37,7 @@ export const CHAT_MESSAGE_PRIVATE_SUBSCRIPTION = gql`
         name
         userId
         avatar
-        isOnline
+        currentlyInMeeting
         isModerator
         color
       }

--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -21,7 +21,7 @@ const ConnectionStatus = () => {
     avatar: u.avatar,
     isModerator: u.isModerator,
     color: u.color,
-    isOnline: u.isOnline,
+    currentlyInMeeting: u.currentlyInMeeting,
   }));
 
   const handleUpdateConnectionAliveAt = () => {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -5,7 +5,7 @@ import UserAvatar from '/imports/ui/components/user-avatar/component';
 import CommonIcon from '/imports/ui/components/common/icon/component';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import Icon from '/imports/ui/components/connection-status/icon/component';
-import Service from '../service';
+import { getHelp } from '../service';
 import Styled from './styles';
 import ConnectionStatusHelper from '../status-helper/component';
 import Auth from '/imports/ui/services/auth';
@@ -147,15 +147,15 @@ const propTypes = {
   }).isRequired,
 };
 
-const isConnectionStatusEmpty = (connectionStatus) => {
+const isConnectionStatusEmpty = (connectionStatusParam) => {
   // Check if it's defined
-  if (!connectionStatus) return true;
+  if (!connectionStatusParam) return true;
 
   // Check if it's an array
-  if (!Array.isArray(connectionStatus)) return true;
+  if (!Array.isArray(connectionStatusParam)) return true;
 
   // Check if is empty
-  if (connectionStatus.length === 0) return true;
+  if (connectionStatusParam.length === 0) return true;
 
   return false;
 };
@@ -166,27 +166,11 @@ class ConnectionStatusComponent extends PureComponent {
 
     const { intl } = this.props;
 
-    this.help = Service.getHelp();
+    this.help = getHelp();
     this.state = {
       selectedTab: 0,
       hasNetworkData: true,
       copyButtonText: intl.formatMessage(intlMessages.copy),
-      networkData: {
-        user: {
-
-        },
-        audio: {
-          audioCurrentUploadRate: 0,
-          audioCurrentDownloadRate: 0,
-          jitter: 0,
-          packetsLost: 0,
-          transportStats: {},
-        },
-        video: {
-          videoCurrentUploadRate: 0,
-          videoCurrentDownloadRate: 0,
-        },
-      },
     };
     this.setButtonMessage = this.setButtonMessage.bind(this);
     this.rateInterval = null;
@@ -299,11 +283,11 @@ class ConnectionStatusComponent extends PureComponent {
 
             <Styled.Name>
               <Styled.Text
-                offline={!conn.user.isOnline}
-                data-test={!conn.user.isOnline ? "offlineUser" : null}
+                offline={!conn.user.currentlyInMeeting}
+                data-test={!conn.user.currentlyInMeeting ? 'offlineUser' : null}
               >
                 {conn.user.name}
-                {!conn.user.isOnline ? ` (${intl.formatMessage(intlMessages.offline)})` : null}
+                {!conn.user.currentlyInMeeting ? ` (${intl.formatMessage(intlMessages.offline)})` : null}
               </Styled.Text>
             </Styled.Name>
             {
@@ -317,7 +301,7 @@ class ConnectionStatusComponent extends PureComponent {
                 </Styled.Status>
               ) : null
             }
-            {conn.clientNotResponding && conn.user.isOnline
+            {conn.clientNotResponding && conn.user.currentlyInMeeting
               ? (
                 <Styled.ClientNotRespondingText>
                   {intl.formatMessage(intlMessages.clientNotResponding)}
@@ -474,7 +458,9 @@ class ConnectionStatusComponent extends PureComponent {
           disabled={!hasNetworkData}
           role="button"
           data-test="copyStats"
+          // eslint-disable-next-line react/jsx-no-bind
           onClick={this.copyNetworkData.bind(this)}
+          // eslint-disable-next-line react/jsx-no-bind
           onKeyPress={this.copyNetworkData.bind(this)}
           tabIndex={0}
         >
@@ -527,8 +513,7 @@ class ConnectionStatusComponent extends PureComponent {
                   <Styled.ConnectionTabSelector selectedClassName="is-selected">
                     <span id="session-logs-tab">{intl.formatMessage(intlMessages.sessionLogs)}</span>
                   </Styled.ConnectionTabSelector>
-                )
-              }
+                )}
             </Styled.ConnectionTabList>
             <Styled.ConnectionTabPanel selectedClassName="is-selected">
               <div>
@@ -544,8 +529,7 @@ class ConnectionStatusComponent extends PureComponent {
                 <Styled.ConnectionTabPanel selectedClassName="is-selected">
                   <ul>{this.renderConnections()}</ul>
                 </Styled.ConnectionTabPanel>
-              )
-            }
+              )}
           </Styled.ConnectionTabs>
         </Styled.Container>
       </Styled.ConnectionStatusModal>

--- a/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
@@ -14,7 +14,7 @@ export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription ConnStatus
       avatar
       color
       isModerator
-      isOnline
+      currentlyInMeeting
     }
     clientNotResponding
     lastUnstableStatus

--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -62,7 +62,7 @@ export const startStatsTimeout = () => {
   if (statsTimeout !== null) clearTimeout(statsTimeout);
 
   statsTimeout = setTimeout(() => {
-    setStats(-1, 'recovery', {});
+    // setStats(-1, 'recovery', {});
   }, STATS.timeout);
 };
 
@@ -80,9 +80,10 @@ export const sortLevel = (a, b) => {
 };
 
 export const sortOnline = (a, b) => {
-  if (!a.user.isOnline && b.user.isOnline) return 1;
-  if (a.user.isOnline === b.user.isOnline) return 0;
-  if (a.user.isOnline && !b.user.isOnline) return -1;
+  if (!a.user.currentlyInMeeting && b.user.currentlyInMeeting) return 1;
+  if (a.user.currentlyInMeeting === b.user.currentlyInMeeting) return 0;
+  if (a.user.currentlyInMeeting && !b.user.currentlyInMeeting) return -1;
+  return 0;
 };
 
 export const isEnabled = () => window.meetingClientSettings.public.stats.enabled;
@@ -107,6 +108,7 @@ export const notification = (level, intl) => {
   Session.setItem('connectionStatusNotified', true);
 
   if (intl) notify(intl.formatMessage(intlMessages.notification), level, 'warning');
+  return null;
 };
 
 /**

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/chatSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/chatSubscription.ts
@@ -17,7 +17,7 @@ const CHATS_SUBSCRIPTION = gql`
         color
         loggedOut
         avatar
-        isOnline
+        currentlyInMeeting
         isModerator
       }
       totalMessages

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -22,7 +22,7 @@ subscription userCurrentSubscription {
     inactivityWarningTimeoutSecs
     isDialIn
     isModerator
-    isOnline
+    currentlyInMeeting
     joinErrorCode
     joinErrorMessage
     joined

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -36,7 +36,7 @@ class ConnectionStatus {
   });
 
   private userNetworkHistory = makeVar<Array<{
-    user: Pick<User, 'userId' | 'avatar' | 'isModerator' | 'color' | 'isOnline' | 'name'>,
+    user: Pick<User, 'userId' | 'avatar' | 'isModerator' | 'color' | 'currentlyInMeeting' | 'name'>,
     lastUnstableStatus: string,
     lastUnstableStatusAt: Date | number,
     clientNotResponding?: boolean,
@@ -173,7 +173,7 @@ class ConnectionStatus {
         avatar: user.avatar,
         isModerator: user.isModerator,
         color: user.color,
-        isOnline: user.isOnline,
+        currentlyInMeeting: user.currentlyInMeeting,
         name: user.name,
       },
       lastUnstableStatus,


### PR DESCRIPTION
### TL;DR
This PR refactors the `isOnline` flag to `currentlyInMeeting` to clarify its meaning, and renames the Hasura role `not_joined_bbb_client` to `bbb_client_not_in_meeting` for better accuracy.

### Description
The current GraphQL flag, `isOnline`, is used to indicate that a user has joined a meeting and has not yet left or been ejected. However, the term "isOnline" can be misleading, as it might be interpreted as the user's general internet connectivity status rather than their active presence in the meeting.

To avoid this ambiguity, the flag is being renamed to `currentlyInMeeting`, which more accurately describes its purpose: to indicate that a user is actively in the meeting.

Additionally, this PR updates the Hasura role naming conventions for better clarity:
- The role `not_joined_bbb_client`, which is used for a user before they join or after they leave a meeting, will be renamed to `bbb_client_not_in_meeting`.
- The term "joined" in the original role name does not clearly differentiate whether a user has ever joined the meeting or is currently present. The new name better represents the user’s status and the rationale for the role assignment.