### PR TITLE
style: adjust confirmation modal props

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/confirmation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/confirmation/component.jsx
@@ -121,6 +121,7 @@ class ConfirmationModal extends Component {
             )}
             <div ref={this.cancelButtonRef}>
               <Styled.CancelButton
+                color="secondary"
                 label={cancelButtonLabel || intl.formatMessage(messages.noLabel)}
                 onClick={() => setIsOpen(false)}
               />


### PR DESCRIPTION
### What does this PR do?

adjusts confirmation modal props, so the secondary button has the correct styling.

#### before

focused
![Screenshot from 2024-09-23 15-49-58](https://github.com/user-attachments/assets/3c85bafb-55fd-48d4-a885-b13d1c1f37e8)

unfocused
![Screenshot from 2024-09-23 15-50-01](https://github.com/user-attachments/assets/65ba89bb-84dd-4244-98f6-b93af58cffec)


#### after

focused
![Screenshot from 2024-09-23 15-49-40](https://github.com/user-attachments/assets/5594d774-c72b-4499-b7e5-8a59c3c58e08)

unfocused
![Screenshot from 2024-09-23 15-49-43](https://github.com/user-attachments/assets/2c03cfc7-4da2-4e53-bb0c-898490c0ffc3)

### How to test
1. join a meeting with recording enabled
2. click the recording indicator button to start/stop recording
3. check the "no" button styles