### PR TITLE
refactor: sonarcloud alerts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -506,10 +506,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   return renderForm();
 };
 
-// eslint-disable-next-line no-empty-pattern
-const ChatMessageFormContainer: React.FC = ({
-  // connected, move to network status
-}) => {
+const ChatMessageFormContainer: React.FC = () => {
   const intl = useIntl();
   const idChatOpen: string = layoutSelect((i: Layout) => i.idChatOpen);
   const isRTL = layoutSelect((i: Layout) => i.isRTL);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -274,7 +274,6 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
             setShouldNotify((prev) => !prev);
           }}
           priority="high"
-          setIsOpen={setIsRecordingNotifyModalOpen}
           isOpen={isRecordingNotifyModalOpen}
           closeModal={() => {
             setIsRecordingNotifyModalOpen(false);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { USER_LEAVE_MEETING } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useMutation } from '@apollo/client';

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
@@ -40,8 +40,6 @@ const LOGOUT_CODE = '680';
 interface RecordingNotifyModalProps {
   toggleShouldNotify: () => void;
   closeModal: () => void;
-  // eslint-disable-next-line react/no-unused-prop-types
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
   isOpen: boolean;
   priority: string;
 }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1094,7 +1094,6 @@ const Whiteboard = React.memo((props) => {
               adjustedZoom = calculateZoomWithGapValue(
                 currentPresentationPage.scaledWidth,
                 currentPresentationPage.scaledHeight,
-                false,
                 widthGap,
               );
 


### PR DESCRIPTION
### What does this PR do?

addresses the following sonarcloud alerts:
 
- whiteboard: This function expects 3 arguments, but 4 were provided.
- chat message form: Unexpected empty object pattern.
- recording indicator: 'setIsOpen' PropType is defined but prop is never used

### How to test

whiteboard, chat message form and recording indicator components should still work the same after these changes.