### PR TITLE
style(actions-bar): Refactor margin styles for span elements in ActionsBar components

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.js
@@ -21,26 +21,24 @@ const ActionsBarWrapper = styled.section`
 const Left = styled.div`
   display: inherit;
   flex: 0;
-
-  > * {
+  > *:not(span) {
     margin: 0 ${smPaddingX};
-
     @media ${smallOnly} {
       margin: 0 ${smPaddingY};
     }
   }
-
+  > span {
+    margin: 0;
+  }
   @media ${smallOnly} {
     bottom: ${smPaddingX};
     left: ${smPaddingX};
     right: auto;
-
     [dir="rtl"] & {
       left: auto;
       right: ${smPaddingX};
     }
   }
-
 `;
 
 const Center = styled.div`
@@ -48,15 +46,15 @@ const Center = styled.div`
   flex-direction: row;
   flex: 1;
   justify-content: center;
-
-  > * {
+  > *:not(span) {
     margin: 0 ${smPaddingX};
-
     @media ${smallOnly} {
       margin: 0 ${smPaddingY};
     }
   }
-
+  > span {
+    margin: 0;
+  }
 `;
 
 const Right = styled.div`
@@ -64,35 +62,34 @@ const Right = styled.div`
   flex-direction: row;
   justify-content: center;
   position: relative;
-
   [dir="rtl"] & {
     right: auto;
     left: ${smPaddingX};
   }
-
   @media ${smallOnly} {
     right: 0;
     left: 0;
     display: contents;
   }
-
-  > * {
+  > *:not(span) {
     margin: 0 ${smPaddingX};
-
     @media ${smallOnly} {
       margin: 0 ${smPaddingY};
     }
   }
+  > span {
+    margin: 0;
+  }
 `;
 
 const RaiseHandButton = styled(Button)`
-${({ ghost }) => ghost && `
-  & > span {
-    box-shadow: none;
-    background-color: transparent !important;
-    border-color: ${colorWhite} !important;
-  }
-   `}
+  ${({ ghost }) => ghost && `
+    & > span {
+      box-shadow: none;
+      background-color: transparent !important;
+      border-color: ${colorWhite} !important;
+    }
+  `}
 `;
 
 const ButtonContainer = styled.div`


### PR DESCRIPTION
### What does this PR do?

This PR adjusts the styles of the actions buttons so they don't create a unnecessary spacing when a modal is opened.

### Closes Issue(s)

I believe there is no issue opened for that, it was found by @antonbsa in one of out daily meetings.

### How to test

Join a meeting and open join video modal - look at actions buttons.


### More
Before

![image](https://github.com/user-attachments/assets/0976901f-4044-4357-808a-65947ecea0b2)

After

![image](https://github.com/user-attachments/assets/e3753722-d9ea-4c5c-a3e9-b1b6c9e96044)

