### PR TITLE
fix(bbb-export-annotation): wrong slide orientation with rotated text

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -423,6 +423,7 @@ async function processPresentationAnnotations() {
   const serverFilenameWithExtension = `${sanitizedServerFilename}.pdf`;
   const mergePDFs = [
     '-dNOPAUSE',
+    '-dAutoRotatePages=/None',
     '-sDEVICE=pdfwrite',
     `-sOUTPUTFILE="${path.join(outputDir, serverFilenameWithExtension)}"`,
     `-dBATCH`].concat(ghostScriptInput);


### PR DESCRIPTION
In the 3.0 annotation export, text is added to the whiteboard as SVG text rather than a rasterized image.

Depending on how that text is rotated, GhostScript may incorrectly infer the orientation of a slide by looking at the rotation of the SVG elements on the canvas.

Since this behavior is not desired in our case, this PR forces GhostScript to retain the original orientation of each page.

#### Steps to reproduce the issue

https://github.com/user-attachments/assets/ce867cb4-f25c-42b1-ad11-85ebd758196c

Thanks to @ramonlsouza for the video and the quick assessment of the issue during the dev call!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to disable automatic page rotation during PDF merging.
  
- **Bug Fixes**
	- Improved PDF processing behavior by refining merge options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->