### PR TITLE
Fix: Restore keyboard navigation on userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Auth from '/imports/ui/services/auth';
 import Storage from '/imports/ui/services/storage/session';
-import KEY_CODES from '/imports/utils/keyCodes';
 import AudioService from '/imports/ui/components/audio/service';
 import logger from '/imports/startup/client/logger';
 import Session from '/imports/ui/services/storage/in-memory';
@@ -280,70 +279,6 @@ const focusFirstDropDownItem = () => {
   list[0].focus();
 };
 
-const roving = (...args) => {
-  const [
-    event,
-    changeState,
-    elementsList,
-    element,
-  ] = args;
-
-  this.selectedElement = element;
-  const numberOfChilds = elementsList.childElementCount;
-  const menuOpen = Session.getItem('dropdownOpen') || false;
-
-  if (menuOpen) {
-    const menuChildren = document.activeElement.getElementsByTagName('li');
-
-    if ([KEY_CODES.ESCAPE, KEY_CODES.ARROW_LEFT].includes(event.keyCode)) {
-      Session.setItem('dropdownOpen', false);
-      document.activeElement.click();
-    }
-
-    if ([KEY_CODES.ARROW_UP].includes(event.keyCode)) {
-      menuChildren[menuChildren.length - 1].focus();
-    }
-
-    if ([KEY_CODES.ARROW_DOWN].includes(event.keyCode)) {
-      for (let i = 0; i < menuChildren.length; i += 1) {
-        if (menuChildren[i].hasAttribute('tabIndex')) {
-          menuChildren[i].focus();
-          break;
-        }
-      }
-    }
-
-    return;
-  }
-
-  if ([KEY_CODES.ESCAPE, KEY_CODES.TAB].includes(event.keyCode)) {
-    Session.setItem('dropdownOpen', false);
-    changeState(null);
-  }
-
-  if (event.keyCode === KEY_CODES.ARROW_DOWN) {
-    const firstElement = elementsList.firstChild;
-    let elRef = element && numberOfChilds > 1 ? element.nextSibling : firstElement;
-
-    elRef = elRef || firstElement;
-    changeState(elRef);
-  }
-
-  if (event.keyCode === KEY_CODES.ARROW_UP) {
-    const lastElement = elementsList.lastChild;
-    let elRef = element ? element.previousSibling : lastElement;
-    elRef = elRef || lastElement;
-    changeState(elRef);
-  }
-
-  if ([KEY_CODES.ARROW_RIGHT, KEY_CODES.SPACE, KEY_CODES.ENTER].includes(event.keyCode)) {
-    const tether = document.activeElement.firstChild;
-    const dropdownTrigger = tether.firstChild;
-    dropdownTrigger?.click();
-    focusFirstDropDownItem();
-  }
-};
-
 const sortUsersByFirstName = (a, b) => {
   const aUser = { sortName: a.firstName ? a.firstName : '' };
   const bUser = { sortName: b.firstName ? b.firstName : '' };
@@ -457,7 +392,6 @@ export default {
   getActiveChats,
   isMeetingLocked,
   isPublicChat,
-  roving,
   getCustomLogoUrl,
   getCustomDarkLogoUrl,
   focusFirstDropDownItem,

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Auth from '/imports/ui/services/auth';
 import Storage from '/imports/ui/services/storage/session';
 import AudioService from '/imports/ui/components/audio/service';
+import KEY_CODES from '/imports/utils/keyCodes';
 import logger from '/imports/startup/client/logger';
 import Session from '/imports/ui/services/storage/in-memory';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
@@ -279,6 +280,70 @@ const focusFirstDropDownItem = () => {
   list[0].focus();
 };
 
+const roving = (...args) => {
+  const [
+    event,
+    changeState,
+    elementsList,
+    element,
+  ] = args;
+
+  this.selectedElement = element;
+  const numberOfChilds = elementsList.childElementCount;
+  const menuOpen = Session.getItem('dropdownOpen') || false;
+
+  if (menuOpen) {
+    const menuChildren = document.activeElement.getElementsByTagName('li');
+
+    if ([KEY_CODES.ESCAPE, KEY_CODES.ARROW_LEFT].includes(event.keyCode)) {
+      Session.setItem('dropdownOpen', false);
+      document.activeElement.click();
+    }
+
+    if ([KEY_CODES.ARROW_UP].includes(event.keyCode)) {
+      menuChildren[menuChildren.length - 1].focus();
+    }
+
+    if ([KEY_CODES.ARROW_DOWN].includes(event.keyCode)) {
+      for (let i = 0; i < menuChildren.length; i += 1) {
+        if (menuChildren[i].hasAttribute('tabIndex')) {
+          menuChildren[i].focus();
+          break;
+        }
+      }
+    }
+
+    return;
+  }
+
+  if ([KEY_CODES.ESCAPE, KEY_CODES.TAB].includes(event.keyCode)) {
+    Session.setItem('dropdownOpen', false);
+    changeState(null);
+  }
+
+  if (event.keyCode === KEY_CODES.ARROW_DOWN) {
+    const firstElement = elementsList.firstChild;
+    let elRef = element && numberOfChilds > 1 ? element.nextSibling : firstElement;
+
+    elRef = elRef || firstElement;
+    changeState(elRef);
+  }
+
+  if (event.keyCode === KEY_CODES.ARROW_UP) {
+    const lastElement = elementsList.lastChild;
+    let elRef = element ? element.previousSibling : lastElement;
+    elRef = elRef || lastElement;
+    changeState(elRef);
+  }
+
+  if ([KEY_CODES.ARROW_RIGHT, KEY_CODES.SPACE, KEY_CODES.ENTER].includes(event.keyCode)) {
+    const tether = document.activeElement.firstChild;
+    const dropdownTrigger = tether.firstChild;
+    dropdownTrigger?.click();
+    focusFirstDropDownItem();
+  }
+};
+
 const sortUsersByFirstName = (a, b) => {
   const aUser = { sortName: a.firstName ? a.firstName : '' };
   const bUser = { sortName: b.firstName ? b.firstName : '' };
@@ -392,6 +457,7 @@ export default {
   getActiveChats,
   isMeetingLocked,
   isPublicChat,
+  roving,
   getCustomLogoUrl,
   getCustomDarkLogoUrl,
   focusFirstDropDownItem,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -75,7 +75,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   }, []);
   // --- End of plugin related code ---
   const rove = (ev: KeyboardEvent) => {
-    if (ev.code === 'Enter') {
+    if (ev.code === 'Enter' || ev.code === 'Space' || (ev.code === 'ArrowDown' && selectedUserRef.current !== document.activeElement)) {
       if (selectedUserRef.current && (selectedUserRef.current === document.activeElement)) {
         selectedUserRef.current.click();
       } else {
@@ -86,6 +86,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
           selectedUserRef.current.focus();
         }
       }
+      return;
     }
 
     if (ev.code === 'ArrowDown' || ev.code === 'ArrowUp') {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -115,7 +115,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
           {
             Array.from({ length: amountOfPages }).map((_, i) => {
               const isLastItem = amountOfPages === (i + 1);
-              const restOfUsers = count % 15;
+              const restOfUsers = count % 50;
               const key = i;
               return i === 0
                 ? (

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 
-import { findDOMNode } from 'react-dom';
 import { UI_DATA_LISTENER_SUBSCRIBED } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/consts';
 import { UserListUiDataPayloads } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data-hooks/user-list/types';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
@@ -9,7 +8,6 @@ import Styled from './styles';
 import {
   USER_AGGREGATE_COUNT_SUBSCRIPTION,
 } from './queries';
-import Service from '/imports/ui/components/user-list/service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import UserListParticipantsPageContainer from './page/component';
 import IntersectionWatcher from './intersection-watcher/intersectionWatcher';
@@ -26,16 +24,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
     [key: number]: User[];
   }>({});
   const userListRef = React.useRef<HTMLDivElement | null>(null);
-  const userItemsRef = React.useRef<HTMLDivElement | null>(null);
-  const [selectedUser, setSelectedUser] = React.useState<HTMLElement>();
-  const { roving } = Service;
-
-  React.useEffect(() => {
-    const firstChild = (selectedUser as HTMLElement)?.firstChild;
-
-    const fourthChild = firstChild?.firstChild?.firstChild?.firstChild;
-    if (fourthChild && fourthChild instanceof HTMLElement) fourthChild.focus();
-  }, [selectedUser]);
+  const selectedUserRef = React.useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     const keys = Object.keys(visibleUsers);
@@ -85,43 +74,50 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
     };
   }, []);
   // --- End of plugin related code ---
+  const rove = (ev: KeyboardEvent) => {
+    if (ev.code === 'Enter') {
+      if (selectedUserRef.current && (selectedUserRef.current === document.activeElement)) {
+        selectedUserRef.current.click();
+      } else {
+        const userItem = document.getElementById('user-index-0');
+        selectedUserRef.current = userItem;
 
-  const rove = (event: React.KeyboardEvent) => {
-    // eslint-disable-next-line react/no-find-dom-node
-    const usrItemsRef = findDOMNode(userItemsRef.current);
-    const usrItemsRefChild = usrItemsRef?.firstChild;
+        if (selectedUserRef.current) {
+          selectedUserRef.current.focus();
+        }
+      }
+    }
 
-    roving(event, setSelectedUser, usrItemsRefChild, selectedUser);
-
-    event.stopPropagation();
+    if (ev.code === 'ArrowDown' || ev.code === 'ArrowUp') {
+      const sum = ev.code === 'ArrowDown' ? 1 : -1;
+      const el = selectedUserRef.current;
+      if (el) {
+        const nextId = Number.parseInt(el.id.split('-')[2], 10) + sum;
+        const nextEl = document.getElementById(`user-index-${nextId}`);
+        if (nextEl) {
+          selectedUserRef.current = nextEl;
+          nextEl.focus();
+        }
+      }
+    }
   };
+
   const amountOfPages = Math.ceil(count / 50);
   return (
-    <Styled.UserListColumn onKeyDown={rove} tabIndex={0}>
-      <Styled.VirtualizedList ref={userListRef}>
-        {
-          Array.from({ length: amountOfPages }).map((_, i) => {
-            const isLastItem = amountOfPages === (i + 1);
-            const restOfUsers = count % 50;
-            const key = i;
-            return i === 0
-              ? (
-                <UserListParticipantsPageContainer
-                  key={key}
-                  index={i}
-                  isLastItem={isLastItem}
-                  restOfUsers={isLastItem ? restOfUsers : 50}
-                  setVisibleUsers={setVisibleUsers}
-                />
-              )
-              : (
-                <IntersectionWatcher
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={i}
-                  ParentRef={userListRef}
-                  isLastItem={isLastItem}
-                  restOfUsers={isLastItem ? restOfUsers : 50}
-                >
+    (
+      <Styled.UserListColumn
+      // @ts-ignore
+        onKeyDown={rove}
+        tabIndex={0}
+      >
+        <Styled.VirtualizedList ref={userListRef}>
+          {
+            Array.from({ length: amountOfPages }).map((_, i) => {
+              const isLastItem = amountOfPages === (i + 1);
+              const restOfUsers = count % 15;
+              const key = i;
+              return i === 0
+                ? (
                   <UserListParticipantsPageContainer
                     key={key}
                     index={i}
@@ -129,12 +125,29 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                     restOfUsers={isLastItem ? restOfUsers : 50}
                     setVisibleUsers={setVisibleUsers}
                   />
-                </IntersectionWatcher>
-              );
-          })
-        }
-      </Styled.VirtualizedList>
-    </Styled.UserListColumn>
+                )
+                : (
+                  <IntersectionWatcher
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={i}
+                    ParentRef={userListRef}
+                    isLastItem={isLastItem}
+                    restOfUsers={isLastItem ? restOfUsers : 50}
+                  >
+                    <UserListParticipantsPageContainer
+                      key={key}
+                      index={i}
+                      isLastItem={isLastItem}
+                      restOfUsers={isLastItem ? restOfUsers : 50}
+                      setVisibleUsers={setVisibleUsers}
+                    />
+                  </IntersectionWatcher>
+                );
+            })
+          }
+        </Styled.VirtualizedList>
+      </Styled.UserListColumn>
+    )
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -69,6 +69,7 @@ declare global {
 interface UserListItemProps {
   user: User;
   lockSettings: LockSettings;
+  index: number;
 }
 
 const renderUserListItemIconsFromPlugin = (
@@ -90,7 +91,7 @@ const Emoji: React.FC<EmojiProps> = ({ emoji, native, size }) => (
   <em-emoji emoji={emoji} native={native} size={size} />
 );
 
-const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
+const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings, index }) => {
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
   let userItemsFromPlugin = [] as PluginSdk.UserListItemAdditionalInformationInterface[];
   if (pluginsExtensibleAreasAggregatedState.userListItemAdditionalInformation) {
@@ -225,7 +226,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
   }
 
   return (
-    <Styled.UserItemContents tabIndex={-1} data-test={(user.userId === Auth.userID) ? 'userListItemCurrent' : 'userListItem'}>
+    <Styled.UserItemContents id={`user-index-${index}`} tabIndex={-1} data-test={(user.userId === Auth.userID) ? 'userListItemCurrent' : 'userListItem'}>
       <Styled.Avatar
         data-test={user.isModerator ? 'moderatorAvatar' : 'viewerAvatar'}
         data-test-presenter={user.presenter ? '' : undefined}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -84,7 +84,7 @@ const UserItemContents = styled.div<UserItemContentsProps>`
     &:first-child {
       margin-top: 0;
     }
-
+    &:focus,
     &:hover {
       outline: transparent;
       outline-style: dotted;
@@ -92,8 +92,7 @@ const UserItemContents = styled.div<UserItemContentsProps>`
       background-color: ${listItemBgHover};
     }
 
-    &:active,
-    &:focus {
+    &:active{
       outline: transparent;
       outline-width: ${borderSize};
       outline-style: solid;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
@@ -26,6 +26,7 @@ interface UsersListParticipantsPage {
   meeting: Meeting;
   currentUser: Partial<User>;
   pageId: string;
+  offset: number;
 }
 
 const UsersListParticipantsPage: React.FC<UsersListParticipantsPage> = ({
@@ -33,13 +34,14 @@ const UsersListParticipantsPage: React.FC<UsersListParticipantsPage> = ({
   currentUser,
   meeting,
   pageId,
+  offset,
 }) => {
   const [openUserAction, setOpenUserAction] = React.useState<string | null>(null);
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
   return (
     <>
       {
-        users.map((user) => {
+        users.map((user, idx) => {
           return (
             <Styled.UserListItem key={user.userId} style={{ direction: isRTL }}>
               <UserActions
@@ -52,7 +54,7 @@ const UsersListParticipantsPage: React.FC<UsersListParticipantsPage> = ({
                 open={user.userId === openUserAction}
                 setOpenUserAction={setOpenUserAction}
               >
-                <ListItem user={user} lockSettings={meeting.lockSettings} />
+                <ListItem index={offset + idx} user={user} lockSettings={meeting.lockSettings} />
               </UserActions>
             </Styled.UserListItem>
           );
@@ -134,6 +136,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
       meeting={meeting ?? {}}
       currentUser={currentUser ?? {}}
       pageId={pageId}
+      offset={offset}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?
This PR intends to restore the keyboard navigation on userlist, I refactored the code to support the pagination and have a easy way to get the element, it stopped work on the migration from the virtual list to the pagenation, before the virtualized returned a ref with all elements on screen and with the removing of it only the parent page was being returned.

OBS: I'm using the key values directly because the KeyCode is deprecated https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

# How to Test

Navigate with tab til reach main userlist area so press, space, enter or arrow down to navigate using arrow keys.