### PR TITLE
fix(meeting-ended): Refactor feedback prompt logic to exclude breakout sessions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -493,8 +493,9 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
     learningDashboardBase,
   } = clientSettings;
 
-  const shouldAskForFeedback = askForFeedbackOnLogout
-    || getFromUserSettings('bbb_ask_for_feedback_on_logout');
+  const shouldAskForFeedback = !isBreakout
+  && (askForFeedbackOnLogout
+  || getFromUserSettings('bbb_ask_for_feedback_on_logout'));
 
   return (
     <MeetingEnded


### PR DESCRIPTION
### What does this PR do?

 This PR refactors the feedback prompt logic to ensure that feedback is only requested after the main meeting session ends, excluding breakout sessions. 

### Closes Issue(s)

Closes #21403 

### How to test

1. Host a main meeting and verify that the feedback prompt appears when the meeting ends.
2. Create a breakout session and confirm that no feedback prompt appears after it ends.
