### PR TITLE
refactor(audio-controls): Refactor padding imports in `input-stream-live-selector/styles.ts` for consistency.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
@@ -9,7 +9,7 @@ import {
   colorOffWhite,
   colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { smPaddingX, smPaddingY } from '/imports/ui/stylesheets/styled-components/general';
+import { smPaddingY, smPadding } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 
 const pulse = keyframes`
@@ -57,7 +57,7 @@ export const MuteToggleButton = styled(Button)`
   
       [dir='rtl'] & {
         margin-right: 0;
-        margin-left: ${smPaddingX};
+        margin-left: -${smPadding};
   
         @media ${smallOnly} {
           margin-left: ${smPaddingY};


### PR DESCRIPTION
### What does this PR do?

This PR adjusts the chevron on RTL layouts.

### More

Before
![image](https://github.com/user-attachments/assets/98ad9492-33b3-4973-a69a-59318b89f264)

After
![image](https://github.com/user-attachments/assets/ec585900-c962-4ecc-a86f-634f36e59ada)

