### PR TITLE
fix: Unlocking specific user to see other viewers cursors not working

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -36,7 +36,6 @@ import deviceInfo from '/imports/utils/deviceInfo';
 import Whiteboard from './component';
 
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
-import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import {
   PRESENTATION_SET_ZOOM,
   PRES_ANNOTATION_DELETE,
@@ -48,6 +47,7 @@ import { useMergedCursorData } from './hooks.ts';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
 import MediaService from '/imports/ui/components/media/service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockContext';
 
 const FORCE_RESTORE_PRESENTATION_ON_NEW_EVENTS = 'bbb_force_restore_presentation_on_new_events';
 
@@ -64,9 +64,8 @@ const WhiteboardContainer = (props) => {
   const [shapes, setShapes] = useState({});
   const [currentPresentationPage, setCurrentPresentationPage] = useState(null);
 
-  const meeting = useMeeting((m) => ({
-    lockSettings: m?.lockSettings,
-  }));
+  const { userLocks } = useLockContext();
+
   const { data: currentUser } = useCurrentUser((user) => ({
     presenter: user.presenter,
     isModerator: user.isModerator,
@@ -378,7 +377,7 @@ const WhiteboardContainer = (props) => {
       meetingId={Auth.meetingID}
       publishCursorUpdate={throttledPublishCursorUpdate}
       otherCursors={cursorArray}
-      hideViewersCursor={meeting?.data?.lockSettings?.hideViewersCursor}
+      hideViewersCursor={userLocks?.hideViewersCursor}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?

Refactor whiteboard container to use lock context for checking if a user has active locks.

### Closes Issue(s)
Closes #21297

### How to test
1. Join in a meeting with a moderator and 2 viewers;
2. Manage users > Lock viewers > See other viewers cursors;
3. Unlock a viewer and move other viewer's cursor;