### PR TITLE
fix (gql-server): Remove strict permission of `bbb-graphql-server` directory

### DIFF
--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -26,7 +26,6 @@ case "$1" in
 #Generate a random password to Hasura to improve security
 if [ ! -f /usr/share/bbb-graphql-server/admin-secret ]; then
   mkdir -p /usr/share/bbb-graphql-server
-  chmod 700  /usr/share/bbb-graphql-server/
   HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
   echo "HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD" > /usr/share/bbb-graphql-server/admin-secret
   chown bigbluebutton:bigbluebutton /usr/share/bbb-graphql-server/admin-secret


### PR DESCRIPTION
Undo `chmod 700 /usr/share/bbb-graphql-server/` introduced in https://github.com/bigbluebutton/bigbluebutton/pull/20993 

It's necessary because the user `postgres` needs to read `/usr/share/bbb-graphql-server/bbb_schema.sql` from the directory.