### PR TITLE
gql-server: Add props to enable a user to Reply a chat message (backend portion)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/SendMessageToBreakoutRoomInternalMsgHdlr.scala
@@ -18,7 +18,7 @@ trait SendMessageToBreakoutRoomInternalMsgHdlr {
       sender <- GroupChatApp.findGroupChatUser(SystemUser.ID, liveMeeting.users2x)
       chat <- state.groupChats.find(GroupChatApp.MAIN_PUBLIC_CHAT)
     } yield {
-      val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.senderName), msg.msg)
+      val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.senderName), msg.msg, replyToMessageId = "")
       val gcm = GroupChatApp.toGroupChatMessage(sender.copy(name = msg.senderName), groupChatMsgFromUser, emphasizedText = true)
       val gcs = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm, GroupChatMessageType.BREAKOUTROOM_MOD_MSG)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -23,7 +23,7 @@ object GroupChatApp {
   def toGroupChatMessage(sender: GroupChatUser, msg: GroupChatMsgFromUser, emphasizedText: Boolean, metadata: Map[String, Any] = Map.empty): GroupChatMessage = {
     val now = System.currentTimeMillis()
     val id = GroupChatFactory.genId()
-    GroupChatMessage(id, now, msg.correlationId, now, now, sender, emphasizedText, msg.message, metadata)
+    GroupChatMessage(id, now, msg.correlationId, now, now, sender, emphasizedText, msg.message, msg.replyToMessageId, metadata)
   }
 
   def toMessageToUser(msg: GroupChatMessage): GroupChatMsgToUser = {
@@ -93,9 +93,9 @@ object GroupChatApp {
     }
 
     val sender = GroupChatUser(SystemUser.ID)
-    val h1 = GroupChatMsgFromUser(correlationId = "cor1", sender = sender, message = "Hello Foo!")
-    val h2 = GroupChatMsgFromUser(correlationId = "cor2", sender = sender, message = "Hello Bar!")
-    val h3 = GroupChatMsgFromUser(correlationId = "cor3", sender = sender, message = "Hello Baz!")
+    val h1 = GroupChatMsgFromUser(correlationId = "cor1", sender = sender, message = "Hello Foo!", replyToMessageId = "")
+    val h2 = GroupChatMsgFromUser(correlationId = "cor2", sender = sender, message = "Hello Bar!", replyToMessageId = "")
+    val h3 = GroupChatMsgFromUser(correlationId = "cor3", sender = sender, message = "Hello Baz!", replyToMessageId = "")
     val state1 = addH(state, SystemUser.ID, liveMeeting, h1)
     val state2 = addH(state1, SystemUser.ID, liveMeeting, h2)
     val state3 = addH(state2, SystemUser.ID, liveMeeting, h3)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageFromApiSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageFromApiSysPubMsgHdlr.scala
@@ -20,7 +20,7 @@ trait SendGroupChatMessageFromApiSysPubMsgHdlr extends HandlerHelpers {
         sender <- GroupChatApp.findGroupChatUser(SystemUser.ID, liveMeeting.users2x)
         chat <- state.groupChats.find(GroupChatApp.MAIN_PUBLIC_CHAT)
       } yield {
-        val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.body.userName), msg.body.message)
+        val groupChatMsgFromUser = GroupChatMsgFromUser(sender.id, sender.copy(name = msg.body.userName), msg.body.message, replyToMessageId = "")
         val gcm = GroupChatApp.toGroupChatMessage(sender.copy(name = msg.body.userName), groupChatMsgFromUser, emphasizedText = true)
         val gcs = GroupChatApp.addGroupChatMessage(liveMeeting.props.meetingProp.intId, chat, state.groupChats, gcm, GroupChatMessageType.API)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
@@ -12,6 +12,7 @@ case class ChatMessageDbModel(
     chatEmphasizedText: Boolean,
     message:            String,
     messageType:        String,
+    replyToMessageId:   Option[String],
     messageMetadata:    Option[String],
     senderId:           Option[String],
     senderName:         String,
@@ -27,6 +28,7 @@ class ChatMessageDbTableDef(tag: Tag) extends Table[ChatMessageDbModel](tag, Non
   val chatEmphasizedText = column[Boolean]("chatEmphasizedText")
   val message = column[String]("message")
   val messageType = column[String]("messageType")
+  val replyToMessageId = column[Option[String]]("replyToMessageId")
   val messageMetadata = column[Option[String]]("messageMetadata")
   val senderId = column[Option[String]]("senderId")
   val senderName = column[String]("senderName")
@@ -34,7 +36,7 @@ class ChatMessageDbTableDef(tag: Tag) extends Table[ChatMessageDbModel](tag, Non
   //  val chat = foreignKey("chat_message_chat_fk", (chatId, meetingId), ChatTable.chats)(c => (c.chatId, c.meetingId), onDelete = ForeignKeyAction.Cascade)
   //  val sender = foreignKey("chat_message_sender_fk", senderId, UserTable.users)(_.userId, onDelete = ForeignKeyAction.SetNull)
 
-  override def * = (messageId, chatId, meetingId, correlationId, createdAt, chatEmphasizedText, message, messageType, messageMetadata, senderId, senderName, senderRole) <> (ChatMessageDbModel.tupled, ChatMessageDbModel.unapply)
+  override def * = (messageId, chatId, meetingId, correlationId, createdAt, chatEmphasizedText, message, messageType, replyToMessageId, messageMetadata, senderId, senderName, senderRole) <> (ChatMessageDbModel.tupled, ChatMessageDbModel.unapply)
 }
 
 object ChatMessageDAO {
@@ -50,6 +52,10 @@ object ChatMessageDAO {
           chatEmphasizedText = groupChatMessage.chatEmphasizedText,
           message = groupChatMessage.message,
           messageType = messageType,
+          replyToMessageId = groupChatMessage.replyToMessageId match {
+            case "" => None
+            case messageId => Some(messageId)
+          },
           messageMetadata = Some(JsonUtils.mapToJson(groupChatMessage.metadata).compactPrint),
           senderId = Some(groupChatMessage.sender.id),
           senderName = groupChatMessage.sender.name,
@@ -94,6 +100,7 @@ object ChatMessageDAO {
           chatEmphasizedText = false,
           message = message,
           messageType = messageType,
+          replyToMessageId = None,
           messageMetadata = Some(JsonUtils.mapToJson(messageMetadata).compactPrint),
           senderId = None,
           senderName = senderName,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/GroupChats.scala
@@ -38,7 +38,7 @@ case class GroupChat(id: String, access: String, createdBy: GroupChatUser,
 
 case class GroupChatMessage(id: String, timestamp: Long, correlationId: String, createdOn: Long,
                             updatedOn: Long, sender: GroupChatUser, chatEmphasizedText: Boolean = false,
-                            message: String, metadata: Map[String, Any] = Map.empty)
+                            message: String, replyToMessageId: String, metadata: Map[String, Any] = Map.empty)
 
 case class GroupChatWindow(windowId: String, chatIds: Vector[String], keepOpen: Boolean, openedBy: String) {
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -17,8 +17,21 @@ object GroupChatMessageType {
 }
 
 case class GroupChatUser(id: String, name: String = "", role: String = "VIEWER")
-case class GroupChatMsgFromUser(correlationId: String, sender: GroupChatUser, message: String, metadata: Map[String, Any] = Map.empty)
-case class GroupChatMsgToUser(id: String, timestamp: Long, correlationId: String, sender: GroupChatUser, chatEmphasizedText: Boolean = false, message: String)
+case class GroupChatMsgFromUser(
+    correlationId:    String,
+    sender:           GroupChatUser,
+    message:          String,
+    replyToMessageId: String,
+    metadata:         Map[String, Any] = Map.empty
+)
+case class GroupChatMsgToUser(
+    id:                 String,
+    timestamp:          Long,
+    correlationId:      String,
+    sender:             GroupChatUser,
+    chatEmphasizedText: Boolean       = false,
+    message:            String
+)
 case class GroupChatInfo(id: String, access: String, createdBy: GroupChatUser, users: Vector[GroupChatUser])
 
 object OpenGroupChatWindowReqMsg { val NAME = "OpenGroupChatWindowReqMsg" }

--- a/bbb-graphql-actions/src/actions/chatSendMessage.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessage.ts
@@ -6,6 +6,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
       [
         {name: 'chatMessageInMarkdownFormat', type: 'string', required: true},
         {name: 'chatId', type: 'string', required: true},
+        {name: 'replyToMessageId', type: 'string', required: false},
         {name: 'metadata', type: 'json', required: false}
       ]
   )
@@ -31,6 +32,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         name: '',
         role: ''
       },
+      replyToMessageId: input.replyToMessageId || "",
       metadata: input.metadata || {},
     },
     chatId: input.chatId 

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -109,6 +109,7 @@ type Mutation {
   chatSendMessage(
     chatId: String!
     chatMessageInMarkdownFormat: String!
+    replyToMessageId: String
     metadata: json
   ): Boolean
 }

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
@@ -7,6 +7,15 @@ configuration:
   custom_name: chat_message_private
   custom_root_fields: {}
 object_relationships:
+  - name: replyToMessage
+    using:
+      manual_configuration:
+        column_mapping:
+          replyToMessageId: messageId
+        insertion_order: null
+        remote_table:
+          name: v_chat_message_private
+          schema: public
   - name: user
     using:
       manual_configuration:
@@ -28,6 +37,7 @@ select_permissions:
         - message
         - messageId
         - messageMetadata
+        - messageSequence
         - messageType
         - senderId
         - senderName

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
@@ -7,6 +7,15 @@ configuration:
   custom_name: chat_message_public
   custom_root_fields: {}
 object_relationships:
+  - name: replyToMessage
+    using:
+      manual_configuration:
+        column_mapping:
+          replyToMessageId: messageId
+        insertion_order: null
+        remote_table:
+          name: v_chat_message_public
+          schema: public
   - name: user
     using:
       manual_configuration:
@@ -28,6 +37,7 @@ select_permissions:
         - message
         - messageId
         - messageMetadata
+        - messageSequence
         - messageType
         - senderId
         - senderName


### PR DESCRIPTION
Aiming to enable the implementation of the feature Reply Chat Message, this PR introduces new fields to Graphql:

Mutation to reply:
```gql
mutation($chatId: String!, $chatMessageInMarkdownFormat: String!, $replyToMessageId: String) {
  chatSendMessage(
    chatId: $chatId, 
    chatMessageInMarkdownFormat: $chatMessageInMarkdownFormat,
    replyToMessageId: $replyToMessageId
  )
}
```

- Subscription to bring the original message and its author:
```gql
subscription {
  chat_message_public {
    message
    user {
      name
    }
    replyToMessage {
      message
      user {
        name
      }
    }
  }
}
```

- New field to know the sequence of that message and them identify the page it lies (it will be useful when the user click on the quote and is redirected to the original message)
```gql
subscription {
  chat_message_public {
	message
	messageSequence
  }
}
```