### PR TITLE
fix(whiteboard): Improve tldraw camera and zoom stability

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -171,8 +171,8 @@ const Whiteboard = React.memo((props) => {
   const lastVisibilityStateRef = React.useRef('');
   const mountedTimeoutIdRef = useRef(null);
 
-  const CAMERA_UPDATE_DELAY = 850;
-  const MOUNTED_CAMERA_DELAY = 1300;
+  const CAMERA_UPDATE_DELAY = 650;
+  const MOUNTED_CAMERA_DELAY = 500;
 
   const customTools = [NoopTool];
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -154,12 +154,10 @@ const Whiteboard = React.memo((props) => {
   const previousTool = React.useRef(null);
   const bgSelectedRef = React.useRef(false);
   const lastVisibilityStateRef = React.useRef('');
+  const mountedTimeoutIdRef = useRef(null);
 
-  const THRESHOLD = 0.1;
-  const CAMERA_UPDATE_DELAY = 1300;
-  const MOUNTED_CAMERA_DELAY = 2000;
-  const lastKnownHeight = React.useRef(presentationAreaHeight);
-  const lastKnownWidth = React.useRef(presentationAreaWidth);
+  const CAMERA_UPDATE_DELAY = 850;
+  const MOUNTED_CAMERA_DELAY = 1300;
 
   const customTools = [NoopTool];
 
@@ -568,6 +566,9 @@ const Whiteboard = React.memo((props) => {
 
           setCamera(baseZoom, adjustedXPos, adjustedYPos);
         }
+
+        isMountedRef.current = true;
+
       }
     }, MOUNTED_CAMERA_DELAY);
   };
@@ -723,10 +724,12 @@ const Whiteboard = React.memo((props) => {
               currentPresentationPageRef.current?.scaledHeight,
             );
 
-            zoomSlide(
-              viewedRegionW, viewedRegionH, nextCam.x, nextCam.y,
-              currentPresentationPageRef.current,
-            );
+            if (isMountedRef.current) {
+              zoomSlide(
+                viewedRegionW, viewedRegionH, nextCam.x, nextCam.y,
+                currentPresentationPageRef.current,
+              );
+            }
           }
         }
 
