### PR TITLE
fix(chat): Improved usability, UI fixes, et al.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -372,6 +372,14 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
           },
         }).then(() => {
           sendCancelEvents();
+        }).catch((e) => {
+          logger.error({
+            logCode: 'chat_edit_message_error',
+            extraInfo: {
+              errorName: e?.name,
+              errorMessage: e?.message,
+            },
+          }, `Editing the message failed: ${e?.message}`);
         });
       } else if (!chatSendMessageLoading) {
         chatSendMessage({

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -138,11 +138,12 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const emojiPickerButtonRef = useRef(null);
   const [isTextAreaFocused, setIsTextAreaFocused] = React.useState(false);
   const [repliedMessageId, setRepliedMessageId] = React.useState<string | null>(null);
-  const [editingMessage, setEditingMessage] = React.useState<EditingMessage | null>(null);
+  const editingMessage = React.useRef<EditingMessage | null>(null);
   const textAreaRef: RefObject<TextareaAutosize> = useRef<TextareaAutosize>(null);
   const { isMobile } = deviceInfo;
   const prevChatId = usePreviousValue(chatId);
   const messageRef = useRef<string>('');
+  const messageBeforeEditingRef = useRef<string | null>(null);
   messageRef.current = message;
   const updateUnreadMessages = (chatId: string, message: string) => {
     const storedData = localStorage.getItem('unsentMessages') || '{}';
@@ -302,16 +303,24 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
     const handleEditingMessage = (e: Event) => {
       if (e instanceof CustomEvent) {
         if (textAreaRef.current) {
+          if (messageBeforeEditingRef.current === null) {
+            messageBeforeEditingRef.current = messageRef.current;
+          }
           setMessage(e.detail.message);
-          setEditingMessage(e.detail);
+          editingMessage.current = e.detail;
         }
       }
     };
 
     const handleCancelEditingMessage = (e: Event) => {
       if (e instanceof CustomEvent) {
-        setMessage('');
-        setEditingMessage(null);
+        if (editingMessage.current) {
+          if (messageBeforeEditingRef.current !== null) {
+            setMessage(messageBeforeEditingRef.current);
+            messageBeforeEditingRef.current = null;
+          }
+          editingMessage.current = null;
+        }
       }
     };
 
@@ -363,11 +372,11 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
         }
       };
 
-      if (editingMessage && !chatEditMessageLoading) {
+      if (editingMessage.current && !chatEditMessageLoading) {
         chatEditMessage({
           variables: {
-            chatId: editingMessage.chatId,
-            messageId: editingMessage.messageId,
+            chatId: editingMessage.current.chatId,
+            messageId: editingMessage.current.messageId,
             chatMessageInMarkdownFormat: msg,
           },
         }).then(() => {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -12,7 +12,6 @@ import {
   smPaddingY,
   borderRadius,
   borderSize,
-  xsPadding,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 import TextareaAutosize from 'react-autosize-textarea';
@@ -52,7 +51,7 @@ const Input = styled(TextareaAutosize)`
   background-clip: padding-box;
   color: ${colorText};
   -webkit-appearance: none;
-  padding: calc(${smPaddingY} * 2.5 - ${xsPadding}) calc(${smPaddingX} * 1.25 - ${xsPadding});
+  padding: calc(${smPaddingY} * 2.5) calc(${smPaddingX} * 1.25);
   resize: none;
   transition: none;
   border-radius: ${borderRadius};
@@ -169,10 +168,8 @@ const InputWrapper = styled.div`
   flex-grow: 1;
   min-width: 0;
   z-index: 0;
-  padding: ${xsPadding} 0 ${xsPadding} ${xsPadding};
-  box-shadow: inset 0.0625rem 0 0 0 ${colorGrayLightest},
-    inset 0 0.0625rem 0 0 ${colorGrayLightest},
-    inset 0 -0.0625rem 0 0 ${colorGrayLightest};
+  padding: 1px 0 1px 1px;
+  border: 1px solid ${colorGrayLightest};
 
   [dir='ltr'] & {
     border-radius: 0.75rem 0 0 0.75rem;
@@ -183,9 +180,7 @@ const InputWrapper = styled.div`
   }
 
   &:focus-within {
-    box-shadow: inset ${xsPadding} 0 0 0 ${colorBlueLight},
-      inset 0 ${xsPadding} 0 0 ${colorBlueLight},
-      inset 0 -${xsPadding} 0 0 ${colorBlueLight};
+    border: 1px solid ${colorBlueLight};
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -43,7 +43,6 @@ const Form = styled.form<FormProps>`
 const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
-  box-shadow: inset 0 0 0 1px ${colorGrayLightest};
   border-radius: 0.75rem;
 `;
 
@@ -51,10 +50,9 @@ const Input = styled(TextareaAutosize)`
   flex: 1;
   background: #fff;
   background-clip: padding-box;
-  margin: ${xsPadding} 0 ${xsPadding} ${xsPadding};
   color: ${colorText};
   -webkit-appearance: none;
-  padding: calc(${smPaddingY} * 2.5) calc(${smPaddingX} * 1.25);
+  padding: calc(${smPaddingY} * 2.5 - ${xsPadding}) calc(${smPaddingX} * 1.25 - ${xsPadding});
   resize: none;
   transition: none;
   border-radius: ${borderRadius};
@@ -171,19 +169,23 @@ const InputWrapper = styled.div`
   flex-grow: 1;
   min-width: 0;
   z-index: 0;
+  padding: ${xsPadding} 0 ${xsPadding} ${xsPadding};
+  box-shadow: inset 0.0625rem 0 0 0 ${colorGrayLightest},
+    inset 0 0.0625rem 0 0 ${colorGrayLightest},
+    inset 0 -0.0625rem 0 0 ${colorGrayLightest};
 
   [dir='ltr'] & {
     border-radius: 0.75rem 0 0 0.75rem;
-    margin-right: ${xsPadding};
   }
 
   [dir='rtl'] & {
     border-radius: 0 0.75rem 0.75rem 0;
-    margin-left: ${xsPadding};
   }
 
   &:focus-within {
-    box-shadow: 0 0 0 ${xsPadding} ${colorBlueLight};
+    box-shadow: inset ${xsPadding} 0 0 0 ${colorBlueLight},
+      inset 0 ${xsPadding} 0 0 ${colorBlueLight},
+      inset 0 -${xsPadding} 0 0 ${colorBlueLight};
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -292,7 +292,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         toggleFollowingTail(false);
       }
       setUserLoadedBackUntilPage((prev) => {
-        if (typeof prev === 'number') {
+        if (typeof prev === 'number' && prev > 0) {
           return prev - 1;
         }
         return prev;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -221,7 +221,12 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   const [chatSendReaction] = useMutation(CHAT_SEND_REACTION_MUTATION);
   const [chatDeleteReaction] = useMutation(CHAT_DELETE_REACTION_MUTATION);
 
-  const sendReaction = (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => {
+  const sendReaction = useCallback((
+    reactionEmoji: string,
+    reactionEmojiId: string,
+    chatId: string,
+    messageId: string,
+  ) => {
     chatSendReaction({
       variables: {
         chatId,
@@ -230,9 +235,14 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmojiId,
       },
     });
-  };
+  }, [chatSendReaction]);
 
-  const deleteReaction = (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => {
+  const deleteReaction = useCallback((
+    reactionEmoji: string,
+    reactionEmojiId: string,
+    chatId: string,
+    messageId: string,
+  ) => {
     chatDeleteReaction({
       variables: {
         chatId,
@@ -241,7 +251,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmojiId,
       },
     });
-  };
+  }, [chatDeleteReaction]);
 
   useEffect(() => {
     if (isSentinelVisible) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -408,6 +408,11 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     }
   };
 
+  const hasToolbar = CHAT_DELETE_ENABLED
+  || CHAT_EDIT_ENABLED
+  || CHAT_REPLY_ENABLED
+  || CHAT_REACTIONS_ENABLED;
+
   return (
     <>
       {
@@ -428,7 +433,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
             <div
               role="listbox"
               ref={messageListRef}
-              tabIndex={0}
+              tabIndex={hasToolbar ? 0 : -1}
               onKeyDown={rove}
               onBlur={() => {
                 setSelectedMessage(null);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -427,7 +427,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     }
   };
 
-  const hasToolbar = CHAT_DELETE_ENABLED
+  const hasMessageToolbar = CHAT_DELETE_ENABLED
     || CHAT_EDIT_ENABLED
     || CHAT_REPLY_ENABLED
     || CHAT_REACTIONS_ENABLED;
@@ -454,11 +454,12 @@ const ChatMessageList: React.FC<ChatListProps> = ({
             data-test="chatMessages"
             isRTL={isRTL}
             ref={updateRefs}
+            $hasMessageToolbar={hasMessageToolbar}
           >
             <div
               role="listbox"
               ref={messageListRef}
-              tabIndex={hasToolbar ? 0 : -1}
+              tabIndex={hasMessageToolbar ? 0 : -1}
               onKeyDown={rove}
               onBlur={() => {
                 setSelectedMessage(null);
@@ -473,7 +474,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
                 tabIndex={-1}
                 aria-hidden
               />
-              <ChatPopupContainer />
+              <ChatPopupContainer hasMessageToolbar={hasMessageToolbar} />
               {Array.from({ length: pagesToLoad }, (_v, k) => k + (firstPageToLoad)).map((page) => {
                 return (
                   <ChatListPage

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -37,6 +37,7 @@ import {
   useIsDeleteChatMessageEnabled,
 } from '/imports/ui/services/features';
 import { CHAT_DELETE_REACTION_MUTATION, CHAT_SEND_REACTION_MUTATION } from './page/chat-message/mutations';
+import logger from '/imports/startup/client/logger';
 
 const PAGE_SIZE = 50;
 
@@ -234,6 +235,14 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmoji,
         reactionEmojiId,
       },
+    }).catch((e) => {
+      logger.error({
+        logCode: 'chat_send_message_reaction_error',
+        extraInfo: {
+          errorName: e?.name,
+          errorMessage: e?.message,
+        },
+      }, `Sending reaction failed: ${e?.message}`);
     });
   }, [chatSendReaction]);
 
@@ -250,6 +259,14 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         reactionEmoji,
         reactionEmojiId,
       },
+    }).catch((e) => {
+      logger.error({
+        logCode: 'chat_delete_message_reaction_error',
+        extraInfo: {
+          errorName: e?.name,
+          errorMessage: e?.message,
+        },
+      }, `Deleting reaction failed: ${e?.message}`);
     });
   }, [chatDeleteReaction]);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -205,7 +205,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     isModerator: c?.isModerator,
     userLockSettings: c?.userLockSettings,
     locked: c?.locked,
-    userId: c.userId,
+    userId: c?.userId,
   }));
   const CHAT_REPLY_ENABLED = useIsReplyChatMessageEnabled();
   const CHAT_REACTIONS_ENABLED = useIsChatMessageReactionsEnabled();

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -573,7 +573,6 @@ function areChatMessagesEqual(prevProps: ChatMessageProps, nextProps: ChatMessag
     'message.user.currentlyInMeeting',
     'message.reactions.length',
     'message.replyToMessage.message',
-    'message.recipientHasSeen',
   ] as const;
   return propsToCompare.every((pointer) => {
     const previousValue = getValueByPointer(prevProps, pointer);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -63,6 +63,7 @@ interface ChatMessageProps {
 
 export interface ChatMessageRef {
   requestFocus: () => void;
+  sequence: number;
 }
 
 const intlMessages = defineMessages({
@@ -170,7 +171,8 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
         requestAnimationFrame(startScrollAnimation);
       }, 0);
     },
-  }), []);
+    sequence: message.messageSequence,
+  }), [message.messageSequence]);
 
   const startScrollAnimation = (timestamp: number) => {
     animationInitialScrollPosition.current = scrollRef.current?.scrollTop || 0;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -553,27 +553,28 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   );
 });
 
+const propsToCompare = [
+  'meetingDisablePublicChat',
+  'meetingDisablePrivateChat',
+  'currentUserDisablePublicChat',
+  'currentUserId',
+  'currentUserIsLocked',
+  'currentUserIsModerator',
+  'chatDeleteEnabled',
+  'chatEditEnabled',
+  'chatReactionsEnabled',
+  'chatReplyEnabled',
+  'focused',
+  'keyboardFocused',
+  'message.createdAt',
+  'message.message',
+  'message.recipientHasSeen',
+  'message.user.currentlyInMeeting',
+  'message.reactions.length',
+  'message.replyToMessage.message',
+] as const;
+
 function areChatMessagesEqual(prevProps: ChatMessageProps, nextProps: ChatMessageProps) {
-  const propsToCompare = [
-    'meetingDisablePublicChat',
-    'meetingDisablePrivateChat',
-    'currentUserDisablePublicChat',
-    'currentUserId',
-    'currentUserIsLocked',
-    'currentUserIsModerator',
-    'chatDeleteEnabled',
-    'chatEditEnabled',
-    'chatReactionsEnabled',
-    'chatReplyEnabled',
-    'focused',
-    'keyboardFocused',
-    'message.createdAt',
-    'message.message',
-    'message.recipientHasSeen',
-    'message.user.currentlyInMeeting',
-    'message.reactions.length',
-    'message.replyToMessage.message',
-  ] as const;
   return propsToCompare.every((pointer) => {
     const previousValue = getValueByPointer(prevProps, pointer);
     const nextValue = getValueByPointer(nextProps, pointer);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -158,9 +158,9 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
 
   if (!currentUserIsModerator) {
     if (isPublicChat) {
-      locked = (currentUserIsLocked && disablePublicChat) || false;
+      locked = currentUserIsLocked && disablePublicChat;
     } else {
-      locked = (currentUserIsLocked && meetingDisablePrivateChat) || false;
+      locked = currentUserIsLocked && meetingDisablePrivateChat;
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -421,6 +421,11 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     && !sameSender
     && !isCustomPluginMessage;
 
+  const onEmojiSelected = useCallback((emoji: { id: string; native: string }) => {
+    sendReaction(emoji.native, emoji.id, message.chatId, message.messageId);
+    setIsToolbarReactionPopoverOpen(false);
+  }, [message.chatId, message.messageId, sendReaction]);
+
   return (
     <Container
       ref={containerRef}
@@ -449,10 +454,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           message={message.message}
           messageSequence={message.messageSequence}
           emphasizedMessage={message.chatEmphasizedText}
-          onEmojiSelected={(emoji) => {
-            sendReaction(emoji.native, emoji.id, message.chatId, message.messageId);
-            setIsToolbarReactionPopoverOpen(false);
-          }}
+          onEmojiSelected={onEmojiSelected}
           onReactionPopoverOpenChange={setIsToolbarReactionPopoverOpen}
           reactionPopoverIsOpen={isToolbarReactionPopoverOpen}
           chatDeleteEnabled={chatDeleteEnabled}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
@@ -47,6 +47,7 @@ const ChatMessageHeader: React.FC<ChatMessageHeaderProps> = ({
             </Styled.ChatUserOffline>
           )
         }
+        <Styled.Center />
         {!deleteTime && editTime && (
           <Styled.EditLabel>
             <Icon iconName="pen_tool" />

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/styles.ts
@@ -31,7 +31,7 @@ export const ChatUserName = styled.div<ChatUserNameProps>`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex-grow: 1;
+  flex-shrink: 1;
 
   ${({ currentlyInMeeting }) => currentlyInMeeting && `
     color: ${colorHeading};
@@ -102,6 +102,10 @@ export const EditLabel = styled.span`
   }
 `;
 
+export const Center = styled.div`
+  flex-grow: 1;
+`;
+
 export default {
   HeaderContent,
   ChatTime,
@@ -109,4 +113,5 @@ export default {
   ChatUserName,
   ChatHeaderText,
   EditLabel,
+  Center,
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/component.tsx
@@ -29,8 +29,10 @@ interface ChatMessageReactionsProps {
       userId: string;
     };
   }[];
-  sendReaction(reactionEmoji: string, reactionEmojiId: string): void;
-  deleteReaction(reactionEmoji: string, reactionEmojiId: string): void;
+  sendReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  deleteReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  chatId: string;
+  messageId: string;
 }
 
 type ReactionItem = {
@@ -46,7 +48,9 @@ const sortByCount = (r1: ReactionItem, r2: ReactionItem) => r2.count - r1.count;
 const sortByLeastRecent = (r1: ReactionItem, r2: ReactionItem) => r1.leastRecent - r2.leastRecent;
 
 const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
-  const { reactions, sendReaction, deleteReaction } = props;
+  const {
+    reactions, sendReaction, deleteReaction, chatId, messageId,
+  } = props;
 
   const { data: currentUser } = useCurrentUser((u) => ({ userId: u.userId }));
   const intl = useIntl();
@@ -101,9 +105,9 @@ const ChatMessageReactions: React.FC<ChatMessageReactionsProps> = (props) => {
               highlighted={details.reactedByMe}
               onClick={() => {
                 if (details.reactedByMe) {
-                  deleteReaction(details.reactionEmoji, details.reactionEmojiId);
+                  deleteReaction(details.reactionEmoji, details.reactionEmojiId, chatId, messageId);
                 } else {
-                  sendReaction(details.reactionEmoji, details.reactionEmojiId);
+                  sendReaction(details.reactionEmoji, details.reactionEmojiId, chatId, messageId);
                 }
               }}
             >

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -37,7 +37,6 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
             },
           }),
         );
-        Storage.removeItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST);
         Storage.setItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST, sequence);
       }}
     >

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/emoji-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/emoji-button/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
-import { colorGray } from '/imports/ui/stylesheets/styled-components/palette';
-import { lgPadding } from '/imports/ui/stylesheets/styled-components/general';
+import { colorGray, colorGrayDark, colorOffWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { smPadding } from '/imports/ui/stylesheets/styled-components/general';
 import { fontSizeSmaller } from '/imports/ui/stylesheets/styled-components/typography';
 
 const EmojiButton = styled.button`
@@ -9,13 +9,15 @@ const EmojiButton = styled.button`
   background: none;
   border: none;
   outline: none;
-  padding: ${lgPadding};
+  padding: ${smPadding};
   color: ${colorGray};
   cursor: pointer;
+  border-radius: 0.25rem;
 
   &:focus,
   &:hover {
-    opacity: 0.5;
+    color: ${colorGrayDark};
+    background-color: ${colorOffWhite};
   }
 
   &:active {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/styles.ts
@@ -4,7 +4,9 @@ import {
   colorGrayLightest,
   colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { $2xlPadding, borderRadius, smPadding } from '/imports/ui/stylesheets/styled-components/general';
+import {
+  $2xlPadding, borderRadius, lgPadding, smPadding,
+} from '/imports/ui/stylesheets/styled-components/general';
 import EmojiPickerComponent from '/imports/ui/components/emoji-picker/component';
 import BaseEmojiButton from './emoji-button/component';
 
@@ -50,6 +52,8 @@ const Container = styled.div`
   border-radius: 1rem;
   background-color: ${colorWhite};
   box-shadow: 0 0.125rem 0.125rem 0 ${colorGrayLighter};
+  padding: ${smPadding} ${lgPadding};
+  gap: ${smPadding};
 `;
 
 const EmojiPickerWrapper = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -26,6 +26,7 @@ import { setLoadedMessageGathering } from '/imports/ui/core/hooks/useLoadedChatM
 import { ChatLoading } from '../../component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import { useStorageKey, STORAGES } from '/imports/ui/services/storage/hooks';
+import Storage from '/imports/ui/services/storage/in-memory';
 import { getValueByPointer } from '/imports/utils/object-utils';
 
 const PAGE_SIZE = 50;
@@ -228,6 +229,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   useEffect(() => {
     if (typeof chatFocusMessageRequest === 'number') {
       messageRefs.current[chatFocusMessageRequest]?.requestFocus();
+      Storage.removeItem(ChatEvents.CHAT_FOCUS_MESSAGE_REQUEST);
     }
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   memo,
   useRef,
+  useCallback,
 } from 'react';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import {
@@ -230,6 +231,11 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
     }
   }, []);
 
+  const updateMessageRef = useCallback((ref: ChatMessageRef | null) => {
+    if (!ref) return;
+    messageRefs.current[ref.sequence] = ref;
+  }, []);
+
   return (
     <React.Fragment key={`messagePage-${page}`}>
       {messages.map((message, index, messagesArray) => {
@@ -249,9 +255,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             focused={focusedId === message.messageSequence}
             keyboardFocused={keyboardFocusedMessageSequence === message.messageSequence}
             editing={editingId === message.messageId}
-            ref={(ref) => {
-              messageRefs.current[message.messageSequence] = ref;
-            }}
+            ref={updateMessageRef}
             meetingDisablePrivateChat={meetingDisablePrivateChat}
             meetingDisablePublicChat={meetingDisablePublicChat}
             currentUserId={currentUserId}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -63,28 +63,29 @@ interface ChatListPageProps extends ChatListPageCommonProps {
   isPublicChat: boolean;
 }
 
+const propsToCompare = [
+  'focusedId',
+  'meetingDisablePublicChat',
+  'meetingDisablePrivateChat',
+  'currentUserDisablePublicChat',
+  'currentUserId',
+  'currentUserIsLocked',
+  'currentUserIsModerator',
+  'chatDeleteEnabled',
+  'chatEditEnabled',
+  'chatReactionsEnabled',
+  'chatReplyEnabled',
+] as const;
+const messagePropsToCompare = [
+  'messageId',
+  'createdAt',
+  'user.currentlyInMeeting',
+  'recipientHasSeen',
+  'message',
+  'reactions.length',
+] as const;
+
 const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPageProps) => {
-  const propsToCompare = [
-    'focusedId',
-    'meetingDisablePublicChat',
-    'meetingDisablePrivateChat',
-    'currentUserDisablePublicChat',
-    'currentUserId',
-    'currentUserIsLocked',
-    'currentUserIsModerator',
-    'chatDeleteEnabled',
-    'chatEditEnabled',
-    'chatReactionsEnabled',
-    'chatReplyEnabled',
-  ] as const;
-  const messagePropsToCompare = [
-    'messageId',
-    'createdAt',
-    'user.currentlyInMeeting',
-    'recipientHasSeen',
-    'message',
-    'reactions.length',
-  ] as const;
   const nextMessages = nextProps?.messages || [];
   const prevMessages = prevProps?.messages || [];
   if (nextMessages.length !== prevMessages.length) return false;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -17,17 +17,17 @@ import { DomElementManipulationHooks } from 'bigbluebutton-html-plugin-sdk/dist/
 import {
   CHAT_MESSAGE_PUBLIC_SUBSCRIPTION,
   CHAT_MESSAGE_PRIVATE_SUBSCRIPTION,
+  ChatMessageSubscriptionResponse,
 } from './queries';
 import { Message } from '/imports/ui/Types/message';
 import ChatMessage, { ChatMessageRef } from './chat-message/component';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
-import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 import { setLoadedMessageGathering } from '/imports/ui/core/hooks/useLoadedChatMessages';
 import { ChatLoading } from '../../component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import { useStorageKey, STORAGES } from '/imports/ui/services/storage/hooks';
 import Storage from '/imports/ui/services/storage/in-memory';
 import { getValueByPointer } from '/imports/utils/object-utils';
+import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 
 const PAGE_SIZE = 50;
 
@@ -318,10 +318,18 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
     ? defaultVariables : { ...defaultVariables, requestedChatId: chatId };
   const isPrivateReadFeedbackEnabled = !isPublicChat && PRIVATE_MESSAGE_READ_FEEDBACK_ENABLED;
 
-  const useChatMessageSubscription = useCreateUseSubscription<Message>(chatQuery, variables);
   const {
-    data: chatMessageData,
-  } = useChatMessageSubscription((msg) => msg) as GraphqlDataHookSubscriptionResponse<Message[]>;
+    data,
+    loading,
+  } = useDeduplicatedSubscription<ChatMessageSubscriptionResponse>(chatQuery, { variables });
+  let chatMessageData: Message[] | null = null;
+  if (data) {
+    if ('chat_message_public' in data) {
+      chatMessageData = data.chat_message_public;
+    } else if ('chat_message_private' in data) {
+      chatMessageData = data.chat_message_private;
+    }
+  }
 
   useEffect(() => {
     // component will unmount
@@ -330,8 +338,8 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
     };
   }, []);
 
+  if (loading) return <ChatLoading isRTL={document.dir === 'rtl'} />;
   if (!chatMessageData) return null;
-  if (chatMessageData.length > 0 && chatId !== chatMessageData[0].chatId) return <ChatLoading isRTL={document.dir === 'rtl'} />;
   if (chatMessageData.length > 0 && chatMessageData[chatMessageData.length - 1].user?.userId) {
     setLastSender(page, chatMessageData[chatMessageData.length - 1].user?.userId);
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -25,46 +25,81 @@ import { setLoadedMessageGathering } from '/imports/ui/core/hooks/useLoadedChatM
 import { ChatLoading } from '../../component';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import { useStorageKey, STORAGES } from '/imports/ui/services/storage/hooks';
+import { getValueByPointer } from '/imports/utils/object-utils';
 
 const PAGE_SIZE = 50;
 
-interface ChatListPageContainerProps {
-  page: number;
-  pageSize: number;
-  setLastSender: (page: number, message: string) => void;
-  lastSenderPreviousPage: string | undefined;
-  chatId: string;
-  markMessageAsSeen: (message: Message) => void;
-  scrollRef: React.RefObject<HTMLDivElement>;
-  focusedId: number | null;
+interface ChatListPageCommonProps {
   firstPageToLoad: number;
+  focusedId: number | null;
+  scrollRef: React.RefObject<HTMLDivElement>;
+  markMessageAsSeen: (message: Message) => void;
+  lastSenderPreviousPage: string | undefined;
+  page: number;
+  meetingDisablePublicChat: boolean;
+  meetingDisablePrivateChat: boolean;
+  currentUserIsModerator: boolean;
+  currentUserIsLocked: boolean;
+  currentUserId: string;
+  currentUserDisablePublicChat: boolean;
+  messageToolbarIsEnabled: boolean;
+  chatReplyEnabled: boolean;
+  chatDeleteEnabled: boolean;
+  chatEditEnabled: boolean;
+  chatReactionsEnabled: boolean;
+  sendReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
+  deleteReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
 }
 
-interface ChatListPageProps {
+interface ChatListPageContainerProps extends ChatListPageCommonProps {
+  pageSize: number;
+  setLastSender: (page: number, message: string) => void;
+  chatId: string;
+}
+
+interface ChatListPageProps extends ChatListPageCommonProps {
   messages: Array<Message>;
   messageReadFeedbackEnabled: boolean;
-  lastSenderPreviousPage: string | undefined;
-  page: number;
-  markMessageAsSeen: (message: Message)=> void;
-  scrollRef: React.RefObject<HTMLDivElement>;
-  focusedId: number | null;
-  firstPageToLoad: number;
+  isPublicChat: boolean;
 }
 
 const areChatPagesEqual = (prevProps: ChatListPageProps, nextProps: ChatListPageProps) => {
+  const propsToCompare = [
+    'focusedId',
+    'meetingDisablePublicChat',
+    'meetingDisablePrivateChat',
+    'currentUserDisablePublicChat',
+    'currentUserId',
+    'currentUserIsLocked',
+    'currentUserIsModerator',
+    'chatDeleteEnabled',
+    'chatEditEnabled',
+    'chatReactionsEnabled',
+    'chatReplyEnabled',
+  ] as const;
+  const messagePropsToCompare = [
+    'messageId',
+    'createdAt',
+    'user.currentlyInMeeting',
+    'recipientHasSeen',
+    'message',
+    'reactions.length',
+  ] as const;
   const nextMessages = nextProps?.messages || [];
   const prevMessages = prevProps?.messages || [];
   if (nextMessages.length !== prevMessages.length) return false;
   return nextMessages.every((nextMessage, idx) => {
     const prevMessage = prevMessages[idx];
-    return (prevMessage.messageId === nextMessage.messageId
-      && prevMessage.createdAt === nextMessage.createdAt
-      && prevMessage?.user?.currentlyInMeeting === nextMessage?.user?.currentlyInMeeting
-      && prevMessage?.recipientHasSeen === nextMessage?.recipientHasSeen
-      && prevMessage?.message === nextMessage?.message
-      && prevMessage?.reactions?.length === nextMessage?.reactions?.length
-    );
-  }) && prevProps.focusedId === nextProps.focusedId;
+    return messagePropsToCompare.every((pointer) => {
+      const previousValue = getValueByPointer(prevMessage, pointer);
+      const nextValue = getValueByPointer(nextMessage, pointer);
+      return previousValue === nextValue;
+    });
+  }) && propsToCompare.every((pointer) => {
+    const previousValue = getValueByPointer(prevProps, pointer);
+    const nextValue = getValueByPointer(nextProps, pointer);
+    return previousValue === nextValue;
+  });
 };
 
 const ChatListPage: React.FC<ChatListPageProps> = ({
@@ -76,6 +111,20 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   scrollRef,
   focusedId,
   firstPageToLoad,
+  meetingDisablePrivateChat,
+  meetingDisablePublicChat,
+  currentUserId,
+  currentUserDisablePublicChat,
+  currentUserIsLocked,
+  currentUserIsModerator,
+  isPublicChat,
+  messageToolbarIsEnabled,
+  chatDeleteEnabled,
+  chatEditEnabled,
+  chatReactionsEnabled,
+  chatReplyEnabled,
+  deleteReaction,
+  sendReaction,
 }) => {
   const { domElementManipulationIdentifiers } = useContext(PluginsContext);
   const messageRefs = useRef<Record<number, ChatMessageRef | null>>({});
@@ -202,6 +251,20 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             ref={(ref) => {
               messageRefs.current[message.messageSequence] = ref;
             }}
+            meetingDisablePrivateChat={meetingDisablePrivateChat}
+            meetingDisablePublicChat={meetingDisablePublicChat}
+            currentUserId={currentUserId}
+            currentUserDisablePublicChat={currentUserDisablePublicChat}
+            currentUserIsLocked={currentUserIsLocked}
+            currentUserIsModerator={currentUserIsModerator}
+            isPublicChat={isPublicChat}
+            hasToolbar={messageToolbarIsEnabled && !!message.user}
+            chatDeleteEnabled={chatDeleteEnabled}
+            chatEditEnabled={chatEditEnabled}
+            chatReactionsEnabled={chatReactionsEnabled}
+            chatReplyEnabled={chatReplyEnabled}
+            deleteReaction={deleteReaction}
+            sendReaction={sendReaction}
           />
         );
       })}
@@ -221,6 +284,19 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   scrollRef,
   focusedId,
   firstPageToLoad,
+  meetingDisablePrivateChat,
+  meetingDisablePublicChat,
+  currentUserId,
+  currentUserDisablePublicChat,
+  currentUserIsLocked,
+  currentUserIsModerator,
+  messageToolbarIsEnabled,
+  chatDeleteEnabled,
+  chatEditEnabled,
+  chatReactionsEnabled,
+  chatReplyEnabled,
+  deleteReaction,
+  sendReaction,
 }) => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_KEY = CHAT_CONFIG.public_group_id;
@@ -263,6 +339,20 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       scrollRef={scrollRef}
       focusedId={focusedId}
       firstPageToLoad={firstPageToLoad}
+      meetingDisablePrivateChat={meetingDisablePrivateChat}
+      meetingDisablePublicChat={meetingDisablePublicChat}
+      currentUserId={currentUserId}
+      currentUserDisablePublicChat={currentUserDisablePublicChat}
+      currentUserIsLocked={currentUserIsLocked}
+      currentUserIsModerator={currentUserIsModerator}
+      isPublicChat={isPublicChat}
+      messageToolbarIsEnabled={messageToolbarIsEnabled}
+      chatDeleteEnabled={chatDeleteEnabled}
+      chatEditEnabled={chatEditEnabled}
+      chatReactionsEnabled={chatReactionsEnabled}
+      chatReplyEnabled={chatReplyEnabled}
+      deleteReaction={deleteReaction}
+      sendReaction={sendReaction}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client';
+import { Message } from '/imports/ui/Types/message';
 
 export const CHAT_MESSAGE_PUBLIC_SUBSCRIPTION = gql`
   subscription chatMessages($limit: Int!, $offset: Int!) {
@@ -106,3 +107,9 @@ export const CHAT_MESSAGE_PRIVATE_SUBSCRIPTION = gql`
     }
   }
 `;
+
+export type ChatMessageSubscriptionResponse = {
+  chat_message_public: Message[]
+} | {
+  chat_message_private: Message[]
+}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -5,12 +5,12 @@ import { ButtonElipsis } from '/imports/ui/stylesheets/styled-components/placeho
 
 interface MessageListProps {
   isRTL: boolean;
+  $hasMessageToolbar: boolean;
 }
 
 export const MessageList = styled(ScrollboxVertical)<MessageListProps>`
   flex-flow: column;
   flex-shrink: 1;
-  padding-top: 2rem;
   outline-style: none;
   overflow-x: hidden;
   user-select: text;
@@ -27,6 +27,10 @@ export const MessageList = styled(ScrollboxVertical)<MessageListProps>`
 
   ${({ isRTL }) => !isRTL && `
     padding-right: ${smPaddingX};
+  `}
+
+  ${({ $hasMessageToolbar }) => $hasMessageToolbar && `
+    padding-top: 2rem;
   `}
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -1,10 +1,6 @@
 import styled from 'styled-components';
-import {
-  smPaddingX,
-  borderRadius,
-} from '/imports/ui/stylesheets/styled-components/general';
+import { smPaddingX } from '/imports/ui/stylesheets/styled-components/general';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
-import { colorGrayDark } from '/imports/ui/stylesheets/styled-components/palette';
 import { ButtonElipsis } from '/imports/ui/stylesheets/styled-components/placeholders';
 
 interface MessageListProps {
@@ -32,15 +28,6 @@ export const MessageList = styled(ScrollboxVertical)<MessageListProps>`
   ${({ isRTL }) => !isRTL && `
     padding-right: ${smPaddingX};
   `}
-`;
-
-export const ButtonLoadMore = styled.button`
-  width: 100%;
-  min-height: 1.5rem;
-  margin-bottom: 0.75rem;
-  background-color: transparent;
-  border-radius: ${borderRadius};
-  border: 1px ridge ${colorGrayDark};
 `;
 
 export const UnreadButton = styled(ButtonElipsis)`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/component.tsx
@@ -8,7 +8,11 @@ import { layoutSelect } from '../../../layout/context';
 import { Layout } from '../../../layout/layoutTypes';
 import { ChatCommands } from '/imports/ui/core/enums/chat';
 
-interface ChatPopupProps {
+interface ChatPopupCommonProps {
+  hasMessageToolbar: boolean;
+}
+
+interface ChatPopupProps extends ChatPopupCommonProps {
   welcomeMessage: string | null;
   welcomeMsgForModerators: string | null;
 }
@@ -31,6 +35,7 @@ const isBoolean = (v: unknown): boolean => {
 };
 
 const ChatPopup: React.FC<ChatPopupProps> = ({
+  hasMessageToolbar,
   welcomeMessage,
   welcomeMsgForModerators,
 }) => {
@@ -60,7 +65,7 @@ const ChatPopup: React.FC<ChatPopupProps> = ({
   }, []);
   if (!showWelcomeMessage && !showWelcomeMessageForModerators) return null;
   return (
-    <PopupContainer>
+    <PopupContainer $hasMessageToolbar={hasMessageToolbar}>
       <PopupContents>
         {showWelcomeMessage && welcomeMessage && (
           <PopupContent
@@ -86,7 +91,9 @@ const ChatPopup: React.FC<ChatPopupProps> = ({
   );
 };
 
-const ChatPopupContainer: React.FC = () => {
+const ChatPopupContainer: React.FC<ChatPopupCommonProps> = (props) => {
+  const { hasMessageToolbar } = props;
+
   const {
     data: welcomeData,
     loading: welcomeLoading,
@@ -104,6 +111,7 @@ const ChatPopupContainer: React.FC = () => {
 
   return (
     <ChatPopup
+      hasMessageToolbar={hasMessageToolbar}
       welcomeMessage={welcomeData.user_welcomeMsgs[0]?.welcomeMsg}
       welcomeMsgForModerators={welcomeData.user_welcomeMsgs[0]?.welcomeMsgForModerators}
     />

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/styles.ts
@@ -1,12 +1,18 @@
 import styled from 'styled-components';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
 
-export const PopupContainer = styled.div`
+export const PopupContainer = styled.div<{
+  $hasMessageToolbar: boolean;
+}>`
   position: sticky;
-  top: -2rem;
+  top: 0;
   max-height: 80%;
   z-index: 3;
   background-color: white;
+
+  ${({ $hasMessageToolbar }) => $hasMessageToolbar && `
+    top: -2rem;
+  `}
 `;
 
 export const PopupContents = styled(ScrollboxVertical)`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/styles.ts
@@ -3,7 +3,7 @@ import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scr
 
 export const PopupContainer = styled.div`
   position: sticky;
-  top: 0;
+  top: -2rem;
   max-height: 80%;
   z-index: 3;
   background-color: white;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
@@ -58,6 +58,7 @@ const Container = styled.div<{ $hidden: boolean; $animations: boolean }>`
 const Message = styled.div`
   line-height: 1rlh;
   flex-grow: 1;
+  min-width: 0;
 `;
 
 const Markdown = styled(ReactMarkdown)<{

--- a/bigbluebutton-html5/imports/utils/object-utils.js
+++ b/bigbluebutton-html5/imports/utils/object-utils.js
@@ -1,0 +1,13 @@
+export const getValueByPointer = (obj, pointer) => {
+  if (pointer === '') return obj;
+  const fields = pointer.split('.');
+  let acc = obj;
+  fields.forEach((field) => {
+    acc = acc?.[field];
+  });
+  return acc;
+};
+
+export default {
+  getValueByPointer,
+};

--- a/bigbluebutton-html5/imports/utils/object-utils.js
+++ b/bigbluebutton-html5/imports/utils/object-utils.js
@@ -1,4 +1,7 @@
 export const getValueByPointer = (obj, pointer) => {
+  if (typeof obj !== 'object') return undefined;
+  if (!obj) return undefined;
+  if (typeof pointer !== 'string') return obj;
   if (pointer === '') return obj;
   const fields = pointer.split('.');
   let acc = obj;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -770,7 +770,7 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: ['reply', 'edit', 'delete', 'reactions']
+    toolbar: []
   userReaction:
     enabled: true
     expire: 30

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -770,7 +770,7 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: []
+    toolbar: ['reply', 'edit', 'delete', 'reactions']
   userReaction:
     enabled: true
     expire: 30


### PR DESCRIPTION
### What does this PR do?

This PR includes a bunch of improvements and fixes for the chat.

- Restore the original message typed in the message input after editing a message.
- Fix messages scrolling behind the welcome message.
- Disable chat roving If no message toolbar feature is enabled.
- Button for cancelling a reply hiding if chat panel is narrowed.
- Add timeout for cleaning up non-visible message pages when the user scrolls to the end of the message list.
- Fix loading spinner not showing when a new page is loading.
- Align offline indicator (which indicates that the sender of a message is offline) on the left-hand side of the message header.
- Add infinite scroll.

- Message input focus style

![Screenshot from 2024-10-29 09-08-53](https://github.com/user-attachments/assets/2a3bfc27-318a-4fba-85e3-eec81470b19d)

- Message toolbar hover styles

![Screenshot from 2024-10-29 09-09-34](https://github.com/user-attachments/assets/13c3554a-aa30-4b9f-b4f1-e858368534e6)


- Fixed offline indicator

![Screenshot from 2024-10-29 09-27-36](https://github.com/user-attachments/assets/08850edd-1ec4-4e96-b5b2-45131fb5d23d)

- Besides those this PR includes some fixes targeting better overall peformance.

### Closes Issue(s)

Closes n/a

### More

Depends on https://github.com/bigbluebutton/bigbluebutton/pull/21521.
