### PR TITLE
fix(plugins): race condition setting extensible areas

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/action-bar/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/action-bar/manager.tsx
@@ -19,7 +19,6 @@ const ActionBarPluginStateContainer = ((
   ] = useState<PluginSdk.ActionsBarInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -33,12 +32,11 @@ const ActionBarPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.actionsBarItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         actionsBarItems: aggregatedActionBarItems,
-      },
-    );
+      }));
   }, [actionBarItems]);
 
   pluginApi.setActionsBarItems = (items: PluginSdk.ActionsBarInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/action-button-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/action-button-dropdown/manager.tsx
@@ -22,7 +22,6 @@ const ActionButtonDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.ActionButtonDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const ActionButtonDropdownPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.actionButtonDropdownItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         actionButtonDropdownItems: aggregatedActionButtonDropdownItems,
-      },
-    );
+      }));
   }, [actionButtonDropdownItems]);
 
   pluginApi.setActionButtonDropdownItems = (items: PluginSdk.ActionButtonDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/audio-settings-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/audio-settings-dropdown/manager.tsx
@@ -21,7 +21,6 @@ const AudioSettingsDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.AudioSettingsDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -35,12 +34,11 @@ const AudioSettingsDropdownPluginStateContainer = ((
         .map((extensibleArea: ExtensibleArea) => extensibleArea.audioSettingsDropdownItems),
     );
 
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         audioSettingsDropdownItems: aggregatedAudioSettingsDropdownItems,
-      },
-    );
+      }));
   }, [audioSettingsDropdownItems]);
 
   pluginApi.setAudioSettingsDropdownItems = (items: PluginSdk.AudioSettingsDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/camera-settings-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/camera-settings-dropdown/manager.tsx
@@ -22,7 +22,6 @@ const CameraSettingsDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.CameraSettingsDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const CameraSettingsDropdownPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.cameraSettingsDropdownItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         cameraSettingsDropdownItems: aggregatedCameraSettingsDropdownItems,
-      },
-    );
+      }));
   }, [cameraSettingsDropdownItems]);
 
   pluginApi.setCameraSettingsDropdownItems = (items: PluginSdk.CameraSettingsDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/floating-window/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/floating-window/manager.tsx
@@ -22,7 +22,6 @@ const FloatingWindowPluginStateContainer = ((
   ] = useState<PluginSdk.FloatingWindowInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const FloatingWindowPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.floatingWindows),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         floatingWindows: aggregatedFloatingWindows,
-      },
-    );
+      }));
   }, [floatingWindows]);
 
   pluginApi.setFloatingWindows = (items: PluginSdk.FloatingWindowInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
@@ -22,7 +22,6 @@ const GenericContentPluginStateContainer = ((
   ] = useState<PluginSdk.GenericContentInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,13 +35,12 @@ const GenericContentPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.genericContentItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         genericContentItems: aggregatedGenericContentItems,
-      },
-    );
-  }, [genericContentItems]);
+      }));
+  }, [genericContentItems, setPluginsExtensibleAreasAggregatedState]);
 
   pluginApi.setGenericContentItems = (items: PluginSdk.GenericContentInterface[]) => {
     const itemsWithId = items.map(generateItemWithId) as PluginSdk.GenericContentInterface[];

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/nav-bar/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/nav-bar/manager.tsx
@@ -22,7 +22,6 @@ const NavBarPluginStateContainer = ((
   ] = useState<PluginSdk.NavBarInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const NavBarPluginStateContainer = ((
         .map((extensibleArea: ExtensibleArea) => extensibleArea.navBarItems),
     );
 
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         navBarItems: aggregatedNavBarItems,
-      },
-    );
+      }));
   }, [navBarItems]);
 
   pluginApi.setNavBarItems = (items: PluginSdk.NavBarInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/options-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/options-dropdown/manager.tsx
@@ -22,7 +22,6 @@ const OptionsDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.OptionsDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const OptionsDropdownPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.optionsDropdownItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         optionsDropdownItems: aggregatedOptionsDropdownItems,
-      },
-    );
+      }));
   }, [optionsDropdownItems]);
 
   pluginApi.setOptionsDropdownItems = (items: PluginSdk.OptionsDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/presentation-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/presentation-dropdown/manager.tsx
@@ -22,7 +22,6 @@ const PresentationDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.PresentationDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const PresentationDropdownPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.presentationDropdownItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         presentationDropdownItems: aggregatedPresentationDropdownItems,
-      },
-    );
+      }));
   }, [presentationDropdownItems]);
 
   pluginApi.setPresentationDropdownItems = (items: PluginSdk.PresentationDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/presentation-toolbar/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/presentation-toolbar/manager.tsx
@@ -22,7 +22,6 @@ const PresentationToolbarPluginStateContainer = ((
   ] = useState<PluginSdk.PresentationToolbarInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const PresentationToolbarPluginStateContainer = ((
         .map((extensibleArea: ExtensibleArea) => extensibleArea.presentationToolbarItems),
     );
 
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         presentationToolbarItems: aggregatedPresentationToolbarItems,
-      },
-    );
+      }));
   }, [presentationToolbarItems]);
 
   pluginApi.setPresentationToolbarItems = (items: PluginSdk.PresentationToolbarInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/screenshare-helper/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/screenshare-helper/manager.tsx
@@ -22,7 +22,6 @@ const ScreenshareHelperPluginStateContainer = ((
   ] = useState<PluginSdk.ScreenshareHelperInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -34,12 +33,11 @@ const ScreenshareHelperPluginStateContainer = ((
         .map((extensibleArea: ExtensibleArea) => extensibleArea.screenshareHelperItems),
     );
 
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         screenshareHelperItems: aggregatedScreenshareHelperItems,
-      },
-    );
+      }));
   }, [screenshareHelperItems]);
 
   pluginApi.setScreenshareHelperItems = (items: PluginSdk.ScreenshareHelperInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-camera-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-camera-dropdown/manager.tsx
@@ -22,7 +22,6 @@ const UserCameraDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.UserCameraDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const UserCameraDropdownPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.userCameraDropdownItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         userCameraDropdownItems: aggregatedUserCameraDropdownItems,
-      },
-    );
+      }));
   }, [userCameraDropdownItems]);
 
   pluginApi.setUserCameraDropdownItems = (items: PluginSdk.UserCameraDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-camera-helper/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-camera-helper/manager.tsx
@@ -22,7 +22,6 @@ const UserCameraHelperPluginStateContainer = ((
   ] = useState<PluginSdk.UserCameraHelperInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -34,12 +33,11 @@ const UserCameraHelperPluginStateContainer = ((
         .map((extensibleArea: ExtensibleArea) => extensibleArea.userCameraHelperItems),
     );
 
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         userCameraHelperItems: aggregatedUserCameraHelperItems,
-      },
-    );
+      }));
   }, [userCameraHelperItems]);
 
   pluginApi.setUserCameraHelperItems = (items: PluginSdk.UserCameraHelperInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-list-dropdown/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-list-dropdown/manager.tsx
@@ -22,7 +22,6 @@ const UserListDropdownPluginStateContainer = ((
   ] = useState<PluginSdk.UserListDropdownInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const UserListDropdownPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.userListDropdownItems),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         userListDropdownItems: aggregatedUserListDropdownItems,
-      },
-    );
+      }));
   }, [userListDropdownItems]);
 
   pluginApi.setUserListDropdownItems = (items: PluginSdk.UserListDropdownInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-list-item-additional-information/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/user-list-item-additional-information/manager.tsx
@@ -22,7 +22,6 @@ const UserListItemAdditionalInformationPluginStateContainer = ((
   ] = useState<PluginSdk.UserListItemAdditionalInformationInterface[]>([]);
 
   const {
-    pluginsExtensibleAreasAggregatedState,
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
@@ -36,12 +35,11 @@ const UserListItemAdditionalInformationPluginStateContainer = ((
       ...Object.values(extensibleAreaMap)
         .map((extensibleArea: ExtensibleArea) => extensibleArea.userListItemAdditionalInformation),
     );
-    setPluginsExtensibleAreasAggregatedState(
+    setPluginsExtensibleAreasAggregatedState((previousState) => (
       {
-        ...pluginsExtensibleAreasAggregatedState,
+        ...previousState,
         userListItemAdditionalInformation: aggregatedUserListItemAdditionalInformation,
-      },
-    );
+      }));
   }, [userListItemAdditionalInformation]);
 
   pluginApi.setUserListItemAdditionalInformation = (items: PluginSdk.UserListItemAdditionalInformationInterface[]) => {


### PR DESCRIPTION
### What does this PR do?
Fixes race condition happening when multiple plugins that add extensible area elements are loaded by the client. The issue is caused by the state update of the extensible area items set by plugins, based on previous state without using a callback. Replaced direct state updates with the appropriate callback pattern to ensure consistent state changes.


### Closes Issue(s)
None

### How to test
1. Configure in the settings.yml 2 or 3 plugins that inject extensible area elements.
2. Join meeting
3. Check plugins are loaded but their UI elements are not displayed(intermittent: might take some tries to reproduce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced state management across various components, ensuring that updates reflect the most recent state.
	- Improved reliability in aggregating items for dropdowns and other UI elements.

- **Bug Fixes**
	- Resolved potential issues with stale state references in multiple components, leading to more consistent behavior.

- **Refactor**
	- Streamlined state update logic in the Action Bar, Audio Settings, Camera Settings, and other components for better performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->