### PR TITLE
ci: Use the default bbb-install.sh for BBB 3.0

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -274,7 +274,7 @@ jobs:
           sudo -i <<'EOF'
           set -e
           cd /root/
-          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release--no-mongo/bbb-install.sh -O bbb-install.sh
+          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release/bbb-install.sh -O bbb-install.sh
           sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
           chmod +x bbb-install.sh
 


### PR DESCRIPTION
While removing MongoDB we had temporarily switched the CI to use a no-mongo branch which is now merged (and deleted)

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Switch back to the official bbb-install branch for BBB 3.0

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #none

### Motivation
<!-- What inspired you to submit this pull request? -->
I deleted the no-mongo branch. Its changes made it to the v3.0.x-release one.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Passing CI

### More
<!-- Anything else we should know when reviewing? -->

