### PR TITLE
fix(audio/muteToggle): Fix mute loading state on push to talk

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -97,6 +97,9 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
         cooldownActive.current = false;
       }, COOLDOWN_TIME);
     }
+    setTimeout(() => {
+      muteLoadingState(false);
+    }, 1000);
   }, []);
 
   useEffect(() => {
@@ -115,7 +118,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
     };
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     muteLoadingState(false);
   }, [muted]);
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where the push to talk used in quick succession would bug the loading animation on mute/unmute button - 
making the loading animation last forever or until next activation of the button

### Before

https://github.com/user-attachments/assets/cb032085-ef2b-4095-830d-3bd70b43635c

### After

https://github.com/user-attachments/assets/fd63ff0b-b162-4616-9c98-f0845318c831


