### PR TITLE
test: Update timer test to avoid false failures + fix hide presentation param on unrelated tests

### DIFF
--- a/bigbluebutton-tests/playwright/core/constants.js
+++ b/bigbluebutton-tests/playwright/core/constants.js
@@ -23,4 +23,4 @@ exports.VIDEO_LOADING_WAIT_TIME = 15000;
 exports.UPLOAD_PDF_WAIT_TIME = 25000 * MULTIPLIER;
 
 exports.CUSTOM_MEETING_ID = 'custom-meeting';
-exports.PARAMETER_HIDE_PRESENTATION_TOAST = 'userdata-bbb_custom_style=.presentationUploaderToast{display: none;}.currentPresentationToast{display:none;}';
+exports.PARAMETER_HIDE_PRESENTATION_TOASTS = 'userdata-bbb_custom_style=.presentationUploaderToast,.currentPresentationToast{display: none;}';

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.js
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.js
@@ -1,10 +1,10 @@
 const { test } = require('@playwright/test');
 const { fullyParallel } = require('../playwright.config');
 const { encodeCustomParams } = require('../parameters/util');
-const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
+const { PARAMETER_HIDE_PRESENTATION_TOASTS } = require('../core/constants');
 const { Layouts } = require('./layouts');
 
-const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
+const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOASTS);
 
 const CUSTOM_MEETING_ID = 'layout_management_meeting';
 
@@ -16,8 +16,8 @@ test.describe("Layout management", () => {
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
-    await layouts.initModPage(page, true, { createParameter: hidePresentationToast, customMeetingId: CUSTOM_MEETING_ID });
-    await layouts.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await layouts.initModPage(page, true, { joinParameter: hidePresentationToast, customMeetingId: CUSTOM_MEETING_ID });
+    await layouts.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await layouts.modPage.shareWebcam();
     await layouts.userPage.shareWebcam();
   });

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -2,7 +2,7 @@ const { test } = require('@playwright/test');
 const { encodeCustomParams } = require('../parameters/util');
 const { Presentation } = require('./presentation');
 
