### PR TITLE
Fix: [3.0] Wrong away toggle initial state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -153,7 +153,7 @@ const ReactionsButton = (props) => {
           {ToggleAFKLabel()}
           <Toggle
             icons={false}
-            defaultChecked={away}
+            checked={away}
             onChange={handleToggleAFK}
             ariaLabel={ToggleAFKLabel()}
             showToggleLabel={false}
@@ -164,7 +164,7 @@ const ReactionsButton = (props) => {
         <>
           <Toggle
             icons={false}
-            defaultChecked={away}
+            checked={away}
             onChange={handleToggleAFK}
             ariaLabel={ToggleAFKLabel()}
             showToggleLabel={false}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the away toggle to show the correct state throughout refreshes. 

### Closes Issue(s)

Closes #21333 

### How to test

Start a meeting, use away toggle and refresh the page.



