### PR TITLE
fix: [3.0 Beta 2] Chat lock settings do not work as expected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -571,7 +571,7 @@ const ChatMessageFormContainer: React.FC = () => {
     if (isPublicChat) {
       locked = (isLocked && disablePublicChat) || false;
     } else {
-      locked = (isLocked && disablePrivateChat) || false;
+      locked = (isLocked && disablePrivateChat && !chat?.participant?.isModerator) || false;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

enable private chat with moderators for locked viewers.

### Closes Issue(s)
Closes #21317

### How to test
1. Join 2 users into a meeting. One moderator, one viewer.
2. lock private chat
3. as moderator open private chat with viewer
4. moderator can send chat messages
5. viewer cannot send chat messages