### PR TITLE
fix(whiteboard): Add timeout for ignoring presentation restoration on new events

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -69,6 +69,8 @@ const getToolbarHeight = () => {
   return height;
 };
 
+const IGNORE_PRESENTATION_RESTORATION_TIMEOUT = 5000;
+
 class Presentation extends PureComponent {
   constructor() {
     super();
@@ -83,6 +85,7 @@ class Presentation extends PureComponent {
       tldrawIsMounting: true,
       isToolbarVisible: true,
       hadPresentation: false,
+      ignorePresentationRestoring: true,
     };
 
     const PAN_ZOOM_INTERVAL = window.meetingClientSettings.public.presentation.panZoomInterval || 200;
@@ -195,6 +198,10 @@ class Presentation extends PureComponent {
         value: 0,
       });
     }
+
+    setTimeout(() => {
+      this.setState({ ignorePresentationRestoring: false });
+    }, IGNORE_PRESENTATION_RESTORATION_TIMEOUT);
   }
 
   componentDidUpdate(prevProps) {
@@ -224,6 +231,7 @@ class Presentation extends PureComponent {
       isPanning,
       presentationId,
       hadPresentation,
+      ignorePresentationRestoring,
     } = this.state;
     const {
       numCameras: prevNumCameras,
@@ -314,6 +322,7 @@ class Presentation extends PureComponent {
         !presentationIsOpen
         && restoreOnUpdate
         && (currentSlide || presentationChanged)
+        && !ignorePresentationRestoring
       ) {
         const slideChanged = currentSlide.id !== prevProps.currentSlide.id;
         const positionChanged = slidePosition.viewBoxHeight


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- When the client is starting up the whiteboard seems to be doing some kind of zoom initialization which is affecting some effects of the presentation component. A timeout was added to ignore presentation restoration in the first 5 seconds after client startup. This fixes a bug where the config `bbbHidePresentationOnJoin` does not take effect.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21581