### PR TITLE
Fix: unpin shared notes when screenshare started

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -149,7 +149,9 @@ class ScreenshareComponent extends React.Component {
     });
 
     Session.setItem('pinnedNotesLastState', isSharedNotesPinned);
-    unpinSharedNotes();
+    if (isPresenter) {
+      unpinSharedNotes();
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
### What does this PR do?
The error was caused by a missing validation when the screenshare starts.

### Closes Issue(s)
Closes #21586

### How to test
- Join with a prenseter and a viewer
- start screenshare 
- look at viewer browser logs


