### PR TITLE
[2.7]ci: update link to download FS sounds.tar.gz

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -64,7 +64,7 @@ jobs:
           - package: bbb-freeswitch
             build-list: bbb-freeswitch-core bbb-freeswitch-sounds
             cache-files-list: freeswitch.placeholder.sh
-            cache-urls-list: http://bigbluebutton.org/downloads/sounds.tar.gz
+            cache-urls-list: https://ubuntu.bigbluebutton.org/sounds.tar.gz
           - package: bbb-webrtc
             build-list: bbb-webrtc-sfu bbb-webrtc-recorder
             cache-files-list: bbb-webrtc-sfu.placeholder.sh bbb-webrtc-recorder.placeholder.sh

--- a/build/packages-template/bbb-freeswitch-core/build.sh
+++ b/build/packages-template/bbb-freeswitch-core/build.sh
@@ -76,7 +76,7 @@ ldconfig
 # libwebsockets start
 # mod_audio_fork needs it (used in built-in speech transcription)
 if [ ! -d libwebsockets ]; then
-  git clone https://github.com/warmcat/libwebsockets.git
+  git clone https://github.com/bigbluebutton/libwebsockets.git
 fi
 cd libwebsockets/
 git checkout v3.2.3
@@ -95,7 +95,7 @@ ldconfig
 # mod_audio_fork start
 # copy mod_audio_fork into place (used in built-in speech transcription)
 if [ ! -d drachtio-freeswitch-modules ]; then
-  git clone https://github.com/drachtio/drachtio-freeswitch-modules.git
+  git clone https://github.com/bigbluebutton/drachtio-freeswitch-modules.git
 fi
 
 cd drachtio-freeswitch-modules

--- a/build/packages-template/bbb-freeswitch-sounds/build.sh
+++ b/build/packages-template/bbb-freeswitch-sounds/build.sh
@@ -32,7 +32,7 @@ CONFDIR=$DESTDIR/opt/freeswitch/etc/freeswitch
 mkdir -p $DESTDIR/opt/freeswitch/share/freeswitch
 
 if [ ! -f sounds.tar.gz ] ; then
-  wget http://bigbluebutton.org/downloads/sounds.tar.gz -O sounds.tar.gz
+  wget https://ubuntu.bigbluebutton.org/sounds.tar.gz -O sounds.tar.gz
 fi
 tar xvfz sounds.tar.gz -C $DESTDIR/opt/freeswitch/share/freeswitch
 


### PR DESCRIPTION
Backporting https://github.com/bigbluebutton/bigbluebutton/pull/21617 to BBB 2.7

Also:
* Switch to using BigBlueButton's fork of drachtio-freeswitch-modules (because the original was deleted. I found someone's clone and luckily it had the commit we use)
* Switch to using BigBlueButton's fork of warmcat/libwebsockets (to avoid issues if the original is deleted)

Note: I am not switching to BBB forks of repositories owned by SignalWire(FreeSWITCH)