### PR TITLE
fix(chat): Several fixes, UI improvements, et al.

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReactionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReactionReqMsgHdlr.scala
@@ -52,9 +52,9 @@ trait DeleteGroupChatMessageReactionReqMsgHdlr extends HandlerHelpers {
           val userIsAParticipant = groupChat.users.exists(u => u.id == user.intId)
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-            val event = buildGroupChatMessageReactionDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji)
+            val event = buildGroupChatMessageReactionDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji, msg.body.reactionEmojiId)
             bus.outGW.send(event)
-            ChatMessageReactionDAO.delete(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji)
+            ChatMessageReactionDAO.delete(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji, msg.body.reactionEmojiId)
           } else {
             val reason = "User isn't a participant of the chat"
             PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
@@ -27,7 +27,7 @@ trait DeleteGroupChatMessageReqMsgHdlr extends HandlerHelpers {
         chatLockedForUser = true
       }
 
-      val userIsModerator = user.role != Roles.MODERATOR_ROLE
+      val userIsModerator = user.role == Roles.MODERATOR_ROLE
 
       if (!userIsModerator && user.locked) {
         val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/EditGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/EditGroupChatMessageReqMsgHdlr.scala
@@ -27,7 +27,7 @@ trait EditGroupChatMessageReqMsgHdlr extends HandlerHelpers {
         chatLockedForUser = true
       }
 
-      val userIsModerator = user.role != Roles.MODERATOR_ROLE
+      val userIsModerator = user.role == Roles.MODERATOR_ROLE
 
       if (!userIsModerator && user.locked) {
         val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageReactionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageReactionReqMsgHdlr.scala
@@ -26,7 +26,7 @@ trait SendGroupChatMessageReactionReqMsgHdlr extends HandlerHelpers {
         chatLockedForUser = true
       }
 
-      val userIsModerator = user.role != Roles.MODERATOR_ROLE
+      val userIsModerator = user.role == Roles.MODERATOR_ROLE
 
       if (!userIsModerator && user.locked) {
         val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
@@ -52,9 +52,9 @@ trait SendGroupChatMessageReactionReqMsgHdlr extends HandlerHelpers {
           val userIsAParticipant = groupChat.users.exists(u => u.id == user.intId)
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-            val event = buildGroupChatMessageReactionSentEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji)
+            val event = buildGroupChatMessageReactionSentEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji, msg.body.reactionEmojiId)
             bus.outGW.send(event)
-            ChatMessageReactionDAO.insert(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji)
+            ChatMessageReactionDAO.insert(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji, msg.body.reactionEmojiId)
           } else {
             val reason = "User isn't a participant of the chat"
             PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageReactionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageReactionDAO.scala
@@ -4,11 +4,12 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{ ProvenShape }
 
 case class ChatMessageReactionDbModel(
-    meetingId:     String,
-    messageId:     String,
-    userId:        String,
-    reactionEmoji: String,
-    createdAt:     java.sql.Timestamp
+    meetingId:       String,
+    messageId:       String,
+    userId:          String,
+    reactionEmoji:   String,
+    reactionEmojiId: String,
+    createdAt:       java.sql.Timestamp
 )
 
 class ChatMessageReactionDbTableDef(tag: Tag) extends Table[ChatMessageReactionDbModel](tag, "chat_message_reaction") {
@@ -16,13 +17,14 @@ class ChatMessageReactionDbTableDef(tag: Tag) extends Table[ChatMessageReactionD
   val messageId = column[String]("messageId", O.PrimaryKey)
   val userId = column[String]("userId", O.PrimaryKey)
   val reactionEmoji = column[String]("reactionEmoji", O.PrimaryKey)
+  val reactionEmojiId = column[String]("reactionEmojiId")
   val createdAt = column[java.sql.Timestamp]("createdAt")
 
-  override def * : ProvenShape[ChatMessageReactionDbModel] = (meetingId, messageId, userId, reactionEmoji, createdAt) <> (ChatMessageReactionDbModel.tupled, ChatMessageReactionDbModel.unapply)
+  override def * : ProvenShape[ChatMessageReactionDbModel] = (meetingId, messageId, userId, reactionEmoji, reactionEmojiId, createdAt) <> (ChatMessageReactionDbModel.tupled, ChatMessageReactionDbModel.unapply)
 }
 
 object ChatMessageReactionDAO {
-  def insert(meetingId: String, messageId: String, userId: String, reactionEmoji: String) = {
+  def insert(meetingId: String, messageId: String, userId: String, reactionEmoji: String, reactionEmojiId: String) = {
     DatabaseConnection.enqueue(
       TableQuery[ChatMessageReactionDbTableDef].forceInsert(
         ChatMessageReactionDbModel(
@@ -30,19 +32,21 @@ object ChatMessageReactionDAO {
           messageId = messageId,
           userId = userId,
           reactionEmoji = reactionEmoji,
+          reactionEmojiId = reactionEmojiId,
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
     )
   }
 
-  def delete(meetingId: String, messageId: String, userId: String, reactionEmoji: String) = {
+  def delete(meetingId: String, messageId: String, userId: String, reactionEmoji: String, reactionEmojiId: String) = {
     DatabaseConnection.enqueue(
       TableQuery[ChatMessageReactionDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.messageId === messageId)
         .filter(_.userId === userId)
         .filter(_.reactionEmoji === reactionEmoji)
+        .filter(_.reactionEmojiId === reactionEmojiId)
         .delete
     )
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -327,20 +327,20 @@ trait HandlerHelpers extends SystemConfiguration {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildGroupChatMessageReactionSentEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String): BbbCommonEnvCoreMsg = {
+  def buildGroupChatMessageReactionSentEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(GroupChatMessageReactionSentEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(GroupChatMessageReactionSentEvtMsg.NAME, meetingId, userId)
-    val body = GroupChatMessageReactionSentEvtMsgBody(chatId, messageId, reactionEmoji)
+    val body = GroupChatMessageReactionSentEvtMsgBody(chatId, messageId, reactionEmoji, reactionEmojiId)
     val event = GroupChatMessageReactionSentEvtMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildGroupChatMessageReactionDeletedEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String): BbbCommonEnvCoreMsg = {
+  def buildGroupChatMessageReactionDeletedEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(GroupChatMessageReactionDeletedEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(GroupChatMessageReactionDeletedEvtMsg.NAME, meetingId, userId)
-    val body = GroupChatMessageReactionDeletedEvtMsgBody(chatId, messageId, reactionEmoji)
+    val body = GroupChatMessageReactionDeletedEvtMsgBody(chatId, messageId, reactionEmoji, reactionEmojiId)
     val event = GroupChatMessageReactionDeletedEvtMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -137,19 +137,19 @@ case class GroupChatMessageDeletedEvtMsgBody(chatId: String, messageId: String)
 
 object SendGroupChatMessageReactionReqMsg { val NAME = "SendGroupChatMessageReactionReqMsg" }
 case class SendGroupChatMessageReactionReqMsg(header: BbbClientMsgHeader, body: SendGroupChatMessageReactionReqMsgBody) extends StandardMsg
-case class SendGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String)
+case class SendGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
 
 object GroupChatMessageReactionSentEvtMsg { val NAME = "GroupChatMessageReactionSentEvtMsg" }
 case class GroupChatMessageReactionSentEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageReactionSentEvtMsgBody) extends BbbCoreMsg
-case class GroupChatMessageReactionSentEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String)
+case class GroupChatMessageReactionSentEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
 
 object DeleteGroupChatMessageReactionReqMsg { val NAME = "DeleteGroupChatMessageReactionReqMsg" }
 case class DeleteGroupChatMessageReactionReqMsg(header: BbbClientMsgHeader, body: DeleteGroupChatMessageReactionReqMsgBody) extends StandardMsg
-case class DeleteGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String)
+case class DeleteGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
 
 object GroupChatMessageReactionDeletedEvtMsg { val NAME = "GroupChatMessageReactionDeletedEvtMsg" }
 case class GroupChatMessageReactionDeletedEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageReactionDeletedEvtMsgBody) extends BbbCoreMsg
-case class GroupChatMessageReactionDeletedEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String)
+case class GroupChatMessageReactionDeletedEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
 
 object UserTypingPubMsg { val NAME = "UserTypingPubMsg" }
 case class UserTypingPubMsg(header: BbbClientMsgHeader, body: UserTypingPubMsgBody) extends StandardMsg

--- a/bbb-graphql-actions/src/actions/chatDeleteMessageReaction.ts
+++ b/bbb-graphql-actions/src/actions/chatDeleteMessageReaction.ts
@@ -7,6 +7,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'chatId', type: 'string', required: true},
         {name: 'messageId', type: 'string', required: true},
         {name: 'reactionEmoji', type: 'string', required: true},
+        {name: 'reactionEmojiId', type: 'string', required: true},
       ]
   )
 
@@ -26,6 +27,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     chatId: input.chatId,
     messageId: input.messageId,
     reactionEmoji: input.reactionEmoji,
+    reactionEmojiId: input.reactionEmojiId,
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
@@ -7,6 +7,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'chatId', type: 'string', required: true},
         {name: 'messageId', type: 'string', required: true},
         {name: 'reactionEmoji', type: 'string', required: true},
+        {name: 'reactionEmojiId', type: 'string', required: true},
       ]
   )
 
@@ -26,6 +27,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     chatId: input.chatId,
     messageId: input.messageId,
     reactionEmoji: input.reactionEmoji,
+    reactionEmojiId: input.reactionEmojiId,
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1174,6 +1174,7 @@ CREATE TABLE "chat_message_reaction" (
 	"messageId" varchar(100) REFERENCES "chat_message"("messageId") ON DELETE CASCADE,
 	"userId" varchar(100) not null,
 	"reactionEmoji" varchar(25),
+    "reactionEmojiId" varchar(50),
 	"createdAt" timestamp with time zone,
     CONSTRAINT chat_message_reaction_pk PRIMARY KEY ("messageId", "userId", "reactionEmoji"),
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -114,6 +114,7 @@ type Mutation {
     chatId: String!
     messageId: String!
     reactionEmoji: String!
+    reactionEmojiId: String!
   ): Boolean
 }
 
@@ -149,6 +150,7 @@ type Mutation {
     chatId: String!
     messageId: String!
     reactionEmoji: String!
+    reactionEmojiId: String!
   ): Boolean
 }
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_reaction.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_reaction.yaml
@@ -23,6 +23,7 @@ select_permissions:
       columns:
         - createdAt
         - reactionEmoji
+        - reactionEmojiId
         - userId
       filter:
         meetingId:

--- a/bigbluebutton-html5/imports/ui/Types/message.ts
+++ b/bigbluebutton-html5/imports/ui/Types/message.ts
@@ -28,7 +28,7 @@ export interface Message {
       name: string;
     } | null;
     messageSequence: number;
-    message: string;
+    message: string | null;
     chatEmphasizedText: boolean;
     user: {
       name: string;

--- a/bigbluebutton-html5/imports/ui/Types/message.ts
+++ b/bigbluebutton-html5/imports/ui/Types/message.ts
@@ -38,6 +38,7 @@ export interface Message {
   reactions: {
     createdAt: string;
     reactionEmoji: string;
+    reactionEmojiId: string;
     user: {
       name: string;
       userId: string;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/component.tsx
@@ -3,7 +3,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import Icon from '/imports/ui/components/common/icon/component';
 import {
-  Cancel, Highlighted, Left, Root,
+  Cancel, Container, Highlighted, Left, Root,
 } from './styles';
 
 const intlMessages = defineMessages({
@@ -51,24 +51,26 @@ const ChatEditingWarning = () => {
 
   return (
     <Root role="note" aria-describedby="cancel-editing-msg">
-      <Left>
-        <Icon iconName="pen_tool" />
-        {editingMessage}
-      </Left>
-      <Cancel
-        onClick={() => {
-          window.dispatchEvent(new CustomEvent(ChatEvents.CHAT_CANCEL_EDIT_REQUEST));
-        }}
-      >
-        {cancelMessage.split(CANCEL_KEY_LABEL)[0]}
+      <Container>
+        <Left>
+          <Icon iconName="pen_tool" />
+          {editingMessage}
+        </Left>
+        <Cancel
+          onClick={() => {
+            window.dispatchEvent(new CustomEvent(ChatEvents.CHAT_CANCEL_EDIT_REQUEST));
+          }}
+        >
+          {cancelMessage.split(CANCEL_KEY_LABEL)[0]}
         &nbsp;
-        <Highlighted>{CANCEL_KEY_LABEL}</Highlighted>
+          <Highlighted>{CANCEL_KEY_LABEL}</Highlighted>
         &nbsp;
-        {cancelMessage.split(CANCEL_KEY_LABEL)[1]}
-      </Cancel>
-      <span className="sr-only" id="cancel-editing-msg">
-        {`${editingMessage} ${cancelMessage}`}
-      </span>
+          {cancelMessage.split(CANCEL_KEY_LABEL)[1]}
+        </Cancel>
+        <span className="sr-only" id="cancel-editing-msg">
+          {`${editingMessage} ${cancelMessage}`}
+        </span>
+      </Container>
     </Root>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/styles.ts
@@ -12,10 +12,6 @@ export const Container = styled.div`
   align-items: center;
   flex-wrap: nowrap;
   color: ${colorGrayLight};
-  position: absolute;
-  right: 0;
-  left: 0;
-  bottom: 100%;
   z-index: 10;
   background-color: ${colorWhite};
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/styles.ts
@@ -1,20 +1,30 @@
 import styled from 'styled-components';
-import { colorGrayLight } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorGrayLight, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import { xlPadding, xsPadding } from '/imports/ui/stylesheets/styled-components/general';
 
 export const Root = styled.div`
+  position: relative;
+`;
+
+export const Container = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
   flex-wrap: nowrap;
   color: ${colorGrayLight};
+  position: absolute;
+  right: 0;
+  left: 0;
+  bottom: 100%;
+  z-index: 10;
+  background-color: ${colorWhite};
 
   [dir='ltr'] & {
-    padding-right: ${xlPadding};
+    margin-right: ${xlPadding};
   }
 
   [dir='rtl'] & {
-    padding-left: ${xlPadding};
+    margin-left: ${xlPadding};
   }
 `;
 
@@ -48,7 +58,8 @@ export const Cancel = styled.button`
 `;
 
 export default {
-  Root,
+  Container,
   Left,
   Cancel,
+  Root,
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -175,10 +175,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     ref: messageListContainerRef,
     current: currentMessageListContainer,
   } = useReactiveRef<HTMLDivElement>(null);
-  const {
-    ref: messageListRef,
-    current: currentMessageList,
-  } = useReactiveRef<HTMLDivElement>(null);
+  const messageListRef = React.useRef<HTMLDivElement>(null);
   const [userLoadedBackUntilPage, setUserLoadedBackUntilPage] = useState<number | null>(null);
   const [lastMessageCreatedAt, setLastMessageCreatedAt] = useState<string>('');
   const [followingTail, setFollowingTail] = React.useState(true);
@@ -189,21 +186,15 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     parentRefProxy: messageListContainerRefProxy,
   } = useIntersectionObserver(messageListContainerRef, sentinelRef);
   const {
-    startObserving: startObservingMessageListStickyScroll,
-    stopObserving: stopObservingMessageListStickyScroll,
-  } = useStickyScroll(currentMessageListContainer, currentMessageList);
-  const {
-    startObserving: startObservingMessageListContainerStickyScroll,
-    stopObserving: stopObservingMessageListContainerStickyScroll,
-  } = useStickyScroll(currentMessageListContainer, currentMessageListContainer);
+    startObserving: startObservingStickyScroll,
+    stopObserving: stopObservingStickyScroll,
+  } = useStickyScroll(currentMessageListContainer, currentMessageListContainer, 'ne');
 
   useEffect(() => {
     if (isSentinelVisible) {
-      startObservingMessageListStickyScroll();
-      startObservingMessageListContainerStickyScroll();
+      startObservingStickyScroll();
     } else {
-      stopObservingMessageListStickyScroll();
-      stopObservingMessageListContainerStickyScroll();
+      stopObservingStickyScroll();
     }
     toggleFollowingTail(isSentinelVisible);
   }, [isSentinelVisible]);
@@ -379,6 +370,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
               {Array.from({ length: pagesToLoad }, (_v, k) => k + (firstPageToLoad)).map((page) => {
                 return (
                   <ChatListPage
+                    firstPageToLoad={firstPageToLoad}
                     key={`page-${page}`}
                     page={page}
                     pageSize={PAGE_SIZE}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -189,12 +189,22 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     parentRefProxy: messageListContainerRefProxy,
   } = useIntersectionObserver(messageListContainerRef, sentinelRef);
   const {
-    startObserving,
-    stopObserving,
+    startObserving: startObservingMessageListStickyScroll,
+    stopObserving: stopObservingMessageListStickyScroll,
   } = useStickyScroll(currentMessageListContainer, currentMessageList);
+  const {
+    startObserving: startObservingMessageListContainerStickyScroll,
+    stopObserving: stopObservingMessageListContainerStickyScroll,
+  } = useStickyScroll(currentMessageListContainer, currentMessageListContainer);
 
   useEffect(() => {
-    if (isSentinelVisible) startObserving(); else stopObserving();
+    if (isSentinelVisible) {
+      startObservingMessageListStickyScroll();
+      startObservingMessageListContainerStickyScroll();
+    } else {
+      stopObservingMessageListStickyScroll();
+      stopObservingMessageListContainerStickyScroll();
+    }
     toggleFollowingTail(isSentinelVisible);
   }, [isSentinelVisible]);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -205,8 +205,9 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
 
   useImperativeHandle(ref, () => ({
     requestFocus() {
-      requestAnimationFrame(startScrollAnimation);
-      requestAnimationFrame(startBackgroundAnimation);
+      setTimeout(() => {
+        requestAnimationFrame(startScrollAnimation);
+      }, 0);
     },
   }), []);
 
@@ -234,6 +235,8 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
       // eslint-disable-next-line no-param-reassign
       scrollContainer.scrollTop = initialPosition - (value * diff);
       requestAnimationFrame(animateScrollPosition);
+    } else {
+      requestAnimationFrame(startBackgroundAnimation);
     }
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -139,7 +139,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
       markMessageAsSeen(message);
     }
   }, [message, messageRef]);
-  const messageContentRef = React.useRef<HTMLDivElement>();
+  const messageContentRef = React.useRef<HTMLDivElement>(null);
   const [editing, setEditing] = React.useState(false);
   const [isToolbarReactionPopoverOpen, setIsToolbarReactionPopoverOpen] = React.useState(false);
   const chatFocusMessageRequest = useStorageKey(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, STORAGES.IN_MEMORY);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -251,7 +251,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
       messageContentRef.current.style.backgroundColor = `rgb(${colorBlueLightestChannel} / ${1 - value})`;
       requestAnimationFrame(animate);
     } else {
-      messageContentRef.current.style.backgroundColor = 'unset';
+      messageContentRef.current.style.backgroundColor = '#f4f6fa';
     }
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -542,7 +542,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
         >
           {message.replyToMessage && !deleteTime && (
           <ChatMessageReplied
-            message={message.replyToMessage.message}
+            message={message.replyToMessage.message || ''}
             sequence={message.replyToMessage.messageSequence}
             emphasizedMessage={message.replyToMessage.chatEmphasizedText}
             deletedByUser={message.replyToMessage.deletedBy?.name ?? null}
@@ -593,7 +593,8 @@ function areChatMessagesEqual(prevProps: ChatMessageProps, nextProps: ChatMessag
     && prevMessage?.message === nextMessage.message
     && prevMessage?.reactions?.length === nextMessage?.reactions?.length
     && prevProps.focused === nextProps.focused
-    && prevProps.keyboardFocused === nextProps.keyboardFocused;
+    && prevProps.keyboardFocused === nextProps.keyboardFocused
+    && prevMessage.replyToMessage?.message === nextMessage.replyToMessage?.message;
 }
 
 export default memo(ChatMesssage, areChatMessagesEqual);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -138,7 +138,7 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
       markMessageAsSeen(message);
     }
   }, [message, messageRef]);
-  const messageContentRef = React.createRef<HTMLDivElement>();
+  const messageContentRef = React.useRef<HTMLDivElement>();
   const [editing, setEditing] = React.useState(false);
   const [isToolbarReactionPopoverOpen, setIsToolbarReactionPopoverOpen] = React.useState(false);
   const chatFocusMessageRequest = useStorageKey(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, STORAGES.IN_MEMORY);
@@ -245,13 +245,13 @@ const ChatMesssage: React.FC<ChatMessageProps> = ({
   }, []);
 
   const animate = useCallback((timestamp: number) => {
-    if (!containerRef.current) return;
+    if (!messageContentRef.current) return;
     const value = (timestamp - animationInitialTimestamp.current) / ANIMATION_DURATION;
     if (value < 1) {
-      containerRef.current.style.backgroundColor = `rgb(${colorBlueLightestChannel} / ${1 - value})`;
+      messageContentRef.current.style.backgroundColor = `rgb(${colorBlueLightestChannel} / ${1 - value})`;
       requestAnimationFrame(animate);
     } else {
-      containerRef.current.style.backgroundColor = 'unset';
+      messageContentRef.current.style.backgroundColor = 'unset';
     }
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -311,7 +311,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     isPresentationUpload?: boolean;
     component: React.ReactNode;
     avatarIcon?: string;
-    isSystemSender?: boolean;
+    isSystemSender: boolean;
     showAvatar: boolean;
     showHeading: boolean;
     showToolbar: boolean;
@@ -329,6 +329,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           showAvatar: true,
           showHeading: true,
           showToolbar: false,
+          isSystemSender: true,
         };
       case ChatMessageType.PRESENTATION:
         return {
@@ -336,6 +337,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           color: '#0F70D7',
           isModerator: false,
           isPresentationUpload: true,
+          isSystemSender: true,
           component: (
             <ChatMessagePresentationContent
               metadata={message.messageMetadata}
@@ -532,6 +534,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           ref={messageContentRef}
           sameSender={message?.user ? sameSender : false}
           isCustomPluginMessage={isCustomPluginMessage}
+          $isSystemSender={messageContent.isSystemSender}
           data-chat-message-id={message?.messageId}
           $highlight={hasToolbar && messageContent.showToolbar && !deleteTime}
           $editing={editing}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -104,7 +104,7 @@ function isInViewport(el: HTMLDivElement) {
 
 const messageRef = React.createRef<HTMLDivElement>();
 
-const ANIMATION_DURATION = 2000;
+const ANIMATION_DURATION = 1000;
 const SCROLL_ANIMATION_DURATION = 500;
 
 const ChatMesssage: React.FC<ChatMessageProps> = ({

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/component.tsx
@@ -23,14 +23,27 @@ interface ChatMessageReactionsProps {
   reactions: {
     createdAt: string;
     reactionEmoji: string;
+    reactionEmojiId: string;
     user: {
       name: string;
       userId: string;
     };
   }[];
-  sendReaction(reactionEmoji: string): void;
-  deleteReaction(reactionEmoji: string): void;
+  sendReaction(reactionEmoji: string, reactionEmojiId: string): void;
+  deleteReaction(reactionEmoji: string, reactionEmojiId: string): void;
 }
+
+type ReactionItem = {
+  count: number;
+  userNames: string[];
+  reactedByMe: boolean;
+  reactionEmoji: string;
+  reactionEmojiId: string;
+  leastRecent: number;
+}
+
+const sortByCount = (r1: ReactionItem, r2: ReactionItem) => r2.count - r1.count;
+const sortByLeastRecent = (r1: ReactionItem, r2: ReactionItem) => r1.leastRecent - r2.leastRecent;
 
 const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
   const { reactions, sendReaction, deleteReaction } = props;
@@ -40,29 +53,36 @@ const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
 
   if (reactions.length === 0) return null;
 
-  const reactionItems: Record<string, { count: number; userNames: string[]; reactedByMe: boolean }> = {};
+  const reactionItems: Record<
+    string,
+    ReactionItem
+  > = {};
 
   reactions.forEach((reaction) => {
-    if (!reactionItems[reaction.reactionEmoji]) {
-      reactionItems[reaction.reactionEmoji] = {
-        count: 0,
-        userNames: [],
-        reactedByMe: false,
+    if (!reactionItems[reaction.reactionEmojiId]) {
+      const reactedByMe = reaction.user.userId === currentUser?.userId;
+      reactionItems[reaction.reactionEmojiId] = {
+        count: 1,
+        userNames: reactedByMe ? [] : [reaction.user.name],
+        reactedByMe,
+        reactionEmoji: reaction.reactionEmoji,
+        reactionEmojiId: reaction.reactionEmojiId,
+        leastRecent: new Date(reaction.createdAt).getTime(),
       };
+      return;
     }
 
-    reactionItems[reaction.reactionEmoji].count += 1;
+    reactionItems[reaction.reactionEmojiId].count += 1;
     if (reaction.user.userId === currentUser?.userId) {
-      reactionItems[reaction.reactionEmoji].reactedByMe = true;
+      reactionItems[reaction.reactionEmojiId].reactedByMe = true;
     } else {
-      reactionItems[reaction.reactionEmoji].userNames.push(reaction.user.name);
+      reactionItems[reaction.reactionEmojiId].userNames.push(reaction.user.name);
     }
   });
 
   return (
     <Styled.ReactionsWrapper>
-      {Object.keys(reactionItems).map((emoji) => {
-        const details = reactionItems[emoji];
+      {Object.values(reactionItems).sort(sortByLeastRecent).sort(sortByCount).map((details) => {
         let label = intl.formatMessage(intlMessages.reactedBy);
         if (details.userNames.length) {
           const users = details.userNames.join(', ');
@@ -81,18 +101,21 @@ const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
               highlighted={details.reactedByMe}
               onClick={() => {
                 if (details.reactedByMe) {
-                  deleteReaction(emoji);
+                  deleteReaction(details.reactionEmoji, details.reactionEmojiId);
                 } else {
-                  sendReaction(emoji);
+                  sendReaction(details.reactionEmoji, details.reactionEmojiId);
                 }
               }}
             >
-              {/* @ts-ignore */}
               <em-emoji
                 size={parseFloat(
                   window.getComputedStyle(document.documentElement).fontSize,
                 )}
-                native={emoji}
+                emoji={{
+                  id: details.reactionEmojiId,
+                  native: details.reactionEmoji,
+                }}
+                native={details.reactionEmoji}
               />
               <span>{details.count}</span>
             </Styled.EmojiWrapper>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/styles.ts
@@ -36,6 +36,7 @@ const ReactionsWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
+  user-select: none;
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -3,7 +3,6 @@ import { defineMessages, useIntl } from 'react-intl';
 import Styled, { DeleteMessage } from './styles';
 import Storage from '/imports/ui/services/storage/in-memory';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
-import ChatMessageTextContent from '../message-content/text-content/component';
 
 const intlMessages = defineMessages({
   deleteMessage: {
@@ -25,6 +24,7 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
   } = props;
 
   const intl = useIntl();
+  const messageChunks = message.split('\n');
 
   return (
     <Styled.Container
@@ -42,11 +42,9 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
     >
       {!deletedByUser && (
         <Styled.Message>
-          <ChatMessageTextContent
-            text={message}
-            emphasizedMessage={emphasizedMessage}
-            dataTest={null}
-          />
+          <Styled.Markdown $emphasizedMessage={emphasizedMessage}>
+            {messageChunks[0]}
+          </Styled.Markdown>
         </Styled.Message>
       )}
       {deletedByUser && (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -28,7 +28,8 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
 
   return (
     <Styled.Container
-      onClick={() => {
+      onClick={(e) => {
+        e.preventDefault();
         window.dispatchEvent(
           new CustomEvent(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, {
             detail: {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/styles.tsx
@@ -1,16 +1,17 @@
 import styled from 'styled-components';
 import {
-  colorGrayLightest, colorPrimary, colorText,
-  colorWhite,
+  colorGrayLight,
+  colorGrayLightest, colorPrimary, colorText, colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { $3xlPadding, lgPadding } from '/imports/ui/stylesheets/styled-components/general';
+import { $3xlPadding, smPadding } from '/imports/ui/stylesheets/styled-components/general';
+import ReactMarkdown from 'react-markdown';
 
 const Container = styled.div`
   border-top-left-radius: 0.5rem;
   border-top-right-radius: 0.5rem;
   background-color: ${colorWhite};
   box-shadow: inset 0 0 0 1px ${colorGrayLightest};
-  padding: ${lgPadding} ${$3xlPadding};
+  padding: ${smPadding} ${$3xlPadding};
   position: relative;
   overflow: hidden;
   cursor: pointer;
@@ -24,34 +25,49 @@ const Container = styled.div`
   }
 `;
 
-const Typography = styled.div`
-  overflow: hidden;
-`;
-
-const Username = styled(Typography)`
-  font-weight: bold;
-  color: ${colorPrimary};
-  line-height: 1rem;
-  font-size: 1rem;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-`;
-
-const Message = styled(Typography)`
-  max-height: 1rem;
-  line-height: 1rem;
+const Message = styled.div`
+  line-height: normal;
   overflow: hidden;
 `;
 
 export const DeleteMessage = styled.span`
-  font-style: italic;
-  font-weight: bold;
+  color: ${colorGrayLight};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const Markdown = styled(ReactMarkdown)<{
+  $emphasizedMessage: boolean;
+}>`
   color: ${colorText};
+
+  ${({ $emphasizedMessage }) => $emphasizedMessage && `
+    font-weight: bold;
+  `}
+
+  & img {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  & p {
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  & code {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 export default {
   Container,
-  Username,
   Message,
   DeleteMessage,
+  Markdown,
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -142,7 +142,7 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
                 e.stopPropagation();
                 onReactionPopoverOpenChange(true);
               }}
-              icon="happy"
+              svgIcon="reactions"
               color="light"
               data-test="reactionsPickerButton"
               ref={setReactionsAnchor}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/emoji-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/emoji-button/component.tsx
@@ -1,18 +1,27 @@
 import React from 'react';
 import Styled from './styles';
 import Icon from '/imports/ui/components/common/icon/component';
+import SvgIcon from '/imports/ui/components/common/icon-svg/component';
 
 interface EmojiButtonProps extends React.ComponentProps<'button'> {
-  icon: string;
+  icon?: string;
+  svgIcon?: string;
 }
 
 const EmojiButton = React.forwardRef<HTMLButtonElement, EmojiButtonProps>((props, ref) => {
   const {
     icon,
+    svgIcon,
     ...buttonProps
   } = props;
 
-  const IconComponent = (<Icon iconName={icon} />);
+  let IconComponent: React.ReactNode = null;
+
+  if (icon) {
+    IconComponent = (<Icon iconName={icon} />);
+  } else if (svgIcon) {
+    IconComponent = (<SvgIcon iconName={svgIcon} />);
+  }
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/emoji-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/emoji-button/styles.ts
@@ -27,6 +27,12 @@ const EmojiButton = styled.button`
     width: 100%;
     height: 100%;
   }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    vertical-align: middle;
+  }
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/mutations.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/mutations.ts
@@ -13,14 +13,24 @@ const CHAT_DELETE_MESSAGE_MUTATION = gql`
 `;
 
 const CHAT_SEND_REACTION_MUTATION = gql`
-  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!) {
-    chatSendMessageReaction(chatId: $chatId, messageId: $messageId, reactionEmoji: $reactionEmoji)
+  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!, $reactionEmojiId: String!) {
+    chatSendMessageReaction(
+      chatId: $chatId,
+      messageId: $messageId,
+      reactionEmoji: $reactionEmoji,
+      reactionEmojiId: $reactionEmojiId
+    )
   }
 `;
 
 const CHAT_DELETE_REACTION_MUTATION = gql`
-  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!) {
-    chatDeleteMessageReaction(chatId: $chatId, messageId: $messageId, reactionEmoji: $reactionEmoji)
+  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!, $reactionEmojiId: String!) {
+    chatDeleteMessageReaction(
+      chatId: $chatId,
+      messageId: $messageId,
+      reactionEmoji: $reactionEmoji,
+      reactionEmojiId: $reactionEmojiId
+    )
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -35,6 +35,7 @@ interface ChatWrapperProps {
 interface ChatContentProps {
   sameSender: boolean;
   isCustomPluginMessage: boolean;
+  $isSystemSender: boolean;
   $editing: boolean;
   $highlight: boolean;
   $reactionPopoverIsOpen: boolean;
@@ -87,9 +88,11 @@ export const ChatContent = styled.div<ChatContentProps>`
   width: 100%;
   border-radius: 0.5rem;
 
-  ${({ $highlight }) => $highlight && `
+  ${({ $isSystemSender }) => !$isSystemSender && `
     background-color: #f4f6fa;
+  `}
 
+  ${({ $highlight }) => $highlight && `
     .chat-message-wrapper:hover > & {
       background-color: ${colorBlueLightest} !important;
     }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -91,7 +91,7 @@ export const ChatContent = styled.div<ChatContentProps>`
     background-color: #f4f6fa;
 
     .chat-message-wrapper:hover > & {
-      background-color: ${colorBlueLightest};
+      background-color: ${colorBlueLightest} !important;
     }
   `}
 
@@ -99,7 +99,7 @@ export const ChatContent = styled.div<ChatContentProps>`
     $editing, $reactionPopoverIsOpen, $focused, $keyboardFocused,
   }) => ($reactionPopoverIsOpen || $editing || $focused || $keyboardFocused)
     && `
-    background-color: ${colorBlueLightest};
+    background-color: ${colorBlueLightest} !important;
   `}
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -103,6 +103,13 @@ export const ChatContent = styled.div<ChatContentProps>`
   `}
 `;
 
+export const ChatContentFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  padding: 0 ${lgPadding} ${lgPadding};
+`;
+
 export const ChatHeader = styled(Header)`
   ${({ isRTL }) => isRTL && `
     padding-left: ${smPaddingX};
@@ -202,14 +209,10 @@ export const Container = styled.div<{ $sequence: number }>`
   }
 `;
 
-export const MessageItemWrapper = styled.div<{ $edited: boolean, $sameSender: boolean }>`
+export const MessageItemWrapper = styled.div`
   display: flex;
   flex-direction: row;
   padding: ${lgPadding} ${$3xlPadding};
-
-  ${({ $edited, $sameSender }) => $edited && $sameSender && `
-    padding-bottom: 0;
-  `}
 `;
 
 export const DeleteMessage = styled.span`
@@ -227,12 +230,7 @@ export const EditLabel = styled.span`
   color: ${colorGrayLight};
   font-size: 75%;
   display: flex;
-  justify-content: flex-end;
   align-items: center;
-  gap: 2px;
-`;
-
-export const EditLabelWrapper = styled.div`
+  gap: 0.125rem;
   line-height: 1;
-  padding: ${xlPadding};
 `;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -113,7 +113,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
     const handleFocusMessageRequest = (e: Event) => {
       if (e instanceof CustomEvent) {
         if (e.detail.sequence) {
-          if ((e.detail.sequence / PAGE_SIZE) < firstPageToLoad) {
+          if (Math.ceil(e.detail.sequence / PAGE_SIZE) < firstPageToLoad) {
             return;
           }
           messageRefs.current[Number.parseInt(e.detail.sequence, 10)]?.requestFocus();

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useState,
   memo,
+  useRef,
 } from 'react';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import { UpdatedEventDetailsForChatMessageDomElements } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/chat/message/types';
@@ -14,12 +15,15 @@ import {
   CHAT_MESSAGE_PRIVATE_SUBSCRIPTION,
 } from './queries';
 import { Message } from '/imports/ui/Types/message';
-import ChatMessage from './chat-message/component';
+import ChatMessage, { ChatMessageRef } from './chat-message/component';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 import { setLoadedMessageGathering } from '/imports/ui/core/hooks/useLoadedChatMessages';
 import { ChatLoading } from '../../component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
+import { useStorageKey, STORAGES } from '/imports/ui/services/storage/hooks';
+
+const PAGE_SIZE = 50;
 
 interface ChatListPageContainerProps {
   page: number;
@@ -30,6 +34,7 @@ interface ChatListPageContainerProps {
   markMessageAsSeen: (message: Message) => void;
   scrollRef: React.RefObject<HTMLDivElement>;
   focusedId: number | null;
+  firstPageToLoad: number;
 }
 
 interface ChatListPageProps {
@@ -40,6 +45,7 @@ interface ChatListPageProps {
   markMessageAsSeen: (message: Message)=> void;
   scrollRef: React.RefObject<HTMLDivElement>;
   focusedId: number | null;
+  firstPageToLoad: number;
 }
 
 const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPageProps) => {
@@ -66,8 +72,13 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   markMessageAsSeen,
   scrollRef,
   focusedId,
+  firstPageToLoad,
 }) => {
   const { domElementManipulationIdentifiers } = useContext(PluginsContext);
+  const messageRefs = useRef<Record<number, ChatMessageRef | null>>({});
+  const chatFocusMessageRequest = useStorageKey(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, STORAGES.IN_MEMORY);
+  const [keyboardFocusedMessageSequence, setKeyboardFocusedMessageSequence] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   const [messagesRequestedFromPlugin, setMessagesRequestedFromPlugin] = useState<
     UpdatedEventDetailsForChatMessageDomElements[]>([]);
@@ -86,7 +97,6 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
     );
   }, [domElementManipulationIdentifiers, messagesRequestedFromPlugin]);
 
-  const [keyboardFocusedMessageSequence, setKeyboardFocusedMessageSequence] = useState<number | null>(null);
   useEffect(() => {
     const handleKeyboardFocusMessageRequest = (e: Event) => {
       if (e instanceof CustomEvent) {
@@ -100,13 +110,46 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
       }
     };
 
+    const handleFocusMessageRequest = (e: Event) => {
+      if (e instanceof CustomEvent) {
+        if (e.detail.sequence) {
+          if ((e.detail.sequence / PAGE_SIZE) < firstPageToLoad) return;
+          messageRefs.current[Number.parseInt(e.detail.sequence, 10)]?.requestFocus();
+        }
+      }
+    };
+
+    const handleChatEditRequest = (e: Event) => {
+      if (e instanceof CustomEvent) {
+        setEditingId(e.detail.messageId);
+      }
+    };
+
+    const handleCancelChatEditRequest = (e: Event) => {
+      if (e instanceof CustomEvent) {
+        setEditingId(null);
+      }
+    };
+
     window.addEventListener(ChatEvents.CHAT_KEYBOARD_FOCUS_MESSAGE_REQUEST, handleKeyboardFocusMessageRequest);
     window.addEventListener(ChatEvents.CHAT_KEYBOARD_FOCUS_MESSAGE_CANCEL, handleKeyboardFocusMessageCancel);
+    window.addEventListener(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, handleFocusMessageRequest);
+    window.addEventListener(ChatEvents.CHAT_EDIT_REQUEST, handleChatEditRequest);
+    window.addEventListener(ChatEvents.CHAT_CANCEL_EDIT_REQUEST, handleCancelChatEditRequest);
 
     return () => {
       window.removeEventListener(ChatEvents.CHAT_KEYBOARD_FOCUS_MESSAGE_REQUEST, handleKeyboardFocusMessageRequest);
       window.removeEventListener(ChatEvents.CHAT_KEYBOARD_FOCUS_MESSAGE_CANCEL, handleKeyboardFocusMessageCancel);
+      window.removeEventListener(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, handleFocusMessageRequest);
+      window.removeEventListener(ChatEvents.CHAT_EDIT_REQUEST, handleChatEditRequest);
+      window.removeEventListener(ChatEvents.CHAT_CANCEL_EDIT_REQUEST, handleCancelChatEditRequest);
     };
+  }, [firstPageToLoad]);
+
+  useEffect(() => {
+    if (typeof chatFocusMessageRequest === 'number') {
+      messageRefs.current[chatFocusMessageRequest]?.requestFocus();
+    }
   }, []);
 
   return (
@@ -127,6 +170,10 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             messageReadFeedbackEnabled={messageReadFeedbackEnabled}
             focused={focusedId === message.messageSequence}
             keyboardFocused={keyboardFocusedMessageSequence === message.messageSequence}
+            editing={editingId === message.messageId}
+            ref={(ref) => {
+              messageRefs.current[message.messageSequence] = ref;
+            }}
           />
         );
       })}
@@ -145,6 +192,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   markMessageAsSeen,
   scrollRef,
   focusedId,
+  firstPageToLoad,
 }) => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_KEY = CHAT_CONFIG.public_group_id;
@@ -186,6 +234,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       markMessageAsSeen={markMessageAsSeen}
       scrollRef={scrollRef}
       focusedId={focusedId}
+      firstPageToLoad={firstPageToLoad}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -113,7 +113,9 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
     const handleFocusMessageRequest = (e: Event) => {
       if (e instanceof CustomEvent) {
         if (e.detail.sequence) {
-          if ((e.detail.sequence / PAGE_SIZE) < firstPageToLoad) return;
+          if ((e.detail.sequence / PAGE_SIZE) < firstPageToLoad) {
+            return;
+          }
           messageRefs.current[Number.parseInt(e.detail.sequence, 10)]?.requestFocus();
         }
       }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
@@ -25,9 +25,10 @@ export const CHAT_MESSAGE_PUBLIC_SUBSCRIPTION = gql`
           color
         }
       }
-      reactions {
+      reactions(order_by: { createdAt: asc }) {
         createdAt
         reactionEmoji
+        reactionEmojiId
         user {
           name
           userId

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -47,40 +47,42 @@ const ChatReplyIntention = () => {
   const hidden = !username || !message;
 
   return (
-    <Styled.Container
-      $hidden={hidden}
-      $animations={animations}
-      onClick={() => {
-        window.dispatchEvent(
-          new CustomEvent(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, {
-            detail: {
-              sequence,
-            },
-          }),
-        );
-        Storage.removeItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST);
-        if (sequence) Storage.setItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, sequence);
-      }}
-    >
-      <Styled.Message>
-        <ChatMessageTextContent
-          text={message || ''}
-          emphasizedMessage={!!emphasizedMessage}
-          dataTest={null}
-        />
-      </Styled.Message>
-      <Styled.CloseBtn
-        onClick={(e) => {
-          e.stopPropagation();
+    <Styled.Root>
+      <Styled.Container
+        $hidden={hidden}
+        $animations={animations}
+        onClick={() => {
           window.dispatchEvent(
-            new CustomEvent(ChatEvents.CHAT_CANCEL_REPLY_INTENTION),
+            new CustomEvent(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, {
+              detail: {
+                sequence,
+              },
+            }),
           );
+          Storage.removeItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST);
+          if (sequence) Storage.setItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, sequence);
         }}
-        icon="close"
-        tabIndex={hidden ? -1 : 0}
-        aria-hidden={hidden}
-      />
-    </Styled.Container>
+      >
+        <Styled.Message>
+          <ChatMessageTextContent
+            text={message || ''}
+            emphasizedMessage={!!emphasizedMessage}
+            dataTest={null}
+          />
+        </Styled.Message>
+        <Styled.CloseBtn
+          onClick={(e) => {
+            e.stopPropagation();
+            window.dispatchEvent(
+              new CustomEvent(ChatEvents.CHAT_CANCEL_REPLY_INTENTION),
+            );
+          }}
+          icon="close"
+          tabIndex={hidden ? -1 : 0}
+          aria-hidden={hidden}
+        />
+      </Styled.Container>
+    </Styled.Root>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -3,7 +3,6 @@ import Styled from './styles';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
-import ChatMessageTextContent from '../chat-message-list/page/chat-message/message-content/text-content/component';
 import Storage from '/imports/ui/services/storage/in-memory';
 
 const ChatReplyIntention = () => {
@@ -45,44 +44,43 @@ const ChatReplyIntention = () => {
   };
 
   const hidden = !username || !message;
+  const messageChunks = message ? message.split('\n') : null;
 
   return (
-    <Styled.Root>
-      <Styled.Container
-        $hidden={hidden}
-        $animations={animations}
-        onClick={() => {
+    <Styled.Container
+      $hidden={hidden}
+      $animations={animations}
+      onClick={() => {
+        window.dispatchEvent(
+          new CustomEvent(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, {
+            detail: {
+              sequence,
+            },
+          }),
+        );
+        Storage.removeItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST);
+        if (sequence) Storage.setItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, sequence);
+      }}
+    >
+      <Styled.Message>
+        <Styled.Markdown
+          $emphasizedMessage={!!emphasizedMessage}
+        >
+          {messageChunks ? messageChunks[0] : ''}
+        </Styled.Markdown>
+      </Styled.Message>
+      <Styled.CloseBtn
+        onClick={(e) => {
+          e.stopPropagation();
           window.dispatchEvent(
-            new CustomEvent(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, {
-              detail: {
-                sequence,
-              },
-            }),
+            new CustomEvent(ChatEvents.CHAT_CANCEL_REPLY_INTENTION),
           );
-          Storage.removeItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST);
-          if (sequence) Storage.setItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, sequence);
         }}
-      >
-        <Styled.Message>
-          <ChatMessageTextContent
-            text={message || ''}
-            emphasizedMessage={!!emphasizedMessage}
-            dataTest={null}
-          />
-        </Styled.Message>
-        <Styled.CloseBtn
-          onClick={(e) => {
-            e.stopPropagation();
-            window.dispatchEvent(
-              new CustomEvent(ChatEvents.CHAT_CANCEL_REPLY_INTENTION),
-            );
-          }}
-          icon="close"
-          tabIndex={hidden ? -1 : 0}
-          aria-hidden={hidden}
-        />
-      </Styled.Container>
-    </Styled.Root>
+        icon="close"
+        tabIndex={hidden ? -1 : 0}
+        aria-hidden={hidden}
+      />
+    </Styled.Container>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
@@ -1,7 +1,9 @@
 import styled, { css } from 'styled-components';
+import ReactMarkdown from 'react-markdown';
 import {
   colorGrayLightest,
   colorPrimary,
+  colorText,
   colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
@@ -12,14 +14,10 @@ import EmojiButton from '../chat-message-list/page/chat-message/message-toolbar/
 const Container = styled.div<{ $hidden: boolean; $animations: boolean }>`
   border-radius: 0.375rem;
   background-color: ${colorWhite};
-  position: absolute;
-  right: 0;
-  left: 0;
-  bottom: 100%;
-  z-index: 10;
-  overflow: hidden;
   box-shadow: inset 0 0 0 1px ${colorGrayLightest};
   display: flex;
+  align-items: center;
+  overflow: hidden;
 
   [dir='ltr'] & {
     border-right: 0.375rem solid ${colorPrimary};
@@ -35,8 +33,8 @@ const Container = styled.div<{ $hidden: boolean; $animations: boolean }>`
         min-height: 0;
       `
     : css`
-        min-height: calc(1rem + ${mdPadding} * 2);
-        height: calc(1rem + ${mdPadding} * 2);
+        min-height: calc(1rlh + ${mdPadding} * 2);
+        height: calc(1rlh + ${mdPadding} * 2);
         padding: ${mdPadding} calc(${smPaddingX} * 1.25);
         margin-bottom: ${smPadding};
 
@@ -57,20 +55,39 @@ const Container = styled.div<{ $hidden: boolean; $animations: boolean }>`
     `}
 `;
 
-const Typography = styled.div`
-  line-height: 1;
-  font-size: 1rem;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
+const Message = styled.div`
+  line-height: 1rlh;
+  flex-grow: 1;
 `;
 
-const Message = styled(Typography)`
-  font-size: 1rem;
-  line-height: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  flex-grow: 1;
+const Markdown = styled(ReactMarkdown)<{
+  $emphasizedMessage: boolean;
+}>`
+  color: ${colorText};
+
+  ${({ $emphasizedMessage }) => $emphasizedMessage && `
+    font-weight: bold;
+  `}
+
+  & img {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  & p {
+    line-height: 1rlh;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  & code {
+    line-height: 1rlh;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 const CloseBtn = styled(EmojiButton)`
@@ -79,13 +96,9 @@ const CloseBtn = styled(EmojiButton)`
   padding: 0;
 `;
 
-const Root = styled.div`
-  position: relative;
-`;
-
 export default {
   Container,
   CloseBtn,
   Message,
-  Root,
+  Markdown,
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
@@ -12,7 +12,11 @@ import EmojiButton from '../chat-message-list/page/chat-message/message-toolbar/
 const Container = styled.div<{ $hidden: boolean; $animations: boolean }>`
   border-radius: 0.375rem;
   background-color: ${colorWhite};
-  position: relative;
+  position: absolute;
+  right: 0;
+  left: 0;
+  bottom: 100%;
+  z-index: 10;
   overflow: hidden;
   box-shadow: inset 0 0 0 1px ${colorGrayLightest};
   display: flex;
@@ -75,8 +79,13 @@ const CloseBtn = styled(EmojiButton)`
   padding: 0;
 `;
 
+const Root = styled.div`
+  position: relative;
+`;
+
 export default {
   Container,
   CloseBtn,
   Message,
+  Root,
 };

--- a/bigbluebutton-html5/imports/ui/hooks/useStickyScroll.ts
+++ b/bigbluebutton-html5/imports/ui/hooks/useStickyScroll.ts
@@ -7,8 +7,12 @@ interface Handlers {
   stopObserving(): void;
 }
 
-const useStickyScroll = (stickyElement: HTMLElement | null, onResizeOf: HTMLElement | null) => {
-  const elHeight = useRef(0);
+const useStickyScroll = (
+  stickyElement: HTMLElement | null,
+  onResizeOf: HTMLElement | null,
+  operator: 'ne' | 'gt' = 'gt',
+) => {
+  const elHeight = useRef(stickyElement?.offsetHeight ?? 0);
   const timeout = useRef<ReturnType<typeof setTimeout>>();
   const observer = useRef<ResizeObserver | null>(null);
   const handlers = useRef<Handlers>({
@@ -25,14 +29,24 @@ const useStickyScroll = (stickyElement: HTMLElement | null, onResizeOf: HTMLElem
       entries.forEach((entry) => {
         const { target } = entry;
         if (target instanceof HTMLElement) {
-          if (target.offsetHeight !== elHeight.current) {
+          let elementHeightChanged = false;
+          switch (operator) {
+            case 'ne': {
+              elementHeightChanged = target.offsetHeight !== elHeight.current;
+              break;
+            }
+            case 'gt':
+            default: {
+              elementHeightChanged = target.offsetHeight > elHeight.current;
+              break;
+            }
+          }
+          if (elementHeightChanged) {
             elHeight.current = target.offsetHeight;
             if (stickyElement) {
               // eslint-disable-next-line no-param-reassign
               stickyElement.scrollTop = stickyElement.scrollHeight + stickyElement.clientHeight;
             }
-          } else {
-            elHeight.current = 0;
           }
         }
       });

--- a/bigbluebutton-html5/imports/ui/hooks/useStickyScroll.ts
+++ b/bigbluebutton-html5/imports/ui/hooks/useStickyScroll.ts
@@ -51,20 +51,20 @@ const useStickyScroll = (
         }
       });
     });
-  }, [stickyElement]);
+  }, [stickyElement, operator]);
 
   handlers.current.startObserving = useCallback(() => {
     if (!onResizeOf) return;
     clearTimeout(timeout.current);
     observer.current?.observe(onResizeOf);
-  }, [onResizeOf, observer.current]);
+  }, [onResizeOf]);
 
   handlers.current.stopObserving = useCallback(() => {
     if (!onResizeOf) return;
     timeout.current = setTimeout(() => {
       observer.current?.unobserve(onResizeOf);
     }, 500);
-  }, [onResizeOf, observer.current]);
+  }, [onResizeOf]);
 
   useEffect(
     () => () => {

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -13,6 +13,7 @@ const colorBlueLight = 'var(--color-blue-light, #54a1f3)';
 const colorBlueLighter = 'var(--color-blue-lighter, #92BCEA)';
 const colorBlueLightest = 'var(--color-blue-lightest, #E4ECF2)';
 const colorBlueLightestChannel = '228 236 242';
+const colorBlueLighterChannel = '146 188 234';
 
 const colorTransparent = 'var(--color-transparent, #ff000000)';
 
@@ -137,6 +138,7 @@ export {
   colorBlueLighter,
   colorBlueLightest,
   colorBlueLightestChannel,
+  colorBlueLighterChannel,
   colorPrimary,
   colorDanger,
   colorDangerDark,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -770,7 +770,7 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: ['reply', 'edit', 'delete', 'reactions']
+    toolbar: []
   userReaction:
     enabled: true
     expire: 30

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -770,7 +770,7 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: []
+    toolbar: ['reply', 'edit', 'delete', 'reactions']
   userReaction:
     enabled: true
     expire: 30


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR includes several chat improvements related to the new chat features (reply, reactions, edit, delete) and the new design.

- Reply preview and replied message now occupy just one line.
- Uses the reactions icon for the reaction button.
- Disables selection of reactions.
- Fixes replied message reference not updating when the replied message is deleted.
- Fixes moderators not being able to delete other user messages.
- Fixes scroll animation overriding message background color.
- Smothen scroll animation.
- Starts message background animation just after scroll animation.
- Changes scroll animation to 1 second.
- Sorts reactions by least recent and then by count.
- Displays message time for all messages.
- Fixes moderators not being able to react to a message if public chat is locked for viewers.
- Fixes moderators not being able to delete a message if public chat is locked for viewers.

![Screenshot from 2024-10-18 14-17-32](https://github.com/user-attachments/assets/35b87e73-2550-4025-a1aa-20fdd315fdf7)

![Screenshot from 2024-10-18 14-17-17](https://github.com/user-attachments/assets/7eafad7f-8841-4cae-b2b5-bb9b2bc2ca62)

![Screenshot from 2024-10-18 14-19-59](https://github.com/user-attachments/assets/a78daccd-85b8-4034-84c6-47da4d6ecf59)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes n/a