### PR TITLE
gql-server: Introduce an endpoint `/api/rest/userMetadata`

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_metadata.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_metadata.yaml
@@ -18,3 +18,15 @@ select_permissions:
               _eq: X-Hasura-MeetingId
           - userId:
               _eq: X-Hasura-UserId
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - parameter
+        - value
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - userId:
+              _eq: X-Hasura-UserId
+    comment: ""

--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -8,3 +8,11 @@
               clientSettingsJson
             }
           }
+      - name: userMetadata
+        query: |
+          query getUserMetadata {
+            user_metadata {
+              parameter
+              value
+            }
+          }

--- a/bbb-graphql-server/metadata/rest_endpoints.yaml
+++ b/bbb-graphql-server/metadata/rest_endpoints.yaml
@@ -7,3 +7,12 @@
     - GET
   name: clientSettings
   url: clientSettings
+- comment: ""
+  definition:
+    query:
+      collection_name: allowed-queries
+      query_name: userMetadata
+  methods:
+    - GET
+  name: userMetadata
+  url: userMetadata

--- a/build/packages-template/bbb-graphql-middleware/graphql.nginx
+++ b/build/packages-template/bbb-graphql-middleware/graphql.nginx
@@ -26,3 +26,14 @@ location /api/rest/clientSettings {
     proxy_set_header Host $host;
     proxy_pass http://127.0.0.1:8085; #Hasura
 }
+
+location /api/rest/userMetadata {
+    auth_request /bigbluebutton/connection/checkGraphqlAuthorization;
+    auth_request_set $meeting_id $sent_http_meeting_id;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    proxy_pass http://127.0.0.1:8085; #Hasura
+}


### PR DESCRIPTION
This pull request introduces a new GET endpoint `/api/rest/userMetadata`, enabling clients to fetch `userdata` properties `bbb_custom_style` and `bbb_custom_style_url` before initiating a GraphQL connection. 
Provided by Hasura, this endpoint includes all standard validations akin to GraphQL queries. 

Additionally, it grants the `bbb_client_not_in_meeting` role permission to access `user_metadata`.

Query used internally:
```gql
query getUserMetadata {
    user_metadata {
      parameter
      value
    }
}
```
Example of response:
```json
{
  "data": {
    "user_metadata": [
      {
        "parameter": "bbb_client_title",
        "value": "test"
      }
    ]
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new role `bbb_client_not_in_meeting` for enhanced user access control.
	- Added a `userMetadata` query to retrieve user-specific metadata.
	- Created a new REST endpoint for accessing user metadata via a GET request.

- **Improvements**
	- Enhanced API functionality with a dedicated endpoint for user metadata access. 

These updates provide more granular control and improved access to user data in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->