### PR TITLE
[2.7] build: Bump bbb-pads to 1.5.3

### DIFF
--- a/bbb-pads.placeholder.sh
+++ b/bbb-pads.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v1.5.2 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads
+git clone --branch v1.5.3 --depth 1 https://github.com/bigbluebutton/bbb-pads bbb-pads


### PR DESCRIPTION
Backport https://github.com/bigbluebutton/bigbluebutton/pull/21071 to BBB 2.7
