### PR TITLE
fix (styles): Update connection status bars background color

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -59,12 +59,14 @@ const DtfInvert = `
   .bnjzQC > div span div:hover {
     background-color: var(--darkreader-selection-background) !important;
   }
-  #connectionBars > div,
   .tl-note__scrim,.tl-arrow-label[data-isediting="true"] > .tl-arrow-label__inner {
     background-color: unset !important;
   }
   textarea {
     caret-color: black !important;
+  }
+  #connectionBars > div {
+    background-color: var(--darkreader-neutral-text) !important;
   }
 `;
 


### PR DESCRIPTION
### What does this PR do?

Refactor styles to update the background color of connection status bars so it does not become invisible in dark mode.

#### before

![Screenshot from 2024-09-27 14-40-51](https://github.com/user-attachments/assets/e218b3b9-ac28-4ca8-8534-a31d888a1d61)

#### after

![Screenshot from 2024-09-27 14-40-34](https://github.com/user-attachments/assets/68432bd5-1d5e-419b-9c17-e21d6c4a0a9e)

### How to test
1. join a meeting with dark mode enabled
2. see connection status icon 
