### PR TITLE
style(nav-bar/recording-indicator): Refactor padding in `RecordingStatusViewOnly` for consistent spacing.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -1,6 +1,7 @@
 import {
   ApolloClient, ApolloProvider, InMemoryCache, NormalizedCacheObject, ApolloLink,
 } from '@apollo/client';
+import { GraphQLError } from 'graphql';
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions';
 import { createClient } from 'graphql-ws';
 import { onError } from '@apollo/client/link/error';
@@ -12,7 +13,6 @@ import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import deviceInfo from '/imports/utils/deviceInfo';
 import BBBWeb from '/imports/api/bbb-web-api';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
-import { GraphQLError } from 'graphql';
 
 interface ConnectionManagerProps {
   children: React.ReactNode;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/styles.ts
@@ -167,7 +167,7 @@ const RecordingStatusViewOnly = styled.div<RecordingStatusViewOnlyProps>`
   display: flex;
 
   ${({ recording }) => recording && `
-    padding: 5px 0 5px 5px;
+    padding: 5px 5px 5px 5px;
     background-color: ${colorDangerDark};
     border: ${borderSizeLarge} solid ${colorDangerDark};
     border-radius: 10px;


### PR DESCRIPTION
### What does this PR do?

This PR fixes a lack of padding when the recording indicator is in "recording mode" - but only for viewers.

### How to test

Start a meeting, start recording and join with a viewer.