### PR TITLE
feat(chat): Highlight user mentions

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -528,6 +528,7 @@ export interface Chat {
   disableEmojis: string[]
   allowedElements: string[]
   toolbar: string[]
+  mention: boolean
 }
 
 export interface SystemMessagesKeys {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/component.tsx
@@ -1,0 +1,106 @@
+import React, {
+  useCallback, useImperativeHandle, useMemo, useState,
+} from 'react';
+import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import { BASIC_USER_INFO, BasicUserInfoSubscriptionResponse } from '/imports/ui/components/chat/chat-graphql/chat-message-list/queries';
+import ChatMentionPickerItem from './item/component';
+import Styled from './styles';
+
+interface ChatMentionPickerProps {
+  input: string;
+  onSelect: (user: { userId: string; name: string }) => void;
+  onClose(): void;
+}
+
+export interface ChatMentionPickerRef {
+  dispatchInputKeyDownEvent(event: React.KeyboardEvent<HTMLTextAreaElement>): void;
+}
+
+const PAGE_SIZE = 5;
+const KEYS = {
+  ARROW_DOWN: 'ArrowDown',
+  ARROW_UP: 'ArrowUp',
+  ENTER: 'Enter',
+  ESC: 'Escape',
+};
+
+const ChatMentionPicker = React.forwardRef<ChatMentionPickerRef, ChatMentionPickerProps>((props, ref) => {
+  const { input, onSelect, onClose } = props;
+  const [numberOfItems, setNumberOfItems] = useState(PAGE_SIZE);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  const { data: userInfoData } = useDeduplicatedSubscription<BasicUserInfoSubscriptionResponse>(BASIC_USER_INFO);
+  const filteredUsers = useMemo(() => {
+    return userInfoData?.user.filter((user) => user.name.includes(input)) ?? [];
+  }, [input, userInfoData]);
+  const count = filteredUsers.length;
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement, UIEvent>) => {
+    if (e.target instanceof HTMLDivElement) {
+      const { scrollTop, scrollHeight, clientHeight } = e.target;
+      if (Math.ceil(scrollTop) >= scrollHeight - clientHeight) {
+        setNumberOfItems((prev) => Math.min(prev + PAGE_SIZE, count));
+      }
+    }
+  }, [count]);
+
+  useImperativeHandle(ref, () => ({
+    dispatchInputKeyDownEvent(event) {
+      switch (event.key) {
+        case KEYS.ARROW_DOWN: {
+          event.preventDefault();
+          setFocusedIndex((prev) => {
+            const next = prev + 1;
+            if (next > count - 1) {
+              return 0;
+            }
+            return next;
+          });
+          break;
+        }
+        case KEYS.ARROW_UP: {
+          event.preventDefault();
+          setFocusedIndex((prev) => {
+            const next = prev - 1;
+            if (next < 0) {
+              setNumberOfItems(count);
+              return count - 1;
+            }
+            return next;
+          });
+          break;
+        }
+        case KEYS.ENTER: {
+          event.preventDefault();
+          onSelect(filteredUsers[focusedIndex]);
+          break;
+        }
+        case KEYS.ESC: {
+          event.preventDefault();
+          onClose();
+          break;
+        }
+        default:
+      }
+    },
+  }), [count, filteredUsers, focusedIndex]);
+
+  return (
+    <Styled.Root>
+      <Styled.Container onScroll={handleScroll}>
+        <Styled.List>
+          {filteredUsers.slice(0, numberOfItems).map((user, index) => (
+            <ChatMentionPickerItem
+              key={`page-${index + 1}`}
+              onSelect={onSelect}
+              user={user}
+              focused={index === focusedIndex}
+            />
+          ))}
+        </Styled.List>
+      </Styled.Container>
+    </Styled.Root>
+  );
+});
+
+export default ChatMentionPicker;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/item/component.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef } from 'react';
+import browserInfo from '/imports/utils/browserInfo';
+import Styled from './styles';
+
+interface ChatMentionPickerItemProps {
+  focused: boolean;
+  onSelect: (user: { userId: string; name: string }) => void;
+  user: {
+    userId: string;
+    name: string;
+    color: string;
+    avatar: string;
+    isModerator: boolean;
+    presenter: boolean;
+  };
+}
+
+const { isChrome, isFirefox, isEdge } = browserInfo;
+
+const ChatMentionPickerItem: React.FC<ChatMentionPickerItemProps> = (props) => {
+  const {
+    onSelect, user, focused,
+  } = props;
+
+  const itemRef = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    if (focused) {
+      itemRef.current?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [focused]);
+
+  return (
+    <Styled.ListItem
+      key={user.userId}
+      ref={itemRef}
+    >
+      <Styled.Button
+        $focused={focused}
+        type="button"
+        onClick={() => {
+          onSelect(user);
+        }}
+      >
+        <Styled.Avatar
+          moderator={user.isModerator}
+          presenter={user.presenter}
+          color={user.color}
+          avatar={user.avatar}
+          isChrome={isChrome}
+          isFirefox={isFirefox}
+          isEdge={isEdge}
+        >
+          {user.avatar.length === 0 ? user.name.toLowerCase().slice(0, 2) : null}
+        </Styled.Avatar>
+        <Styled.Username>
+          {user.name}
+        </Styled.Username>
+      </Styled.Button>
+    </Styled.ListItem>
+  );
+};
+
+export default ChatMentionPickerItem;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/item/styles.ts
@@ -1,0 +1,156 @@
+import styled, { css } from 'styled-components';
+import {
+  userIndicatorsOffset, mdPaddingY, indicatorPadding, smPaddingX,
+} from '/imports/ui/stylesheets/styled-components/general';
+import {
+  userListBg, colorSuccess, colorWhite, colorPrimary,
+  colorBlueLightest,
+  colorGrayDark,
+} from '/imports/ui/stylesheets/styled-components/palette';
+
+const ListItem = styled.li`
+  height: 50px;
+`;
+
+const Button = styled.button<{ $focused: boolean }>`
+  height: 100%;
+  width: 100%;
+  background: none;
+  border: none;
+  outline: none;
+  padding: ${smPaddingX};
+  display: flex;
+  align-items: center;
+
+  &:hover, &:focus {
+    background-color: ${colorBlueLightest};
+  }
+
+  ${({ $focused }) => $focused && css`
+    background-color: ${colorBlueLightest};
+  `}
+`;
+
+const Username = styled.span`
+  font-size: 90%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 400;
+  color: ${colorGrayDark};
+  margin: 0 0 0 ${smPaddingX};
+`;
+
+interface AvatarProps {
+  moderator?: boolean;
+  presenter?: boolean;
+  color?: string;
+  avatar?: string;
+  isChrome?: boolean;
+  isFirefox?: boolean;
+  isEdge?: boolean;
+}
+
+const Avatar = styled.div<AvatarProps>`
+  position: relative;
+  height: 2.25rem;
+  width: 2.25rem;
+  min-width: 2.25rem;
+  border-radius: 50%;
+  text-align: center;
+  border: 2px solid transparent;
+  user-select: none;
+  color: ${colorWhite} !important;
+  font-size: 110%;
+  text-transform: capitalize;
+  display: flex;
+  justify-content: center;
+  align-items:center;
+
+  ${({ color }) => css`
+    background-color: ${color};
+  `}
+
+  &:after,
+  &:before {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    padding-top: .5rem;
+    padding-right: 0;
+    padding-left: 0;
+    padding-bottom: 0;
+    color: inherit;
+    top: auto;
+    left: auto;
+    bottom: ${userIndicatorsOffset};
+    right: ${userIndicatorsOffset};
+    border: 1.5px solid ${userListBg};
+    border-radius: 50%;
+    background-color: ${colorSuccess};
+    color: ${colorWhite};
+    opacity: 0;
+    font-family: 'bbb-icons';
+    font-size: .65rem;
+    line-height: 0;
+    text-align: center;
+    vertical-align: middle;
+    letter-spacing: -.65rem;
+    z-index: 1;
+
+    [dir="rtl"] & {
+      left: ${userIndicatorsOffset};
+      right: auto;
+      padding-right: .65rem;
+      padding-left: 0;
+    }
+  }
+
+  ${({ moderator }) => moderator && css`
+    border-radius: 5px;
+    color: ${colorWhite} !important;
+  `}
+
+  ${({ presenter }) => presenter && css`
+    &:before {
+      content: "\\00a0\\e90b\\00a0";
+      padding: ${mdPaddingY} !important;
+      opacity: 1;
+      top: ${userIndicatorsOffset};
+      left: ${userIndicatorsOffset};
+      bottom: auto;
+      right: auto;
+      border-radius: 5px;
+      background-color: ${colorPrimary};
+
+      [dir="rtl"] & {
+        left: auto;
+        right: ${userIndicatorsOffset};
+        letter-spacing: -.33rem;
+      }
+    }
+  `}
+
+  ${({
+    presenter, isChrome, isFirefox, isEdge,
+  }) => presenter && (isChrome || isFirefox || isEdge) && css`
+    &:before {
+      padding: ${indicatorPadding} !important;
+    }
+  `}
+
+  ${({ avatar, color }) => avatar?.length !== 0 && css`
+    background-image: url(${avatar});
+    background-repeat: no-repeat;
+    background-size: contain;
+    border: 2px solid ${color};
+  `}
+`;
+
+export default {
+  ListItem,
+  Button,
+  Avatar,
+  Username,
+};

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-mention-picker/styles.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { colorGrayLightest, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { smPaddingX } from '/imports/ui/stylesheets/styled-components/general';
+import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
+
+const Root = styled.div`
+  height: 150px;
+  overflow: hidden;
+  border: 1px solid ${colorGrayLightest};
+  border-radius: 8px;
+  position: absolute;
+  bottom: 110%;
+  z-index: 100;
+  background-color: ${colorWhite};
+
+  [dir="ltr"] & {
+    left: 0;
+    right: ${smPaddingX};
+  }
+
+  [dir="rtl"] & {
+    left: ${smPaddingX};
+    right: 0;
+  }
+`;
+
+const Container = styled(ScrollboxVertical)`
+  height: 100%;
+  overflow: auto;
+`;
+
+const List = styled.ul`
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+`;
+
+export default {
+  Container,
+  List,
+  Root,
+};

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -17,7 +17,7 @@ import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import { Message } from '/imports/ui/Types/message';
 import ChatListPage from './page/component';
-import LAST_SEEN_MUTATION from './queries';
+import LAST_SEEN_MUTATION, { BASIC_USER_INFO, BasicUserInfoSubscriptionResponse } from './queries';
 import {
   MessageList,
   UnreadButton,
@@ -37,6 +37,7 @@ import {
 } from '/imports/ui/services/features';
 import { CHAT_DELETE_REACTION_MUTATION, CHAT_SEND_REACTION_MUTATION } from './page/chat-message/mutations';
 import logger from '/imports/startup/client/logger';
+import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 
 const PAGE_SIZE = 50;
 const CLEANUP_TIMEOUT = 3000;
@@ -217,6 +218,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     locked: c?.locked,
     userId: c?.userId,
   }));
