### PR TITLE
feat (port from 2.7): Add `userLockSettings` to allow `disablePublicChat` for individual users (backend portion only)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -26,11 +26,16 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
 
     val chatDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("chat")
     var chatLocked: Boolean = false
+    var chatLockedForUser: Boolean = false
 
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
       groupChat <- state.groupChats.find(msg.body.chatId)
     } yield {
+      if (groupChat.access == GroupChatAccess.PUBLIC && user.userLockSettings.disablePublicChat) {
+        chatLockedForUser = true
+      }
+
       if (user.role != Roles.MODERATOR_ROLE && user.locked) {
         val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
         if (groupChat.access == GroupChatAccess.PRIVATE) {
@@ -48,7 +53,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
       }
     }
 
-    if (!chatDisabled && !(applyPermissionCheck && chatLocked)) {
+    if (!chatDisabled && !(applyPermissionCheck && chatLocked) && !chatLockedForUser) {
       val newState = for {
         sender <- GroupChatApp.findGroupChatUser(msg.header.userId, liveMeeting.users2x)
         chat <- state.groupChats.find(msg.body.chatId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -44,6 +44,7 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
       )
 
       if (!(user.role == Roles.VIEWER_ROLE && user.locked && permissions.disablePubChat)
+        && !user.userLockSettings.disablePublicChat
         && ((user.away && !msg.body.away) || (!user.away && msg.body.away))) {
         ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.USER_AWAY_STATUS_MSG, msgMeta, user.name)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserLockSettingsInMeetingCmdMsgHdlr.scala
@@ -1,0 +1,44 @@
+package org.bigbluebutton.core.apps.users
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.{ UserLockSettings, Users2x, VoiceUsers }
+import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+
+trait ChangeUserLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
+  this: MeetingActor =>
+
+  val outGW: OutMsgRouter
+
+  def handleChangeUserLockSettingsInMeetingCmdMsg(msg: ChangeUserLockSettingsInMeetingCmdMsg) {
+
+    def build(meetingId: String, userId: String, disablePubChat: Boolean, setBy: String): BbbCommonEnvCoreMsg = {
+      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+      val envelope = BbbCoreEnvelope(UserLockSettingsInMeetingChangedEvtMsg.NAME, routing)
+      val body = UserLockSettingsInMeetingChangedEvtMsgBody(userId, disablePubChat = disablePubChat, setBy = setBy)
+      val header = BbbClientMsgHeader(UserLockSettingsInMeetingChangedEvtMsg.NAME, meetingId, userId)
+      val event = UserLockSettingsInMeetingChangedEvtMsg(header, body)
+
+      BbbCommonEnvCoreMsg(envelope, event)
+    }
+
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to lock user chat in meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+    } else {
+      log.info("Lock user chat. meetingId=" + props.meetingProp.intId + " userId=" + msg.body.userId + " disablePubChat=" + msg.body.disablePubChat)
+
+      val updatedUserLockSettings = UserLockSettings(disablePublicChat = msg.body.disablePubChat)
+
+      for {
+        user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+        _ <- Users2x.setUserLockSettings(liveMeeting.users2x, user.intId, updatedUserLockSettings)
+      } yield {
+        val event = build(props.meetingProp.intId, msg.body.userId, msg.body.disablePubChat, msg.body.setBy)
+        outGW.send(event)
+      }
+
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp2x.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.running.MeetingActor
 trait UsersApp2x
   extends UserLeaveReqMsgHdlr
   with LockUserInMeetingCmdMsgHdlr
+  with ChangeUserLockSettingsInMeetingCmdMsgHdlr
   with LockUsersInMeetingCmdMsgHdlr
   with ClearAllUsersReactionCmdMsgHdlr {
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -1,5 +1,5 @@
 package org.bigbluebutton.core.db
-import org.bigbluebutton.core.models.{RegisteredUser, VoiceUserState}
+import org.bigbluebutton.core.models.{RegisteredUser, UserLockSettings, VoiceUserState}
 import slick.jdbc.PostgresProfile.api._
 
 case class UserDbModel(
@@ -90,6 +90,7 @@ object UserDAO {
 
     UserConnectionStatusDAO.insert(meetingId, regUser.id)
     UserMetadataDAO.insert(meetingId, regUser.id, regUser.userMetadata)
+    UserLockSettingsDAO.insertOrUpdate(meetingId, regUser.id, UserLockSettings())
     UserClientSettingsDAO.insertOrUpdate(meetingId, regUser.id, JsonUtils.stringToJson("{}"))
     ChatUserDAO.insertUserPublicChat(meetingId, regUser.id)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserLockSettingsDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserLockSettingsDAO.scala
@@ -1,0 +1,34 @@
+package org.bigbluebutton.core.db
+
+import org.bigbluebutton.core.models.UserLockSettings
+import slick.jdbc.PostgresProfile.api._
+import slick.lifted.ProvenShape
+
+case class UserLockSettingsDbModel(
+    meetingId:              String,
+    userId:                 String,
+    disablePublicChat:      Boolean,
+)
+
+class UserLockSettingsDbTableDef(tag: Tag) extends Table[UserLockSettingsDbModel](tag, "user_lockSettings") {
+  val meetingId = column[String]("meetingId", O.PrimaryKey)
+  val userId = column[String]("userId", O.PrimaryKey)
+  val disablePublicChat = column[Boolean]("disablePublicChat")
+
+  override def * : ProvenShape[UserLockSettingsDbModel] = (meetingId, userId, disablePublicChat) <> (UserLockSettingsDbModel.tupled, UserLockSettingsDbModel.unapply)
+}
+
+object UserLockSettingsDAO {
+  def insertOrUpdate(meetingId: String, userId: String, userLockSettings: UserLockSettings) = {
+    DatabaseConnection.enqueue(
+      TableQuery[UserLockSettingsDbTableDef].insertOrUpdate(
+        UserLockSettingsDbModel(
+          meetingId = meetingId,
+          userId = userId,
+          disablePublicChat = userLockSettings.disablePublicChat,
+        ),
+      )
+    )
+  }
+
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.models
 
 import com.softwaremill.quicklens._
-import org.bigbluebutton.core.db.{ UserDAO, UserReactionDAO, UserStateDAO }
+import org.bigbluebutton.core.db.{ UserDAO, UserLockSettingsDAO, UserReactionDAO, UserStateDAO }
 import org.bigbluebutton.core.util.TimeUtil
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -241,6 +241,17 @@ object Users2x {
     }
   }
 
+  def setUserLockSettings(users: Users2x, intId: String, userLockSettings: UserLockSettings): Option[UserState] = {
+    for {
+      u <- findWithIntId(users, intId)
+    } yield {
+      val newUser = u.modify(_.userLockSettings).setTo(userLockSettings)
+      UserLockSettingsDAO.insertOrUpdate(u.meetingId, u.intId, userLockSettings)
+      users.save(newUser)
+      newUser
+    }
+  }
+
   def setUserSpeechLocale(users: Users2x, intId: String, locale: String): Option[UserState] = {
     for {
       u <- findWithIntId(users, intId)
@@ -413,6 +424,8 @@ case class OldPresenter(userId: String, changedPresenterOn: Long)
 
 case class UserLeftFlag(left: Boolean, leftOn: Long)
 
+case class UserLockSettings(disablePublicChat: Boolean = false)
+
 case class UserState(
     intId:                 String,
     extId:                 String,
@@ -440,8 +453,8 @@ case class UserState(
     userLeftFlag:          UserLeftFlag,
     speechLocale:          String              = "",
     captionLocale:         String              = "",
-    userMetadata:          Map[String, String] = Map.empty
-
+    userMetadata:          Map[String, String] = Map.empty,
+    userLockSettings:      UserLockSettings    = UserLockSettings()
 )
 
 case class UserIdAndName(id: String, name: String)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -372,6 +372,8 @@ class ReceivedJsonMsgHandlerActor(
       // Lock settings
       case LockUserInMeetingCmdMsg.NAME =>
         routeGenericMsg[LockUserInMeetingCmdMsg](envelope, jsonNode)
+      case ChangeUserLockSettingsInMeetingCmdMsg.NAME =>
+        routeGenericMsg[ChangeUserLockSettingsInMeetingCmdMsg](envelope, jsonNode)
       case ChangeLockSettingsInMeetingCmdMsg.NAME =>
         routeGenericMsg[ChangeLockSettingsInMeetingCmdMsg](envelope, jsonNode)
       case LockUsersInMeetingCmdMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -590,6 +590,9 @@ class MeetingActor(
       case m: LockUserInMeetingCmdMsg =>
         handleLockUserInMeetingCmdMsg(m)
         updateUserLastActivity(m.body.lockedBy)
+      case m: ChangeUserLockSettingsInMeetingCmdMsg =>
+        handleChangeUserLockSettingsInMeetingCmdMsg(m)
+        updateUserLastActivity(m.body.setBy)
       case m: LockUsersInMeetingCmdMsg =>
         handleLockUsersInMeetingCmdMsg(m)
         updateUserLastActivity(m.body.lockedBy)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -303,6 +303,23 @@ case class LockUsersInMeetingCmdMsg(header: BbbClientMsgHeader, body: LockUsersI
 case class LockUsersInMeetingCmdMsgBody(lock: Boolean, lockedBy: String, except: Vector[String])
 
 /**
+ * Sent by client to set user lock setting.
+ */
+object ChangeUserLockSettingsInMeetingCmdMsg { val NAME = "ChangeUserLockSettingsInMeetingCmdMsg" }
+case class ChangeUserLockSettingsInMeetingCmdMsg(
+    header: BbbClientMsgHeader,
+    body:   ChangeUserLockSettingsInMeetingCmdMsgBody
+) extends StandardMsg
+case class ChangeUserLockSettingsInMeetingCmdMsgBody(userId: String, disablePubChat: Boolean, setBy: String)
+
+object UserLockSettingsInMeetingChangedEvtMsg { val NAME = "UserLockSettingsInMeetingChangedEvtMsg" }
+case class UserLockSettingsInMeetingChangedEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   UserLockSettingsInMeetingChangedEvtMsgBody
+) extends BbbCoreMsg
+case class UserLockSettingsInMeetingChangedEvtMsgBody(userId: String, disablePubChat: Boolean, setBy: String)
+
+/**
  * Sent by client to set lock setting.
  */
 object ChangeLockSettingsInMeetingCmdMsg { val NAME = "ChangeLockSettingsInMeetingCmdMsg" }

--- a/bbb-graphql-actions/src/actions/userSetUserLockSettings.ts
+++ b/bbb-graphql-actions/src/actions/userSetUserLockSettings.ts
@@ -1,0 +1,33 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotModerator(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'userId', type: 'string', required: true},
+        {name: 'disablePubChat', type: 'boolean', required: true},
+      ]
+  )
+
+  const eventName = `ChangeUserLockSettingsInMeetingCmdMsg`;
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = { 
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    setBy: routing.userId,
+    userId: input.userId,
+    disablePubChat: input.disablePubChat,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -530,6 +530,18 @@ CASE WHEN u."role" = 'MODERATOR' THEN w."welcomeMsgForModerators" ELSE NULL END 
 FROM "user" u
 join meeting_welcome w USING("meetingId");
 
+create table "user_lockSettings" (
+    "meetingId"             varchar(100),
+    "userId"                varchar(50),
+    "disablePublicChat"     boolean,
+    CONSTRAINT "user_lockSettings_pkey" PRIMARY KEY ("meetingId", "userId"),
+    FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
+);
+create index "idx_user_lockSettings_pk_reverse" on "user_lockSettings"("userId", "meetingId");
+
+CREATE VIEW "v_user_lockSettings" AS
+SELECT *
+FROM "user_lockSettings";
 
 CREATE TABLE "user_voice" (
     "meetingId" varchar(100),

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -605,6 +605,13 @@ type Mutation {
 }
 
 type Mutation {
+  userSetUserLockSettings(
+    userId: String!
+    disablePubChat: Boolean!
+  ): Boolean
+}
+
+type Mutation {
   userThirdPartyInfoResquest(
     externalUserId: String!
   ): Boolean

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -547,6 +547,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: userSetUserLockSettings
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: userThirdPartyInfoResquest
     definition:
       kind: synchronous

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -34,6 +34,16 @@ object_relationships:
         remote_table:
           name: v_meeting
           schema: public
+  - name: userLockSettings
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_lockSettings
+          schema: public
   - name: voice
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -70,6 +70,16 @@ object_relationships:
         remote_table:
           name: v_user_clientSettings
           schema: public
+  - name: userLockSettings
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_lockSettings
+          schema: public
   - name: userMetadata
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_lockSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_lockSettings.yaml
@@ -1,0 +1,23 @@
+table:
+  name: v_user_lockSettings
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_lockSettings
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - disablePublicChat
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - _or:
+              - userId:
+                  _eq: X-Hasura-UserId
+              - meetingId:
+                  _eq: X-Hasura-ModeratorInMeeting
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -52,6 +52,7 @@
 - "!include public_v_user_connectionStatusReport.yaml"
 - "!include public_v_user_current.yaml"
 - "!include public_v_user_guest.yaml"
+- "!include public_v_user_lockSettings.yaml"
 - "!include public_v_user_metadata.yaml"
 - "!include public_v_user_reaction.yaml"
 - "!include public_v_user_ref.yaml"


### PR DESCRIPTION
Add `userLockSettings` to allow `disablePublicChat` for individual users

This PR introduces `userLockSettings`, which includes an option to set `disablePublicChat` for specific users, rather than only for all locked viewers as before. This implementation covers the backend and GraphQL portions; the frontend changes will be addressed in a separate PR. 

This is a port of #20585, originally implemented for version 2.7 using the old architecture with MongoDB.

- Mutation to set `user.userLockSettings.disablePubChat`:
```gql
mutation($disablePubChat: Boolean!, $userId: String!) {
  userSetUserLockSettings(disablePubChat: $disablePubChat, userId: $userId)
}
```

- Subscription `user`
```gql
subscription {
  user {
    userId
    userLockSettings {
      disablePublicChat
    }
  }
}
```

- Subscription `user_current`
```gql
subscription {
  user_current {
    userId
    userLockSettings {
      disablePublicChat
    }
  }
}
```