### PR TITLE
Documentation: Adding documentation about default logo

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1335,6 +1335,10 @@ defaultGuestPolicy=ALWAYS_ACCEPT
 
 Ensure that the parameter `displayBrandingArea` is set to `true` in bbb-html5's configuration, restart BigBlueButton server with `sudo bbb-conf --restart` and pass `logo=<image-url>` in Custom parameters when creating the meeting.
 
+### Changing the default logo
+
+To update the default logo, navigate to the `images` folder located at `bigbluebutton-config/assets/`, and replace the `logo.png` file with your new logo.
+
 ## Other meeting configs available
 These configs can be set in `/etc/bigbluebutton/bbb-web.properties`
 

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1337,7 +1337,7 @@ Ensure that the parameter `displayBrandingArea` is set to `true` in bbb-html5's 
 
 ### Changing the default logo
 
-To update the default logo, navigate to the `images` folder located at `bigbluebutton-config/assets/`, and replace the `logo.png` file with your new logo.
+To update the default logo, navigate to the `images` folder located at `/var/www/bigbluebutton-default/assets/images/`, and replace the `logo.png` file with your new logo.
 
 ## Other meeting configs available
 These configs can be set in `/etc/bigbluebutton/bbb-web.properties`


### PR DESCRIPTION
### What does this PR do?

As requested on issue #17139 this PR adds documentation about default logo, since all other items were documented already.

### Closes Issue(s)

Closes #17139 
