### PR TITLE
Fix: Conference PIN (phone dial-in) doesn't show the needed pound sign in popup

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
@@ -49,7 +49,7 @@ class AudioDial extends React.PureComponent {
         <Styled.ConferenceText>
           {intl.formatMessage(intlMessages.audioDialConfrenceText)}
         </Styled.ConferenceText>
-        <Styled.Telvoice>{formattedTelVoice}</Styled.Telvoice>
+        <Styled.Telvoice>{`#${formattedTelVoice}`}</Styled.Telvoice>
         <Styled.TipBox>
           <Styled.TipIndicator>
             {`${intl.formatMessage(intlMessages.tipIndicator)}: `}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
@@ -49,7 +49,7 @@ class AudioDial extends React.PureComponent {
         <Styled.ConferenceText>
           {intl.formatMessage(intlMessages.audioDialConfrenceText)}
         </Styled.ConferenceText>
-        <Styled.Telvoice>{`#${formattedTelVoice}`}</Styled.Telvoice>
+        <Styled.Telvoice>{`${formattedTelVoice} #`}</Styled.Telvoice>
         <Styled.TipBox>
           <Styled.TipIndicator>
             {`${intl.formatMessage(intlMessages.tipIndicator)}: `}


### PR DESCRIPTION
### What does this PR do?

this PR ads the # as trailing sign in dial in modal for conference pin

### Closes Issue(s)

#20956

### How to test

To test it you can either use dial in to join audio or disable the condition for the modal to appear making it visible and in doing so being able to see the trailing sign.


