### PR TITLE
fix(whiteboard): Get current shape list from tldraw api for access management

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -57,6 +57,12 @@ const createCamera = (pageId, zoomLevel) => ({
   z: zoomLevel,
 });
 
+const createLookup = (arr) =>
+  arr.reduce((acc, entry) => {
+    acc[entry.id] = entry;
+    return acc;
+  }, {});
+
 const defaultUser = {
   userId: '',
 };
@@ -655,8 +661,8 @@ const Whiteboard = React.memo((props) => {
 
         // Update existing shapes and add them to the batch
         Object.values(updated).forEach(([, record]) => {
-          const createdBy = prevShapesRef.current[record?.id]?.meta?.createdBy
-            || currentUser?.userId;
+          const formattedLookup = createLookup(editor.getCurrentPageShapes());
+          const createdBy = formattedLookup[record?.id]?.meta?.createdBy || currentUser?.userId;
           const updatedRecord = {
             ...record,
             meta: {
@@ -825,18 +831,10 @@ const Whiteboard = React.memo((props) => {
         const newNext = next;
         if (next?.typeName === 'instance_page_state') {
           if (isPresenterRef.current || isModeratorRef.current) return next;
-          const createLookup = (arr) =>
-            arr.reduce((acc, entry) => {
-              acc[entry.id] = entry;
-              return acc;
-            }, {});
-
-          const formattedLookup = createLookup(prevShapesRef.current);
+          const formattedLookup = createLookup(editor.getCurrentPageShapes());
 
           // Filter selectedShapeIds based on shape owner
-          if (next.selectedShapeIds.length > 0
-            && !isEqual(prev.selectedShapeIds, next.selectedShapeIds)
-          ) {
+          if (next.selectedShapeIds.length > 0) {
             newNext.selectedShapeIds = next.selectedShapeIds.filter((shapeId) => {
               const shapeOwner = formattedLookup[shapeId]?.meta?.createdBy;
               return !shapeOwner || shapeOwner === currentUser?.userId;


### PR DESCRIPTION

### What does this PR do?
This PR improves shape access control by using the tldraw API to retrieve the current shape list, ensuring users can only interact with shapes they created (unless they are a presenter/moderator).


### Motivation
Previously, there were cases where viewers could unintentionally access shapes locally they did not create.

before:
![shape-access-bug](https://github.com/user-attachments/assets/41a370ce-fec4-4566-9a5a-dba5a1c698ac)

after:
![shape-access-fix](https://github.com/user-attachments/assets/8f524047-65cf-4d6f-a315-ccd633765758)
