### PR TITLE
style: improve long username display in userlist and breakout creation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/styles.ts
@@ -52,7 +52,7 @@ const ContentContainer = styled.div`
   display: grid;
   grid-template-columns: 1fr 2fr;
   grid-template-areas: "sidebar content";
-  grid-gap: 1.5rem;
+  grid-gap: 1rem;
 `;
 
 const Alert = styled.div<withValidProp>`
@@ -104,7 +104,7 @@ const BreakoutNameInput = styled.input`
 `;
 
 const BreakoutBox = styled(ScrollboxVertical)<BreakoutBoxProps>`
-  width: 100%;
+  max-width: 13rem;
   height: 10rem;
   border: 1px solid ${colorGrayLightest};
   border-radius: ${borderRadius};
@@ -272,7 +272,6 @@ const FreeJoinCheckbox = styled.input`
 const RoomUserItem = styled.p`
   margin: 0;
   padding: .25rem 0 .25rem .25rem;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -135,6 +135,7 @@ const Avatar = styled.div<AvatarProps>`
   position: relative;
   height: 2.25rem;
   width: 2.25rem;
+  min-width: 2.25rem;
   border-radius: 50%;
   text-align: center;
   font-size: .85rem;
@@ -367,6 +368,7 @@ const UserNameContainer = styled.div`
   margin: 0 0 0 ${smPaddingX};
   justify-content: center;
   font-size: 90%;
+  max-width: 70%;
 
   [dir="rtl"]  & {
     margin: 0 ${smPaddingX} 0 0;


### PR DESCRIPTION
### What does this PR do?

Adjusts userlist and breakout creation modal so layout does not break if a participant joins with a long name

#### before
breakout creation modal:
![breakout-before](https://github.com/user-attachments/assets/f2e7f7ad-8f15-4eb6-bfac-b439357fab2f)

userlist:
![userlist-before](https://github.com/user-attachments/assets/2d75d038-3979-40e6-9ff6-04b0d6b89c01)


#### after

breakout creation modal:
![breakout-after](https://github.com/user-attachments/assets/d947bca4-5b80-44dd-849d-dacfa3168c20)

userlist:
![userlist-after](https://github.com/user-attachments/assets/8ce1fab3-a914-4284-a39b-68f07d5f0f0f)

### Closes Issue(s)
Closes #19900

### How to test

1. Create a User with a long combination of first name and last name (e.g.: fridolin max winfried manfred joachim Mueller Meier Schmitz)
2. join with a user with short name
3. Check if the user avatar size in userlist is different for the user with a long name
4. Create new Breakout-Rooms under Settings
5. Assign the user to a room manually
6. Watch the assignment fields of each room change
