### PR TITLE
fix: recording icon does not appear on mobile devices

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -257,7 +257,7 @@ export default class Button extends BaseButton {
     } = this.props;
 
     if (svgIcon) {
-      return (<Styled.ButtonSvgIcon iconName={svgIcon} />);
+      return (<Styled.ButtonSvgIcon iconName={svgIcon} wrapped />);
     }
 
     if (iconName) {

--- a/bigbluebutton-html5/imports/ui/components/common/icon-svg/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/icon-svg/component.tsx
@@ -4,6 +4,7 @@ import Styled from './styles';
 interface IconProps {
   iconName: string;
   rotate?: boolean;
+  wrapped?: boolean;
 }
 
 const iconsMap: { [key: string]: JSX.Element } = {
@@ -68,9 +69,14 @@ const iconsMap: { [key: string]: JSX.Element } = {
 const Icon: React.FC<IconProps> = ({
   iconName = '',
   rotate = false,
+  wrapped = false,
 }) => {
   if (!iconsMap[iconName]) {
     return null;
+  }
+
+  if (!wrapped) {
+    return iconsMap[iconName];
   }
 
   return (


### PR DESCRIPTION
### What does this PR do?

Fix issue with recording button icon not appearing on mobile devices due to it being wrapped in a div by default.

The bug was being caused by the new "icon svg" component implementation, that included a styled div that is used by some icons, but not all.

### How to test
1. create a meeting with recording enabled
2. join the meeting on a mobile device
3. the recording button (and its icon) should be displayed