### PR TITLE
fix(external-video-player): fix seek functionality to the external video player(non youtube)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -341,7 +341,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   };
 
-
   const isMinimized = width === 0 && height === 0;
 
   // @ts-ignore accessing lib private property

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -326,6 +326,22 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   };
 
+  const handleOnSeek = async (seconds: number) => {
+    if (isPresenter) {
+      let rate = playerRef.current?.getInternalPlayer()?.getPlaybackRate() ?? 1;
+      if (rate instanceof Promise) {
+        rate = await rate;
+      }
+
+      sendMessage('seek', {
+        rate,
+        time: seconds,
+      });
+      playerRef.current?.seekTo(seconds, 'seconds');
+    }
+  };
+
+
   const isMinimized = width === 0 && height === 0;
 
   // @ts-ignore accessing lib private property
@@ -391,6 +407,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           volume={volume}
           onStart={handleOnStart}
           onPlay={handleOnPlay}
+          onSeek={handleOnSeek}
           onDuration={handleDuration}
           onProgress={handleProgress}
           onPause={handleOnStop}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the seek functionality of non-youtube players in external video.

### Closes Issue(s)

Closes #19981 with help of PR #21469

### How to test

Start a meeting, use external video with non-youtube video sources, and try do skip the video by clicking the progress bar.

