### PR TITLE
fix(bbb-web): fix plugins not loading nor running into breakout-rooms

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -99,6 +99,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         breakout.captureSlides,
         breakout.captureNotesFilename,
         breakout.captureSlidesFilename,
+        pluginProp = liveMeeting.props.pluginProp,
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -1,5 +1,7 @@
 package org.bigbluebutton.common2.msgs
 
+import java.util
+
 object BreakoutRoomEndedEvtMsg { val NAME = "BreakoutRoomEndedEvtMsg" }
 case class BreakoutRoomEndedEvtMsg(header: BbbClientMsgHeader, body: BreakoutRoomEndedEvtMsgBody) extends BbbCoreMsg
 case class BreakoutRoomEndedEvtMsgBody(parentId: String, breakoutId: String)
@@ -56,6 +58,7 @@ case class BreakoutRoomDetail(
     captureSlides:           Boolean,
     captureNotesFilename:    String,
     captureSlidesFilename:   String,
+    pluginProp:              util.Map[String, AnyRef],
 )
 
 /**

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -464,15 +464,13 @@ public class MeetingService implements MessageListener {
     }
     return urlContents;
   }
-  public synchronized boolean createMeeting(Meeting m, Map<String, Object> plugins) {
-    return createMeetingInternal(m, plugins);
-  }
 
   public synchronized boolean createMeeting(Meeting m) {
-    return createMeetingInternal(m, null);
+    Map<String, Object> pluginsMap = new HashMap<>();
+    return createMeeting(m, pluginsMap);
   }
 
-  private boolean createMeetingInternal(Meeting m, Map<String, Object> plugins) {
+  public synchronized boolean createMeeting(Meeting m, Map<String, Object> plugins) {
     String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(m.getExternalId());
     Meeting existingId = getNotEndedMeetingWithId(internalMeetingId);
     Meeting existingTelVoice = getNotEndedMeetingWithTelVoice(m.getTelVoice());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -576,16 +576,18 @@ public class ParamsProcessorUtil {
 
         // Parse Plugins Manifests from config and param
         ArrayList<PluginManifest> listOfPluginManifests = new ArrayList<PluginManifest>();
-        //Process plugins from config
-        if(defaultPluginManifests != null && !defaultPluginManifests.isEmpty()) {
-            ArrayList<PluginManifest> pluginManifestsFromConfig = processPluginManifests(defaultPluginManifests);
-            listOfPluginManifests.addAll(pluginManifestsFromConfig);
-        }
-        //Process plugins from /create param
-        String pluginManifestsParam = params.get(ApiParams.PLUGIN_MANIFESTS);
-        if (!StringUtils.isEmpty(pluginManifestsParam)) {
-            ArrayList<PluginManifest> pluginManifestsFromParam = processPluginManifests(pluginManifestsParam);
-            listOfPluginManifests.addAll(pluginManifestsFromParam);
+        if (!isBreakout){
+            //Process plugins from config
+            if (defaultPluginManifests != null && !defaultPluginManifests.isEmpty()) {
+                ArrayList<PluginManifest> pluginManifestsFromConfig = processPluginManifests(defaultPluginManifests);
+                listOfPluginManifests.addAll(pluginManifestsFromConfig);
+            }
+            //Process plugins from /create param
+            String pluginManifestsParam = params.get(ApiParams.PLUGIN_MANIFESTS);
+            if (!StringUtils.isEmpty(pluginManifestsParam)) {
+                ArrayList<PluginManifest> pluginManifestsFromParam = processPluginManifests(pluginManifestsParam);
+                listOfPluginManifests.addAll(pluginManifestsFromParam);
+            }
         }
 
         // Check if VirtualBackgrounds is disabled

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -1,5 +1,7 @@
 package org.bigbluebutton.api.messaging.messages;
 
+import java.util.Map;
+
 public class CreateBreakoutRoom implements IMessage {
 
     public final String meetingId;
@@ -23,6 +25,7 @@ public class CreateBreakoutRoom implements IMessage {
     public final Boolean captureSlides; // Upload annotated breakout slides to main room after breakout room end
     public final String captureNotesFilename;
     public final String captureSlidesFilename;
+    public final Map<String, Object> pluginProp;
 
     public CreateBreakoutRoom(String meetingId,
 															String parentMeetingId,
@@ -43,7 +46,8 @@ public class CreateBreakoutRoom implements IMessage {
                                                             Boolean captureNotes,
                                                             Boolean captureSlides,
                                                             String captureNotesFilename,
-                                                            String captureSlidesFilename) {
+                                                            String captureSlidesFilename,
+                                                            Map<String, Object> pluginProp) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -64,5 +68,6 @@ public class CreateBreakoutRoom implements IMessage {
         this.captureSlides = captureSlides;
         this.captureNotesFilename = captureNotesFilename;
         this.captureSlidesFilename = captureSlidesFilename;
+        this.pluginProp = pluginProp;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -127,6 +127,7 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.captureSlides,
       msg.body.room.captureNotesFilename,
       msg.body.room.captureSlidesFilename,
+      msg.body.room.pluginProp,
     ))
     
   }


### PR DESCRIPTION
### What does this PR do?

It fixes plugins not running into breakout-rooms, so now, the same plugins that run on the main-room are going to also run into the breakouts.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/127

### Motivation

There are some required plugins that will run into breakouts, so this must have been sorted out.

### How to test

Really simple:

- Load a plugin into your BBB session (via create parameter or `.properties` bbb-web configuration)
- See if it runs in the main room;
- Create a breakout-room;
- See if it runs into the breakout you just created.


### More

Demo of the newly fixed behaviour:

https://github.com/user-attachments/assets/72f67558-b071-4395-b759-025b09e1c83d

For this Demo, and for the tests, I used [SampleActionButtonDropdownPlugin](https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tree/main/samples/sample-action-button-dropdown-plugin) already in the manifest structure. But it's possible to test it with the pick-random-user-plugin as well (this last one has the manifest structure already)

  
