### PR TITLE
Usability: Changing push to talk cooldown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -65,7 +65,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
   const cooldownActive = useRef<boolean>(false);
   const cooldownTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const COOLDOWN_TIME = 1500;
+  const COOLDOWN_TIME = 800;
 
   const handlePushToTalk = useCallback((action: 'down' | 'up', event: KeyboardEvent) => {
     const activeElement = document.activeElement as HTMLElement | null;


### PR DESCRIPTION
### What does this PR do?

This PR reduces the cooldown for the push-to-talk feature to address instances where reactivating the microphone takes too long after the initial use.

### Motivation

During daily meetings, some users have reported experiencing delays when re-activating their microphones.


### How to test

I don't believe the changes require testing, but testing the microphone re-activation time and suggesting more comfortable numbers could improve the overall user experience with this feature.
