### PR TITLE
fix(breakout): avatar URL not showing in breakouts

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -63,13 +63,20 @@ object BreakoutRoomsUtil extends SystemConfiguration {
     checksum(apiCall.concat(baseString).concat(sharedSecret))
   }
 
-  def joinParams(username: String, userId: String, isBreakout: Boolean, breakoutMeetingId: String,
-                 password: String): (collection.immutable.Map[String, String], collection.immutable.Map[String, String]) = {
+  def joinParams(
+      username:          String,
+      userId:            String,
+      isBreakout:        Boolean,
+      breakoutMeetingId: String,
+      avatarURL:         String,
+      password:          String
+  ): (collection.immutable.Map[String, String], collection.immutable.Map[String, String]) = {
     val params = collection.immutable.HashMap(
       "fullName" -> urlEncode(username),
       "userID" -> urlEncode(userId),
       "isBreakout" -> urlEncode(isBreakout.toString()),
       "meetingID" -> urlEncode(breakoutMeetingId),
+      "avatarURL" -> urlEncode(avatarURL),
       "password" -> urlEncode(password),
       "redirect" -> urlEncode("true")
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
@@ -41,8 +41,14 @@ object BreakoutHdlrHelpers extends SystemConfiguration {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, userId)
       apiCall = "join"
-      (redirectParams, redirectToHtml5Params) = BreakoutRoomsUtil.joinParams(user.name, userId + "-" + roomSequence, true,
-        externalMeetingId, liveMeeting.props.password.moderatorPass)
+      (redirectParams, redirectToHtml5Params) = BreakoutRoomsUtil.joinParams(
+        user.name,
+        userId + "-" + roomSequence,
+        true,
+        externalMeetingId,
+        user.avatar,
+        liveMeeting.props.password.moderatorPass
+      )
       // We generate a first url with redirect -> true
       redirectBaseString = BreakoutRoomsUtil.createBaseString(redirectParams)
       redirectJoinURL = BreakoutRoomsUtil.createJoinURL(bbbWebAPI, apiCall, redirectBaseString,


### PR DESCRIPTION
### What does this PR do?

> Since we started using images as user's avatar this was missing. Now akka-apps will add the user's avatarURL along with the join API URL's params generated for each user.

Fixes avatarUrl not showing inside breakou rooms

### How to test

- Create a metting and join with a user with avatarURL set in parameters.
- Start breakout room and join with the user with avatar
- The avatar should also be shown in the UserList inside the breakout room