### PR TITLE
Disable react devtools in prod

### DIFF
--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -14,6 +14,27 @@ import MeetingClient from '/client/meetingClient';
 
 const STARTUP_CRASH_METADATA = { logCode: 'app_startup_crash', logMessage: 'Possible startup crash' };
 const APP_CRASH_METADATA = { logCode: 'app_crash', logMessage: 'Possible app crash' };
+/* eslint-disable */
+if (
+  process.env.NODE_ENV === 'production'
+  //  @ts-ignore
+  && window.__REACT_DEVTOOLS_GLOBAL_HOOK__
+) {
+  //  @ts-ignore
+  for (const prop in window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+    if (prop === 'renderers') {
+      //  @ts-ignore
+      // prevents console error when dev tools try to iterate of renderers
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = new Map();
+      continue;
+    }
+    //  @ts-ignore
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] === 'function'
+      ? Function.prototype
+      : null;
+  }
+}
+/* eslint-enable */
 
 const Main: React.FC = () => {
   return (


### PR DESCRIPTION
What does this PR do?
Following thr PR https://github.com/bigbluebutton/bigbluebutton/pull/21043, this PR disable the react devtools in production