### PR TITLE
fix (html5): prevent error if `learningDashboardBase` is missing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/learning-dashboard/service.js
@@ -76,7 +76,7 @@ const setLearningDashboardCookie = () => {
 
     // In a cluster setup it will be necessary to specify the root domain
     // because the Dashboard might be in a different subdomain
-    if (learningDashboardBase.startsWith('http')) {
+    if (learningDashboardBase && learningDashboardBase.startsWith('http')) {
       const commonDomain = findCommonDomain(learningDashboardBase, window.location.href);
       if (commonDomain !== '') {
         cookieString += `;domain=${commonDomain}`;


### PR DESCRIPTION
Small fix to avoid error in case `.settings.public.app.learningDashboardBase` is not set.