### PR TITLE
suppress output of 'docker image prune' command

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -127,7 +127,7 @@ remove_raw_of_published_recordings
 #
 # Remove untagged and unamed docker images, cleanning /var/lib/docker/overlay2
 #
-docker image prune -f
+docker image prune -f | grep -v "Total reclaimed space:"
 
 #
 # Remove old *.afm and *.pfb files from /tmp directory (if any exist)


### PR DESCRIPTION
As it seems 'docker image prune' is the only command in the cronjob which creates an output. Let's filterout it's standard message.