### PR TITLE
Fix: recoding start being triggered by any key

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -193,8 +193,10 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
       onClick={() => {
         recordingToggle(micUser, recording);
       }}
-      onKeyDown={() => {
-        recordingToggle(micUser, recording);
+      onKeyDown={(ev) => {
+        if (ev.key === 'Enter') {
+          recordingToggle(micUser, recording);
+        }
       }}
     >
       {recordingIndicatorIcon}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -194,6 +194,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
         recordingToggle(micUser, recording);
       }}
       onKeyDown={(ev) => {
+        ev.preventDefault();
         if (ev.key === 'Enter') {
           recordingToggle(micUser, recording);
         }


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue when navigating through keyboard over recording status was triggering the start recording modal, it was happening because the function to trigger the modal was not filtering which key could enable it, I made it support only the `Enter` key. 

### Closes Issue(s)
No issue was Opened


### How to test
1. Select Meeting name in navbar.
2. press Tab twice in the keyboard.
3. See the start recording modal open.
