### PR TITLE
refactor/fix(settings): Refactor animation settings retrieval to fix problem with refreshing.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -208,13 +208,7 @@ const LayoutObserver: React.FC = () => {
   useEffect(() => {
     if (Session.equals('layoutReady', true) && (sidebarContentPanel === PANELS.NONE)) {
       if (!checkedUserSettings.current) {
-        const showAnimationsDefault = getFromUserSettings(
-          'bbb_show_animations_default',
-          window.meetingClientSettings.public.app.defaultSettings.application.animations,
-        );
-
         const Settings = getSettingsSingletonInstance();
-        Settings.application.animations = showAnimationsDefault;
         Settings.save(setLocalSettings);
 
         if (getFromUserSettings('bbb_show_participants_on_login', window.meetingClientSettings.public.layout.showParticipantsOnLogin) && !deviceInfo.isPhone) {

--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -33,11 +33,17 @@ class Settings {
       || navigator.language
       || writableDefaultValues.application.locale;
 
+    const showAnimationsDefault = getFromUserSettings(
+      'bbb_show_animations_default',
+      window.meetingClientSettings.public.app.defaultSettings.application.animations,
+    );
+
     const showDarkThemeDefault = getFromUserSettings(
       'bbb_prefer_dark_theme',
       window.meetingClientSettings.public.app.defaultSettings.application.darkTheme,
     );
 
+    writableDefaultValues.application.animations = showAnimationsDefault;
     writableDefaultValues.application.darkTheme = showDarkThemeDefault;
 
     this.setDefault(writableDefaultValues);


### PR DESCRIPTION
### What does this PR do?

This PR refactors a custom parameter/setting that was not persisting across page refreshes. It complements the changes introduced in PR [21255
](https://github.com/bigbluebutton/bigbluebutton/pull/21255).
### Closes Issue(s)

#21260

### How to test

1. Start a meeting using custom parameters: `bbb_prefer_dark_theme=true` or `bbb_show_animations_default=false`
2. Test one of the parameters above by trying to use animations or setting dark theme to off in the settings
3. See if they persist
