### PR TITLE
fix(learning-dashboard): show all sessions of users with the same internalID

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -50,9 +50,13 @@ case class User(
 
 case class UserId(
   intId:         String,
+  sessions: Vector[UserSession] = Vector(UserSession()),
+  userLeftFlag:  Boolean = false,
+)
+
+case class UserSession(
   registeredOn:  Long = System.currentTimeMillis(),
   leftOn:        Long = 0,
-  userLeftFlag:  Boolean = false,
 )
 
 case class Poll(
@@ -286,12 +290,12 @@ class LearningDashboardActor(
   }
 
   private def findUserByIntId(meeting: Meeting, intId: String): Option[User] = {
-    meeting.users.values.find(u => u.currentIntId == intId ||  (u.currentIntId == null && u.intIds.exists(uId => uId._2.intId == intId && uId._2.leftOn == 0)))
+    meeting.users.values.find(u => u.currentIntId == intId ||  (u.currentIntId == null && u.intIds.exists(uId => uId._2.intId == intId && uId._2.sessions.last.leftOn == 0)))
   }
 
   private def findUserByExtId(meeting: Meeting, extId: String, filterUserLeft: Boolean = false): Option[User] = {
     meeting.users.values.find(u => {
-      u.extId == extId && (filterUserLeft == false || !u.intIds.exists(uId => uId._2.leftOn == 0 && uId._2.userLeftFlag == false))
+      u.extId == extId && (filterUserLeft == false || !u.intIds.exists(uId => uId._2.sessions.last.leftOn == 0 && uId._2.userLeftFlag == false))
     })
   }
 
@@ -309,14 +313,21 @@ class LearningDashboardActor(
         for {
           userId <- user.intIds.get(msg.body.userId)
         } yield {
-          val updatedUser = user.copy(currentIntId = userId.intId, intIds = user.intIds + (userId.intId -> userId.copy(leftOn = 0, userLeftFlag = false)))
+          val updatedUserId = userId.copy(
+            sessions = userId.sessions.init :+ userId.sessions.last.copy(leftOn = 0),
+            userLeftFlag = false
+          )
+          val updatedUser = user.copy(
+            currentIntId = userId.intId,
+            intIds = user.intIds + (userId.intId -> updatedUserId)
+          )
           val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
 
           meetings += (updatedMeeting.intId -> updatedMeeting)
         }
       } else {
         val userLeftFlagged = meeting.users.values.filter(u => u.intIds.exists(uId => {
-          uId._2.intId == msg.body.userId && uId._2.userLeftFlag == true && uId._2.leftOn == 0
+          uId._2.intId == msg.body.userId && uId._2.userLeftFlag == true && uId._2.sessions.last.leftOn == 0
         }))
 
         //Flagged user must be reactivated, once UserJoinedMeetingEvtMsg won't be sent
@@ -353,12 +364,17 @@ class LearningDashboardActor(
   private def handleUserLeftMeetingEvtMsg(msg: UserLeftMeetingEvtMsg): Unit = {
     for {
       meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
-      user <- meeting.users.values.find(u => u.intIds.exists(uId => uId._2.intId == msg.body.intId && uId._2.leftOn == 0))
+      user <- meeting.users.values.find(u => u.intIds.exists(uId => uId._2.intId == msg.body.intId && uId._2.sessions.last.leftOn == 0))
       userId <- user.intIds.get(msg.body.intId)
     } yield {
+      val updatedSessions = userId.sessions.init :+ userId.sessions.last.copy(leftOn = System.currentTimeMillis())
+      val updatedUserId = userId.copy(
+        userLeftFlag = true,
+        sessions = updatedSessions
+      )
       val updatedUser = user.copy(
         currentIntId = if(user.currentIntId == userId.intId) null else user.currentIntId,
-        intIds = user.intIds + (userId.intId -> userId.copy(leftOn = System.currentTimeMillis()))
+        intIds = user.intIds + (userId.intId -> updatedUserId)
       )
       val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
 
@@ -478,7 +494,11 @@ class LearningDashboardActor(
       endUserTalk(meeting, user)
 
       if(user.isDialIn) {
-        val updatedUser = user.copy(intIds = user.intIds + (userId.intId -> userId.copy(leftOn = System.currentTimeMillis())))
+        val updatedSessions = userId.sessions.init :+ userId.sessions.last.copy(leftOn = System.currentTimeMillis())
+        val updatedUserId = userId.copy(
+          sessions = updatedSessions
+        )
+        val updatedUser = user.copy(intIds = user.intIds + (userId.intId -> updatedUserId))
         val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
 
         meetings += (updatedMeeting.intId -> updatedMeeting)
@@ -653,9 +673,15 @@ class LearningDashboardActor(
     user.copy(
       currentIntId = null,
       intIds = user.intIds.map(uId => {
-        if(uId._2.leftOn > 0) (uId._1 -> uId._2)
+        if(uId._2.sessions.last.leftOn > 0) (uId._1 -> uId._2)
         else if(forceFlaggedIdsToLeft == false && uId._2.userLeftFlag == true) (uId._1 -> uId._2)
-        else (uId._1 -> uId._2.copy(leftOn = endedOn))
+        else {
+          val updatedSessions = uId._2.sessions.init :+ uId._2.sessions.last.copy(leftOn = endedOn)
+          val updatedUserId = uId._2.copy(
+            sessions = updatedSessions
+          )
+          (uId._1 -> updatedUserId)
+        }
       }),
       talk = user.talk.copy(
         totalTime = user.talk.totalTime + (if (user.talk.lastTalkStartedOn > 0) (endedOn - user.talk.lastTalkStartedOn) else 0),
@@ -691,20 +717,25 @@ class LearningDashboardActor(
           )
           , currentTime, false)
 
+        val currentUserId = user.intIds.get(intId).getOrElse(UserId(intId, sessions = Vector()))
+
         meetings += (meeting.intId -> meeting.copy(
           //Set leftOn to same intId in past user records
           users = meeting.users.map(u => {
             (u._1 -> u._2.copy(
               intIds = u._2.intIds.map(uId => {
                 (uId._1 -> {
-                  if (uId._2.intId == intId && uId._2.leftOn == 0) uId._2.copy(leftOn = currentTime)
+                  if (uId._2.intId == intId && uId._2.sessions.last.leftOn == 0) {
+                    val updatedSessions = uId._2.sessions.init :+ uId._2.sessions.last.copy(leftOn = currentTime)
+                     uId._2.copy(sessions = updatedSessions)
+                  }
                   else uId._2
                 })
               })))
           }) + (user.userKey -> user.copy(
             currentIntId = intId,
-            intIds = user.intIds + (intId -> user.intIds.get(intId).getOrElse(UserId(intId, currentTime)).copy(
-              leftOn = 0,
+            intIds = user.intIds + (intId -> currentUserId.copy(
+              sessions = currentUserId.sessions :+ UserSession(currentTime),
               userLeftFlag = false
             ))
           ))

--- a/bbb-learning-dashboard/src/components/UserDetails/component.jsx
+++ b/bbb-learning-dashboard/src/components/UserDetails/component.jsx
@@ -53,11 +53,14 @@ const UserDatailsComponent = (props) => {
   const currTime = () => new Date().getTime();
 
   // Join and left times.
-  const registeredTimes = Object.values(user.intIds).map((intId) => intId.registeredOn);
-  const leftTimes = Object.values(user.intIds).map((intId) => intId.leftOn);
+  const registeredTimes = Object.values(user.intIds)
+    .map((intId) => intId.sessions.map((session) => session.registeredOn)).flat();
+  const leftTimes = Object.values(user.intIds)
+    .map((intId) => intId.sessions.map((session) => session.leftOn)).flat();
   const joinTime = Math.min(...registeredTimes);
   const leftTime = Math.max(...leftTimes);
-  const currentlyInMeeting = Object.values(user.intIds).some((intId) => intId.leftOn === 0);
+  const currentlyInMeeting = Object.values(user.intIds)
+    .some((intId) => intId.sessions.some((session) => session.leftOn === 0));
 
   // Used in the calculation of the online loader.
   const sessionDuration = (endedOn || currTime()) - createdOn;

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -100,15 +100,17 @@ class UsersTable extends React.Component {
       },
       onlineTimeOrder(a, b) {
         const onlineTimeA = Object.values(a.intIds).reduce((prev, intId) => (
-          prev + ((intId.leftOn > 0
-            ? intId.leftOn
-            : (new Date()).getTime()) - intId.registeredOn)
+          prev + intId.sessions.reduce((prev2, session) => (
+            prev2 + (session.leftOn > 0
+              ? session.leftOn
+              : (new Date()).getTime()) - session.registeredOn), 0)
         ), 0);
 
         const onlineTimeB = Object.values(b.intIds).reduce((prev, intId) => (
-          prev + ((intId.leftOn > 0
-            ? intId.leftOn
-            : (new Date()).getTime()) - intId.registeredOn)
+          prev + intId.sessions.reduce((prev2, session) => (
+            prev2 + (session.leftOn > 0
+              ? session.leftOn
+              : (new Date()).getTime()) - session.registeredOn), 0)
         ), 0);
 
         if (onlineTimeA < onlineTimeB) {
@@ -251,68 +253,70 @@ class UsersTable extends React.Component {
                         >
                           {user.name}
                         </button>
-                        { Object.values(user.intIds || {}).map((intId, index) => (
-                          <>
-                            <p className="text-xs text-gray-700 dark:text-gray-400">
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                className="h-4 w-4 inline"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth="2"
-                                  d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
-                                />
-                              </svg>
-                              <FormattedDate
-                                value={intId.registeredOn}
-                                month="short"
-                                day="numeric"
-                                hour="2-digit"
-                                minute="2-digit"
-                                second="2-digit"
-                              />
-                            </p>
-                            { intId.leftOn > 0
-                              ? (
-                                <p className="text-xs text-gray-700 dark:text-gray-400">
-                                  <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    className="h-4 w-4 inline"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke="currentColor"
-                                  >
-                                    <path
-                                      strokeLinecap="round"
-                                      strokeLinejoin="round"
-                                      strokeWidth="2"
-                                      d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                                    />
-                                  </svg>
-
-                                  <FormattedDate
-                                    value={intId.leftOn}
-                                    month="short"
-                                    day="numeric"
-                                    hour="2-digit"
-                                    minute="2-digit"
-                                    second="2-digit"
+                        { Object.values(user.intIds || {}).map((intId, index) => intId.sessions
+                          .map((session, sessionIndex) => (
+                            <>
+                              <p className="text-xs text-gray-700 dark:text-gray-400">
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  className="h-4 w-4 inline"
+                                  fill="none"
+                                  viewBox="0 0 24 24"
+                                  stroke="currentColor"
+                                >
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth="2"
+                                    d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
                                   />
-                                </p>
-                              )
-                              : null }
-                            { index === Object.values(user.intIds).length - 1
-                              ? null
-                              : (
-                                <hr className="my-1" />
-                              ) }
-                          </>
-                        )) }
+                                </svg>
+                                <FormattedDate
+                                  value={session.registeredOn}
+                                  month="short"
+                                  day="numeric"
+                                  hour="2-digit"
+                                  minute="2-digit"
+                                  second="2-digit"
+                                />
+                              </p>
+                              { session.leftOn > 0
+                                ? (
+                                  <p className="text-xs text-gray-700 dark:text-gray-400">
+                                    <svg
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      className="h-4 w-4 inline"
+                                      fill="none"
+                                      viewBox="0 0 24 24"
+                                      stroke="currentColor"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth="2"
+                                        d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                                      />
+                                    </svg>
+
+                                    <FormattedDate
+                                      value={session.leftOn}
+                                      month="short"
+                                      day="numeric"
+                                      hour="2-digit"
+                                      minute="2-digit"
+                                      second="2-digit"
+                                    />
+                                  </p>
+                                )
+                                : null }
+                              { index === Object.values(user.intIds).length - 1
+                                && sessionIndex === intId?.sessions.length - 1
+                                ? null
+                                : (
+                                  <hr className="my-1" />
+                                ) }
+                            </>
+                          ))) }
                       </div>
                     </td>
                     <td className={`px-4 py-3 text-sm text-center items-center ${opacity}`} data-test="userOnlineTimeDashboard">
@@ -332,16 +336,17 @@ class UsersTable extends React.Component {
                       </svg>
                       &nbsp;
                       { tsToHHmmss(Object.values(user.intIds).reduce((prev, intId) => (
-                        prev + ((intId.leftOn > 0
-                          ? intId.leftOn
-                          : (new Date()).getTime()) - intId.registeredOn)
-                      ), 0)) }
+                        prev + intId.sessions.reduce((prev2, session) => ((session.leftOn > 0
+                          ? prev2 + session.leftOn
+                          : prev2 + (new Date()).getTime()) - session.registeredOn), 0)), 0)) }
                       <br />
                       {
                         (function getPercentage() {
                           const { intIds } = user;
                           const percentage = Object.values(intIds || {}).reduce((prev, intId) => (
-                            prev + getOnlinePercentage(intId.registeredOn, intId.leftOn)
+                            prev + intId.sessions.reduce((prev2, session) => (
+                              prev2 + getOnlinePercentage(session.registeredOn, session.leftOn)
+                            ), 0)
                           ), 0);
 
                           return (
@@ -475,7 +480,8 @@ class UsersTable extends React.Component {
                     }
                     <td className="px-3.5 2xl:px-4 py-3 text-xs text-center" data-test="userStatusDashboard">
                       {
-                        Object.values(user.intIds)[Object.values(user.intIds).length - 1].leftOn > 0
+                        Object.values(user.intIds)[Object.values(user.intIds).length - 1]
+                          .sessions.slice(-1)[0].leftOn > 0
                           ? (
                             <span className="px-2 py-1 font-semibold leading-tight text-red-700 bg-red-100 rounded-full">
                               <FormattedMessage id="app.learningDashboard.usersTable.userStatusOffline" defaultMessage="Offline" />

--- a/bbb-learning-dashboard/src/index.js
+++ b/bbb-learning-dashboard/src/index.js
@@ -7,6 +7,24 @@ import { UserDetailsProvider } from './components/UserDetails/context';
 
 const RTL_LANGUAGES = ['ar', 'dv', 'fa', 'he'];
 
+function isValidLocale(locale) {
+  try {
+    const intl = new Intl.Locale(locale);
+    return !!intl;
+  } catch (error) {
+    return false;
+  }
+}
+
+function normalizeLocale(lang) {
+  const lParts = lang.split('-');
+
+  // 'pt' returns 'pt'
+  // 'pt-br' and 'pt-BR' return 'pt_BR'
+  // 'pt_BR' returns 'pt_BR'
+  return lParts.length > 1 ? `${lParts[0]}_${lParts[1].toUpperCase()}` : lang;
+}
+
 function getLanguage() {
   let { language } = navigator;
 
@@ -34,7 +52,7 @@ class Dashboard extends React.Component {
 
   setMessages() {
     const fetchMessages = (lang) => new Promise((resolve, reject) => {
-      const url = `/html5client/locales/${lang.replace('-', '_')}.json`;
+      const url = `/html5client/locales/${normalizeLocale(lang)}.json`;
       fetch(url).then((response) => {
         if (!response.ok) return reject();
         return resolve(response.json());
@@ -70,9 +88,11 @@ class Dashboard extends React.Component {
   render() {
     const { intlLocale, intlMessages } = this.state;
 
+    const locale = isValidLocale(intlLocale) ? intlLocale : undefined;
+
     return (
       <UserDetailsProvider>
-        <IntlProvider defaultLocale="en" locale={intlLocale} messages={intlMessages}>
+        <IntlProvider defaultLocale="en" locale={locale} messages={intlMessages}>
           <App />
         </IntlProvider>
       </UserDetailsProvider>

--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -211,8 +211,8 @@ export function makeUserCSVData(users, polls, intl) {
   }
 
   for (let i = 0; i < pollValues.length; i += 1) {
-    // Add the poll question headers
-    header += `,${pollValues[i].question || `Poll ${i + 1}`}`;
+    // Add the poll question headers (remove spaces and line breaks)
+    header += `,${pollValues[i].question.replace(/\s+/g, ' ').trim() || `Poll ${i + 1}`}`;
 
     // Add the anonymous answers
     anonymousRecord += `,"${pollValues[i].anonymousAnswers.join('\r\n')}"`;

--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -46,6 +46,14 @@ export function getActivityScore(user, allUsers, totalOfPolls) {
 
 export function getSumOfTime(eventsArr) {
   return eventsArr.reduce((prevVal, elem) => {
+    if (elem?.sessions) {
+      return prevVal + elem.sessions.reduce((prevVal2, session) => {
+        if (session.leftOn > 0) {
+          return prevVal2 + (session.leftOn - session.registeredOn);
+        }
+        return prevVal2 + (new Date().getTime() - session.registeredOn);
+      }, 0);
+    }
     if ((elem.stoppedOn || elem.leftOn) > 0) {
       return prevVal + ((elem.stoppedOn || elem.leftOn) - (elem.startedOn || elem.registeredOn));
     }
@@ -55,8 +63,8 @@ export function getSumOfTime(eventsArr) {
 
 export function getJoinTime(eventsArr) {
   return eventsArr.reduce((prevVal, elem) => {
-    if (prevVal === 0 || elem.registeredOn < prevVal) {
-      return elem.registeredOn;
+    if (prevVal === 0 || elem.sessions[0].registeredOn < prevVal) {
+      return elem.sessions[0].registeredOn;
     }
     return prevVal;
   }, 0);
@@ -64,8 +72,8 @@ export function getJoinTime(eventsArr) {
 
 export function getLeaveTime(eventsArr) {
   return eventsArr.reduce((prevVal, elem) => {
-    if (elem.leftOn > prevVal) {
-      return elem.leftOn;
+    if (elem.sessions[elem.sessions.length - 1].leftOn > prevVal) {
+      return elem.sessions[elem.sessions.length - 1].leftOn;
     }
     return prevVal;
   }, 0);


### PR DESCRIPTION
### What does this PR do?
Store and show sessions of users that re-enter (reopen tab) with the same internalID.

Example how it was:
![image](https://github.com/user-attachments/assets/cc7edcb4-10ad-4e24-adf3-5e7dfb11fab5)
And now, after the user reopens the tab:
![image](https://github.com/user-attachments/assets/d5620cf6-1215-4ee4-b66a-61f84e48dc2e)


### Motivation
Previously, when a user closes the tab and later rejoin with same url, the learning dashboard treated it as the user never left, so the online time of the user was wrong.


### How to test
- Join a session and close/rejoin multiple times with same user and same URL (wait for the user to leave userList before rejoining)
- Open learning dashboard and check join and left times, and also online time, it should show all sessions and calculate the online time correctly.


### More
Also include some bonus fixes for localization strings and poll content breaking exported csv.
 