### PR TITLE
refactor(audio): make audio join cancel configurable

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -616,6 +616,7 @@ export interface Audio2 {
   defaultListenOnlyBridge: string
   bridges: Bridge[]
   retryThroughRelay: boolean
+  allowAudioJoinCancel: boolean
 }
 
 export interface Screenshare2 {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
@@ -75,9 +75,14 @@ export const leaveEchoTest = () => {
 };
 
 export const closeModal = (callback) => {
+  const ALLOW_AUDIO_JOIN_CANCEL = window.meetingClientSettings.public.media.audio.allowAudioJoinCancel;
+
   if (Service.isConnecting()) {
+    if (!ALLOW_AUDIO_JOIN_CANCEL) return;
+
     Service.forceExitAudio();
   }
+
   callback();
 };
 

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -631,6 +631,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           },
         ],
         retryThroughRelay: false,
+        allowAudioJoinCancel: true,
       },
       stunTurnServersFetchAddress: '/bigbluebutton/api/stuns',
       cacheStunTurnServers: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -840,6 +840,11 @@ public:
       # Forces a retry with iceTransportPolicy = 'relay' if the first attempt
       # fails with a few selected errors codes (eg 1007, 1010)
       retryThroughRelay: false
+      # allowAudioJoinCancel: permit users to cancel audio join requests by
+      # letting them close the audio modal while audio is being negotiated.
+      # If false, the audio modal will be locked until the audio is successfully
+      # joined or the request fails.
+      allowAudioJoinCancel: true
     stunTurnServersFetchAddress: '/bigbluebutton/api/stuns'
     cacheStunTurnServers: true
     fallbackStunServer: ''


### PR DESCRIPTION
### What does this PR do?

- [refactor(audio): make audio join cancel configurable](https://github.com/bigbluebutton/bigbluebutton/commit/82a208ff78fa844ad0805a7b27dcf51a3a915796) 
  - [Audio was made "cancellable" a while ago](https://github.com/bigbluebutton/bigbluebutton/pull/13821) by allowing users to close the
  audio modal while audio is being negotiated. By looking through metrics,
  I have a theory that this may be:
    1. increasing error rates artificially
    2. confusing end users who mistakenly click outside of the modal.
  - Cancelling audio join should not be an option in the first place if
  there's no good way to let users know how to roll back from that
  situation (there isn't, right now). There are also timeouts in place in
  both audio bridges so that it doesn't stay "loading" forever.
  - This commit adds a new flag `public.media.audio.allowAudioJoinCancel`
  that makes the aforementioned behavior configurable. Default value is
  preserved (true, allow). The idea is for this flag to be used in field
  trials to validate behaviors 1) and 2) - and then decide what's the best
  UX flow.

### Closes Issue(s)

None

### Motivation

See commit log.
This is more of a field trial flag right now. Real usage data (waiting for it
to have a significant sampling) or UI/UX folks (already relayed to) will 
validate or deny this PR's reasoning. Expect a follow up (to be determined).

### How to test

1. Set `public.media.audio.allowAudioJoinCancel: false`
2. Try closing the audio modal while the connection is being established

### More

PR that made the process "cancellable": https://github.com/bigbluebutton/bigbluebutton/pull/13821

