### PR TITLE
test(ci): add timeout-minutes on install test dependecies step

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -345,6 +345,7 @@ jobs:
           EOF
       - name: Install test dependencies
         working-directory: ./bigbluebutton-tests/playwright
+        timeout-minutes: 5
         run: |
           sh -c '
           npm ci

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -345,7 +345,7 @@ jobs:
           EOF
       - name: Install test dependencies
         working-directory: ./bigbluebutton-tests/playwright
-        timeout-minutes: 5
+        timeout-minutes: 25
         run: |
           sh -c '
           npm ci


### PR DESCRIPTION
### What does this PR do?
This PR intends to add a maximum time for `Install test dependencies` as it recently got stuck taking 1hour+ in a process that usually takes up to 5 minutes
