### PR TITLE
refactor: Speed improvement for the presentation export

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -103,13 +103,11 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
 
           val whiteboardId = s"${presId}/${pageNumber.toString}"
           val presentationPage: PresentationPage = currentPres.get.pages(whiteboardId)
-          val xOffset: Double = presentationPage.xOffset
-          val yOffset: Double = presentationPage.yOffset
-          val widthRatio: Double = presentationPage.widthRatio
-          val heightRatio: Double = presentationPage.heightRatio
+          val width: Double = presentationPage.width
+          val height: Double = presentationPage.height
           val whiteboardHistory: Array[AnnotationVO] = liveMeeting.wbModel.getHistory(whiteboardId)
 
-          val page = new PresentationPageForExport(pageNumber, xOffset, yOffset, widthRatio, heightRatio, whiteboardHistory)
+          val page = new PresentationPageForExport(pageNumber, width, height, whiteboardHistory)
           getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages :+ page)
         } else {
           getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
@@ -5,10 +5,8 @@ case class AnnotationVO(id: String, annotationInfo: scala.collection.immutable.M
 
 case class PresentationPageForExport(
   page: Int,
-  xOffset: Double,
-  yOffset: Double,
-  widthRatio: Double,
-  heightRatio: Double,
+  width: Double,
+  height: Double,
   annotations: Array[AnnotationVO],
 )
 

--- a/bbb-export-annotations/package-lock.json
+++ b/bbb-export-annotations/package-lock.json
@@ -13,7 +13,6 @@
         "form-data": "^4.0.0",
         "opentype.js": "^1.3.4",
         "perfect-freehand": "^1.0.16",
-        "probe-image-size": "^7.2.3",
         "redis": "^4.0.3",
         "sanitize-filename": "^1.6.3",
         "svgdom": "^0.1.17"
@@ -398,14 +397,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/deep-is": {
@@ -815,17 +806,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -965,7 +945,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/mime-db": {
       "version": "1.51.0",
@@ -998,32 +979,11 @@
         "node": "*"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/needle": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -1113,16 +1073,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "dependencies": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
       }
     },
     "node_modules/proxy-from-env": {
@@ -1220,11 +1170,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -1258,27 +1203,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/stream-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
-      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
-      "dependencies": {
-        "debug": "2"
-      }
-    },
-    "node_modules/stream-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/stream-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
@@ -1737,14 +1661,6 @@
         "which": "^2.0.1"
       }
     },
-    "debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
-    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2045,14 +1961,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -2161,7 +2069,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.51.0",
@@ -2185,26 +2094,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "needle": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -2274,16 +2168,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
-    },
-    "probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "requires": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
-      }
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -2356,11 +2240,6 @@
         "glob": "^7.1.3"
       }
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "sanitize-filename": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
@@ -2388,29 +2267,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "stream-parser": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
-      "integrity": "sha1-FhhUhpRCACGhGC/wrxkRwSl2F3M=",
-      "requires": {
-        "debug": "2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
     },
     "string.prototype.codepointat": {
       "version": "0.2.1",

--- a/bbb-export-annotations/package.json
+++ b/bbb-export-annotations/package.json
@@ -13,7 +13,6 @@
     "form-data": "^4.0.0",
     "opentype.js": "^1.3.4",
     "perfect-freehand": "^1.0.16",
-    "probe-image-size": "^7.2.3",
     "redis": "^4.0.3",
     "sanitize-filename": "^1.6.3",
     "svgdom": "^0.1.17"

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -7,7 +7,6 @@ import WorkerStarter from '../lib/utils/worker-starter.js';
 import {workerData} from 'worker_threads';
 import path from 'path';
 import sanitize from 'sanitize-filename';
-import probe from 'probe-image-size';
 import redis from 'redis';
 import {PresAnnStatusMsg} from '../lib/utils/message-builder.js';
 import {sortByKey} from '../shapes/helpers.js';
@@ -322,15 +321,18 @@ async function processPresentationAnnotations() {
     } else if (fs.existsSync(`${bgImagePath}.jpeg`)) {
       backgroundFormat = 'jpeg';
     } else {
-      logger.error(`Skipping slide ${currentSlide.page} (${jobId})`);
+      logger.error(`Skipping slide ${currentSlide.page} (${jobId}): unknown extension`);
       continue;
     }
 
-    const dimensions = probe.sync(
-        fs.readFileSync(`${bgImagePath}.${backgroundFormat}`));
+    // Rescale slide width and height to match tldraw coordinates
+    const slideWidth = currentSlide.width;
+    const slideHeight = currentSlide.height;
 
-    const slideWidth = parseInt(dimensions.width, 10);
-    const slideHeight = parseInt(dimensions.height, 10);
+    if (!slideWidth || !slideHeight) {
+      logger.error(`Skipping slide ${currentSlide.page} (${jobId}): unknown dimensions`);
+      continue;
+    }
 
     const maxImageWidth = config.process.maxImageWidth;
     const maxImageHeight = config.process.maxImageHeight;


### PR DESCRIPTION
### What does this PR do?
The presentation export uses `probe-image-size` to determine slide dimensions, needed to overlay annotations.

This process, however, loads the slides from the file system, which is slow and introduces a dependency. Since the width and height are already measured during the initial upload, we can re-use the values stored on a per-slide basis in `akka-bbb-apps` instead.

### Motivation
Faster exports, less bloated code, and easier maintenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated presentation page export functionality to use absolute dimensions (width and height) instead of offsets and ratios.
	- Enhanced error logging for slide processing, providing clearer messages when slides are skipped or dimensions are unavailable.

- **Chores**
	- Removed the dependency on `probe-image-size`, streamlining the project and simplifying slide dimension handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->