### PR TITLE
fix(notes): Shared notes gets disconnected when switching sidebar panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
@@ -97,7 +97,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
   const sessionData = padSessionData?.sharedNotes_session ?? [];
   const session = sessionData.find((s) => s.sharedNotesExtId === externalId);
   const hasPad = !!hasPadData && hasPadData.sharedNotes.length > 0;
-  const hasSession = !!session?.sessionId;
+  const hasSession = session?.sessionId !== undefined;
   const sessionIds = new Set<string>(sessionData.map((s) => s.sessionId));
 
   if (hasPad && !hasSession && hasPermission) {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/container.jsx
@@ -8,7 +8,8 @@ import {
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
 
-const SidebarContentContainer = () => {
+const SidebarContentContainer = (props) => {
+  const { isSharedNotesPinned } = props;
   const sidebarContentInput = layoutSelectInput((i) => i.sidebarContent);
   const sidebarContentOutput = layoutSelectOutput((i) => i.sidebarContent);
   const layoutContextDispatch = layoutDispatch();
@@ -37,6 +38,7 @@ const SidebarContentContainer = () => {
       amIPresenter={amIPresenter}
       amIModerator={amIModerator}
       currentSlideId={currentSlideId}
+      isSharedNotesPinned={isSharedNotesPinned}
     />
   );
 };


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Fixes a bug where the shared notes gets disconnected when it is pinned and the user navigates between the sidebar panels. Etherpad then offers to be reconnected. This was being caused by a missing condition variable which tells us when the shared notes is pinned, making it render in both places (sidebar content and presentation area).

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21570