### PR TITLE
fix: raise hand remains selected on mobile devices

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -84,6 +84,7 @@ const ReactionsButton = (props) => {
         raiseHand: !raiseHand,
       },
     });
+    document.activeElement.blur();
   };
 
   const handleToggleAFK = () => {

--- a/bigbluebutton-html5/imports/ui/components/common/menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/styles.js
@@ -117,12 +117,30 @@ const BBBMenuItem = styled(MenuItem)`
     }
   `}
   ${({ $roundButtons, $isToggle }) => $roundButtons && !$isToggle && `
-    &:focus,
-    &:hover {
-      background-color: ${colorWhite} !important;
-      div div div {
-        background-color: ${colorPrimary} !important;
-        border: 1px solid ${colorPrimary} !important;
+    @media (hover: hover) {
+      &:focus,
+      &:hover {
+        background-color: ${colorWhite} !important;
+        div div div {
+          background-color: ${colorPrimary} !important;
+          border: 1px solid ${colorPrimary} !important;
+        }
+      }
+    }
+
+    @media (hover: none) {
+      &:focus {
+        background-color: ${colorWhite} !important;
+        div div div {
+          background-color: ${colorPrimary} !important;
+          border: 1px solid ${colorPrimary} !important;
+        }
+      }
+      &:hover {
+        background-color: ${colorWhite} !important;
+        div div div {
+          background-color: none !important;
+        }
       }
     }
   `}


### PR DESCRIPTION
### What does this PR do?

- Updates the raise hand button to to remove focus when raise hand is used.
- Updates the styles of the menu component to not display hover styles in mobile devices.


https://github.com/user-attachments/assets/9f45d858-5928-4bca-abc1-d9e760269736


### Closes Issue(s)
Closes #21292

### How to test
1. join a meeting on a mobile device
2. open reactions bar, select raise hand
3. select raise hand again
4. raise hand button should not be selected