### PR TITLE
fix(webcam): do not skip video preview if initial device is already shared

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -277,9 +277,12 @@ class VideoPreview extends Component {
 
   shouldSkipVideoPreview() {
     const { skipPreviewFailed } = this.state;
-    const { forceOpen } = this.props;
+    const { cameraAsContent, forceOpen, webcamDeviceId } = this.props;
 
-    return PreviewService.getSkipVideoPreview() && !forceOpen && !skipPreviewFailed;
+    // If the initial stream is already shared give the user the chance to choose the device
+    const shared = this.isAlreadyShared(webcamDeviceId);
+
+    return PreviewService.getSkipVideoPreview() && !forceOpen && !skipPreviewFailed && !shared;
   }
 
   componentDidMount() {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Since **camera as content** and **video preview** share the same UI component, `userdata-bbb_skip_video_preview=true` makes the same device be shared twice if the user shares webcam and then shares camera as content, and vice versa.

This PR adds an extra condition to ignore `userdata-bbb_skip_video_preview=true` and allow the user to select the device if the initial device is already shared.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21165