### PR TITLE
fix(audio): clear input device IDs if getUserMedia fails, +

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -362,7 +362,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
 
       const handleInitError = (_error) => {
         mapErrorCode(_error);
-        if (RETRYABLE_ERRORS.includes(_error?.errorCode)
+        if (!RETRYABLE_ERRORS.includes(_error?.errorCode)
           || !RETRY_THROUGH_RELAY
           || this.reconnecting) {
           reject(_error);

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -16,6 +16,8 @@ import {
   storeAudioInputDeviceId,
   getStoredAudioOutputDeviceId,
   storeAudioOutputDeviceId,
+  getAudioConstraints,
+  doGUM,
 } from '/imports/api/audio/client/bridge/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import { makeVar } from '@apollo/client';
@@ -335,8 +337,6 @@ class AudioManager {
   }
 
   joinMicrophone() {
-    this.audioJoinStartTime = new Date();
-    this.logAudioJoinTime = false;
     this.isListenOnly = false;
     this.isEchoTest = false;
 
@@ -354,8 +354,6 @@ class AudioManager {
   }
 
   joinEchoTest() {
-    this.audioJoinStartTime = new Date();
-    this.logAudioJoinTime = false;
     this.isListenOnly = false;
     this.isEchoTest = true;
 
@@ -390,62 +388,76 @@ class AudioManager {
       });
   }
 
-  joinAudio(callOptions, callStateCallback) {
-    return this.bridge
-      .joinAudio(callOptions, callStateCallback.bind(this))
-      .catch((error) => {
-        const { name, message } = error;
-        const errorPayload = {
-          type: 'MEDIA_ERROR',
-          errMessage: message || 'MEDIA_ERROR',
-          errCode: AudioErrors.MIC_ERROR.UNKNOWN,
-        };
+  async joinAudio(callOptions, callStateCallback) {
+    try {
+      // If there's no input stream, we need to get one via getUserMedia
+      if (callOptions?.inputStream == null
+        && !this.shouldBypassGUM()
+        && !callOptions.isListenOnly) {
+        const constraints = getAudioConstraints({ deviceId: this?.bridge?.inputDeviceId });
+        this.inputStream = await doGUM({ audio: constraints });
+        // eslint-disable-next-line no-param-reassign
+        callOptions.inputStream = this.inputStream;
+      }
 
-        switch (name) {
-          case 'NotAllowedError':
-            errorPayload.errCode = AudioErrors.MIC_ERROR.NO_PERMISSION;
-            logger.error({
-                logCode: 'audiomanager_error_getting_device',
-                extraInfo: {
-                  errorName: error.name,
-                  errorMessage: error.message,
-                },
-              },
-              `Error getting microphone - {${error.name}: ${error.message}}`,
-            );
-            break;
-          case 'NotFoundError':
-            errorPayload.errCode = AudioErrors.MIC_ERROR.DEVICE_NOT_FOUND;
-            logger.error({
-                logCode: 'audiomanager_error_device_not_found',
-                extraInfo: {
-                  errorName: error.name,
-                  errorMessage: error.message,
-                },
-              },
-              `Error getting microphone - {${error.name}: ${error.message}}`,
-            );
-            break;
-          default:
-            logger.error({
-              logCode: 'audiomanager_error_unknown',
-              extraInfo: {
-                errorName: error.name,
-                errorMessage: error.message,
-              },
-            }, `Error enabling audio - {${name}: ${message}}`);
-            break;
-        }
+      // Start tracking audio join time here to avoid counting time spent on
+      // getUserMedia prompts. We're primarily focused on negotiation times here.
+      // We're only concerned with gUM timeouts - and it'll throw an error which
+      // is logged accordingly whenever it times out.
+      this.audioJoinStartTime = new Date();
+      this.logAudioJoinTime = false;
 
-        this.isConnecting = false;
+      await this.bridge.joinAudio(callOptions, callStateCallback.bind(this));
+    } catch (error) {
+      // Reset audio join time tracking if an error occurs
+      this.audioJoinStartTime = null;
+      this.logAudioJoinTime = false;
+      const { name, message } = error;
+      const errorPayload = {
+        type: 'MEDIA_ERROR',
+        errMessage: message || 'MEDIA_ERROR',
+        errCode: AudioErrors.MIC_ERROR.UNKNOWN,
+      };
 
-        throw errorPayload;
-      });
+      switch (name) {
+        case 'NotAllowedError':
+          errorPayload.errCode = AudioErrors.MIC_ERROR.NO_PERMISSION;
+          logger.error({
+            logCode: 'audiomanager_error_getting_device',
+            extraInfo: {
+              errorName: error.name,
+              errorMessage: error.message,
+            },
+          }, `Error getting microphone - {${error.name}: ${error.message}}`);
+          break;
+        case 'NotFoundError':
+          errorPayload.errCode = AudioErrors.MIC_ERROR.DEVICE_NOT_FOUND;
+          logger.error({
+            logCode: 'audiomanager_error_device_not_found',
+            extraInfo: {
+              errorName: error.name,
+              errorMessage: error.message,
+            },
+          }, `Error getting microphone - {${error.name}: ${error.message}}`);
+          break;
+        default:
+          logger.error({
+            logCode: 'audiomanager_error_unknown',
+            extraInfo: {
+              errorName: error.name,
+              errorMessage: error.message,
+            },
+          }, `Error enabling audio - {${name}: ${message}}`);
+          break;
+      }
+
+      this.isConnecting = false;
+
+      throw errorPayload;
+    }
   }
 
   async joinListenOnly() {
-    this.audioJoinStartTime = new Date();
-    this.logAudioJoinTime = false;
     this.isListenOnly = true;
     this.isEchoTest = false;
 
@@ -532,7 +544,12 @@ class AudioManager {
     this.isConnecting = false;
 
     const STATS = window.meetingClientSettings.public.stats;
-    const secondsToActivateAudio = (new Date() - this.audioJoinStartTime) / 1000;
+    // If we don't have a start time, something went wrong with the tracking code
+    // Log it as 0 seconds to keep things consistent, but 0 should be treated
+    // as an invalid value and be ignored in any log analysis.
+    const secondsToActivateAudio = this.audioJoinStartTime > 0
+      ? (new Date() - this.audioJoinStartTime) / 1000
+      : 0;
 
     if (!this.logAudioJoinTime) {
       this.logAudioJoinTime = true;

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -432,6 +432,8 @@ class AudioManager {
           break;
         case 'NotFoundError':
           errorPayload.errCode = AudioErrors.MIC_ERROR.DEVICE_NOT_FOUND;
+          // Reset the input device ID so the user can select a new one
+          this.changeInputDevice(null);
           logger.error({
             logCode: 'audiomanager_error_device_not_found',
             extraInfo: {


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): check error codes before retrying on start failure](https://github.com/bigbluebutton/bigbluebutton/commit/a07e319e903e8274a122a93c963b1fbb0b238364) 
  - The check for whether an error code is deemed "retryable" in
sfu-audio-bridge's joinAudio code is reversed - which may cause
unwarranted audio retries on join failures.
- [fix(audio): prevent overlapping sessions from gUM-induced timeouts](https://github.com/bigbluebutton/bigbluebutton/commit/d0ad8afe64d119a03b46efe71d61a064178f444e) 
  - `getUserMedia` is called by each audio bridge if it hasn't been
triggered during pre-flight screens. This ties gUM to the bridge's
negotiation timers and audio-manager's activation tracking, leading to
two issues:
    - A gUM prompt left unanswered for over 30 seconds can cause an
    incorrect 1010 (negotiation timeout) audio error.
    - If `retryThroughRelay: true`, and a joinAudio timeout occurs due to an
    unanswered gUM prompt, but the user responds while the system retries
    the connection, it can create overlapping audio sessions, resulting in
    mute state inconsistencies when `muteOnStart: true`.
  - This commit addresses these issues by moving gUM handling to the
audio-manager before any bridge action. This removes gUM from the
negotiation timeout trackers, ensuring that gUM errors are treated as
browser API errors (as expected).
- [fix(audio): clear input device IDs if getUserMedia fails](https://github.com/bigbluebutton/bigbluebutton/commit/c2161b9a14a6a3f0c4633e9cdb20817121e48c4b) 
  - Stored input device IDs are not cleaned up whenever getUserMedia fails
with `NotFoundError` (i.e.: device not found). This causes a couple of
issues whenever skipEchoIfPreviousDevice is enabled:
    - An unnecessary error screen if the user retries audio from scratch
    (it should just go straight to the audio settings modal)
    - A retry loop if no other devices are present in the system

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/21466 (c2161b9a14a6a3f0c4633e9cdb20817121e48c4b)


### How to test

- For c2161b9a14a6a3f0c4633e9cdb20817121e48c4b, follow the steps in #21466
- For the other two:
  1. Enable retryThroughRelay (settings.yml)
  2. Join a meeting via a private browser session
  3. Leave the getUserMedia prompt hanging for more than 30s
  4. Accept the permission request and join audio
