### PR TITLE
Fix: [3.0] External video is overlapping the webcams on the mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -62,7 +62,8 @@ const LayoutEngine = () => {
 
     const cameraDockBounds = {};
 
-    if (cameraDockInput.numCameras === 0 && selectedLayout !== LAYOUT_TYPE.VIDEO_FOCUS) {
+    if ((cameraDockInput.numCameras === 0 && selectedLayout !== LAYOUT_TYPE.VIDEO_FOCUS)
+      || (isOpen && windowHeight() < 350)) {
       cameraDockBounds.width = 0;
       cameraDockBounds.height = 0;
 

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -63,7 +63,10 @@ const LayoutEngine = () => {
     const cameraDockBounds = {};
 
     if ((cameraDockInput.numCameras === 0 && selectedLayout !== LAYOUT_TYPE.VIDEO_FOCUS)
-      || (isOpen && windowHeight() < 350)) {
+      || (isOpen
+    && windowHeight() < 350
+    && selectedLayout !== LAYOUT_TYPE.VIDEO_FOCUS
+    && selectedLayout !== LAYOUT_TYPE.PRESENTATION_FOCUS)) {
       cameraDockBounds.width = 0;
       cameraDockBounds.height = 0;
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where the cameras dock and presentation would overlap, mainly in smaller screens.

The PR solves the issue by "removing" the cameras from the screen when the get too small, also, the layout gets to take advantage and use more space to fit the presentation in this case.

### Closes Issue(s)

Closes #21339 

### How to test
Initate a BBB meeting and play around with the window size, when it gets bellow 350 pixels, it will eliminate the cameras from layout. It's better if tested on samller screens but also works in big ones.

### More

[screensize.webm](https://github.com/user-attachments/assets/d05a00d2-cea7-46a2-a9e0-2cef2c196934)
