### PR TITLE
fix (akka-apps): Improve user joining flow and others

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationUploadTokenReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationUploadTokenReqMsgHdlr.scala
@@ -89,7 +89,7 @@ trait PresentationUploadTokenReqMsgHdlr extends RightsManagementTrait {
         broadcastPresentationUploadTokenPassResp(msg, token, presentationId)
         broadcastPresentationUploadTokenSysPubMsg(msg, token, presentationId)
 
-        PresPresentationDAO.insertToken(
+        PresPresentationDAO.insertUploadTokenIfNotExists(
           meetingId,
           msg.header.userId,
           msg.body.uploadTemporaryId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -52,7 +52,8 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
     notifyPreviousUsersWithSameExtId(regUser)
     clearCachedVoiceUser(regUser)
     clearExpiredUserState(regUser)
-    ForceUserGraphqlReconnection(regUser)
+    forceUserGraphqlReconnection(regUser)
+    updateGraphqlDatabase(regUser)
 
     newState
   }
@@ -154,9 +155,16 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
     VoiceUsers.recoverVoiceUser(liveMeeting.voiceUsers, regUser.id)
 
   private def clearExpiredUserState(regUser: RegisteredUser) =
-    UserStateDAO.updateExpired(regUser.meetingId, regUser.id, false)
+    UserStateDAO.updateExpired(regUser.meetingId, regUser.id, expired = false)
 
-  private def ForceUserGraphqlReconnection(regUser: RegisteredUser) =
+  private def forceUserGraphqlReconnection(regUser: RegisteredUser) = {
     Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "user_joined", outGW)
+  }
+
+  private def updateGraphqlDatabase(regUser: RegisteredUser) = {
+    if (!regUser.joined) {
+      RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, regUser, joined = true)
+    }
+  }
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -2,29 +2,19 @@ package org.bigbluebutton.core.running
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.api.{BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg, EndBreakoutRoomInternalMsg}
+import org.bigbluebutton.core.api.{ BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg, EndBreakoutRoomInternalMsg }
 import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.apps.users.UsersApp
 import org.bigbluebutton.core.apps.voice.VoiceApp
-import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
-import org.bigbluebutton.core.db.{BreakoutRoomUserDAO, MeetingDAO, MeetingRecordingDAO, NotificationDAO, UserBreakoutRoomDAO}
-import org.bigbluebutton.core.domain.{MeetingEndReason, MeetingState2x}
+import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
+import org.bigbluebutton.core.db.{ BreakoutRoomUserDAO, MeetingDAO, MeetingRecordingDAO, NotificationDAO, UserBreakoutRoomDAO }
+import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core2.message.senders.{MsgBuilder, UserJoinedMeetingEvtMsgBuilder}
+import org.bigbluebutton.core2.message.senders.{ MsgBuilder, UserJoinedMeetingEvtMsgBuilder }
 import org.bigbluebutton.core.util.TimeUtil
 
 trait HandlerHelpers extends SystemConfiguration {
-
-  def trackUserJoin(
-      liveMeeting: LiveMeeting,
-      regUser:     RegisteredUser,
-  ): Unit = {
-    if (!regUser.joined) {
-      RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, regUser, joined = true)
-    }
-
-  }
 
   def sendUserLeftFlagUpdatedEvtMsg(
       outGW:       OutMsgRouter,
@@ -46,8 +36,6 @@ trait HandlerHelpers extends SystemConfiguration {
     val nu = for {
       regUser <- RegisteredUsers.findWithToken(authToken, liveMeeting.registeredUsers)
     } yield {
-      trackUserJoin(liveMeeting, regUser)
-
       // Flag that an authed user had joined the meeting in case
       // we need to end meeting when all authed users have left.
       if (regUser.authed) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/UserInfoService.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/UserInfoService.scala
@@ -19,7 +19,7 @@ object UserInfoService {
 
 class UserInfoService(system: ActorSystem, bbbActor: ActorRef) {
   implicit def executionContext: ExecutionContextExecutor = system.dispatcher
-  implicit val timeout: Timeout = 2 seconds
+  implicit val timeout: Timeout = 5 seconds
 
   def getUserInfo(sessionToken: String): Future[ApiResponse] = {
     val future = bbbActor.ask(GetUserApiMsg(sessionToken)).mapTo[ApiResponse]

--- a/bbb-graphql-middleware/internal/akka_apps/client.go
+++ b/bbb-graphql-middleware/internal/akka_apps/client.go
@@ -62,7 +62,9 @@ func AkkaAppsGetSessionVariablesFrom(browserConnectionId string, sessionToken st
 		return nil, fmt.Errorf("response key not found in the parsed object")
 	}
 	if response != "authorized" {
-		logger.Error(response)
+		message, _ := respBodyAsMap["message"]
+		logger.Errorf("not authorized: Response: %s, Message: %s", response, message)
+
 		return nil, fmt.Errorf("user not authorized")
 	}
 


### PR DESCRIPTION
This PR implements two improvements:

### Refactor user join handler to refresh Hasura role before setting `joined=true`
Ensure that the GraphQL reconnection—and thus the user's Hasura role update from `bbb_client_not_in_meeting` to `bbb_client`—occurs before the client is informed they've joined (`joined=true`). This prevents a race condition where the client might send GraphQL queries before having the necessary permissions, as only `bbb_client` can perform most queries. By updating the role first, we guarantee the client can successfully execute queries after joining.

### Avoid timeout error on `/userInfo` endpoint (used by Hasura to obtain User Role)
Increase Pekko message timeout up to 5s for the `/userInfo` endpoint to prevent timeouts when fetching user information. During high load or cold starts, establishing connections between actors can exceed 2 seconds. This change avoids such issues by extending the timeout.

Also added more details to middleware logs to clarify reasons for user authorization failures, making debugging easier.

### Improve presentation insertion to prevent duplicates

Previously, we checked if a presentation existed before inserting it into the database. However, concurrent checks sometimes led to race conditions where the same presentation was inserted twice, causing errors and blocking subsequent page additions. This update removes the existence check and directly attempts to insert the presentation using an "IF NOT EXISTS" clause. This streamlines the process, enhances performance, and prevents ID duplication errors.

Closes #20980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced user join functionality with the addition of a method to update the user's join status in the database.
  - Improved error logging for unauthorized access, providing clearer insights into issues.

- **Improvements**
  - Updated method for inserting upload tokens to prevent duplicates, enhancing data integrity.
  - Increased timeout for user information requests, allowing for longer wait times for responses.

- **Bug Fixes**
  - Removed outdated method for tracking user joins, streamlining the user management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->