### PR TITLE
refactor (ci/tests): Stop any ongoing processes before retrying to install bbb

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -298,9 +298,9 @@ jobs:
             killall apt-get
             killall dpkg
             # Remove the lock files that may have been left behind
-            rm /var/lib/dpkg/lock-frontend
-            rm /var/lib/dpkg/lock
-            rm /var/cache/apt/archives/lock
+            rm -f /var/lib/dpkg/lock-frontend
+            rm -f /var/lib/dpkg/lock
+            rm -f /var/cache/apt/archives/lock
             # Reconfigure the package manager
             dpkg --configure -a
             # Clean up any partially installed packages

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -292,9 +292,21 @@ jobs:
               echo "Installation failed with exit code $COMMAND_EXIT_CODE"
               echo "Retrying installation within $RETRY_INTERVAL seconds..."
               sleep $RETRY_INTERVAL
-              # Remove lock in case the timeout was during an apt install
-              rm -f /var/lib/dpkg/lock
             fi
+
+            # Stop any ongoing processes related to apt-get or dpkg that might be stuck
+            killall apt-get
+            killall dpkg
+            # Remove the lock files that may have been left behind
+            rm /var/lib/dpkg/lock-frontend
+            rm /var/lib/dpkg/lock
+            rm /var/cache/apt/archives/lock
+            # Reconfigure the package manager
+            dpkg --configure -a
+            # Clean up any partially installed packages
+            apt-get clean
+            apt-get autoremove
+
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done
 

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -293,20 +293,26 @@ jobs:
               echo "Retrying installation within $RETRY_INTERVAL seconds..."
               sleep $RETRY_INTERVAL
             fi
-
             # Stop any ongoing processes related to apt-get or dpkg that might be stuck
-            killall apt-get
-            killall dpkg
+            # Use -q to suppress "no process found" messages
+            killall -q apt-get || true
+            killall -q dpkg || true
+
             # Remove the lock files that may have been left behind
-            rm -f /var/lib/dpkg/lock-frontend
-            rm -f /var/lib/dpkg/lock
-            rm -f /var/cache/apt/archives/lock
+            # Group lock file removal for better readability
+            for lock in \
+              /var/lib/dpkg/lock-frontend \
+              /var/lib/dpkg/lock \
+              /var/cache/apt/archives/lock; do
+              rm -f "$lock"
+            done
+
             # Reconfigure the package manager
             dpkg --configure -a
+
             # Clean up any partially installed packages
             apt-get clean
             apt-get autoremove
-
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done
 

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -293,26 +293,24 @@ jobs:
               echo "Retrying installation within $RETRY_INTERVAL seconds..."
               sleep $RETRY_INTERVAL
             fi
-            # Stop any ongoing processes related to apt-get or dpkg that might be stuck
+            echo "Stop any ongoing processes related to apt-get or dpkg that might be stuck"
             # Use -q to suppress "no process found" messages
             killall -q apt-get || true
             killall -q dpkg || true
 
-            # Remove the lock files that may have been left behind
+            echo "Remove the lock files that may have been left behind"
             # Group lock file removal for better readability
-            for lock in \
-              /var/lib/dpkg/lock-frontend \
-              /var/lib/dpkg/lock \
-              /var/cache/apt/archives/lock; do
-              rm -f "$lock"
-            done
+            rm -f /var/lib/dpkg/lock-frontend
+            rm -f /var/lib/dpkg/lock
+            rm -f /var/cache/apt/archives/lock
 
-            # Reconfigure the package manager
+            echo "Reconfigure the package manager"
             dpkg --configure -a
 
-            # Clean up any partially installed packages
+            echo "Clean up any partially installed packages"
             apt-get clean
             apt-get autoremove
+
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done
 


### PR DESCRIPTION
This PR adds steps to clean up incomplete installations when the "Install BBB" step times out.

When the "Install BBB" step times out, it can leave ongoing apt installations in an incomplete state, preventing retries. This PR introduces cleanup steps to ensure that any interrupted installations are properly handled, allowing the process to restart smoothly.