### PR TITLE
fix (gql-server): Connection Status with time empty when user has a single occurrence of connection problem

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -810,9 +810,9 @@ BEGIN
     "lastNetworkRttInMs" = NEW."networkRttInMs",
     "lastOccurrenceAt" = current_timestamp
     WHERE "meetingId"=NEW."meetingId" AND "userId"=NEW."userId" AND "status"= NEW."status" RETURNING *)
-    INSERT INTO "user_connectionStatusMetrics"("meetingId","userId","status","occurrencesCount", "firstOccurrenceAt",
+    INSERT INTO "user_connectionStatusMetrics"("meetingId","userId","status","occurrencesCount", "firstOccurrenceAt", "lastOccurrenceAt",
     "highestNetworkRttInMs", "lowestNetworkRttInMs", "lastNetworkRttInMs")
-    SELECT NEW."meetingId", NEW."userId", NEW."status", 1, current_timestamp,
+    SELECT NEW."meetingId", NEW."userId", NEW."status", 1, current_timestamp, current_timestamp,
     NEW."networkRttInMs", NEW."networkRttInMs", NEW."networkRttInMs"
     WHERE NOT EXISTS (SELECT * FROM upsert);
 


### PR DESCRIPTION
When the user has a single occurrence of connection issue, the time is not populated properly:

<table>

<tr><td>

Before:

![image](https://github.com/user-attachments/assets/56e4c8a6-a7ab-49b5-9136-a730747c28b3)

</td></tr>

<tr><td>

After:

![image](https://github.com/user-attachments/assets/e8986f5c-6fd6-47d0-a839-1e28f05df718)

</td></tr>

</table>



How to reproduce:
Send a single mutation indicating that the connections RTT is bad:

<table><tr><td>

![image](https://github.com/user-attachments/assets/8aeeaf1d-6f89-4528-8702-1ff2da06e79e)

</td></tr></table>


It helps to fix #21406, but the problem when client is not responding still happens.