### PR TITLE
test: Update test steps that frequently fail in CI

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.js
@@ -41,9 +41,6 @@ class Presentation extends MultiUsers {
     await this.modPage.waitAndClick(e.shareCameraAsContent);
     await this.modPage.hasElement(e.videoPreview, 'should display the camera preview when sharing camera as content');
     await this.modPage.waitAndClick(e.startSharingWebcam);
-    await this.modPage.hasElement(e.screenshareConnecting);
-
-    await this.modPage.wasRemoved(e.screenshareConnecting);
     await this.modPage.hasElement(e.screenShareVideo);
     // close all notifications displayed before comparing screenshots
     for (const closeButton of await this.modPage.getLocator(e.closeToastBtn).all()) {
@@ -320,7 +317,6 @@ class Presentation extends MultiUsers {
     }
     await this.modPage.waitAndClick(e.sendPresentationInCurrentStateBtn);
     await this.modPage.hasElement(e.downloadPresentationToast);
-    await this.modPage.hasElement(e.smallToastMsg, 20000);
     await this.userPage.hasElement(e.downloadPresentation, ELEMENT_WAIT_EXTRA_LONG_TIME);
     const downloadPresentationLocator = this.userPage.getLocator(e.downloadPresentation);
     await this.userPage.handleDownload(downloadPresentationLocator, testInfo);

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -59,7 +59,8 @@ test.describe.parallel('Presentation', () => {
     await presentation.hidePresentationToolbar();
   });
 
-  test('Zoom In, Zoom Out, Reset Zoom', { tag: '@ci' }, async ({ browser, context, page }) => {
+  test('Zoom In, Zoom Out, Reset Zoom', { tag: ['@ci', '@flaky'] }, async ({ browser, context, page }) => {
+    // @flaky: see https://github.com/bigbluebutton/bigbluebutton/issues/21266
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.zoom();


### PR DESCRIPTION
### What does this PR do?
This PR does the following changes to avoid/fix tests frequently failing in CI runs:
- **Share camera**: removes unnecessary check for "connecting" element;
- **Send presentation with annotation**: Removes check for toast notification after sending the file - doesn't show anymore
- **Zoom**: bug spotted. test flagged as flaky and issue opened + linked (#21266 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined presentation sharing process by removing unnecessary checks, enhancing user experience during presentations.
  
- **Bug Fixes**
	- Updated test case for 'Zoom In, Zoom Out, Reset Zoom' to reflect its flaky nature, improving testing accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->