### PR TITLE
style/enhancement: Adapting poll results to various screen types.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -4,6 +4,7 @@ import {
 } from 'recharts';
 import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { defineMessages, useIntl } from 'react-intl';
+import deviceInfo from '/imports/utils/deviceInfo';
 import Styled from './styles';
 
 interface ChatPollContentProps {
@@ -95,12 +96,13 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
   });
 
   const useHeight = height || translatedAnswers.length * 50;
+  const useWidth = deviceInfo.isPortrait() ? '100%' : '130%';
   return (
     <Styled.PollWrapper data-test="chatPollMessageText">
       <Styled.PollText>
         {pollData.questionText}
       </Styled.PollText>
-      <ResponsiveContainer width="90%" height={useHeight}>
+      <ResponsiveContainer width={useWidth} height={useHeight}>
         <BarChart
           data={translatedAnswers}
           layout="vertical"

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/styles.ts
@@ -12,7 +12,8 @@ export const PollText = styled.div`
 `;
 
 export const PollWrapper = styled.div`
-  width: 100%;
+  width: 90%;
+  margin-left: -50px;
 `;
 
 export default {


### PR DESCRIPTION
### What does this PR do?

This PR  adapts the chat poll results to smaller and differently oriented screens.

### How to test

To test it, open BBB and publish a poll, then try mobile orientations (landscape and portrait)


### Examples

Mobile/Landscape
![image](https://github.com/user-attachments/assets/f9515f79-9028-46ea-a4df-c2cde240b8ad)

Mobile/Portrait
![image](https://github.com/user-attachments/assets/60089e76-e104-4d7c-97ee-20f424f3079f)

Desktop/Web
![image](https://github.com/user-attachments/assets/6f9443a6-89e7-42ae-a635-519c7692b758)


