### PR TITLE
Enhancement: Sort the list of names in breakout dialog similar to the Users list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -186,6 +186,15 @@ type User = {
   isModerator: boolean;
 };
 
+type Room = {
+  [key: string]: {
+    users: User[];
+  id: string;
+  name: string;
+  size: number;
+  }
+};
+
 const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   moveUser,
   rooms,
@@ -217,9 +226,9 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   };
 
   const updateSortedRooms = () => {
-    const newSortedRooms = { ...rooms };
+    const newSortedRooms: Room = { ...rooms };
     Object.keys(newSortedRooms).forEach((roomNumber: string) => {
-      newSortedRooms[roomNumber as string] = {
+      newSortedRooms[roomNumber] = {
         ...newSortedRooms[roomNumber],
         users: sortUsers(newSortedRooms[roomNumber].users),
       };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -186,15 +186,6 @@ type User = {
   isModerator: boolean;
 };
 
-type Room = {
-  [key: string]: {
-    users: User[];
-  id: string;
-  name: string;
-  size: number;
-  }
-};
-
 const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   moveUser,
   rooms,
@@ -226,7 +217,7 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   };
 
   const updateSortedRooms = () => {
-    const newSortedRooms: Room = { ...rooms };
+    const newSortedRooms = { ...rooms };
     Object.keys(newSortedRooms).forEach((roomNumber: string) => {
       newSortedRooms[roomNumber] = {
         ...newSortedRooms[roomNumber],

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -201,8 +201,8 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   const intl = useIntl();
   const [sortedRooms, setSortedRooms] = useState(rooms);
 
-  const sortUsers = (users) => {
-    return [...users].sort((a, b) => {
+  const sortUsers = (user) => {
+    return [...user].sort((a, b) => {
       if (a.isModerator !== b.isModerator) {
         return a.isModerator ? -1 : 1;
       }
@@ -212,15 +212,11 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
 
   const updateSortedRooms = () => {
     const newSortedRooms = { ...rooms };
-    Object.keys(newSortedRooms).forEach((roomNumber) => {
-      if (newSortedRooms[roomNumber] && Array.isArray(newSortedRooms[roomNumber].users)) {
-        newSortedRooms[roomNumber] = {
-          ...newSortedRooms[roomNumber],
-          users: sortUsers(newSortedRooms[roomNumber].users),
-        };
-      } else {
-        newSortedRooms[roomNumber] = { users: [] };
-      }
+    Object.keys(newSortedRooms).forEach((roomNumber: string) => {
+      newSortedRooms[roomNumber] = {
+        ...newSortedRooms[roomNumber],
+        users: sortUsers(newSortedRooms[roomNumber].users),
+      };
     });
     setSortedRooms(newSortedRooms);
   };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -218,10 +218,11 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
 
   const updateSortedRooms = () => {
     const newSortedRooms = { ...rooms };
-    Object.keys(newSortedRooms).forEach((roomNumber: string) => {
-      newSortedRooms[roomNumber] = {
-        ...newSortedRooms[roomNumber],
-        users: sortUsers(newSortedRooms[roomNumber].users),
+    Object.keys(newSortedRooms).forEach((roomNumber) => {
+      const roomNumberInt = parseInt(roomNumber, 10);
+      newSortedRooms[roomNumberInt] = {
+        ...newSortedRooms[roomNumberInt],
+        users: sortUsers(newSortedRooms[roomNumberInt].users),
       };
     });
     setSortedRooms(newSortedRooms);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -201,7 +201,7 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   const intl = useIntl();
   const [sortedRooms, setSortedRooms] = useState(rooms);
 
-  const sortUsers = (user) => {
+  const sortUsers = (user: Array<T>) => {
     return [...user].sort((a, b) => {
       if (a.isModerator !== b.isModerator) {
         return a.isModerator ? -1 : 1;

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -219,7 +219,7 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   const updateSortedRooms = () => {
     const newSortedRooms = { ...rooms };
     Object.keys(newSortedRooms).forEach((roomNumber: string) => {
-      newSortedRooms[roomNumber] = {
+      newSortedRooms[roomNumber as string] = {
         ...newSortedRooms[roomNumber],
         users: sortUsers(newSortedRooms[roomNumber].users),
       };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/breakout-room-user-assignment/component.tsx
@@ -180,6 +180,12 @@ const intlMessages = defineMessages({
 
 const isMe = (intId: string) => intId === Auth.userID;
 
+type User = {
+  userId: string;
+  name: string;
+  isModerator: boolean;
+};
+
 const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   moveUser,
   rooms,
@@ -201,8 +207,8 @@ const BreakoutRoomUserAssignment: React.FC<ChildComponentProps> = ({
   const intl = useIntl();
   const [sortedRooms, setSortedRooms] = useState(rooms);
 
-  const sortUsers = (user: Array<T>) => {
-    return [...user].sort((a, b) => {
+  const sortUsers = (users: User[]) => {
+    return [...users].sort((a, b) => {
       if (a.isModerator !== b.isModerator) {
         return a.isModerator ? -1 : 1;
       }


### PR DESCRIPTION
### What does this PR do?

This PR adds sorting to breakout rooms similar to what happens in the user list.

### Closes Issue(s)

#21031

### How to test

To test this PR just enter the meeting with multiple users with different names, open the breakout room modal and check if the names in the boxes are sorted correctly by adding them both randomly and one by one to the rooms.
