### PR TITLE
Fix: [3.0 Beta2] Pinning shared notes onto whiteboard crashes whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -175,18 +175,7 @@ const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
   const { area, isToSharedNotesBeShow } = props;
 
   const hasPermission = useHasPermission();
-  const [pinnedPadDataState, setPinnedPadDataState] = useState<PinnedPadSubscriptionResponse | null>(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: pinnedPadData } = await useDeduplicatedSubscription(
-        PINNED_PAD_SUBSCRIPTION,
-      );
-      setPinnedPadDataState(pinnedPadData || []);
-    };
-
-    fetchData();
-  }, []);
+  const { data: pinnedPadData } = useDeduplicatedSubscription<PinnedPadSubscriptionResponse>(PINNED_PAD_SUBSCRIPTION);
 
   const { data: currentUserData } = useCurrentUser((user) => ({
     presenter: user.presenter,
@@ -209,10 +198,10 @@ const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
   const { isOpen: isSidebarContentOpen } = sidebarContent;
   const isGridLayout = useStorageKey('isGridEnabled');
 
-  const shouldShowSharedNotesOnPresentationArea = isGridLayout ? !!pinnedPadDataState
-    && pinnedPadDataState.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id
-    && isSidebarContentOpen : !!pinnedPadDataState
-    && pinnedPadDataState.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
+  const shouldShowSharedNotesOnPresentationArea = isGridLayout ? !!pinnedPadData
+    && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id
+    && isSidebarContentOpen : !!pinnedPadData
+    && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
 
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
   const isScreenBroadcasting = useIsScreenBroadcasting();


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where the notes were not able to retrieve the notes data upon pinning, and in so, making the WB "crash".

### Closes Issue(s)

Closes #21283 

### How to test

Start a meeting, pin shared notes onto WB.

### More
After fix

https://github.com/user-attachments/assets/9159875a-0a5f-48e9-ab2c-10e88c2b9c5e

