### PR TITLE
fix: No layout selected in modal for users other than presenter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -55,6 +55,7 @@ const propTypes = {
   shouldShowExternalVideo: PropTypes.bool,
   enforceLayout: PropTypes.string,
   setLocalSettings: PropTypes.func.isRequired,
+  hasMeetingLayout: PropTypes.bool,
 };
 
 const PushLayoutEngine = (props) => {
@@ -88,6 +89,7 @@ const PushLayoutEngine = (props) => {
     selectedLayout,
     setMeetingLayout,
     setPushLayout,
+    hasMeetingLayout,
   } = props;
 
   useEffect(() => {
@@ -154,7 +156,7 @@ const PushLayoutEngine = (props) => {
         }
       }, 0);
     }
-  }, []);
+  }, [hasMeetingLayout]);
 
   useEffect(() => {
     const meetingLayoutDidChange = meetingLayout !== prevProps.meetingLayout;
@@ -353,10 +355,6 @@ const PushLayoutEngineContainer = (props) => {
   const enforceLayout = validateEnforceLayout(currentUserData);
   const meetingPresentationIsOpen = !meetingPresentationMinimized;
 
-  if (!meetingLayout) {
-    return null;
-  }
-
   return (
     <PushLayoutEngine
       {...{
@@ -385,6 +383,7 @@ const PushLayoutEngineContainer = (props) => {
         selectedLayout,
         setMeetingLayout,
         setPushLayout,
+        hasMeetingLayout: !!meetingLayout,
         ...props,
       }}
     />

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -353,6 +353,10 @@ const PushLayoutEngineContainer = (props) => {
   const enforceLayout = validateEnforceLayout(currentUserData);
   const meetingPresentationIsOpen = !meetingPresentationMinimized;
 
+  if (!meetingLayout) {
+    return null;
+  }
+
   return (
     <PushLayoutEngine
       {...{


### PR DESCRIPTION
### What does this PR do?

Delays push layout component render until meeting data is available

### Closes Issue(s)
Closes #21138

### How to test
1. Create and join a meeting;
2. Check the layout management modal (correct layout is selected)
3. Join another user;
4. Check the layout management modal (default layout should be selected)

### More
The layout modal bug occurred because the push layout component was rendered before the meeting data was available.
