### PR TITLE
fix: run full RTC stats collection only when necessary

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -4,7 +4,6 @@ import { UPDATE_CONNECTION_ALIVE_AT } from './mutations';
 import {
   getStatus,
   handleAudioStatsEvent,
-  startMonitoringNetwork,
 } from '/imports/ui/components/connection-status/service';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 
@@ -85,8 +84,9 @@ const ConnectionStatus = () => {
     const STATS_ENABLED = window.meetingClientSettings.public.stats.enabled;
 
     if (STATS_ENABLED) {
+      // This will generate metrics usage to determine alert statuses based
+      // on WebRTC stats
       window.addEventListener('audiostats', handleAudioStatsEvent);
-      startMonitoringNetwork();
     }
 
     return () => {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { CONNECTION_STATUS_REPORT_SUBSCRIPTION } from '../queries';
-import Service from '../service';
+import {
+  sortConnectionData,
+  startMonitoringNetwork,
+  stopMonitoringNetwork,
+} from '../service';
 import Component from './component';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
@@ -9,18 +13,20 @@ import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStat
 
 const ConnectionStatusContainer = (props) => {
   const { data } = useDeduplicatedSubscription(CONNECTION_STATUS_REPORT_SUBSCRIPTION);
-  const connectionData = data ? Service.sortConnectionData(data.user_connectionStatusReport) : [];
+  const connectionData = data ? sortConnectionData(data.user_connectionStatusReport) : [];
   const { data: currentUser } = useCurrentUser((u) => ({ isModerator: u.isModerator }));
   const amIModerator = !!currentUser?.isModerator;
 
-  const newtworkData = useReactiveVar(connectionStatus.getNetworkDataVar());
+  const networkData = useReactiveVar(connectionStatus.getNetworkDataVar());
 
   return (
     <Component
       {...props}
       connectionData={connectionData}
       amIModerator={amIModerator}
-      networkData={newtworkData}
+      networkData={networkData}
+      startMonitoringNetwork={startMonitoringNetwork}
+      stopMonitoringNetwork={stopMonitoringNetwork}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?

- [fix: run full RTC stats collection only when necessary](https://github.com/bigbluebutton/bigbluebutton/commit/3e9e7e3e2b284fe55c418a36f980ea0a913a4892)
  - In BBB 3.0, a change was made to collect full WebRTC stats continuously.
This method gathers stats from *all* peers and *all* senders and receivers
every 2 seconds. Originally, it was intended to run only when the user opened
the connection status dialog, providing in-depth info in the UI and making it
available for copying.
  - This new behavior is not ideal. Running full stats collection every 2 seconds
in meetings with 20+ peers/transceivers wastes client resources since the
collected data is unused 99% of the time.
  - This commit reverts to the pre-3.0 behavior (≤2.7), where full stats collection
(`startNetworkMonitoring`) runs only when the connection status modal is open.
As a bonus, it fixes the packet loss status transition log to use the packet
loss percentage, which is the actual trigger metric.


### Closes Issue(s)

None

### Motivation

See first item in https://github.com/bigbluebutton/bigbluebutton/issues/20919#issuecomment-2318254606
See last item in https://github.com/bigbluebutton/bigbluebutton/issues/20919#issuecomment-2318247657
Preparing the terrain for when #21036 is ported.