### PR TITLE
feat (gql-actions): Add validation for emojis

### DIFF
--- a/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
@@ -1,5 +1,7 @@
 import { RedisMessage } from '../types';
 import {throwErrorIfInvalidInput} from "../imports/validation";
+import {ValidationError} from "../types/ValidationError";
+const emojiRegex = /^(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base})(\u200D(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}))*$/u;
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfInvalidInput(input,
@@ -10,6 +12,10 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'reactionEmojiId', type: 'string', required: true},
       ]
   )
+
+  if(typeof input.reactionEmoji !== 'string' || !emojiRegex.test(input.reactionEmoji)) {
+    throw new ValidationError(`Parameter 'reactionEmoji' contains an invalid Emoji`, 400);
+  }
 
   const eventName = `SendGroupChatMessageReactionReqMsg`;
   const routing = {

--- a/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
+++ b/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
@@ -1,5 +1,7 @@
 import { RedisMessage } from '../types';
 import {throwErrorIfInvalidInput} from "../imports/validation";
+import {ValidationError} from "../types/ValidationError";
+const emojiRegex = /^(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base})(\u200D(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F|\p{Emoji_Modifier_Base}))*$/u;
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfInvalidInput(input,
@@ -7,6 +9,10 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'reactionEmoji', type: 'string', required: true},
       ]
   )
+
+  if(typeof input.reactionEmoji !== 'string' || !emojiRegex.test(input.reactionEmoji)) {
+    throw new ValidationError(`Parameter 'reactionEmoji' contains an invalid Emoji`, 400);
+  }
 
   const eventName = `ChangeUserReactionEmojiReqMsg`;
 


### PR DESCRIPTION
The mutations `chatSendMessageReaction` and `userSetReactionEmoji` should accept only emoji chars.
This PR implements a validation to reject the mutation in case of invalid characters or invalid length:

![image](https://github.com/user-attachments/assets/f714d73a-dd7e-4a37-8dd3-d77d1f35e730)

