### PR TITLE
fix(dark-theme): adjust Dark Reader CSS selectors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -32,6 +32,9 @@ const DtfInvert = `
   section[id="ActionsBar"] {
     background-color: var(--darkreader-neutral-background) !important;
   }
+  div[id="app"] {
+    background-color: var(--darkreader-neutral-background) !important;
+  }
   select {
     border: 0.1rem solid #FFFFFF !important;
   }
@@ -49,54 +52,41 @@ const DtfInvert = `
   .tl-container {
     background-color: var(--tl-background) !important;
   }
-  #TD-Tools button, #TD-TopPanel-Undo, #TD-TopPanel-Redo, #TD-Styles {
-    border-color: transparent !important;
+  .tlui-slider__thumb {
+    background-color: var(--darkreader-text--color-text-1) !important;
   }
-  [id="TD-StylesMenu"],
-  [id="TD-Styles-Color-Container"],
+  .tlui-button[data-state="hinted"]::after {
+    background-color: var(--darkreader-selection-background) !important;
+  }
+  div.tlui-toolbar__inner > div.tlui-toolbar__tools.fade-in {
+    background: var(--darkreader-border--color-selected) !important;
+  }
+  div[id="cameraDock"] {
+    background-color: var(--darkreader-neutral-background) !important;
+  }
+  .bnjzQC > div span div:hover {
+    background-color: var(--darkreader-selection-background) !important;
+  }
   #connectionBars > div
 `;
 
 const DtfBrandingInvert = `
-  body {
-    background-color: var(--darkreader-neutral-background) !important;
-  }
-  header[id="Navbar"] {
-    background-color: var(--darkreader-neutral-background) !important;
-  }
-  section[id="ActionsBar"] {
-    background-color: var(--darkreader-neutral-background) !important;
-  }
-  select {
-    border: 0.1rem solid #FFFFFF !important;
-  }
-  select[data-test="skipSlide"] {
-    border: unset !important;
-  }
-  div[data-test="presentationContainer"] {
-    background-color: var(--darkreader-neutral-background) !important;
-  }
-  select {
-    border-top: unset !important;
-    border-right: unset !important;
-    border-left: unset !important;
-  }
-  .tl-container {
-    background-color: var(--tl-background) !important;
-  }
-  #TD-Tools button, #TD-TopPanel-Undo, #TD-TopPanel-Redo, #TD-Styles {
-    border-color: transparent !important;
-  }
-  [id="TD-StylesMenu"],
-  [id="TD-Styles-Color-Container"],
-  div[data-test="brandingArea"],
-  #connectionBars > div
+  ${DtfInvert},
+  div[data-test="brandingArea"]
 `;
 
 const DtfCss = `
   [id="colorPicker"],
   path,
-  svg
+  svg,
+  g,
+  line,
+  textarea,
+  rect,
+  circle,
+  .tlui-buttons__grid > button,
+  .tlui-popover > button,
+  .tl-html-container > div.tl-text-shape__wrapper.tl-text-shadow
 `;
 
 const DtfImages = `

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -86,7 +86,15 @@ const DtfCss = `
   circle,
   .tlui-buttons__grid > button,
   .tlui-popover > button,
-  .tl-html-container > div.tl-text-shape__wrapper.tl-text-shadow
+  .tl-html-container > div.tl-text-shape__wrapper.tl-text-shadow,
+  .tl-text,
+  .tl-text-input,
+  .tl-text-content,
+  .tl-text-label__inner,
+  .tl-note__container,
+  .tl-text.tl-text-content,
+  .tl-arrow-label,
+  .tl-arrow-label__inner
 `;
 
 const DtfImages = `

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -67,7 +67,13 @@ const DtfInvert = `
   .bnjzQC > div span div:hover {
     background-color: var(--darkreader-selection-background) !important;
   }
-  #connectionBars > div
+  #connectionBars > div,
+  .tl-note__scrim,.tl-arrow-label[data-isediting="true"] > .tl-arrow-label__inner {
+    background-color: unset !important;
+  }
+  textarea {
+    caret-color: black !important;
+  }
 `;
 
 const DtfBrandingInvert = `

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -50,7 +50,9 @@ const DtfInvert = `
     border-left: unset !important;
   }
   .tl-container {
-    background-color: var(--tl-background) !important;
+    .tl-image {
+      background-color: white !important;
+    }
   }
   .tlui-slider__thumb {
     background-color: var(--darkreader-text--color-text-1) !important;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -29,6 +29,7 @@ import {
 } from "./utils";
 import { useMouseEvents, useCursor } from "./hooks";
 import { notifyShapeNumberExceeded, getCustomEditorAssetUrls, getCustomAssetUrls } from "./service";
+import AppService from '/imports/ui/components/app/service';
 
 import NoopTool from './custom-tools/noop-tool/component';
 
@@ -445,6 +446,13 @@ const Whiteboard = React.memo(function Whiteboard(props) {
     setTldrawAPI(editor);
 
     editor?.user?.updateUserPreferences({ locale: language });
+    
+    if (darkTheme) {
+      // force darkReader to reload to fix some cases
+      // where tldraw dark theme isn't applied
+      AppService.setDarkTheme(false);
+      AppService.setDarkTheme(true);
+    }
 
     const debouncePersistShape = debounce({ delay: 0 }, persistShapeWrapper);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -447,13 +447,6 @@ const Whiteboard = React.memo(function Whiteboard(props) {
 
     editor?.user?.updateUserPreferences({ locale: language });
     
-    if (darkTheme) {
-      // force darkReader to reload to fix some cases
-      // where tldraw dark theme isn't applied
-      AppService.setDarkTheme(false);
-      AppService.setDarkTheme(true);
-    }
-
     const debouncePersistShape = debounce({ delay: 0 }, persistShapeWrapper);
 
     const colorStyles = [

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -29,7 +29,6 @@ import {
 } from "./utils";
 import { useMouseEvents, useCursor } from "./hooks";
 import { notifyShapeNumberExceeded, getCustomEditorAssetUrls, getCustomAssetUrls } from "./service";
-import AppService from '/imports/ui/components/app/service';
 
 import NoopTool from './custom-tools/noop-tool/component';
 
@@ -446,7 +445,7 @@ const Whiteboard = React.memo(function Whiteboard(props) {
     setTldrawAPI(editor);
 
     editor?.user?.updateUserPreferences({ locale: language });
-    
+
     const debouncePersistShape = debounce({ delay: 0 }, persistShapeWrapper);
 
     const colorStyles = [


### PR DESCRIPTION
### What does this PR do?
Clean up inverted css selectors passed to Dark Reader and add new ones for elements not correctly transformed to dark theme. These include the tldraw color picker, text shape color, selected color indicator, tool opacity slider, and camera dock background.
Comparsion:
Before and after:
![whiteboard_](https://github.com/user-attachments/assets/d9dae401-f9ba-49b5-8f34-a76b49e8caa4) ![whiteboard](https://github.com/user-attachments/assets/19350cae-99ab-48ff-afa3-cfc45c337b72)
![cameraDock-background_](https://github.com/user-attachments/assets/43a39943-ef5a-4b53-9f23-feb6818189fa)
![cameraDock-background](https://github.com/user-attachments/assets/4cdd45b8-0582-476e-968a-1b5ed350e7dc)