### PR TITLE
Style: Adjust font size and add margin to offline user indicator (chat/message-header)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/styles.ts
@@ -56,9 +56,10 @@ export const ChatUserOffline = styled.span`
   font-weight: 100;
   text-transform: lowercase;
   font-style: italic;
-  font-size: 90%;
+  font-size: 85%;
   line-height: 1;
   user-select: none;
+  margin-right: calc(${lineHeightComputed} / 2);
 `;
 
 export const ChatTime = styled.time`


### PR DESCRIPTION
### What does this PR do?

This PR adjusts font size and add margin to offline user indicator

### Motivation

The motivation for this PR is to update the styles and ensure that the information display aligns with the overall design pattern of BBB's user interface.

### How to test

As it is a visual change, I believe the screenshots will suffice, but in case one wants to test it anyway, you could open an instance of 30 and see the visual changes.

### Before

![WhatsApp Image 2024-09-12 at 10 25 38_980ca6ad](https://github.com/user-attachments/assets/f11d2783-1e74-48aa-b45b-d4d495a665e5)

### After 

![WhatsApp Image 2024-09-12 at 10 25 57_02463b01](https://github.com/user-attachments/assets/f9c32240-4ae3-4c1a-9a43-c3ce046167e7)



