### PR TITLE
refactor (ci/tests): Replace retry method for `./bbb-install.sh` step

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -291,6 +291,8 @@ jobs:
               echo "Installation failed with exit code $COMMAND_EXIT_CODE"
               echo "Retrying installation within $RETRY_INTERVAL seconds..."
               sleep $RETRY_INTERVAL
+              # Remove lock in case the timeout was during an apt install
+              sudo rm -f /var/lib/dpkg/lock
             fi
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -278,17 +278,20 @@ jobs:
             echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install BBB..."
 
             # Run the command with timeout and handle its exit code
-            (timeout $TIMEOUT $COMMAND && COMMAND_EXIT_CODE=$?) || COMMAND_EXIT_CODE=1
-
+            # Capture both stdout and stderr
+            OUTPUT=$(timeout $TIMEOUT $COMMAND 2>&1) || COMMAND_EXIT_CODE=$?
+            
             if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
               SUCCESS=1
               break
             elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
-              echo "Command timed out. Retrying to install BBB..."
+              echo "Installation timed out after ${TIMEOUT} seconds. Retrying..."
             else
-              echo "Command failed with exit code $COMMAND_EXIT_CODE. Retrying to install BBB..."
+              echo "Installation failed with exit code $COMMAND_EXIT_CODE"
+              echo "Error output:"
+              echo "$OUTPUT"
+              echo "Retrying installation..."
             fi
-
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done
 

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -271,6 +271,7 @@ jobs:
           COMMAND="./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/"
           TIMEOUT=1200  # 20 minutes
           MAX_RETRIES=3
+          RETRY_INTERVAL=60
           RETRY_COUNT=0
           SUCCESS=0
 
@@ -280,7 +281,7 @@ jobs:
             # Run the command with timeout and handle its exit code
             # Capture both stdout and stderr
             OUTPUT=$(timeout $TIMEOUT $COMMAND 2>&1) || COMMAND_EXIT_CODE=$?
-            
+
             if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
               SUCCESS=1
               break
@@ -290,7 +291,8 @@ jobs:
               echo "Installation failed with exit code $COMMAND_EXIT_CODE"
               echo "Error output:"
               echo "$OUTPUT"
-              echo "Retrying installation..."
+              echo "Retrying installation within $RETRY_INTERVAL seconds..."
+              sleep $RETRY_INTERVAL
             fi
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -257,24 +257,44 @@ jobs:
           apt --purge -y remove apache2-bin
           '
       - name: Install BBB
-        uses: nick-fields/retry@v3
         env:
           NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
           ACTIONS_RUNNER_DEBUG: true
-        with:
-          timeout_minutes: 25
-          max_attempts: 2
-          retry_on: any
-          command: |
-            sudo -i <<EOF
-            set -e
-            cd /root/ && wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release--no-mongo/bbb-install.sh -O bbb-install.sh
-            cat bbb-install.sh | sed "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" | bash -s -- -v jammy-30-dev -s bbb-ci.test -j -d /certs/
-            bbb-conf --salt bbbci
-            sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json
-            sudo yq e -i '.log_level = "TRACE"' /usr/share/bbb-graphql-middleware/config.yml
-            bbb-conf --restart
-            EOF
+        run: |
+          sudo -i <<EOF
+          set -e
+          cd /root/
+          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release--no-mongo/bbb-install.sh -O bbb-install.sh
+          sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
+          chmod +x bbb-install.sh
+          COMMAND="./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/"
+          TIMEOUT=1500  # 25 minutes
+          MAX_RETRIES=2
+          RETRY_COUNT=0
+          SUCCESS=0
+          while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+            echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install BBB..."
+            timeout $TIMEOUT $COMMAND
+
+            if [[ $? -eq 0 ]]; then
+              SUCCESS=1
+              break
+            else
+              echo "Attempt $((RETRY_COUNT + 1)) failed. Retrying to install BBB..."
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+            fi
+          done
+
+          if [[ $SUCCESS -eq 0 ]]; then
+            echo "All attempts to install BBB failed."
+            exit 1
+          fi
+
+          bbb-conf --salt bbbci
+          sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json
+          sudo yq e -i '.log_level = "TRACE"' /usr/share/bbb-graphql-middleware/config.yml
+          bbb-conf --restart
+          EOF
       - name: List systemctl services
         timeout-minutes: 1
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -280,6 +280,7 @@ jobs:
 
             # Run the command with timeout and handle its exit code
             # Capture both stdout and stderr
