### PR TITLE
feat(plugins): Notification API support for plugins

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -4,6 +4,7 @@ import PluginSidekickOptionsContainerUiCommandsHandler from './sidekick-options-
 import PluginPresentationAreaUiCommandsHandler from './presentation/handler';
 import PluginUserStatusUiCommandsHandler from './user-status/handler';
 import PluginConferenceUiCommandsHandler from './conference/handler';
+import PluginNotificationUiCommandsHandler from './notification/handler';
 
 const PluginUiCommandsHandler = () => (
   <>
@@ -12,6 +13,7 @@ const PluginUiCommandsHandler = () => (
     <PluginPresentationAreaUiCommandsHandler />
     <PluginUserStatusUiCommandsHandler />
     <PluginConferenceUiCommandsHandler />
+    <PluginNotificationUiCommandsHandler />
   </>
 );
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/notification/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/notification/handler.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { NotificationEnum } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/notification/enums';
+import { SendNotificationCommandArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/notification/types';
+import { notify } from '/imports/ui/services/notification';
+
+const PluginNotificationUiCommandsHandler = () => {
+  const handleSendNotification = (event: CustomEvent<SendNotificationCommandArguments>) => {
+    const { detail: information } = event;
+    notify(information.message, information.type,
+      information.icon, information.options,
+      information.content, information.small);
+  };
+
+  useEffect(() => {
+    window.addEventListener(
+      NotificationEnum.SEND,
+      handleSendNotification as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        NotificationEnum.SEND,
+        handleSendNotification as EventListener,
+      );
+    };
+  }, []);
+  return null;
+};
+
+export default PluginNotificationUiCommandsHandler;


### PR DESCRIPTION
### What does this PR do?

It allows the user to send a notification client-side. If, on the other hand, a developer wants to make it so that everyone receives a notification at the same time,  they can easily do it with the help of a data-channel.

### How to test

I, myself, used the `sample-action-button-dropdown` to test it. I already left the necessary code change there to make it easier to test. But, one can simply use this API in whatever plugin they want.

### More

See demo, below:


https://github.com/user-attachments/assets/628fbca2-0c5c-416a-86ac-68ce6bc57fdd


We can always change the UI, of course, but mind that this PR doesn't aim to change the structure of the notification itself, it simply wants to simply open the possibility for a plugin to send a notification in the current notify structure.

But again, this is arguable, so if you have a suggestion, please comment down below.

Closely related to https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/132