### PR TITLE
refactor: adjust inline comment for packet loss metric usage

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -69,8 +69,8 @@ export const handleAudioStatsEvent = (event) => {
     //
     // This metric is DIFFERENT from the one used in the connection status modal
     // (see the network data object in this file). The network data one is an
-    // absolute counter of INBOUND packets lost - and it should be used to determine
-    // alert triggers
+    // absolute counter of INBOUND packets lost - and it *SHOULD NOT* be used to 
+    // determine alert triggers
     connectionStatus.setPacketLossStatus(
       getStatus(window.meetingClientSettings.public.stats.loss, loss),
     );


### PR DESCRIPTION
### What does this PR do?

- [refactor: adjust inline comment for packet loss metric usage](https://github.com/bigbluebutton/bigbluebutton/commit/3fbe4be441313f8092bcda125ce01b47a9adeb11) 
  * Adjust an inline comment in connection status' service about packet loss metric
usage.
  * Now it correctly states that the absolute counter SHOULD NOT be used for
alert triggers.


### Closes Issue(s)

None