### PR TITLE
build(livekit): livekit-server@1.7.2, lk@2.2.0

### DIFF
--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -2,8 +2,8 @@
 
 TARGET=`basename $(pwd)`
 
-SERVER_VERSION=1.5.1
-CLI_VERSION=1.3.0
+SERVER_VERSION=1.7.2
+CLI_VERSION=2.2.0
 
 PACKAGE=$(echo $TARGET | cut -d'_' -f1)
 VERSION=$(echo $TARGET | cut -d'_' -f2)
@@ -32,7 +32,7 @@ cp livekit.yaml $DESTDIR/usr/share/livekit-server
 mkdir -p $DESTDIR/usr/bin
 
 curl https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz  -Lo - | tar -C $DESTDIR/usr/bin -xzf - livekit-server
-curl https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/livekit-cli_${CLI_VERSION}_linux_amd64.tar.gz -Lo - | tar -C $DESTDIR/usr/bin -xzf - livekit-cli
+curl https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz -Lo - | tar -C $DESTDIR/usr/bin -xzf - lk
 
 fpm -s dir -C $DESTDIR -n $PACKAGE \
     --version $VERSION --epoch 2 \


### PR DESCRIPTION
### What does this PR do?

- [build(livekit): livekit-server@1.7.2, lk@2.2.0](https://github.com/bigbluebutton/bigbluebutton/commit/915278cf7f739300eb352f5050ced10365c7759e) 
  - livekit-server@1.7.2: https://github.com/livekit/livekit/releases/tag/v1.7.2
  - lk@2.2.0: https://github.com/livekit/livekit-cli/releases/tag/v2.2.0
    * Notice the rename: `livekit-cli` -> `lk`. Old name still supported, but deprecated.

### Closes Issue(s)

None

### Motivation

Related to #21059 