### PR TITLE
fix(whiteboard): Disable tldraw right-click options

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -679,7 +679,7 @@ const Whiteboard = React.memo((props) => {
 
           if (!isEqual(prev.hoveredShapeId, next.hoveredShapeId)) {
             const hoveredShapeOwner = prevShapesRef.current[next.hoveredShapeId]?.meta?.createdBy;
-            if (hoveredShapeOwner !== currentUser?.userId) {
+            if (hoveredShapeOwner !== currentUser?.userId || next.hoveredShapeId?.includes('shape:BG-')) {
               newNext.hoveredShapeId = null;
             }
           }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -151,6 +151,7 @@ const Whiteboard = React.memo((props) => {
   const initialViewBoxWidthRef = React.useRef(null);
   const initialViewBoxHeightRef = React.useRef(null);
   const previousTool = React.useRef(null);
+  const bgSelectedRef = React.useRef(false);
 
   const THRESHOLD = 0.1;
   const CAMERA_UPDATE_DELAY = 650;
@@ -714,6 +715,14 @@ const Whiteboard = React.memo((props) => {
 
         return newNext;
       };
+
+      editor.store.onAfterChange = (prev, next) => {
+        if (next['selectedShapeIds'] && next['selectedShapeIds']?.some(id => id.includes('shape:BG'))) {
+          bgSelectedRef.current = true;
+        } else if ((next['selectedShapeIds'] && !next['selectedShapeIds']?.some(id => id.includes('shape:BG')))) {
+          bgSelectedRef.current = false;
+        }
+      }
 
       if (!isPresenterRef.current && !hasWBAccessRef.current) {
         editor.setCurrentTool('noop');
@@ -1575,6 +1584,7 @@ const Whiteboard = React.memo((props) => {
       <Styled.TldrawV2GlobalStyle
         {...{
           hasWBAccess: hasWBAccessRef.current,
+          bgSelected: bgSelectedRef.current,
           isPresenter,
           isRTL,
           isMultiUserActive,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -106,9 +106,16 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     }
   `}
 
-  [data-testid="menu-item.toggle-lock"],
+  ${({ bgSelected }) => (bgSelected) && `
+      [data-testid="menu-item.toggle-lock"],
+      [data-testid="menu-item.toggle-locked"],
+      [data-testid="menu-item.paste"],
+      [data-testid="menu-item.copy"] {
+        display: none !important;
+      }
+  `}
+
   [data-testid="menu-item.modify"],
-  [data-testid="menu-item.edit-link"],
   [data-testid="menu-item.conversions"],
   .tlui-helper-buttons,
   [data-testid="main.page-menu"],

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -106,6 +106,10 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     }
   `}
 
+  [data-testid="menu-item.toggle-lock"],
+  [data-testid="menu-item.modify"],
+  [data-testid="menu-item.edit-link"],
+  [data-testid="menu-item.conversions"],
   .tlui-helper-buttons,
   [data-testid="main.page-menu"],
   [data-testid="main.menu"],


### PR DESCRIPTION
### What does this PR do?
This PR disables the native tldraw options that are not yet fully supported and, in some cases, can cause issues. The disabled options include:

- Edit Link
- Toggle Lock
- Reorder
- Move to Page
- Copy as
- Export as

The following options are still available:

- Cut
- Copy
- Paste
- Select All
- Select None
- Delete
- Duplicate


### Closes Issue(s)

Closes #21314 
