### PR TITLE
gql-server: Allow all users to share screens (not only presenter) (backend portion)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UserBroadcastCamStartMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UserBroadcastCamStartMsgHdlr.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.core.apps.webcam
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers.permissionFailed
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.models.{ WebcamStream, Webcams }
 import org.bigbluebutton.core.running.LiveMeeting
@@ -16,11 +17,11 @@ trait UserBroadcastCamStartMsgHdlr {
   ): Unit = {
     val meetingId = liveMeeting.props.meetingProp.intId
 
-    def broadcastEvent(meetingId: String, userId: String, streamId: String): Unit = {
+    def broadcastEvent(meetingId: String, userId: String, streamId: String, contentType: String, hasAudio: Boolean): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
       val envelope = BbbCoreEnvelope(UserBroadcastCamStartedEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(UserBroadcastCamStartedEvtMsg.NAME, meetingId, userId)
-      val body = UserBroadcastCamStartedEvtMsgBody(userId, streamId)
+      val body = UserBroadcastCamStartedEvtMsgBody(userId, streamId, contentType, hasAudio: Boolean)
       val event = UserBroadcastCamStartedEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
 
@@ -44,11 +45,13 @@ trait UserBroadcastCamStartMsgHdlr {
         liveMeeting
       )
     } else {
-      val webcam = new WebcamStream(msg.body.stream, msg.header.userId, Set.empty)
+      val userIsPresenter = !permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)
+      val startFocused = msg.body.contentType == 'screenshare' && userIsPresenter
+      val webcam = new WebcamStream(msg.body.stream, msg.header.userId, msg.body.contentType, msg.body.hasAudio, focused = startFocused, Set.empty)
 
       for {
         _ <- Webcams.addWebcamStream(liveMeeting.props.meetingProp.intId, liveMeeting.webcams, webcam)
-      } yield broadcastEvent(meetingId, msg.header.userId, msg.body.stream)
+      } yield broadcastEvent(meetingId, msg.header.userId, msg.body.stream, msg.body.contentType, msg.body.hasAudio)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCameraDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCameraDAO.scala
@@ -7,14 +7,20 @@ case class UserCameraDbModel(
         streamId:      String,
         meetingId:     String,
         userId:        String,
+        contentType:   String,
+        hasAudio:      Boolean,
+        focused:       Boolean,
 )
 
 class UserCameraDbTableDef(tag: Tag) extends Table[UserCameraDbModel](tag, None, "user_camera") {
   override def * = (
-    streamId, meetingId, userId) <> (UserCameraDbModel.tupled, UserCameraDbModel.unapply)
+    streamId, meetingId, userId, contentType, hasAudio, focused) <> (UserCameraDbModel.tupled, UserCameraDbModel.unapply)
   val streamId = column[String]("streamId", O.PrimaryKey)
   val meetingId = column[String]("meetingId")
   val userId = column[String]("userId")
+  val contentType = column[String]("contentType")
+  val hasAudio = column[Boolean]("hasAudio")
+  val focused = column[Boolean]("focused")
 }
 
 object UserCameraDAO {
@@ -26,6 +32,9 @@ object UserCameraDAO {
           streamId = webcam.streamId,
           meetingId = meetingId,
           userId = webcam.userId,
+          contentType = webcam.contentType,
+          hasAudio = webcam.hasAudio,
+          focused = webcam.focused,
         )
       )
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Webcams.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Webcams.scala
@@ -98,4 +98,11 @@ class Webcams {
   }
 }
 
