### PR TITLE
Client: Add ms suffix to RTT values in logs

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -73,7 +73,7 @@ class ConnectionStatus {
 
   public setRttValue(value: number): void {
     if (value !== this.rttValue()) {
-      logger.debug({ logCode: 'stats_rtt_value_state' }, `RTT value changed to ${value}`);
+      logger.debug({ logCode: 'stats_rtt_value_state' }, `RTT value changed to ${value}ms`);
       this.rttValue(value);
     }
   }
@@ -103,7 +103,7 @@ class ConnectionStatus {
 
   public setRttStatus(value: string): void {
     if (value !== this.rttStatus()) {
-      logger.info({ logCode: 'stats_rtt_status_state' }, `Connection status changed to ${value} (rtt=${this.rttValue()})`);
+      logger.info({ logCode: 'stats_rtt_status_state' }, `Connection status changed to ${value} (rtt=${this.rttValue()}ms)`);
       this.rttStatus(value);
     }
   }


### PR DESCRIPTION
### What does this PR do?

This PR introduces a small update to the logging format by appending the "ms" (milliseconds) suffix to the RTT (Round-Trip Time) values.

### Motivation

This change is intended to make the time unit explicit and improve log readability.

### How to test

Open browser console and type RTT in the filter, the logs should show up.
