### PR TITLE
fix(whiteboard): Add null check for shapes before usage

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -229,7 +229,7 @@ const Whiteboard = React.memo((props) => {
   }, [fitToWidth]);
 
   React.useEffect(() => {
-    if (!isEqual(prevShapesRef.current, shapes)) {
+    if (shapes && !isEqual(prevShapesRef.current, shapes)) {
       prevShapesRef.current = shapes;
       tlEditorRef.current?.store.mergeRemoteChanges(() => {
         const shapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
@@ -771,8 +771,10 @@ const Whiteboard = React.memo((props) => {
       });
 
       editor.store.mergeRemoteChanges(() => {
-        const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
-         editor.store.put(remoteShapesArray);
+        if (shapes) {
+          const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
+          editor.store.put(remoteShapesArray);
+        }
       });
 
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where the presentation area crashes when joining a breakout room that’s still loading the slide. It adds null checks for the shapes object to prevent errors from undefined or null values during whiteboard initialization.

### Closes Issue(s)
Closes #21691 
