### PR TITLE
test: Add webcam fullscreen test in CI

### DIFF
--- a/bigbluebutton-tests/playwright/webcam/webcam.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.js
@@ -84,6 +84,7 @@ class Webcam extends Page {
     });
     await this.waitAndClick(e.dropdownWebcamButton);
     await this.waitAndClick(e.webcamsFullscreenButton);
+    await sleep(1500);  // enforce a delay to ensure the webcam is in fullscreen
     // get fullscreen webcam size
     const { width, height } = await this.getLocator('video').boundingBox();
     await expect(width + 1, 'should the width to be the same as window width').toBe(windowWidth);  // not sure why there is a difference of 1 pixel

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -36,7 +36,7 @@ test.describe.parallel('Webcam', () => {
     await webcam.changeVideoQuality();
   });
 
-  test('Webcam fullscreen', async ({ browser, page }) => {
+  test('Webcam fullscreen', { tag: '@ci' }, async ({ browser, page }) => {
     const webcam = new Webcam(browser, page);
     await webcam.init(true, true);
     await webcam.webcamFullscreen();


### PR DESCRIPTION
### What does this PR do?
I recently noticed during testing that this test was unstable due to asserting too quickly after applying the webcam full screen, which could cause unexpected results. This PR adds a timeout before the assertion + enables the test in the CI