### PR TITLE
fix: Client crashes on activity check

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/activity-check/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/activity-check/container.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 import { useMutation } from '@apollo/client';
 import ActivityCheck from './component';
 import { USER_SEND_ACTIVITY_SIGN } from './mutations';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
-const ActivityCheckContainer = () => {
+const ActivityCheckContainer = ({ intl }) => {
   const [userActivitySign] = useMutation(USER_SEND_ACTIVITY_SIGN);
   const { data: currentUserData } = useCurrentUser((user) => ({
     inactivityWarningDisplay: user.inactivityWarningDisplay,
@@ -21,8 +22,14 @@ const ActivityCheckContainer = () => {
       userActivitySign={userActivitySign}
       inactivityCheck={inactivityWarningDisplay}
       responseDelay={inactivityWarningTimeoutSecs}
+      intl={intl}
     />
   );
+};
+ActivityCheckContainer.propTypes = {
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default injectIntl(ActivityCheckContainer);


### PR DESCRIPTION
### What does this PR do?

restores intl prop in activity check component

### Closes Issue(s)
Closes #21306

### How to test
Set in `/etc/bigbluebutton/bbb-web.properties`

```
userInactivityInspectTimerInMinutes=1
userInactivityThresholdInMinutes=2
userActivitySignResponseDelayInMinutes=1

```

restart `sudo bbb-conf --restart`

1. Create a session
2. Join with moderator
3. Send a chat message
4. Stop moving the cursor (even go to a different browser tab)
5. Wait a couple of minutes