### PR TITLE
fix(whiteboard): Use complete api call to end shape editing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -70,7 +70,7 @@ const useMouseEvents = ({
     if (!(presentationInnerWrapper && presentationInnerWrapper.contains(event.target))) {
       const editingShape = tlEditorRef.current?.getEditingShape();
       if (editingShape) {
-        return tlEditorRef.current?.setEditingShape(null);
+        return tlEditorRef.current?.complete();
       }
     }
     return undefined;


### PR DESCRIPTION
### What does this PR do?
This PR improves the handling of ongoing shape editing. It replaces the manual approach of setting `editingShape` to null with the `complete()` method from the tldraw API. This ensures that all in-progress interactions, such as shape editing, are properly finalized and ended.

### Motivation
The previous method of manually setting `editingShape` to null was insufficient and could result in the error: "Uncaught Error: Expected an editing shape!"

before:
![shape-edit-error](https://github.com/user-attachments/assets/82d8fab9-2a78-4302-b13a-cc2edbd55daa)

after:
![shape-edit-error-fix](https://github.com/user-attachments/assets/986fb15d-6563-454f-bf5c-a07f044b359d)
