### PR TITLE
refactor(nav-bar/talking-indicator): Refactor styles in `TalkingIndicator` to conditionally apply styles based on user role.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -140,10 +140,14 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
           color="primary"
           icon={icon}
           size="lg"
-          style={{
-            backgroundColor: color,
-            border: `solid 2px ${color}`,
-          }}
+          style={
+            isModerator
+              ? {
+                backgroundColor: color,
+                border: `solid 2px ${color}`,
+              }
+              : undefined
+          }
         >
           {talking ? (
             <Styled.Hidden id="description">
@@ -179,11 +183,13 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
         aria-label={ariaLabel}
         color="primary"
         size="sm"
-        style={{
-          backgroundColor: '#4a148c',
-          border: 'solid 2px #4a148c',
-          cursor: 'default',
-        }}
+        style={
+          isModerator ? {
+            backgroundColor: '#4a148c',
+            border: 'solid 2px #4a148c',
+            cursor: 'default',
+          } : undefined
+        }
       />
     );
   };

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/styles.ts
@@ -115,6 +115,7 @@ const TalkingIndicatorButton = styled(Button)`
   ${({ $isViewer }) => $isViewer
     && `
     cursor: default;
+    pointer-events: none;
   `}
 `;
 


### PR DESCRIPTION
### What does this PR do?

This PR Adjusts the style and functionality of talking indicator based on the user's role.

### How to test

Join a meeting with both moderator/presenter and viewer and put out pointer over the talking indicator.

### More

https://github.com/user-attachments/assets/a9ade71f-9287-4bc3-bf12-bdb6008f73a3



