### PR TITLE
style(sidebar): Update sidebar handle styles to improve chat scroll.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -121,8 +121,18 @@ const SidebarContent = (props) => {
         height,
       }}
       handleStyles={{
-        left: { height: '100vh' },
-        right: { height: '100vh' },
+        left: {
+          width: '4px',
+          height: '100vh',
+          left: '-2px',
+          cursor: 'ew-resize',
+        },
+        right: {
+          width: '12px',
+          height: '100vh',
+          right: '-12px',
+          cursor: 'ew-resize',
+        },
       }}
     >
       {sidebarContentPanel === PANELS.CHAT

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -116,7 +116,7 @@ const SidebarContent = (props) => {
         top,
         left,
         right,
-        zIndex,
+        zIndex: '2',
         width,
         height,
       }}


### PR DESCRIPTION
### What does this PR do?

This PR moves the chat resizing trigger to the side (very very slightly), so the scrollbar on the chat could become easier to click.
 
### Closes Issue(s)

Closes #21471 

### How to test

Create a meeting, spam the chat with message so the scroll would appear, then try and click it.

