### PR TITLE
Fix: Conference PIN (phone dial-in) doesn't show the needed pound sign in popup (port to 30)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-dial/component.jsx
@@ -49,7 +49,7 @@ class AudioDial extends React.PureComponent {
         <Styled.ConferenceText>
           {intl.formatMessage(intlMessages.audioDialConfrenceText)}
         </Styled.ConferenceText>
-        <Styled.Telvoice>{formattedTelVoice}</Styled.Telvoice>
+        <Styled.Telvoice>{`${formattedTelVoice} #`}</Styled.Telvoice>
         <Styled.TipBox>
           <Styled.TipIndicator>
             {`${intl.formatMessage(intlMessages.tipIndicator)}: `}


### PR DESCRIPTION
### What does this PR do?

This PR is a port from the same fix on 27 version - [PR2113](https://github.com/bigbluebutton/bigbluebutton/pull/21113)