### PR TITLE
Fix(Akka): [3.0] - maxParticipants is applying one less than the parameter value

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -79,7 +79,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
 
   private def validateMaxParticipants(regUser: RegisteredUser): Either[(String, String), Unit] = {
     val userHasJoinedAlready = RegisteredUsers.checkUserExtIdHasJoined(regUser.externId, liveMeeting.registeredUsers)
-    val maxParticipants = liveMeeting.props.usersProp.maxUsers - 1
+    val maxParticipants = liveMeeting.props.usersProp.maxUsers
 
     if (maxParticipants > 0 && //0 = no limit
       RegisteredUsers.numUniqueJoinedUsers(liveMeeting.registeredUsers) >= maxParticipants &&


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where the user would set a max number of participants, and the parameter would allow 1 user less than the set number.

### Closes Issue(s)

#19426 (partial)

### Motivation

The motivation was to make the parameter a little more usable.

### How to test

Set the number of max users in the join parameter, and enter with the number of users you set.
