### PR TITLE
Fix: Infinity loading screen when meeting doesn't exist on Graphql

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -208,6 +208,13 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
     logger.debug(`Error on user authentication: ${error}`);
   }
 
+  if (
+    !userInfoLoading
+    && (userInfoData?.meeting.length === 0 && userInfoData?.user_current.length === 0)
+  ) {
+    throw new Error('Meeting Not Found.', { cause: 'meeting_not_found' });
+  }
+
   if (!data || data.user_current.length === 0) return null;
   if (!userInfoData
       || userInfoData.meeting.length === 0


### PR DESCRIPTION
### What does this PR do?
This PR intends to fix a bug when the user session doesn't exist in graphql the client keeps in infinity loading, It happens because every query returns empty in the case, I verify if the query loaded and the query came empty, in that case I throw a error that no data was found.

### Closes Issue(s)
Doesn't close but related to #21285

### How to test
- Join a meeting
- Run this Command on server console `sudo -u postgres psql -d bbb_graphql -c "delete from meeting where 1=1"`