@@ -866,8 +869,8 @@ const Whiteboard = React.memo((props) => {
           viewportHeight = currentPresentationPageRef.current?.scaledViewBoxHeight;
         }
 
-        const presentationWidthLocal = currentPresentationPage?.scaledWidth || 0;
-        const presentationHeightLocal = currentPresentationPage?.scaledHeight || 0;
+        const presentationWidthLocal = currentPresentationPageRef.current?.scaledWidth || 0;
+        const presentationHeightLocal = currentPresentationPageRef.current?.scaledHeight || 0;
 
         // Adjust camera position to ensure it stays within bounds
         const panned = next?.id?.includes('camera') && (prev.x !== next.x || prev.y !== next.y);
@@ -904,8 +907,9 @@ const Whiteboard = React.memo((props) => {
       }
     }
 
-    adjustCameraOnMount(true);
-    isMountedRef.current = true;
+    mountedTimeoutIdRef.current = setTimeout(() => {
+      adjustCameraOnMount(!isPresenterRef.current);
+    }, MOUNTED_CAMERA_DELAY);
   };
 
   const calculateZoomWithGapValue = (
@@ -1195,100 +1199,80 @@ const Whiteboard = React.memo((props) => {
       if (!initialViewBoxHeightRef.current) {
         initialViewBoxHeightRef.current = currentPresentationPageRef.current?.scaledViewBoxHeight;
       }
-      // Calculate the absolute difference
-      const heightDifference = Math.abs(
-        presentationAreaHeight - lastKnownHeight.current,
-      );
-      const widthDifference = Math.abs(
-        presentationAreaWidth - lastKnownWidth.current,
-      );
 
-      // Check if the difference is greater than the threshold
-      if (heightDifference > THRESHOLD || widthDifference > THRESHOLD) {
-        // Update the last known dimensions
-        lastKnownHeight.current = presentationAreaHeight;
-        lastKnownWidth.current = presentationAreaWidth;
+      if (
+        presentationAreaHeight > 0 &&
+        presentationAreaWidth > 0 &&
+        tlEditor &&
+        currentPresentationPage &&
+        currentPresentationPage.scaledWidth > 0 &&
+        currentPresentationPage.scaledHeight > 0
+      ) {
+        const currentZoom = zoomValueRef.current || HUNDRED_PERCENT;
+        const baseZoom = calculateZoomValue(
+          currentPresentationPageRef.current.scaledWidth,
+          currentPresentationPageRef.current.scaledHeight
+        );
+        let adjustedZoom = (baseZoom * currentZoom) / HUNDRED_PERCENT;
 
-        if (
-          presentationAreaHeight > 0
-          && presentationAreaWidth > 0
-          && tlEditor
-          && currentPresentationPage
-          && currentPresentationPage.scaledWidth > 0
-          && currentPresentationPage.scaledHeight > 0
-        ) {
-          const currentZoom = zoomValueRef.current || HUNDRED_PERCENT;
-          const baseZoom = calculateZoomValue(
-            currentPresentationPageRef.current.scaledWidth,
-            currentPresentationPageRef.current.scaledHeight,
-          );
-          let adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
-          if (isPresenter) {
-            const container = document.querySelector(
-              '[data-test="presentationContainer"]',
+        if (isPresenter) {
+          const container = document.querySelector('[data-test="presentationContainer"]');
+          const innerWrapper = document.getElementById('presentationInnerWrapper');
+          const containerWidth = container ? container.offsetWidth : 0;
+          const innerWrapperWidth = innerWrapper ? innerWrapper.offsetWidth : 0;
+          const widthGap = Math.max(containerWidth - innerWrapperWidth, 0);
+          const camera = tlEditorRef.current.getCamera();
+
+          if (widthGap > 0) {
+            adjustedZoom = calculateZoomWithGapValue(
+              currentPresentationPageRef.current.scaledWidth,
+              currentPresentationPageRef.current.scaledHeight,
+              widthGap
             );
-            const innerWrapper = document.getElementById(
-              'presentationInnerWrapper',
-            );
-            const containerWidth = container ? container.offsetWidth : 0;
-            const innerWrapperWidth = innerWrapper
-              ? innerWrapper.offsetWidth
-              : 0;
-            const widthGap = Math.max(containerWidth - innerWrapperWidth, 0);
-            const camera = tlEditorRef.current.getCamera();
 
-            if (widthGap > 0) {
-              adjustedZoom = calculateZoomWithGapValue(
-                currentPresentationPageRef.current.scaledWidth,
-                currentPresentationPageRef.current.scaledHeight,
-                widthGap,
-              );
-
-              adjustedZoom *= currentZoom / HUNDRED_PERCENT;
-            } else {
-              adjustedZoom = baseZoom * (currentZoom / HUNDRED_PERCENT);
-            }
-
-            const zoomToApply = widthGap > 0
-              ? adjustedZoom
-              : baseZoom * (currentZoom / HUNDRED_PERCENT);
-
-            const formattedPageId = Number(curPageIdRef?.current);
-
-            const updatedCurrentCam = {
-              ...camera,
-              z: adjustedZoom,
-            };
-
-            let cameras = [
-              createCamera(formattedPageId - 1, zoomToApply),
-              updatedCurrentCam,
-              createCamera(formattedPageId + 1, zoomToApply),
-            ];
-            cameras = cameras.filter((cam) => cam.id !== 'camera:page:0');
-            tlEditorRef.current.store.put(cameras);
+            adjustedZoom *= currentZoom / HUNDRED_PERCENT;
           } else {
-            // Viewer logic
-            const newZoom = calculateZoomValue(
-              currentPresentationPage.scaledViewBoxWidth,
-              currentPresentationPage.scaledViewBoxHeight,
-            );
-
-            const camera = tlEditorRef.current.getCamera();
-            const formattedPageId = Number(curPageIdRef?.current);
-            const updatedCurrentCam = {
-              ...camera,
-              z: newZoom,
-            };
-
-            let cameras = [
-              createCamera(formattedPageId - 1, newZoom),
-              updatedCurrentCam,
-              createCamera(formattedPageId + 1, newZoom),
-            ];
-            cameras = cameras.filter((cam) => cam.id !== 'camera:page:0');
-            tlEditorRef.current.store.put(cameras);
+            adjustedZoom = (baseZoom * currentZoom) / HUNDRED_PERCENT;
           }
+
+          const zoomToApply =
+            widthGap > 0 ? adjustedZoom : (baseZoom * currentZoom) / HUNDRED_PERCENT;
+
+          const formattedPageId = Number(curPageIdRef?.current);
+
+          const updatedCurrentCam = {
+            ...camera,
+            z: adjustedZoom,
+          };
+
+          let cameras = [
+            createCamera(formattedPageId - 1, zoomToApply),
+            updatedCurrentCam,
+            createCamera(formattedPageId + 1, zoomToApply),
+          ];
+          cameras = cameras.filter((cam) => cam.id !== 'camera:page:0');
+          tlEditorRef.current.store.put(cameras);
+        } else {
+          // Viewer logic
+          const newZoom = calculateZoomValue(
+            currentPresentationPage.scaledViewBoxWidth,
+            currentPresentationPage.scaledViewBoxHeight
+          );
+
+          const camera = tlEditorRef.current.getCamera();
+          const formattedPageId = Number(curPageIdRef?.current);
+          const updatedCurrentCam = {
+            ...camera,
+            z: newZoom,
+          };
+
+          let cameras = [
+            createCamera(formattedPageId - 1, newZoom),
+            updatedCurrentCam,
+            createCamera(formattedPageId + 1, newZoom),
+          ];
+          cameras = cameras.filter((cam) => cam.id !== 'camera:page:0');
+          tlEditorRef.current.store.put(cameras);
         }
       }
     };
@@ -1492,28 +1476,14 @@ const Whiteboard = React.memo((props) => {
   }, [curPageId]);
 
   React.useEffect(() => {
-    if (isMountedRef.current) {
-      adjustCameraOnMount(false);
-    }
-  }, [
-    isMountedRef.current,
-    selectedLayout,
-    isInfiniteWhiteboard,
-    fitToWidthRef.current,
-    presentationWidth,
-    curPageId,
-    isPresenter,
-    animations,
-    locale,
-    darkTheme,
-  ]);
-
-  React.useEffect(() => {
     setTldrawIsMounting(true);
     return () => {
       isMountedRef.current = false;
       localStorage.removeItem('initialViewBoxWidth');
       localStorage.removeItem('initialViewBoxHeight');
+      if (mountedTimeoutIdRef.current) {
+        clearTimeout(mountedTimeoutIdRef.current);
+      }
     };
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -124,6 +124,21 @@ const Whiteboard = React.memo((props) => {
 
   const [tlEditor, setTlEditor] = React.useState(null);
   const [isMounting, setIsMounting] = React.useState(true);
+  const [isTabVisible, setIsTabVisible] = React.useState(document.visibilityState === 'visible');
+
+  React.useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        setIsTabVisible(true);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
 
   if (isMounting) {
     setDefaultEditorAssetUrls(getCustomEditorAssetUrls());
@@ -1561,6 +1576,10 @@ const Whiteboard = React.memo((props) => {
   // TODO: we should add the dependency  list in [] parameter here
   // so this is not run on every render
   });
+
+  if (!isTabVisible) {
+    return null;
+  }
 
   return (
     <div

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -50,6 +50,7 @@ import MediaService from '/imports/ui/components/media/service';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import { debounce } from '/imports/utils/debounce';
 import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockContext';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
 
 const FORCE_RESTORE_PRESENTATION_ON_NEW_EVENTS = 'bbb_force_restore_presentation_on_new_events';
 
@@ -198,53 +199,11 @@ const WhiteboardContainer = (props) => {
 
   const cursorArray = useMergedCursorData();
 
-  const { data: annotationStreamData } = useSubscription(ANNOTATION_HISTORY_STREAM, {
-    variables: { updatedAt: new Date(0).toISOString() },
-    skip: !curPageId,
-    onSubscriptionData: ({ subscriptionData }) => {
-      const annotationStream = subscriptionData.data?.pres_annotation_history_curr_stream || [];
-
-      const shapeMap = new Map();
-
-      annotationStream.forEach((annotation) => {
-        const { annotationId, annotationInfo } = annotation;
-        shapeMap.set(annotationId, annotation);
-      });
-
-      const validShapes = [];
-      const annotationsToBeRemoved = new Set();
-
-      //Process only the latest occurrence of each shape
-      shapeMap.forEach(({ annotationId, annotationInfo }) => {
-        if (!annotationInfo) {
-          annotationsToBeRemoved.add(annotationId);
-        } else {
-          validShapes.push({ ...annotationInfo, id: annotationId });
-        }
-      });
-
-      setShapes(() => {
-        const finalShapes = validShapes.filter(
-          (shape) => !annotationsToBeRemoved.has(shape.id)
-        );
-
-        if (finalShapes.length > 0) {
-          const restoreOnUpdate = getFromUserSettings(
-            FORCE_RESTORE_PRESENTATION_ON_NEW_EVENTS,
-            window.meetingClientSettings.public.presentation.restoreOnUpdate,
-          );
-
-          if (restoreOnUpdate) {
-            MediaService.setPresentationIsOpen(layoutContextDispatch, true);
-          }
-        }
-
-        return finalShapes;
-      });
-
-      setRemovedShapes(Array.from(annotationsToBeRemoved));
-    },
-  });
+  const {
+    data: currentMeeting,
+  } = useMeeting((m) => ({
+    createdTime: m.createdTime,
+  }));
 
   const { data: initialPageAnnotations, refetch: refetchInitialPageAnnotations } = useQuery(
     CURRENT_PAGE_ANNOTATIONS_QUERY,
@@ -252,6 +211,65 @@ const WhiteboardContainer = (props) => {
       skip: !curPageId,
     },
   );
+
+  const lastUpdatedAt = useMemo(() => {
+    if (!initialPageAnnotations?.pres_annotation_curr?.length) {
+      return currentMeeting?.createdTime
+        ? new Date(currentMeeting.createdTime).toISOString()
+        : null;
+    }
+    return initialPageAnnotations.pres_annotation_curr.reduce((latest, annotation) => {
+      const updatedAt = new Date(annotation.lastUpdatedAt);
+      return updatedAt > latest ? updatedAt : latest;
+    }, new Date(0)).toISOString();
+  }, [initialPageAnnotations]);
+
+  const { data: annotationStreamData } = useSubscription(ANNOTATION_HISTORY_STREAM, {
+    variables: { updatedAt: lastUpdatedAt },
+    skip: !curPageId || !lastUpdatedAt,
+    onSubscriptionData: ({ subscriptionData }) => {
+      const annotationStream =
+        subscriptionData.data?.pres_annotation_history_curr_stream || [];
+
+      const processedAnnotationIds = new Set();
+      const validShapes = [];
+      const annotationsToBeRemoved = new Set();
+
+      for (let i = annotationStream.length - 1; i >= 0; i--) {
+        const annotation = annotationStream[i];
+        const { annotationId, annotationInfo } = annotation;
+
+        if (processedAnnotationIds.has(annotationId)) {
+          continue;
+        }
+
+        processedAnnotationIds.add(annotationId);
+
+        if (!annotationInfo) {
+          annotationsToBeRemoved.add(annotationId);
+        } else {
+          validShapes.push({ ...annotationInfo, id: annotationId });
+        }
+      }
+
+      setShapes(() => {
+        if (validShapes.length > 0) {
+          const restoreOnUpdate = getFromUserSettings(
+            FORCE_RESTORE_PRESENTATION_ON_NEW_EVENTS,
+            window.meetingClientSettings.public.presentation.restoreOnUpdate
+          );
+
+          if (restoreOnUpdate) {
+            MediaService.setPresentationIsOpen(layoutContextDispatch, true);
+          }
+        }
+
+        return validShapes.length > 0 ? validShapes : [];
+      });
+
+      setRemovedShapes(Array.from(annotationsToBeRemoved || []));
+    },
+  });
 
   React.useEffect(() => {
     if (curPageIdRef.current) {
@@ -288,18 +306,16 @@ const WhiteboardContainer = (props) => {
       }
     });
 
-    setShapes(() => {
-      return [
-        ...updatedAnnotations.map(({ annotationInfo, annotationId }) => ({
-          ...annotationInfo,
-          id: annotationId,
-        })),
-        ...newAnnotations.map(({ annotationInfo, annotationId }) => ({
-          ...annotationInfo,
-          id: annotationId,
-        })),
-      ];
-    });
+    setShapes(() => [
+      ...updatedAnnotations.map(({ annotationInfo, annotationId }) => ({
+        ...annotationInfo,
+        id: annotationId,
+      })),
+      ...newAnnotations.map(({ annotationInfo, annotationId }) => ({
+        ...annotationInfo,
+        id: annotationId,
+      })),
+    ]);
 
     if (updatedAnnotations.length > 0 || newAnnotations.length > 0) {
       const restoreOnUpdate = getFromUserSettings(
@@ -312,7 +328,7 @@ const WhiteboardContainer = (props) => {
       }
     }
 
-    setRemovedShapes(Array.from(annotationsToBeRemoved));
+    setRemovedShapes(annotationsToBeRemoved.length > 0 ? annotationsToBeRemoved : []);
   };
 
   useEffect(() => {
@@ -320,6 +336,14 @@ const WhiteboardContainer = (props) => {
       processAnnotations(initialPageAnnotations.pres_annotation_curr);
     }
   }, [initialPageAnnotations]);
+
+  useEffect(() => {
+    if (!curPageId || !lastUpdatedAt) {
+      setShapes([]);
+      setRemovedShapes([]);
+    }
+  }, [curPageId, lastUpdatedAt]);
+  
 
   const bgShape = [];
 


### PR DESCRIPTION
### What does this PR do?
This PR improves the stability of the camera position and zoom in the TLDraw. It also defers the loading of TLDraw until the browser tab comes into focus. This adjustment addresses an issue where the TLDraw API's `getViewportPageBounds` function would return incorrect default values if the library was loaded while the browser was not in focus.


### Motivation
The camera position and zoom could easily fall out of sync due to `getViewportPageBounds` returning incorrect default values when the tab is not in focus.