### PR TITLE
feat(chat): improve messages rendering

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -1,4 +1,9 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
 import { UpdatedEventDetailsForChatMessageDomElements } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/chat/message/types';
 import { Message } from '/imports/ui/Types/message';
 import { defineMessages, useIntl } from 'react-intl';
@@ -304,4 +309,12 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
   );
 };
 
-export default ChatMesssage;
+function areChatMessagesEqual(prevProps: ChatMessageProps, nextProps: ChatMessageProps) {
+  const prevMessage = prevProps?.message;
+  const nextMessage = nextProps?.message;
+  return prevMessage?.createdAt === nextMessage?.createdAt
+    && prevMessage?.user?.currentlyInMeeting === nextMessage?.user?.currentlyInMeeting
+    && prevMessage?.recipientHasSeen === nextMessage.recipientHasSeen;
+}
+
+export default memo(ChatMesssage, areChatMessagesEqual);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -54,7 +54,7 @@ const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPage
   });
 };
 
-const ChatListPage: React.FC<ChatListPageProps> = memo(({
+const ChatListPage: React.FC<ChatListPageProps> = ({
   messages,
   messageReadFeedbackEnabled,
   lastSenderPreviousPage,
@@ -103,7 +103,9 @@ const ChatListPage: React.FC<ChatListPageProps> = memo(({
       })}
     </div>
   );
-}, areChatPagesEqual);
+};
+
+const MemoizedChatListPage = memo(ChatListPage, areChatPagesEqual);
 
 const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   page,
@@ -147,7 +149,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   }
   setLoadedMessageGathering(page, chatMessageData);
   return (
-    <ChatListPage
+    <MemoizedChatListPage
       messages={chatMessageData}
       lastSenderPreviousPage={lastSenderPreviousPage}
       messageReadFeedbackEnabled={isPrivateReadFeedbackEnabled}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import React, { useContext, useEffect, useState } from 'react';
+import React, {
+  useContext,
+  useEffect,
+  useState,
+  memo,
+} from 'react';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import { UpdatedEventDetailsForChatMessageDomElements } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/chat/message/types';
 import { HookEvents } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
@@ -35,7 +40,21 @@ interface ChatListPageProps {
   scrollRef: React.RefObject<HTMLDivElement>;
 }
 
-const ChatListPage: React.FC<ChatListPageProps> = ({
+const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPageProps) => {
+  const nextMessages = nextProps?.messages || [];
+  const prevMessages = prevProps?.messages || [];
+  if (nextMessages.length !== prevMessages.length) return false;
+  return nextMessages.every((nextMessage, idx) => {
+    const prevMessage = prevMessages[idx];
+    return (prevMessage.messageId === nextMessage.messageId
+      && prevMessage.createdAt === nextMessage.createdAt
+      && prevMessage?.user?.currentlyInMeeting === nextMessage?.user?.currentlyInMeeting
+      && prevMessage?.recipientHasSeen === nextMessage?.recipientHasSeen
+    );
+  });
+};
+
+const ChatListPage: React.FC<ChatListPageProps> = memo(({
   messages,
   messageReadFeedbackEnabled,
   lastSenderPreviousPage,
@@ -84,7 +103,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
       })}
     </div>
   );
-};
+}, areChatPagesEqual);
 
 const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   page,


### PR DESCRIPTION
### What does this PR do?
This PR adds memoization and comparsion functions to the chat pages and chat messages to prevent whole chat re-renders and unnecessary message re-renders caused by React's default shallow comparsion mechanism. The comparsion functions ensure that only the pertinent message attributes trigger a component's re-render.

Messages sent by a user are not updated (re-rendered) when their role change. In other words, the chat messages reflect the user's role at the time the message was sent. Altering the message to reflect the user's current role could confuse participants, as it would modify the context of the past conversation. This behavior has been validated by the UI/UX team and brings benefits such as performance improvements and consistent behavior with how playback handles such messages.

Before:
![before_chat_message](https://github.com/user-attachments/assets/1d17ec96-2ee2-4a83-b337-7a4532b09006)


After:
![after_chat_message](https://github.com/user-attachments/assets/d836f0f9-a74a-49b2-8eb1-8b788f6c64ce)


### Closes Issue(s)
None


### How to test
Either add `console.log`s to see chat message renders or use ReactDevTools while interacting with the chat.


