### PR TITLE
ci: Update freeswtich build cache link

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -69,7 +69,7 @@ jobs:
           - package: bbb-freeswitch
             build-list: bbb-freeswitch-core bbb-freeswitch-sounds
             cache-files-list: freeswitch.placeholder.sh
-            cache-urls-list: http://bigbluebutton.org/downloads/sounds.tar.gz
+            cache-urls-list: https://ubuntu.bigbluebutton.org/sounds.tar.gz
           - package: bbb-webrtc
             build-list: bbb-webrtc-sfu bbb-webrtc-recorder
             cache-files-list: bbb-webrtc-sfu.placeholder.sh bbb-webrtc-recorder.placeholder.sh

--- a/build/packages-template/bbb-freeswitch-sounds/build.sh
+++ b/build/packages-template/bbb-freeswitch-sounds/build.sh
@@ -32,7 +32,7 @@ CONFDIR=$DESTDIR/opt/freeswitch/etc/freeswitch
 mkdir -p $DESTDIR/opt/freeswitch/share/freeswitch
 
 if [ ! -f sounds.tar.gz ] ; then
-  wget http://bigbluebutton.org/downloads/sounds.tar.gz -O sounds.tar.gz
+  wget https://ubuntu.bigbluebutton.org/sounds.tar.gz -O sounds.tar.gz
 fi
 tar xvfz sounds.tar.gz -C $DESTDIR/opt/freeswitch/share/freeswitch
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the freeswitch build cache link due to recent failures in CI runs

![image](https://github.com/user-attachments/assets/573366b3-b321-4673-bc0f-6184ae2bbe01)
