### PR TITLE
fix (build): bypass docker error (retry script not working)

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -57,7 +57,7 @@ max_retries=5
 retry_wait=300  # wait time in seconds (5 minutes)
 
 while [[ $retry_count -lt $max_retries ]]; do
-    if sudo docker pull "$DOCKER_IMAGE"; then
+    if sudo docker pull "$DOCKER_IMAGE" || false; then
         echo "Docker image pulled successfully."
         break
     else

--- a/build/setup.sh
+++ b/build/setup.sh
@@ -62,7 +62,7 @@ while [[ $retry_count -lt $max_retries ]]; do
         break
     else
         echo "Failed to pull Docker image, attempt $((retry_count+1))/$max_retries."
-        ((retry_count++))
+        retry_count=$((retry_count+1))
         if [[ $retry_count -lt $max_retries ]]; then
             echo "Waiting for $retry_wait seconds before retrying..."
             sleep $retry_wait


### PR DESCRIPTION
Small fix for the PR #21038.
The retry script is not working properly, as reported by @antonbsa:

![image](https://github.com/user-attachments/assets/7e875d01-ec8a-4057-aa5c-b467014b4515)


