### PR TITLE
Fix: When in Grid Layout, presentation does not become visible on "Restore presentation" unless chat column is open

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/common/button/component';
 import Session from '/imports/ui/services/storage/in-memory';
+import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import {
+  layoutSelectInput,
+} from '/imports/ui/components/layout/context';
+import { useStorageKey } from '/imports/ui/services/storage/hooks';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -59,6 +64,10 @@ const PresentationOptionsContainer = ({
   && !hasExternalVideo && !hasScreenshare
   && !hasPinnedSharedNotes && !hasGenericContent
   && !hasCameraAsContent;
+  const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
+  const isChatOpen = sidebarContent.sidebarContentPanel === PANELS.CHAT;
+  const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
+  const isGridLayout = useStorageKey('isGridEnabled');
   return (
     <Button
       icon={`${buttonType}${!presentationIsOpen ? '_off' : ''}`}
@@ -71,6 +80,20 @@ const PresentationOptionsContainer = ({
       circle
       size="lg"
       onClick={() => {
+        if (!isChatOpen && isGridLayout && !presentationIsOpen) {
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+            value: PANELS.CHAT,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_ID_CHAT_OPEN,
+            value: PUBLIC_CHAT_ID,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+            value: true,
+          });
+        }
         setPresentationIsOpen(layoutContextDispatch, !presentationIsOpen);
         if (onlyPresentation) {
           Session.setItem('presentationLastState', !presentationIsOpen);


### PR DESCRIPTION
### What does this PR do?

This PR fixes a behavior  where the restore presentation button wouldn't work as expected due to the presentation being bellow the chat in grid layout.

### Closes Issue(s)

#18966 

### How to test

To test it, start a meeting and set it to grid layout, then minimize presentation, close the chat and finally - restore presentation.


