### PR TITLE
Fix: Border radius on system messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -21,6 +21,7 @@ export const ChatMessage = styled.div<ChatMessageProps>`
   ${({ systemMsg }) => systemMsg && `
   background: ${systemMessageBackgroundColor};
   border: 1px solid ${systemMessageBorderColor};
+  border-radius: 0.2rem;
   font-weight: ${btnFontWeight};
   padding: ${fontSizeBase};
   text-color: #1f252b;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -4,6 +4,7 @@ import {
   systemMessageBorderColor,
   colorText,
 } from '/imports/ui/stylesheets/styled-components/palette';
+import { borderRadius } from 'imports/ui/stylesheets/styled-components/general';
 import { fontSizeBase, btnFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
 
 interface ChatMessageProps {
@@ -21,7 +22,7 @@ export const ChatMessage = styled.div<ChatMessageProps>`
   ${({ systemMsg }) => systemMsg && `
   background: ${systemMessageBackgroundColor};
   border: 1px solid ${systemMessageBorderColor};
-  border-radius: 0.2rem;
+  border-radius: ${borderRadius};
   font-weight: ${btnFontWeight};
   padding: ${fontSizeBase};
   text-color: #1f252b;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -4,7 +4,7 @@ import {
   systemMessageBorderColor,
   colorText,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { borderRadius } from 'imports/ui/stylesheets/styled-components/general';
+import { borderRadius } from '/imports/ui/stylesheets/styled-components/general';
 import { fontSizeBase, btnFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
 
 interface ChatMessageProps {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the border radius in system messages being different from one another.

### How to test

I don't believe this needs real testing, just by observing the changes it is possible to see the changes.

### Before changes 

![image](https://github.com/user-attachments/assets/9e096546-4fbd-426b-993c-62ebc118a460)

### After changes

![image](https://github.com/user-attachments/assets/eb017e51-e448-4bfe-9873-343da2e92dd8)


