### PR TITLE
fix (gql-middleware): Wrong rate limit for mutations

### DIFF
--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -63,7 +63,7 @@ RangeLoop:
 
 					//Rate limiter from config max_connection_mutations_per_minute
 					ctxRateLimiter, _ := context.WithTimeout(browserConnection.Context, 30*time.Second)
-					if err := browserConnection.FromBrowserToHasuraRateLimiter.Wait(ctxRateLimiter); err != nil {
+					if err := browserConnection.FromBrowserToGqlActionsRateLimiter.Wait(ctxRateLimiter); err != nil {
 						sendErrorMessage(
 							browserConnection,
 							browserMessage.ID,


### PR DESCRIPTION
It was using the wrong rate limiter for mutations.

Which was causing problems for example: Not being able to jump slides after a bunch of actions.