### PR TITLE
Fix: [3.0] Can't exit webcam in fullscreen mode on the mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/fullscreen-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/fullscreen-button/component.jsx
@@ -22,7 +22,6 @@ const propTypes = {
   fullscreenRef: PropTypes.instanceOf(Element),
   dark: PropTypes.bool,
   bottom: PropTypes.bool,
-  isIphone: PropTypes.bool,
   isFullscreen: PropTypes.bool,
   elementName: PropTypes.string,
   handleToggleFullScreen: PropTypes.func.isRequired,
@@ -37,7 +36,6 @@ const FullscreenButtonComponent = ({
   elementName = '',
   elementId,
   elementGroup,
-  isIphone = false,
   isFullscreen = false,
   layoutContextDispatch,
   currentElement,
@@ -47,8 +45,6 @@ const FullscreenButtonComponent = ({
   fullscreenRef = null,
   handleToggleFullScreen,
 }) => {
-  if (isIphone) return null;
-
   const formattedLabel = (fullscreen) => (fullscreen
     ? intl.formatMessage(
       intlMessages.fullscreenUndoButton,

--- a/bigbluebutton-html5/imports/ui/components/common/fullscreen-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/fullscreen-button/container.jsx
@@ -9,8 +9,6 @@ export default (props) => {
   const handleToggleFullScreen = (ref) => FullscreenService.toggleFullScreen(ref);
   const { isFullscreen } = props;
 
-  const isIphone = !!(navigator.userAgent.match(/iPhone/i));
-
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const { element: currentElement, group: currentGroup } = fullscreen;
   const layoutContextDispatch = layoutDispatch();
@@ -20,7 +18,6 @@ export default (props) => {
       {...props}
       {...{
         handleToggleFullScreen,
-        isIphone,
         isFullscreen,
         currentElement,
         currentGroup,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -110,7 +110,6 @@ const propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   handleToggleFullscreen: PropTypes.func.isRequired,
-  noIOSFullscreen: PropTypes.bool,
   amIModerator: PropTypes.bool,
   shortcuts: PropTypes.string,
   isBreakoutRoom: PropTypes.bool,
@@ -129,7 +128,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  noIOSFullscreen: true,
   amIModerator: false,
   shortcuts: '',
   isBreakoutRoom: false,
@@ -186,14 +184,13 @@ class OptionsDropdown extends PureComponent {
   getFullscreenItem(menuItems) {
     const {
       intl,
-      noIOSFullscreen,
       handleToggleFullscreen,
     } = this.props;
     const { isFullscreen } = this.state;
 
     const ALLOW_FULLSCREEN = window.meetingClientSettings.public.app.allowFullscreen;
 
-    if (noIOSFullscreen || !ALLOW_FULLSCREEN) return null;
+    if (!ALLOW_FULLSCREEN) return null;
 
     let fullscreenLabel = intl.formatMessage(intlMessages.fullscreenLabel);
     let fullscreenDesc = intl.formatMessage(intlMessages.fullscreenDesc);

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/container.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import deviceInfo from '/imports/utils/deviceInfo';
-import browserInfo from '/imports/utils/browserInfo';
 import OptionsDropdown from './component';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
 import { layoutSelect } from '../../layout/context';
@@ -12,11 +11,6 @@ import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import Session from '/imports/ui/services/storage/in-memory';
 import { useIsLayoutsEnabled } from '/imports/ui/services/features';
-
-const { isIphone } = deviceInfo;
-const { isSafari, isValidSafariVersion } = browserInfo;
-
-const noIOSFullscreen = !!(((isSafari && !isValidSafariVersion) || isIphone));
 
 const setAudioCaptions = (value) => Session.setItem('audioCaptions', value);
 
@@ -58,7 +52,6 @@ const OptionsDropdownContainer = (props) => {
       handleToggleFullscreen: FullscreenService.toggleFullScreen,
       audioCaptionsSet: (value) => setAudioCaptions(value),
       isMobile: deviceInfo.isMobile,
-      noIOSFullscreen,
       isBreakoutRoom: currentMeeting?.isBreakout,
       // TODO: Replace/Remove
       isMeteorConnected: true,


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where mobile users (Iphone) don't have exit full-screen button.

### Closes Issue(s)

Closes #21332 


