### PR TITLE
refactor: Remove the "Raise Hand" experience from the reactions bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -12,6 +12,7 @@ import Button from '/imports/ui/components/common/button/component';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import { LAYOUT_TYPE } from '../layout/enums';
 import ReactionsButtonContainer from '/imports/ui/components/actions-bar/reactions-button/container';
+import RaiseHandButtonContainer from '/imports/ui/components/actions-bar/raise-hand-button/container';
 
 const intlMessages = defineMessages({
   actionsBarLabel: {
@@ -181,6 +182,7 @@ class ActionsBar extends PureComponent {
               />
             )}
             {this.renderReactionsButton()}
+            <RaiseHandButtonContainer />
             {this.renderPluginsActionBarItems(ActionsBarPosition.RIGHT)}
           </Styled.Center>
           <Styled.Right>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import PropTypes from 'prop-types';
+import { convertRemToPixels } from '/imports/utils/dom-utils';
+import data from '@emoji-mart/data';
+import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
+import { init } from 'emoji-mart';
+import { SET_RAISE_HAND } from '/imports/ui/core/graphql/mutations/userMutations';
+import { useMutation } from '@apollo/client';
+import Styled from './styles';
+
+const RaiseHandButton = (props) => {
+  const {
+    intl,
+    userId,
+    raiseHand,
+    shortcuts,
+  } = props;
+
+  // initialize emoji-mart data, need for the new version
+  init({ data });
+
+  const [setRaiseHand] = useMutation(SET_RAISE_HAND);
+
+  const intlMessages = defineMessages({
+    raiseHandLabel: {
+      id: 'app.actionsBar.reactions.raiseHand',
+      description: 'raise Hand Label',
+    },
+    notRaiseHandLabel: {
+      id: 'app.actionsBar.reactions.lowHand',
+      description: 'not Raise Hand Label',
+    },
+  });
+
+  const handleRaiseHandButtonClick = () => {
+    setRaiseHand({
+      variables: {
+        userId,
+        raiseHand: !raiseHand,
+      },
+    });
+    document.activeElement.blur();
+  };
+
+  const emojiProps = {
+    size: convertRemToPixels(1.5),
+    padding: '4px',
+  };
+
+  const handReaction = {
+    id: 'hand',
+    native: '✋',
+  };
+
+  const icon = !raiseHand ? 'hand' : null;
+
+  const customIcon = raiseHand
+    ? (
+      <em-emoji
+        key={handReaction.id}
+        native={handReaction.native}
+        emoji={handReaction}
+        {...emojiProps}
+      />
+    )
+    : null;
+
+  const label = raiseHand ? intlMessages.notRaiseHandLabel : intlMessages.raiseHandLabel;
+
+  return (
+    <Styled.RaiseHandButton
+      data-test="reactionsButton"
+      icon={icon}
+      customIcon={customIcon}
+      label={intl.formatMessage(label)}
+      description="Reactions"
+      ghost={!raiseHand}
+      onKeyPress={() => { }}
+      onClick={() => handleRaiseHandButtonClick()}
+      color={customIcon ? 'primary' : 'default'}
+      accessKey={shortcuts.raisehand}
+      hideLabel
+      circle
+      size="lg"
+    />
+  );
+};
+
+const propTypes = {
+  intl: PropTypes.shape({
+    formatMessage: PropTypes.func.isRequired,
+  }).isRequired,
+  userId: PropTypes.string.isRequired,
+  raiseHand: PropTypes.bool,
+  shortcuts: PropTypes.shape({
+    raisehand: PropTypes.string,
+  }).isRequired,
+};
+
+RaiseHandButton.propTypes = propTypes;
+
+export default withShortcutHelper(RaiseHandButton, ['raiseHand']);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/container.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import RaiseHandButton from './component';
+import Auth from '/imports/ui/services/auth';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+
+const RaiseHandButtonContainer = ({ ...props }) => {
+  const { data: currentUserData } = useCurrentUser((user) => ({
+    raiseHand: user.raiseHand,
+  }));
+
+  const currentUser = {
+    userId: Auth.userID,
+    raiseHand: currentUserData?.raiseHand,
+  };
+
+  return (
+    <RaiseHandButton {...{
+      ...currentUser,
+      ...props,
+    }}
+    />
+  );
+};
+
+export default injectIntl(RaiseHandButtonContainer);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/styles.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import Button from '/imports/ui/components/common/button/component';
+
+const RaiseHandButton = styled(Button)`
+${({ ghost }) => ghost && `
+  & > span {
+    box-shadow: none;
+    background-color: transparent !important;
+    border-color: ${colorWhite} !important;
+  }
+   `}
+`;
+
+export default {
+  RaiseHandButton,
+};

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -4,9 +4,8 @@ import PropTypes from 'prop-types';
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import { convertRemToPixels } from '/imports/utils/dom-utils';
 import data from '@emoji-mart/data';
-import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { init } from 'emoji-mart';
-import { SET_RAISE_HAND, SET_REACTION_EMOJI } from '/imports/ui/core/graphql/mutations/userMutations';
+import { SET_REACTION_EMOJI } from '/imports/ui/core/graphql/mutations/userMutations';
 import { SET_AWAY } from '/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/mutations';
 import { useMutation } from '@apollo/client';
 import Toggle from '/imports/ui/components/common/switch/component';
@@ -20,12 +19,9 @@ const ReactionsButton = (props) => {
   const {
     intl,
     actionsBarRef,
-    userId,
-    raiseHand,
     away,
     muted,
     isMobile,
-    shortcuts,
     currentUserReaction,
     autoCloseReactionsBar,
   } = props;
@@ -35,7 +31,6 @@ const ReactionsButton = (props) => {
   // initialize emoji-mart data, need for the new version
   init({ data });
 
-  const [setRaiseHand] = useMutation(SET_RAISE_HAND);
   const [setAway] = useMutation(SET_AWAY);
   const [setReactionEmoji] = useMutation(SET_REACTION_EMOJI);
 
@@ -47,14 +42,6 @@ const ReactionsButton = (props) => {
     reactionsLabel: {
       id: 'app.actionsBar.reactions.reactionsButtonLabel',
       description: 'reactions Label',
-    },
-    raiseHandLabel: {
-      id: 'app.actionsBar.reactions.raiseHand',
-      description: 'raise Hand Label',
-    },
-    notRaiseHandLabel: {
-      id: 'app.actionsBar.reactions.lowHand',
-      description: 'not Raise Hand Label',
     },
     setAwayLabel: {
       id: 'app.actionsBar.reactions.setAway',
@@ -77,16 +64,6 @@ const ReactionsButton = (props) => {
     setReactionEmoji({ variables: { reactionEmoji: reaction } });
   };
 
-  const handleRaiseHandButtonClick = () => {
-    setRaiseHand({
-      variables: {
-        userId,
-        raiseHand: !raiseHand,
-      },
-    });
-    document.activeElement.blur();
-  };
-
   const handleToggleAFK = () => {
     muteAway(muted, away, voiceToggle);
     setAway({
@@ -99,14 +76,6 @@ const ReactionsButton = (props) => {
   const ToggleAFKLabel = () => (away
     ? intl.formatMessage(intlMessages.setActiveLabel)
     : intl.formatMessage(intlMessages.setAwayLabel));
-
-  const RaiseHandButtonLabel = () => {
-    if (isMobile) return null;
-
-    return raiseHand
-      ? intl.formatMessage(intlMessages.notRaiseHandLabel)
-      : intl.formatMessage(intlMessages.raiseHandLabel);
-  };
 
   const customStyles = {
     top: '-1rem',
@@ -123,11 +92,6 @@ const ReactionsButton = (props) => {
   const emojiProps = {
     size: convertRemToPixels(1.5),
     padding: '4px',
-  };
-
-  const handReaction = {
-    id: 'hand',
-    native: '✋',
   };
 
   const awayReaction = {
@@ -178,24 +142,13 @@ const ReactionsButton = (props) => {
     customStyles: { ...actionCustomStyles, width: 'auto' },
   });
 
-  actions.push({
-    label: <Styled.RaiseHandButtonWrapper accessKey={shortcuts.raisehand} isMobile={isMobile} data-test={raiseHand ? 'lowerHandBtn' : 'raiseHandBtn'} active={raiseHand}><em-emoji key={handReaction.id} native={handReaction.native} emoji={{ id: handReaction.id }} {...emojiProps} />{RaiseHandButtonLabel()}</Styled.RaiseHandButtonWrapper>,
-    key: 'hand',
-    onClick: () => handleRaiseHandButtonClick(),
-    customStyles: { ...actionCustomStyles, width: 'auto' },
-  });
-
-  const svgIcon = !raiseHand && !away && currentUserReaction === 'none' ? 'reactions' : null;
+  const svgIcon = !away && currentUserReaction === 'none' ? 'reactions' : null;
   const currentUserReactionEmoji = REACTIONS.find(({ native }) => native === currentUserReaction);
 
   let customIcon = null;
 
-  if (raiseHand) {
-    customIcon = <em-emoji key={handReaction.id} native={handReaction.native} emoji={handReaction} {...emojiProps} />;
-  } else {
-    if (!svgIcon) {
-      customIcon = <em-emoji key={currentUserReactionEmoji?.id} native={currentUserReactionEmoji?.native} emoji={{ id: currentUserReactionEmoji?.id }} {...emojiProps} />;
-    }
+  if (!svgIcon) {
+    customIcon = <em-emoji key={currentUserReactionEmoji?.id} native={currentUserReactionEmoji?.native} emoji={{ id: currentUserReactionEmoji?.id }} {...emojiProps} />;
   }
 
   if (away) {
@@ -206,7 +159,7 @@ const ReactionsButton = (props) => {
     <BBBMenu
       trigger={(
         <Styled.ReactionsDropdown id="interactionsButton">
-          <Styled.RaiseHandButton
+          <Styled.ReactionsButton
             data-test="reactionsButton"
             svgIcon={svgIcon}
             customIcon={customIcon}
@@ -232,7 +185,7 @@ const ReactionsButton = (props) => {
       isHorizontal={!isMobile}
       isMobile={isMobile}
       isEmoji
-      roundButtons={true}
+      roundButtons
       keepOpen={!autoCloseReactionsBar}
       opts={{
         id: 'reactions-dropdown-menu',
@@ -259,4 +212,4 @@ const propTypes = {
 
 ReactionsButton.propTypes = propTypes;
 
-export default withShortcutHelper(ReactionsButton, ['raiseHand']);
+export default ReactionsButton;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/container.jsx
@@ -18,7 +18,6 @@ const ReactionsButtonContainer = ({ ...props }) => {
   const isMobile = browserWidth <= SMALL_VIEWPORT_BREAKPOINT;
 
   const { data: currentUserData } = useCurrentUser((user) => ({
-    raiseHand: user.raiseHand,
     away: user.away,
     voice: user.voice,
     reactionEmoji: user.reactionEmoji,
@@ -27,7 +26,6 @@ const ReactionsButtonContainer = ({ ...props }) => {
 
   const currentUser = {
     userId: Auth.userID,
-    raiseHand: currentUserData?.raiseHand,
     away: currentUserData?.away,
     muted: !unmutedUsers[Auth.userID],
   };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/styles.js
@@ -9,7 +9,7 @@ import {
   btnPrimaryActiveBg,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
-const RaiseHandButton = styled(Button)`
+const ReactionsButton = styled(Button)`
 ${({ ghost }) => ghost && `
   & > span {
     box-shadow: none;
@@ -57,7 +57,7 @@ const ButtonWrapper = styled.div`
   `}
 `;
 
-const RaiseHandButtonWrapper = styled(ButtonWrapper)`
+const ReactionsButtonWrapper = styled(ButtonWrapper)`
   width: 2.5rem;
   border-radius: 1.7rem;
 
@@ -94,9 +94,9 @@ const ToggleButtonWrapper = styled(ButtonWrapper)`
 `;
 
 export default {
-  RaiseHandButton,
+  ReactionsButton,
   ReactionsDropdown,
   ButtonWrapper,
-  RaiseHandButtonWrapper,
+  ReactionsButtonWrapper,
   ToggleButtonWrapper,
 };

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -218,7 +218,7 @@ class BBBMenu extends React.Component {
     } = this.props;
     const actionsItems = this.makeMenuItems();
 
-    const roundedCornersStyles = { borderRadius: '1.8rem' };
+    const roundedCornersStyles = { borderRadius: '3rem' };
     let menuStyles = { zIndex: 999 };
 
     if (customStyles) {


### PR DESCRIPTION
### What does this PR do?

- moves raise hand feature to a new button
- adjusts reactions bar border-radius


https://github.com/user-attachments/assets/b8466242-2a75-4e11-976a-a7b03b69f9a5


### Closes Issue(s)
Closes #21341

