### PR TITLE
fix(client): convert meeting metadata to expected format

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/meeting-settings/index.js
@@ -17,7 +17,12 @@ window.addEventListener('graphqlSubscription', (e) => {
     const { data } = response;
     if (data) {
       const { metadata = [], voiceSettings } = data.meeting[0];
-      settings(metadata);
+      // convert metadata format to { key: value }
+      const result = metadata.reduce((acc, item) => {
+        acc[item.name] = item.value;
+        return acc;
+      }, {});
+      settings(result);
       voiceConf(voiceSettings.voiceConf);
     }
   }


### PR DESCRIPTION
### What does this PR do?
The metadata is comming from server with { name: metaname, value: metavalue }, which is not compatible with getFromMeetingSettings, so it's not reading corretly. Convert it before storing.

### Motivation
Meeting metadata was not being read correctly in client.


### How to test
Create a meeting with some meta, e.g. `media-server-video`, see if it is changing the related feature.