### PR TITLE
docs: clarify transparentListenOnly::true behavior

### DIFF
--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -21,9 +21,10 @@ We have done significant work to adopt the newly released version 2 of tl;draw. 
 
 #### Improved UX for joining audio for transparentListenOnly
 
-If `transparentListenOnly` is enabled on the server, when you try to join audio in a session you will no longer be asked to choose between joining with a microphone or in ListenOnly mode.
+When transparentListenOnly is enabled on the server, users can now switch seamlessly between Listen Only and Microphone modes without needing to rejoin audio.
 
-Instead, you are presented directly with the echo test and audio options.
+To further improve the user experience, you can disable listenOnlyMode (`public.app.listenOnlyMode` in `/etc/bigbluebutton/bbb-html5.yml` or `userdata-bbb_listen_only_mode`). 
+This removes the need to choose between Microphone or Listen Only mode when joining audio in a session. Instead, you are taken directly to the audio configuration screen.
 
 ![audio controls when joining audio](/img/30/30-ui-join-audio.png)
 


### PR DESCRIPTION
### What does this PR do?

- [docs: clarify transparentListenOnly::true behavior](https://github.com/bigbluebutton/bigbluebutton/commit/6647a982c1bacc1ef022ace4baaa2c969a674597) 
  - The changes in https://github.com/bigbluebutton/bigbluebutton/pull/20782
do not mean that enabling `transparentListenOnly: true` sets `listenOnlyMode: false`.
I.e., the user prompt to choose between mic or listen-only still exists. Instead, it
allows users to seamlessly switch between modes without rejoining audio.
  - While the goal is for `transparentListenOnly: true` to eventually imply `listenOnlyMode:
false`, the default audio activation behavior is still under review by the UI team, and
the current default remains unchanged.
  - This commit updates the "What's New" documentation to reflect these points correctly.

### Closes Issue(s)

None

### Motivation

Follow up to https://github.com/bigbluebutton/bigbluebutton/pull/21104