-const customStyleAvoidUploadingNotifications = encodeCustomParams(`userdata-bbb_custom_style=.presentationUploaderToast{display: none;}`);
+const customStyleAvoidNotificationToasts = encodeCustomParams(`userdata-bbb_custom_style=.presentationUploaderToast,.currentPresentationToast{display: none;}`);
 
 test.describe.parallel('Presentation', () => {
   // https://docs.bigbluebutton.org/2.7/testing/release-testing/#navigation-automated
@@ -35,7 +35,7 @@ test.describe.parallel('Presentation', () => {
   // https://docs.bigbluebutton.org/2.7/testing/release-testing/#fit-to-width-option
   test('Presentation fit to width @ci', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
-    await presentation.initModPage(page, true, { createParameter: customStyleAvoidUploadingNotifications });
+    await presentation.initModPage(page, true, { joinParameter: customStyleAvoidNotificationToasts });
     await presentation.initUserPage(true, context);
     await presentation.fitToWidthTest();
   });
@@ -118,7 +118,7 @@ test.describe.parallel('Presentation', () => {
 
     test('Remove previous presentation from previous presenter', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
-      await presentation.initModPage(page, true, { createParameter: customStyleAvoidUploadingNotifications });
+      await presentation.initModPage(page, true, { joinParameter: customStyleAvoidNotificationToasts });
       await presentation.initUserPage(true, context);
       await presentation.removePreviousPresentationFromPreviousPresenter();
     });

--- a/bigbluebutton-tests/playwright/user/timer.js
+++ b/bigbluebutton-tests/playwright/user/timer.js
@@ -55,34 +55,38 @@ class Timer extends MultiUsers {
     // check for initial values
     await this.modPage.hasText(e.timerCurrent, /05:00/);
     await this.modPage.hasValue(e.minutesInput, '05');
+    await this.modPage.hasValue(e.secondsInput, '00');
 
     // start timer and check the current values
-    await this.modPage.getLocator(e.secondsInput).press('Backspace');
-    await this.modPage.type(e.secondsInput, '4');
     await this.clickOnTimerControl();
-    await this.modPage.hasText(e.timerCurrent, /05:01/);
-    await this.modPage.hasText(e.timerIndicator, /05:01/);
+    await Promise.all([
+      this.modPage.hasText(e.timerCurrent, /04:57/),
+      this.modPage.hasText(e.timerIndicator, /04:57/),
+    ]);
 
     // change input value and check if the timer is updated
     await this.clickOnTimerControl(false);
-    await this.modPage.getLocator(e.secondsInput).press('Backspace');
-    await this.modPage.type(e.secondsInput, '50');
+    await this.modPage.type(e.secondsInput, '5');
     await this.clickOnTimerControl();
-    await this.modPage.hasText(e.timerCurrent, /04:56/);
-    await this.modPage.hasText(e.timerIndicator, /04:56/);
+    await Promise.all([
+      this.modPage.hasText(e.timerCurrent, /05:02/),
+      this.modPage.hasText(e.timerIndicator, /05:02/),
+    ]);
 
-    // reset an active timer and check if the values are set to the previous values
-    await this.clickOnTimerControl();
-    await sleep(2000);
+    // reset timer and check if the values are set to the previous values
+    await this.clickOnTimerControl(false);
     await this.modPage.waitAndClick(e.resetTimerStopwatch);
-    await this.modPage.hasText(e.timerCurrent, /05:00/);
-    await this.modPage.hasText(e.timerIndicator, /05:00/);
+    await Promise.all([
+      this.modPage.hasText(e.timerCurrent, /05:05/),
+      this.modPage.hasText(e.timerIndicator, /05:05/),
+    ]);
 
     // check if the timer stops when clicking on the timer indicator
     await this.clickOnTimerControl();
     const timerValueAfterStartingTimer = await timeInSeconds(timerCurrentLocator);
     const timerIndicatorValueAfterStartingTimer = await timeInSeconds(timerIndicatorLocator);
     await this.modPage.waitAndClick(e.timerIndicator);
+    await sleep(2000);
     await expect(timerValueAfterStartingTimer).toBe(await timeInSeconds(timerCurrentLocator));
     await expect(timerIndicatorValueAfterStartingTimer).toBe(await timeInSeconds(timerIndicatorLocator));
   }

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -1,4 +1,5 @@
 const { test, devices } = require('@playwright/test');
+const { encodeCustomParams } = require('../parameters/util');
 const { Status } = require('./status');
 const { MultiUsers } = require('./multiusers');
 const { GuestPolicy } = require('./guestPolicy');
@@ -7,6 +8,8 @@ const { MobileDevices } = require('./mobileDevices');
 const { Timer } = require('./timer');
 const motoG4 = devices['Moto G4'];
 const iPhone11 = devices['iPhone 11'];
+
+const customStyleAvoidNotificationToasts = encodeCustomParams(`userdata-bbb_custom_style=.presentationUploaderToast,.currentPresentationToast{display: none;}`);
 
 test.describe.parallel('User', () => {
   test.describe.parallel('Actions', () => {
@@ -31,13 +34,13 @@ test.describe.parallel('User', () => {
 
     test('Stopwatch @ci', async ({ browser, context, page })=> {
       const timer = new Timer(browser, context);
-      await timer.initModPage(page, true);
+      await timer.initModPage(page, true, { joinParameter: customStyleAvoidNotificationToasts });
       await timer.stopwatchTest();
     });
 
     test('Timer @ci', async ({ browser, context, page })=> {
       const timer = new Timer(browser, context);
-      await timer.initModPage(page, true);
+      await timer.initModPage(page, true, { joinParameter: customStyleAvoidNotificationToasts });
       await timer.timerTest();
     });
   });

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -1,5 +1,6 @@
 const { test, devices } = require('@playwright/test');
 const { encodeCustomParams } = require('../parameters/util');
+const { PARAMETER_HIDE_PRESENTATION_TOASTS } = require('../core/constants');
 const { Status } = require('./status');
 const { MultiUsers } = require('./multiusers');
 const { GuestPolicy } = require('./guestPolicy');
@@ -9,7 +10,7 @@ const { Timer } = require('./timer');
 const motoG4 = devices['Moto G4'];
 const iPhone11 = devices['iPhone 11'];
 
-const customStyleAvoidNotificationToasts = encodeCustomParams(`userdata-bbb_custom_style=.presentationUploaderToast,.currentPresentationToast{display: none;}`);
+const customStyleAvoidNotificationToasts = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOASTS);
 
 test.describe.parallel('User', () => {
   test.describe.parallel('Actions', () => {

--- a/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js
+++ b/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js
@@ -12,7 +12,7 @@ const { Eraser } = require('./eraser');
 const { DrawArrow } = require('./drawArrow');
 const { MultiUsers } = require('../user/multiusers');
 const { encodeCustomParams } = require('../parameters/util');
-const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
+const { PARAMETER_HIDE_PRESENTATION_TOASTS } = require('../core/constants');
 const { DeleteDrawing } = require('./deleteDrawing');
 const { UndoDrawing } = require('./undoDraw');
 const { RedoDrawing } = require('./redoDraw');
@@ -20,7 +20,7 @@ const { ChangeStyles } = require('./changeStyles');
 const { RealTimeText } = require('./realTimeText');
 const { ShapeOptions } = require('./shapeOptions');
 
-const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
+const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOASTS);
 
 test.describe.parallel('Whiteboard @ci', () => {
   test('Draw rectangle', async ({ browser, page }) => {
@@ -44,127 +44,127 @@ test.describe.parallel('Whiteboard tools - visual regression', () => {
 
   test('Draw rectangle', async ({ browser, context, page }) => {
     const drawRectangle = new DrawRectangle(browser, context);
-    await drawRectangle.initModPage(page, true, { customMeetingId: 'draw_rectangle_meeting', createParameter: hidePresentationToast });
-    await drawRectangle.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawRectangle.initModPage(page, true, { customMeetingId: 'draw_rectangle_meeting', joinParameter: hidePresentationToast });
+    await drawRectangle.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawRectangle.test();
   });
 
   test('Draw ellipse', async ({ browser, context, page }) => {
     const drawEllipse = new DrawEllipse(browser, context);
-    await drawEllipse.initModPage(page, true, { customMeetingId: 'draw_ellipse_meeting', createParameter: hidePresentationToast });
-    await drawEllipse.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawEllipse.initModPage(page, true, { customMeetingId: 'draw_ellipse_meeting', joinParameter: hidePresentationToast });
+    await drawEllipse.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawEllipse.test();
   });
 
   test('Draw triangle', async ({ browser, context, page }) => {
     const drawTriangle = new DrawTriangle(browser, context);
-    await drawTriangle.initModPage(page, true, { customMeetingId: 'draw_triangle_meeting', createParameter: hidePresentationToast });
-    await drawTriangle.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawTriangle.initModPage(page, true, { customMeetingId: 'draw_triangle_meeting', joinParameter: hidePresentationToast });
+    await drawTriangle.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawTriangle.test();
   });
 
   test('Draw line', async ({ browser, context, page }) => {
     const drawLine = new DrawLine(browser, context);
-    await drawLine.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await drawLine.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawLine.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await drawLine.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawLine.test();
   });
 
   test('Draw with pencil', async ({ browser, context, page }) => {
     const drawPencil = new DrawPencil(browser, context);
-    await drawPencil.initModPage(page, true, { customMeetingId: 'draw_pencil_meeting', createParameter: hidePresentationToast });
-    await drawPencil.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawPencil.initModPage(page, true, { customMeetingId: 'draw_pencil_meeting', joinParameter: hidePresentationToast });
+    await drawPencil.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawPencil.test();
   });
 
   test('Type text', async ({ browser, context, page }) => {
     const drawText = new DrawText(browser, context);
-    await drawText.initModPage(page, true, { customMeetingId: 'draw_text_meeting', createParameter: hidePresentationToast });
-    await drawText.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawText.initModPage(page, true, { customMeetingId: 'draw_text_meeting', joinParameter: hidePresentationToast });
+    await drawText.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawText.test();
   });
 
   test('Create sticky note', async ({ browser, context, page }) => {
     const drawStickyNote = new DrawStickyNote(browser, context);
-    await drawStickyNote.initModPage(page, true, { customMeetingId: 'draw_sticky_meeting', createParameter: hidePresentationToast });
-    await drawStickyNote.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawStickyNote.initModPage(page, true, { customMeetingId: 'draw_sticky_meeting', joinParameter: hidePresentationToast });
+    await drawStickyNote.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawStickyNote.test();
   });
 
   test('Pan', async ({ browser, context, page }) => {
     const pan = new Pan(browser, context);
-    await pan.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await pan.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await pan.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await pan.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await pan.test();
   });
 
   test('Eraser', async ({ browser, context, page }) => {
     const eraser = new Eraser(browser, context);
-    await eraser.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await eraser.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await eraser.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await eraser.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await eraser.test();
   });
 
   test('Draw arrow', async ({ browser, context, page }) => {
     const drawArrow = new DrawArrow(browser, context);
-    await drawArrow.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await drawArrow.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await drawArrow.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await drawArrow.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await drawArrow.test();
   });
 
   test('Delete drawing', async ({ browser, context, page }) => {
     const deleteDrawing = new DeleteDrawing(browser, context);
-    await deleteDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await deleteDrawing.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await deleteDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await deleteDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await deleteDrawing.test();
   });
 
   test('Undo drawing', async ({ browser, context, page }) => {
     const undoDrawing = new UndoDrawing(browser, context);
-    await undoDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await undoDrawing.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await undoDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await undoDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await undoDrawing.test();
   });
 
   test('Redo drawing', async ({ browser, context, page }) => {
     const redoDrawing = new RedoDrawing(browser, context);
-    await redoDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await redoDrawing.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await redoDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await redoDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await redoDrawing.test();
   });
 
   test('Change color', async ({ browser, context, page }) => {
     const changeColor = new ChangeStyles(browser, context);
-    await changeColor.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await changeColor.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await changeColor.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await changeColor.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await changeColor.changingColor();
   });
 
   test('Fill drawing', async ({ browser, context, page }) => {
     const fillDrawing = new ChangeStyles(browser, context);
-    await fillDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await fillDrawing.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await fillDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await fillDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await fillDrawing.fillDrawing();
   });
 
   test('Dash drawing', async ({ browser, context, page }) => {
     const dashDrawing = new ChangeStyles(browser, context);
-    await dashDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await dashDrawing.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await dashDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await dashDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await dashDrawing.dashDrawing();
   });
 
   test('Size drawing', async ({ browser, context, page }) => {
     const sizeDrawing = new ChangeStyles(browser, context);
-    await sizeDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await sizeDrawing.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await sizeDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await sizeDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await sizeDrawing.sizeDrawing();
   });
 
   test('Real time text typing', async ({ browser, context, page }) => {
     const realTimeText = new RealTimeText(browser, context);
-    await realTimeText.initModPage(page, true, { customMeetingId: 'draw_line_meeting', createParameter: hidePresentationToast });
-    await realTimeText.initUserPage(true, context, { createParameter: hidePresentationToast });
+    await realTimeText.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
+    await realTimeText.initUserPage(true, context, { joinParameter: hidePresentationToast });
     await realTimeText.realTimeTextTyping();
   });
 


### PR DESCRIPTION
### What does this PR do?
This PR changes the test flow in order to avoid false failures we've been facing recently. in addition, I've fixed the way we prevent the presentation notifications when we don't need to check them and they might cause difficulties in the assertions/snapshot comparisons