### PR TITLE
feat: allow parent room moderators to kick other users in breakouts

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -69,14 +69,17 @@ object BreakoutRoomsUtil extends SystemConfiguration {
       isBreakout:        Boolean,
       breakoutMeetingId: String,
       avatarURL:         String,
+      role:              String,
       password:          String
   ): (collection.immutable.Map[String, String], collection.immutable.Map[String, String]) = {
+    val moderator = role == "MODERATOR"
     val params = collection.immutable.HashMap(
       "fullName" -> urlEncode(username),
       "userID" -> urlEncode(userId),
       "isBreakout" -> urlEncode(isBreakout.toString()),
       "meetingID" -> urlEncode(breakoutMeetingId),
       "avatarURL" -> urlEncode(avatarURL),
+      "userdata-bbb_parent_room_moderator" -> urlEncode(moderator.toString()),
       "password" -> urlEncode(password),
       "redirect" -> urlEncode("true")
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -63,13 +63,20 @@ object BreakoutRoomsUtil extends SystemConfiguration {
     checksum(apiCall.concat(baseString).concat(sharedSecret))
   }
 
-  def joinParams(username: String, userId: String, isBreakout: Boolean, breakoutMeetingId: String,
-                 password: String): (collection.immutable.Map[String, String], collection.immutable.Map[String, String]) = {
+  def joinParams(
+      username:          String,
+      userId:            String,
+      isBreakout:        Boolean,
+      breakoutMeetingId: String,
+      avatarURL:         String,
+      password:          String
+  ): (collection.immutable.Map[String, String], collection.immutable.Map[String, String]) = {
     val params = collection.immutable.HashMap(
       "fullName" -> urlEncode(username),
       "userID" -> urlEncode(userId),
       "isBreakout" -> urlEncode(isBreakout.toString()),
       "meetingID" -> urlEncode(breakoutMeetingId),
+      "avatarURL" -> urlEncode(avatarURL),
       "password" -> urlEncode(password),
       "redirect" -> urlEncode("true")
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
@@ -41,8 +41,14 @@ object BreakoutHdlrHelpers extends SystemConfiguration {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, userId)
       apiCall = "join"
-      (redirectParams, redirectToHtml5Params) = BreakoutRoomsUtil.joinParams(user.name, userId + "-" + roomSequence, true,
-        externalMeetingId, liveMeeting.props.password.moderatorPass)
+      (redirectParams, redirectToHtml5Params) = BreakoutRoomsUtil.joinParams(
+        user.name,
+        userId + "-" + roomSequence,
+        true,
+        externalMeetingId,
+        user.avatar,
+        liveMeeting.props.password.moderatorPass
+      )
       // We generate a first url with redirect -> true
       redirectBaseString = BreakoutRoomsUtil.createBaseString(redirectParams)
       redirectJoinURL = BreakoutRoomsUtil.createJoinURL(bbbWebAPI, apiCall, redirectBaseString,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
@@ -47,6 +47,7 @@ object BreakoutHdlrHelpers extends SystemConfiguration {
         true,
         externalMeetingId,
         user.avatar,
+        user.role,
         liveMeeting.props.password.moderatorPass
       )
       // We generate a first url with redirect -> true

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -26,7 +26,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
       PermissionCheck.VIEWER_LEVEL,
       liveMeeting.users2x,
       msg.header.userId
-    ) || liveMeeting.props.meetingProp.isBreakout) {
+    )) {
 
       val reason = "No permission to eject user from meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/service.ts
@@ -6,6 +6,7 @@ import {
 import Auth from '/imports/ui/services/auth';
 import logger from '/imports/startup/client/logger';
 import { toggleMuteMicrophone } from '/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 export const isVoiceOnlyUser = (userId: string) => userId.toString().startsWith('v_');
 
@@ -25,6 +26,9 @@ export const generateActionsPermissions = (
   const isDialInUser = isVoiceOnlyUser(subjectUser.userId);
   const amISubjectUser = isMe(subjectUser.userId);
   const isSubjectUserModerator = subjectUser.isModerator;
+  // Breakout rooms mess up with role permissions
+  // A breakout room user that has a moderator role in it's parent room
+  const parentRoomModerator = getFromUserSettings('bbb_parent_room_moderator', false);
   const isSubjectUserGuest = subjectUser.guest;
   const hasAuthority = currentUser.isModerator || amISubjectUser;
   const allowedToChatPrivately = !amISubjectUser && !isDialInUser;
@@ -42,7 +46,7 @@ export const generateActionsPermissions = (
   // if currentUser is a moderator, allow removing other users
   const allowedToRemove = amIModerator
     && !amISubjectUser
-    && !isBreakout;
+    && (!isBreakout || parentRoomModerator);
 
   const allowedToPromote = amIModerator
     && !amISubjectUser

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1398,8 +1398,8 @@ Useful tools for development:
 | `userdata-bbb_skip_echotest_if_previous_device=` | (Introduced in BigBlueButton 3.0) If set to `true`, the user will not see the "echo test" if session has valid input/output devices stored previously | `false`       |
 | `userdata-bbb_override_default_locale=`        | (Introduced in BigBlueButton 2.3) If set to `de`, the user's browser preference will be ignored - the client will be shown in 'de' (i.e. German) regardless of the otherwise preferred locale 'en' (or other)                                                                                                                   | `null`        |
 | `userdata-bbb_hide_presentation_on_join`        | (Introduced in BigBlueButton 2.6) If set to `true` it will make the user enter the meeting with presentation minimized (Only for non-presenters), not permanent. 
-
-| `userdata-bbb_direct_leave_button` | (Introduced in BigBlueButton 2.7) If set to `true` it will make a button to leave the meeting appear to the left of the Options menu. | `false` |                                                                                                                  | `false`        |
+| `userdata-bbb_direct_leave_button` | (Introduced in BigBlueButton 2.7) If set to `true` it will make a button to leave the meeting appear to the left of the Options menu. | `false`  |
+| `userdata-bbb_parent_room_moderator=` | (Introduced in BigBlueButton 3.0) Only used in breakouts: if set to `true`, user will have permission to kick other users inside the breakout | `false`                                                                      
 
 #### Branding parameters
 


### PR DESCRIPTION
### What does this PR do?

- Included a new userdata `userdata-bbb_parent_room_moderator` so akka-apps can
signal the HTML5 client that the user had a moderator role when the breakout room
was created. 
- This user will have an extra permission inside the breakout room where
he/she will be able to kick other users out.
- This userdata is passed automatically by akka-apps when creating the breakout joinUrl

### Motivation
Possibility for moderators to enter a breakout and have better control.

### How to test
- Start a metting with some moderators and viewers.
- Start breakouts and join with viewer and moderator
- The moderator should see the "Remove User" option when clicking a user name inside the breakout

### More
Built on top of https://github.com/bigbluebutton/bigbluebutton/pull/21470 to avoid conflicts.
