### PR TITLE
build: Upgrade LibreOffice to 24.08.0.3

### DIFF
--- a/bbb-libreoffice/docker/Dockerfile
+++ b/bbb-libreoffice/docker/Dockerfile
@@ -1,1 +1,1 @@
-FROM bigbluebutton/bbb-libreoffice:7.6.2-20231020-161900
+FROM bigbluebutton/bbb-libreoffice:24.08.0-20240909-132800


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Upgrades LibreOffice (used for presentation conversion) from 7.6.2 to 24.08.0.3.
(note that LO changed their versioning. We did not miss huge changes, just this is the release from August 2024)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none
Build PR: https://github.com/bigbluebutton/bigbluebutton-docker-libreoffice/pull/9
Related: #19045

### Motivation
<!-- What inspired you to submit this pull request? -->
We are debugging some conversion edge cases. We thought upgrading to the latest would be welcome.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
I tested on 3.0.0-beta.1 via:
`/usr/bin/docker run bbb-soffice sh -c "/usr/bin/soffice --version"` -- check your current version. Expect 7.6.x
`docker pull bigbluebutton/bbb-libreoffice:24.08.0-20240909-132800` -- pull this version.
`docker image rm bbb-soffice:latest -f` -- remove the current LO image (just to be certain)
`docker image tag bigbluebutton/bbb-libreoffice:24.08.0-20240909-132800 bbb-soffice:latest` -- claim that the image we want to test is the latest (just to avoid having to tweak image names in the code/configs)
`bbb-conf --restart`
`/usr/bin/docker run bbb-soffice sh -c "/usr/bin/soffice --version"` -- should show `LibreOffice 24.8.0.3 0bdf1299c94fe897b119f97f3c613e9dca6be583`

Once we confirm we are using the desired LibreOffice version, upload a PPTX or other file needing conversion to PDF and inspect if the conversion result looks fine.

### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
