### PR TITLE
!build: Use the default postgresql version (14) for Ubuntu 22.04

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -274,7 +274,7 @@ jobs:
           sudo -i <<'EOF'
           set -e
           cd /root/
-          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/ubuntu-version-of-postgres/bbb-install.sh -O bbb-install.sh
+          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release/bbb-install.sh -O bbb-install.sh
           sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
           chmod +x bbb-install.sh
 

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -274,7 +274,7 @@ jobs:
           sudo -i <<'EOF'
           set -e
           cd /root/
-          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release--no-mongo/bbb-install.sh -O bbb-install.sh
+          wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/ubuntu-version-of-postgres/bbb-install.sh -O bbb-install.sh
           sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
           chmod +x bbb-install.sh
 

--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -33,8 +33,9 @@ cp -r bbb_schema.sql metadata config.yaml staging/usr/share/bbb-graphql-server
 chmod -R a+rX staging/usr/share/bbb-graphql-server
 
 #Copy BBB configs for Postgres
-mkdir -p staging/etc/postgresql/17/main/conf.d
-cp bbb-pg.conf staging/etc/postgresql/17/main/conf.d
+POSTGRES_MAJOR_VERSION=14
+mkdir -p staging/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/conf.d
+cp bbb-pg.conf staging/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/conf.d
 
 cp bbb-graphql-server.service staging/lib/systemd/system/bbb-graphql-server.service
 

--- a/build/packages-template/bbb-graphql-server/opts-jammy.sh
+++ b/build/packages-template/bbb-graphql-server/opts-jammy.sh
@@ -1,3 +1,3 @@
 . ./opts-global.sh
 
-OPTS="$OPTS -d postgresql-17,postgresql-contrib,gnupg2,curl,apt-transport-https,ca-certificates,libkrb5-3,libpq5,libnuma1,unixodbc-dev -t deb"
+OPTS="$OPTS -d postgresql-14,postgresql-contrib,gnupg2,curl,apt-transport-https,ca-certificates,libkrb5-3,libpq5,libnuma1,unixodbc-dev -t deb"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Switches the required version for `postgresql` from the recently added 17
to the version which comes with Ubuntu 22.04 -- `postgresql-14`

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21441 
Together with  https://github.com/bigbluebutton/bbb-install/pull/759 closes #21386 

### Motivation
<!-- What inspired you to submit this pull request? -->
When we/I added the code from https://github.com/bigbluebutton/bbb-install/pull/759
that allowed for postgres to get upgraded on reruns of bbb-install.sh
See #21386 for the mess that created (basically no predictability on which postgres you are using)
Also that meant we could not reliably override configs for postgres - see #21441 

https://github.com/bigbluebutton/bigbluebutton/pull/21588 was an attempt to add predictability
however, we could still not guarantee that version 17 would be used if bbb-install.sh was to silently pull version 18 later on.

Switching back from 17 to 14 allows us to stick to a major version
without having to _pin_ (risking missing important patches)
It also means some hassle when upgrading to BBB 3.0.0-beta.5 if you were running an earlier BBB 3.0
It also means though, that we give up on any performance gains/new functionality for Postgres after 14



### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->


### More
<!-- Anything else we should know when reviewing? -->
- [ ] When https://github.com/bigbluebutton/bbb-install/pull/759 is merged, update the bbb-install.sh command for CI here.
