### PR TITLE
html5: Set Cache Expiry to 24 Hours in Webpack Configuration

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -20,6 +20,7 @@ const config = {
   cache: {
     type: 'filesystem',
     allowCollectingMemory: true,
+    maxAge: 86400000,
   },
   devtool: 'source-map',
   plugins: [


### PR DESCRIPTION
### What does this PR do?
Implements a timeout for cache be stored in filesystem, using the property [maxAge](https://webpack.js.org/configuration/cache/#cachemaxage), i reduced it to one day (default is one month).