### PR TITLE
feat(common-web): Add asynchronous fetch to plugin's manifests

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -88,6 +88,7 @@ public class MeetingService implements MessageListener {
   private SlidesGenerationProgressNotifier notifier;
 
   private long usersTimeout;
+  private int numPluginManifestsFetchingThreads;
   private long waitingGuestUsersTimeout;
   private int sessionsCleanupDelayInMinutes;
   private long enteredUsersTimeout;
@@ -396,7 +397,7 @@ public class MeetingService implements MessageListener {
     Map<String, String> metadata = m.getMetadata();
     List<CompletableFuture<Void>> futures = new ArrayList<>();
     // The maximum number of threads can be adjusted later on
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    ExecutorService executorService = Executors.newFixedThreadPool(numPluginManifestsFetchingThreads);
     for (PluginManifest pluginManifest : m.getPluginManifests()) {
       CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
         try {
@@ -1512,6 +1513,10 @@ public class MeetingService implements MessageListener {
 
   public void setWaitingGuestUsersTimeout(long value) {
     waitingGuestUsersTimeout = value;
+  }
+
+  public void setNumPluginManifestsFetchingThreads(int value) {
+    numPluginManifestsFetchingThreads = value;
   }
 
   public void setSessionsCleanupDelayInMinutes(int value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -19,12 +19,15 @@
 package org.bigbluebutton.api;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -445,9 +448,14 @@ public class MeetingService implements MessageListener {
           Map<String, Object> manifestWrapper = new HashMap<>();
           manifestWrapper.put("manifest", manifestObject);
           urlContents.put(pluginKey, manifestWrapper);
+        } catch (MalformedURLException e) {
+          log.error("Invalid URL: {}", pluginManifest.getUrl(), e);
+        } catch (JsonProcessingException e) {
+          log.error("Failed to parse JSON from URL: {}", pluginManifest.getUrl(), e);
+        } catch (IOException e) {
+          log.error("I/O error when fetching URL: {}", pluginManifest.getUrl(), e);
         } catch (Exception e) {
-          log.error("Failed with the following plugin manifest URL: {}. Error: ", pluginManifest.getUrl(), e);
-          log.error("Therefore this plugin will not be loaded");
+          log.error("Unexpected error processing plugin manifest from URL: {}", pluginManifest.getUrl(), e);
         }
       }, executorService);
       futures.add(future);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -458,7 +458,7 @@ public class MeetingService implements MessageListener {
         } catch (Exception e) {
           log.error("Unexpected error processing plugin manifest from URL: {}", pluginManifest.getUrl(), e);
         }
-      }, executorService).orTimeout(pluginManifestFetchTimeout, TimeUnit.MILLISECONDS)
+      }, executorService).orTimeout(pluginManifestFetchTimeout, TimeUnit.SECONDS)
       .exceptionally(ex -> {
         if (ex instanceof TimeoutException) {
           log.warn("Timeout occurred when fetching URL: {}", pluginManifest.getUrl());

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -82,17 +82,14 @@ numConversionThreads=5
 numFileProcessorThreads=2
 
 #------------------------------------
-# Number of threads the BBB server uses to fetch the list of plugins
-# at the beginning of a session (/create). Min=1 means a slower fetch response
-# - will delay the entire list causing slower create response, and therefore,
-# slower client join. Max=half the number of cores for very powerful servers
+# Number of threads used to fetch plugin manifest URLs concurrently during /create flow
 #------------------------------------
 numPluginManifestsFetchingThreads=5
 
 #------------------------------------
-# Each plugin manifest fetch shouldn't take longer than this time (milliseconds)
+# Each plugin manifest fetch shouldn't take longer than this time (seconds)
 #------------------------------------
-pluginManifestFetchTimeout=3000
+pluginManifestFetchTimeout=15
 
 #------------------------------------
 # Timeout(secs) to wait for pdf to svg conversion (timeout for each tool called during the process)

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -82,6 +82,11 @@ numConversionThreads=5
 numFileProcessorThreads=2
 
 #------------------------------------
+# Number of threads to process file uploads
+#------------------------------------
+numPluginManifestsFetchingThreads=5
+
+#------------------------------------
 # Timeout(secs) to wait for pdf to svg conversion (timeout for each tool called during the process)
 #------------------------------------
 svgConversionTimeout=60

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -82,7 +82,10 @@ numConversionThreads=5
 numFileProcessorThreads=2
 
 #------------------------------------
-# Number of threads to process file uploads
+# Number of threads the BBB server uses to fetch the list of plugins
+# at the beginning of a session (/create). Min=1 means a slower fetch response
+# - will delay the entire list causing slower create response, and therefore,
+# slower client join. Max=half the number of cores for very powerful servers
 #------------------------------------
 numPluginManifestsFetchingThreads=5
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -90,6 +90,11 @@ numFileProcessorThreads=2
 numPluginManifestsFetchingThreads=5
 
 #------------------------------------
+# Each plugin manifest fetch shouldn't take longer than this time (milliseconds)
+#------------------------------------
+pluginManifestFetchTimeout=3000
+
+#------------------------------------
 # Timeout(secs) to wait for pdf to svg conversion (timeout for each tool called during the process)
 #------------------------------------
 svgConversionTimeout=60

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -58,6 +58,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="usersTimeout" value="${usersTimeout}"/>
         <property name="enteredUsersTimeout" value="${enteredUsersTimeout}"/>
         <property name="numPluginManifestsFetchingThreads" value="${numPluginManifestsFetchingThreads}"/>
+        <property name="pluginManifestFetchTimeout" value="${pluginManifestFetchTimeout}"/>
         <property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>
     </bean>
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -57,6 +57,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="callbackUrlService" ref="callbackUrlService"/>
         <property name="usersTimeout" value="${usersTimeout}"/>
         <property name="enteredUsersTimeout" value="${enteredUsersTimeout}"/>
+        <property name="numPluginManifestsFetchingThreads" value="${numPluginManifestsFetchingThreads}"/>
         <property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>
     </bean>
 


### PR DESCRIPTION
### What does this PR do?

It basically makes the plugin's manifests fetches asynchronous, so that if someone has lot's of plugins to load, it will take mostly the same amount of time as if they had a few.

### How to test

Besides testing if the plugins still load normally (combining 2 or 3), one can add logs in the beginning of the manifest fetch and at the end, and one more after all the futures had been completed. This way, it's possible to analyse if the processes occurred parallel to one another.
