### PR TITLE
feat: announce new presenter in chat, under config `announcePresenterChangeInChat`

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -1,13 +1,16 @@
 package org.bigbluebutton.core.apps.users
 
+import org.bigbluebutton.ClientSettings.{ getConfigPropertyValueByPathAsBooleanOrElse, getConfigPropertyValueByPathAsIntOrElse }
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.presentationpod.SetPresenterInPodActionHandler
 import org.bigbluebutton.core.apps.ExternalVideoModel
+import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.models.{ PresentationPod, RegisteredUsers, UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.requestBroadcastStop
+import org.bigbluebutton.core.db.ChatMessageDAO
 import org.bigbluebutton.core2.message.senders.Sender
 
 trait AssignPresenterReqMsgHdlr extends RightsManagementTrait {
@@ -102,6 +105,27 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
         } yield {
           Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, newPres.intId, u.sessionToken, "role_changed", outGW)
         }
+
+        //Chat message to announce new presenter
+        val announcePresenterChangeInChat = getConfigPropertyValueByPathAsBooleanOrElse(
+          liveMeeting.clientSettings,
+          "public.chat.announcePresenterChangeInChat",
+          alternativeValue = true
+        )
+
+        if (announcePresenterChangeInChat) {
+          val assignedByName = Users2x.findWithIntId(liveMeeting.users2x, assignedBy).get match {
+            case u: UserState => u.name
+            case _            => ""
+          }
+
+          //System message
+          val msgMeta = Map(
+            "assignedBy" -> assignedByName
+          )
+          ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.USER_IS_PRESENTER_MSG, msgMeta, newPres.name)
+        }
+
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -3,15 +3,17 @@ package org.bigbluebutton.core.apps.users
 import org.apache.pekko.actor.ActorContext
 import org.apache.pekko.event.Logging
 import org.bigbluebutton.Boot.eventBus
+import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPathAsBooleanOrElse
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.api.SetPresenterInDefaultPodInternalMsg
 import org.bigbluebutton.core.apps.ExternalVideoModel
+import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
 import org.bigbluebutton.core2.message.senders.{MsgBuilder, Sender}
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
-import org.bigbluebutton.core.db.UserStateDAO
+import org.bigbluebutton.core.db.{ChatMessageDAO, UserStateDAO}
 
 object UsersApp {
   def broadcastAddUserToPresenterGroup(meetingId: String, userId: String, requesterId: String,
@@ -78,6 +80,19 @@ object UsersApp {
       } yield {
         Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "role_changed", outGW)
       }
+
+      //Chat message to announce new presenter
+      val announcePresenterChangeInChat = getConfigPropertyValueByPathAsBooleanOrElse(
+        liveMeeting.clientSettings,
+        "public.chat.announcePresenterChangeInChat",
+        alternativeValue = true
+      )
+
+      if (announcePresenterChangeInChat) {
+        //System message
+        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", GroupChatMessageType.USER_IS_PRESENTER_MSG, Map(), newPresenter.name)
+      }
+
     }
   }
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -13,6 +13,7 @@ object GroupChatMessageType {
   val BREAKOUTROOM_MOD_MSG = "breakoutRoomModeratorMsg"
   val PUBLIC_CHAT_HIST_CLEARED = "publicChatHistoryCleared"
   val USER_AWAY_STATUS_MSG = "userAwayStatusMsg"
+  val USER_IS_PRESENTER_MSG = "userIsPresenterMsg"
   val PLUGIN = "plugin"
 }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -80,6 +80,14 @@ const intlMessages = defineMessages({
     id: 'app.chat.clearPublicChatMessage',
     description: 'message of when clear the public chat',
   },
+  userIsPresenter: {
+    id: 'app.chat.isPresenter',
+    description: 'message when user is set presenter',
+  },
+  userIsPresenterSetBy: {
+    id: 'app.chat.isPresenterSetBy',
+    description: 'message when user is set presenter by someone else',
+  },
   userAway: {
     id: 'app.chat.away',
     description: 'message when user is away',
@@ -375,6 +383,27 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             <ChatMessageNotificationContent
               iconName="time"
               text={awayMessage}
+            />
+          ),
+          showAvatar: false,
+          showHeading: false,
+          showToolbar: false,
+        };
+      }
+      case ChatMessageType.USER_IS_PRESENTER_MSG: {
+        const { assignedBy } = JSON.parse(message.messageMetadata);
+        const userIsPresenterMsg = (assignedBy)
+          ? `${intl.formatMessage(intlMessages.userIsPresenterSetBy, { 0: message.senderName, 1: assignedBy })}`
+          : `${intl.formatMessage(intlMessages.userIsPresenter, { 0: message.senderName })}`;
+        return {
+          name: message.senderName,
+          color: '#0F70D7',
+          isModerator: true,
+          isSystemSender: true,
+          component: (
+            <ChatMessageNotificationContent
+              iconName="presentation"
+              text={userIsPresenterMsg}
             />
           ),
           showAvatar: false,

--- a/bigbluebutton-html5/imports/ui/core/enums/chat.ts
+++ b/bigbluebutton-html5/imports/ui/core/enums/chat.ts
@@ -22,5 +22,6 @@ export const enum ChatMessageType {
   CHAT_CLEAR = 'publicChatHistoryCleared',
   BREAKOUT_ROOM = 'breakoutRoomModeratorMsg',
   USER_AWAY_STATUS_MSG = 'userAwayStatusMsg',
+  USER_IS_PRESENTER_MSG = 'userIsPresenterMsg',
   PLUGIN = 'plugin'
 }

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -774,6 +774,7 @@ public:
     # available options for toolbar: reply, edit, delete, reactions
     # example: ['reply', 'delete']
     toolbar: []
+    announcePresenterChangeInChat: true
   userReaction:
     enabled: true
     expire: 30

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -31,6 +31,8 @@
     "app.chat.emptyLogLabel": "Chat log empty",
     "app.chat.away": "is away",
     "app.chat.notAway": "is back online",
+    "app.chat.isPresenter": "{0} is now the presenter",
+    "app.chat.isPresenterSetBy": "{0} is now the presenter, set by {1}",
     "app.chat.clearPublicChatMessage": "The public chat history was cleared by a moderator",
     "app.chat.multi.typing": "Multiple users are typing",
     "app.chat.someone.typing": "Someone is typing",


### PR DESCRIPTION
Automatically send a chat message announcing when a new presenter is set.

It is enabled by default, but there is a config to disable at `settings.yml`, `public.chat.announcePresenterChangeInChat`.

![image](https://github.com/user-attachments/assets/f96a8790-6944-4b66-9644-db5902801ccf)

Closes: #21573