### PR TITLE
build(fix): File permissions in packages should not depend on umask of build system

### DIFF
--- a/build/packages-template/bbb-graphql-middleware/build.sh
+++ b/build/packages-template/bbb-graphql-middleware/build.sh
@@ -33,6 +33,7 @@ cp bbb-graphql-client-settings-cache.conf staging/etc/nginx/conf.d
 
 # Create config file
 cp config/config.yml staging/usr/share/bbb-graphql-middleware/config.yml
+chmod a+r staging/usr/share/bbb-graphql-middleware/config.yml
 
 cp bbb-graphql-middleware.service staging/lib/systemd/system/bbb-graphql-middleware.service
 

--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -30,6 +30,7 @@ cp -r hasura-graphql staging/usr/local/bin/hasura-graphql-engine
 
 cp -r hasura-config.env staging/etc/default/bbb-graphql-server
 cp -r bbb_schema.sql metadata config.yaml staging/usr/share/bbb-graphql-server
+chmod -R a+rX staging/usr/share/bbb-graphql-server
 
 #Copy BBB configs for Postgres
 mkdir -p staging/etc/postgresql/16/main/conf.d


### PR DESCRIPTION
…f build system

If the build system for packages has a umask of `0077`, cloned repositories will have no permissions for group and other. If build scripts just copy files, permissions will persist. This commit fixes permissions for some files which otherwise prevents startup `bbb-graphql-server.service` and `bbb-graphql-middleware.service`.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Fixes permissions in packages. Makes build process less dependant on the umask of the package build system.

If the build system for packages has a umask of 0077, cloned repositories will have no permissions for group and other. As the build scripts for some packages just copy from clone git repos, this will preserve the permissions in the package and prevent the following services from startup:

* `bbb-graphql-server.service`
* `bbb-graphql-middleware.service`

This patch grants everyone read permissions to the files in the packages which prevented service startup.

Similar to #20347