+            COMMAND_EXIT_CODE=0
             timeout $TIMEOUT $COMMAND || COMMAND_EXIT_CODE=$?
 
             if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -293,7 +293,7 @@ jobs:
               echo "Retrying installation within $RETRY_INTERVAL seconds..."
               sleep $RETRY_INTERVAL
               # Remove lock in case the timeout was during an apt install
-              sudo rm -f /var/lib/dpkg/lock
+              rm -f /var/lib/dpkg/lock
             fi
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -269,22 +269,27 @@ jobs:
           chmod +x bbb-install.sh
 
           COMMAND="./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/"
-          TIMEOUT=1500  # 25 minutes
-          MAX_RETRIES=2
+          TIMEOUT=1200  # 20 minutes
+          MAX_RETRIES=3
           RETRY_COUNT=0
           SUCCESS=0
 
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
             echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install BBB..."
-            timeout $TIMEOUT $COMMAND
 
-            if [[ $? -eq 0 ]]; then
+            # Run the command with timeout and handle its exit code
+            (timeout $TIMEOUT $COMMAND && COMMAND_EXIT_CODE=$?) || COMMAND_EXIT_CODE=1
+
+            if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
               SUCCESS=1
               break
+            elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
+              echo "Command timed out. Retrying to install BBB..."
             else
-              echo "Attempt $((RETRY_COUNT + 1)) failed. Retrying to install BBB..."
-              RETRY_COUNT=$((RETRY_COUNT + 1))
+              echo "Command failed with exit code $COMMAND_EXIT_CODE. Retrying to install BBB..."
             fi
+
+            RETRY_COUNT=$((RETRY_COUNT + 1))
           done
 
           if [[ $SUCCESS -eq 0 ]]; then

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -261,17 +261,19 @@ jobs:
           NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
           ACTIONS_RUNNER_DEBUG: true
         run: |
-          sudo -i <<EOF
+          sudo -i <<'EOF'
           set -e
           cd /root/
           wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release--no-mongo/bbb-install.sh -O bbb-install.sh
           sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
           chmod +x bbb-install.sh
+
           COMMAND="./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/"
           TIMEOUT=1500  # 25 minutes
           MAX_RETRIES=2
           RETRY_COUNT=0
           SUCCESS=0
+
           while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
             echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install BBB..."
             timeout $TIMEOUT $COMMAND

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -280,7 +280,7 @@ jobs:
 
             # Run the command with timeout and handle its exit code
             # Capture both stdout and stderr
-            OUTPUT=$(timeout $TIMEOUT $COMMAND 2>&1) || COMMAND_EXIT_CODE=$?
+            timeout $TIMEOUT $COMMAND || COMMAND_EXIT_CODE=$?
 
             if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
               SUCCESS=1
@@ -289,8 +289,6 @@ jobs:
               echo "Installation timed out after ${TIMEOUT} seconds. Retrying..."
             else
               echo "Installation failed with exit code $COMMAND_EXIT_CODE"
-              echo "Error output:"
-              echo "$OUTPUT"
               echo "Retrying installation within $RETRY_INTERVAL seconds..."
               sleep $RETRY_INTERVAL
             fi

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -269,7 +269,7 @@ jobs:
           chmod +x bbb-install.sh
 
           COMMAND="./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/"
-          TIMEOUT=1200  # 20 minutes
+          TIMEOUT=1500  # 25 minutes
           MAX_RETRIES=3
           RETRY_INTERVAL=60
           RETRY_COUNT=0


### PR DESCRIPTION
The step "Install BBB" in our workflow sometimes exceeds 25 minutes, and it needs a retry mechanism to handle such long runtimes. We were previously using the `nick-fields/retry@v3` library for this purpose, but it's not functioning correctly in our case.

There is an unresolved issue with this library, reported some time ago, with no recent updates or responses from the maintainers: https://github.com/nick-fields/retry/issues/114.

To address this, I am replacing the use of the external library with a shell script to manage timeouts and retries. This should provide better control and reliability for the `Install BBB` step.

----
Fix:

![image](https://github.com/user-attachments/assets/6819cb01-bcc3-473e-8b21-99df5ec19f2d)

