### PR TITLE
fix(captions/speech): Fix logger debug message placement in stop function

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -196,8 +196,8 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
   }, [locale]);
 
   const stop = useCallback(() => {
-    logger.debug('Stopping browser speech recognition');
     if (speechRecognitionRef.current) {
+      logger.debug('Stopping browser speech recognition');
       if (!speechHasStarted.started) {
         return;
       }


### PR DESCRIPTION
### What does this PR do?

This PR ensures that the log message Stopbrowser speech recognition is only sent when speech recognition (CC) is enabled, reducing unnecessary log entries when speech recognition is off.

### Closes Issue(s)

Closes #21577




