### PR TITLE
Ease in loading anim

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -337,7 +337,7 @@ const ButtonWrapper = styled(BaseButton)`
     border-radius: 50%;
     border: 2px solid white;
     border-top-color: transparent;
-    animation: spin 1.5s linear infinite;
+    animation: spin 1.5s ease-in infinite;
   }
   @keyframes spin {
     0% {

--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -337,10 +337,14 @@ const ButtonWrapper = styled(BaseButton)`
     border-radius: 50%;
     border: 2px solid white;
     border-top-color: transparent;
-    animation: spin 1.5s ease-in infinite;
+    animation: spin 1.5s ease infinite;
   }
   @keyframes spin {
     0% {
+        opacity: 0;
+    }
+    33% {
+        opacity: 1;
         transform: rotate(0deg);
     }
     100% {


### PR DESCRIPTION
### What does this PR do?

This PR is simply an ease-in to the loading of buttons, due to the animations starting and ending too fast on low latency environments the user could be under the impression it was a visual bug.  This PR also will make the animation start after 500ms of clicking the button, making it smoother on lower latencies.

### Closes Issue(s)

Doesn't close any issues but it's a reference to a change requested in PR [20918](https://github.com/bigbluebutton/bigbluebutton/pull/20918)


