### PR TITLE
ci: Improve retry for `Install BBB` step in Automated Tests

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -303,6 +303,7 @@ jobs:
             rm -f /var/lib/dpkg/lock-frontend
             rm -f /var/lib/dpkg/lock
             rm -f /var/cache/apt/archives/lock
+            rm -f /var/cache/debconf/config.dat
 
             echo "Reconfigure the package manager"
             dpkg --configure -a

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -255,6 +255,7 @@ jobs:
         run: |
           sudo sh -c '
           apt --purge -y remove apache2-bin
+          apt-mark hold firefox #hold ff once bbb-install frequently stuck at `Installing the firefox snap`
           '
       - name: Install BBB
         env:


### PR DESCRIPTION
This PR will solve two issues during `Install BBB` step on Automated tests:

- When retrying to install BBB, it's missing to unlock the file `/var/cache/debconf/config.dat`
![image](https://github.com/user-attachments/assets/1cf62dc2-1f44-43a9-9656-8c71395cac52)

- BBB-Install very often stuck on step `Installing the firefox snap`, so it will hold this package to avoid upgrading it.
 ![image](https://github.com/user-attachments/assets/c2501c78-2b24-4c75-88e6-6995e80706b4)
