### PR TITLE
fix: `allowRequestsWithoutSession` not working for Graphql endpoints

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -353,6 +353,8 @@ useDefaultDarkLogo=false
 defaultLogoURL=${bigbluebutton.web.serverURL}/images/logo.png
 defaultDarkLogoURL=${bigbluebutton.web.serverURL}/images/darklogo.png
 
+# WARNING: Enabling `allowRequestsWithoutSession` can reduce security.
+# Use only if required, e.g., for third-party integrations like iframes, and ensure safeguards are in place.
 # Allow requests without JSESSIONID to be handled (default = false)
 allowRequestsWithoutSession=false
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -78,7 +78,8 @@ class ConnectionController {
       String sessionToken = request.getHeader("x-session-token")
 
       UserSession userSession = meetingService.getUserSessionWithSessionToken(sessionToken)
-      Boolean isSessionTokenValid = session[sessionToken] != null
+      Boolean allowRequestsWithoutSession = meetingService.getAllowRequestsWithoutSession(sessionToken)
+      Boolean isSessionTokenValid = session[sessionToken] != null || allowRequestsWithoutSession
 
       response.addHeader("Cache-Control", "no-cache")
 


### PR DESCRIPTION
The authentication for Graphql endpoints was not considering the config `allowRequestsWithoutSession`.
This PR fix it and add an warning for this config that will help to better understand the reason of its existence.

[Screencast from 2024-11-25 17-06-42.webm](https://github.com/user-attachments/assets/18d649f9-a952-45f0-96dd-52d095554afc)

Fix: #21697 #21129