### PR TITLE
[2.7] build(bbb-webrtc-sfu): v2.15.0

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.15.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.15.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
v2.15.0
---
* feat: add restartIce support for video/screenshare modules
* refactor: rename ICE restart flag to `restartIce`, true by default
* build: pino@9.3.2
* build: config@3.3.12
* build: ws@8.18.0
* build: bufferutil@4.0.8
* build: mcs-js@0.0.20
* build: uuid@10.0.0
* build: mediasoup-client@3.7.16
* build: mediasoup@3.14.14
* build: SIP.js@v0.7.5.14