### PR TITLE
fix(chat): Loading a new message page freezes the client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -372,6 +372,14 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
           },
         }).then(() => {
           sendCancelEvents();
+        }).catch((e) => {
+          logger.error({
+            logCode: 'chat_edit_message_error',
+            extraInfo: {
+              errorName: e?.name,
+              errorMessage: e?.message,
+            },
+          }, `Editing the message failed: ${e?.message}`);
         });
       } else if (!chatSendMessageLoading) {
         chatSendMessage({

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -221,7 +221,12 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   const [chatSendReaction] = useMutation(CHAT_SEND_REACTION_MUTATION);
   const [chatDeleteReaction] = useMutation(CHAT_DELETE_REACTION_MUTATION);
 
-  const sendReaction = (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => {
+  const sendReaction = useCallback((
+    reactionEmoji: string,
+    reactionEmojiId: string,
+    chatId: string,
+    messageId: string,
+  ) => {
     chatSendReaction({
       variables: {
         chatId,
@@ -230,9 +235,14 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmojiId,
       },
     });
-  };
+  }, [chatSendReaction]);
 
-  const deleteReaction = (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => {
+  const deleteReaction = useCallback((
+    reactionEmoji: string,
+    reactionEmojiId: string,
+    chatId: string,
+    messageId: string,
+  ) => {
     chatDeleteReaction({
       variables: {
         chatId,
@@ -241,7 +251,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmojiId,
       },
     });
-  };
+  }, [chatDeleteReaction]);
 
   useEffect(() => {
     if (isSentinelVisible) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -37,6 +37,7 @@ import {
   useIsDeleteChatMessageEnabled,
 } from '/imports/ui/services/features';
 import { CHAT_DELETE_REACTION_MUTATION, CHAT_SEND_REACTION_MUTATION } from './page/chat-message/mutations';
+import logger from '/imports/startup/client/logger';
 
 const PAGE_SIZE = 50;
 
@@ -234,6 +235,14 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmoji,
         reactionEmojiId,
       },
+    }).catch((e) => {
+      logger.error({
+        logCode: 'chat_send_message_reaction_error',
+        extraInfo: {
+          errorName: e?.name,
+          errorMessage: e?.message,
+        },
+      }, `Sending reaction failed: ${e?.message}`);
     });
   }, [chatSendReaction]);
 
@@ -250,6 +259,14 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmoji,
         reactionEmojiId,
       },
+    }).catch((e) => {
+      logger.error({
+        logCode: 'chat_delete_message_reaction_error',
+        extraInfo: {
+          errorName: e?.name,
+          errorMessage: e?.message,
+        },
+      }, `Deleting reaction failed: ${e?.message}`);
     });
   }, [chatDeleteReaction]);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -205,7 +205,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     isModerator: c?.isModerator,
     userLockSettings: c?.userLockSettings,
     locked: c?.locked,
-    userId: c.userId,
+    userId: c?.userId,
   }));
   const CHAT_REPLY_ENABLED = useIsReplyChatMessageEnabled();
   const CHAT_REACTIONS_ENABLED = useIsChatMessageReactionsEnabled();

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -573,7 +573,6 @@ function areChatMessagesEqual(prevProps: ChatMessageProps, nextProps: ChatMessag
     'message.user.currentlyInMeeting',
     'message.reactions.length',
     'message.replyToMessage.message',
-    'message.recipientHasSeen',
   ] as const;
   return propsToCompare.every((pointer) => {
     const previousValue = getValueByPointer(prevProps, pointer);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -63,6 +63,7 @@ interface ChatMessageProps {
 
 export interface ChatMessageRef {
   requestFocus: () => void;
+  sequence: number;
 }
 
 const intlMessages = defineMessages({
@@ -170,7 +171,8 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
         requestAnimationFrame(startScrollAnimation);
       }, 0);
     },
-  }), []);
+    sequence: message.messageSequence,
+  }), [message.messageSequence]);
 
   const startScrollAnimation = (timestamp: number) => {
     animationInitialScrollPosition.current = scrollRef.current?.scrollTop || 0;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -553,27 +553,28 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   );
 });
 
