### PR TITLE
fix(connection): tweak `shouldRetry` handler logging

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -158,10 +158,14 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
             const terminated = isDetailedError && error.code === 4499;
 
             if (terminated) {
-              logger.info(
-                { logCode: 'connection_terminated' },
-                'Connection terminated (4499)',
-              );
+              logger.info({
+                logCode: 'connection_terminated',
+                extraInfo: {
+                  errorName: error.name,
+                  errorMessage: error.message,
+                  errorReason: error.reason,
+                },
+              }, 'Connection terminated (4499)');
             } else if (isDetailedError) {
               logger.error({
                 logCode: 'connection_error',
@@ -172,10 +176,14 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
                 },
               }, `Connection error (${error.code})`);
             } else {
-              logger.error(
-                { logCode: 'connection_error' },
-                `Connection error: ${JSON.stringify(error)}`,
-              );
+              logger.error({
+                logCode: 'connection_error',
+                extraInfo: {
+                  errorName: 'Error',
+                  errorMessage: JSON.stringify(error),
+                  errorReason: 'Unknown',
+                },
+              }, `Connection error: ${JSON.stringify(error)}`);
             }
 
             if (error && typeof error === 'object' && 'code' in error && error.code === 4403) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Polishes the logging of the _shouldRetry_ handler of the graphql client. It is logging the `TerminatedCloseEvent` as error. Instead log it as info.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
n/a

### Motivation

Logging it as error can cause confusion, since it is not a fatal error.

### More

See https://the-guild.dev/graphql/ws/docs/classes/client.TerminatedCloseEvent.
