### PR TITLE
feat(record-and-playback): Added chat features to recordings

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/PublicChatRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/PublicChatRecordEvent.scala
@@ -28,6 +28,10 @@ class PublicChatRecordEvent extends AbstractChatRecordEvent {
     eventMap.put(SENDERID, senderId)
   }
 
+  final def setMessageId(messageId: String) {
+    eventMap.put(MESSAGE_ID, messageId)
+  }
+
   def setSenderRole(senderRole: String): Unit = {
     eventMap.put(SENDER_ROLE, senderRole)
   }
@@ -49,6 +53,7 @@ object PublicChatRecordEvent {
   private final val SENDERID = "senderId"
   private final val MESSAGE = "message"
   private final val SENDER_ROLE = "senderRole"
+  private final val MESSAGE_ID = "messageId"
   private final val CHAT_EMPHASIZED_TEXT = "chatEmphasizedText"
   private final val REPLY_TO_MESSAGEID = "replyToMessageId"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -155,6 +155,7 @@ class RedisRecorderActor(
     if (msg.body.chatId == GroupChatApp.MAIN_PUBLIC_CHAT) {
       val ev = new PublicChatRecordEvent()
       ev.setMeetingId(msg.header.meetingId)
+      ev.setMessageId(msg.body.msg.id)
       ev.setSenderId(msg.body.msg.sender.id)
       ev.setMessage(msg.body.msg.message)
       ev.setSenderRole(msg.body.msg.sender.role)

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -817,6 +817,7 @@ module BigBlueButton
           message_id = event.at_xpath('./messageId')&.content
 
           chats << {
+            id: message_id,
             in: timestamp - offset,
             out: nil,
             sender_id: sender_id,
@@ -834,6 +835,11 @@ module BigBlueButton
           chats.each do |chat|
             chat[:out] = clear_timestamp if chat[:out].nil?
           end
+        when %w[CHAT DeletePublicChatMessageRecordEvent]
+          next if timestamp < start_time
+          message_id = event.at_xpath('./messageId')&.content
+          index_to_be_deleted = chats.index { |message| message[:id] === message_id }
+          chats.delete_at(index_to_be_deleted)
         when %w[PARTICIPANT RecordStatusEvent]
           record = event.at_xpath('status').content == 'true'
           next if timestamp < start_time

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -842,14 +842,14 @@ module BigBlueButton
 
           # Properly delete this message
           index_to_be_deleted = chats.index { |message| message[:id] === message_id }
-          chats.delete_at(index_to_be_deleted)
+          chats.delete_at(index_to_be_deleted) unless index_to_be_deleted.nil?
         when %w[CHAT EditPublicChatMessageRecordEvent]
           next if timestamp < start_time
           message_id = event.at_xpath('./messageId')&.content
           new_message_content = event.at_xpath('./message')&.content
-          index_to_be_deleted = chats.index { |message| message[:id] === message_id }
-          chats[index_to_be_deleted][:message] = new_message_content
-          chats[index_to_be_deleted][:lastEditedTimestamp] = timestamp
+          index_to_be_edited = chats.index { |message| message[:id] === message_id }
+          chats[index_to_be_edited][:message] = new_message_content unless index_to_be_edited.nil?
+          chats[index_to_be_edited][:lastEditedTimestamp] = timestamp unless index_to_be_edited.nil?
         when %w[PARTICIPANT RecordStatusEvent]
           record = event.at_xpath('status').content == 'true'
           next if timestamp < start_time

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -840,6 +840,13 @@ module BigBlueButton
           message_id = event.at_xpath('./messageId')&.content
           index_to_be_deleted = chats.index { |message| message[:id] === message_id }
           chats.delete_at(index_to_be_deleted)
+        when %w[CHAT EditPublicChatMessageRecordEvent]
+          next if timestamp < start_time
+          message_id = event.at_xpath('./messageId')&.content
+          new_message_content = event.at_xpath('./message')&.content
+          index_to_be_deleted = chats.index { |message| message[:id] === message_id }
+          chats[index_to_be_deleted][:message] = new_message_content
+          chats[index_to_be_deleted][:lastEditedTimestamp] = timestamp
         when %w[PARTICIPANT RecordStatusEvent]
           record = event.at_xpath('status').content == 'true'
           next if timestamp < start_time

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1128,7 +1128,16 @@ def process_chat_messages(events, bbb_props)
         chattimeline[:out] = (chat[:out] / 1000.0).round(1)
       end
 
-      xml.chattimeline(**chattimeline)
+      xml.chattimeline(**chattimeline) do
+        # Add reactions only if present
+        if chat[:reactions]
+          xml.reactions do
+            chat[:reactions].each do |emoji, count|
+              xml.reaction(emoji: emoji, count: count)
+            end
+          end
+        end
+      end
     end
   end
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1122,6 +1122,7 @@ def process_chat_messages(events, bbb_props)
         chatEmphasizedText: chat[:chatEmphasizedText],
         senderRole: chat[:senderRole],
         message: chat[:message],
+        lastEditedTimestamp: chat[:lastEditedTimestamp],
         target: 'chat',
       }
       if (chat[:out])

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1117,11 +1117,13 @@ def process_chat_messages(events, bbb_props)
     BigBlueButton::Events.get_chat_events(events, @meeting_start.to_i, @meeting_end.to_i, bbb_props).each do |chat|
       chattimeline = {
         in: (chat[:in] / 1000.0).round(1),
+        id: chat[:id],
         direction: 'down',
         name: chat[:sender],
         chatEmphasizedText: chat[:chatEmphasizedText],
         senderRole: chat[:senderRole],
         message: chat[:message],
+        replyToMessageId: chat[:replyToMessageId],
         lastEditedTimestamp: chat[:lastEditedTimestamp],
         target: 'chat',
       }


### PR DESCRIPTION
### What does this PR do?

It adds chat features to the recordings, that being:
- Reply;
- Reaction;
- Edition;
- Deletion;

All those new chat features are supported now for the record-and-playback as described in #21645 

### Closes Issue(s)

Closes #21645 

### How to test

- Checkout to this PR;
- Into the development environment (BBB server or container): go to the record-and-playback directory and run `./deploy; sudo systemctl restart bbb-rap-starter; sudo systemctl restart bbb-rap-resque-worker.service`
- Then clone https://github.com/bigbluebutton/bbb-playback and checkout to my PR there;
- Run `./deploy` of the playback;
- Record a session and wait until the recording is generated (this may take a while);
- See results.


### More

Closely related to https://github.com/bigbluebutton/bbb-playback/pull/286

Demo:

https://github.com/user-attachments/assets/1c060127-a874-4fa1-8785-c461338cecb6

**One comment:**

In the issue, it was required that:
> Chat reply
...
If replying to a chat message that was edited, ensure the original is being quoted.

But this goes against one of the premises of the requirements, which is:

> Display the final version of the chat message (unless it was deleted).

So to be coherent, I took the liberty to let the replied version of the message be always the last revision (if edited).

What I propose: In another PR, we should not display only the last revision for an edited message, we should go through every version as it changes for a specific message. This would open up the possibility to make the reply referring to the revision it had at the time the user sent the response, therefore eliminating this minor issue.

Let me know what you think, if agreed, I will open up an issue for that!