### PR TITLE
refactor (api): Add Markdown support to welcome messages and deprecate previous HTML parameters

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -44,7 +44,10 @@ public class ApiParams {
     public static final String MAX_PARTICIPANTS = "maxParticipants";
     public static final String MEETING_ID = "meetingID";
     public static final String META = "meta";
+    public static final String WELCOME = "welcome";
     public static final String MODERATOR_ONLY_MESSAGE = "moderatorOnlyMessage";
+    public static final String WELCOME_MESSAGE = "welcomeMessage";
+    public static final String WELCOME_MESSAGE_FOR_MODERATORS = "welcomeMessageForModerators";
     public static final String MODERATOR_PW = "moderatorPW";
     public static final String MUTE_ON_START = "muteOnStart";
     public static final String MEETING_KEEP_EVENTS = "meetingKeepEvents";
@@ -69,7 +72,6 @@ public class ApiParams {
     public static final String MAX_PINNED_CAMERAS = "maxPinnedCameras";
     public static final String MEETING_EXPIRE_IF_NO_USER_JOINED_IN_MINUTES = "meetingExpireIfNoUserJoinedInMinutes";
     public static final String MEETING_EXPIRE_WHEN_LAST_USER_LEFT_IN_MINUTES = "meetingExpireWhenLastUserLeftInMinutes";
-    public static final String WELCOME = "welcome";
     public static final String ROLE = "role";
     public static final String GROUPS = "groups";
     public static final String DISABLED_FEATURES = "disabledFeatures";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -814,7 +814,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.VOICE_BRIDGE, message.voiceConfId);
       params.put(ApiParams.DURATION, message.durationInMinutes.toString());
       params.put(ApiParams.RECORD, message.record.toString());
-      params.put(ApiParams.WELCOME, getMeeting(message.parentMeetingId).getWelcomeMessageTemplate());
+      params.put(ApiParams.WELCOME_MESSAGE, getMeeting(message.parentMeetingId).getWelcomeMessageTemplate());
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -59,7 +59,7 @@ public class Meeting {
 	private Boolean notifyRecordingIsOn;
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
-	private String welcomeMsgForModerators = "";
+	private String welcomeMsgForModerators;
 	private String loginUrl;
 	private String logoutUrl;
 	private int logoutTimer = 0;
@@ -169,6 +169,7 @@ public class Meeting {
         telVoice = builder.telVoice;
         welcomeMsgTemplate = builder.welcomeMsgTemplate;
         welcomeMsg = builder.welcomeMsg;
+        welcomeMsgForModerators = builder.welcomeMsgForModerators;
         dialNumber = builder.dialNumber;
         metadata = builder.metadata;
         createdTime = builder.createdTime;
@@ -363,14 +364,6 @@ public class Meeting {
 		return endTime;
 	}
 
-	public void setWelcomeMsgForModerators(String msg) {
-		welcomeMsgForModerators = msg;
-	}
-
-	public String getWelcomeMsgForModerators() {
-		return welcomeMsgForModerators;
-	}
-
 	public void setEndTime(long t) {
 		endTime = t;
 	}
@@ -469,12 +462,16 @@ public class Meeting {
 		return presentationUploadExternalUrl;
 	}
 
-  public String getWelcomeMessageTemplate() {
+  	public String getWelcomeMessageTemplate() {
     return welcomeMsgTemplate;
   }
 
 	public String getWelcomeMessage() {
 		return welcomeMsg;
+	}
+
+	public String getWelcomeMsgForModerators() {
+		return welcomeMsgForModerators;
 	}
 
 	public String getDefaultAvatarURL() {
@@ -958,6 +955,7 @@ public class Meeting {
     	private String telVoice;
     	private String welcomeMsgTemplate;
     	private String welcomeMsg;
+    	private String welcomeMsgForModerators;
     	private String loginUrl;
     	private String logoutUrl;
     	private String bannerColor;
@@ -1109,6 +1107,11 @@ public class Meeting {
     		welcomeMsg = w;
     		return this;
     	}
+
+		public Builder withWelcomeMessageForModerators(String w) {
+			welcomeMsgForModerators = w;
+			return this;
+		}
 
 	    public Builder withWelcomeMessageTemplate(String w) {
             welcomeMsgTemplate = w;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -462,9 +462,9 @@ public class Meeting {
 		return presentationUploadExternalUrl;
 	}
 
-  	public String getWelcomeMessageTemplate() {
-    return welcomeMsgTemplate;
-  }
+	public String getWelcomeMessageTemplate() {
+		return welcomeMsgTemplate;
+	}
 
 	public String getWelcomeMessage() {
 		return welcomeMsg;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/popup-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-popup/popup-content/component.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import {
   defineMessages, useIntl,
 } from 'react-intl';
+import ReactMarkdown from 'react-markdown';
 import {
-  PopupContentBox, PopupContentHeader, PopupContentBody, CloseButton,
+  PopupContentBox, PopupContentHeader, CloseButton,
 } from './styles';
 
 interface PopupContentProps {
@@ -37,7 +38,11 @@ const PopupContent: React.FC<PopupContentProps> = ({ message, closePopup }) => {
           data-test="closePopup"
         />
       </PopupContentHeader>
-      <PopupContentBody dangerouslySetInnerHTML={{ __html: message }} />
+      <ReactMarkdown
+        linkTarget="_blank"
+      >
+        {message}
+      </ReactMarkdown>
     </PopupContentBox>
   );
 };

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -214,9 +214,9 @@ defaultMeetingLayout=CUSTOM_LAYOUT
 #
 # native2ascii -encoding UTF8 bigbluebutton.properties bigbluebutton.properties
 #
-#defaultWelcomeMessage=Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="https://bigbluebutton.org/teachers/tutorials/"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the speaker button.  Use a headset to avoid causing background noise for others.
-#defaultWelcomeMessageFooter=This server is running <a href="https://bigbluebutton.org/" target="_blank"><u>BigBlueButton</u></a>.
 
+# Default welcome message (supports Markdown syntax),
+# It will be overridden by the /create param `welcomeMessage`
 defaultWelcomeMessage=Welcome to **%%CONFNAME%%**!\
 \n  \nFor help on using BigBlueButton see these (short) [Tutorial videos](https://bigbluebutton.org/teachers/tutorials/).\
 \n  \nTo join the audio bridge click the speaker button.  Use a headset to avoid causing background noise for others.

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -214,8 +214,13 @@ defaultMeetingLayout=CUSTOM_LAYOUT
 #
 # native2ascii -encoding UTF8 bigbluebutton.properties bigbluebutton.properties
 #
-defaultWelcomeMessage=Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="https://bigbluebutton.org/teachers/tutorials/"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the speaker button.  Use a headset to avoid causing background noise for others.
-defaultWelcomeMessageFooter=This server is running <a href="https://bigbluebutton.org/" target="_blank"><u>BigBlueButton</u></a>.
+#defaultWelcomeMessage=Welcome to <b>%%CONFNAME%%</b>!<br><br>For help on using BigBlueButton see these (short) <a href="https://bigbluebutton.org/teachers/tutorials/"><u>tutorial videos</u></a>.<br><br>To join the audio bridge click the speaker button.  Use a headset to avoid causing background noise for others.
+#defaultWelcomeMessageFooter=This server is running <a href="https://bigbluebutton.org/" target="_blank"><u>BigBlueButton</u></a>.
+
+defaultWelcomeMessage=Welcome to **%%CONFNAME%%**!\
+\n  \nFor help on using BigBlueButton see these (short) [Tutorial videos](https://bigbluebutton.org/teachers/tutorials/).\
+\n  \nTo join the audio bridge click the speaker button.  Use a headset to avoid causing background noise for others.
+defaultWelcomeMessageFooter=This server is running [BigBlueButton](https://bigbluebutton.org/).
 
 # Default maximum number of users a meeting can have.
 # Current default is 0 (meeting doesn't have a user limit).

--- a/bigbluebutton-web/src/test/groovy/org/bigbluebutton/web/controllers/ApiControllerSpec.groovy
+++ b/bigbluebutton-web/src/test/groovy/org/bigbluebutton/web/controllers/ApiControllerSpec.groovy
@@ -20,7 +20,7 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
   def apiVersion = "2.0"
   def securitySalt = "b4578c133b8a49acaecacbb3abec91a1"
   def defaultServerUrl = "http://127.0.0.1"
-  def welcomeMessage = "<br>Welcome to <b>%%CONFNAME%%</b>!"
+  def welcomeMessage = "Welcome to **%%CONFNAME%%**!"
   def logoutUrl = defaultServerUrl + "/api/logout"
 
   def setupSpec() {}

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1,4 +1,4 @@
----
+w---
 id: customize
 slug: /administration/customize
 title: Server Customization
@@ -838,7 +838,9 @@ defaultDialAccessNumber=613-555-1234
 and set `defaultWelcomeMessageFooter` to
 
 ```properties
-defaultWelcomeMessageFooter=<br><br>To join this meeting by phone, dial:<br>  %%DIALNUM%%<br>Then enter %%CONFNUM%%# as the conference PIN number.
+defaultWelcomeMessageFooter=To join this meeting by phone, dial:\
+\n%%DIALNUM%%\
+\nThen enter %%CONFNUM%%# as the conference PIN number.
 ```
 
 Save `/etc/bigbluebutton/bbb-web.properties` and restart BigBlueButton again. Each user that joins a session will see a message in the chat similar to.
@@ -1148,7 +1150,7 @@ HERE
 
 #### Change the default welcome message
 
-The default welcome message is built from three parameters: two system-wide parameters (see below) and the `welcome` parameter from the BigBlueButton `create` API call.
+The default welcome message is built from three parameters: two system-wide parameters (see below) and the `welcomeMessage` parameter from the BigBlueButton `create` API call.
 
 You'll find the two system-wide welcome parameters `defaultWelcomeMessage` and `defaultWelcomeMessageFooter` in `/usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties`.
 
@@ -1157,11 +1159,11 @@ defaultWelcomeMessage=<default welcome message>
 defaultWelcomeMessageFooter=<default welcome message footer>
 ```
 
-When a front-end creates a BigBlueButton session, it may also pass a `welcome` parameter in the [create](/development/api#create) API call.
+When a front-end creates a BigBlueButton session, it may also pass a `welcomeMessage` parameter in the [create](/development/api#create) API call.
 
-The final welcome message shown to the user (as blue text in the Chat window) is a composite of `welcome` + `defaultWelcomeMessage` + `defaultWelcomeMessageFooter`.
+The final welcome message shown to the user is a composite of `welcomeMessage` (or `defaultWelcomeMessage`) + `defaultWelcomeMessageFooter`.
 
-The welcome message is fixed for the duration of a meeting. If you want to see the effect of changing the `welcome` parameter, you must [end](/development/api#end) the current meeting or wait until the BigBlueButton server removes it from memory (which occurs about two minutes after the last person has left). You can overwrite these values in file `/etc/bigbluebutton/bbb-web.properties`, just remember to restart BigBlueButton with `sudo bbb-conf --restart` for the new values to take effect.
+The welcome message is fixed for the duration of a meeting. If you want to see the effect of changing the `welcomeMessage` parameter, you must [end](/development/api#end) the current meeting or wait until the BigBlueButton server removes it from memory (which occurs about two minutes after the last person has left). You can overwrite these values in file `/etc/bigbluebutton/bbb-web.properties`, just remember to restart BigBlueButton with `sudo bbb-conf --restart` for the new values to take effect.
 
 #### Modify localization for the client (override with the latest locale)
 

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -29,7 +29,19 @@ const createEndpointTableData = [
     "name": "welcome",
     "required": false,
     "type": "String",
-    "description": (<>A welcome message that gets displayed on the chat window when the participant joins. You can include keywords (<code className="language-plaintext highlighter-rouge">%%CONFNAME%%</code>, <code className="language-plaintext highlighter-rouge">%%DIALNUM%%</code>, <code className="language-plaintext highlighter-rouge">%%CONFNUM%%</code>) which will be substituted automatically.<br /><br /> This parameter overrides the default <code className="language-plaintext highlighter-rouge">defaultWelcomeMessage</code> in <code className="language-plaintext highlighter-rouge">bigbluebutton.properties</code>.<br /><br /> The welcome message has limited support for HTML formatting. Be careful about copy/pasted HTML from e.g. MS Word, as it can easily exceed the maximum supported URL length when used on a GET request.</>)
+    "description": (<><b>[DEPRECATED]</b> Removed in 3.0, temporarily still handled, please transition to welcomeMessage.</>)
+  },
+  {
+    "name": "welcomeMessage",
+    "required": false,
+    "type": "String",
+    "description": (<>A welcome message using markdown syntax that gets displayed when the participant joins. You can include keywords (<code className="language-plaintext highlighter-rouge">%%CONFNAME%%</code>, <code className="language-plaintext highlighter-rouge">%%DIALNUM%%</code>, <code className="language-plaintext highlighter-rouge">%%CONFNUM%%</code>) which will be substituted automatically.<br /><br /> This parameter overrides the default <code className="language-plaintext highlighter-rouge">defaultWelcomeMessage</code> in <code className="language-plaintext highlighter-rouge">bigbluebutton.properties</code>.</>)
+  },
+  {
+    "name": "welcomeMessageForModerators",
+    "required": false,
+    "type": "String",
+    "description": (<>A welcome message using markdown syntax that gets displayed when the moderator joins.<br /><br /> The value is interpreted in the same way as the <code className="language-plaintext highlighter-rouge">welcomeMessage</code> parameter.</>)
   },
   {
     "name": "dialNumber",
@@ -128,7 +140,7 @@ const createEndpointTableData = [
     "name": "moderatorOnlyMessage",
     "required": false,
     "type": "String",
-    "description": (<>Display a message to all moderators in the public chat.<br /><br /> The value is interpreted in the same way as the <code className="language-plaintext highlighter-rouge">welcome</code> parameter.</>)
+    "description": (<><b>[DEPRECATED]</b> Removed in 3.0, temporarily still handled, please transition to `welcomeMessageForModerators`.</>)
   },
   {
     "name": "autoStartRecording",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -111,7 +111,7 @@ Updated in 2.7:
 
 Updated in 3.0:
 
-- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`;
+- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`, `welcomeMessage`, `welcomeMessageForModerators`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`; **Deprecated:** `welcome`, `moderatorOnlyMessage`.
 - **join** - **Added:** `enforceLayout`, `userdata-bbb_default_layout`, `userdata-bbb_skip_echotest_if_previous_device`, `userdata-bbb_prefer_dark_theme`. **Removed:** `defaultLayout` (replaced by `userdata-bbb_default_layout`) and removed support for all HTTP request methods except GET.
 - **sendChatMessage** endpoint was first introduced.
 - **enter** endpoint was removed. It was only used internally, never part of the api documentation.


### PR DESCRIPTION
This PR continues the work started by @Scroody in #20713 by introducing Markdown support for welcome messages, while keeping the existing HTML parameters functional but deprecated.

**New Parameters (support Markdown syntax):**
- `welcomeMessage`
- `welcomeMessageForModerators`

**Deprecated Parameters (HTML syntax will be converted to Markdown internally):**
- `welcome`
- `moderatorOnlyMessage`

**Updated Configurations:**
- `defaultWelcomeMessage` and `defaultWelcomeMessageFooter` now accept both HTML and Markdown for backward compatibility. All HTML content will be internally converted to Markdown. In future releases, only Markdown will be supported.

Closes #18593