### PR TITLE
build: Umask fixes for 2.7 build scripts

### DIFF
--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -92,6 +92,7 @@ cp mongod_start_pre.sh staging/usr/share/meteor/bundle
 chmod +rx staging/usr/share/meteor/bundle/mongod_start_pre.sh
 
 cp mongo-ramdisk.conf staging/usr/share/meteor/bundle
+chmod 644 staging/usr/share/meteor/bundle/mongo-ramdisk.conf
 
 mkdir -p staging/usr/lib/systemd/system
 cp bbb-html5.service staging/usr/lib/systemd/system

--- a/build/packages-template/bbb-libreoffice-docker/build.sh
+++ b/build/packages-template/bbb-libreoffice-docker/build.sh
@@ -24,9 +24,9 @@ cp assets/etherpad-export.sh staging/usr/share/bbb-libreoffice-conversion/etherp
 cp assets/convert-local.sh  staging/usr/share/bbb-libreoffice-conversion/convert-local.sh
 cp assets/convert-remote.sh staging/usr/share/bbb-libreoffice-conversion/convert-remote.sh
 
-chmod +x staging/usr/share/bbb-libreoffice-conversion/convert-local.sh
-chmod +x staging/usr/share/bbb-libreoffice-conversion/convert-remote.sh
-chmod +x staging/usr/share/bbb-libreoffice-conversion/etherpad-export.sh
+chmod 755 staging/usr/share/bbb-libreoffice-conversion/convert-local.sh
+chmod 755 staging/usr/share/bbb-libreoffice-conversion/convert-remote.sh
+chmod 755 staging/usr/share/bbb-libreoffice-conversion/etherpad-export.sh
 
 
 cp -r docker staging/usr/share/bbb-libreoffice

--- a/build/packages-template/bbb-playback-presentation/build.sh
+++ b/build/packages-template/bbb-playback-presentation/build.sh
@@ -23,9 +23,12 @@ done
 
 mkdir -p staging/usr/local/bigbluebutton/core
 cp -r scripts staging/usr/local/bigbluebutton/core
+chmod a+rx staging/usr/local/bigbluebutton/core/scripts/process/*.rb
+chmod a+rx staging/usr/local/bigbluebutton/core/scripts/publish/*.rb
 
 mkdir -p staging/var/bigbluebutton
 cp -r playback staging/var/bigbluebutton
+chmod -R a+rX staging/var/bigbluebutton
 
 mkdir -p staging/usr/share/bigbluebutton/nginx
 mv staging/usr/local/bigbluebutton/core/scripts/presentation.nginx staging/usr/share/bigbluebutton/nginx

--- a/build/packages-template/bbb-playback-video/build.sh
+++ b/build/packages-template/bbb-playback-video/build.sh
@@ -23,7 +23,10 @@ done
 
 mkdir -p staging/usr/local/bigbluebutton/core
 cp -r scripts staging/usr/local/bigbluebutton/core
+chmod a+rx staging/usr/local/bigbluebutton/core/scripts/process/*.rb
+chmod a+rx staging/usr/local/bigbluebutton/core/scripts/publish/*.rb
 cp -r playback staging/usr/local/bigbluebutton/core
+chmod -R a+rX staging/usr/local/bigbluebutton/core/playback/
 
 mkdir -p staging/usr/share/bigbluebutton/nginx
 mv staging/usr/local/bigbluebutton/core/scripts/playback-video.nginx staging/usr/share/bigbluebutton/nginx

--- a/build/packages-template/bbb-record-core/build.sh
+++ b/build/packages-template/bbb-record-core/build.sh
@@ -26,7 +26,6 @@ done
 
 mkdir -p staging/var/log/bigbluebutton
 cp -r scripts lib Gemfile Gemfile.lock  staging/usr/local/bigbluebutton/core
-chmod 644 staging/usr/local/bigbluebutton/core/Rakefile
 
 pushd staging/usr/local/bigbluebutton/core
   bundle config set --local deployment true
@@ -41,6 +40,7 @@ pushd staging/usr/local/bigbluebutton/core
 popd
 
 cp Rakefile  staging/usr/local/bigbluebutton/core
+chmod 644 staging/usr/local/bigbluebutton/core/Rakefile
 cp bbb-record-core.logrotate staging/etc/logrotate.d
 
 SYSTEMDSYSTEMUNITDIR=$(pkg-config --variable systemdsystemunitdir systemd)

--- a/build/packages-template/bbb-record-core/build.sh
+++ b/build/packages-template/bbb-record-core/build.sh
@@ -26,6 +26,7 @@ done
 
 mkdir -p staging/var/log/bigbluebutton
 cp -r scripts lib Gemfile Gemfile.lock  staging/usr/local/bigbluebutton/core
+chmod 644 staging/usr/local/bigbluebutton/core/Rakefile
 
 pushd staging/usr/local/bigbluebutton/core
   bundle config set --local deployment true


### PR DESCRIPTION
### What does this PR do?
Fixes permissions in packages if packages are built with a restrictive umask such as `0077`. It fixes missing read permissions which prevent service startup.