### PR TITLE
fix(whiteboard): Lower min zoom to 25 percent for infinite whiteboard

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -26,8 +26,8 @@ case class PresentationPage(
     current:     Boolean             = false,
     xOffset:     Double              = 0,
     yOffset:     Double              = 0,
-    widthRatio:  Double              = 100D,
-    heightRatio: Double              = 100D,
+    widthRatio:  Double              = 100.0,
+    heightRatio: Double              = 100.0,
     width:       Double              = 1440D,
     height:      Double              = 1080D,
     converted:   Boolean             = false,
@@ -172,11 +172,12 @@ case class PresentationPod(id: String, currentPresenter: String,
   def resizePage(presentationId: String, pageId: String,
                  xOffset: Double, yOffset: Double, widthRatio: Double,
                  heightRatio: Double, slideNumber: Int): Option[(PresentationPod, PresentationPage)] = {
-    // Force coordinate that are out-of-bounds inside valid values
-    // 0.25D is 400% zoom
-    // 100D-checkedWidth is the maximum the page can be moved over
-    val checkedWidth = Math.min(widthRatio, 100D) //if (widthRatio <= 100D) widthRatio else 100D
-    val checkedHeight = Math.min(heightRatio, 100D)
+    val minZoom = 25.0
+    val maxZoom = 400.0
+
+    val checkedWidth = Math.max(minZoom, Math.min(widthRatio, maxZoom))
+    val checkedHeight = Math.max(minZoom, Math.min(heightRatio, maxZoom))
+
     val checkedXOffset = xOffset
     val checkedYOffset = yOffset
 
@@ -191,7 +192,6 @@ case class PresentationPod(id: String, currentPresenter: String,
       (addPresentation(newPres), nPage)
     }
   }
-
 }
 
 case class PresentationPodManager(presentationPods: collection.immutable.Map[String, PresentationPod]) {

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import WhiteboardContainer from '/imports/ui/components/whiteboard/container';
-import { HUNDRED_PERCENT, MAX_PERCENT } from '/imports/utils/slideCalcUtils';
+import { HUNDRED_PERCENT, MAX_PERCENT, MIN_PERCENT } from '/imports/utils/slideCalcUtils';
 import { SPACE } from '/imports/utils/keyCodes';
 import { defineMessages, injectIntl } from 'react-intl';
 import { toast } from 'react-toastify';
@@ -507,9 +507,11 @@ class Presentation extends PureComponent {
   }
 
   zoomChanger(zoom) {
+    const { currentSlide } = this.props;
     let boundZoom = parseInt(zoom);
-    if (boundZoom < HUNDRED_PERCENT) {
-      boundZoom = HUNDRED_PERCENT;
+    const min = currentSlide?.infiniteWhiteboard ? MIN_PERCENT : HUNDRED_PERCENT;
+    if (boundZoom < min) {
+      boundZoom = min;
     } else if (boundZoom > MAX_PERCENT) {
       boundZoom = MAX_PERCENT;
     }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -7,6 +7,7 @@ import Button from '/imports/ui/components/common/button/component';
 import {
   HUNDRED_PERCENT,
   MAX_PERCENT,
+  MIN_PERCENT,
   STEP,
 } from '/imports/utils/slideCalcUtils';
 import {
@@ -132,8 +133,6 @@ class PresentationToolbar extends PureComponent {
       zoom, setIsPanning, fitToWidth, fitToWidthHandler, currentSlideNum,
     } = this.props;
     const { wasFTWActive } = this.state;
-
-    if (zoom <= HUNDRED_PERCENT && zoom !== prevProps.zoom && !fitToWidth) setIsPanning();
 
     if ((prevProps?.currentSlideNum !== currentSlideNum) && (!fitToWidth && wasFTWActive)) {
       setTimeout(() => {
@@ -539,7 +538,7 @@ class PresentationToolbar extends PureComponent {
                 zoomValue={zoom}
                 currentSlideNum={currentSlideNum}
                 change={this.change}
-                minBound={HUNDRED_PERCENT}
+                minBound={isInfiniteWhiteboard ? MIN_PERCENT : HUNDRED_PERCENT}
                 maxBound={MAX_PERCENT}
                 step={STEP}
                 isInfiniteWhiteboard={isInfiniteWhiteboard}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
@@ -1,6 +1,9 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
+import {
+  HUNDRED_PERCENT
+} from '/imports/utils/slideCalcUtils';
 import Styled from './styles';
 import HoldButton from './holdButton/component';
 
@@ -151,6 +154,7 @@ class ZoomTool extends PureComponent {
     const { stateZoomValue } = this.state;
 
     let zoomOutAriaLabel = intl.formatMessage(intlMessages.zoomOutLabel);
+
     if (zoomValue > minBound) {
       zoomOutAriaLabel += ` ${intl.formatNumber(((zoomValue - step) / 100), { style: 'percent' })}`;
     }
@@ -193,7 +197,7 @@ class ZoomTool extends PureComponent {
             <Styled.ResetZoomButton
               aria-label={intl.formatMessage(intlMessages.resetZoomLabel)}
               aria-describedby="resetZoomDescription"
-              disabled={(stateZoomValue === minBound) || !isMeteorConnected}
+              disabled={(stateZoomValue === HUNDRED_PERCENT) || !isMeteorConnected}
               color="light"
               customIcon={stateZoomPct}
               size="md"

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1049,8 +1049,13 @@ const Whiteboard = React.memo((props) => {
           -slideShape.y +
           (viewportHeight - slideShape.props.h * camera.z) / (2 * camera.z);
 
-        const panningOffsetX = camera.x - centeredCameraX;
-        const panningOffsetY = camera.y - centeredCameraY;
+        let panningOffsetX = 0;
+        let panningOffsetY = 0;
+
+        if (zoomValue !== 100) {
+          panningOffsetX = camera.x - centeredCameraX;
+          panningOffsetY = camera.y - centeredCameraY;
+        }
 
         const newCenteredCameraX =
           -slideShape.x +
@@ -1628,7 +1633,7 @@ const Whiteboard = React.memo((props) => {
     >
       <Tldraw
         autoFocus={false}
-        key={`tldrawv2-${presentationId}-${animations}-${isInfiniteWhiteboard}`}
+        key={`tldrawv2-${presentationId}-${animations}`}
         forceMobile
         hideUi={!(hasWBAccessRef.current || isPresenter)}
         onMount={handleTldrawMount}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -526,8 +526,8 @@ const Whiteboard = React.memo((props) => {
           setCamera(baseZoom, adjustedXPos, adjustedYPos);
         } else if (includeViewerLogic) {
           baseZoom = calculateZoomValue(
-            currentPresentationPage.scaledViewBoxWidth,
-            currentPresentationPage.scaledViewBoxHeight,
+            currentPresentationPageRef.current.scaledViewBoxWidth,
+            currentPresentationPageRef.current.scaledViewBoxHeight,
           );
 
           const presenterXOffset = currentPresentationPageRef.current.xOffset;
@@ -535,10 +535,10 @@ const Whiteboard = React.memo((props) => {
 
           const adjustedXPos = isInfiniteWhiteboard
             ? presenterXOffset
-            : currentPresentationPage.xOffset;
+            : currentPresentationPageRef.current.xOffset;
           const adjustedYPos = isInfiniteWhiteboard
             ? presenterYOffset
-            : currentPresentationPage.yOffset;
+            : currentPresentationPageRef.current.yOffset;
 
           setCamera(baseZoom, adjustedXPos, adjustedYPos);
         }
@@ -945,6 +945,7 @@ const Whiteboard = React.memo((props) => {
       setIsMouseDown,
       setIsWheelZoom,
       setWheelZoomTimeout,
+      isInfiniteWhiteboard,
     },
   );
 
@@ -1053,7 +1054,6 @@ const Whiteboard = React.memo((props) => {
         zoomValue !== prevZoomValueRef.current
       ) {
         tlEditor.setCamera(nextCamera, { duration: 175 });
-
         timeoutId = setTimeout(() => {
           if (zoomValue === HUNDRED_PERCENT && !fitToWidthRef.current) {
             zoomChanger(HUNDRED_PERCENT);
@@ -1062,11 +1062,11 @@ const Whiteboard = React.memo((props) => {
             // Recalculate viewed region width and height for zoomSlide call
             const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
               tlEditorRef.current.getViewportPageBounds().w,
-              currentPresentationPage.scaledWidth,
+              currentPresentationPageRef.current.scaledWidth,
             );
             const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
               tlEditorRef.current.getViewportPageBounds().h,
-              currentPresentationPage.scaledHeight,
+              currentPresentationPageRef.current.scaledHeight,
             );
 
             zoomSlide(viewedRegionW, viewedRegionH, nextCamera.x, nextCamera.y);
@@ -1084,15 +1084,15 @@ const Whiteboard = React.memo((props) => {
     // A slight delay to ensure the canvas has rendered
     const timeoutId = setTimeout(() => {
       if (
-        currentPresentationPage.scaledWidth > 0
-        && currentPresentationPage.scaledHeight > 0
+        currentPresentationPageRef.current.scaledWidth > 0
+        && currentPresentationPageRef.current.scaledHeight > 0
       ) {
         // Subtract the toolbar height from the presentation area height for the presenter
         const adjustedPresentationAreaHeight = isPresenter
           ? presentationAreaHeight - 40
           : presentationAreaHeight;
-        const slideAspectRatio = currentPresentationPage.scaledWidth
-          / currentPresentationPage.scaledHeight;
+        const slideAspectRatio = currentPresentationPageRef.current.scaledWidth
+          / currentPresentationPageRef.current.scaledHeight;
         const presentationAreaAspectRatio = presentationAreaWidth / adjustedPresentationAreaHeight;
 
         let initialZoom;
@@ -1100,10 +1100,10 @@ const Whiteboard = React.memo((props) => {
         if (slideAspectRatio > presentationAreaAspectRatio
           || (fitToWidthRef.current && isPresenter)
         ) {
-          initialZoom = presentationAreaWidth / currentPresentationPage.scaledWidth;
+          initialZoom = presentationAreaWidth / currentPresentationPageRef.current.scaledWidth;
         } else {
           initialZoom = adjustedPresentationAreaHeight
-            / currentPresentationPage.scaledHeight;
+            / currentPresentationPageRef.current.scaledHeight;
         }
 
         initialZoomRef.current = initialZoom;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1017,68 +1017,96 @@ const Whiteboard = React.memo((props) => {
     let timeoutId = null;
 
     if (
-      tlEditor
-      && curPageIdRef.current
-      && currentPresentationPage
-      && isPresenter
-      && isWheelZoomRef.current === false
+      tlEditor &&
+      curPageIdRef.current &&
+      currentPresentationPage &&
+      isPresenter &&
+      !isWheelZoomRef.current
     ) {
-      const zoomLevelForReset = (fitToWidthRef.current || !initialZoomRef.current)
-        ? calculateZoomValue(
-          currentPresentationPage.scaledWidth,
-          currentPresentationPage.scaledHeight,
-        ) : initialZoomRef.current;
+      const zoomLevelForReset =
+        fitToWidthRef.current || !initialZoomRef.current
+          ? calculateZoomValue(
+              currentPresentationPage.scaledWidth,
+              currentPresentationPage.scaledHeight
+            )
+          : initialZoomRef.current;
 
-      const zoomCamera = zoomValue === HUNDRED_PERCENT
-        ? zoomLevelForReset
-        : (zoomLevelForReset * zoomValue) / HUNDRED_PERCENT;
+      const zoomCamera = (zoomLevelForReset * zoomValue) / HUNDRED_PERCENT;
+      const slideShape = tlEditorRef.current.getShape(`shape:BG-${curPageIdRef.current}`);
       const camera = tlEditorRef.current.getCamera();
 
-      const nextCamera = {
-        x:
-          zoomValue === HUNDRED_PERCENT
-            ? 0
-            : (camera.x
-              + (tlEditorRef.current.getViewportPageBounds().w / 2 / zoomCamera
-              - tlEditorRef.current.getViewportPageBounds().w / 2 / camera.z)),
-        y:
-          zoomValue === HUNDRED_PERCENT
-            ? 0
-            : (camera.y
-              + (tlEditorRef.current.getViewportPageBounds().h / 2 / zoomCamera
-              - tlEditorRef.current.getViewportPageBounds().h / 2 / camera.z)),
-        z: zoomCamera,
-      };
+      const viewportScreenBounds = tlEditorRef.current.getViewportScreenBounds();
+      const viewportWidth = viewportScreenBounds.width;
+      const viewportHeight = viewportScreenBounds.height;
 
-      if (
-        zoomValue !== prevZoomValueRef.current
-      ) {
-        tlEditor.setCamera(nextCamera, { duration: 175 });
-        timeoutId = setTimeout(() => {
-          if (zoomValue === HUNDRED_PERCENT && !fitToWidthRef.current) {
-            zoomChanger(HUNDRED_PERCENT);
-            zoomSlide(HUNDRED_PERCENT, HUNDRED_PERCENT, 0, 0);
-          } else {
-            // Recalculate viewed region width and height for zoomSlide call
-            const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
-              tlEditorRef.current.getViewportPageBounds().w,
-              currentPresentationPageRef.current.scaledWidth,
-            );
-            const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
-              tlEditorRef.current.getViewportPageBounds().h,
-              currentPresentationPageRef.current.scaledHeight,
-            );
+      let newCamera;
 
-            zoomSlide(viewedRegionW, viewedRegionH, nextCamera.x, nextCamera.y);
-          }
-        }, 500);
+      if (slideShape) {
+        const centeredCameraX =
+          -slideShape.x +
+          (viewportWidth - slideShape.props.w * camera.z) / (2 * camera.z);
+        const centeredCameraY =
+          -slideShape.y +
+          (viewportHeight - slideShape.props.h * camera.z) / (2 * camera.z);
+
+        const panningOffsetX = camera.x - centeredCameraX;
+        const panningOffsetY = camera.y - centeredCameraY;
+
+        const newCenteredCameraX =
+          -slideShape.x +
+          (viewportWidth - slideShape.props.w * zoomCamera) / (2 * zoomCamera);
+        const newCenteredCameraY =
+          -slideShape.y +
+          (viewportHeight - slideShape.props.h * zoomCamera) / (2 * zoomCamera);
+
+        newCamera = {
+          x: newCenteredCameraX + panningOffsetX,
+          y: newCenteredCameraY + panningOffsetY,
+          z: zoomCamera,
+        };
+      } else {
+        newCamera = {
+          x:
+            camera.x +
+            ((viewportWidth / 2) / camera.z - (viewportWidth / 2) / zoomCamera),
+          y:
+            camera.y +
+            ((viewportHeight / 2) / camera.z - (viewportHeight / 2) / zoomCamera),
+          z: zoomCamera,
+        };
       }
+
+      if (newCamera) {
+        tlEditorRef.current.setCamera(newCamera, { duration: 175 });
+      }
+
+      timeoutId = setTimeout(() => {
+        const viewportBounds = tlEditorRef.current.getViewportPageBounds();
+        const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
+          viewportBounds.w,
+          currentPresentationPageRef.current.scaledWidth
+        );
+        const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
+          viewportBounds.h,
+          currentPresentationPageRef.current.scaledHeight
+        );
+        const updatedCamera = tlEditorRef.current.getCamera();
+
+        zoomSlide(
+          viewedRegionW,
+          viewedRegionH,
+          updatedCamera.x,
+          updatedCamera.y,
+          currentPresentationPageRef.current
+        );
+      }, 500);
     }
 
-    // Update the previous zoom value ref with the current zoom value
     prevZoomValueRef.current = zoomValue;
     return () => clearTimeout(timeoutId);
-  }, [zoomValue, tlEditor, curPageId, isWheelZoomRef.current, fitToWidthRef.current]);
+  }, [
+    zoomValue, tlEditor, curPageId, isWheelZoomRef.current, fitToWidthRef.current,
+  ]);
 
   React.useEffect(() => {
     // A slight delay to ensure the canvas has rendered

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -35,6 +35,7 @@ const useMouseEvents = ({
   setIsMouseDown,
   setIsWheelZoom,
   setWheelZoomTimeout,
+  isInfiniteWhiteboard,
 }) => {
   const timeoutIdRef = React.useRef();
 
@@ -111,7 +112,7 @@ const useMouseEvents = ({
     setIsWheelZoom(true);
 
     const MAX_ZOOM_FACTOR = 4; // Represents 400%
-    const MIN_ZOOM_FACTOR = 1; // Represents 100%
+    const MIN_ZOOM_FACTOR = isInfiniteWhiteboard ? .25 : 1;
     const ZOOM_IN_FACTOR = 0.25;
     const ZOOM_OUT_FACTOR = 0.25;
 

--- a/bigbluebutton-html5/imports/utils/slideCalcUtils.js
+++ b/bigbluebutton-html5/imports/utils/slideCalcUtils.js
@@ -1,5 +1,6 @@
 export const HUNDRED_PERCENT = 100;
 export const MAX_PERCENT = 400;
+export const MIN_PERCENT = 25;
 export const MYSTERY_NUM = 2;
 export const STEP = 25;
 
@@ -13,18 +14,12 @@ export default class SlideCalcUtil {
    */
   static calcViewedRegionWidth(vpw, cpw) {
     const width = (vpw / cpw) * HUNDRED_PERCENT;
-    if (width > HUNDRED_PERCENT) {
-      return HUNDRED_PERCENT;
-    }
-    return width;
+    return Math.max(MIN_PERCENT, width);
   }
 
   static calcViewedRegionHeight(vph, cph) {
     const height = (vph / cph) * HUNDRED_PERCENT;
-    if (height > HUNDRED_PERCENT) {
-      return HUNDRED_PERCENT;
-    }
-    return height;
+    return Math.max(MIN_PERCENT, height);
   }
 
   static calcCalcPageSizeWidth(ftp, vpw, vrw) {


### PR DESCRIPTION
### What does this PR do?
This PR updates the zoom functionality on the infinite whiteboard by lowering the minimum zoom level to 25%. This enhancement allows users to zoom out beyond the slide boundary

![zoom-out-25](https://github.com/user-attachments/assets/2aaa70ab-96cb-477f-8d13-a562299c0827)


### Closes Issue(s)

Closes #21103 

