### PR TITLE
fix (bbb-conf): Exclude the `pluginManifests` config from the non-empty value check

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -677,6 +677,7 @@ check_configuration() {
     ignore_configs_args+=(-e "redis.pass")
     ignore_configs_args+=(-e "redisPassword")
     ignore_configs_args+=(-e "disabledFeatures")
+    ignore_configs_args+=(-e "pluginManifests")
 
     for file in $CONFIG_FILES ; do
         if [ ! -f $file ]; then


### PR DESCRIPTION
In `bbb-conf`, exclude the `pluginManifests` config from the non-empty value check in `bigbluebutton.properties`, as it is expected to be null and does not cause issues.

Before:
![image](https://github.com/user-attachments/assets/ffa243c5-4a30-4dc5-b632-72248e2b65be)

After:
![image](https://github.com/user-attachments/assets/c5adf764-f80a-49cd-b428-84ddbcb00524)
