### PR TITLE
Restore preload next slide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -32,6 +32,19 @@ export interface CursorSubscriptionResponse {
   pres_page_cursor: Array<userCursorResponse>;
 }
 
+export const PRE_LOAD_PAGE_URL_QUERY = gql`
+  query PreLoadPages($presentationId: String!, $offset: Int!, $limit: Int!) {
+    pres_page(offset: $offset, 
+    limit: $limit, order_by: {num: asc}, where: {presentation: {presentationId: {_eq: $presentationId}}}) {
+      svgUrl: urlsJson(path: "$.svg")
+      num
+      presentation {
+        presentationId
+      }
+    }
+  }
+`;
+
 export const CURRENT_PRESENTATION_PAGE_SUBSCRIPTION = gql`subscription CurrentPresentationPagesSubscription {
   pres_page_curr {
     height


### PR DESCRIPTION
### What does this PR do?
Restore pre load next slides, it wasn't implemented when migrated to graphql, I've add a query that runs only when the setting is enabled and moved the `fetchedpresentation` to a useRef instead of a global variable.


### How to test
Set the number of `preloadNextSlides`, open the network tab on client and  see the loaded slides.

