### PR TITLE
feat (gql-server): Introduces graphql Type `user_presenceLog` to indicate users that have joined

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_presenceLog.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_presenceLog.yaml
@@ -1,0 +1,26 @@
+table:
+  name: v_user_presenceLog
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_presenceLog
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - currentlyInMeeting
+        - extId
+        - isModerator
+        - userId
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - _or:
+              - isModerator:
+                  _eq: true
+              - meetingId:
+                  _eq: X-Hasura-UserListNotLockedInMeeting
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -56,6 +56,7 @@
 - "!include public_v_user_guest.yaml"
 - "!include public_v_user_lockSettings.yaml"
 - "!include public_v_user_metadata.yaml"
+- "!include public_v_user_presenceLog.yaml"
 - "!include public_v_user_reaction.yaml"
 - "!include public_v_user_ref.yaml"
 - "!include public_v_user_transcriptionError.yaml"


### PR DESCRIPTION
This PR adds the `user_presenceLog` type to the GraphQL schema, which will enable tracking of users' presence in the meeting, including those who have already exited the session. This functionality is essential for teachers to view a comprehensive list of attendees, including those no longer in the meeting.
```gql
subscription {
  user_presenceLog {
    extId
    userId
    currentlyInMeeting
    isModerator
  }
}
```

It is not intended to be used by the Client. But it will be useful for plugins.

---

It also adds a column `user.firstJoinedAt` that was necessary to track if the user has already joined in the meeting (in the past).
This column is not being provided by any graphql Type, but it can easily be provided in the future if necessary.