### PR TITLE
Consistently call docker with sudo privileges (2.7 backport)

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -64,7 +64,7 @@ sudo docker run --rm --detach --cidfile $DOCKER_CONTAINER_ID_FILE \
 #        -v "$CACHE_DIR/$DISTRO/.m2:/root/.m2" \
 #        -v "$TMP/$TARGET:$TMP/$TARGET"  \
 
-docker attach --no-stdin $(cat $DOCKER_CONTAINER_ID_FILE)
+sudo docker attach --no-stdin $(sudo cat $DOCKER_CONTAINER_ID_FILE)
 sudo rm $DOCKER_CONTAINER_ID_FILE
 
 find artifacts


### PR DESCRIPTION
### What does this PR do?

Ensures that docker is always called with sudo privileges during package build. If the user does not have access to the docker socket, root privileges are required.

This is a backport of #21363