### PR TITLE
fix(timer): beep failing to play intermittently

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1555,6 +1555,12 @@ SELECT
         when "startedAt" + (("time" - coalesce("accumulated",0)) * interval '1 milliseconds') >= current_timestamp then true
         else false
      end "running",
+    case when
+        "stopwatch" is false
+        and "startedAt" + (("time" - coalesce("accumulated",0)) * interval '1 milliseconds') <= current_timestamp
+        then true
+        else false
+    end "elapsed",
      "active",
      "time",
      "accumulated",

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_timer.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_timer.yaml
@@ -18,6 +18,7 @@ select_permissions:
         - startedOn
         - stopwatch
         - time
+        - elapsed
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
@@ -14,6 +14,7 @@ interface TimerIndicatorProps {
   passedTime: number;
   stopwatch: boolean;
   songTrack: string;
+  elapsed?: boolean;
   running: boolean;
   isModerator: boolean;
   sidebarNavigationIsOpen: boolean;
@@ -25,6 +26,7 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
   passedTime,
   stopwatch,
   songTrack,
+  elapsed,
   running,
   isModerator,
   sidebarNavigationIsOpen,
@@ -96,13 +98,6 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
         setTime((prev) => {
           if (stopwatch) return (Math.round(prev / 1000) * 1000) + 1000;
           const t = (Math.floor(prev / 1000) * 1000) - 1000;
-          if (t <= 0) {
-            if (!alreadyNotified.current) {
-              triggered.current = false;
-              alreadyNotified.current = true;
-              if (alarm.current) alarm.current.play();
-            }
-          }
           return t < 0 ? 0 : t;
         });
       }, 1000);
@@ -114,6 +109,16 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, [running]);
+
+  useEffect(() => {
+    if (elapsed) {
+      if (!alreadyNotified.current) {
+        triggered.current = false;
+        alreadyNotified.current = true;
+        if (alarm.current) alarm.current.play();
+      }
+    }
+  }, [elapsed]);
 
   useEffect(() => {
     if (!running) return;
@@ -204,6 +209,7 @@ const TimerIndicatorContainer: React.FC = () => {
 
   const {
     accumulated,
+    elapsed,
     running,
     startedOn,
     stopwatch,
@@ -225,6 +231,7 @@ const TimerIndicatorContainer: React.FC = () => {
       passedTime={timePassed}
       stopwatch={stopwatch ?? false}
       songTrack={songTrack ?? 'noTrack'}
+      elapsed={elapsed}
       running={running ?? false}
       isModerator={currentUser?.isModerator ?? false}
       sidebarNavigationIsOpen={sidebarNavigationIsOpen}

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -102,7 +102,7 @@ const intlMessages = defineMessages({
   },
 });
 
-interface TimerPanelProps extends TimerData {
+interface TimerPanelProps extends Omit<TimerData, 'elapsed'> {
   timePassed: number;
 }
 

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/timer.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/timer.ts
@@ -9,6 +9,7 @@ export interface TimerData {
   running: boolean;
   startedOn: number;
   startedAt: string;
+  elapsed: boolean;
 }
 
 export interface GetTimerResponse {
@@ -26,6 +27,7 @@ export const GET_TIMER = gql`
       running
       startedOn
       startedAt
+      elapsed
     }
   }
 `;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes timer beep failing to play intermittently. This is due to the interval being cleaned up before it reaches `0`. This PR separates _updating the time_ and _playing the beep_ into different things. _Updating the time_ will keep as-is, each client updating its own local state. In order to know when to play the beep, this PR adds a new auto-generated server-side flag, `elapsed`, which becomes `true` when the timer reaches its endpoint. Clients will observe such flag to know when beeping.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21156

### How to test

1. `cd ./bbb-graphql-server && ./deploy.sh`
2. Join a session with several users.
3. Start the timer.
4. When it reaches `0` it should always beep for all users.

