### PR TITLE
feat: add `bbb_hide_notifications`

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -107,6 +107,7 @@ const intlMessages = defineMessages({
 
 const propTypes = {
   darkTheme: PropTypes.bool.isRequired,
+  hideNotificationToasts: PropTypes.bool.isRequired,
 };
 
 class App extends Component {
@@ -250,6 +251,7 @@ class App extends Component {
       darkTheme,
       intl,
       genericMainContentId,
+      hideNotificationToasts,
     } = this.props;
 
     const {
@@ -317,7 +319,7 @@ class App extends Component {
             ) : null}
           <AudioCaptionsSpeechContainer />
           {this.renderAudioCaptions()}
-          <PresentationUploaderToastContainer intl={intl} />
+          { !hideNotificationToasts && <PresentationUploaderToastContainer intl={intl} /> }
           <UploaderContainer />
           <BreakoutJoinConfirmationContainerGraphQL />
           <AudioContainer {...{
@@ -327,7 +329,7 @@ class App extends Component {
             setVideoPreviewModalIsOpen: this.setVideoPreviewModalIsOpen,
           }}
           />
-          <ToastContainer rtl />
+          { !hideNotificationToasts && <ToastContainer rtl /> }
           <ChatAlertContainerGraphql />
           <RaiseHandNotifier />
           <ManyWebcamsNotifier />

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -54,6 +54,7 @@ const AppContainer = (props) => {
   const captionsStyle = layoutSelectOutput((i) => i.captions);
   const presentation = layoutSelectInput((i) => i.presentation);
   const sharedNotesInput = layoutSelectInput((i) => i.sharedNotes);
+  const { hideNotificationToasts } = layoutSelectInput((i) => i.notificationsBar);
 
   const setSpeechOptions = useSetSpeechOptions();
   const { data: pinnedPadData } = useDeduplicatedSubscription(PINNED_PAD_SUBSCRIPTION);
@@ -105,6 +106,7 @@ const AppContainer = (props) => {
           shouldShowPresentation,
           genericMainContentId: genericMainContent.genericContentId,
           audioCaptions: <AudioCaptionsLiveContainer />,
+          hideNotificationToasts,
           darkTheme,
         }}
         {...props}

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -106,7 +106,8 @@ const AppContainer = (props) => {
           shouldShowPresentation,
           genericMainContentId: genericMainContent.genericContentId,
           audioCaptions: <AudioCaptionsLiveContainer />,
-          hideNotificationToasts,
+          hideNotificationToasts: hideNotificationToasts
+            || getFromUserSettings('bbb_hide_notifications', false),
           darkTheme,
         }}
         {...props}

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -205,6 +205,24 @@ const reducer = (state, action) => {
       };
     }
 
+    // NOTIFICATION TOASTS
+    case ACTIONS.SET_HIDE_NOTIFICATION_TOASTS: {
+      const { notificationsBar } = state.input;
+      if (notificationsBar.hideNotificationToasts === action.value) {
+        return state;
+      }
+      return {
+        ...state,
+        input: {
+          ...state.input,
+          notificationsBar: {
+            ...notificationsBar,
+            hideNotificationToasts: action.value,
+          },
+        },
+      };
+    }
+
     // NAV BAR
 
     case ACTIONS.SET_HAS_NAVBAR: {

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -53,6 +53,7 @@ export const ACTIONS = {
 
   SET_HAS_BANNER_BAR: 'setHasBannerBar',
   SET_HAS_NOTIFICATIONS_BAR: 'setHasNotificationsBar',
+  SET_HIDE_NOTIFICATION_TOASTS: 'setHideNotificationToasts',
 
   SET_HAS_NAVBAR: 'setHasNavBar',
   SET_NAVBAR_OUTPUT: 'setNavBarOutput',

--- a/bigbluebutton-html5/imports/ui/components/layout/initState.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/initState.js
@@ -14,6 +14,7 @@ export const INITIAL_INPUT_STATE = {
   },
   notificationsBar: {
     hasNotification: false,
+    hideNotificationToasts: false,
   },
   navBar: {
     hasNavBar: true,

--- a/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
@@ -108,6 +108,7 @@ interface NavBar {
 
 interface NotificationsBar {
     hasNotification: boolean;
+    hideNotificationToasts: boolean;
 }
 
 interface Size {

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -109,6 +109,11 @@ const LayoutObserver: React.FC = () => {
       value: !getFromUserSettings('bbb_hide_nav_bar', false),
     });
 
+    layoutContextDispatch({
+      type: ACTIONS.SET_HIDE_NOTIFICATION_TOASTS,
+      value: getFromUserSettings('bbb_hide_notifications', false),
+    });
+
     window.addEventListener('localeChanged', () => {
       layoutContextDispatch({
         type: ACTIONS.SET_IS_RTL,


### PR DESCRIPTION
### What does this PR do?
Introduces a mechanism to control the rendering of notification toasts in the layout context and attach that to a join parameter called `userdata-bbb_hide_notifications`. When this parameter is set to `true`, all notification toasts are suppressed in the client. 

### Closes Issue(s)
None

### How to test
Use the join parameter `userdata-bbb_hide_notifications` and check whether notification toasts are rendered in the client. Some events that trigger notification toasts are: lock settings update, layout propagation, presentation upload...
