### PR TITLE
fix: fullscreen button does not work

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -212,7 +212,7 @@ class OptionsDropdown extends PureComponent {
           icon: fullscreenIcon,
           label: fullscreenLabel,
           description: fullscreenDesc,
-          onClick: handleToggleFullscreen,
+          onClick: () => handleToggleFullscreen(),
         },
       )
     );


### PR DESCRIPTION
### What does this PR do?

Fix incorrect call to function used to enter fullscreen

### How to test

1. join a meeting
2. open "options" dropdown
3. select "Fullscreen Application" (first item)

![2024-10-09_14-25](https://github.com/user-attachments/assets/0368bf95-99d7-42bb-9aa0-34905fc6acee)
