### PR TITLE
Fix: hook being used inside useEffect

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -93,22 +93,10 @@ const ActionsBarContainer = (props) => {
   const amIPresenter = currentUserData?.presenter;
   const amIModerator = currentUserData?.isModerator;
   const [pinnedPadDataState, setPinnedPadDataState] = useState(null);
+  const { data: pinnedPadData } = useDeduplicatedSubscription(
+    PINNED_PAD_SUBSCRIPTION,
+  );
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: pinnedPadData } = await useDeduplicatedSubscription(
-        PINNED_PAD_SUBSCRIPTION,
-      );
-      setPinnedPadDataState(pinnedPadData || []);
-    };
-
-    fetchData();
-  }, []);
-
-  const isSharedNotesPinnedFromGraphql = !!pinnedPadDataState
-    && pinnedPadDataState.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
-
-  const isSharedNotesPinned = isSharedNotesPinnedFromGraphql;
   const allowExternalVideo = useIsExternalVideoEnabled();
   const connected = useReactiveVar(connectionStatus.getConnectedStatusVar());
   const intl = useIntl();
@@ -131,7 +119,12 @@ const ActionsBarContainer = (props) => {
     && (deviceInfo.isPhone || isLayeredView.matches);
   if (actionsBarStyle.display === false) return null;
   if (!currentMeeting) return null;
+  if (!pinnedPadData) return null;
 
+  const isSharedNotesPinnedFromGraphql = !!pinnedPadData
+  && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
+
+  const isSharedNotesPinned = isSharedNotesPinnedFromGraphql;
   return (
     <ActionsBar {
       ...{

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
@@ -191,29 +191,12 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
 };
 
 const UserNotesContainerGraphql: React.FC<UserNotesContainerGraphqlProps> = (props) => {
-  type PinnedPadData = {
-    sharedNotes: Array<{
-      sharedNotesExtId: string;
-    }>;
-  };
   const { userLocks } = props;
   const disableNotes = userLocks.userNotes;
-  const [pinnedPadDataState, setPinnedPadDataState] = useState<PinnedPadData | null>(null);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const { data: pinnedPadData } = await useDeduplicatedSubscription(
-        PINNED_PAD_SUBSCRIPTION,
-      );
-      setPinnedPadDataState(pinnedPadData || []);
-    };
-
-    fetchData();
-  }, []);
-
+  const { data: pinnedPadData } = useDeduplicatedSubscription(
+    PINNED_PAD_SUBSCRIPTION,
+  );
   const NOTES_CONFIG = window.meetingClientSettings.public.notes;
-
-  const isPinned = !!pinnedPadDataState && pinnedPadDataState.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const sidebarContent = layoutSelectInput((i: any) => i.sidebarContent);
@@ -226,7 +209,9 @@ const UserNotesContainerGraphql: React.FC<UserNotesContainerGraphqlProps> = (pro
   const hasUnreadNotes = useHasUnreadNotes();
   const markNotesAsRead = () => setNotesLastRev(rev);
   const isEnabled = NotesService.useIsEnabled();
+  if (!pinnedPadData) return null;
 
+  const isPinned = !!pinnedPadData && pinnedPadData?.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
   return (
     <UserNotesGraphql
       disableNotes={disableNotes}


### PR DESCRIPTION
### What does this PR do?
This PR fixed a console error being emitted every time the userlist is closed, it was introduce at #20975, because of a `useDeduplicateSubscription` hook being used inside a useEffect hook, React doesn't allow the use of hooks inside of lifecycle hooks of a component thwoing a error.

### Closes Issue(s)
No issues was opened.

### How to test
1. Open devtools
2. Clear the logs
3. Open/close the userlist several times.

