### PR TITLE
ci: Removes the special scheduling policies for `bbb-webrtc-sfu`

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -256,6 +256,15 @@ jobs:
           sudo sh -c '
           apt --purge -y remove apache2-bin
           apt-mark hold firefox #hold ff once bbb-install frequently stuck at `Installing the firefox snap`
+
+          #bbb-webrtc-sfu: removes the special scheduling policies
+          mkdir -p /etc/systemd/system/bbb-webrtc-sfu.service.d/
+          tee /etc/systemd/system/bbb-webrtc-sfu.service.d/override.conf > /dev/null <<EOL
+          [Service]
+          CPUSchedulingPolicy=other
+          Nice=19
+          EOL
+          systemctl daemon-reload
           '
       - name: Install BBB
         env:
@@ -337,15 +346,15 @@ jobs:
           sudo yq e -i '.log_level = "TRACE"' /usr/share/bbb-graphql-middleware/config.yml
           cat > /etc/bigbluebutton/bbb-conf/apply-config.sh << HERE
           #!/bin/bash
-          
+
           # Pull in the helper functions for configuring BigBlueButton
           source /etc/bigbluebutton/bbb-conf/apply-lib.sh
-          
+
           # Available configuration options
-          
+
           enableHTML5ClientLog
           #enableUFWRules
-          
+
           HERE
           chmod +x /etc/bigbluebutton/bbb-conf/apply-config.sh
           bbb-conf --restart


### PR DESCRIPTION
Removes the special scheduling policies for `bbb-webrtc-sfu`

It adds an override file for `bbb-webrtc-sfu` that changes the `CPUSchedulingPolicy=other`, default was `CPUSchedulingPolicy=fifo`

reason:
Subprocess forking does cause CPU hikes, but it's still unclear why some envs get those processes pegged at 100% in restricted environments (informed by @prlanzarin)

![image](https://github.com/user-attachments/assets/62324b5b-ce43-4de0-b019-0bbf8b652a70)


PS: It's not clear if this issue affects Automated Tests, but it is a possible cause that makes `install-bbb` stuck very often.