+const propsToCompare = [
+  'meetingDisablePublicChat',
+  'meetingDisablePrivateChat',
+  'currentUserDisablePublicChat',
+  'currentUserId',
+  'currentUserIsLocked',
+  'currentUserIsModerator',
+  'chatDeleteEnabled',
+  'chatEditEnabled',
+  'chatReactionsEnabled',
+  'chatReplyEnabled',
+  'focused',
+  'keyboardFocused',
+  'message.createdAt',
+  'message.message',
+  'message.recipientHasSeen',
+  'message.user.currentlyInMeeting',
+  'message.reactions.length',
+  'message.replyToMessage.message',
+] as const;
+
 function areChatMessagesEqual(prevProps: ChatMessageProps, nextProps: ChatMessageProps) {
-  const propsToCompare = [
-    'meetingDisablePublicChat',
-    'meetingDisablePrivateChat',
-    'currentUserDisablePublicChat',
-    'currentUserId',
-    'currentUserIsLocked',
-    'currentUserIsModerator',
-    'chatDeleteEnabled',
-    'chatEditEnabled',
-    'chatReactionsEnabled',
-    'chatReplyEnabled',
-    'focused',
-    'keyboardFocused',
-    'message.createdAt',
-    'message.message',
-    'message.recipientHasSeen',
-    'message.user.currentlyInMeeting',
-    'message.reactions.length',
-    'message.replyToMessage.message',
-  ] as const;
   return propsToCompare.every((pointer) => {
     const previousValue = getValueByPointer(prevProps, pointer);
     const nextValue = getValueByPointer(nextProps, pointer);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -158,9 +158,9 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
 
   if (!currentUserIsModerator) {
     if (isPublicChat) {
-      locked = (currentUserIsLocked && disablePublicChat) || false;
+      locked = currentUserIsLocked && disablePublicChat;
     } else {
-      locked = (currentUserIsLocked && meetingDisablePrivateChat) || false;
+      locked = currentUserIsLocked && meetingDisablePrivateChat;
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -421,6 +421,11 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     && !sameSender
     && !isCustomPluginMessage;
 
+  const onEmojiSelected = useCallback((emoji: { id: string; native: string }) => {
+    sendReaction(emoji.native, emoji.id, message.chatId, message.messageId);
+    setIsToolbarReactionPopoverOpen(false);
+  }, [message.chatId, message.messageId, sendReaction]);
+
   return (
     <Container
       ref={containerRef}
@@ -449,10 +454,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           message={message.message}
           messageSequence={message.messageSequence}
           emphasizedMessage={message.chatEmphasizedText}
-          onEmojiSelected={(emoji) => {
-            sendReaction(emoji.native, emoji.id, message.chatId, message.messageId);
-            setIsToolbarReactionPopoverOpen(false);
-          }}
+          onEmojiSelected={onEmojiSelected}
           onReactionPopoverOpenChange={setIsToolbarReactionPopoverOpen}
           reactionPopoverIsOpen={isToolbarReactionPopoverOpen}
           chatDeleteEnabled={chatDeleteEnabled}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/component.tsx
@@ -29,8 +29,10 @@ interface ChatMessageReactionsProps {
       userId: string;
     };
   }[];
-  sendReaction(reactionEmoji: string, reactionEmojiId: string): void;
-  deleteReaction(reactionEmoji: string, reactionEmojiId: string): void;
+  sendReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  deleteReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  chatId: string;
+  messageId: string;
 }
 
 type ReactionItem = {
@@ -46,7 +48,9 @@ const sortByCount = (r1: ReactionItem, r2: ReactionItem) => r2.count - r1.count;
 const sortByLeastRecent = (r1: ReactionItem, r2: ReactionItem) => r1.leastRecent - r2.leastRecent;
 
 const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
-  const { reactions, sendReaction, deleteReaction } = props;
+  const {
+    reactions, sendReaction, deleteReaction, chatId, messageId,
+  } = props;
 
   const { data: currentUser } = useCurrentUser((u) => ({ userId: u.userId }));
   const intl = useIntl();
@@ -101,9 +105,9 @@ const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
               highlighted={details.reactedByMe}
               onClick={() => {
                 if (details.reactedByMe) {
-                  deleteReaction(details.reactionEmoji, details.reactionEmojiId);
+                  deleteReaction(details.reactionEmoji, details.reactionEmojiId, chatId, messageId);
                 } else {
-                  sendReaction(details.reactionEmoji, details.reactionEmojiId);
+                  sendReaction(details.reactionEmoji, details.reactionEmojiId, chatId, messageId);
                 }
               }}
             >

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   memo,
   useRef,
+  useCallback,
 } from 'react';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import {
@@ -230,6 +231,11 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
     }
   }, []);
 
+  const updateMessageRef = useCallback((ref: ChatMessageRef | null) => {
+    if (!ref) return;
+    messageRefs.current[ref.sequence] = ref;
+  }, []);
+
   return (
     <React.Fragment key={`messagePage-${page}`}>
       {messages.map((message, index, messagesArray) => {
@@ -249,9 +255,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             focused={focusedId === message.messageSequence}
             keyboardFocused={keyboardFocusedMessageSequence === message.messageSequence}
             editing={editingId === message.messageId}
-            ref={(ref) => {
-              messageRefs.current[message.messageSequence] = ref;
-            }}
+            ref={updateMessageRef}
             meetingDisablePrivateChat={meetingDisablePrivateChat}
             meetingDisablePublicChat={meetingDisablePublicChat}
             currentUserId={currentUserId}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -63,28 +63,29 @@ interface ChatListPageProps extends ChatListPageCommonProps {
   isPublicChat: boolean;
 }
 
+const propsToCompare = [
+  'focusedId',
+  'meetingDisablePublicChat',
+  'meetingDisablePrivateChat',
+  'currentUserDisablePublicChat',
+  'currentUserId',
+  'currentUserIsLocked',
+  'currentUserIsModerator',
+  'chatDeleteEnabled',
+  'chatEditEnabled',
+  'chatReactionsEnabled',
+  'chatReplyEnabled',
+] as const;
+const messagePropsToCompare = [
+  'messageId',
+  'createdAt',
+  'user.currentlyInMeeting',
+  'recipientHasSeen',
+  'message',
+  'reactions.length',
+] as const;
+
 const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPageProps) => {
-  const propsToCompare = [
-    'focusedId',
-    'meetingDisablePublicChat',
-    'meetingDisablePrivateChat',
-    'currentUserDisablePublicChat',
-    'currentUserId',
-    'currentUserIsLocked',
-    'currentUserIsModerator',
-    'chatDeleteEnabled',
-    'chatEditEnabled',
-    'chatReactionsEnabled',
-    'chatReplyEnabled',
-  ] as const;
-  const messagePropsToCompare = [
-    'messageId',
-    'createdAt',
-    'user.currentlyInMeeting',
-    'recipientHasSeen',
-    'message',
-    'reactions.length',
-  ] as const;
   const nextMessages = nextProps?.messages || [];
   const prevMessages = prevProps?.messages || [];
   if (nextMessages.length !== prevMessages.length) return false;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -25,46 +25,81 @@ import { setLoadedMessageGathering } from '/imports/ui/core/hooks/useLoadedChatM
 import { ChatLoading } from '../../component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import { useStorageKey, STORAGES } from '/imports/ui/services/storage/hooks';
+import { getValueByPointer } from '/imports/utils/object-utils';
 
 const PAGE_SIZE = 50;
 
-interface ChatListPageContainerProps {
-  page: number;
-  pageSize: number;
-  setLastSender: (page: number, message: string) => void;
-  lastSenderPreviousPage: string | undefined;
-  chatId: string;
-  markMessageAsSeen: (message: Message) => void;
-  scrollRef: React.RefObject<HTMLDivElement>;
-  focusedId: number | null;
+interface ChatListPageCommonProps {
   firstPageToLoad: number;
+  focusedId: number | null;
+  scrollRef: React.RefObject<HTMLDivElement>;
+  markMessageAsSeen: (message: Message) => void;
+  lastSenderPreviousPage: string | undefined;
+  page: number;
+  meetingDisablePublicChat: boolean;
+  meetingDisablePrivateChat: boolean;
+  currentUserIsModerator: boolean;
+  currentUserIsLocked: boolean;
+  currentUserId: string;
+  currentUserDisablePublicChat: boolean;
+  messageToolbarIsEnabled: boolean;
+  chatReplyEnabled: boolean;
+  chatDeleteEnabled: boolean;
+  chatEditEnabled: boolean;
+  chatReactionsEnabled: boolean;
+  sendReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
+  deleteReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
 }
 
-interface ChatListPageProps {
+interface ChatListPageContainerProps extends ChatListPageCommonProps {
+  pageSize: number;
+  setLastSender: (page: number, message: string) => void;
+  chatId: string;
+}
+
+interface ChatListPageProps extends ChatListPageCommonProps {
   messages: Array<Message>;
   messageReadFeedbackEnabled: boolean;
-  lastSenderPreviousPage: string | undefined;
-  page: number;
-  markMessageAsSeen: (message: Message)=> void;
-  scrollRef: React.RefObject<HTMLDivElement>;
-  focusedId: number | null;
-  firstPageToLoad: number;
+  isPublicChat: boolean;
 }
 
 const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPageProps) => {
+  const propsToCompare = [
+    'focusedId',
+    'meetingDisablePublicChat',
+    'meetingDisablePrivateChat',
+    'currentUserDisablePublicChat',
+    'currentUserId',
+    'currentUserIsLocked',
+    'currentUserIsModerator',
+    'chatDeleteEnabled',
+    'chatEditEnabled',
+    'chatReactionsEnabled',
+    'chatReplyEnabled',
+  ] as const;
+  const messagePropsToCompare = [
+    'messageId',
+    'createdAt',
+    'user.currentlyInMeeting',
+    'recipientHasSeen',
+    'message',
+    'reactions.length',
+  ] as const;
   const nextMessages = nextProps?.messages || [];
   const prevMessages = prevProps?.messages || [];
   if (nextMessages.length !== prevMessages.length) return false;
   return nextMessages.every((nextMessage, idx) => {
     const prevMessage = prevMessages[idx];
-    return (prevMessage.messageId === nextMessage.messageId
-      && prevMessage.createdAt === nextMessage.createdAt
-      && prevMessage?.user?.currentlyInMeeting === nextMessage?.user?.currentlyInMeeting
-      && prevMessage?.recipientHasSeen === nextMessage?.recipientHasSeen
-      && prevMessage?.message === nextMessage?.message
-      && prevMessage?.reactions?.length === nextMessage?.reactions?.length
-    );
-  }) && prevProps.focusedId === nextProps.focusedId;
+    return messagePropsToCompare.every((pointer) => {
+      const previousValue = getValueByPointer(prevMessage, pointer);
+      const nextValue = getValueByPointer(nextMessage, pointer);
+      return previousValue === nextValue;
+    });
+  }) && propsToCompare.every((pointer) => {
+    const previousValue = getValueByPointer(prevProps, pointer);
+    const nextValue = getValueByPointer(nextProps, pointer);
+    return previousValue === nextValue;
+  });
 };
 
 const ChatListPage: React.FC<ChatListPageProps> = ({
@@ -76,6 +111,20 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   scrollRef,
   focusedId,
   firstPageToLoad,
+  meetingDisablePrivateChat,
+  meetingDisablePublicChat,
+  currentUserId,
+  currentUserDisablePublicChat,
+  currentUserIsLocked,
+  currentUserIsModerator,
+  isPublicChat,
+  messageToolbarIsEnabled,
+  chatDeleteEnabled,
+  chatEditEnabled,
+  chatReactionsEnabled,
+  chatReplyEnabled,
+  deleteReaction,
+  sendReaction,
 }) => {
   const { domElementManipulationIdentifiers } = useContext(PluginsContext);
   const messageRefs = useRef<Record<number, ChatMessageRef | null>>({});
@@ -202,6 +251,20 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             ref={(ref) => {
               messageRefs.current[message.messageSequence] = ref;
             }}
+            meetingDisablePrivateChat={meetingDisablePrivateChat}
+            meetingDisablePublicChat={meetingDisablePublicChat}
+            currentUserId={currentUserId}
+            currentUserDisablePublicChat={currentUserDisablePublicChat}
+            currentUserIsLocked={currentUserIsLocked}
+            currentUserIsModerator={currentUserIsModerator}
+            isPublicChat={isPublicChat}
+            hasToolbar={messageToolbarIsEnabled && !!message.user}
+            chatDeleteEnabled={chatDeleteEnabled}
+            chatEditEnabled={chatEditEnabled}
+            chatReactionsEnabled={chatReactionsEnabled}
+            chatReplyEnabled={chatReplyEnabled}
+            deleteReaction={deleteReaction}
+            sendReaction={sendReaction}
           />
         );
       })}
@@ -221,6 +284,19 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   scrollRef,
   focusedId,
   firstPageToLoad,
+  meetingDisablePrivateChat,
+  meetingDisablePublicChat,
+  currentUserId,
+  currentUserDisablePublicChat,
+  currentUserIsLocked,
+  currentUserIsModerator,
+  messageToolbarIsEnabled,
+  chatDeleteEnabled,
+  chatEditEnabled,
+  chatReactionsEnabled,
+  chatReplyEnabled,
+  deleteReaction,
+  sendReaction,
 }) => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_KEY = CHAT_CONFIG.public_group_id;
