### PR TITLE
fix(captions/speech): Fix logger debug message placement in `start` function

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -219,9 +219,8 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
   }, [locale]);
 
   const start = (settedLocale: string) => {
-    logger.debug('Starting browser speech recognition');
-
     if (speechRecognitionRef.current && isLocaleValid(settedLocale)) {
+      logger.debug('Starting browser speech recognition');
       speechRecognitionRef.current.lang = settedLocale;
 
       if (speechHasStarted.started) {


### PR DESCRIPTION
### What does this PR do?

This PR ensures that the log message Starting browser speech recognition is only sent when speech recognition (CC) is enabled, reducing unnecessary log entries when speech recognition is off.

### Closes Issue(s)

Closes #21577 

### How to test

Look for the log message with and without CC on.