-case class WebcamStream(streamId: String, userId: String, subscribers: Set[String])
+case class WebcamStream(
+    streamId:    String,
+    userId:      String,
+    contentType: String,
+    hasAudio:    Boolean,
+    focused:     Boolean,
+    subscribers: Set[String]
+)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -115,7 +115,7 @@ object FakeUserGenerator {
 
   def createFakeWebcamStreamFor(userId: String, subscribers: Set[String]): WebcamStream = {
     val streamId = RandomStringGenerator.randomAlphanumericString(10)
-    WebcamStream(streamId, userId, subscribers)
+    WebcamStream(streamId, userId, "camera", hasAudio = false, focused = false, subscribers)
   }
 
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
@@ -7,8 +7,10 @@ case class UserBroadcastCamStartedEvtMsg(
     body:   UserBroadcastCamStartedEvtMsgBody
 ) extends BbbCoreMsg
 case class UserBroadcastCamStartedEvtMsgBody(
-    userId: String,
-    stream: String
+    userId:      String,
+    stream:      String,
+    contentType: String,
+    hasAudio:    Boolean
 )
 
 object UserBroadcastCamStartMsg { val NAME = "UserBroadcastCamStartMsg" }
@@ -16,7 +18,11 @@ case class UserBroadcastCamStartMsg(
     header: BbbClientMsgHeader,
     body:   UserBroadcastCamStartMsgBody
 ) extends StandardMsg
-case class UserBroadcastCamStartMsgBody(stream: String)
+case class UserBroadcastCamStartMsgBody(
+    stream:      String,
+    contentType: String,
+    hasAudio:    Boolean
+)
 
 object UserBroadcastCamStopMsg { val NAME = "UserBroadcastCamStopMsg" }
 case class UserBroadcastCamStopMsg(
@@ -179,3 +185,10 @@ case class CamStreamSubscribedInSfuEvtMsgBody(
     subscriberStreamId: String,
     sfuSessionId:       String // Subscriber's SFU session ID
 )
+
+/**
+ * Sent from client to change the video focus state (used to send screenshare to presentation area).
+ */
+object SetCamFocusStateReqMsg { val NAME = "SetCamFocusStateReqMsg" }
+case class SetCamFocusStateReqMsg(header: BbbClientMsgHeader, body: SetCamFocusStateReqMsgBody) extends StandardMsg
+case class SetCamFocusStateReqMsgBody(streamId: String, focused: Boolean, setBy: String)

--- a/bbb-graphql-actions/src/actions/cameraBroadcastStart.ts
+++ b/bbb-graphql-actions/src/actions/cameraBroadcastStart.ts
@@ -1,12 +1,23 @@
 import { RedisMessage } from '../types';
 import {throwErrorIfInvalidInput} from "../imports/validation";
+import {ValidationError} from "../types/ValidationError";
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfInvalidInput(input,
       [
         {name: 'stream', type: 'string', required: true},
+        {name: 'contentType', type: 'string', required: true},
+        {name: 'hasAudio', type: 'boolean', required: false},
       ]
   )
+
+  const allowedContentTypes = ['screenshare', 'camera'];
+  if (typeof input.contentType !== 'string' || !allowedContentTypes.includes(input.contentType)) {
+    throw new ValidationError(
+        `Field contentType is invalid (allowed ${allowedContentTypes.join(' or ')}).`,
+        400
+    );
+  }
 
   const eventName = `UserBroadcastCamStartMsg`;
 
@@ -22,7 +33,9 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   };
 
   const body = {
-    stream: input.stream
+    stream: input.stream,
+    contentType: input.contentType,
+    hasAudio: input.hasAudio || false
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-actions/src/actions/cameraSetFocused.ts
+++ b/bbb-graphql-actions/src/actions/cameraSetFocused.ts
@@ -1,0 +1,32 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput, throwErrorIfNotModerator, throwErrorIfNotPresenter} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'streamId', type: 'string', required: true},
+        {name: 'focused', type: 'boolean', required: true},
+      ]
+  )
+
+  const eventName = `SetCamFocusStateReqMsg`;
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = { 
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    setBy: routing.userId,
+    streamId: input.streamId,
+    focused: input.focused
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -637,10 +637,14 @@ CREATE TABLE "user_camera" (
 	"streamId" varchar(150) PRIMARY KEY,
 	"meetingId" varchar(100),
     "userId" varchar(50),
+    "contentType" varchar(50), --camera or screenshare
+    "hasAudio" boolean,
+    "focused" boolean,
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 CREATE INDEX "idx_user_camera_userId" ON "user_camera"("meetingId", "userId");
 CREATE INDEX "idx_user_camera_userId_reverse" ON "user_camera"("userId", "meetingId");
+CREATE INDEX "idx_user_camera_meeting_contentType" ON "user_camera"("meetingId", "contentType");
 
 CREATE OR REPLACE VIEW "v_user_camera" AS
 SELECT * FROM "user_camera";
@@ -1524,7 +1528,7 @@ create table "screenshare"(
 "meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 "voiceConf" varchar(50),
 "screenshareConf" varchar(50),
-"contentType" varchar(50),
+"contentType" varchar(50), --camera or screenshare
 "stream" varchar(100),
 "vidWidth" integer,
 "vidHeight" integer,

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -29,6 +29,9 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
+        - contentType
+        - focused
+        - hasAudio
         - streamId
         - userId
       filter:

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
@@ -44,7 +44,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
   const [cameraBroadcastStart] = useMutation(CAMERA_BROADCAST_START);
 
   const sendUserShareWebcam = (cameraId: string) => {
-    return cameraBroadcastStart({ variables: { cameraId } });
+    return cameraBroadcastStart({ variables: { cameraId, contentType: 'camera' } });
   };
 
   const playStart = (cameraId: string) => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/mutations.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/mutations.ts
@@ -1,9 +1,10 @@
 import { gql } from '@apollo/client';
 
 export const CAMERA_BROADCAST_START = gql`
-  mutation CameraBroadcastStart($cameraId: String!) {
+  mutation CameraBroadcastStart($cameraId: String!, $contentType: String!) {
     cameraBroadcastStart(
       stream: $cameraId
+      contentType: $contentType
     )
   }
 `;


### PR DESCRIPTION
We are enabling screen sharing for all users, not just the presenter.

**Implementation:**

- Users share screens using the existing `user_camera` collection.
- Screen shares act as `user_camera` streams.
- Added `contentType` field to indicate if a stream is from a camera or a screen share.
- Future plan to rename `user_camera` to `user_stream`.

**GraphQL Schema Updates:**

- **Subscription `user_camera`:**

  ```graphql
  subscription {
    user_camera {
      streamId
      contentType
      hasAudio
      focused
      user {
        name
      }
    }
  }
  ```

- **Mutation `cameraBroadcastStart`:**

  - **New required field:** `contentType`
  - **New optional field:** `hasAudio`