### PR TITLE
Fix problem with customizable logoutURL in bbb-web

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1834,13 +1834,22 @@ class ApiController {
     }
   }
 
+  private String subLogoutParams(params, logoutURL) {
+    String newURL = logoutURL;
+    newURL = newURL.replace('%%MEETINGID%%', params.meetingID != null ? params.meetingID : "");
+    newURL = newURL.replace('%%USERID%%', params.userID != null ? params.userID : "");
+    newURL = newURL.replace('%%USERNAME%%', params.fullName != null ? params.fullName : "");
+
+    return newURL;
+  }
+
   private void respondWithRedirect(errorsJSONArray, redirectUrl = "") {
-    String logoutUrl = paramsProcessorUtil.getDefaultLogoutUrl()
+    String logoutUrl = subLogoutParams(params, paramsProcessorUtil.getDefaultLogoutUrl())
     URI oldUri = URI.create(logoutUrl)
 
     if (!StringUtils.isEmpty(params.logoutURL)) {
       try {
-        oldUri = URI.create(params.logoutURL)
+        oldUri = URI.create(subLogoutParams(params, params.logoutURL))
       } catch (Exception e) {
         // Do nothing, the variable oldUri was already initialized
       }


### PR DESCRIPTION
This fixes a bug that happens after https://github.com/bigbluebutton/bigbluebutton/pull/20965

#### To Reproduce the bug

1. Set logoutURL to a templated URL (e.g.: bigbluebutton.web.logoutURL=${bigbluebutton.web.serverURL}/feedback?meetingId=%%MEETINGID%%&userId=%%USERID%% on bigbluebutton.properties
2. Create a meeting, join with a moderator
3. Set guest policy to "deny all"
4. Join as a guest (guest=true)

The first commit fixes this by actually implementing the customizable parameters in bbb-web.

The second commit removes all unused references to this logoutURL in the recording API. This is done because this code was inacessible (redirectResponse was always set to false when called).