### PR TITLE
fix: [3.0] Can't access user list when in landscape mode on mobile and with a few features opened

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { GenericSidekickContent } from 'bigbluebutton-html-plugin-sdk';
 import Styled from './styles';
 import UserListParticipants from './user-participants/user-list-participants/component';
 import ChatList from './user-messages/chat-list/component';
@@ -9,8 +10,10 @@ import GuestPanelOpenerContainer from '../user-list-graphql/user-participants-ti
 import UserPollsContainer from './user-polls/container';
 import BreakoutRoomContainer from './breakout-room/container';
 import UserTitleContainer from '../user-list-graphql/user-participants-title/component';
-import { GenericSidekickContent } from 'bigbluebutton-html-plugin-sdk';
 import GenericSidekickContentNavButtonContainer from './generic-sidekick-content-button/container';
+import deviceInfo from '/imports/utils/deviceInfo';
+
+const { isMobile, isPortrait } = deviceInfo;
 
 const propTypes = {
   currentUser: PropTypes.shape({
@@ -43,17 +46,34 @@ class UserContent extends PureComponent {
 
     return (
       <Styled.Content data-test="userListContent">
-        {isChatEnabled ? <ChatList /> : null}
-        <UserNotesContainer />
-        {isTimerActive && <TimerContainer isModerator={currentUser?.role === ROLE_MODERATOR} />}
-        {currentUser?.role === ROLE_MODERATOR ? (
-          <GuestPanelOpenerContainer />
-          ) : null}
-        <UserPollsContainer isPresenter={currentUser?.presenter} />
-        <BreakoutRoomContainer />
-        <GenericSidekickContentNavButtonContainer />
-        <UserTitleContainer />
-        <UserListParticipants compact={compact} />
+        {isMobile || (isMobile && isPortrait) ? (
+          <Styled.ScrollableList role="tabpanel" tabIndex={0}>
+            <Styled.List>
+              {isChatEnabled ? <ChatList /> : null}
+              <UserNotesContainer />
+              {isTimerActive
+              && <TimerContainer isModerator={currentUser?.role === ROLE_MODERATOR} />}
+              {currentUser?.role === ROLE_MODERATOR ? <GuestPanelOpenerContainer /> : null}
+              <UserPollsContainer isPresenter={currentUser?.presenter} />
+              <BreakoutRoomContainer />
+              <GenericSidekickContentNavButtonContainer />
+              <UserTitleContainer />
+              <UserListParticipants compact={compact} />
+            </Styled.List>
+          </Styled.ScrollableList>
+        ) : (
+          <>
+            {isChatEnabled ? <ChatList /> : null}
+            <UserNotesContainer />
+            {isTimerActive && <TimerContainer isModerator={currentUser?.role === ROLE_MODERATOR} />}
+            {currentUser?.role === ROLE_MODERATOR ? <GuestPanelOpenerContainer /> : null}
+            <UserPollsContainer isPresenter={currentUser?.presenter} />
+            <BreakoutRoomContainer />
+            <GenericSidekickContentNavButtonContainer />
+            <UserTitleContainer />
+            <UserListParticipants compact={compact} />
+          </>
+        )}
       </Styled.Content>
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
@@ -7,6 +7,9 @@ import useChat from '/imports/ui/core/hooks/useChat';
 import { Chat } from '/imports/ui/Types/chat';
 import Service from '/imports/ui/components/user-list/service';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
+import deviceInfo from '/imports/utils/deviceInfo';
+
+const { isMobile } = deviceInfo;
 
 const intlMessages = defineMessages({
   messagesTitle: {
@@ -16,7 +19,7 @@ const intlMessages = defineMessages({
 });
 
 interface ChatListProps {
-    chats: Chat[],
+  chats: Chat[],
 }
 
 const getActiveChats = (chats: Chat[], chatNodeRef: React.Ref<HTMLButtonElement>) => chats.map((chat) => (
@@ -40,8 +43,8 @@ const getActiveChats = (chats: Chat[], chatNodeRef: React.Ref<HTMLButtonElement>
 ));
 
 const ChatList: React.FC<ChatListProps> = ({ chats }) => {
-  const messageListRef = React.useRef<HTMLDivElement | null >(null);
-  const messageItemsRef = React.useRef<HTMLDivElement | null >(null);
+  const messageListRef = React.useRef<HTMLDivElement | null>(null);
+  const messageItemsRef = React.useRef<HTMLDivElement | null>(null);
   const [selectedChat, setSelectedChat] = React.useState<HTMLElement>();
   const { roving } = Service;
   const chatNodeRef = React.useRef<HTMLButtonElement | null>(null);
@@ -66,18 +69,21 @@ const ChatList: React.FC<ChatListProps> = ({ chats }) => {
           {intl.formatMessage(intlMessages.messagesTitle)}
         </Styled.MessagesTitle>
       </Styled.Container>
-      <Styled.ScrollableList
-        role="tabpanel"
-        tabIndex={0}
-        ref={messageListRef}
-        onKeyDown={rove}
-      >
-        <Styled.List ref={messageItemsRef}>
-          <TransitionGroup>
-            {getActiveChats(chats, chatNodeRef) ?? null}
-          </TransitionGroup>
-        </Styled.List>
-      </Styled.ScrollableList>
+      {!isMobile ? (
+        <Styled.ScrollableList
+          role="tabpanel"
+          tabIndex={0}
+          ref={messageListRef}
+          onKeyDown={rove}
+        >
+          <Styled.List ref={messageItemsRef}>
+            <TransitionGroup>
+              {getActiveChats(chats, chatNodeRef) ?? null}
+            </TransitionGroup>
+          </Styled.List>
+        </Styled.ScrollableList>
+      )
+        : (getActiveChats(chats, chatNodeRef) ?? null) }
     </Styled.Messages>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/styles.ts
@@ -8,13 +8,19 @@ import {
 import {
   borderSize, smPaddingX, lgPaddingY, mdPaddingY,
 } from '/imports/ui/stylesheets/styled-components/general';
+import deviceInfo from '/imports/utils/deviceInfo';
+
+const { isMobile } = deviceInfo;
 
 const Messages = styled.div`
   flex-grow: 0;
   display: flex;
   flex-flow: column;
   flex-shrink: 0;
-  max-height: 30vh;
+
+  ${!isMobile && `
+    max-height: 30vh;
+  `}
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the moderator would be unable to reach the user list, due to too many tabs opened in this user list area making it go down and disappear.

The PR also removes the private chat scroll bar on mobile devices and adds a 'general', that way, the user to get to navigate with 3 different scrolls and instead can use only one.

Note that this changes DON'T mess with the user list scroll nor it's pagination, which is made based on the screen size.

Also, the design team was consulted for this change.

### Closes Issue(s)

Closes #21328

### Motivation

The motivation for the making of this PR was that adding another scroll to acess the rest of the elements such as:  Notes, Guest Policy and etc... Could be a little annoying for the user.

### How to test

Enter a BBB meeting with a presenter on mobile,  add as many tabs as possible (notes, breakout, timer e etc ..) and many user as possible.

### More

[scrollMobile.webm](https://github.com/user-attachments/assets/7e89d5ce-861a-4b30-a217-7e893879664d)
