### PR TITLE
fix(audio): ensure initial local mute state when muteOnStart=true

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -58,7 +58,7 @@ class AudioManager {
     };
 
     this.defineProperties({
-      isMuted: makeVar(false),
+      isMuted: makeVar(true),
       isConnected: makeVar(false),
       isConnecting: makeVar(false),
       isHangingUp: makeVar(false),
@@ -67,7 +67,6 @@ class AudioManager {
       isTalking: makeVar(false),
       isWaitingPermissions: makeVar(false),
       error: makeVar(null),
-      muteHandle: makeVar(null),
       autoplayBlocked: makeVar(false),
       isReconnecting: makeVar(false),
       bypassGUM: makeVar(false),
@@ -89,6 +88,7 @@ class AudioManager {
     };
 
     this.BREAKOUT_AUDIO_TRANSFER_STATES = BREAKOUT_AUDIO_TRANSFER_STATES;
+    this._voiceActivityObserver = null;
 
     window.addEventListener('StopAudioTracks', () => this.forceExitAudio());
   }
@@ -192,17 +192,37 @@ class AudioManager {
       && this.fullAudioBridge?.supportsTransparentListenOnly();
   }
 
-  async init(userData, audioEventHandler) {
+  observeVoiceActivity() {
+    // Observe voice activity changes to update any relevant *local* states
+    // (see onVoiceUserChanges)
+    if (!this._voiceActivityObserver) {
+      const subHash = stringToHash(JSON.stringify({
+        subscription: VOICE_ACTIVITY,
+      }));
+      this._voiceActivityObserver = GrahqlSubscriptionStore.makeSubscription(VOICE_ACTIVITY);
+      window.addEventListener('graphqlSubscription', (e) => {
+        const { subscriptionHash, response } = e.detail;
+        if (subscriptionHash === subHash) {
+          if (response) {
+            const { data } = response;
+            const voiceUser = data.user_voice_activity_stream.find((v) => v.userId === Auth.userID);
+            this.onVoiceUserChanges(voiceUser);
+          }
+        }
+      });
+    }
+  }
+
+  init(userData, audioEventHandler) {
+    this.userData = userData;
     this.inputDeviceId = getStoredAudioInputDeviceId() || DEFAULT_INPUT_DEVICE_ID;
     this.outputDeviceId = getCurrentAudioSinkId();
     this._applyCachedOutputDeviceId();
     this._trackPermissionStatus();
     this.loadBridges(userData);
-    this.userData = userData;
-    this.initialized = true;
-    this.audioEventHandler = audioEventHandler;
-    await this.loadBridges(userData);
     this.transparentListenOnlySupported = this.supportsTransparentListenOnly();
+    this.audioEventHandler = audioEventHandler;
+    this.initialized = true;
   }
 
   /**
@@ -212,7 +232,7 @@ class AudioManager {
    * @param {Object} userData The Object representing user data to be passed to
    *                      the bridge.
    */
-  async loadBridges(userData) {
+  loadBridges(userData) {
     let FullAudioBridge = SIPBridge;
     let ListenOnlyBridge = SFUAudioBridge;
 
@@ -448,8 +468,19 @@ class AudioManager {
 
   onAudioJoining() {
     this.isConnecting = true;
-    this.isMuted = false;
+    this.isMuted = true;
     this.error = false;
+    this.observeVoiceActivity();
+    // Ensure the local mute state (this.isMuted) is aligned with the initial
+    // placeholder value before joining audio.
+    // Currently, the server sets the placeholder mute state to *true*, and this
+    // is only communicated via observeVoiceActivity's subscription if the initial
+    // state differs from the placeholder or when the state changes.
+    // Refer to user_voice_activity DB schema for details.
+    // tl;dr: without enforcing the initial mute state here, the client won't be
+    // locally muted if the audio channel starts muted (e.g., dialplan-level
+    // muteOnStart).
+    this.setSenderTrackEnabled(!this.isMuted);
 
     return Promise.resolve();
   }
@@ -501,24 +532,6 @@ class AudioManager {
     this.isConnecting = false;
 
     const STATS = window.meetingClientSettings.public.stats;
-
-    // listen to the VoiceUsers changes and update the flag
-    if (!this.muteHandle) {
-      const subHash = stringToHash(JSON.stringify({
-        subscription: VOICE_ACTIVITY,
-      }));
-      this.muteHandle = GrahqlSubscriptionStore.makeSubscription(VOICE_ACTIVITY);
-      window.addEventListener('graphqlSubscription', (e) => {
-        const { subscriptionHash, response } = e.detail;
-        if (subscriptionHash === subHash) {
-          if (response) {
-            const { data } = response;
-            const voiceUser = data.user_voice_activity_stream.find((v) => v.userId === Auth.userID);
-            this.onVoiceUserChanges(voiceUser);
-          }
-        }
-      });
-    }
     const secondsToActivateAudio = (new Date() - this.audioJoinStartTime) / 1000;
 
     if (!this.logAudioJoinTime) {


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): ensure initial local mute state when muteOnStart=true](https://github.com/bigbluebutton/bigbluebutton/commit/47018e5a6543e510a009cdb677ca324c592ae087) 
  - When `muteOnStart=true`, the initial local mute state in AudioManager is
desynced from the server. This issue stems from two recent changes:
    - Decoupling voice activity updates from the main user_voice subscription,
    which introduced an implicit muted state placeholder value
    of true instead of false. See user_voice_activity's DB schema
    propagation rules.
    - Introduction of dialplan-level muteOnStart, muting channels on creation
    rather than after.
  - Without properly updating AudioManager's `isMuted` placeholder, no 
   user_voice_activity update triggers *when joining audio* with 
   muteOnStart=true, causing two issues:
    - Sender tracks are not locally muted on audio join.
    - Opening the audio settings modal while muted will cause the
    microphone to be incorrectly *unmuted* once it's closed (first try only).
  - This fix sets AudioManager's `isMuted` placeholder to true, matching the
server. Additionally:
    - Enforce the local mute state before joining audio to ensure the desired
    sender track state. Should make this a bit more future proof.
    - Track `user_voice_activity` before joining audio (rather than after)
    to avoid race conditions.
    - Clean up `AudioManager.init` (loadBridges no longer returns a promise etc).

### Closes Issue(s)

None

### How to test

1. Join audio with muteOnStart=true
2. Open audio settings
3. Close audio settings 
   - Current behavior: unmutes
   - Desired behavior: preserves initial state (muted)
