### PR TITLE
style: adjust userlist item margin

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/styles.ts
@@ -52,8 +52,6 @@ const UserItemContents = styled.div<UserItemContentsProps>`
   position: static;
   padding: .45rem;
   width: 100%;
-  margin-left: .5rem;
-
 
   ${({ selected }) => selected && `
     background-color: ${listItemBgHover};

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/styles.ts
@@ -272,6 +272,7 @@ const VirtualizedList = styled(ScrollboxVertical)`
 
 const UserListItem = styled.div`
   padding: .25em 0;
+  margin-left: .5rem;
 `;
 
 export default {


### PR DESCRIPTION
### What does this PR do?

Refactor user list item styles to prevent userlist item being cut due to margin being applied to the wrong element.

#### before

![Screenshot from 2024-10-23 13-40-46](https://github.com/user-attachments/assets/1999db32-2816-435a-a2cf-0547fcece68c)

#### after

![Screenshot from 2024-10-23 13-40-18](https://github.com/user-attachments/assets/fcffd2d3-51f4-4478-8eae-bff3483b722d)
