### PR TITLE
refactor (gql-server): Rename `user_camera` prop from `focused` to `showAsContent`

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/SetCamShowAsContentReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/SetCamShowAsContentReqMsgHdlr.scala
@@ -1,0 +1,63 @@
+package org.bigbluebutton.core.apps.webcam
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers.permissionFailed
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.UserCameraDAO
+import org.bigbluebutton.core.models.{ WebcamStream, Webcams }
+import org.bigbluebutton.core.running.LiveMeeting
+
+trait SetCamShowAsContentReqMsgHdlr {
+  this: WebcamApp2x =>
+
+  def handle(
+      msg:         SetCamShowAsContentReqMsg,
+      liveMeeting: LiveMeeting,
+      bus:         MessageBus
+  ): Unit = {
+    val meetingId = liveMeeting.props.meetingProp.intId
+
+    def broadcastEvent(meetingId: String, userId: String, streamId: String, showAsContent: Boolean, setBy: String): Unit = {
+      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
+      val envelope = BbbCoreEnvelope(SetCamShowAsContentEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(SetCamShowAsContentEvtMsg.NAME, meetingId, userId)
+      val body = SetCamShowAsContentEvtMsgBody(streamId, showAsContent, setBy)
+      val event = SetCamShowAsContentEvtMsg(header, body)
+      val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+      bus.outGW.send(msgEvent)
+    }
+
+    val userIsPresenter = !permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)
+
+    if (!userIsPresenter) {
+      val reason = "No permission to set showAsContent for camera."
+      PermissionCheck.ejectUserForFailedPermission(
+        meetingId,
+        msg.header.userId,
+        reason,
+        bus.outGW,
+        liveMeeting
+      )
+    } else {
+      for {
+        webcam <- Webcams.findWithStreamId(liveMeeting.webcams, msg.body.streamId)
+      } yield {
+        if (webcam.contentType != "screenshare") {
+          val reason = "Only screenshare can be set as content."
+          PermissionCheck.ejectUserForFailedPermission(
+            meetingId,
+            msg.header.userId,
+            reason,
+            bus.outGW,
+            liveMeeting
+          )
+        } else {
+          broadcastEvent(meetingId, msg.header.userId, webcam.streamId, msg.body.showAsContent, msg.body.setBy)
+          UserCameraDAO.updateShowAsContent(meetingId, webcam.streamId, msg.body.showAsContent)
+        }
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UserBroadcastCamStartMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UserBroadcastCamStartMsgHdlr.scala
@@ -46,8 +46,8 @@ trait UserBroadcastCamStartMsgHdlr {
       )
     } else {
       val userIsPresenter = !permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)
-      val startFocused = msg.body.contentType == "screenshare" && userIsPresenter
-      val webcam = WebcamStream(msg.body.stream, msg.header.userId, msg.body.contentType, msg.body.hasAudio, focused = startFocused, Set.empty)
+      val startAsContent = msg.body.contentType == "screenshare" && userIsPresenter
+      val webcam = WebcamStream(msg.body.stream, msg.header.userId, msg.body.contentType, msg.body.hasAudio, showAsContent = startAsContent, Set.empty)
 
       for {
         _ <- Webcams.addWebcamStream(liveMeeting.props.meetingProp.intId, liveMeeting.webcams, webcam)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/WebcamApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/WebcamApp2x.scala
@@ -13,7 +13,8 @@ class WebcamApp2x(implicit val context: ActorContext)
   with GetWebcamsOnlyForModeratorReqMsgHdlr
   with UpdateWebcamsOnlyForModeratorCmdMsgHdlr
   with UserBroadcastCamStartMsgHdlr
-  with UserBroadcastCamStopMsgHdlr {
+  with UserBroadcastCamStopMsgHdlr
+  with SetCamShowAsContentReqMsgHdlr {
 
   val log = Logging(context.system, getClass)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCameraDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserCameraDAO.scala
@@ -9,18 +9,18 @@ case class UserCameraDbModel(
         userId:        String,
         contentType:   String,
         hasAudio:      Boolean,
-        focused:       Boolean,
+        showAsContent: Boolean,
 )
 
 class UserCameraDbTableDef(tag: Tag) extends Table[UserCameraDbModel](tag, None, "user_camera") {
   override def * = (
-    streamId, meetingId, userId, contentType, hasAudio, focused) <> (UserCameraDbModel.tupled, UserCameraDbModel.unapply)
+    streamId, meetingId, userId, contentType, hasAudio, showAsContent) <> (UserCameraDbModel.tupled, UserCameraDbModel.unapply)
   val streamId = column[String]("streamId", O.PrimaryKey)
   val meetingId = column[String]("meetingId")
   val userId = column[String]("userId")
   val contentType = column[String]("contentType")
   val hasAudio = column[Boolean]("hasAudio")
-  val focused = column[Boolean]("focused")
+  val showAsContent = column[Boolean]("showAsContent")
 }
 
 object UserCameraDAO {
@@ -34,9 +34,19 @@ object UserCameraDAO {
           userId = webcam.userId,
           contentType = webcam.contentType,
           hasAudio = webcam.hasAudio,
-          focused = webcam.focused,
+          showAsContent = webcam.showAsContent,
         )
       )
+    )
+  }
+
+  def updateShowAsContent(meetingId: String, streamId: String, showAsContent: Boolean) = {
+    DatabaseConnection.enqueue(
+      TableQuery[UserCameraDbTableDef]
+        .filter(_.meetingId === meetingId)
+        .filter(_.streamId === streamId)
+        .map(cam => cam.showAsContent)
+        .update(showAsContent)
     )
   }
 
@@ -47,6 +57,5 @@ object UserCameraDAO {
         .delete
     )
   }
-
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Webcams.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Webcams.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.core.models
 
 import org.bigbluebutton.core.db.UserCameraDAO
-
 import collection.immutable.HashMap
 
 object Webcams {
@@ -99,10 +98,10 @@ class Webcams {
 }
 
 case class WebcamStream(
-    streamId:    String,
-    userId:      String,
-    contentType: String,
-    hasAudio:    Boolean,
-    focused:     Boolean,
-    subscribers: Set[String]
+    streamId:      String,
+    userId:        String,
+    contentType:   String,
+    hasAudio:      Boolean,
+    showAsContent: Boolean,
+    subscribers:   Set[String]
 )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -131,6 +131,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[UserBroadcastCamStartMsg](envelope, jsonNode)
       case UserBroadcastCamStopMsg.NAME =>
         routeGenericMsg[UserBroadcastCamStopMsg](envelope, jsonNode)
+      case SetCamShowAsContentReqMsg.NAME =>
+        routeGenericMsg[SetCamShowAsContentReqMsg](envelope, jsonNode)
       case GetCamBroadcastPermissionReqMsg.NAME =>
         routeGenericMsg[GetCamBroadcastPermissionReqMsg](envelope, jsonNode)
       case GetCamSubscribePermissionReqMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -725,6 +725,9 @@ class MeetingActor(
       case m: UserBroadcastCamStopMsg =>
         webcamApp2x.handle(m, liveMeeting, msgBus)
         updateUserLastActivity(m.header.userId)
+      case m: SetCamShowAsContentReqMsg =>
+        webcamApp2x.handle(m, liveMeeting, msgBus)
+        updateUserLastActivity(m.header.userId)
       case m: GetCamBroadcastPermissionReqMsg  => webcamApp2x.handle(m, liveMeeting, msgBus)
       case m: GetCamSubscribePermissionReqMsg  => webcamApp2x.handle(m, liveMeeting, msgBus)
       case m: CamStreamSubscribedInSfuEvtMsg   => webcamApp2x.handle(m, liveMeeting, msgBus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -83,6 +83,7 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
       case m: TransferUserToVoiceConfSysMsg                  => logMessage(msg)
       case m: UserBroadcastCamStartMsg                       => logMessage(msg)
       case m: UserBroadcastCamStopMsg                        => logMessage(msg)
+      case m: SetCamShowAsContentReqMsg                      => logMessage(msg)
       case m: UserBroadcastCamStoppedEvtMsg                  => logMessage(msg)
       case m: UserBroadcastCamStartedEvtMsg                  => logMessage(msg)
       case m: EjectUserFromMeetingSysMsg                     => logMessage(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -115,7 +115,7 @@ object FakeUserGenerator {
 
   def createFakeWebcamStreamFor(userId: String, subscribers: Set[String]): WebcamStream = {
     val streamId = RandomStringGenerator.randomAlphanumericString(10)
-    WebcamStream(streamId, userId, "camera", hasAudio = false, focused = false, subscribers)
+    WebcamStream(streamId, userId, "camera", hasAudio = false, showAsContent = false, subscribers)
   }
 
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WebcamsMsgs.scala
@@ -187,8 +187,15 @@ case class CamStreamSubscribedInSfuEvtMsgBody(
 )
 
 /**
- * Sent from client to change the video focus state (used to send screenshare to presentation area).
+ * Sent from client to change the video showAsContent (used to send screenshare to presentation area).
  */
-object SetCamFocusStateReqMsg { val NAME = "SetCamFocusStateReqMsg" }
-case class SetCamFocusStateReqMsg(header: BbbClientMsgHeader, body: SetCamFocusStateReqMsgBody) extends StandardMsg
-case class SetCamFocusStateReqMsgBody(streamId: String, focused: Boolean, setBy: String)
+object SetCamShowAsContentReqMsg { val NAME = "SetCamShowAsContentReqMsg" }
+case class SetCamShowAsContentReqMsg(header: BbbClientMsgHeader, body: SetCamShowAsContentReqMsgBody) extends StandardMsg
+case class SetCamShowAsContentReqMsgBody(streamId: String, showAsContent: Boolean, setBy: String)
+
+object SetCamShowAsContentEvtMsg { val NAME = "SetCamShowAsContentEvtMsg" }
+case class SetCamShowAsContentEvtMsg(
+    header: BbbClientMsgHeader,
+    body:   SetCamShowAsContentEvtMsgBody
+) extends BbbCoreMsg
+case class SetCamShowAsContentEvtMsgBody(streamId: String, showAsContent: Boolean, setBy: String)

--- a/bbb-graphql-actions/src/actions/cameraSetShowAsContent.ts
+++ b/bbb-graphql-actions/src/actions/cameraSetShowAsContent.ts
@@ -6,11 +6,11 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   throwErrorIfInvalidInput(input,
       [
         {name: 'streamId', type: 'string', required: true},
-        {name: 'focused', type: 'boolean', required: true},
+        {name: 'showAsContent', type: 'boolean', required: true},
       ]
   )
 
-  const eventName = `SetCamFocusStateReqMsg`;
+  const eventName = `SetCamShowAsContentReqMsg`;
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,
     userId: sessionVariables['x-hasura-userid'] as String
@@ -25,7 +25,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   const body = {
     setBy: routing.userId,
     streamId: input.streamId,
-    focused: input.focused
+    showAsContent: input.showAsContent
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -639,12 +639,12 @@ CREATE TABLE "user_camera" (
     "userId" varchar(50),
     "contentType" varchar(50), --camera or screenshare
     "hasAudio" boolean,
-    "focused" boolean,
+    "showAsContent" boolean,
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 CREATE INDEX "idx_user_camera_userId" ON "user_camera"("meetingId", "userId");
 CREATE INDEX "idx_user_camera_userId_reverse" ON "user_camera"("userId", "meetingId");
-CREATE INDEX "idx_user_camera_meeting_contentType" ON "user_camera"("meetingId", "contentType", "focused");
+CREATE INDEX "idx_user_camera_meeting_contentType" ON "user_camera"("meetingId", "contentType", "showAsContent");
 
 CREATE OR REPLACE VIEW "v_user_camera" AS
 SELECT * FROM "user_camera";

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -64,6 +64,13 @@ type Mutation {
 }
 
 type Mutation {
+  cameraSetShowAsContent(
+    streamId: String!
+    showAsContent: Boolean!
+  ): Boolean
+}
+
+type Mutation {
   captionAddLocale(
     locale: String!
   ): Boolean

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -65,6 +65,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: cameraSetShowAsContent
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: captionAddLocale
     definition:
       kind: synchronous

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -30,7 +30,7 @@ select_permissions:
     permission:
       columns:
         - contentType
-        - focused
+        - showAsContent
         - hasAudio
         - streamId
         - userId


### PR DESCRIPTION
- Subscription
```gql
subscription {
	user_camera {
	  showAsContent
	}
}
```

- Mutation (only for `presenter` and `contentType='screenshare'`)
```gql
mutation($streamId: String!, $showAsContent: Boolean!) {
  cameraSetShowAsContent(streamId: $streamId, showAsContent: $showAsContent)
}
```

Related #21303