### PR TITLE
fix(whiteboard): Increase batch size for annotation history stream

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -132,7 +132,7 @@ export const CURRENT_PAGE_ANNOTATIONS_STREAM = gql`subscription annotationsStrea
 export const ANNOTATION_HISTORY_STREAM = gql`
   subscription annotationHistoryStream($updatedAt: timestamptz) {
     pres_annotation_history_curr_stream(
-      batch_size: 100,
+      batch_size: 1000,
       cursor: {initial_value: {updatedAt: $updatedAt}, ordering: ASC}
     ) {
       annotationId


### PR DESCRIPTION
### What does this PR do?
This PR increases the batch size for the pres_annotation_history_curr stream to prevent sync issues when multiple shapes are removed or updated simultaneously.

### Motivation
Previously, deleting a large number of shapes could leave artifacts on the whiteboard for other viewers.

before:
![delete-bug](https://github.com/user-attachments/assets/66a6fffb-dbec-4881-83b0-3bf332ce9310)


after:
![delete-bug-fix](https://github.com/user-attachments/assets/9aa3a243-09cc-40d0-b4dc-b0696ab4ad84)
