### PR TITLE
feat(screenshare): add support for troubleshooting links

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -74,6 +74,10 @@ const intlMessages = defineMessages({
     id: 'app.screenshare.screensharePermissionError',
     description: 'Screen sharing failure due to lack of permission',
   },
+  toastHelpLabel: {
+    id: 'app.screenshare.screenshareToastHelpLabel',
+    description: 'Label of the help button in toast notifications that opens external link',
+  }
 });
 
 const getErrorLocale = (errorCode) => {
@@ -121,10 +125,21 @@ const ScreenshareButton = ({
   amIPresenter = false,
   isMeteorConnected,
 }) => {
+  const TROUBLESHOOTING_URLS = window.meetingClientSettings.public.media.screenshareTroubleshootingLinks;
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
   const isCameraAsContentBroadcasting = useIsCameraAsContentBroadcasting();
 
   const [isScreenshareUnavailableModalOpen, setScreenshareUnavailableModalIsOpen] = useState(false);
+
+  const getHelpInfoForError = (errorCode) => {
+    if (TROUBLESHOOTING_URLS && Object.keys(TROUBLESHOOTING_URLS).includes(errorCode)) {
+      return {
+        helpLink: TROUBLESHOOTING_URLS[errorCode],
+        helpLabel: intl.formatMessage(intlMessages.toastHelpLabel),
+      };
+    }
+    return {};
+  }
 
   // This is the failure callback that will be passed to the /api/screenshare/kurento.js
   // script on the presenter's call
@@ -135,9 +150,10 @@ const ScreenshareButton = ({
     } = error;
 
     const localizedError = getErrorLocale(errorCode);
+    const helpInfo =  getHelpInfoForError(errorCode);
 
     if (localizedError) {
-      notify(intl.formatMessage(localizedError, { 0: errorCode }), 'error', 'desktop');
+      notify(intl.formatMessage(localizedError, { 0: errorCode }), 'error', 'desktop', { ...helpInfo });
       logger.error({
         logCode: 'screenshare_failed',
         extraInfo: { errorCode, errorMessage },

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -117,6 +117,11 @@ const getErrorLocale = (errorCode) => {
   }
 };
 
+const getToastType = (errorCode) => {
+  if ([SCREENSHARING_ERRORS.NotAllowedError.errorCode].includes(errorCode)) return 'warning';
+  return 'error';
+}
+
 const ScreenshareButton = ({
   intl,
   enabled,
@@ -151,9 +156,10 @@ const ScreenshareButton = ({
 
     const localizedError = getErrorLocale(errorCode);
     const helpInfo =  getHelpInfoForError(errorCode);
+    const toastType = getToastType(errorCode);
 
     if (localizedError) {
-      notify(intl.formatMessage(localizedError, { 0: errorCode }), 'error', 'desktop', { ...helpInfo });
+      notify(intl.formatMessage(localizedError, { 0: errorCode }), toastType, 'desktop', { ...helpInfo });
       logger.error({
         logCode: 'screenshare_failed',
         extraInfo: { errorCode, errorMessage },

--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { toast } from 'react-toastify';
 import { isEqual } from 'radash';
-
+import Styled from './styles';
 import Toast from '/imports/ui/components/common/toast/component';
 
 let lastToast = {
@@ -28,6 +28,20 @@ export function notify(message, type = 'default', icon, options, content, small)
   };
 
   if (!toast.isActive(lastToast.id) || !isEqual(lastToastProps, toastProps)) {
+    if (options?.helpLink != null && options?.helpLabel != null) {
+      const id = toast(
+        <div role="alert">
+          <Toast {...toastProps} />
+          <Styled.Button onClick={() => { window.open(options.helpLink); }}>
+            {options.helpLabel}
+          </Styled.Button>
+        </div>, settings,
+      );
+
+      lastToast = { id, ...toastProps };
+
+      return id;
+    }
     if (toast.isActive(lastToast.id)
       && isEqual(lastToastProps.key, toastProps.key) && options?.autoClose > 0) {
       toast.update(

--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -32,9 +32,13 @@ export function notify(message, type = 'default', icon, options, content, small)
       const id = toast(
         <div role="alert">
           <Toast {...toastProps} />
-          <Styled.Button onClick={() => { window.open(options.helpLink); }}>
-            {options.helpLabel}
-          </Styled.Button>
+          <Styled.HelpLinkButton
+            label={options.helpLabel}
+            color="default"
+            size="sm"
+            onClick={() => { window.open(options.helpLink); }}
+            data-test="helpLinkToastButton"
+          />
         </div>, settings,
       );
 

--- a/bigbluebutton-html5/imports/ui/services/notification/styles.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/styles.js
@@ -1,17 +1,19 @@
 import styled from 'styled-components';
+import Button from '/imports/ui/components/common/button/component';
+import { 
+  toastMargin,
+} from '/imports/ui/stylesheets/styled-components/general';
+import {
+  colorPrimary,
+} from '/imports/ui/stylesheets/styled-components/palette';
 
-const Button = styled.div`
+const HelpLinkButton = styled(Button)`
   position: relative;
-  background: none!important;
-  border: none;
-  padding: 0!important;
-  font-weight: bold;
-  color: #069;
-  text-decoration: underline;
-  cursor: pointer;
-  left: 15.7%;
-  font-size: 12px;
-  top: 2px;
+  width: 100%;
+  margin-top: ${toastMargin};
+  color: ${colorPrimary};
+  background-color: transparent;
+  
 `;
 
-export default { Button };
+export default { HelpLinkButton };

--- a/bigbluebutton-html5/imports/ui/services/notification/styles.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/styles.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+const Button = styled.div`
+  position: relative;
+  background: none!important;
+  border: none;
+  padding: 0!important;
+  font-weight: bold;
+  color: #069;
+  text-decoration: underline;
+  cursor: pointer;
+  left: 15.7%;
+  font-size: 12px;
+  top: 2px;
+`;
+
+export default { Button };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -910,6 +910,10 @@ public:
     #  0: 'https://link.bigbluebutton.org/unk'
     # muteAudioOutputWhenAway: mute output audio if user is in away mode
     muteAudioOutputWhenAway: false
+    # Index is the error code:
+    #   - 1136: permission denied
+    screenshareTroubleshootingLinks:
+      1136: 'https://support.bigbluebutton.org/hc/en-us/articles/1500005316582-Share-my-screen#:~:text=Error%201136%3A%20Permission%20to%20capture,able%20to%20screen%20share%20again'
   stats:
     enabled: true
     interval: 10000

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -227,6 +227,7 @@
     "app.screenshare.screenshareRetryOtherEnvError": "Code {0}. Could not share the screen. Try again using a different browser or device.",
     "app.screenshare.screenshareUnsupportedEnv": "Code {0}. Browser is not supported. Try again using a different browser or device.",
     "app.screenshare.screensharePermissionError": "Code {0}. Permission to capture the screen needs to be granted.",
+    "app.screenshare.screenshareToastHelpLabel": "Learn more", 
     "app.cameraAsContent.presenterLoadingLabel": "Your camera is loading",
     "app.cameraAsContent.viewerLoadingLabel": "The presenter's camera is loading",
     "app.cameraAsContent.presenterSharingLabel": "You are now presenting your camera",


### PR DESCRIPTION
### What does this PR do?
Adds support for troubleshooting links for screenshare errors, similar to the troubleshooting links introduced for audio in [#20174](https://github.com/bigbluebutton/bigbluebutton/pull/20174). The troubleshooting links can be specified through settings option: `public.media.screenshareTroubleshootingLinks`, with links indexed by error codes they correspond to.
Adds default troubleshooting link for error 1136: [https://support.bigbluebutton.org/hc/en-us/articles/1500005316582-Share-my-screen#:~:text=Error%201136%3A%20Permission%20to%20capture,able%20to%20screen%20share%20again](https://support.bigbluebutton.org/hc/en-us/articles/1500005316582-Share-my-screen#:~:text=Error%201136%3A%20Permission%20to%20capture,able%20to%20screen%20share%20again)

Additionally, it changes the toast notification for screenshare error code `1136` to a less aggressive type. This adjustment was made because error code `1136` is also triggered when a user cancels the screenshare during tab selection, which doesn't warrant an alarming error message.
- [feat(screenshare): add support for troubleshooting links](https://github.com/bigbluebutton/bigbluebutton/commit/fa5fa6844c02903e3b3297b3ac5d22809524a96d) 
  Adds setting option to specify troubleshooting links to each error code
of screenshare. When a troubleshooting link for the given error exists,
the toast notification about the error is displayed with a 'Learn more'
button that when clicked leads the user to the external link. When there
is no link set for the specific error code, the button is not displayed.


- [fix(screenshare): change toast type for error code 1136](https://github.com/bigbluebutton/bigbluebutton/commit/a58f335b2ced2f31671683bc89fdee912c037201) 
  Changed toast type from 'error' to 'warning' for error code 1136 when
sharing screen. This adjustment was made because error code 1136 is also
returned when the user cancels screen sharing during the tab selection
process. Displaying an error toast in this situation could cause
unnecessary alarm for users, as they were simply canceling an operation.

### Screenshots
Original toast notification for screenshare error `1136`:
![screenshare_cancel_error_30](https://github.com/user-attachments/assets/be04db3c-279a-4520-820c-7bdbeeb7cde6)


Modified toast notification for screenshare error `1136`, with 'warning' and troubleshooting link:
![screenshare_cancel_warning](https://github.com/user-attachments/assets/c4a76fcd-022d-4386-8ef8-f6df1cff2573)



### How to test
1. Join meeting.
2. Click to share screen.
3. Cancel during the tab selection.
4. Verify the modified toast notification