+  const { data: userInfoData } = useDeduplicatedSubscription<BasicUserInfoSubscriptionResponse>(BASIC_USER_INFO);
   const CHAT_REPLY_ENABLED = useIsReplyChatMessageEnabled();
   const CHAT_REACTIONS_ENABLED = useIsChatMessageReactionsEnabled();
   const CHAT_EDIT_ENABLED = useIsEditChatMessageEnabled();
@@ -449,6 +451,10 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     endSentinelParentRefProxy.current = el;
   }, []);
 
+  const userNames = useMemo(() => {
+    return userInfoData?.user ? userInfoData.user.map((u) => u.name) : [];
+  }, [userInfoData]);
+
   return (
     <>
       {
@@ -523,6 +529,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
                     chatReplyEnabled={CHAT_REPLY_ENABLED}
                     deleteReaction={deleteReaction}
                     sendReaction={sendReaction}
+                    userNames={userNames}
                   />
                 );
               })}
@@ -538,7 +545,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
             />
           </MessageList>,
           renderUnreadNotification,
-          <ChatReplyIntention key="chatReplyIntention" />,
+          <ChatReplyIntention key="chatReplyIntention" userNames={userNames} />,
           <ChatEditingWarning key="chatEditingWarning" />,
         ]
       }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -60,6 +60,7 @@ interface ChatMessageProps {
   chatReactionsEnabled: boolean;
   sendReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
   deleteReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
+  userNames: string[];
 }
 
 export interface ChatMessageRef {
@@ -141,6 +142,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   chatReplyEnabled,
   deleteReaction,
   sendReaction,
+  userNames,
 }, ref) => {
   const intl = useIntl();
   const markMessageAsSeenOnScrollEnd = useCallback(() => {
@@ -340,6 +342,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             <ChatMessageTextContent
               emphasizedMessage
               text={message.message}
+              userNames={userNames}
             />
           ),
           showAvatar: true,
@@ -397,6 +400,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
               <ChatMessageTextContent
                 emphasizedMessage={message.chatEmphasizedText}
                 text={message.message}
+                userNames={userNames}
               />
             ),
         };
