### PR TITLE
fix(whiteboard): Restrict pan keyboard shortcut to presenter only

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -397,7 +397,7 @@ const Whiteboard = React.memo((props) => {
       }
     }
 
-    if (simpleKeyMap[key]) {
+    if (!event.altKey && !event.ctrlKey && !event.shiftKey && simpleKeyMap[key]) {
       event.preventDefault();
       event.stopPropagation();
       simpleKeyMap[key]();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -338,7 +338,11 @@ const Whiteboard = React.memo((props) => {
       v: () => tlEditorRef.current?.setCurrentTool('select'),
       d: () => tlEditorRef.current?.setCurrentTool('draw'),
       e: () => tlEditorRef.current?.setCurrentTool('eraser'),
-      h: () => tlEditorRef.current?.setCurrentTool('hand'),
+      h: () => {
+        if (isPresenterRef.current) {
+          tlEditorRef.current?.setCurrentTool('hand');
+        }
+      },
       r: () => tlEditorRef.current?.setCurrentTool('rectangle'),
       o: () => tlEditorRef.current?.setCurrentTool('ellipse'),
       a: () => tlEditorRef.current?.setCurrentTool('arrow'),


### PR DESCRIPTION
### What does this PR do?

This PR restricts the "hand" tool keyboard shortcut to only the presenter, preventing non-presenters from activating it.

### Closes Issue(s)

Closes #21304 