### PR TITLE
style: adjust locked shared notes label icon and text

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
@@ -158,8 +158,11 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
             ? (
               <Styled.NotesLock>
                 {/* @ts-ignore */}
-                <Icon iconName="lock" />
-                <span id="lockedNotes">{`${intl.formatMessage(intlMessages.locked)} ${intl.formatMessage(intlMessages.byModerator)}`}</span>
+                <span id="lockedNotes">
+                  <Icon iconName="lock" />
+                  &nbsp;
+                  {`${intl.formatMessage(intlMessages.locked)} ${intl.formatMessage(intlMessages.byModerator)}`}
+                </span>
               </Styled.NotesLock>
             ) : null}
           {isPinned

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/styles.ts
@@ -31,8 +31,9 @@ const NotesLock = styled.div`
   font-size: ${fontSizeSmaller};
   color: ${colorGray};
 
-  > i {
+  > span i {
     font-size: ${fontSizeXS};
+    left: 0;
   }
 `;
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -162,7 +162,7 @@
     "app.userList.presenter": "Presenter",
     "app.userList.you": "You",
     "app.userList.locked": "Locked",
-    "app.userList.byModerator": "by (Moderator)",
+    "app.userList.byModerator": "(by moderator)",
     "app.userList.label": "User list",
     "app.userList.toggleCompactView.label": "Toggle compact view mode",
     "app.userList.moderator": "Moderator",


### PR DESCRIPTION
### What does this PR do?

refactor shared notes "locked" label to improve readability

#### before
![Screenshot from 2024-11-13 10-06-49](https://github.com/user-attachments/assets/96fe99b4-664e-4934-a604-b2a8d15cd84b)

#### after

![Screenshot from 2024-11-13 10-03-03](https://github.com/user-attachments/assets/fea07496-d178-4aac-9f28-62cae159b8aa)


### How to test
