### PR TITLE
Fix CORS Header for rendered slides

### DIFF
--- a/bigbluebutton-web/nginx-confs/presentation-slides.nginx
+++ b/bigbluebutton-web/nginx-confs/presentation-slides.nginx
@@ -20,35 +20,26 @@
 # causes tomcat to OOM. (ralam sept 20, 2018)
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/svg\/(?<page_num>\d+)$ {
-		default_type image/svg+xml;
+                default_type image/svg+xml;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide$page_num.svg;
-                if ($bbb_loadbalancer_node) {
-                    add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-                }
+                add_header 'Access-Control-Allow-Origin' '*' always;
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/pdf\/(?<job_id>[A-Za-z0-9]+)\/annotated_slides.pdf$ {
-		        default_type application/pdf;
+                default_type application/pdf;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/pdfs/$job_id/annotated_slides.pdf;
-                if ($bbb_loadbalancer_node) {
-                    add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-                }
+                add_header 'Access-Control-Allow-Origin' '*' always;
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/thumbnail\/(?<page_num>\d+)$ {
-		default_type image/png;
+                default_type image/png;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/thumbnails/thumb-$page_num.png;
-                if ($bbb_loadbalancer_node) {
-                    add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-                }
+                add_header 'Access-Control-Allow-Origin' '*' always;
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/textfiles\/(?<page_num>\d+)$ {
-		default_type text/plain;
+                default_type text/plain;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/textfiles/slide-$page_num.txt;
-                if ($bbb_loadbalancer_node) {
-                    add_header 'Access-Control-Allow-Origin' $bbb_loadbalancer_node always;
-                }
+                add_header 'Access-Control-Allow-Origin' '*' always;
         }
-
 


### PR DESCRIPTION
### What does this PR do?
Always add CORS headers to requests to the rendered slides. There is no authentication required to access the slides, so we can allow requests from anywhere.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21262 

### Motivation

There should be no good reason not to use the cluster setup if you run multiple nodes.