### PR TITLE
fix: Layout settings reachable from Plus menu as well as 3 dot menu

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -12,7 +12,6 @@ import { PANELS, ACTIONS, LAYOUT_TYPE } from '../../layout/enums';
 import { uniqueId } from '/imports/utils/string-utils';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
 import { screenshareHasEnded } from '/imports/ui/components/screenshare/service';
-import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Session from '/imports/ui/services/storage/in-memory';
 
 const propTypes = {
@@ -183,8 +182,6 @@ class ActionsDropdown extends PureComponent {
       isCameraAsContentEnabled,
       isTimerFeatureEnabled,
       presentations,
-      isDirectLeaveButtonEnabled,
-      isLayoutsEnabled,
       isPresentationEnabled,
       isPresentationManagementDisabled,
     } = this.props;
@@ -264,23 +261,6 @@ class ActionsDropdown extends PureComponent {
         key: this.timerId,
         onClick: () => this.handleTimerClick(),
         dataTest: 'timerStopWatchFeature',
-      });
-    }
-
-    const Settings = getSettingsSingletonInstance();
-    const { selectedLayout } = Settings.application;
-    const shouldShowManageLayoutButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
-      && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
-      && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
-
-    if (shouldShowManageLayoutButton && isLayoutsEnabled && (amIModerator || amIPresenter)) {
-      actions.push({
-        icon: 'manage_layout',
-        label: intl.formatMessage(intlMessages.layoutModal),
-        key: 'layoutModal',
-        onClick: () => this.setLayoutModalIsOpen(true),
-        dataTest: 'manageLayoutBtn',
-        divider: !isDirectLeaveButtonEnabled,
       });
     }
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/container.jsx
@@ -5,7 +5,6 @@ import { layoutSelectInput, layoutDispatch, layoutSelect } from '../../layout/co
 import { SMALL_VIEWPORT_BREAKPOINT, ACTIONS, PANELS } from '../../layout/enums';
 import {
   useIsCameraAsContentEnabled,
-  useIsLayoutsEnabled,
   useIsPresentationEnabled,
   useIsTimerFeatureEnabled,
 } from '/imports/ui/services/features';
@@ -88,7 +87,6 @@ const ActionsDropdownContainer = (props) => {
   };
 
   const isDropdownOpen = useStorageKey('dropdownOpen');
-  const isLayoutsEnabled = useIsLayoutsEnabled();
   const isPresentationEnabled = useIsPresentationEnabled();
   const isTimerFeatureEnabled = useIsTimerFeatureEnabled();
   const isCameraAsContentEnabled = useIsCameraAsContentEnabled();
@@ -111,7 +109,6 @@ const ActionsDropdownContainer = (props) => {
         activateTimer,
         deactivateTimer: timerDeactivate,
         shortcuts: openActions,
-        isLayoutsEnabled,
         isPresentationEnabled,
         isPresentationManagementDisabled,
         ...props,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -406,6 +406,7 @@ class OptionsDropdown extends PureComponent {
           icon: 'manage_layout',
           label: intl.formatMessage(intlMessages.layoutModal),
           onClick: () => this.setLayoutModalIsOpen(true),
+          dataTest: 'manageLayoutBtn',
         },
       );
     }

--- a/bigbluebutton-tests/playwright/layouts/layouts.js
+++ b/bigbluebutton-tests/playwright/layouts/layouts.js
@@ -4,7 +4,7 @@ const { reopenChatSidebar, checkScreenshots } = require('./util');
 
 class Layouts extends MultiUsers {
   async focusOnPresentation() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.waitAndClick(e.manageLayoutBtn);
     await this.modPage.waitAndClick(e.focusOnPresentation);
     await this.modPage.waitAndClick(e.updateLayoutBtn);
@@ -15,7 +15,7 @@ class Layouts extends MultiUsers {
   }
 
   async gridLayout() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.waitAndClick(e.manageLayoutBtn);
     await this.modPage.waitAndClick(e.focusOnVideo);
     await this.modPage.waitAndClick(e.updateLayoutBtn);
@@ -26,7 +26,7 @@ class Layouts extends MultiUsers {
   }
 
   async smartLayout() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.waitAndClick(e.manageLayoutBtn);
     await this.modPage.waitAndClick(e.smartLayout);
     await this.modPage.waitAndClick(e.updateLayoutBtn);
@@ -43,7 +43,7 @@ class Layouts extends MultiUsers {
   }
 
   async customLayout() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.waitAndClick(e.manageLayoutBtn);
     await this.modPage.waitAndClick(e.customLayout);
     await this.modPage.waitAndClick(e.updateLayoutBtn);
@@ -80,7 +80,7 @@ class Layouts extends MultiUsers {
   }
 
   async updateEveryone() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.waitAndClick(e.manageLayoutBtn);
     await this.modPage.waitAndClick(e.customLayout);
     await this.modPage.waitAndClickElement(e.updateEveryoneLayoutToggle);

--- a/bigbluebutton-tests/playwright/parameters/disabledFeatures.js
+++ b/bigbluebutton-tests/playwright/parameters/disabledFeatures.js
@@ -40,7 +40,7 @@ class DisabledFeatures extends MultiUsers {
   }
 
   async layouts() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.wasRemoved(e.manageLayoutBtn, 'should not display manage layout option when the actions is open');
   }
 
@@ -145,7 +145,7 @@ class DisabledFeatures extends MultiUsers {
   }
 
   async layoutsExclude() {
-    await this.modPage.waitAndClick(e.actions);
+    await this.modPage.waitAndClick(e.optionsButton);
     await this.modPage.hasElement(e.manageLayoutBtn, 'should display the manage layout button');
   }
 


### PR DESCRIPTION
### What does this PR do?

removes layout settings option from actions dropdown - it is still available in options dropdown (3 dots menu)

### Closes Issue(s)
Closes #21592