### PR TITLE
fix: Prevent moderators from deleting others' chat messages in Breakout Rooms

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
@@ -54,7 +54,9 @@ trait DeleteGroupChatMessageReqMsgHdlr extends HandlerHelpers {
           val userIsOwner = gcMessage.sender.id == user.intId
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-            if (userIsOwner || userIsModerator) {
+            if (userIsOwner ||
+              (userIsModerator && !liveMeeting.props.meetingProp.isBreakout) //not allowed in breakoutRooms as everyone is moderator
+              ) {
               val updatedGroupChat = GroupChatApp.deleteGroupChatMessage(liveMeeting.props.meetingProp.intId, groupChat, state.groupChats, gcMessage, user.intId)
 
               val event = buildGroupChatMessageDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id)

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -201,6 +201,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   } = useStickyScroll(currentMessageListContainer, currentMessageListContainer, 'ne');
   const { data: meeting } = useMeeting((m) => ({
     lockSettings: m?.lockSettings,
+    isBreakout: m?.isBreakout,
   }));
   const { data: currentUser } = useCurrentUser((c) => ({
     isModerator: c?.isModerator,
@@ -468,6 +469,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
                     currentUserId={currentUser?.userId ?? ''}
                     currentUserIsLocked={!!currentUser?.locked}
                     currentUserIsModerator={!!currentUser?.isModerator}
+                    isBreakoutRoom={!!meeting?.isBreakout}
                     messageToolbarIsEnabled={messageToolbarIsEnabled}
                     chatDeleteEnabled={CHAT_DELETE_ENABLED}
                     chatEditEnabled={CHAT_EDIT_ENABLED}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -51,6 +51,7 @@ interface ChatMessageProps {
   currentUserIsLocked: boolean;
   currentUserId: string;
   currentUserDisablePublicChat: boolean;
+  isBreakoutRoom: boolean;
   isPublicChat: boolean;
   hasToolbar: boolean;
   chatReplyEnabled: boolean;
@@ -131,6 +132,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   currentUserId,
   currentUserIsLocked,
   currentUserIsModerator,
+  isBreakoutRoom,
   isPublicChat,
   hasToolbar,
   chatDeleteEnabled,
@@ -453,6 +455,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           username={message.user?.name}
           own={message.user?.userId === currentUserId}
           amIModerator={currentUserIsModerator}
+          isBreakoutRoom={isBreakoutRoom}
           message={message.message}
           messageSequence={message.messageSequence}
           emphasizedMessage={message.chatEmphasizedText}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -51,6 +51,7 @@ interface ChatMessageToolbarProps {
   username: string;
   own: boolean;
   amIModerator: boolean;
+  isBreakoutRoom: boolean;
   message: string;
   messageSequence: number;
   emphasizedMessage: boolean;
@@ -70,7 +71,7 @@ interface ChatMessageToolbarProps {
 const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const {
     messageId, chatId, message, username, onEmojiSelected, deleted,
-    messageSequence, emphasizedMessage, own, amIModerator, locked,
+    messageSequence, emphasizedMessage, own, amIModerator, isBreakoutRoom, locked,
     onReactionPopoverOpenChange, reactionPopoverIsOpen, hasToolbar, keyboardFocused,
     chatDeleteEnabled, chatEditEnabled, chatReactionsEnabled, chatReplyEnabled,
   } = props;
@@ -110,7 +111,7 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const showReplyButton = chatReplyEnabled;
   const showReactionsButton = chatReactionsEnabled;
   const showEditButton = chatEditEnabled && own;
-  const showDeleteButton = chatDeleteEnabled && (own || amIModerator);
+  const showDeleteButton = chatDeleteEnabled && (own || (amIModerator && !isBreakoutRoom));
   const showDivider = (showReplyButton || showReactionsButton) && (showEditButton || showDeleteButton);
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -43,6 +43,7 @@ interface ChatListPageCommonProps {
   currentUserIsLocked: boolean;
   currentUserId: string;
   currentUserDisablePublicChat: boolean;
+  isBreakoutRoom: boolean;
   messageToolbarIsEnabled: boolean;
   chatReplyEnabled: boolean;
   chatDeleteEnabled: boolean;
@@ -119,6 +120,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   currentUserDisablePublicChat,
   currentUserIsLocked,
   currentUserIsModerator,
+  isBreakoutRoom,
   isPublicChat,
   messageToolbarIsEnabled,
   chatDeleteEnabled,
@@ -262,6 +264,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             currentUserDisablePublicChat={currentUserDisablePublicChat}
             currentUserIsLocked={currentUserIsLocked}
             currentUserIsModerator={currentUserIsModerator}
+            isBreakoutRoom={isBreakoutRoom}
             isPublicChat={isPublicChat}
             hasToolbar={messageToolbarIsEnabled && !!message.user}
             chatDeleteEnabled={chatDeleteEnabled}
@@ -295,6 +298,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   currentUserDisablePublicChat,
   currentUserIsLocked,
   currentUserIsModerator,
+  isBreakoutRoom,
   messageToolbarIsEnabled,
   chatDeleteEnabled,
   chatEditEnabled,
@@ -350,6 +354,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       currentUserDisablePublicChat={currentUserDisablePublicChat}
       currentUserIsLocked={currentUserIsLocked}
       currentUserIsModerator={currentUserIsModerator}
+      isBreakoutRoom={isBreakoutRoom}
       isPublicChat={isPublicChat}
       messageToolbarIsEnabled={messageToolbarIsEnabled}
       chatDeleteEnabled={chatDeleteEnabled}


### PR DESCRIPTION
Deleting others' chat messages is not allowed in Breakout Rooms, as all participants are moderators.

![image](https://github.com/user-attachments/assets/9022432a-1678-4208-983d-7b395e8da11d)
