### PR TITLE
Fix: `userdata-bbb_force_listen_only`param applying to moderator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -101,6 +101,8 @@ const AudioModalContainer = (props) => {
   );
   const isTranscriptionEnabled = useIsAudioTranscriptionEnabled();
 
+  if (!currentUserData) return null;
+
   return (
     <AudioModal
       away={away}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where the `userdata-bbb_force_listen_only` param would include moderators when it shouldn't.

The real problem was that the data was being requested before obtained, and in doing so being assumed false.
The solution was to contdition the return to identify if it had the whole data before rendering. 

### Closes Issue(s)

Closes #21326

### How to test

Create a BBB meeting using `userdata-bbb_force_listen_only` param - Join with both Moderator and Viewer.

### More

Before

https://github.com/user-attachments/assets/6b5e749d-f91b-4131-b410-8bb98cb9a93a

After

[Screencast from 2024-10-04 11-12-19.webm](https://github.com/user-attachments/assets/f7c279a2-4a84-4197-adc5-47ab4cb40316)


