### PR TITLE
refactor(config/settings): Remove unused toolbar configs from `settings.yml`.

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1042,48 +1042,6 @@ public:
         # family: mono|sans|script|serif
         family: script
     toolbar:
-      multiUserPenOnly: false
-      colors:
-        - label: black
-          value: '#000000'
-        - label: white
-          value: '#ffffff'
-        - label: red
-          value: '#ff0000'
-        - label: orange
-          value: '#ff8800'
-        - label: eletricLime
-          value: '#ccff00'
-        - label: Lime
-          value: '#00ff00'
-        - label: Cyan
-          value: '#00ffff'
-        - label: dodgerBlue
-          value: '#0088ff'
-        - label: blue
-          value: '#0000ff'
-        - label: violet
-          value: '#8800ff'
-        - label: magenta
-          value: '#ff00ff'
-        - label: silver
-          value: '#c0c0c0'
-      thickness:
-        - value: 14
-        - value: 12
-        - value: 10
-        - value: 8
-        - value: 6
-        - value: 4
-        - value: 2
-        - value: 1
-      font_sizes:
-        - value: 36
-        - value: 32
-        - value: 28
-        - value: 24
-        - value: 20
-        - value: 16
       tools:
         - icon: select_tool
           value: select


### PR DESCRIPTION
### What does this PR do?

This PR refactors a piece of the bbb settings so we don't have unnecessary code.

### Closes Issue(s)

#16168 

### Extra information

As requested in the #16168 issue:
 

- [ ] We should chat about which configs we no longer need (and remove them)

 

- [x] ensure maxStickyNoteLength is still functional

- [x]  open separate issues about items we need to re-implement, for example - configurable preventing viewers from using sticky notes, reimplement multiUserPenOnly.