### PR TITLE
recording: Fix recording external video logic

### DIFF
--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1228,14 +1228,16 @@ def process_external_video_events(_events, package_dir)
     external_video_events.each do |event|
       BigBlueButton.logger.info("Processing rec event #{re} and external video event #{event}")
       start_timestamp = event[:start_timestamp]
+      stop_timestamp = event[:stop_timestamp]
       timestamp = (translate_timestamp(start_timestamp) / 1000).to_i
       # do not add same external_video twice
       next if external_videos.find { |ev| ev[:timestamp] == timestamp }
 
       re_start_timestamp = re[:start_timestamp]
       re_stop_timestamp = re[:stop_timestamp]
-      next unless ((start_timestamp >= re_start_timestamp) && (start_timestamp <= re_stop_timestamp)) ||
-                  ((start_timestamp < re_start_timestamp) && (re_stop_timestamp >= re_start_timestamp))
+      next unless ((start_timestamp >= re_start_timestamp) && (start_timestamp < re_stop_timestamp)) ||
+                  ((stop_timestamp > re_start_timestamp) && (stop_timestamp <= re_stop_timestamp)) ||
+                  ((start_timestamp <= re_start_timestamp) && (stop_timestamp >= re_stop_timestamp) && (re_stop_timestamp > re_start_timestamp))
 
       external_videos << {
         timestamp: timestamp,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fix the logic whether an external video is included in the playback.

### Motivation
To me the condition when we include external video in the playback looks strange. 
Before the fix, an external video that has finished playing before the recording start is also included in the playback.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
- start a meeting
- play an external video without recording
- finish playing the video
- start recording
- finish recording
- see the external video is included in the playback before the fix, after the fix, it does not appear.
