### PR TITLE
refactor (gql-server): Increases the size limit of the `value` column in the metadata tables

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -173,8 +173,8 @@ SELECT "meeting_usersPolicies"."meetingId",
 
 create table "meeting_metadata" (
 	"meetingId" 		varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
-    "name"              varchar(100),
-    "value"             varchar(100),
+    "name"              varchar(255),
+    "value"             varchar(1000),
     CONSTRAINT "meeting_metadata_pkey" PRIMARY KEY ("meetingId","name")
 );
 create index "idx_meeting_metadata_meetingId" on "meeting_metadata"("meetingId");
@@ -510,7 +510,7 @@ create table "user_metadata"(
     "meetingId" varchar(100),
     "userId" varchar(50),
 	"parameter" varchar(255),
-	"value" varchar(255),
+	"value" varchar(1000),
 	CONSTRAINT "user_metadata_pkey" PRIMARY KEY ("meetingId", "userId","parameter"),
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );


### PR DESCRIPTION
- The current size limit for the `value` column in the `meeting_metadata` table is 100 characters. In some cases, this is insufficient as the parameter can exceed that limit.
- To resolve this, the column size is increased to 1000 characters.
  
- Similarly, the `value` column in the `user_metadata` table had a limit of 255 characters. Since it's difficult to predict the size of incoming data, the limit is also increased to 1000 characters to accommodate larger values.

Reported by @prlanzarin and @ffdixon.