### PR TITLE
fix: locale issues

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlAdapter.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlAdapter.tsx
@@ -34,7 +34,7 @@ const IntlAdapter: React.FC<IntlAdapterProps> = ({
 
   useEffect(() => {
     intlHolder.setIntl(intl);
-  }, [currentLocale]);
+  }, [intl]);
 
   const sendUiDataToPlugins = () => {
     window.dispatchEvent(new CustomEvent(PluginSdk.IntlLocaleUiDataNames.CURRENT_LOCALE, {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -100,7 +100,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
         loading={isConnecting}
       />
     );
-  }, [isConnected, disabled, joinAudioShortcut, away]);
+  }, [isConnected, disabled, joinAudioShortcut, away, intl.locale]);
 
   useEffect(() => {
     if (isEchoTest) {


### PR DESCRIPTION
### What does this PR do?

fix:
1. issue where the "join audio" button tooltip would be displayed in the wrong language after switching locales
2. issue where the "settings have been saved" toast would be displayed in the wrong language after switching locales

### How to test
for item 1:
1. join a meeting
2. change language in settings menu
3. save settings
4. see join audio button tooltip

for item 2:
1. join a meeting
2. change language to any (A) language
5. save settings
6. change language to any (B) language
7. save settings
8. change font size in settings menu
9. save settings
10. see "settings have been saved" message being displayed in "A" language instead of "B"