### PR TITLE
refactor (gql-server): Create dedicated postgres users for each application

### DIFF
--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -46,8 +46,8 @@ postgres {
             serverName = "127.0.0.1"
             portNumber = "5432"
             databaseName = "bbb_graphql"
-            user = "postgres"
-            password = "bbb_graphql"
+            user = "bbb_core"
+            password = "bbb_core"
         }
         numThreads = 1
         maxConnections = 1

--- a/bbb-graphql-server/deploy.sh
+++ b/bbb-graphql-server/deploy.sh
@@ -25,28 +25,38 @@ sudo runuser -u postgres -- psql -q -c "alter database bbb_graphql set timezone 
 echo "Creating tables in bbb_graphql"
 sudo runuser -u postgres -- psql -U postgres -d bbb_graphql -q -f bbb_schema.sql --set ON_ERROR_STOP=on
 
+HASURA_DATABASE_NAME="hasura_app"
+DB_EXISTS=$(sudo runuser -u postgres -- psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$HASURA_DATABASE_NAME'")
+if [ "$DB_EXISTS" = '1' ]
+then
+    echo "Database $HASURA_DATABASE_NAME already exists"
+else
+    sudo runuser -u postgres -- psql -c "create database hasura_app"
+    echo "Database $HASURA_DATABASE_NAME created"
+fi
+
 echo "Creating users"
-# Create user hasura_app@hasura_app (for hasura metadata)
-sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='hasura_app'" | grep -q 1 || \
-  sudo runuser -u postgres -- psql -c "CREATE USER hasura_app WITH PASSWORD 'hasura_app'"
-sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE hasura_app TO hasura_app"
-sudo runuser -u postgres -- psql -d hasura_app -c "GRANT USAGE ON SCHEMA hdb_catalog TO hasura_app"
-sudo runuser -u postgres -- psql -d hasura_app -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA hdb_catalog TO hasura_app"
-sudo runuser -u postgres -- psql -d hasura_app -c "ALTER DEFAULT PRIVILEGES IN SCHEMA hdb_catalog GRANT ALL PRIVILEGES ON TABLES TO hasura_app"
+  # Create user hasura_app@hasura_app (for hasura metadata)
+  sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='hasura_app'" | grep -q 1 || \
+    sudo runuser -u postgres -- psql -c "CREATE USER hasura_app WITH PASSWORD 'hasura_app'"
+  sudo runuser -u postgres -- psql -c "ALTER DATABASE $HASURA_DATABASE_NAME OWNER TO hasura_app"
+  sudo runuser -u postgres -- psql -c "GRANT ALL PRIVILEGES ON DATABASE $HASURA_DATABASE_NAME TO hasura_app"
 
-# Create user bbb_core@bbb_graphql (for akka-apps)
-sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
-  sudo runuser -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"
-sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_core"
-sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bbb_core"
-sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bbb_core"
+  # Create user bbb_core@bbb_graphql (for akka-apps)
+  sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
+    sudo runuser -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"
+  sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_core"
+  sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bbb_core"
+  sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO bbb_core"
+  sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bbb_core"
+  sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bbb_core"
 
-# Create user bbb_hasura@bbb_graphql (for Hasura ReadOnly)
-sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_hasura'" | grep -q 1 || \
-  sudo runuser -u postgres -- psql -c "CREATE USER bbb_hasura WITH PASSWORD 'bbb_hasura'"
-sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_hasura"
-sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO bbb_hasura"
-sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO bbb_hasura"
+  # Create user bbb_hasura@bbb_graphql (for Hasura ReadOnly)
+  sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_hasura'" | grep -q 1 || \
+    sudo runuser -u postgres -- psql -c "CREATE USER bbb_hasura WITH PASSWORD 'bbb_hasura'"
+  sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_hasura"
+  sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO bbb_hasura"
+  sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO bbb_hasura"
 
 
 echo "Starting Hasura"

--- a/bbb-graphql-server/deploy.sh
+++ b/bbb-graphql-server/deploy.sh
@@ -25,6 +25,30 @@ sudo runuser -u postgres -- psql -q -c "alter database bbb_graphql set timezone 
 echo "Creating tables in bbb_graphql"
 sudo runuser -u postgres -- psql -U postgres -d bbb_graphql -q -f bbb_schema.sql --set ON_ERROR_STOP=on
 
+echo "Creating users"
+# Create user hasura_app@hasura_app (for hasura metadata)
+sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='hasura_app'" | grep -q 1 || \
+  sudo runuser -u postgres -- psql -c "CREATE USER hasura_app WITH PASSWORD 'hasura_app'"
+sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE hasura_app TO hasura_app"
+sudo runuser -u postgres -- psql -d hasura_app -c "GRANT USAGE ON SCHEMA hdb_catalog TO hasura_app"
+sudo runuser -u postgres -- psql -d hasura_app -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA hdb_catalog TO hasura_app"
+sudo runuser -u postgres -- psql -d hasura_app -c "ALTER DEFAULT PRIVILEGES IN SCHEMA hdb_catalog GRANT ALL PRIVILEGES ON TABLES TO hasura_app"
+
+# Create user bbb_core@bbb_graphql (for akka-apps)
+sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
+  sudo runuser -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"
+sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_core"
+sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bbb_core"
+sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bbb_core"
+
+# Create user bbb_hasura@bbb_graphql (for Hasura ReadOnly)
+sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_hasura'" | grep -q 1 || \
+  sudo runuser -u postgres -- psql -c "CREATE USER bbb_hasura WITH PASSWORD 'bbb_hasura'"
+sudo runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_hasura"
+sudo runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO bbb_hasura"
+sudo runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO bbb_hasura"
+
+
 echo "Starting Hasura"
 sudo systemctl start bbb-graphql-server
 

--- a/bbb-graphql-server/metadata/databases/databases.yaml
+++ b/bbb-graphql-server/metadata/databases/databases.yaml
@@ -16,7 +16,7 @@
   kind: postgres
   configuration:
     connection_info:
-      database_url: postgres://postgres:bbb_graphql@127.0.0.1:5432/bbb_graphql
+      database_url: postgres://bbb_hasura:bbb_hasura@127.0.0.1:5432/bbb_graphql
       isolation_level: read-committed
       pool_settings:
         connection_lifetime: 3600

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -36,6 +36,8 @@ case "$1" in
   runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
     runuser -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"
   runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_core"
+  runuser -u postgres -- psql -d bbb_graphql -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bbb_core"
+  runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO bbb_core"
   runuser -u postgres -- psql -d bbb_graphql -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bbb_core"
   runuser -u postgres -- psql -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bbb_core"
 

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -25,6 +25,8 @@ case "$1" in
   fi
 
   # Create user hasura_app@hasura_app (for hasura metadata)
+  runuser -u postgres -- psql -d hasura_app -tc "SELECT 1 FROM pg_namespace WHERE nspname='hdb_catalog'" | grep -q 1 || \
+    runuser -u postgres -- psql -d hasura_app -c "CREATE SCHEMA hdb_catalog"
   runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='hasura_app'" | grep -q 1 || \
     runuser -u postgres -- psql -c "CREATE USER hasura_app WITH PASSWORD 'hasura_app'"
   runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE hasura_app TO hasura_app"

--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -30,12 +30,6 @@ case "$1" in
   runuser -u postgres -- psql -c "ALTER DATABASE $HASURA_DATABASE_NAME OWNER TO hasura_app"
   runuser -u postgres -- psql -c "GRANT ALL PRIVILEGES ON DATABASE $HASURA_DATABASE_NAME TO hasura_app"
 
-
-  runuser -u postgres -- psql -c "GRANT CONNECT ON DATABASE hasura_app TO hasura_app"
-  runuser -u postgres -- psql -d hasura_app -c "GRANT USAGE ON SCHEMA hdb_catalog TO hasura_app"
-  runuser -u postgres -- psql -d hasura_app -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA hdb_catalog TO hasura_app"
-  runuser -u postgres -- psql -d hasura_app -c "ALTER DEFAULT PRIVILEGES IN SCHEMA hdb_catalog GRANT ALL PRIVILEGES ON TABLES TO hasura_app"
-
   # Create user bbb_core@bbb_graphql (for akka-apps)
   runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
     runuser -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"

--- a/build/packages-template/bbb-graphql-server/hasura-config.env
+++ b/build/packages-template/bbb-graphql-server/hasura-config.env
@@ -1,4 +1,4 @@
-HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:bbb_graphql@127.0.0.1:5432/hasura_app
+HASURA_GRAPHQL_DATABASE_URL=postgres://hasura_app:hasura_app@127.0.0.1:5432/hasura_app
 #HASURA_GRAPHQL_METADATA_DATABASE_URL=postgres://postgres:bbb_graphql@127.0.0.1:5432/hasura_app
 #HASURA_GRAPHQL_NO_OF_RETRIES
 HASURA_GRAPHQL_LOG_LEVEL=warn


### PR DESCRIPTION
This PR introduces dedicated PostgreSQL users for each application, replacing the use of the general `postgres` user across all applications. The new users are as follows:

- `bbb_core`: for Akka-Apps application
- `bbb_hasura`: for Hasura (read-only access)
- `hasura_app`: for Hasura metadata

This setup facilitates better monitoring by allowing us to track which application is making queries and to monitor each application's connection count. 

Additionally, it enables the possibility of setting a `max_connections` limit per application in the future.