### PR TITLE
fix: chat popup notification for user away does not contain information

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -54,6 +54,14 @@ const intlMessages = defineMessages({
     id: 'app.toast.chat.pollClick',
     description: 'chat toast click message for polls',
   },
+  userAway: {
+    id: 'app.chat.away',
+    description: 'message when user is away',
+  },
+  userNotAway: {
+    id: 'app.chat.notAway',
+    description: 'message when user is no longer away',
+  },
 });
 
 const ALERT_DURATION = 4000; // 4 seconds
@@ -124,6 +132,14 @@ const ChatAlertGraphql: React.FC<ChatAlertGraphqlProps> = (props) => {
   }
 
   const mapTextContent = (msg: Message) => {
+    if (msg.messageType === ChatMessageType.USER_AWAY_STATUS_MSG) {
+      const { away } = JSON.parse(msg.messageMetadata as string);
+
+      return away
+        ? intl.formatMessage(intlMessages.userAway)
+        : intl.formatMessage(intlMessages.userNotAway);
+    }
+
     if (msg.messageType === ChatMessageType.CHAT_CLEAR) {
       return intl.formatMessage(intlMessages.publicChatClear);
     }


### PR DESCRIPTION
### What does this PR do?

Adjusts chat notification popup so it correctly displays user away message

#### before
![Screenshot from 2024-09-18 09-25-16](https://github.com/user-attachments/assets/8926942f-57c3-4ffe-a2e7-c09b7b5101af)

#### after
![Screenshot from 2024-09-18 09-24-48](https://github.com/user-attachments/assets/72e744fc-e13f-4965-88ef-244d21c5748e)

### How to test

1. join a meeting with 2 users
2. user A enables chat popup notifications
3. user A closes chat area
4. user B enters away mode
5. notification displayed for user A should contain a message "user B is away"
