### PR TITLE
feat (port from 2.7): Add userLockSettings to allow disablePublicChat for individual users (frontend portion)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -32,7 +32,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
       groupChat <- state.groupChats.find(msg.body.chatId)
     } yield {
-      if (groupChat.access == GroupChatAccess.PUBLIC && user.userLockSettings.disablePublicChat) {
+      if (groupChat.access == GroupChatAccess.PUBLIC && user.userLockSettings.disablePublicChat && user.role != Roles.MODERATOR_ROLE) {
         chatLockedForUser = true
       }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -44,7 +44,7 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
       )
 
       if (!(user.role == Roles.VIEWER_ROLE && user.locked && permissions.disablePubChat)
-        && !user.userLockSettings.disablePublicChat
+        && (!user.userLockSettings.disablePublicChat || user.role == Roles.MODERATOR_ROLE)
         && ((user.away && !msg.body.away) || (!user.away && msg.body.away))) {
         ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.USER_AWAY_STATUS_MSG, msgMeta, user.name)
       }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -539,9 +539,13 @@ create table "user_lockSettings" (
 );
 create index "idx_user_lockSettings_pk_reverse" on "user_lockSettings"("userId", "meetingId");
 
-CREATE VIEW "v_user_lockSettings" AS
-SELECT *
-FROM "user_lockSettings";
+CREATE VIEW "v_user_lockSettings" as
+SELECT
+l."meetingId",
+l."userId",
+case when "user"."isModerator" then false else l."disablePublicChat" end "disablePublicChat"
+FROM "user_lockSettings" l
+join "user" on "user"."meetingId" = l."meetingId" and "user"."userId" = l."userId";
 
 CREATE TABLE "user_voice" (
     "meetingId" varchar(100),

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -64,6 +64,10 @@ export interface BreakoutRooms {
   startedAt: string;
 }
 
+export interface userLockSettings {
+  disablePublicChat: boolean;
+}
+
 export interface User {
   authToken: string;
   userId: string;
@@ -109,4 +113,5 @@ export interface User {
   away: boolean;
   raiseHand: boolean;
   breakoutRooms: BreakoutRooms;
+  userLockSettings: userLockSettings;
 }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -521,6 +521,7 @@ const ChatMessageFormContainer: React.FC = ({
 
   const { data: currentUser } = useCurrentUser((c) => ({
     isModerator: c?.isModerator,
+    userLockSettings: c?.userLockSettings,
     locked: c?.locked,
   }));
 
@@ -534,8 +535,9 @@ const ChatMessageFormContainer: React.FC = ({
 
   const isModerator = currentUser?.isModerator;
   const isPublicChat = chat?.public;
-  const isLocked = currentUser?.locked;
-  const disablePublicChat = meeting?.lockSettings?.disablePublicChat;
+  const isLocked = currentUser?.locked || currentUser?.userLockSettings?.disablePublicChat;
+  const disablePublicChat = meeting?.lockSettings?.disablePublicChat
+    || currentUser?.userLockSettings?.disablePublicChat;
   const disablePrivateChat = meeting?.lockSettings?.disablePrivateChat;
 
   let locked = false;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
@@ -108,9 +108,10 @@ const TypingIndicatorContainer: React.FC = () => {
   const intl = useIntl();
   const { data: currentUser } = useCurrentUser((user: Partial<User>) => {
     return {
-      userId: user.userId,
-      isModerator: user.isModerator,
-      locked: user.locked,
+      userId: user?.userId,
+      isModerator: user?.isModerator,
+      locked: user?.locked,
+      userLockSettings: user?.userLockSettings,
     };
   });
   // eslint-disable-next-line no-unused-expressions, no-console
@@ -127,10 +128,11 @@ const TypingIndicatorContainer: React.FC = () => {
     lockSettings: m?.lockSettings,
   }));
 
-  const isLocked = currentUser?.locked;
+  const isLocked = currentUser?.locked || currentUser?.userLockSettings?.disablePublicChat;
   const isModerator = currentUser?.isModerator;
   const isPublicChat = chat?.public;
-  const disablePublicChat = meeting?.lockSettings?.disablePublicChat;
+  const disablePublicChat = meeting?.lockSettings?.disablePublicChat
+    || currentUser?.userLockSettings?.disablePublicChat;
   const disablePrivateChat = meeting?.lockSettings?.disablePrivateChat;
 
   let locked = false;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -121,7 +121,8 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
   if (user.mobile && LABEL.mobile) {
     subs.push(intl.formatMessage(messages.mobile));
   }
-  if (user.locked && lockSettings?.hasActiveLockSetting && !user.isModerator) {
+  if ((user.locked || user.userLockSettings?.disablePublicChat)
+      && (user.userLockSettings?.disablePublicChat || lockSettings?.hasActiveLockSetting) && !user.isModerator) {
     subs.push(
       <span key={uniqueId('lock-')}>
         <Icon iconName="lock" />

--- a/bigbluebutton-html5/imports/ui/core/graphql/mutations/userMutations.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/mutations/userMutations.ts
@@ -99,6 +99,15 @@ export const USER_LEAVE_MEETING = gql`
   }
 `;
 
+export const SET_USER_CHAT_LOCKED = gql`
+  mutation UserSetChatLocked($disablePubChat: Boolean!, $userId: String!) {
+    userSetUserLockSettings(
+      userId: $userId,
+      disablePubChat: $disablePubChat,
+    )
+  }
+`;
+
 export default {
   SET_CAMERA_PINNED,
   SET_RAISE_HAND,
@@ -111,4 +120,5 @@ export default {
   SET_EXIT_REASON,
   SET_SPEECH_LOCALE,
   USER_LEAVE_MEETING,
+  SET_USER_CHAT_LOCKED,
 };

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -71,6 +71,9 @@ subscription userCurrentSubscription {
       spoke
       listenOnly
     }
+    userLockSettings {
+      disablePublicChat
+    }
   }
 }
 `;

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -53,6 +53,9 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
       shortName
       currentlyInRoom
     }
+    userLockSettings {
+      disablePublicChat
+    }
   }
 }`;
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -173,6 +173,8 @@
     "app.userList.menu.lockUser.label": "Lock {0}",
     "app.userList.menu.directoryLookup.label": "Directory Lookup",
     "app.userList.menu.makePresenter.label": "Make presenter",
+    "app.userList.menu.lockPublicChat.label": "Lock public chat",
+    "app.userList.menu.unlockPublicChat.label": "Unlock public chat",
     "app.userList.userOptions.manageUsersLabel": "Manage users",
     "app.userList.userOptions.muteAllLabel": "Mute all users",
     "app.userList.userOptions.muteAllDesc": "Mutes all users in the session",


### PR DESCRIPTION
### What does this PR do?

Implements the frontend portion of #21117, allowing disablePublicChat for individual users and tweaks backend validation so the flag is ignored for moderators.

### Closes Issue(s)
Closes #20825

### How to test

1. join a meeting with a moderator and a viewer
2. moderator opens the userlist dropdown for the viewer and selects "lock public chat"
3. viewer public chat is locked