### PR TITLE
style(connection-status): Enhance mobile responsiveness for connection status and recording indicator components.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
@@ -6,6 +6,7 @@ import ConnectionStatusService from '/imports/ui/components/connection-status/se
 import Icon from '/imports/ui/components/connection-status/icon/component';
 import Styled from './styles';
 import Auth from '/imports/ui/services/auth';
+import deviceInfo, { isMobile } from '/imports/utils/deviceInfo';
 
 const intlMessages = defineMessages({
   label: {
@@ -73,6 +74,7 @@ class ConnectionStatusButton extends PureComponent {
             circle
             onClick={() => {}}
             data-test="connectionStatusButton"
+            isMobile={isMobile}
           />
           {this.renderModal(isModalOpen)}
         </Styled.ButtonWrapper>

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/styles.js
@@ -6,6 +6,9 @@ const IconWrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
+  ${({ isMobile }) => isMobile && `
+    margin: 0 0 0 .2rem;
+  `}
   margin: 0 .5rem;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
@@ -9,6 +9,13 @@ const LeaveButton = styled(Button)`
     }
   `}
 
+  ${({ state }) => state === 'closed' && `
+  @media ${smallOnly} {
+    margin-left: 0;
+    margin-right: 0;
+  }
+`}
+
   ${({ state, isMobile }) => state === 'closed' && !isMobile && `
     margin-left: 1.0rem;
     margin-right: 0.5rem;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
 } from 'react';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
-import deviceInfo from '/imports/utils/deviceInfo';
+import deviceInfo, { isMobile } from '/imports/utils/deviceInfo';
 import {
   GET_MEETING_RECORDING_DATA,
   GET_MEETING_RECORDING_POLICIES,
@@ -237,10 +237,15 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
   if (!record) return null;
   return (
     <>
-      {record ? (
+      {record && !isMobile ? (
         <Styled.PresentationTitleSeparator aria-hidden="true">|</Styled.PresentationTitleSeparator>
       ) : null}
-      <Styled.RecordingIndicator data-test="recordingIndicator">
+      <Styled.RecordingIndicator
+        data-test="recordingIndicator"
+        isPhone={isMobile}
+        recording={recording}
+        disabled={!showButton}
+      >
         {showButton ? recordingButton : null}
         {showButton ? null : (
           <Tooltip

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/styles.ts
@@ -21,6 +21,7 @@ interface RecordingIndicatorIconProps {
 interface RecordingIndicatorProps {
   recording: boolean;
   disabled: boolean;
+  isPhone?: boolean;
 }
 
 interface RecordingStatusViewOnlyProps {
@@ -142,7 +143,11 @@ const PresentationTitleSeparator = styled.span`
   margin: 0 1rem;
 `;
 
-const RecordingIndicator = styled.div`
+const RecordingIndicator = styled.div<RecordingIndicatorProps>`
+  ${({ isPhone }) => isPhone && `
+    margin-left: ${smPaddingX};
+  `}
+
   &:hover {
     outline: transparent;
     outline-style: dotted;
@@ -162,7 +167,7 @@ const RecordingStatusViewOnly = styled.div<RecordingStatusViewOnlyProps>`
   display: flex;
 
   ${({ recording }) => recording && `
-    padding: 5px;
+    padding: 5px 0 5px 5px;
     background-color: ${colorDangerDark};
     border: ${borderSizeLarge} solid ${colorDangerDark};
     border-radius: 10px;


### PR DESCRIPTION
### What does this PR do?

This PR re-sets some values to mobile, so the navbar is fully acessible all the time

### Before

<img src="https://github.com/user-attachments/assets/828560bc-50de-4269-a8e1-02f8dc3c4c5b" width="400" />

### After 

<img src="https://github.com/user-attachments/assets/22c53c42-e5d1-4835-b6ca-14ed37c6fab6" width="400" />

### How to test

Join BBB on your phone, and play around with navbar elements

