### PR TITLE
fix: disable ICE restart for recvonly endpoints

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -383,7 +383,9 @@ export default class SFUAudioBridge extends BaseAudioBridge {
           mediaStreamFactory: this.mediaStreamFactory,
           gatheringTimeout: GATHERING_TIMEOUT,
           transparentListenOnly: isTransparentListenOnlyEnabled(),
-          restartIce: RESTART_ICE,
+          // ICE restart only works for publishers right now - recvonly full
+          // reconnection works ok without it.
+          restartIce: RESTART_ICE && !isListenOnly,
           restartIceMaxRetries: RESTART_ICE_RETRIES,
         };
 

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -367,7 +367,9 @@ export default class KurentoScreenshareBridge {
       forceRelay: shouldForceRelay(),
       traceLogs: TRACE_LOGS,
       gatheringTimeout: GATHERING_TIMEOUT,
-      restartIce: RESTART_ICE,
+      // ICE restart only works for publishers right now - recvonly full
+      // reconnection works ok without it.
+      restartIce: false,
       restartIceMaxRetries: RESTART_ICE_RETRIES,
     };
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.jsx
@@ -1078,7 +1078,9 @@ class VideoProvider extends Component {
           break;
 
         case 'failed':
-          if (!RESTART_ICE) {
+          // ICE restart only works for publishers right now - recvonly full
+          // reconnection works ok without it.
+          if (!RESTART_ICE || !peer?.isPublisher) {
             handleFatalFailure();
           } else {
             try {


### PR DESCRIPTION
### What does this PR do?

- [fix: disable ICE restart for recvonly endpoints](https://github.com/bigbluebutton/bigbluebutton/commit/3a5c3df5382065ecffe6473c92c839991d7eacf0) 
  - The experimental ICE restart introduced in commit https://github.com/bigbluebutton/bigbluebutton/commit/d2dde8a9b19a700ff427371d4122126cb28bda1d should only be
used for `sendonly` or `sendrecv` transports. There are two main reasons:
    - Server-side changes are required to support `recvonly` endpoints,
    particularly the proper handling of the server’s `setup` role in the
    its SDPs during an ICE restart. These changes are too broad for now,
    so they are deferred to future releases (SFU@v2.16/BBB@3.0).
    - Full reconnections for `recvonly` endpoints are currently reliable,
    unlike for `send*` endpoints. ICE restarts could still provide benefits
    for `recvonly` endpoints, but we need the server updates first.
  - This commit disables ICE restart for `recvonly` endpoints, even if the
mechanism is enabled. Support for those will be added in SFU@v2.16/BBB 3.0.

### Closes Issue(s)

None

### Motivation

Follow up to #21008 