### PR TITLE
Fix(webcam): do not display fullscreen button on iPhone

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
@@ -119,6 +119,7 @@ const UserActions: React.FC<UserActionProps> = (props) => {
   const intl = useIntl();
   const enableVideoMenu = window.meetingClientSettings.public.kurento.enableVideoMenu || false;
   const { isFirefox } = browserInfo;
+  const isIphone = !!(navigator.userAgent.match(/iPhone/i));
 
   const [setCameraPinned] = useMutation(SET_CAMERA_PINNED);
   const pinEnabledForCurrentUser = useIsVideoPinEnabledForCurrentUser(amIModerator);
@@ -144,7 +145,7 @@ const UserActions: React.FC<UserActionProps> = (props) => {
     const disabledCams = (Session.getItem('disabledCams') || []) as string[];
     const isCameraDisabled = Array.isArray(disabledCams) && disabledCams?.includes(cameraId);
     const enableSelfCamIntlKey = !isCameraDisabled ? 'disable' : 'enable';
-    const ALLOW_FULLSCREEN = window.meetingClientSettings.public.app.allowFullscreen;
+    const ALLOW_FULLSCREEN = !isIphone ? window.meetingClientSettings.public.app.allowFullscreen : false;
 
     const menuItems = [];
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where the button to enable fullscreen of a webcam appears for iPhone users.

### Closes Issue(s)

Closes #21332 