@@ -415,6 +419,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             <ChatMessageTextContent
               emphasizedMessage={message.chatEmphasizedText}
               text={message.message}
+              userNames={userNames}
             />
           ),
         };
@@ -530,6 +535,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             sequence={message.replyToMessage.messageSequence}
             emphasizedMessage={message.replyToMessage.chatEmphasizedText}
             deletedByUser={message.replyToMessage.deletedBy?.name ?? null}
+            userNames={userNames}
           />
           )}
           {!deleteTime && (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import Styled from './styles';
+import CustomMarkdownLink from '/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/component';
+import { findAndReplaceMentions } from '/imports/ui/components/chat/chat-graphql/utils';
 
 interface ChatMessageTextContentProps {
   text: string;
   emphasizedMessage: boolean;
   dataTest?: string | null;
+  userNames: string[];
 }
 const ChatMessageTextContent: React.FC<ChatMessageTextContentProps> = ({
   text,
   emphasizedMessage,
+  userNames,
   dataTest = 'messageContent',
 }) => {
-  const { allowedElements } = window.meetingClientSettings.public.chat;
+  const { allowedElements, mention: mentionEnabled } = window.meetingClientSettings.public.chat;
 
   return (
     <Styled.ChatMessage emphasizedMessage={emphasizedMessage} data-test={dataTest}>
@@ -20,10 +24,12 @@ const ChatMessageTextContent: React.FC<ChatMessageTextContentProps> = ({
         linkTarget="_blank"
         allowedElements={allowedElements}
         unwrapDisallowed
+        components={{ a: CustomMarkdownLink }}
       >
-        {text}
+        {mentionEnabled ? findAndReplaceMentions(text, userNames) : text}
       </ReactMarkdown>
     </Styled.ChatMessage>
   );
 };
+
 export default ChatMessageTextContent;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -3,6 +3,8 @@ import { defineMessages, useIntl } from 'react-intl';
 import Styled, { DeleteMessage } from './styles';
 import Storage from '/imports/ui/services/storage/in-memory';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
+import CustomMarkdownLink from '/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/component';
+import { findAndReplaceMentions } from '/imports/ui/components/chat/chat-graphql/utils';
 
 const intlMessages = defineMessages({
   deleteMessage: {
@@ -16,15 +18,18 @@ interface MessageRepliedProps {
   sequence: number;
   emphasizedMessage: boolean;
   deletedByUser: string | null;
+  userNames: string[];
 }
 
 const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
   const {
-    message, sequence, emphasizedMessage, deletedByUser,
+    message, sequence, emphasizedMessage, deletedByUser, userNames,
   } = props;
 
   const intl = useIntl();
   const messageChunks = message.split('\n');
+
+  const { mention: mentionEnabled } = window.meetingClientSettings.public.chat;
 
   return (
     <Styled.Container
@@ -49,9 +54,10 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
             $emphasizedMessage={emphasizedMessage}
             linkTarget="_blank"
             allowedElements={window.meetingClientSettings.public.chat.allowedElements}
+            components={{ a: CustomMarkdownLink }}
             unwrapDisallowed
           >
-            {messageChunks[0]}
+            {mentionEnabled ? findAndReplaceMentions(messageChunks[0], userNames) : messageChunks[0]}
           </Styled.Markdown>
         </Styled.Message>
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -52,6 +52,7 @@ interface ChatListPageCommonProps {
   chatReactionsEnabled: boolean;
   sendReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
   deleteReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
+  userNames: string[];
 }
 
 interface ChatListPageContainerProps extends ChatListPageCommonProps {
@@ -130,6 +131,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   chatReplyEnabled,
   deleteReaction,
   sendReaction,
+  userNames,
 }) => {
   const { domElementManipulationIdentifiers } = useContext(PluginsContext);
   const messageRefs = useRef<Record<number, ChatMessageRef | null>>({});
@@ -275,6 +277,7 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             chatReplyEnabled={chatReplyEnabled}
             deleteReaction={deleteReaction}
             sendReaction={sendReaction}
+            userNames={userNames}
           />
         );
       })}
@@ -308,6 +311,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   chatReplyEnabled,
   deleteReaction,
   sendReaction,
+  userNames,
 }) => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_KEY = CHAT_CONFIG.public_group_id;
@@ -373,6 +377,7 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       chatReplyEnabled={chatReplyEnabled}
       deleteReaction={deleteReaction}
       sendReaction={sendReaction}
+      userNames={userNames}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/queries.ts
@@ -9,4 +9,34 @@ const LAST_SEEN_MUTATION = gql`
   }
 `;
 
+export interface BasicUserInfoSubscriptionResponse {
+  user: {
+    userId: string;
+    name: string;
+    isModerator: boolean;
+    color: string;
+    avatar: string;
+    presenter: boolean;
+  }[];
+}
+
+export const BASIC_USER_INFO = gql`
+  subscription UserNames {
+    user(
+      order_by: [
+        { presenter: desc },
+        { role: asc },
+        { nameSortable: asc },
+      ],
+    ) {
+      userId
+      name
+      isModerator
+      color
+      avatar
+      presenter
+    }
+  }
+`;
+
 export default LAST_SEEN_MUTATION;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -4,8 +4,15 @@ import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import Storage from '/imports/ui/services/storage/in-memory';
+import { findAndReplaceMentions } from '/imports/ui/components/chat/chat-graphql/utils';
+import CustomMarkdownLink from '/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/component';
 
-const ChatReplyIntention = () => {
+interface ChatReplyIntentionProps {
+  userNames: string[];
+}
+
+const ChatReplyIntention: React.FC<ChatReplyIntentionProps> = (props) => {
+  const { userNames } = props;
   const [username, setUsername] = useState<string>();
   const [message, setMessage] = useState<string>();
   const [emphasizedMessage, setEmphasizedMessage] = useState<boolean>();
@@ -46,6 +53,12 @@ const ChatReplyIntention = () => {
   const hidden = !username || !message;
   const messageChunks = message ? message.split('\n') : null;
 
+  const { mention: mentionEnabled } = window.meetingClientSettings.public.chat;
+
+  const replaceMentions = (msg: string) => {
+    return mentionEnabled ? findAndReplaceMentions(msg, userNames) : msg;
+  };
+
   return (
     <Styled.Container
       $hidden={hidden}
@@ -65,8 +78,9 @@ const ChatReplyIntention = () => {
       <Styled.Message>
         <Styled.Markdown
           $emphasizedMessage={!!emphasizedMessage}
+          components={{ a: CustomMarkdownLink }}
         >
-          {messageChunks ? messageChunks[0] : ''}
+          {messageChunks ? replaceMentions(messageChunks[0]) : ''}
         </Styled.Markdown>
       </Styled.Message>
       <Styled.CloseBtn

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/component.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { ReactMarkdownProps } from 'react-markdown/lib/complex-types';
+import Styled from './styles';
+
+type Props = Omit<React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>, 'ref'> & ReactMarkdownProps;
+
+const CustomMarkdownLink: React.FC<Props> = (props) => {
+  const { children, node, ...rest } = props;
+  if (typeof node.properties?.href === 'string' && node.properties.href.includes('mention://')) {
+    return <Styled.Mention>{children}</Styled.Mention>;
+  }
+  return <a {...rest}>{children}</a>;
+};
+
+export default CustomMarkdownLink;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/custom-markdown-components/link/styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+import { colorPrimary, colorBlueLighterChannel } from '/imports/ui/stylesheets/styled-components/palette';
+
+const Mention = styled.strong`
+  color: ${colorPrimary};
+  background-color: rgb(${colorBlueLighterChannel} / 0.5);
+  display: inline-block;
+  padding: 4px;
+  border-radius: 8px;
+  line-height: 1;
+
+  &:hover {
+    background-color: rgb(${colorBlueLighterChannel} / 0.75);
+  }
+`;
+
+export default {
+  Mention,
+};

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/utils.ts
@@ -1,0 +1,21 @@
+const mentionRegex = /@[^@]+/;
+
+function findAndReplaceMentions(msg: string, userNames: string[]) {
+  // Check if there are any possible mentions.
+  // That way, we avoid iterating over all users unnecessarily.
+  if (mentionRegex.test(msg)) {
+    return userNames.reduce((acc, username) => {
+      const userNameRegex = new RegExp(`@${username}`, 'gi');
+      return acc.replaceAll(userNameRegex, `[@${username}](mention://placeholder)`);
+    }, msg);
+  }
+  return msg;
+}
+
+export {
+  findAndReplaceMentions,
+};
+
+export default {
+  findAndReplaceMentions,
+};

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -571,6 +571,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         'strong',
       ],
       toolbar: [],
+      mention: false,
     },
     userReaction: {
       enabled: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -773,7 +773,9 @@ public:
     allowedElements: ['a', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ol', 'ul', 'p', 'strong']
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
-    toolbar: []
+    toolbar: ['reply', 'edit', 'delete', 'reactions']
+    # When enabled, user mentions in the format of '@<username>' will be highlighted.
+    mention: false
   userReaction:
     enabled: true
     expire: 30


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR implements chat mentions. Message substrings in the format of `@<username>` will be highlighted. When typing `@<any-text>`, a mention picker will show up giving the user a chance to choose which user to mention. The user can then use the mouse or keyboard navigation to choose a mention.

![Screenshot from 2024-11-20 17-34-30](https://github.com/user-attachments/assets/400af427-5a7e-475f-82aa-54ce2e03d9a1)

![Screenshot from 2024-11-20 17-35-07](https://github.com/user-attachments/assets/038207e8-90c7-4a7d-92f1-47214c1a2611)

![Screenshot from 2024-11-20 17-35-18](https://github.com/user-attachments/assets/76724d89-9a6d-4416-b860-55b5bc065bf4)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
n/a