### PR TITLE
fix(common-web): Make plugin manifest accept "-" character for placeholders

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -370,7 +370,7 @@ public class MeetingService implements MessageListener {
   public String replaceMetaParametersIntoManifestTemplate(String manifestContent, Map<String, String> metadata)
           throws NoSuchFieldException {
     // Pattern to match ${variable} in the input string
-    Pattern pattern = Pattern.compile("\\$\\{(\\w+)}");
+    Pattern pattern = Pattern.compile("\\$\\{([\\w-]+)}");
     Matcher matcher = pattern.matcher(manifestContent);
 
     StringBuilder result = new StringBuilder();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -370,7 +370,8 @@ public class MeetingService implements MessageListener {
   public String replaceMetaParametersIntoManifestTemplate(String manifestContent, Map<String, String> metadata)
           throws NoSuchFieldException {
     // Pattern to match ${variable} in the input string
-    Pattern pattern = Pattern.compile("\\$\\{([\\w-]+)}");
+    Pattern pattern = Pattern.compile("\\$\\{([\\w\\-]+)\\}");
+
     Matcher matcher = pattern.matcher(manifestContent);
 
     StringBuilder result = new StringBuilder();


### PR DESCRIPTION
### What does this PR do?

Just makes plugin manifest accept "-" character.

### Motivation

Make manifests like this:

```json
{
// ...
"remoteDataSources": [
      {
          "name": "allUsers",
          "url": "${meta_my-callback-url}",
          "fetchMode": "onMeetingCreate",
          "permissions": ["moderator", "viewer"]
      }
  ]
}
```

be correctly interpreted.