### PR TITLE
style(layout/modal): Removing custom layout (visually) from layouts modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -161,6 +161,7 @@ const LayoutModalComponent = ({
         .map((layout) => (
           <Styled.ButtonLayoutContainer key={layout}>
             <Styled.LayoutBtn
+              layout={layout}
               label=""
               customIcon={(
                 <Styled.IconSvg
@@ -178,7 +179,10 @@ const LayoutModalComponent = ({
               aria-describedby="layout-btn-desc"
               data-test={`${layout}Layout`}
             />
-            <Styled.LabelLayoutNames aria-hidden>{intl.formatMessage(intlMessages[`${layout}Layout`])}</Styled.LabelLayoutNames>
+            <Styled.LabelLayoutNames
+              layout={layout}
+              aria-hidden>{intl.formatMessage(intlMessages[`${layout}Layout`])}
+            </Styled.LabelLayoutNames>
           </Styled.ButtonLayoutContainer>
         ))}
     </Styled.ButtonsContainer>

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/styles.js
@@ -65,6 +65,11 @@ const LayoutBtn = styled(Button)`
   width: fit-content;
 
   @media ${smallOnly} {
+
+    ${({ layout }) => (layout === 'custom') && `
+      display: none;
+    `};
+    
     margin: 0.5rem;
     border: ${colorWhite} solid 4px;
     border-radius: 10px;
@@ -163,6 +168,13 @@ const ButtonBottomContainer = styled.div`
 const LabelLayoutNames = styled.label`
   text-align: center;
   margin: 0 0 0.1rem 0;
+
+  @media ${smallOnly} {
+    ${({ layout }) => (layout === 'custom') && `
+     display: none;
+    `};
+    margin: 0 0 3rem 0;
+  };
 `;
 
 const ToggleLabel = styled.span`


### PR DESCRIPTION
### What does this PR do?

This PR visaully removes the custom layout from the layouts modal and also applies some style so the modal doesn't look so empty.

### Closes Issue(s)

closes #21293 & #17939

### How to test

Join BBB as mobile, open the layout modal.

### Before

![image](https://github.com/user-attachments/assets/18ab6b56-9c2c-44f8-91a7-dbcc250e5f25)

### After 

![image](https://github.com/user-attachments/assets/ddf25471-90bb-4273-8d31-bd02b23df814)




