### PR TITLE
chore: upgrade FreeSWITCH to 1.10.12 (port)

### DIFF
--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -2,5 +2,5 @@ mkdir freeswitch
 cd freeswitch
 git init
 git remote add origin https://github.com/signalwire/freeswitch.git
-git fetch --depth 1 origin v1.10.11
+git fetch --depth 1 origin v1.10.12
 git checkout FETCH_HEAD


### PR DESCRIPTION
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/21066 to BBB 2.7