### PR TITLE
build/tests: Attempt to fix a random error during the tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -262,8 +262,9 @@ jobs:
           NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
           ACTIONS_RUNNER_DEBUG: true
         with:
-          timeout_minutes: 25
+          timeout_minutes: 15
           max_attempts: 2
+          retry_on: any
           command: |
             sudo -i <<EOF
             set -e

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -26,17 +26,17 @@ case "$1" in
 
   echo "Postgresql configured"
 
-#Generate a random password to Hasura to improve security
-if [ ! -f /usr/share/bbb-graphql-server/admin-secret ]; then
-  HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
-  echo "HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD" > /usr/share/bbb-graphql-server/admin-secret
-  chmod 755 /usr/share/bbb-graphql-server/admin-secret
-  echo "Set a random password to Hasura at /usr/share/bbb-graphql-server/admin-secret"
-fi
+  #Generate a random password to Hasura to improve security
+  if [ ! -f /usr/share/bbb-graphql-server/admin-secret ]; then
+    HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
+    echo "HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD" > /usr/share/bbb-graphql-server/admin-secret
+    chmod 755 /usr/share/bbb-graphql-server/admin-secret
+    echo "Set a random password to Hasura at /usr/share/bbb-graphql-server/admin-secret"
+  fi
 
-#Set admin secret for Hasura CLI
-HASURA_ADM_PASSWORD=$(grep '^HASURA_GRAPHQL_ADMIN_SECRET=' /usr/share/bbb-graphql-server/admin-secret | cut -d '=' -f 2)
-sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb-graphql-server/config.yaml
+  #Set admin secret for Hasura CLI
+  HASURA_ADM_PASSWORD=$(grep '^HASURA_GRAPHQL_ADMIN_SECRET=' /usr/share/bbb-graphql-server/admin-secret | cut -d '=' -f 2)
+  sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb-graphql-server/config.yaml
 
   if [ ! -f /.dockerenv ]; then
     systemctl enable bbb-graphql-server.service
@@ -56,6 +56,8 @@ sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb
     cd ..
     rm -rf /usr/share/bbb-graphql-server/metadata
   fi
+
+  echo "Graphql-server after-install finished"
 
   ;;
 

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -52,7 +52,7 @@ sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb
 
     # Apply BBB metadata in Hasura
     cd /usr/share/bbb-graphql-server
-    /usr/local/bin/hasura metadata apply --skip-update-check
+    timeout 15s /usr/local/bin/hasura metadata apply --skip-update-check
     cd ..
     rm -rf /usr/share/bbb-graphql-server/metadata
   fi


### PR DESCRIPTION
Tests frequently fail at the `Install BBB` step, showing the error below. It is unclear whether the issue originates from the command `/usr/local/bin/hasura metadata apply --skip-update-check` or occurs in a subsequent step. 

To diagnose this, we propose setting a timeout for the `metadata apply` step and adding a confirmation message to verify that the script has reached its end.

![image](https://github.com/user-attachments/assets/adac29e3-149d-4292-adf3-27fa0f35bbc6)
