### PR TITLE
fix: number of participants in userlist is not correctly displayed after switching to RTL locale

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/component.tsx
@@ -26,12 +26,16 @@ const UserTitle: React.FC<UserTitleProps> = ({
   return (
     <Styled.Container>
       <Styled.SmallTitle>
-        {intl.formatMessage(messages.usersTitle)}
         <span
           data-test-users-count={count}
           data-test-users-with-audio-count={countWithAudio}
         >
-          {` (${count.toLocaleString('en-US', { notation: 'standard' })})`}
+          {intl.formatMessage(
+            messages.usersTitle,
+            {
+              0: count.toLocaleString('en-US', { notation: 'standard' }),
+            },
+          )}
         </span>
       </Styled.SmallTitle>
       <UserTitleOptionsContainer />

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -152,7 +152,7 @@
     "app.user.activityCheck": "User activity check",
     "app.user.activityCheck.label": "Check if user is still in session ({0})",
     "app.user.activityCheck.check": "Check",
-    "app.userList.usersTitle": "Users",
+    "app.userList.usersTitle": "Users ({0})",
     "app.userList.participantsTitle": "Participants",
     "app.userList.messagesTitle": "Messages",
     "app.userList.notesTitle": "Notes",


### PR DESCRIPTION
### What does this PR do?

Update user participants title to include the number of users in the locale string, preventing an issue with participants number being displayed as `USERS) 1(` instead of `USERS (1)` after switching to a RTL locale and back to an LTR locale

#### before

https://github.com/user-attachments/assets/a3201992-d928-486b-90e5-27480f0c47c5

#### after

https://github.com/user-attachments/assets/2174bc91-1c6e-4dc3-bab3-456310d85cae



### How to test
1. join a meeting
2. switch language to arabic
3. switch language back to english
4. see error