### PR TITLE
chore(audio): add I/O device data to audio logs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -79,6 +79,8 @@ interface InputStreamLiveSelectorProps extends InputStreamLiveSelectorContainerP
   away: boolean;
   permissionStatus: string;
   supportsTransparentListenOnly: boolean;
+  updateInputDevices: (devices: InputDeviceInfo[]) => void;
+  updateOutputDevices: (devices: MediaDeviceInfo[]) => void;
 }
 
 const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
@@ -100,6 +102,8 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   permissionStatus,
   supportsTransparentListenOnly,
   openAudioSettings,
+  updateInputDevices,
+  updateOutputDevices,
 }) => {
   const intl = useIntl();
   const toggleVoice = useToggleVoice();
@@ -164,6 +168,9 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
         const audioOutputDevices = devices.filter((i) => i.kind === AUDIO_OUTPUT);
         setInputDevices(audioInputDevices as InputDeviceInfo[]);
         setOutputDevices(audioOutputDevices);
+        // Update audio devices in AudioManager
+        updateInputDevices(audioInputDevices as InputDeviceInfo[]);
+        updateOutputDevices(audioOutputDevices);
 
         if (inAudio) updateRemovedDevices(audioInputDevices, audioOutputDevices);
       })
@@ -308,6 +315,12 @@ const InputStreamLiveSelectorContainer: React.FC<InputStreamLiveSelectorContaine
   const permissionStatus = useReactiveVar(AudioManager._permissionStatus.value) as string;
   // @ts-ignore - temporary while hybrid (meteor+GraphQl)
   const supportsTransparentListenOnly = useReactiveVar(AudioManager._transparentListenOnlySupported.value) as boolean;
+  const updateInputDevices = (devices: InputDeviceInfo[] = []) => {
+    AudioManager.inputDevices = devices;
+  };
+  const updateOutputDevices = (devices: MediaDeviceInfo[] = []) => {
+    AudioManager.outputDevices = devices;
+  };
 
   return (
     <InputStreamLiveSelector
@@ -330,6 +343,8 @@ const InputStreamLiveSelectorContainer: React.FC<InputStreamLiveSelectorContaine
       openAudioSettings={openAudioSettings}
       permissionStatus={permissionStatus}
       supportsTransparentListenOnly={supportsTransparentListenOnly}
+      updateInputDevices={updateInputDevices}
+      updateOutputDevices={updateOutputDevices}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -38,6 +38,8 @@ const propTypes = {
   leaveEchoTest: PropTypes.func.isRequired,
   changeInputDevice: PropTypes.func.isRequired,
   changeOutputDevice: PropTypes.func.isRequired,
+  updateInputDevices: PropTypes.func.isRequired,
+  updateOutputDevices: PropTypes.func.isRequired,
   isEchoTest: PropTypes.bool.isRequired,
   isConnecting: PropTypes.bool.isRequired,
   isConnected: PropTypes.bool.isRequired,
@@ -207,6 +209,8 @@ const AudioModal = ({
   unmuteOnExit = false,
   permissionStatus = null,
   isTranscriptionEnabled,
+  updateInputDevices,
+  updateOutputDevices,
 }) => {
   const [content, setContent] = useState(initialContent);
   const [hasError, setHasError] = useState(false);
@@ -528,6 +532,8 @@ const AudioModal = ({
         permissionStatus={permissionStatus}
         isTranscriptionEnabled={isTranscriptionEnabled}
         skipAudioOptions={skipAudioOptions}
+        updateInputDevices={updateInputDevices}
+        updateOutputDevices={updateOutputDevices}
       />
     );
   };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -129,6 +129,8 @@ const AudioModalContainer = (props) => {
       liveChangeInputDevice={Service.liveChangeInputDevice}
       changeInputStream={Service.changeInputStream}
       changeOutputDevice={Service.changeOutputDevice}
+      updateInputDevices={Service.updateInputDevices}
+      updateOutputDevices={Service.updateOutputDevices}
       joinEchoTest={Service.joinEchoTest}
       exitAudio={Service.exitAudio}
       localEchoEnabled={LOCAL_ECHO_TEST_ENABLED}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -21,6 +21,8 @@ const propTypes = {
   changeInputDevice: PropTypes.func.isRequired,
   liveChangeInputDevice: PropTypes.func.isRequired,
   changeOutputDevice: PropTypes.func.isRequired,
+  updateInputDevices: PropTypes.func.isRequired,
+  updateOutputDevices: PropTypes.func.isRequired,
   handleBack: PropTypes.func.isRequired,
   handleConfirmation: PropTypes.func.isRequired,
   handleGUMFailure: PropTypes.func.isRequired,
@@ -384,11 +386,16 @@ class AudioSettings extends React.Component {
   }
 
   updateDeviceList() {
+    const { updateInputDevices, updateOutputDevices } = this.props;
+
     return navigator.mediaDevices.enumerateDevices()
       .then((devices) => {
         const audioInputDevices = devices.filter((i) => i.kind === 'audioinput');
         const audioOutputDevices = devices.filter((i) => i.kind === 'audiooutput');
 
+        // Update audio devices in AudioManager
+        updateInputDevices(audioInputDevices);
+        updateOutputDevices(audioOutputDevices);
         this.setState({
           audioInputDevices,
           audioOutputDevices,

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -186,6 +186,8 @@ export default {
     outputDeviceId,
     isLive,
   ) => AudioManager.changeOutputDevice(outputDeviceId, isLive),
+  updateInputDevices: (devices) => { AudioManager.inputDevices = devices },
+  updateOutputDevices: (devices) => { AudioManager.outputDevices = devices },
   toggleMuteMicrophone,
   toggleMuteMicrophoneSystem,
   isConnectedToBreakout: () => {


### PR DESCRIPTION
### What does this PR do?

- [chore(audio): add I/O device data to audio logs](https://github.com/bigbluebutton/bigbluebutton/commit/0ecf665aca) 
  - I/O device IDs are logged in some specific logCodes, but they aren't too
useful on their own without the rest of the MediaDeviceInfo object. We
need that extra data (label, group) to be able to better investigate
incorrect device issues and NotFoundError occurrences.
  - Register full I/O device info whenever the client fetches them and add
those, unfiltered, to the following logCodes:
    - audiomanager_error_getting_device
    - audiomanager_error_device_not_found
    - audiomanager_error_unknown
    - audio_joined
    - audio_ended
    - audio_failure
    - audiomanager_input_live_device_change_failure
    - audiomanager_output_device_change_failure

### Closes Issue(s)

None

### How to test

1. Enable client logging
2. Join/leave audio
3. Check `audio_joined/audio_ended` extraInfo for the newly added fields