### PR TITLE
fix(whiteboard): Only show hide toolbar option to users with WB access

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -126,6 +126,7 @@ const PresentationMenu = (props) => {
     currentUser,
     whiteboardId,
     persistShape,
+    hasWBAccess,
   } = props;
 
   const [state, setState] = useState({
@@ -378,7 +379,9 @@ const PresentationMenu = (props) => {
       );
     }
 
-    menuItems.push(
+    const showVisibilityOption = currentUser?.presenter || hasWBAccess;
+
+    showVisibilityOption && menuItems.push(
       {
         key: 'list-item-toolvisibility',
         dataTest: 'toolVisibility',


### PR DESCRIPTION
### What does this PR do?
This PR removes the hide toolbar menu option for users who do not have access to the whiteboard.

### Closes Issue(s)
Closes #21404 
