### PR TITLE
docs: install.md: suggest current vserver model

### DIFF
--- a/docs/docs/administration/install.md
+++ b/docs/docs/administration/install.md
@@ -34,7 +34,7 @@ For production, we recommend the following minimum requirements
 - A hostname (such as bbb.example.com) for setup of a SSL certificate
 - IPV4 and IPV6 address
 
-If you install BigBlueButton on a virtual machine in the cloud, we recommend you choose an instance type that has dedicated CPU.  These are usually called "compute-intensive" instances.  On Digital Ocean we recommend the c-8 compute intensive instances (or larger). On AWS we recommend c5a.2xlarge (or larger).  On Hetzner we recommend the AX52 servers or CCX32 instances.
+If you install BigBlueButton on a virtual machine in the cloud, we recommend you choose an instance type that has dedicated CPU.  These are usually called "compute-intensive" instances.  On Digital Ocean we recommend the c-8 compute intensive instances (or larger). On AWS we recommend c5a.2xlarge (or larger).  On Hetzner we recommend the AX52 servers or CCX33 instances.
 
 If you are setting up BigBlueButton for local development on your workstation, you can relax some of the above requirements as there will only be few users on the server. Starting with the above requirements, you can reduce them as follows
 


### PR DESCRIPTION
### What does this PR do?
The install.md docs page was suggesting a vserver model which is not available any more. This PR updates the suggestion to the same but newer hardware model.


### Motivation
Avoid confusion of new users.


### How to test
- open https://www.hetzner.com/cloud/ and look for `CCX32`. It is not there any more.
- open https://www.hetzner.com/cloud/ and look for `CCX33`. It is there and shows the suggested dedicated 8 CPU cores and 32 GB RAM.