### PR TITLE
fix(audio): Returning from breakout does not always rejoin you in main room audio

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/hooks.ts
@@ -2,26 +2,26 @@ import {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import { useSubscription } from '@apollo/client';
-import { GetIfUserJoinedBreakoutRoomResponse, getIfUserJoinedBreakoutRoom } from '../../breakout-room/breakout-room/queries';
+import { GetIsUserCurrentlyInBreakoutRoomResponse, getIsUserCurrentlyInBreakoutRoom } from '../../breakout-room/breakout-room/queries';
 
-type BreakoutCount = GetIfUserJoinedBreakoutRoomResponse;
+type BreakoutCount = GetIsUserCurrentlyInBreakoutRoomResponse;
 type Callback = () => void;
 
 const useBreakoutExitObserver = () => {
-  const [joinedRooms, setJoinedRooms] = useState<number>(0);
+  const [numberOfCurrentRooms, setNumberOfCurrentRooms] = useState<number>(0);
   const [observing, setObserving] = useState(false);
   const callbacks = useRef<Map<string, Callback>>(new Map());
   const oneTimeCallbacks = useRef<Callback[]>([]);
-  const { data: userJoinedBreakoutData } = useSubscription<BreakoutCount>(
-    getIfUserJoinedBreakoutRoom,
+  const { data: userIsCurrentlyInBreakoutRoomData } = useSubscription<BreakoutCount>(
+    getIsUserCurrentlyInBreakoutRoom,
     { skip: !observing },
   );
-  const userJoinedRooms = userJoinedBreakoutData?.breakoutRoom_aggregate.aggregate.count ?? 0;
+  const numberOfCurrentRoomsGql = userIsCurrentlyInBreakoutRoomData?.breakoutRoom_aggregate.aggregate.count ?? 0;
 
   useEffect(() => {
-    if (userJoinedRooms !== joinedRooms) {
-      setJoinedRooms((prev) => {
-        if (userJoinedRooms === 0 && prev > 0) {
+    if (numberOfCurrentRoomsGql !== numberOfCurrentRooms) {
+      setNumberOfCurrentRooms((prevNumberOfCurrentRooms) => {
+        if (numberOfCurrentRoomsGql === 0 && prevNumberOfCurrentRooms > 0) {
           callbacks.current.forEach((value) => value());
           oneTimeCallbacks.current.forEach((c) => c());
           oneTimeCallbacks.current = [];
@@ -29,10 +29,10 @@ const useBreakoutExitObserver = () => {
             setObserving(false);
           }
         }
-        return userJoinedRooms;
+        return numberOfCurrentRoomsGql;
       });
     }
-  }, [userJoinedRooms]);
+  }, [numberOfCurrentRoomsGql]);
 
   return useMemo(() => ({
     resetCallbacks: () => {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/queries.ts
@@ -25,7 +25,7 @@ export interface GetBreakoutDataResponse {
   breakoutRoom: BreakoutRoom[];
 }
 
-export interface GetIfUserJoinedBreakoutRoomResponse {
+export interface GetIsUserCurrentlyInBreakoutRoomResponse {
   breakoutRoom_aggregate:{
   aggregate: {
     count: number;
@@ -58,8 +58,8 @@ export const getBreakoutData = gql`
   }
 `;
 
-export const getIfUserJoinedBreakoutRoom = gql`
-  subscription getIdUserJoinedABreakout {
+export const getIsUserCurrentlyInBreakoutRoom = gql`
+  subscription getIsUserCurrentlyInBreakoutRoom {
     breakoutRoom_aggregate(where: {isUserCurrentlyInRoom: {_eq: true}}) {
       aggregate {
         count
@@ -70,5 +70,5 @@ export const getIfUserJoinedBreakoutRoom = gql`
 
 export default {
   getBreakoutData,
-  getIfUserJoinedBreakoutRoom,
+  getIsUserCurrentlyInBreakoutRoom,
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/queries.ts
@@ -60,7 +60,7 @@ export const getBreakoutData = gql`
 
 export const getIfUserJoinedBreakoutRoom = gql`
   subscription getIdUserJoinedABreakout {
-    breakoutRoom_aggregate(where: {hasJoined: {_eq: true}}) {
+    breakoutRoom_aggregate(where: {isUserCurrentlyInRoom: {_eq: true}}) {
       aggregate {
         count
       }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

FIxes a bug where the audio does not reconnect automatically on breakout room exit. The main room relies on the `hasJoined` field of the `breakoutRoom` subscription to check when the user left the breakout room. However, that flag is `true` for some users, `false` for others (bug?). `isUserCurrentlyInRoom` seems to be a more consistent flag as of https://github.com/bigbluebutton/bigbluebutton/pull/20475.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21044

### More

How to reproduce the bug:

1. Join a session with 8 users (1 moderator and 7 viewers, for example).
2. Join full audio on all of them and keep all unmuted.
3. Create breakout rooms and assign all users.
4. Join the breakout rooms for all users.
5. As moderator, end the breakout rooms.
6. See just a few users rejoin in main room audio, most of them fail to rejoin.