### PR TITLE
fix: respect animations setting in user avatar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -18,6 +18,7 @@ import { PluginsContext } from '/imports/ui/components/components-data/plugin-co
 import { useIsReactionsEnabled } from '/imports/ui/services/features';
 import useWhoIsTalking from '/imports/ui/core/hooks/useWhoIsTalking';
 import useWhoIsUnmuted from '/imports/ui/core/hooks/useWhoIsUnmuted';
+import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 
 const messages = defineMessages({
   moderator: {
@@ -224,6 +225,9 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
     return modifiedElements;
   }
 
+  const Settings = getSettingsSingletonInstance();
+  const animations = Settings?.application?.animations;
+
   return (
     <Styled.UserItemContents tabIndex={-1} data-test={(user.userId === Auth.userID) ? 'userListItemCurrent' : 'userListItem'}>
       <Styled.Avatar
@@ -239,7 +243,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings }) => {
         noVoice={!voiceUser?.joined}
         color={user.color}
         whiteboardAccess={hasWhiteboardAccess}
-        animations
+        animations={animations}
         avatar={userAvatarFiltered}
         isChrome={isChrome}
         isFirefox={isFirefox}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -315,6 +315,10 @@ const Avatar = styled.div<AvatarProps>`
   ${({ talking, animations, color }) => talking && animations && color && css`
     animation: ${pulse(color)} 1s infinite ease-in;
   `}
+
+  ${({ talking, animations }) => talking && !animations && `
+    box-shadow: 0 0 0 4px currentColor;
+  `}
   // ================ talking animation ================
   // ================ image ================
   ${({ avatar, emoji, color }) => avatar?.length !== 0 && !emoji && css`


### PR DESCRIPTION
### What does this PR do?

Adjusts user avatar component in userlist, so it does not animate when animations are disabled

### How to test
1. join a meeting
2. join audio
3. disable animations in client settings
4. speak
5. user avatar in the userlist should not have any animations