### PR TITLE
fix(tooltip): Fix tooltip interactivity and update toolbar options in settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/tooltip/component.jsx
@@ -92,7 +92,7 @@ class Tooltip extends Component {
       content: title,
       delay: overrideDelay,
       duration: animations ? ANIMATION_DURATION : 0,
-      interactive: true,
+      interactive: false,
       interactiveBorder: 10,
       onShow: this.onShow,
       onHide: this.onHide,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -773,7 +773,7 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: ['reply', 'edit', 'delete', 'reactions']
+    toolbar: []
   userReaction:
     enabled: true
     expire: 30

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -773,7 +773,7 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: []
+    toolbar: ['reply', 'edit', 'delete', 'reactions']
   userReaction:
     enabled: true
     expire: 30


### PR DESCRIPTION
### What does this PR do?

This PR changes a setting on tooltips (tippy) - the `interactive` option is set to `false`.

### Motivation

This change was made to prevent some tooltips to overlap and/or stay opened in situations where they shouldn't.
 _e.g_  The new chat interactions, as in the image bellow:

![image](https://github.com/user-attachments/assets/46a84941-b661-44cf-acf4-3bdde0379d40)

### How to test

Hover the mouse over any button or element that has a tooltip, when you move your pointer away from the element, the tooltip should vanish.

