### PR TITLE
fix: Push to talk intercepting shortcut with modifier

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -75,9 +75,14 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
         || activeElement.isContentEditable);
     const Settings = getSettingsSingletonInstance();
     const pushToTalkEnabled = Settings?.application?.pushToTalkEnabled;
-    if ((cooldownActive.current || event.key !== 'm' || isInputField) || !pushToTalkEnabled) {
-      return;
-    }
+    if (
+      !pushToTalkEnabled
+        || cooldownActive.current
+        || event.key !== 'm'
+        || event.altKey
+        || event.ctrlKey
+        || isInputField
+    ) return;
 
     if (action === 'down' && !isKeyDown.current) {
       isKeyDown.current = true;


### PR DESCRIPTION
### What does this PR do?
This PR stops the push-to-talk shortcut from intercepting when the m key is pressed along with a modifier key (e.g., Alt or Ctrl).
### Motivation
related to #21032, where the push-to-talk functionality was triggering even when modifier keys were used with the m key.