### PR TITLE
fix: Presence switch in menu is reversed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -112,6 +112,10 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.reactions.active',
     description: 'Active Label',
   },
+  presenceLabel: {
+    id: 'app.navBar.optionsDropdown.presenceLabel',
+    description: 'Presence Label',
+  },
 });
 
 const propTypes = {
@@ -293,7 +297,7 @@ class OptionsDropdown extends PureComponent {
     this.menuItems.push({
       label: (
         <Styled.AwayOption>
-          <>Presence</>
+          <>{intl.formatMessage(intlMessages.presenceLabel)}</>
           <Styled.ToggleButtonWrapper>
             <Styled.AFKLabel>{ToggleAFKLabel()}</Styled.AFKLabel>
             <Toggle

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -302,7 +302,6 @@ class OptionsDropdown extends PureComponent {
               onChange={handleToggleAFK}
               ariaLabel={ToggleAFKLabel()}
               showToggleLabel={false}
-              invertColors
             />
           </Styled.ToggleButtonWrapper>
         </Styled.AwayOption>

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -493,6 +493,7 @@
     "app.navBar.optionsDropdown.endMeetingDesc": "Terminates the current session",
     "app.navBar.optionsDropdown.endMeetingLabel": "End session",
     "app.navBar.optionsDropdown.endMeetingForAllLabel": "End session for all",
+    "app.navBar.optionsDropdown.presenceLabel": "Presence",
     "app.navBar.userListToggleBtnLabel": "User list toggle",
     "app.navBar.toggleUserList.ariaLabel": "Users and messages toggle",
     "app.navBar.toggleUserList.newMessages": "with new message notification",


### PR DESCRIPTION
### What does this PR do?

- inverts presence switch colors
- adds localization for presence label

### Closes Issue(s)
Closes #21590