### PR TITLE
fix(notes): incorrect pin state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import getFromUserSettings from '/imports/ui/services/users-settings';
@@ -92,21 +92,10 @@ const ActionsBarContainer = (props) => {
   };
   const amIPresenter = currentUserData?.presenter;
   const amIModerator = currentUserData?.isModerator;
-  const [pinnedPadDataState, setPinnedPadDataState] = useState(null);
+  const { data: pinnedPadData } = useDeduplicatedSubscription(PINNED_PAD_SUBSCRIPTION);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: pinnedPadData } = await useDeduplicatedSubscription(
-        PINNED_PAD_SUBSCRIPTION,
-      );
-      setPinnedPadDataState(pinnedPadData || []);
-    };
-
-    fetchData();
-  }, []);
-
-  const isSharedNotesPinnedFromGraphql = !!pinnedPadDataState
-    && pinnedPadDataState.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
+  const isSharedNotesPinnedFromGraphql = !!pinnedPadData
+    && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
 
   const isSharedNotesPinned = isSharedNotesPinnedFromGraphql;
   const allowExternalVideo = useIsExternalVideoEnabled();

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
@@ -8,6 +8,7 @@ import { notify } from '/imports/ui/services/notification';
 import { layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
 import {
   PINNED_PAD_SUBSCRIPTION,
+  PinnedPadSubscriptionResponse,
 } from '/imports/ui/components/notes/queries';
 import Styled from './styles';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
@@ -191,29 +192,12 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
 };
 
 const UserNotesContainerGraphql: React.FC<UserNotesContainerGraphqlProps> = (props) => {
-  type PinnedPadData = {
-    sharedNotes: Array<{
-      sharedNotesExtId: string;
-    }>;
-  };
   const { userLocks } = props;
   const disableNotes = userLocks.userNotes;
-  const [pinnedPadDataState, setPinnedPadDataState] = useState<PinnedPadData | null>(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: pinnedPadData } = await useDeduplicatedSubscription(
-        PINNED_PAD_SUBSCRIPTION,
-      );
-      setPinnedPadDataState(pinnedPadData || []);
-    };
-
-    fetchData();
-  }, []);
-
+  const { data: pinnedPadData } = useDeduplicatedSubscription<PinnedPadSubscriptionResponse>(PINNED_PAD_SUBSCRIPTION);
   const NOTES_CONFIG = window.meetingClientSettings.public.notes;
 
-  const isPinned = !!pinnedPadDataState && pinnedPadDataState.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
+  const isPinned = !!pinnedPadData && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sidebarContent = layoutSelectInput((i: any) => i.sidebarContent);


### PR DESCRIPTION
### What does this PR do?
This commit reverts the changes introduced in commits 00f2647 and 95ba412. It moves the subscription for shared notes out of the `useEffect` since hooks cannot be placed inside it and therefore was not being executed properly.

### Closes Issue(s)
Closes #21420

### How to test
1. Join meeting
2. Open shared notes
3. Pin them
4. Check whether clicking on the sidebar button does not open an empty panel 


### More
After reverting the commits 00f2647 and 95ba412 the console started showing(again) errors about bad React set states, but that is an issue with the `useDeduplicatedSubscription` hook and the way it creates subscriptions inside render.
