### PR TITLE
Fix: Presentation uploader toast not appearing sometimes when converting notes from breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
@@ -58,7 +58,7 @@ const intlMessages = defineMessages({
   },
   SCAN_FAILED: {
     id: 'app.presentationUploder.upload.scanFailed',
-    description: 'error that the file could not be uploaded because scanning failed'
+    description: 'error that the file could not be uploaded because scanning failed',
   },
   CONVERSION_TIMEOUT: {
     id: 'app.presentationUploder.conversion.conversionTimeout',
@@ -487,11 +487,12 @@ export const PresentationUploaderToast = ({
     });
   }, [presentations]);
 
-  let activeToast = Session.getItem('presentationUploaderToastId');
+  const activeToast = Session.getItem('presentationUploaderToastId');
+
   const showToast = convertingPresentations.length > 0;
 
-  if (showToast && !activeToast) {
-    activeToast = toast.info(() => renderToastList(convertingPresentations, intl), {
+  if (showToast && !toast.isActive(activeToast)) {
+    const convertingPresToast = toast.info(() => renderToastList(convertingPresentations, intl), {
       hideProgressBar: true,
       autoClose: false,
       newestOnTop: true,
@@ -501,7 +502,7 @@ export const PresentationUploaderToast = ({
         Session.setItem('presentationUploaderToastId', null);
       },
     });
-    Session.setItem('presentationUploaderToastId', activeToast);
+    Session.setItem('presentationUploaderToastId', convertingPresToast);
   } else if (!showToast && activeToast) {
     handleDismissToast(activeToast);
   } else {


### PR DESCRIPTION
### What does this PR do?
The condition to create a new toast was looking for the toastId and not verifying if This notification is enable or not, changing it to verify the toast is active removed the error, Looks like with the status updating too frequently caused notification have a race condition and load a new notification if the old is not active.

### Closes Issue(s)
Closes #21321


### How to test
Open a breakout with the option `Save shared notes` in the breakout edit the shared notes and finish the breakout meeting, but the best approach to test it is use the automated test described in the issue.


![image](https://github.com/user-attachments/assets/7303e1c9-536c-4aa9-b379-cae55ba71d2b)

