### PR TITLE
fix(actions-bar/reactions-button): Update reactions button label to Share a reaction

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -76,7 +76,7 @@ const ReactionsButton = (props) => {
 
   const svgIcon = currentUserReaction === 'none' ? 'reactions' : null;
   const currentUserReactionEmoji = REACTIONS.find(({ native }) => native === currentUserReaction);
-d
+
   let customIcon = null;
 
   if (!svgIcon) {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -31,6 +31,7 @@ const ReactionsButton = (props) => {
     reactionsLabel: {
       id: 'app.actionsBar.reactions.reactionsButtonLabel',
       description: 'reactions Label',
+      defaultMessage: 'Share a reaction',
     },
   });
 
@@ -75,7 +76,7 @@ const ReactionsButton = (props) => {
 
   const svgIcon = currentUserReaction === 'none' ? 'reactions' : null;
   const currentUserReactionEmoji = REACTIONS.find(({ native }) => native === currentUserReaction);
-
+d
   let customIcon = null;
 
   if (!svgIcon) {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -697,7 +697,7 @@
     "app.actionsBar.actionsDropdown.captionsDesc": "Toggles captions pane",
     "app.actionsBar.actionsDropdown.takePresenter": "Take presenter",
     "app.actionsBar.actionsDropdown.takePresenterDesc": "Assign yourself as the new presenter",
-    "app.actionsBar.reactions.reactionsButtonLabel": "Reactions bar",
+    "app.actionsBar.reactions.reactionsButtonLabel": "Share a reaction",
     "app.actionsBar.reactions.raiseHand": "Raise your hand",
     "app.actionsBar.reactions.lowHand": "Lower your hand",
     "app.actionsBar.reactions.autoCloseReactionsBarLabel": "Auto close the reactions bar",


### PR DESCRIPTION
### What does this PR do?

This PR changes the tooltip text on "Reactions bar" to "Share a reaction".

### How to test

Just mind the tooltip of the reactions button.

