### PR TITLE
fix (akka-apps): Banned users being able to rejoin (when they have customdata)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -55,23 +55,30 @@ trait RegisterUserReqMsgHdlr {
 
     val guestStatus = msg.body.guestStatus
 
-    val regUser = RegisteredUsers.create(msg.body.intUserId, msg.body.extUserId,
-      msg.body.name, msg.body.role, msg.body.authToken,
-      msg.body.avatarURL,
-      msg.body.webcamBackgroundURL,
-      ColorPicker.nextColor(liveMeeting.props.meetingProp.intId), msg.body.guest, msg.body.authed, guestStatus, msg.body.excludeFromDashboard, false)
-
-    checkUserConcurrentAccesses(regUser)
-
-    RegisteredUsers.add(liveMeeting.registeredUsers, regUser)
-
     val userCustomData: Map[String, String] = msg.body.userCustomData.map {
       case (k, v) => k -> v.toString
     }
 
-    if (userCustomData.nonEmpty) {
-      RegisteredUsers.updateUserCustomData(liveMeeting.registeredUsers, regUser, userCustomData)
-    }
+    val regUser = RegisteredUsers.create(
+      msg.body.intUserId,
+      msg.body.extUserId,
+      msg.body.name,
+      msg.body.role,
+      msg.body.authToken,
+      msg.body.avatarURL,
+      msg.body.webcamBackgroundURL,
+      ColorPicker.nextColor(liveMeeting.props.meetingProp.intId),
+      msg.body.guest,
+      msg.body.authed,
+      guestStatus,
+      msg.body.excludeFromDashboard,
+      loggedOut = false,
+      userCustomData = userCustomData
+    )
+
+    checkUserConcurrentAccesses(regUser)
+
+    RegisteredUsers.add(liveMeeting.registeredUsers, regUser)
 
     log.info("Register user success. meetingId=" + liveMeeting.props.meetingProp.intId
       + " userId=" + msg.body.extUserId + " user=" + regUser)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ValidateAuthTokenReqMsgHdlr.scala
@@ -21,6 +21,7 @@ trait ValidateAuthTokenReqMsgHdlr extends HandlerHelpers {
     var failReasonCode = EjectReasonCode.VALIDATE_TOKEN
 
     log.info("Number of registered users [{}]", RegisteredUsers.numRegisteredUsers(liveMeeting.registeredUsers))
+
     val regUser = RegisteredUsers.getRegisteredUserWithToken(msg.body.authToken, msg.body.userId,
       liveMeeting.registeredUsers)
     regUser match {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -35,7 +35,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
     def registerUserInRegisteredUsers() = {
       val regUser = RegisteredUsers.create(msg.body.intId, msg.body.voiceUserId,
         msg.body.callerIdName, Roles.VIEWER_ROLE, msg.body.intId, "", "",
-        userColor, true, true, GuestStatus.WAIT, true, false)
+        userColor, true, true, GuestStatus.WAIT, true, false, Map.empty)
       RegisteredUsers.add(liveMeeting.registeredUsers, regUser)
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -6,7 +6,7 @@ import org.bigbluebutton.core.domain.BreakoutRoom2x
 object RegisteredUsers {
   def create(userId: String, extId: String, name: String, roles: String,
              token: String, avatar: String, webcamBackground: String, color: String, guest: Boolean, authenticated: Boolean,
-             guestStatus: String, excludeFromDashboard: Boolean, loggedOut: Boolean): RegisteredUser = {
+             guestStatus: String, excludeFromDashboard: Boolean, loggedOut: Boolean, userCustomData: Map[String, String]): RegisteredUser = {
     new RegisteredUser(
       userId,
       extId,
@@ -25,6 +25,7 @@ object RegisteredUsers {
       false,
       false,
       loggedOut,
+      userCustomData = userCustomData
     )
   }
 
@@ -79,7 +80,6 @@ object RegisteredUsers {
   }
 
   def add(users: RegisteredUsers, user: RegisteredUser): Vector[RegisteredUser] = {
-
     findWithExternUserId(user.externId, users) match {
       case Some(u) =>
         if (u.banned) {
@@ -165,12 +165,6 @@ object RegisteredUsers {
     u
   }
 
-  def updateUserCustomData(users: RegisteredUsers, user: RegisteredUser, userCustomData: Map[String, String]): RegisteredUser = {
-    val u = user.modify(_.userCustomData).setTo(userCustomData)
-    users.save(u)
-    u
-  }
-
 }
 
 class RegisteredUsers {
@@ -210,7 +204,7 @@ case class RegisteredUser(
     joined:                   Boolean,
     banned:                   Boolean,
     loggedOut:                Boolean,
-    lastBreakoutRoom:         BreakoutRoom2x = null,
+    lastBreakoutRoom:         BreakoutRoom2x      = null,
     userCustomData:           Map[String, String] = Map.empty
 )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -57,7 +57,7 @@ object FakeUserGenerator {
     val color = "#ff6242"
 
     val ru = RegisteredUsers.create(userId = id, extId, name, role,
-      authToken, avatarURL, webcamBackgroundURL, color, guest, authed, guestStatus = GuestStatus.ALLOW, false, false)
+      authToken, avatarURL, webcamBackgroundURL, color, guest, authed, guestStatus = GuestStatus.ALLOW, false, false, Map.empty)
     RegisteredUsers.add(users, ru)
     ru
   }


### PR DESCRIPTION
Fix an issue where users that joined with `userdata-` params set was not being able to be banned.

This PR change the way the user is registered in akka-apps, 
Now it requires the prop `userCustomData` when creating a new user, because the function that populated `userCustomData` later was causing the issue.

Closes #21207