### PR TITLE
Fix: Emoji window dislocating chat input area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -119,6 +119,15 @@ const EmojiButton = styled(Button)`
 `;
 
 const EmojiPickerWrapper = styled.div`
+position: absolute;
+bottom: calc(100% + 0.5rem);
+left: 0;
+right: 0;
+border: 1px solid ${colorGrayLighter};
+border-radius: ${borderRadius};
+box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+z-index: 1000;
+
   .emoji-mart {
     max-width: 100% !important;
   }
@@ -148,7 +157,9 @@ const ChatMessageError = styled.div`
   margin-left: 0.05rem;
 `;
 
-const EmojiPicker = styled(EmojiPickerComponent)``;
+const EmojiPicker = styled(EmojiPickerComponent)`
+  position: relative;
+`;
 
 export default {
   Form,


### PR DESCRIPTION
### What does this PR do?

This PR fixes a big where the chat input area would dislocate from its position once the emoji window got open.

### After fix

https://github.com/user-attachments/assets/9f66dec1-a1e2-4fb3-b362-3e6d3b191deb


### Before fix

https://github.com/user-attachments/assets/1c05ddb2-d20d-4603-bc71-f7aada70bb1c


