### PR TITLE
fix(modal/confirmation): Ensure focus is triggered on cancel button after modal update.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/confirmation/component.jsx
@@ -34,7 +34,18 @@ class ConfirmationModal extends Component {
 
     this.state = {
       checked: false,
+      triggeredFocus: false,
     };
+    this.cancelButtonRef = React.createRef();
+  }
+
+  componentDidUpdate() {
+    const { triggeredFocus } = this.state;
+
+    if (!triggeredFocus && this.cancelButtonRef.current) {
+      this.cancelButtonRef.current.children[0].focus();
+      this.setState({ triggeredFocus: true });
+    }
   }
 
   render() {
@@ -108,10 +119,12 @@ class ConfirmationModal extends Component {
                 }}
               />
             )}
-            <Styled.CancelButton
-              label={cancelButtonLabel || intl.formatMessage(messages.noLabel)}
-              onClick={() => setIsOpen(false)}
-            />
+            <div ref={this.cancelButtonRef}>
+              <Styled.CancelButton
+                label={cancelButtonLabel || intl.formatMessage(messages.noLabel)}
+                onClick={() => setIsOpen(false)}
+              />
+            </div>
           </Styled.Footer>
         </Styled.Container>
       </Styled.ConfirmationModal>


### PR DESCRIPTION
### What does this PR do?

This PR sets focus on the "no" button on the end meeting modal.

### Motivation

This changes were made to improve accessibility on the end meeting modal - since before this changes the focus of the page was thrown into the body of the HTML. The choice of focusing the no button, was due to the chance of the user wrongly pressing enter in case the "end meeting" button was focused, making the user end the meeting unwillingly.

### How to test
To test it, start a meeting and try to end the meeting, when the modal open you should see the "no" button selected, as the screenshots in the end of this PR.

### Before

![image](https://github.com/user-attachments/assets/f0c9e0d3-8b38-4f9d-860c-9e9e76b839d2)

### After

![image](https://github.com/user-attachments/assets/66d9f717-1fce-4931-b0a3-bc209d32352c)
