### PR TITLE
[3.0] feat: add experimental support for ICE restart

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -355,6 +355,10 @@ export default class SFUAudioBridge extends BaseAudioBridge {
       const GATHERING_TIMEOUT = SETTINGS.public.kurento.gatheringTimeout;
       const RETRY_THROUGH_RELAY = MEDIA.audio.retryThroughRelay || false;
       const { audio: NETWORK_PRIORITY } = MEDIA.networkPriorities || {};
+      const {
+        enabled: RESTART_ICE = false,
+        retries: RESTART_ICE_RETRIES = 1,
+      } = SETTINGS.public.kurento?.restartIce?.audio || {};
 
       const handleInitError = (_error) => {
         mapErrorCode(_error);
@@ -389,6 +393,10 @@ export default class SFUAudioBridge extends BaseAudioBridge {
           gatheringTimeout: GATHERING_TIMEOUT,
           transparentListenOnly: isTransparentListenOnlyEnabled(),
           bypassGUM,
+          // ICE restart only works for publishers right now - recvonly full
+          // reconnection works ok without it.
+          restartIce: RESTART_ICE && !isListenOnly,
+          restartIceMaxRetries: RESTART_ICE_RETRIES,
         };
 
         this.broker = new AudioBroker(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -276,6 +276,9 @@ export default class KurentoScreenshareBridge {
       forceRelay: shouldForceRelay(),
       traceLogs: TRACE_LOGS,
       gatheringTimeout: GATHERING_TIMEOUT,
+      // ICE restart only works for publishers right now - recvonly full
+      // reconnection works ok without it.
+      restartIce: false,
     };
 
     this.broker = new ScreenshareBroker(
@@ -318,6 +321,10 @@ export default class KurentoScreenshareBridge {
       const TRACE_LOGS = SFU_CONFIG.traceLogs;
       const { screenshare: NETWORK_PRIORITY } = SETTINGS.public.media.networkPriorities || {};
       const GATHERING_TIMEOUT = SFU_CONFIG.gatheringTimeout;
+      const {
+        enabled: RESTART_ICE = false,
+        retries: RESTART_ICE_RETRIES = 3,
+      } = SFU_CONFIG.restartIce?.screenshare || {};
       this.onerror = onFailure;
       this.connectionAttempts += 1;
       this.role = SEND_ROLE;
@@ -355,6 +362,8 @@ export default class KurentoScreenshareBridge {
         traceLogs: TRACE_LOGS,
         networkPriority: NETWORK_PRIORITY,
         gatheringTimeout: GATHERING_TIMEOUT,
+        restartIce: RESTART_ICE,
+        restartIceMaxRetries: RESTART_ICE_RETRIES,
       };
 
       this.broker = new ScreenshareBroker(

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/audio-broker.js
@@ -162,6 +162,9 @@ class AudioBroker extends BaseBroker {
         this.onstart(parsedMessage.success);
         this.started = true;
         break;
+      case 'restartIceResponse':
+        this.handleRestartIceResponse(parsedMessage);
+        break;
       case 'webRTCAudioError':
       case 'error':
         this.handleSFUError(parsedMessage);

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/screenshare-broker.js
@@ -41,6 +41,8 @@ class ScreenshareBroker extends BaseBroker {
     // traceLogs
     // networkPriority
     // gatheringTimeout
+    // restartIce
+    // restartIceMaxRetries
     Object.assign(this, options);
   }
 
@@ -96,6 +98,9 @@ class ScreenshareBroker extends BaseBroker {
         break;
       case 'iceCandidate':
         this.handleIceCandidate(parsedMessage.candidate);
+        break;
+      case 'restartIceResponse':
+        this.handleRestartIceResponse(parsedMessage);
         break;
       case 'error':
         this.handleSFUError(parsedMessage);

--- a/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
+++ b/bigbluebutton-html5/imports/ui/services/bbb-webrtc-sfu/sfu-base-broker.js
@@ -6,6 +6,7 @@ const WS_HEARTBEAT_OPTS = {
   interval: 15000,
   delay: 3000,
 };
+const ICE_RESTART = 'restartIce';
 
 class BaseBroker {
   static getPeerRole(role) {
@@ -43,6 +44,9 @@ class BaseBroker {
     this.signallingTransportOpen = false;
     this.logCodePrefix = `${this.sfuComponent}_broker`;
     this.peerConfiguration = {};
+    this.restartIce = false;
+    this.restartIceMaxRetries = 3;
+    this._restartIceRetries = 0;
 
     this.onbeforeunload = this.onbeforeunload.bind(this);
     this._onWSError = this._onWSError.bind(this);
@@ -291,18 +295,47 @@ class BaseBroker {
   handleConnectionStateChange (eventIdentifier) {
     if (this.webRtcPeer) {
       const { peerConnection } = this.webRtcPeer;
-      const connectionState = peerConnection.connectionState;
-      if (eventIdentifier) {
-        notifyStreamStateChange(eventIdentifier, connectionState);
-      }
-
-      if (connectionState === 'failed' || connectionState === 'closed') {
+      const { connectionState } = peerConnection;
+      const handleFatalFailure = () => {
         if (this.webRtcPeer?.peerConnection) {
           this.webRtcPeer.peerConnection.onconnectionstatechange = null;
         }
         // 1307: "ICE_STATE_FAILED",
         const error = BaseBroker.assembleError(1307);
         this.onerror(error);
+      };
+
+      if (eventIdentifier) notifyStreamStateChange(eventIdentifier, connectionState);
+
+      switch (connectionState) {
+        case 'closed':
+          handleFatalFailure();
+          break;
+
+        case 'failed':
+          if (!this.restartIce) {
+            handleFatalFailure();
+          } else {
+            try {
+              this.requestRestartIce();
+            } catch (error) {
+              handleFatalFailure();
+            }
+          }
+          break;
+
+        case 'connected':
+          if (this._restartIceRetries > 0) {
+            this._restartIceRetries = 0;
+            logger.info({
+              logCode: `${this.logCodePrefix}_ice_restarted`,
+              extraInfo: { sfuComponent: this.sfuComponent },
+            }, 'ICE restart successful');
+          }
+          break;
+
+        default:
+          break;
       }
     }
   }
@@ -344,6 +377,52 @@ class BaseBroker {
       // IT STILL HAPPENS - prlanzarin sept 2019
       // still happens - prlanzarin sept 2020
       peer.iceQueue.push(candidate);
+    }
+  }
+
+  // Sends a message to the SFU to restart ICE
+  requestRestartIce() {
+    if (this._restartIceRetries >= this.restartIceMaxRetries) {
+      throw new Error('Max ICE restart retries reached');
+    }
+
+    const message = {
+      id: ICE_RESTART,
+      type: this.sfuComponent,
+      role: this.role,
+    };
+
+    this._restartIceRetries += 1;
+    logger.warn({
+      logCode: `${this.logCodePrefix}_restart_ice`,
+      extraInfo: {
+        sfuComponent: this.sfuComponent,
+        retries: this._restartIceRetries,
+      },
+    }, `Requesting ICE restart (${this._restartIceRetries}/${this.restartIceMaxRetries})`);
+    this.sendMessage(message);
+  }
+
+  handleRestartIceResponse({ sdp }) {
+    if (this.webRtcPeer) {
+      this.webRtcPeer.restartIce(sdp, this.offering).catch((error) => {
+        logger.error({
+          logCode: `${this.logCodePrefix}_restart_ice_error`,
+          extraInfo: {
+            errorMessage: error?.message,
+            errorCode: error?.code,
+            errorName: error?.name,
+            sfuComponent: this.sfuComponent,
+          },
+        }, 'ICE restart failed');
+
+        if (this.webRtcPeer?.peerConnection) {
+          this.webRtcPeer.peerConnection.onconnectionstatechange = null;
+        }
+
+        // 1307: "ICE_STATE_FAILED",
+        this.onerror(BaseBroker.assembleError(1307));
+      });
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/peer.js
@@ -463,6 +463,42 @@ export default class WebRtcPeer extends EventEmitter2 {
       });
   }
 
+  restartIce(remoteSdp, initiator) {
+    if (this.isPeerConnectionClosed()) {
+      this.logger.error('BBB::WebRtcPeer::restartIce - peer connection closed');
+      throw new Error('Peer connection is closed');
+    }
+
+    const sdp = new RTCSessionDescription({
+      type: initiator ? 'offer' : 'answer',
+      sdp: remoteSdp,
+    });
+
+    this.logger.debug('BBB::WebRtcPeer::restartIce - setting remote description', sdp);
+
+    // If this peer was the original initiator, process remote first
+    if (initiator) {
+      return this.peerConnection.setRemoteDescription(sdp)
+        .then(() => this.peerConnection.createAnswer())
+        .then((answer) => this.peerConnection.setLocalDescription(answer))
+        .then(() => {
+          const localDescription = this.getLocalSessionDescriptor();
+          this.logger.debug('BBB::WebRtcPeer::restartIce - local description set', localDescription.sdp);
+          return localDescription.sdp;
+        });
+    }
+
+    // not the initiator - need to create offer first
+    return this.peerConnection.createOffer({ iceRestart: true })
+      .then((newOffer) => this.peerConnection.setLocalDescription(newOffer))
+      .then(() => {
+        const localDescription = this.getLocalSessionDescriptor();
+        this.logger.debug('BBB::WebRtcPeer::restartIce - local description set', localDescription.sdp);
+        return localDescription.sdp;
+      })
+      .then(() => this.peerConnection.setRemoteDescription(sdp));
+  }
+
   dispose() {
     this.logger.debug('BBB::WebRtcPeer::dispose');
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -322,6 +322,21 @@ public:
     # Controls whether ICE candidates should be signaled to bbb-webrtc-sfu.
     # Enable this if you want to use Kurento as the media server.
     signalCandidates: false
+    # restartIce: controls whether ICE restarts should be signaled to bbb-webrtc-sfu
+    #   whenever peers of the selected type (audio, video, screenshare) transition
+    #   to failure states. Disabled by default (experimental).
+    # restartIce.<mediaType>.retries: number of ICE restart retries before giving up
+    #   (i.e.: throwing an error). Default is 1 for audio, 3 for video and screenshare.
+    restartIce:
+      audio:
+        enabled: false
+        retries: 1
+      video:
+        enabled: false
+        retries: 3
+      screenshare:
+        enabled: false
+        retries: 3
     # traceLogs: <Boolean> - enable trace logs in SFU peers
     traceLogs: false
     cameraTimeouts:


### PR DESCRIPTION
### What does this PR do?

Ports https://github.com/bigbluebutton/bigbluebutton/pull/21008 and https://github.com/bigbluebutton/bigbluebutton/pull/21189 from 2.7 into 3.0.

- [feat: add experimental support for ICE restart](https://github.com/bigbluebutton/bigbluebutton/commit/a57f7cd0af0483decd01cd4f4b6eb7884a8ad738) 
  - We currently use full renegotiation for audio, video, and screen sharing
reconnections, which involves re-creating transports and signaling channels
from scratch. While effective in some scenarios, this approach is slow and,
especially with outbound cameras and screen sharing, prone to failures.
  - To counter that, WebRTC provides a mechanism to restart ICE without needing
to re-create the peer connection. This allows us to avoid full renegotiation
and bypass some server-side signaling limitations. Implementing ICE restart
should make outbound camera/screen sharing reconnections more reliable and
faster.
  - This commit implements the ICE restart procedure for all WebRTC components'
*outbound* peers. It is based on bbb-webrtc-sfu >= v2.15.0-beta.0, which
added support for ICE restart requests. This feature is *off by default*.
To enable it, adjust the following flag:
    - `/etc/bigbluebutton/bbb-html5.yml`: `public.kurento.restartIce`
      * Refer to the inline documentation; this can be enabled on the client side
    per media type.

### Closes Issue(s)

Closes #21184 