### PR TITLE
fix (akka-apps): graphql flag `breakoutRoom.hasJoined` is not accurate

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
@@ -118,7 +118,7 @@ object BreakoutHdlrHelpers extends SystemConfiguration {
 
     eventBus.publish(BigBlueButtonEvent(
       liveMeeting.props.breakoutProps.parentId,
-      new BreakoutRoomUsersUpdateInternalMsg(liveMeeting.props.breakoutProps.parentId, liveMeeting.props.meetingProp.intId,
+      BreakoutRoomUsersUpdateInternalMsg(liveMeeting.props.breakoutProps.parentId, liveMeeting.props.meetingProp.intId,
         breakoutUsers, breakoutVoiceUsers)
     ))
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -76,14 +76,18 @@ object BreakoutRoomUserDAO {
   }
 
   def updateUserJoined(meetingId: String, usersInRoom: Vector[String], breakoutRoom: BreakoutRoom2x) = {
-    DatabaseConnection.enqueue(
-      sqlu"""UPDATE "breakoutRoom_user" SET
+    for {
+      userInRoom <- usersInRoom
+    } yield {
+      DatabaseConnection.enqueue(
+        sqlu"""UPDATE "breakoutRoom_user" SET
                 "joinedAt" = current_timestamp
                 WHERE "meetingId" = ${meetingId}
-                AND "userId" in (${usersInRoom.mkString(",")})
+                AND "userId" = ${userInRoom}
                 AND "breakoutRoomId" = ${breakoutRoom.id}
                 AND "joinedAt" is null"""
-    )
+      )
+    }
   }
 
   def insertBreakoutRoom(userId: String, room: BreakoutRoom2x, liveMeeting: LiveMeeting) = {


### PR DESCRIPTION
Fix the flag `hasJoined` that indicates if the user has joined in a breakout room.
That was not being updated properly as reported by @JoVictorNunes.

```gql
subscription {
  breakoutRoom {
    userId
    hasJoined
  }
}
```