### PR TITLE
[3.0] build(bbb-webrtc-sfu): v2.16.0

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.15.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.16.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
v2.16.0
---
* feat(mediasoup): pipe mediasoup logs to webrtc-sfu's logger
  - All piped logs have their `msg` field prefixed with `[SFU_MEDIASOUP]`.
  The log pipe can be disabled via `mediasoup.pipeLogs` (bool).
* refactor(mediasoup): review log levels and metadata