### PR TITLE
gql-server: Allow users to edit and delete chat messages (backend portion)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
@@ -1,0 +1,76 @@
+package org.bigbluebutton.core.apps.groupchats
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.{ Roles, Users2x }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+import org.bigbluebutton.core2.MeetingStatus2x
+
+trait DeleteGroupChatMessageReqMsgHdlr extends HandlerHelpers {
+  this: GroupChatHdlrs =>
+
+  def handle(msg: DeleteGroupChatMessageReqMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
+    val chatDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("chat")
+    var chatLocked: Boolean = false
+    var chatLockedForUser: Boolean = false
+
+    var newState = state
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
+      groupChat <- state.groupChats.find(msg.body.chatId)
+    } yield {
+      if (groupChat.access == GroupChatAccess.PUBLIC && user.userLockSettings.disablePublicChat && user.role != Roles.MODERATOR_ROLE) {
+        chatLockedForUser = true
+      }
+
+      val userIsModerator = user.role != Roles.MODERATOR_ROLE
+
+      if (!userIsModerator && user.locked) {
+        val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+        if (groupChat.access == GroupChatAccess.PRIVATE) {
+          val modMembers = groupChat.users.filter(cu => Users2x.findWithIntId(liveMeeting.users2x, cu.id) match {
+            case Some(user) => user.role == Roles.MODERATOR_ROLE
+            case None       => false
+          })
+          // don't lock private chats that involve a moderator
+          if (modMembers.isEmpty) {
+            chatLocked = permissions.disablePrivChat
+          }
+        } else {
+          chatLocked = permissions.disablePubChat
+        }
+      }
+
+      if (!chatDisabled && !(applyPermissionCheck && chatLocked) && !chatLockedForUser) {
+        for {
+          gcMessage <- groupChat.msgs.find(gcm => gcm.id == msg.body.messageId)
+        } yield {
+          val chatIsPrivate = groupChat.access == GroupChatAccess.PRIVATE
+          val userIsAParticipant = groupChat.users.exists(u => u.id == user.intId)
+          val userIsOwner = gcMessage.sender.id == user.intId
+
+          if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
+            if (userIsOwner || userIsModerator) {
+              val updatedGroupChat = GroupChatApp.deleteGroupChatMessage(liveMeeting.props.meetingProp.intId, groupChat, state.groupChats, gcMessage)
+
+              val event = buildGroupChatMessageDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id)
+              bus.outGW.send(event)
+              newState = state.update(updatedGroupChat)
+            } else {
+              val reason = "User doesn't have permission to delete chat message"
+              PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+            }
+          } else {
+            val reason = "User isn't a participant of the chat"
+            PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+          }
+        }
+      }
+    }
+
+    newState
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
@@ -54,7 +54,7 @@ trait DeleteGroupChatMessageReqMsgHdlr extends HandlerHelpers {
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
             if (userIsOwner || userIsModerator) {
-              val updatedGroupChat = GroupChatApp.deleteGroupChatMessage(liveMeeting.props.meetingProp.intId, groupChat, state.groupChats, gcMessage)
+              val updatedGroupChat = GroupChatApp.deleteGroupChatMessage(liveMeeting.props.meetingProp.intId, groupChat, state.groupChats, gcMessage, user.intId)
 
               val event = buildGroupChatMessageDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id)
               bus.outGW.send(event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/EditGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/EditGroupChatMessageReqMsgHdlr.scala
@@ -1,0 +1,77 @@
+package org.bigbluebutton.core.apps.groupchats
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.{ Roles, Users2x }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+import org.bigbluebutton.core2.MeetingStatus2x
+
+trait EditGroupChatMessageReqMsgHdlr extends HandlerHelpers {
+  this: GroupChatHdlrs =>
+
+  def handle(msg: EditGroupChatMessageReqMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): MeetingState2x = {
+    val chatDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("chat")
+    var chatLocked: Boolean = false
+    var chatLockedForUser: Boolean = false
+
+    var newState = state
+
+    for {
+      user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
+      groupChat <- state.groupChats.find(msg.body.chatId)
+    } yield {
+      if (groupChat.access == GroupChatAccess.PUBLIC && user.userLockSettings.disablePublicChat && user.role != Roles.MODERATOR_ROLE) {
+        chatLockedForUser = true
+      }
+
+      val userIsModerator = user.role != Roles.MODERATOR_ROLE
+
+      if (!userIsModerator && user.locked) {
+        val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+        if (groupChat.access == GroupChatAccess.PRIVATE) {
+          val modMembers = groupChat.users.filter(cu => Users2x.findWithIntId(liveMeeting.users2x, cu.id) match {
+            case Some(user) => user.role == Roles.MODERATOR_ROLE
+            case None       => false
+          })
+          // don't lock private chats that involve a moderator
+          if (modMembers.isEmpty) {
+            chatLocked = permissions.disablePrivChat
+          }
+        } else {
+          chatLocked = permissions.disablePubChat
+        }
+      }
+
+      if (!chatDisabled && !(applyPermissionCheck && chatLocked) && !chatLockedForUser) {
+        for {
+          gcMessage <- groupChat.msgs.find(gcm => gcm.id == msg.body.messageId)
+        } yield {
+          val chatIsPrivate = groupChat.access == GroupChatAccess.PRIVATE
+          val userIsAParticipant = groupChat.users.exists(u => u.id == user.intId)
+          val userIsOwner = gcMessage.sender.id == user.intId
+
+          if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
+            if (userIsOwner) {
+              val editedGCMessage = gcMessage.copy(message = msg.body.message)
+              val updatedGroupChat = GroupChatApp.updateGroupChatMessage(liveMeeting.props.meetingProp.intId, groupChat, state.groupChats, editedGCMessage)
+
+              val event = buildGroupChatMessageEditedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, editedGCMessage)
+              bus.outGW.send(event)
+              newState = state.update(updatedGroupChat)
+            } else {
+              val reason = "User doesn't have permission to edit chat message"
+              PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+            }
+          } else {
+            val reason = "User isn't a participant of the chat"
+            PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+          }
+        }
+      }
+    }
+
+    newState
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -43,6 +43,20 @@ object GroupChatApp {
     chats.update(c)
   }
 
+  def updateGroupChatMessage(meetingId: String, chat: GroupChat, chats: GroupChats, msg: GroupChatMessage): GroupChats = {
+    ChatMessageDAO.update(meetingId, chat.id, msg.id, msg.message)
+
+    val c = chat.update(msg)
+    chats.update(c)
+  }
+
+  def deleteGroupChatMessage(meetingId: String, chat: GroupChat, chats: GroupChats, msg: GroupChatMessage): GroupChats = {
+    ChatMessageDAO.softDelete(meetingId, chat.id, msg.id)
+
+    val c = chat.delete(msg.id)
+    chats.update(c)
+  }
+
   def findGroupChatUser(userId: String, users: Users2x): Option[GroupChatUser] = {
     Users2x.findWithIntId(users, userId) match {
       case Some(u) => Some(GroupChatUser(u.intId, u.name, u.role))

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChat.scala
@@ -50,8 +50,8 @@ object GroupChatApp {
     chats.update(c)
   }
 
-  def deleteGroupChatMessage(meetingId: String, chat: GroupChat, chats: GroupChats, msg: GroupChatMessage): GroupChats = {
-    ChatMessageDAO.softDelete(meetingId, chat.id, msg.id)
+  def deleteGroupChatMessage(meetingId: String, chat: GroupChat, chats: GroupChats, msg: GroupChatMessage, deletedBy: String): GroupChats = {
+    ChatMessageDAO.softDelete(meetingId, chat.id, msg.id, deletedBy)
 
     val c = chat.delete(msg.id)
     chats.update(c)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChatHdlrs.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/GroupChatHdlrs.scala
@@ -9,6 +9,8 @@ class GroupChatHdlrs(implicit val context: ActorContext)
   with GetGroupChatMsgsReqMsgHdlr
   with GetGroupChatsReqMsgHdlr
   with SendGroupChatMessageMsgHdlr
+  with EditGroupChatMessageReqMsgHdlr
+  with DeleteGroupChatMessageReqMsgHdlr
   with SendGroupChatMessageFromApiSysPubMsgHdlr
   with SetGroupChatVisibleReqMsgHdlr
   with SetGroupChatLastSeenReqMsgHdlr {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageDAO.scala
@@ -8,15 +8,17 @@ case class ChatMessageDbModel(
     chatId:             String,
     meetingId:          String,
     correlationId:      String,
-    createdAt:          java.sql.Timestamp,
     chatEmphasizedText: Boolean,
-    message:            String,
+    message:            Option[String],
     messageType:        String,
     replyToMessageId:   Option[String],
     messageMetadata:    Option[String],
     senderId:           Option[String],
     senderName:         String,
-    senderRole:         Option[String]
+    senderRole:         Option[String],
+    createdAt:          java.sql.Timestamp,
+    updatedAt:          Option[java.sql.Timestamp],
+    deletedAt:          Option[java.sql.Timestamp]
 )
 
 class ChatMessageDbTableDef(tag: Tag) extends Table[ChatMessageDbModel](tag, None, "chat_message") {
@@ -24,9 +26,8 @@ class ChatMessageDbTableDef(tag: Tag) extends Table[ChatMessageDbModel](tag, Non
   val chatId = column[String]("chatId")
   val meetingId = column[String]("meetingId")
   val correlationId = column[String]("correlationId")
-  val createdAt = column[java.sql.Timestamp]("createdAt")
   val chatEmphasizedText = column[Boolean]("chatEmphasizedText")
-  val message = column[String]("message")
+  val message = column[Option[String]]("message")
   val messageType = column[String]("messageType")
   val replyToMessageId = column[Option[String]]("replyToMessageId")
   val messageMetadata = column[Option[String]]("messageMetadata")
@@ -35,22 +36,28 @@ class ChatMessageDbTableDef(tag: Tag) extends Table[ChatMessageDbModel](tag, Non
   val senderRole = column[Option[String]]("senderRole")
   //  val chat = foreignKey("chat_message_chat_fk", (chatId, meetingId), ChatTable.chats)(c => (c.chatId, c.meetingId), onDelete = ForeignKeyAction.Cascade)
   //  val sender = foreignKey("chat_message_sender_fk", senderId, UserTable.users)(_.userId, onDelete = ForeignKeyAction.SetNull)
+  val createdAt = column[java.sql.Timestamp]("createdAt")
+  val updatedAt = column[Option[java.sql.Timestamp]]("updatedAt")
+  val deletedAt = column[Option[java.sql.Timestamp]]("deletedAt")
 
-  override def * = (messageId, chatId, meetingId, correlationId, createdAt, chatEmphasizedText, message, messageType, replyToMessageId, messageMetadata, senderId, senderName, senderRole) <> (ChatMessageDbModel.tupled, ChatMessageDbModel.unapply)
+  override def * = (
+    messageId, chatId, meetingId, correlationId, chatEmphasizedText,
+    message, messageType, replyToMessageId, messageMetadata, senderId, senderName, senderRole,
+    createdAt, updatedAt, deletedAt
+  ) <> (ChatMessageDbModel.tupled, ChatMessageDbModel.unapply)
 }
 
 object ChatMessageDAO {
   def insert(meetingId: String, chatId: String, groupChatMessage: GroupChatMessage, messageType: String) = {
     DatabaseConnection.enqueue(
-      TableQuery[ChatMessageDbTableDef].insertOrUpdate(
+      TableQuery[ChatMessageDbTableDef].forceInsert(
         ChatMessageDbModel(
           messageId = groupChatMessage.id,
           chatId = chatId,
           meetingId = meetingId,
           correlationId = groupChatMessage.correlationId,
-          createdAt = new java.sql.Timestamp(System.currentTimeMillis()),
           chatEmphasizedText = groupChatMessage.chatEmphasizedText,
-          message = groupChatMessage.message,
+          message = Some(groupChatMessage.message),
           messageType = messageType,
           replyToMessageId = groupChatMessage.replyToMessageId match {
             case "" => None
@@ -60,6 +67,9 @@ object ChatMessageDAO {
           senderId = Some(groupChatMessage.sender.id),
           senderName = groupChatMessage.sender.name,
           senderRole = Some(groupChatMessage.sender.role),
+          createdAt = new java.sql.Timestamp(System.currentTimeMillis()),
+          updatedAt = None,
+          deletedAt = None,
         )
       )
     )
@@ -90,27 +100,55 @@ object ChatMessageDAO {
 
   def insertSystemMsg(meetingId: String, chatId: String, message: String, messageType: String, messageMetadata: Map[String,Any], senderName: String) = {
     DatabaseConnection.enqueue(
-      TableQuery[ChatMessageDbTableDef].insertOrUpdate(
+      TableQuery[ChatMessageDbTableDef].forceInsert(
         ChatMessageDbModel(
           messageId = GroupChatFactory.genId(),
           chatId = chatId,
           meetingId = meetingId,
           correlationId = "",
-          createdAt = new java.sql.Timestamp(System.currentTimeMillis()),
           chatEmphasizedText = false,
-          message = message,
+          message = Some(message),
           messageType = messageType,
           replyToMessageId = None,
           messageMetadata = Some(JsonUtils.mapToJson(messageMetadata).compactPrint),
           senderId = None,
           senderName = senderName,
-          senderRole = None
+          senderRole = None,
+          createdAt = new java.sql.Timestamp(System.currentTimeMillis()),
+          updatedAt = None,
+          deletedAt = None,
         )
       )
     )
 
     //Set chat visible for all participant users
     ChatUserDAO.updateChatVisible(meetingId, chatId, visible = true)
+  }
+
+  def update(meetingId: String, chatId: String, messageId: String, message: String) = {
+    //The database will automatically keep the previous message as history
+    DatabaseConnection.enqueue(
+      TableQuery[ChatMessageDbTableDef]
+        .filter(_.meetingId === meetingId)
+        .filter(_.chatId === chatId)
+        .filter(_.messageId === messageId)
+        .filter(_.message.nonEmpty)
+        .map(u => u.message)
+        .update(Some(message))
+    )
+  }
+
+  def softDelete(meetingId: String, chatId: String, messageId: String) = {
+    //set message=NULL instead of delete it from db, because the client will show "Message deleted"
+    DatabaseConnection.enqueue(
+      TableQuery[ChatMessageDbTableDef]
+        .filter(_.meetingId === meetingId)
+        .filter(_.chatId === chatId)
+        .filter(_.messageId === messageId)
+        .filter(_.message.nonEmpty)
+        .map(u => u.message)
+        .update(None)
+    )
   }
 
   def deleteAllFromChat(meetingId: String, chatId: String) = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -404,6 +404,10 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[SendGroupChatMessageMsg](envelope, jsonNode)
       case SendGroupChatMessageFromApiSysPubMsg.NAME =>
         routeGenericMsg[SendGroupChatMessageFromApiSysPubMsg](envelope, jsonNode)
+      case EditGroupChatMessageReqMsg.NAME =>
+        routeGenericMsg[EditGroupChatMessageReqMsg](envelope, jsonNode)
+      case DeleteGroupChatMessageReqMsg.NAME =>
+        routeGenericMsg[DeleteGroupChatMessageReqMsg](envelope, jsonNode)
       case GetGroupChatMsgsReqMsg.NAME =>
         routeGenericMsg[GetGroupChatMsgsReqMsg](envelope, jsonNode)
       case CreateGroupChatReqMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -309,4 +309,22 @@ trait HandlerHelpers extends SystemConfiguration {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildGroupChatMessageEditedEvtMsg(meetingId: String, chatId: String, userId: String, msg: GroupChatMessage): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GroupChatMessageEditedEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GroupChatMessageEditedEvtMsg.NAME, meetingId, userId)
+    val body = GroupChatMessageEditedEvtMsgBody(chatId, msg.id, msg.message)
+    val event = GroupChatMessageEditedEvtMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
+  def buildGroupChatMessageDeletedEvtMsg(meetingId: String, chatId: String, userId: String, messageId: String): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+    val envelope = BbbCoreEnvelope(GroupChatMessageDeletedEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(GroupChatMessageDeletedEvtMsg.NAME, meetingId, userId)
+    val body = GroupChatMessageDeletedEvtMsgBody(chatId, messageId)
+    val event = GroupChatMessageDeletedEvtMsg(header, body)
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -705,6 +705,12 @@ class MeetingActor(
         updateUserLastActivity(m.body.msg.sender.id)
       case m: SendGroupChatMessageFromApiSysPubMsg =>
         state = groupChatApp.handle(m, state, liveMeeting, msgBus)
+      case m: EditGroupChatMessageReqMsg =>
+        state = groupChatApp.handle(m, state, liveMeeting, msgBus)
+        updateUserLastActivity(m.header.userId)
+      case m: DeleteGroupChatMessageReqMsg =>
+        state = groupChatApp.handle(m, state, liveMeeting, msgBus)
+        updateUserLastActivity(m.header.userId)
 
       // Plugin
       case m: PluginDataChannelPushEntryMsg    => pluginHdlrs.handle(m, state, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -135,6 +135,8 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
 
       // Group Chats
       case m: SendGroupChatMessageMsg => logChatMessage(msg)
+      case m: EditGroupChatMessageReqMsg => logChatMessage(msg)
+      case m: DeleteGroupChatMessageReqMsg => logChatMessage(msg)
       case m: GroupChatMessageBroadcastEvtMsg => logChatMessage(msg)
       case m: GetGroupChatMsgsReqMsg => logChatMessage(msg)
       case m: GetGroupChatMsgsRespMsg => logChatMessage(msg)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -119,6 +119,22 @@ object GroupChatMessageBroadcastEvtMsg { val NAME = "GroupChatMessageBroadcastEv
 case class GroupChatMessageBroadcastEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageBroadcastEvtMsgBody) extends BbbCoreMsg
 case class GroupChatMessageBroadcastEvtMsgBody(chatId: String, msg: GroupChatMsgToUser)
 
+object EditGroupChatMessageReqMsg { val NAME = "EditGroupChatMessageReqMsg" }
+case class EditGroupChatMessageReqMsg(header: BbbClientMsgHeader, body: EditGroupChatMessageReqMsgBody) extends StandardMsg
+case class EditGroupChatMessageReqMsgBody(chatId: String, messageId: String, message: String)
+
+object GroupChatMessageEditedEvtMsg { val NAME = "GroupChatMessageEditedEvtMsg" }
+case class GroupChatMessageEditedEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageEditedEvtMsgBody) extends BbbCoreMsg
+case class GroupChatMessageEditedEvtMsgBody(chatId: String, messageId: String, message: String)
+
+object DeleteGroupChatMessageReqMsg { val NAME = "DeleteGroupChatMessageReqMsg" }
+case class DeleteGroupChatMessageReqMsg(header: BbbClientMsgHeader, body: DeleteGroupChatMessageReqMsgBody) extends StandardMsg
+case class DeleteGroupChatMessageReqMsgBody(chatId: String, messageId: String)
+
+object GroupChatMessageDeletedEvtMsg { val NAME = "GroupChatMessageDeletedEvtMsg" }
+case class GroupChatMessageDeletedEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageDeletedEvtMsgBody) extends BbbCoreMsg
+case class GroupChatMessageDeletedEvtMsgBody(chatId: String, messageId: String)
+
 object UserTypingPubMsg { val NAME = "UserTypingPubMsg" }
 case class UserTypingPubMsg(header: BbbClientMsgHeader, body: UserTypingPubMsgBody) extends StandardMsg
 case class UserTypingPubMsgBody(chatId: String)

--- a/bbb-graphql-actions/src/actions/chatDeleteMessage.ts
+++ b/bbb-graphql-actions/src/actions/chatDeleteMessage.ts
@@ -1,0 +1,30 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'chatId', type: 'string', required: true},
+        {name: 'messageId', type: 'string', required: true},
+      ]
+  )
+
+  const eventName = `DeleteGroupChatMessageReqMsg`;
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = { 
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    chatId: input.chatId,
+    messageId: input.messageId,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-actions/src/actions/chatEditMessage.ts
+++ b/bbb-graphql-actions/src/actions/chatEditMessage.ts
@@ -1,0 +1,32 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'chatId', type: 'string', required: true},
+        {name: 'messageId', type: 'string', required: true},
+        {name: 'chatMessageInMarkdownFormat', type: 'string', required: true},
+      ]
+  )
+
+  const eventName = `EditGroupChatMessageReqMsg`;
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = { 
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    chatId: input.chatId,
+    messageId: input.messageId,
+    message: input.chatMessageInMarkdownFormat,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -999,6 +999,7 @@ CREATE TABLE "chat_message" (
 	"senderRole" varchar(20),
 	"createdAt" timestamp with time zone not null,
 	"editedAt" timestamp with time zone,
+	"deletedByUserId" varchar(100),
 	"deletedAt" timestamp with time zone,
     CONSTRAINT chat_fk FOREIGN KEY ("chatId", "meetingId") REFERENCES "chat"("chatId", "meetingId") ON DELETE CASCADE
 );
@@ -1124,6 +1125,7 @@ SELECT  cu."meetingId",
         cm."senderRole",
         cm."createdAt",
         cm."editedAt",
+        cm."deletedByUserId",
         cm."deletedAt",
         CASE WHEN chat_with."lastSeenAt" >= cm."createdAt" THEN true ELSE false end "recipientHasSeen"
 FROM chat_message cm

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -997,7 +997,9 @@ CREATE TABLE "chat_message" (
     "senderId" varchar(100),
     "senderName" varchar(255),
 	"senderRole" varchar(20),
-	"createdAt" timestamp with time zone,
+	"createdAt" timestamp with time zone not null,
+	"updatedAt" timestamp with time zone,
+	"deletedAt" timestamp with time zone,
     CONSTRAINT chat_fk FOREIGN KEY ("chatId", "meetingId") REFERENCES "chat"("chatId", "meetingId") ON DELETE CASCADE
 );
 CREATE INDEX "idx_chat_message_chatId" ON "chat_message"("chatId","meetingId");
@@ -1032,6 +1034,47 @@ $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER "update_chatUser_clear_lastTypingAt_trigger" AFTER INSERT ON chat_message FOR EACH ROW
 EXECUTE FUNCTION "update_chatUser_clear_lastTypingAt_trigger_func"();
+
+
+
+CREATE TABLE "chat_message_history" (
+	"messageId" varchar(100) REFERENCES "chat_message"("messageId") ON DELETE CASCADE,
+	"meetingId" varchar(100),
+	"messageVersionSequence" integer, --populated via trigger
+	"message" text,
+	"messageCreatedAt" timestamp with time zone,
+	"movedToHistoryAt" timestamp with time zone default current_timestamp,
+    CONSTRAINT chat_message_history_pk PRIMARY KEY ("messageId", "messageVersionSequence")
+);
+CREATE INDEX "chat_message_history_seq_idx" ON "chat_message_history"("messageId","messageVersionSequence");
+
+CREATE OR REPLACE VIEW "v_chat_message_history" AS SELECT * FROM "chat_message_history";
+
+CREATE OR REPLACE FUNCTION "update_chat_message_history_trigger_func"()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW."message" <> OLD."message" THEN
+        insert into "chat_message_history"("messageId", "meetingId", "messageVersionSequence", "message", "messageCreatedAt")
+	    values (OLD."messageId",
+	            OLD."meetingId",
+	            (select count(1) from "chat_message_history" prev where prev."messageId" = OLD."messageId"),
+	            OLD."message",
+	            coalesce(OLD."updatedAt",OLD."createdAt")
+	            );
+
+	    IF NEW."message" IS NULL THEN
+            NEW."deletedAt" = current_timestamp;
+        ELSE
+            NEW."updatedAt" = current_timestamp;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_chat_message_history_trigger" BEFORE UPDATE OF "message" ON "chat_message"
+    FOR EACH ROW EXECUTE FUNCTION "update_chat_message_history_trigger_func"();
 
 
 CREATE OR REPLACE VIEW "v_chat" AS
@@ -1084,6 +1127,8 @@ SELECT  cu."meetingId",
         cm."senderName",
         cm."senderRole",
         cm."createdAt",
+        cm."updatedAt",
+        cm."deletedAt",
         CASE WHEN chat_with."lastSeenAt" >= cm."createdAt" THEN true ELSE false end "recipientHasSeen"
 FROM chat_message cm
 JOIN chat_user cu ON cu."meetingId" = cm."meetingId" AND cu."chatId" = cm."chatId"

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -96,6 +96,21 @@ type Mutation {
 }
 
 type Mutation {
+  chatDeleteMessage(
+    chatId: String!
+    messageId: String!
+  ): Boolean
+}
+
+type Mutation {
+  chatEditMessage(
+    chatId: String!
+    messageId: String!
+    chatMessageInMarkdownFormat: String!
+  ): Boolean
+}
+
+type Mutation {
   chatPublicClearHistory: Boolean
 }
 

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -89,6 +89,18 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: chatDeleteMessage
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
+  - name: chatEditMessage
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: chatPublicClearHistory
     definition:
       kind: synchronous

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
@@ -44,7 +44,7 @@ select_permissions:
         - senderId
         - senderName
         - senderRole
-        - updatedAt
+        - editedAt
       filter:
         _and:
           - meetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
@@ -34,15 +34,17 @@ select_permissions:
         - chatId
         - correlationId
         - createdAt
+        - deletedAt
         - message
         - messageId
         - messageMetadata
         - messageSequence
         - messageType
+        - recipientHasSeen
         - senderId
         - senderName
         - senderRole
-        - recipientHasSeen
+        - updatedAt
       filter:
         _and:
           - meetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_private.yaml
@@ -7,6 +7,16 @@ configuration:
   custom_name: chat_message_private
   custom_root_fields: {}
 object_relationships:
+  - name: deletedBy
+    using:
+      manual_configuration:
+        column_mapping:
+          deletedByUserId: userId
+          meetingId: meetingId
+        insertion_order: null
+        remote_table:
+          name: v_user_ref
+          schema: public
   - name: replyToMessage
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
@@ -43,7 +43,7 @@ select_permissions:
         - senderId
         - senderName
         - senderRole
-        - updatedAt
+        - editedAt
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
@@ -7,6 +7,16 @@ configuration:
   custom_name: chat_message_public
   custom_root_fields: {}
 object_relationships:
+  - name: deletedBy
+    using:
+      manual_configuration:
+        column_mapping:
+          deletedByUserId: userId
+          meetingId: meetingId
+        insertion_order: null
+        remote_table:
+          name: v_user_ref
+          schema: public
   - name: replyToMessage
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_public.yaml
@@ -34,6 +34,7 @@ select_permissions:
         - chatId
         - correlationId
         - createdAt
+        - deletedAt
         - message
         - messageId
         - messageMetadata
@@ -42,6 +43,7 @@ select_permissions:
         - senderId
         - senderName
         - senderRole
+        - updatedAt
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId


### PR DESCRIPTION
This PR introduces two new mutations for editing and deleting chat messages:

```gql
mutation($chatId: String!, $messageId: String!, $chatMessageInMarkdownFormat: String!) {
  chatEditMessage(chatId: $chatId, messageId: $messageId, chatMessageInMarkdownFormat: $chatMessageInMarkdownFormat)
}
```

```gql
mutation($chatId: String!, $messageId: String!) {
  chatDeleteMessage(chatId: $chatId, messageId: $messageId)
}
```

Additionally, three new fields are added to the `chat_message` type for both public and private chats:

```gql
subscription {
  chat_message_public {
    editedAt
    deletedAt
    deletedBy {
      name
    }
  }
}
```

```gql
subscription {
  chat_message_public {
    editedAt
    deletedAt
    deletedBy {
      name
    }
  }
}
```

A new `chat_message_history` table has been introduced to store previous versions of edited or deleted messages.

When a message is deleted, its content is set to `null`, and the `deletedAt` field is populated. The client should display the message as `"This message was removed"`.

### Future work:
- **Message history:** While message history is being stored, it is not yet retrievable. In this version, moderators cannot view previous versions of edited or deleted messages. This feature will be added in future PRs.
- **Time limits:** Currently, message owners can edit and delete their messages at any time, and moderators can delete any message. A future config will introduce time limits (e.g., 5 minutes) for editing or deleting messages.