### PR TITLE
fix(audio): local echo not tracking output device changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -508,7 +508,11 @@ class AudioSettings extends React.Component {
           {!withEcho ? (
             <AudioTestContainer id="audioTest" />
           ) : (
-            <LocalEchoContainer intl={intl} stream={stream} />
+            <LocalEchoContainer
+              intl={intl}
+              outputDeviceId={outputDeviceId}
+              stream={stream}
+            />
           )}
         </Styled.LabelSmall>
         {this.renderAudioCaptionsSelector()}

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/component.jsx
@@ -17,6 +17,8 @@ const propTypes = {
   deattachEchoStream: PropTypes.func.isRequired,
   shouldUseRTCLoopback: PropTypes.func.isRequired,
   createAudioRTCLoopback: PropTypes.func.isRequired,
+  outputDeviceId: PropTypes.string,
+  setAudioSink: PropTypes.func.isRequired,
 };
 
 const intlMessages = defineMessages({
@@ -38,6 +40,8 @@ const LocalEcho = ({
   deattachEchoStream,
   shouldUseRTCLoopback,
   createAudioRTCLoopback,
+  outputDeviceId,
+  setAudioSink,
 }) => {
   const loopbackAgent = useRef(null);
   const [hearing, setHearing] = useState(initialHearingState);
@@ -69,6 +73,10 @@ const LocalEcho = ({
   useEffect(() => {
     applyHearingState(stream);
   }, [stream, hearing]);
+
+  useEffect(() => {
+    if (outputDeviceId) setAudioSink(outputDeviceId);
+  }, [outputDeviceId]);
 
   return (
     <Styled.LocalEchoTestButton

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/container.jsx
@@ -16,6 +16,7 @@ const LocalEchoContainer = (props) => {
       deattachEchoStream={LocalEchoService.deattachEchoStream}
       shouldUseRTCLoopback={LocalEchoService.shouldUseRTCLoopback}
       createAudioRTCLoopback={LocalEchoService.createAudioRTCLoopback}
+      setAudioSink={LocalEchoService.setAudioSink}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
@@ -1,5 +1,6 @@
 import LocalPCLoopback from '/imports/ui/services/webrtc-base/local-pc-loopback';
 import browserInfo from '/imports/utils/browserInfo';
+import logger from '/imports/startup/client/logger';
 
 const LOCAL_MEDIA_TAG = '#local-media';
 
@@ -125,9 +126,27 @@ const playEchoStream = async (stream, loopbackAgent = null) => {
   }
 };
 
+const setAudioSink = (deviceId) => {
+  const audioElement = document.querySelector(LOCAL_MEDIA_TAG);
+
+  if (audioElement.setSinkId) {
+    audioElement.setSinkId(deviceId).catch((error) => {
+      logger.warn({
+        logCode: 'localecho_output_change_error',
+        extraInfo: {
+          errorName: error?.name,
+          errorMessage: error?.message,
+          deviceId,
+        },
+      }, `Error setting audio sink in local echo test: ${error?.name}`);
+    });
+  }
+};
+
 export default {
   shouldUseRTCLoopback,
   createAudioRTCLoopback,
   deattachEchoStream,
   playEchoStream,
+  setAudioSink,
 };


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): local echo not tracking output device changes](https://github.com/bigbluebutton/bigbluebutton/pull/21121/commits/9070a651ec731920819e636adcbd53a4cae1c1fb) 
  * Commit 325887e32535d2aa09265af7d1c511c3f60bc2b8 split the local echo audio
element from the main audio element to allow concurrent playback without the
risk of interfering with one another.
  * This introduced a regression where local echo doesn't track output device
changes. The main audio element (i.e. the meeting's audio) is not affected by
this regression.
  * This commit ensures local echo reacts to output device changes as needed.

### Closes Issue(s)

None

### Motivation

Follow up to #20782 


### How to test

- Open the audio settings modal
- Change output devices while checking audio feedback