### PR TITLE
fix(audio-captions): label generation for audio captions with custom locales

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/component.tsx
@@ -162,10 +162,15 @@ const AudioCaptionsButton: React.FC<AudioCaptionsButtonProps> = ({
         if (availableVoice === availableVoices[0]) {
           indexToInsertSeparator = index;
         }
+
+        const label = intlMessages[availableVoice as keyof typeof intlMessages]
+          ? intl.formatMessage(intlMessages[availableVoice as keyof typeof intlMessages])
+          : AudioCaptionsService.getLocaleName(availableVoice);
+
         return (
           {
             icon: '',
-            label: intl.formatMessage(intlMessages[availableVoice as keyof typeof intlMessages]),
+            label,
             key: availableVoice,
             iconRight: selectedLocale.current === availableVoice ? 'check' : null,
             customStyles: (selectedLocale.current === availableVoice) && Styled.SelectedLabel,

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
@@ -8,6 +8,7 @@ import {
   useFixedLocale,
   isGladia,
   useIsAudioTranscriptionEnabled,
+  getLocaleName,
 } from '../service';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { SET_SPEECH_LOCALE } from '/imports/ui/core/graphql/mutations/userMutations';
@@ -152,7 +153,11 @@ const AudioCaptionsSelect: React.FC<AudioCaptionsSelectProps> = ({
           key={v}
           value={v}
         >
-          {intl.formatMessage(intlMessages[v as keyof typeof intlMessages])}
+          {
+          intlMessages[v as keyof typeof intlMessages]
+            ? intl.formatMessage(intlMessages[v as keyof typeof intlMessages])
+            : getLocaleName(v)
+          }
         </option>
       ))}
     </Styled.Select>

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -84,6 +84,13 @@ export const useFixedLocale = () => {
   return useIsAudioTranscriptionEnabled() && FORCE_LOCALE;
 };
 
+export const getLocaleName = (locale: string) => {
+  const languageNames = new Intl.DisplayNames([locale], {
+    type: 'language',
+  });
+  return languageNames.of(locale);
+};
+
 export default {
   getSpeechVoices,
   useIsAudioTranscriptionEnabled,
@@ -94,4 +101,5 @@ export default {
   useFixedLocale,
   isGladia,
   splitTranscript,
+  getLocaleName,
 };


### PR DESCRIPTION
### What does this PR do?

Refactors the label generation for audio captions in the audio-captions button and captions components. Instead of directly using the intl formatMessage function, the label is now generated using the intlMessages object and the getLocaleName function from the audio-captions service. This change prevents an issue with custom locales.

### How to test

1. Add a new locale in `public.app.audioCaptions.language.available` settings
2. Join a meeting
3. Try to select a locale for transcription in the audio join modal