### PR TITLE
fix: client logger streams being created at export time

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/logger/index.ts
+++ b/bigbluebutton-html5/imports/startup/client/logger/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line max-classes-per-file
 import { createLogger, Logger, stdSerializers } from 'browser-bunyan';
 import { ConsoleFormattedStream } from '@browser-bunyan/console-formatted-stream';
 import { ConsoleRawStream } from '@browser-bunyan/console-raw-stream';
@@ -88,4 +90,45 @@ class BBBClientLogger {
   }
 }
 
-export default BBBClientLogger.logger;
+export default class LoggerFactory {
+  private static instance: Logger | null = null;
+
+  public static getLogger() {
+    if (!LoggerFactory.instance) {
+      LoggerFactory.instance = BBBClientLogger.logger;
+    }
+    return LoggerFactory.instance;
+  }
+
+  public static error(...args: any[]) {
+    LoggerFactory.getLogger().error(...args);
+  }
+
+  public static warn(...args: any[]) {
+    LoggerFactory.getLogger().warn(...args);
+  }
+
+  public static info(...args: any[]) {
+    LoggerFactory.getLogger().info(...args);
+  }
+
+  public static debug(...args: any[]) {
+    LoggerFactory.getLogger().debug(...args);
+  }
+
+  public static trace(...args: any[]) {
+    LoggerFactory.getLogger().trace(...args);
+  }
+
+  public static log(...args: any[]) {
+    LoggerFactory.getLogger().log(...args);
+  }
+
+  public static addStream(stream: ConsoleRawStream | ServerLoggerStream) {
+    LoggerFactory.getLogger().addStream(stream);
+  }
+
+  public static getStreams() {
+    return LoggerFactory.getLogger().streams;
+  }
+}

--- a/bigbluebutton-html5/imports/startup/client/logger/index.ts
+++ b/bigbluebutton-html5/imports/startup/client/logger/index.ts
@@ -101,34 +101,30 @@ export default class LoggerFactory {
   }
 
   public static error(...args: any[]) {
-    LoggerFactory.getLogger().error(...args);
+    LoggerFactory.getLogger().error(...args as [any, ...any[]]);
   }
 
   public static warn(...args: any[]) {
-    LoggerFactory.getLogger().warn(...args);
+    LoggerFactory.getLogger().warn(...args as [any, ...any[]]);
   }
 
   public static info(...args: any[]) {
-    LoggerFactory.getLogger().info(...args);
+    LoggerFactory.getLogger().info(...args as [any, ...any[]]);
   }
 
   public static debug(...args: any[]) {
-    LoggerFactory.getLogger().debug(...args);
+    LoggerFactory.getLogger().debug(...args as [any, ...any[]]);
   }
 
   public static trace(...args: any[]) {
-    LoggerFactory.getLogger().trace(...args);
+    LoggerFactory.getLogger().trace(...args as [any, ...any[]]);
   }
 
-  public static log(...args: any[]) {
-    LoggerFactory.getLogger().log(...args);
-  }
-
-  public static addStream(stream: ConsoleRawStream | ServerLoggerStream) {
+  public static addStream(stream: any) {
     LoggerFactory.getLogger().addStream(stream);
   }
 
   public static getStreams() {
-    return LoggerFactory.getLogger().streams;
+    return (LoggerFactory.getLogger() as any).streams;
   }
 }

--- a/bigbluebutton-html5/imports/startup/client/logger/index.ts
+++ b/bigbluebutton-html5/imports/startup/client/logger/index.ts
@@ -69,6 +69,7 @@ class BBBClientLogger {
 
   public static get logger() {
     if (BBBClientLogger.default) return BBBClientLogger.default;
+
     const LOG_CONFIG = window.meetingClientSettings?.public?.clientLog;
     if (LOG_CONFIG && !BBBClientLogger.default) {
       BBBClientLogger.default = createLogger({
@@ -78,6 +79,7 @@ class BBBClientLogger {
         src: true,
       });
     }
+
     if (!BBBClientLogger.fallback) {
       BBBClientLogger.fallback = createLogger({
         name: 'clientLogger',
@@ -86,18 +88,14 @@ class BBBClientLogger {
         src: true,
       });
     }
-    return BBBClientLogger.fallback;
+
+    return BBBClientLogger.default || BBBClientLogger.fallback;
   }
 }
 
 export default class LoggerFactory {
-  private static instance: Logger | null = null;
-
   public static getLogger() {
-    if (!LoggerFactory.instance) {
-      LoggerFactory.instance = BBBClientLogger.logger;
-    }
-    return LoggerFactory.instance;
+    return BBBClientLogger.logger;
   }
 
   public static error(...args: any[]) {

--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
@@ -37,7 +37,7 @@ class ErrorBoundary extends Component {
   componentDidMount() {
     const data = window.meetingClientSettings.public;
     const logConfig = data?.clientLog;
-    if (logConfig && logger?.streams.length === 0) {
+    if (logConfig && logger?.getStreams().length === 0) {
       generateLoggerStreams(logConfig).forEach((stream) => {
         logger.addStream(stream);
       });


### PR DESCRIPTION
### What does this PR do?

Adjusts BBBClientLogger to work with the new way to get client settings - logger streams were being created at export time (when client settings are not yet available).

### Motivation
issue reported by @antobinary + @prlanzarin 

### How to test
1. start bigbluebutton with any `clientLog` settings other than the default ones
2. join a meeting
