### PR TITLE
fix(chat): Slightly tweak message time label position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -8,7 +8,6 @@ import {
   $3xlPadding,
   xlPadding,
   mdPadding,
-  smPadding,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
   fontSizeBase,
@@ -112,19 +111,20 @@ export const ChatContent = styled.div<ChatContentProps>`
 export const ChatContentFooter = styled.div`
   justify-content: flex-end;
   gap: 0.25rem;
-  padding: ${smPadding} 0 0 ${smPadding};
   position: absolute;
-  bottom: calc(${lgPadding} + 2px);
+  bottom: 0.25rem;
+  line-height: 1;
+  font-size: 95%;
   display: none;
   background-color: inherit;
   border-radius: 0.5rem;
 
   [dir="rtl"] & {
-    left: ${$3xlPadding};
+    left: 0.25rem;
   }
 
   [dir="ltr"] & {
-    right: ${$3xlPadding};
+    right: 0.25rem;
   }
 
   .chat-message-wrapper-focused &,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Does a small change to the position of the message time label, preventing it from both overlapping the message text and being overlapped by the toolbar.

#### Before

![Screenshot from 2024-11-21 11-01-47](https://github.com/user-attachments/assets/b6d86a62-86e2-49cd-911f-3821b69e1070)

#### Now

![Screenshot from 2024-11-21 10-51-01](https://github.com/user-attachments/assets/d2b3b240-411d-4926-87c7-3c6b67e28665)

![Screenshot from 2024-11-21 10-50-48](https://github.com/user-attachments/assets/74a3ad87-f960-4464-b9cf-1ba0b55d1444)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
n/a