### PR TITLE
Fix incorrect merge in recording audio processing

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -145,9 +145,9 @@ module BigBlueButton
               ffmpeg_filter << "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT}"
             end
 
-            ffmpeg_filter << ",atempo=#{speed},atrim=start=#{ms_to_s(audio[:timestamp])}" if speed != 1
+            ffmpeg_filter << ',asetpts=N'
 
-            ffmpeg_filter << ",asetpts=N"
+            ffmpeg_filter << ",atempo=#{speed},atrim=start=#{ms_to_s(audio[:timestamp])}" if speed != 1
           else
             BigBlueButton.logger.info "  Generating silence"
 


### PR DESCRIPTION
The merge of 2.7 code into 3.0 dropped a change from d402f519c61adcc260ff20c978718dfddf509eca which was part of a fix to prevent a recording processing hang when processing deskshare streams which contain audio. Re-apply that change.