### PR TITLE
fix: poll results always on first page

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -288,7 +288,7 @@ object Polls {
     shape += "isLocked" -> java.lang.Boolean.valueOf(false)
     shape += "index" -> "a1"
     shape += "rotation" -> Integer.valueOf(0)
-    shape += "parentId" -> "page:1"
+    shape += "parentId" -> s"page:${page.num}"
     shape += "typeName" -> "shape"
     shape += "opacity" -> Integer.valueOf(1)
     shape += "id" -> s"shape:poll-result-${result.id}"


### PR DESCRIPTION
### What does this PR do?

Resolves an issue where poll results would not display on the whiteboard if the current slide is not the first, caused by the parentId being hardcoded in akka-apps.

### How to test

1. join a meeting with 2 users
2. go to any slide in the whiteboard (other than the first)
3. start a poll
4. publish poll results
5. poll results should appear in the current slide, not in the first one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the polling feature by dynamically linking the `parentId` to the current page number, improving flexibility and responsiveness.
  
- **Bug Fixes**
	- Resolved hardcoded `parentId` assignment, ensuring it accurately reflects the current page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->