### PR TITLE
Fix: close event emitting a terminal error

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -217,10 +217,8 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
               // Check if it's a CloseEvent (which includes HTTP errors during WebSocket handshake)
               if (e instanceof CloseEvent) {
                 logger.error(`WebSocket closed with code ${e.code}: ${e.reason}`);
-                loadingContextInfo.setLoading(false, '');
-                setTerminalError('Server closed the connection');
+                connectionStatus.setConnectedStatus(false);
               }
-              connectionStatus.setConnectedStatus(false);
             },
             connected: (socket) => {
               activeSocket.current = socket as WebSocket;


### PR DESCRIPTION
### What does this PR do?
This PR addresses the issue where the GraphQL connection’s close events were triggering a terminal error. The terminal error was intended to be generated only when the connection is rejected due to reasons such as insufficient permissions or an invalid session, not from a close event. With this fix, the close event will now simply update the connection status to "disconnected" and emit a log. Terminal errors will only be triggered by reconnection failures, such as permission issues or exceeded retry attempts.


### Closes Issue(s)
Closes #21147

### How to test

Join a new meeting and restart bbb-graphql-middleware using the command `sudo systemctl restart bbb-graphql-middleware`

