### PR TITLE
build: postgres to restart together with BBB

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -360,16 +360,13 @@ start_bigbluebutton () {
         fi
     fi
 
-    echo "Reloading NginX configuration"
-    systemctl reload nginx
-
     echo "Starting BigBlueButton"
 
     systemctl restart bigbluebutton.target
 }
 
 display_bigbluebutton_status () {
-    units="nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka"
+    units="nginx freeswitch $REDIS_SERVICE bbb-apps-akka bbb-fsesl-akka postgresql"
 
     if [ -f /usr/lib/systemd/system/bbb-graphql-actions.service ]; then
         units="$units bbb-graphql-actions"

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -52,7 +52,7 @@ cp include_default.nginx staging/usr/share/bigbluebutton/
 cp bigbluebutton.target staging/usr/lib/systemd/system/
 
 # inject dependency to bigbluebutton.target
-for unit in freeswitch nginx redis-server; do
+for unit in freeswitch nginx redis-server postgres; do
   mkdir -p "staging/usr/lib/systemd/system/${unit}.service.d"
   cp bigbluebutton.conf "staging/usr/lib/systemd/system/${unit}.service.d/"
 done

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -52,7 +52,7 @@ cp include_default.nginx staging/usr/share/bigbluebutton/
 cp bigbluebutton.target staging/usr/lib/systemd/system/
 
 # inject dependency to bigbluebutton.target
-for unit in freeswitch nginx redis-server postgres; do
+for unit in freeswitch nginx redis-server postgresql; do
   mkdir -p "staging/usr/lib/systemd/system/${unit}.service.d"
   cp bigbluebutton.conf "staging/usr/lib/systemd/system/${unit}.service.d/"
 done

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -2,13 +2,6 @@
 
 TARGET=`basename $(pwd)`
 
-# inject dependency to bigbluebutton.target
-for unit in freeswitch nginx redis-server; do
-  mkdir -p "staging/usr/lib/systemd/system/${unit}.service.d"
-  cp bigbluebutton.conf "staging/usr/lib/systemd/system/${unit}.service.d/"
-done
-
-
 PACKAGE=$(echo $TARGET | cut -d'_' -f1)
 VERSION=$(echo $TARGET | cut -d'_' -f2)
 DISTRO=$(echo $TARGET | cut -d'_' -f3)
@@ -57,6 +50,12 @@ mkdir -p staging/usr/share/bigbluebutton/nginx
 cp include_default.nginx staging/usr/share/bigbluebutton/
 
 cp bigbluebutton.target staging/usr/lib/systemd/system/
+
+# inject dependency to bigbluebutton.target
+for unit in freeswitch nginx redis-server; do
+  mkdir -p "staging/usr/lib/systemd/system/${unit}.service.d"
+  cp bigbluebutton.conf "staging/usr/lib/systemd/system/${unit}.service.d/"
+done
 
 . ./opts-$DISTRO.sh
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- included postgres in bigbluebutton.target (which means it gets restarted together with the rest of the services via `bbb-conf --restart`)
- includes `nginx`, `freeswitch`, `redis-server` in bigbluebutton.target (which means they get restarted together with the rest of the services via `bbb-conf --restart`)   -- this was mostly done by @danimo in https://github.com/bigbluebutton/bigbluebutton/commit/61ce7ab9b658cea6e069faf91c96e6cb1d90f349 but the overrides were getting cleared later in the `bbb-config` building, so they never really worked.
- `postgres` included in the `bbb-conf --status` list
- no longer reload nginx on `bbb-conf --restart` as it gets restarted anyway


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/21446

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

- [ ] a working BBB after restart
- [ ] `systemctl list-dependencies bigbluebutton.target` to include nginx, postgres, freeswitch, redis-client

```
bigbluebutton@anton-droplet-1921:~/bigbluebutton/build$ systemctl list-dependencies bigbluebutton.target 
bigbluebutton.target
● ├─bbb-apps-akka.service
● ├─bbb-export-annotations.service
● ├─bbb-fsesl-akka.service
● ├─bbb-graphql-actions.service
● ├─bbb-graphql-middleware.service
● ├─bbb-graphql-server.service
● ├─bbb-pads.service
● ├─bbb-rap-caption-inbox.service
● ├─bbb-rap-resque-worker.service
● ├─bbb-rap-starter.service
● ├─bbb-web.service
● ├─bbb-webrtc-recorder.service
● ├─bbb-webrtc-sfu.service
● ├─etherpad.service
● ├─freeswitch.service
● ├─nginx.service
● ├─postgresql.service
● └─redis-server.service
```

- [ ] when running `bbb-conf --check` postgres to be listed

```
...
postgresql ———————————————————► [✔ - active]
...
```


### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
