### PR TITLE
feat(akka): add feature to decide whether the plugin will run on the breakout-rooms or not

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -82,10 +82,10 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       val roomSlides = if (breakout.allPages) -1 else presSlide;
 
       val scalaPluginProp = liveMeeting.props.pluginProp.asScala
-      val filterPluginsNotEnabledInBreakouts: ((String, Plugin)) => Boolean = { case (_, plugin) =>
+      val filterPluginsEnabledForBreakoutRooms: ((String, Plugin)) => Boolean = { case (_, plugin) =>
         plugin.manifest.content.enabledForBreakoutRooms.getOrElse(false)
       }
-      val filteredPlugins = getPlugins(liveMeeting.plugins).filter(filterPluginsNotEnabledInBreakouts)
+      val filteredPlugins = getPlugins(liveMeeting.plugins).filter(filterPluginsEnabledForBreakoutRooms)
 
       val filteredPluginProp = scalaPluginProp.filter { case (key, _) => filteredPlugins.contains(key) }.asJava
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -61,6 +61,11 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     val presSlide = getPresentationSlide(state) // The current slide
     val parentId = liveMeeting.props.meetingProp.intId
     var rooms = new collection.immutable.HashMap[String, BreakoutRoom2x]
+    val filteredPluginProp = liveMeeting.props.pluginProp.asScala
+      .filter { case (key, _) =>
+        getPlugins(liveMeeting.plugins).get(key).exists(_.manifest.content.enabledForBreakoutRooms)
+      }
+      .asJava
 
     var i = 0
     for (room <- msg.body.rooms) {
@@ -80,13 +85,6 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
 
     for (breakout <- rooms.values.toVector) {
       val roomSlides = if (breakout.allPages) -1 else presSlide;
-
-      val filteredPluginProp = liveMeeting.props.pluginProp.asScala
-        .filter { case (key, _) =>
-          getPlugins(liveMeeting.plugins).get(key).exists(_.manifest.content.enabledForBreakoutRooms)
-        }
-        .asJava
-
       val roomDetail = new BreakoutRoomDetail(
         breakout.id, breakout.name,
         liveMeeting.props.meetingProp.intId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -83,7 +83,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
 
       val scalaPluginProp = liveMeeting.props.pluginProp.asScala
       val filterPluginsNotEnabledInBreakouts: ((String, Plugin)) => Boolean = { case (_, plugin) =>
-        plugin.manifest.content.enabledInBreakoutRoom.getOrElse(false)
+        plugin.manifest.content.enabledForBreakoutRooms.getOrElse(false)
       }
       val filteredPlugins = getPlugins(liveMeeting.plugins).filter(filterPluginsNotEnabledInBreakouts)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -81,13 +81,11 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     for (breakout <- rooms.values.toVector) {
       val roomSlides = if (breakout.allPages) -1 else presSlide;
 
-      val scalaPluginProp = liveMeeting.props.pluginProp.asScala
-      val filterPluginsEnabledForBreakoutRooms: ((String, Plugin)) => Boolean = { case (_, plugin) =>
-        plugin.manifest.content.enabledForBreakoutRooms.getOrElse(false)
-      }
-      val filteredPlugins = getPlugins(liveMeeting.plugins).filter(filterPluginsEnabledForBreakoutRooms)
-
-      val filteredPluginProp = scalaPluginProp.filter { case (key, _) => filteredPlugins.contains(key) }.asJava
+      val filteredPluginProp = liveMeeting.props.pluginProp.asScala
+        .filter { case (key, _) =>
+          getPlugins(liveMeeting.plugins).get(key).exists(_.manifest.content.enabledForBreakoutRooms)
+        }
+        .asJava
 
       val roomDetail = new BreakoutRoomDetail(
         breakout.id, breakout.name,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -36,7 +36,7 @@ case class PluginManifestContent(
     requiredSdkVersion:            String,
     name:                          String,
     javascriptEntrypointUrl:       String,
-    enabledInBreakoutRoom:         Option[Boolean]                = None,
+    enabledForBreakoutRooms:       Option[Boolean]                = None,
     javascriptEntrypointIntegrity: Option[String]                 = None,
     localesBaseUrl:                Option[String]                 = None,
     eventPersistence:              Option[EventPersistence]       = None,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -36,6 +36,7 @@ case class PluginManifestContent(
     requiredSdkVersion:            String,
     name:                          String,
     javascriptEntrypointUrl:       String,
+    enabledInBreakoutRoom:         Option[Boolean]                = None,
     javascriptEntrypointIntegrity: Option[String]                 = None,
     localesBaseUrl:                Option[String]                 = None,
     eventPersistence:              Option[EventPersistence]       = None,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -36,7 +36,7 @@ case class PluginManifestContent(
     requiredSdkVersion:            String,
     name:                          String,
     javascriptEntrypointUrl:       String,
-    enabledForBreakoutRooms:       Option[Boolean]                = None,
+    enabledForBreakoutRooms:       Boolean                        = false,
     javascriptEntrypointIntegrity: Option[String]                 = None,
     localesBaseUrl:                Option[String]                 = None,
     eventPersistence:              Option[EventPersistence]       = None,


### PR DESCRIPTION
### What does this PR do?

It creates a new feature to the plugin's manifest: Allowing (or not) the plugin to run in the breakout-rooms.

As a default, if this property is not set in manifest, it will be taken as false, so that plugin will not load on breakout-rooms. If, however, the developer wants it to run in the breakout-rooms, they need to explicitly tell in the manifest by setting `enabledForBreakoutRooms` as true.

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/126


### How to test
Take one of the plugins that already has the manifest structure, such as the https://github.com/bigbluebutton/plugin-pick-random-user, and do the following steps:

- Run it either in dev mode or not (as is);
- Create a meeting with the plugin (either by `/create` parameters or by `.properties` configuration file from bbb-web);
- Check if the plugin is running properly in the main session;
- Create a breakout-room and join it;
- Once inside, check if the plugin is running there;

If the plugin has the property `enabledForBreakoutRooms` set as true, it should run normally in the last step, whereas if it's set to false or it is not set at all, it should not be running on the breakouts (last step).  