@@ -263,6 +339,20 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       scrollRef={scrollRef}
       focusedId={focusedId}
       firstPageToLoad={firstPageToLoad}
+      meetingDisablePrivateChat={meetingDisablePrivateChat}
+      meetingDisablePublicChat={meetingDisablePublicChat}
+      currentUserId={currentUserId}
+      currentUserDisablePublicChat={currentUserDisablePublicChat}
+      currentUserIsLocked={currentUserIsLocked}
+      currentUserIsModerator={currentUserIsModerator}
+      isPublicChat={isPublicChat}
+      messageToolbarIsEnabled={messageToolbarIsEnabled}
+      chatDeleteEnabled={chatDeleteEnabled}
+      chatEditEnabled={chatEditEnabled}
+      chatReactionsEnabled={chatReactionsEnabled}
+      chatReplyEnabled={chatReplyEnabled}
+      deleteReaction={deleteReaction}
+      sendReaction={sendReaction}
     />
   );
 };

--- a/bigbluebutton-html5/imports/utils/object-utils.js
+++ b/bigbluebutton-html5/imports/utils/object-utils.js
@@ -1,0 +1,13 @@
+export const getValueByPointer = (obj, pointer) => {
+  if (pointer === '') return obj;
+  const fields = pointer.split('.');
+  let acc = obj;
+  fields.forEach((field) => {
+    acc = acc?.[field];
+  });
+  return acc;
+};
+
+export default {
+  getValueByPointer,
+};

--- a/bigbluebutton-html5/imports/utils/object-utils.js
+++ b/bigbluebutton-html5/imports/utils/object-utils.js
@@ -1,4 +1,7 @@
 export const getValueByPointer = (obj, pointer) => {
+  if (typeof obj !== 'object') return undefined;
+  if (!obj) return undefined;
+  if (typeof pointer !== 'string') return obj;
   if (pointer === '') return obj;
   const fields = pointer.split('.');
   let acc = obj;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- When the user clicks `Load more messages` the client freezes for a few seconds before rendering the new page. This was happening because the message component was overheaded with hook calls and data access which were triggering an additional render. In order to fix that, all those hook calls within the message component were placed in the parent component (more stable, doesn't rerender frequently) and passed as props to the message component.

### Closes Issue(s)

Closes #21434 

### How to test

1. Start a session.
2. Go to the chat.
3. Type 100+ messages.
4. Scroll up and click 'Load more messages'.
