### PR TITLE
Fix: Force reconnection in case of stale connection.

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -99,6 +99,7 @@ export interface App {
   disableWebsocketFallback: boolean
   maxMutationPayloadSize: number
   enableApolloDevTools: boolean
+  terminateAndRetryConnection: number
 }
 
 export interface BbbTabletApp {

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -91,7 +91,7 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
   const [terminalError, setTerminalError] = React.useState<string | Error>('');
   const [MeetingSettings] = useMeetingSettings();
   const enableDevTools = MeetingSettings.public.app.enableApolloDevTools;
-  const terminateAndRetry = MeetingSettings.public.app.terminateAndRetryConnection;
+  const terminateAndRetry = MeetingSettings.public.app.terminateAndRetryConnection ?? 30_000; // Default to 30 seconds
 
   useEffect(() => {
     BBBWeb.index().then(({ data }) => {
@@ -110,11 +110,13 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
       if (tsLastMessageRef.current !== 0 && tsLastPingMessageRef.current !== 0) {
         if ((tsNow - tsLastMessageRef.current > boundary.current) && connectionStatus.getServerIsResponding()) {
           connectionStatus.setServerIsResponding(false);
-          terminateTimeoutRef.current = window.setTimeout(() => {
-            // The apollo client will try to reconnect after the connection is terminated
-            // if the option to reconnect is true
-            apolloContextHolder.getLink().terminate();
-          }, terminateAndRetry);
+          if (!terminateTimeoutRef.current) {
+            terminateTimeoutRef.current = window.setTimeout(() => {
+              // The apollo client will try to reconnect after the connection is terminated
+              // if the option to reconnect is true
+              apolloContextHolder.getLink().terminate();
+            }, terminateAndRetry);
+          }
         } else if ((tsNow - tsLastPingMessageRef.current > boundary.current) && connectionStatus.getPingIsComing()) {
           connectionStatus.setPingIsComing(false);
         }
@@ -127,7 +129,12 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
         }
       }
     }, 5_000);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      if (terminateTimeoutRef.current !== undefined) {
+        clearTimeout(terminateTimeoutRef.current);
+      }
+    };
   }, []);
 
   useEffect(() => {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -3,6 +3,7 @@ import { MeetingClientSettings } from '../../Types/meetingClientSettings';
 export const meetingClientSettingsInitialValues: MeetingClientSettings = {
   public: {
     app: {
+      terminateAndRetryConnection: 30000,
       mobileFontSize: '16px',
       desktopFontSize: '14px',
       audioChatNotification: false,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -85,6 +85,9 @@ public:
     warnAboutUnsavedContentOnMeetingEnd: false
     # Flag used to enable apollo dev tools in production
     enableApolloDevTools: false
+    # Time used when the client connection is stale
+    # and a new connection is attempted 
+    terminateAndRetryConnection: 30_000
     # Allows users to enable automatic transcription when joining a meeting.
     # Automatic transcription requires the browser to support the web
     # speech API, which involves sending voice data to third-party servers!


### PR DESCRIPTION
### What does this PR do?
This PR intends to make the client terminates the connection when notice that it's stale, the own apollo client tries to reconnect when the `shouldRetry` returns `true`, I also set a configurable amount of time to try the reconnection.


### Closes Issue(s)
Closes #21062


### How to test
Join the client and switch network or turn on/off a VPN.
