### PR TITLE
style: adjust raise hand icon position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/styles.js
@@ -10,6 +10,10 @@ ${({ ghost }) => ghost && `
     border-color: ${colorWhite} !important;
   }
    `}
+   
+   & span i {
+    left: -.05rem;
+   }
 `;
 
 export default {


### PR DESCRIPTION
### What does this PR do?

Moves raise hand icon .05 rem left so it gets centered

#### before
![Screenshot from 2024-10-17 16-38-13](https://github.com/user-attachments/assets/35f9ab49-49db-4514-b883-fdd491e13f8c)

#### after

![Screenshot from 2024-10-17 16-38-55](https://github.com/user-attachments/assets/a72b937e-6af0-47cd-890b-1f2fca1816ce)
