### PR TITLE
fix: not all error boundaries should close audio/Apollo

### DIFF
--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -39,11 +39,19 @@ if (
 const Main: React.FC = () => {
   return (
     <SettingsLoader>
-      <ErrorBoundary Fallback={ErrorScreen} logMetadata={STARTUP_CRASH_METADATA}>
+      <ErrorBoundary
+        Fallback={ErrorScreen}
+        logMetadata={STARTUP_CRASH_METADATA}
+        isCritical
+      >
         <LoadingScreenHOC>
           <IntlLoaderContainer>
             {/* from there the error messages are located */}
-            <LocatedErrorBoundary Fallback={ErrorScreen} logMetadata={APP_CRASH_METADATA}>
+            <LocatedErrorBoundary
+              Fallback={ErrorScreen}
+              logMetadata={APP_CRASH_METADATA}
+              isCritical
+            >
               <ConnectionManager>
                 <PresenceManager>
                   <CustomUsersSettings>

--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
@@ -12,6 +12,10 @@ const propTypes = {
     logCode: PropTypes.string,
     logMessage: PropTypes.string,
   }),
+  // isCritical: flags this error boundary as critical for the app's lifecycle,
+  // which means that the app should not continue to run if this error boundary
+  // is triggered. If true, terminates RTC audio connections and the Apollo client.
+  isCritical: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -21,6 +25,7 @@ const defaultProps = {
     logCode: 'Error_Boundary_wrapper',
     logMessage: 'generic error boundary logger',
   },
+  isCritical: false,
 };
 
 class ErrorBoundary extends Component {
@@ -55,27 +60,32 @@ class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    window.dispatchEvent(new Event('StopAudioTracks'));
-    const data = window.meetingClientSettings.public.media;
-    const mediaElement = document.querySelector(data?.mediaTag || '#remote-media');
-    if (mediaElement) {
-      mediaElement.pause();
-      mediaElement.srcObject = null;
-    }
-    const apolloClient = apolloContextHolder.getClient();
+    const { isCritical } = this.props;
 
-    if (apolloClient) {
-      apolloClient.stop();
+    if (isCritical) {
+      window.dispatchEvent(new Event('StopAudioTracks'));
+      const data = window.meetingClientSettings.public.media;
+      const mediaElement = document.querySelector(data?.mediaTag || '#remote-media');
+      if (mediaElement) {
+        mediaElement.pause();
+        mediaElement.srcObject = null;
+      }
+      const apolloClient = apolloContextHolder.getClient();
+
+      if (apolloClient) {
+        apolloClient.stop();
+      }
+
+      const ws = apolloContextHolder.getLink();
+      if (ws) {
+        // delay to termintate the connection, for user receive the end eject message
+        setTimeout(() => {
+          apolloClient.setLink(ApolloLink.empty());
+          ws.terminate();
+        }, 5000);
+      }
     }
 
-    const ws = apolloContextHolder.getLink();
-    if (ws) {
-      // delay to termintate the connection, for user receive the end eject message
-      setTimeout(() => {
-        apolloClient.setLink(ApolloLink.empty());
-        ws.terminate();
-      }, 5000);
-    }
     this.setState({
       error,
       errorInfo,


### PR DESCRIPTION
### What does this PR do?

- [fix: not all error boundaries should close audio/Apollo](https://github.com/bigbluebutton/bigbluebutton/commit/b6a962ff73b1a70c056d35ee7347d174ea0370eb) 
  * Currently, all error boundaries close audio and Apollo connections once
an error is caught. This is not the correct behavior as not all error
boundaries are critical, e.g.: the presentation crashing should _not_
break the whole client. It also deviates from how error boundaries
worked in 2.7
  * Add a new prop to the ErrorBoundary/LocatedErrorBoundary components
called isCritical that flags an error boundary instance as critical to the
app's lifecycle. If true, it'll close Apollo/audio. The default behavior is
isCritical=false, and the only critical error boundaries are the ones
located in the app's root (/client/main.tsx).

### Closes Issue(s)

None