### PR TITLE
refactor (build/gql-server): Moves the Hasura admin password file and drop netstat

### DIFF
--- a/bbb-graphql-server/deploy.sh
+++ b/bbb-graphql-server/deploy.sh
@@ -30,7 +30,7 @@ sudo systemctl start bbb-graphql-server
 
 #Check if Hasura is ready before applying metadata
 HASURA_PORT=8085
-while ! sudo netstat -tuln | grep ":$HASURA_PORT " > /dev/null; do
+while ! sudo ss -tuln | grep ":$HASURA_PORT " > /dev/null; do
     echo "Waiting for Hasura's port ($HASURA_PORT) to be ready..."
     sleep 1
 done

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -27,15 +27,19 @@ case "$1" in
   echo "Postgresql configured"
 
   #Generate a random password to Hasura to improve security
-  if [ ! -f /usr/share/bbb-graphql-server/admin-secret ]; then
+  if [ ! -f /etc/default/bbb-graphql-server-admin-pass ]; then
     HASURA_RANDOM_ADM_PASSWORD=$(openssl rand -base64 32 | sed 's/=//g' | sed 's/+//g' | sed 's/\///g')
-    echo "HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD" > /usr/share/bbb-graphql-server/admin-secret
-    chmod 755 /usr/share/bbb-graphql-server/admin-secret
-    echo "Set a random password to Hasura at /usr/share/bbb-graphql-server/admin-secret"
+    echo "# This password is randomly generated during the installation of BigBlueButton." > /etc/default/bbb-graphql-server-admin-pass
+    echo "# It serves as the admin password for the bbb-graphql-server (Hasura)." >> /etc/default/bbb-graphql-server-admin-pass
+    echo "# The admin can change this password at any time without any issues." >> /etc/default/bbb-graphql-server-admin-pass
+    echo "HASURA_GRAPHQL_ADMIN_SECRET=$HASURA_RANDOM_ADM_PASSWORD" >> /etc/default/bbb-graphql-server-admin-pass
+    chown root:root /etc/default/bbb-graphql-server-admin-pass
+    chmod 600 /etc/default/bbb-graphql-server-admin-pass
+    echo "Set a random password to Hasura at /etc/default/bbb-graphql-server-admin-pass"
   fi
 
   #Set admin secret for Hasura CLI
-  HASURA_ADM_PASSWORD=$(grep '^HASURA_GRAPHQL_ADMIN_SECRET=' /usr/share/bbb-graphql-server/admin-secret | cut -d '=' -f 2)
+  HASURA_ADM_PASSWORD=$(grep '^HASURA_GRAPHQL_ADMIN_SECRET=' /etc/default/bbb-graphql-server-admin-pass | cut -d '=' -f 2)
   sed -i "s/^admin_secret: .*/admin_secret: $HASURA_ADM_PASSWORD/g" /usr/share/bbb-graphql-server/config.yaml
 
   if [ ! -f /.dockerenv ]; then

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -49,7 +49,7 @@ case "$1" in
 
     #Check if Hasura is ready before applying metadata
     HASURA_PORT=8085
-    while ! netstat -tuln | grep ":$HASURA_PORT " > /dev/null; do
+    while ! ss -tuln | grep ":$HASURA_PORT " > /dev/null; do
         echo "Waiting for Hasura's port ($HASURA_PORT) to be ready..."
         sleep 1
     done

--- a/build/packages-template/bbb-graphql-server/bbb-graphql-server.service
+++ b/build/packages-template/bbb-graphql-server/bbb-graphql-server.service
@@ -14,7 +14,7 @@ EnvironmentFile=/etc/default/bbb-graphql-server
 # Optional file (the service should not fail if the file does not exist)
 EnvironmentFile=-/etc/bigbluebutton/bbb-graphql-server.env
 # Load Hasura password
-EnvironmentFile=/usr/share/bbb-graphql-server/admin-secret
+EnvironmentFile=/etc/default/bbb-graphql-server-admin-pass
 ExecStart=/usr/local/bin/hasura-graphql-engine serve
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/build/packages-template/bbb-graphql-server/opts-jammy.sh
+++ b/build/packages-template/bbb-graphql-server/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -d postgresql,postgresql-contrib,gnupg2,curl,apt-transport-https,ca-certificates,libkrb5-3,libpq5,libnuma1,unixodbc-dev,net-tools -t deb"
+OPTS="$OPTS -d postgresql,postgresql-contrib,gnupg2,curl,apt-transport-https,ca-certificates,libkrb5-3,libpq5,libnuma1,unixodbc-dev -t deb"


### PR DESCRIPTION
1. **Hasura Password Path Update**
   - **Change:** Moved the Hasura admin password file from `/usr/share/bbb-graphql-server/admin-secret` to `/etc/default/bbb-graphql-server-admin-pass`.
   - **Reason:** The change aligns with @danimo recommendation that `/etc` should be used for mutable files, providing better alignment with file hierarchy standards.
   - **Additional Context:** Comments were added to the code to provide more context about the purpose and usage of this file.
   - **Permissions:** Set the file owner to `root:root` with permissions `600`, ensuring that it is only readable by the root user, following Danimo's security suggestion.

2. **Command Update from `netstat` to `ss`**
   - **Change:** Replaced the usage of `netstat` with `ss` in the codebase.
   - **Reason:** `netstat` is deprecated and no longer commonly used. `ss` serves as a more modern and suitable replacement with similar syntax, as recommended by @danimo.