### PR TITLE
fix (gql-middleware): Fix memory leaks

### DIFF
--- a/bbb-graphql-middleware/internal/common/CustomCache.go
+++ b/bbb-graphql-middleware/internal/common/CustomCache.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"sync"
+	"time"
 )
 
 var GlobalCacheLocks = NewCacheLocks()
@@ -32,6 +33,17 @@ func (c *CacheLocks) Unlock(id uint32) {
 	c.mutex.Lock()
 	if mtx, exists := c.locks[id]; exists {
 		mtx.Unlock()
+		go c.RemoveLockId(id, 30)
+	}
+	c.mutex.Unlock()
+}
+
+func (c *CacheLocks) RemoveLockId(id uint32, delayInSecs time.Duration) {
+	time.Sleep(delayInSecs * time.Second)
+
+	c.mutex.Lock()
+	if _, exists := c.locks[id]; exists {
+		delete(c.locks, id)
 	}
 	c.mutex.Unlock()
 }

--- a/bbb-graphql-middleware/internal/common/SafeChannelByte.go
+++ b/bbb-graphql-middleware/internal/common/SafeChannelByte.go
@@ -45,6 +45,10 @@ func (s *SafeChannelByte) Closed() bool {
 }
 
 func (s *SafeChannelByte) Close() {
+	if s.Frozen() {
+		s.UnfreezeChannel()
+	}
+
 	s.mux.Lock()
 	defer s.mux.Unlock()
 


### PR DESCRIPTION
This PR addresses two memory leaks that were causing the service to accumulate memory without releasing it.

1. **Global lock cleanup**: The global lock used to prevent processing the same message multiple times was not being removed. This lock is now automatically cleared after 30 seconds, once all connections have benefitted from the cache.
   
2. **Channel closure issue**: A routine was failing to close properly due to a frozen channel. The channel will now always be unfrozen before attempting to close it, ensuring proper routine shutdown.

With these fixes, memory usage returns to its normal state after all users leave the meeting, and the garbage collector can reclaim memory after a few minutes.

Kudos to @prlanzarin for reporting this issue 👏