### PR TITLE
fix: audio alerts for user join/leave only work if push alerts are enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -39,21 +39,24 @@ const Notifications: React.FC = () => {
   const Settings = getSettingsSingletonInstance();
   const {
     userJoinPushAlerts,
+    userJoinAudioAlerts,
     userLeavePushAlerts,
+    userLeaveAudioAlerts,
     guestWaitingPushAlerts,
+    guestWaitingAudioAlerts,
   } = Settings.application;
 
   const excludedMessageIds = [];
 
-  if (!userJoinPushAlerts) {
+  if (!userJoinPushAlerts && !userJoinAudioAlerts) {
     excludedMessageIds.push('app.notification.userJoinPushAlert');
   }
 
-  if (!userLeavePushAlerts) {
+  if (!userLeavePushAlerts && !userLeaveAudioAlerts) {
     excludedMessageIds.push('app.notification.userLeavePushAlert');
   }
 
-  if (!guestWaitingPushAlerts) {
+  if (!guestWaitingPushAlerts && !guestWaitingAudioAlerts) {
     excludedMessageIds.push('app.userList.guest.pendingGuestAlert');
   }
 


### PR DESCRIPTION
### What does this PR do?
Refactor notifications component to handle audio alerts when push alerts are not enabled

### How to test
1. join a meeting with user A
2. enable user join/leave audio alerts for user A, but keep push alerts disabled
3. join with another user (user B)
4. user A should hear an audio alert