### PR TITLE
fix (gql-actions): Allow to send keycap emojis as reactions

### DIFF
--- a/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
@@ -1,7 +1,7 @@
 import { RedisMessage } from '../types';
 import {throwErrorIfInvalidInput} from "../imports/validation";
 import {ValidationError} from "../types/ValidationError";
-const emojiRegex = /^(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}\uFE0F|\p{Emoji_Modifier_Base}|\p{Regional_Indicator}{2})(\u200D(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}\uFE0F|\p{Emoji_Modifier_Base}|\p{Regional_Indicator}{2}))*$/u;
+import { EMOJI_REGEX } from '../imports/emojiValidation';
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfInvalidInput(input,
@@ -13,7 +13,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
       ]
   )
 
-  if(typeof input.reactionEmoji !== 'string' || !emojiRegex.test(input.reactionEmoji)) {
+  if(typeof input.reactionEmoji !== 'string' || !EMOJI_REGEX.test(input.reactionEmoji)) {
     throw new ValidationError(`Parameter 'reactionEmoji' contains an invalid Emoji`, 400);
   }
 

--- a/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
+++ b/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
@@ -1,7 +1,7 @@
 import { RedisMessage } from '../types';
 import {throwErrorIfInvalidInput} from "../imports/validation";
 import {ValidationError} from "../types/ValidationError";
-const emojiRegex = /^(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}\uFE0F|\p{Emoji_Modifier_Base}|\p{Regional_Indicator}{2})(\u200D(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}\uFE0F|\p{Emoji_Modifier_Base}|\p{Regional_Indicator}{2}))*$/u;
+import { EMOJI_REGEX } from '../imports/emojiValidation';
 
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfInvalidInput(input,
@@ -10,7 +10,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
       ]
   )
 
-  if(typeof input.reactionEmoji !== 'string' || !emojiRegex.test(input.reactionEmoji)) {
+  if(typeof input.reactionEmoji !== 'string' || !EMOJI_REGEX.test(input.reactionEmoji)) {
     throw new ValidationError(`Parameter 'reactionEmoji' contains an invalid Emoji`, 400);
   }
 

--- a/bbb-graphql-actions/src/imports/emojiValidation.ts
+++ b/bbb-graphql-actions/src/imports/emojiValidation.ts
@@ -1,0 +1,11 @@
+/**
+ * Regex pattern for validating emoji characters. Matches:
+ * - Emoji presentations
+ * - Extended pictographic with variation selectors
+ * - Emoji modifier bases (e.g., skin tones)
+ * - Regional indicators (flags)
+ * - Zero-width joiner sequences
+ *
+ * Note: Based on Unicode 15.1. May need updates for future Unicode versions.
+ */
+export const EMOJI_REGEX = /^(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}\uFE0F|\p{Emoji_Modifier_Base}|\p{Regional_Indicator}{2}|[0-9#*]\uFE0F?\u20E3)(\u200D(?:\p{Emoji_Presentation}|\p{Extended_Pictographic}\uFE0F|\p{Emoji_Modifier_Base}|\p{Regional_Indicator}{2}|[0-9#*]\uFE0F?\u20E3))*$/u;


### PR DESCRIPTION
Current validation doesn't accept emojis like 1️⃣.

![image](https://github.com/user-attachments/assets/1d57964d-dce8-4284-bb9a-3cc80316d913)


This small fix adds `[0-9#*]\uFE0F?\u20E3` to the regex.

---

- **`[0-9#*]`**: Matches any single digit from **0** to **9**, or the characters **#** or **\***.
- **`\uFE0F?`**: Matches the **Variation Selector-16** (VS16). VS16 indicates that the preceding character should be displayed as an emoji.
- **`\u20E3`**: Matches the **Combining Enclosing Keycap**, which combines with the preceding character to create the keycap emoji.