### PR TITLE
Greceful resources haproxy cleanup during the daily cron job

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -134,3 +134,8 @@ docker image prune -f
 #
 find /tmp -name "*.afm" -mtime +$history -delete
 find /tmp -name "*.pfb" -mtime +$history -delete
+
+#
+# Reload HAproxy to cleanup unused FD and drop time in queue to the minimum
+#
+sudo systemctl reload haproxy


### PR DESCRIPTION
### What does this PR do?
This pull request aims to trigger a HAProxy reload to release unused file descriptors, optimising resource utilization, and gracefully transition to a clean in-memory configuration. By closing unused FDs and applying configuration changes smoothly, we ensure efficient resource management and uninterrupted service availability.

### Closes Issue(s)
N/A

### Motivation
Monitoring reports that servers heavily relying on embedded coturn, have high Haproxy time in queue value for "backend coturn" proxy configuration. It can lead to audio quality drop and even audio disconnections.

The monitoring screenshot below show the effect of reloading HAproxy service.

![image](https://github.com/user-attachments/assets/7b365496-0724-45e2-b8d9-ce39bee70b4f)

### How to test
By simply running `sudo systemctl reload haproxy` and Zabbix 7.0 HAproxy monitoring enabled you should see the value of "Backend Turn: time" drop to 0 without affecting the running services.


### More
- Reference to the `reload` command that shows graceful resources cleanup https://github.com/haproxy/haproxy/blob/95d3edd68fb3681a5b1d48d023b4e55e3ac56390/src/mworker.c#L738
