### PR TITLE
fix: Snapshot of slide shows only annotations but no image

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -10,6 +10,7 @@ import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import browserInfo from '/imports/utils/browserInfo';
 import AppService from '/imports/ui/components/app/service';
+import PresentationService from '/imports/ui/components/presentation/service';
 
 const intlMessages = defineMessages({
   downloading: {
@@ -240,7 +241,8 @@ const PresentationMenu = (props) => {
               // filter shapes that are inside the slide
               const backgroundShape = getShape('slide-background-shape');
               const shapes = getShapes(currentPageId);
-              const svgString = await copySvg(shapes.map((shape) => shape.id));
+              const baseSvgString = await copySvg(shapes.map((shape) => shape.id));
+              const svgString = await PresentationService.replaceImageHrefWithBase64(baseSvgString);
               const container = document.createElement('div');
               container.innerHTML = svgString;
               const svgElem = container.firstChild;

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -4032,9 +4032,9 @@
       "integrity": "sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q=="
     },
     "html-to-image": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.9.0.tgz",
-      "integrity": "sha512-9gaDCIYg62Ek07F2pBk76AHgYZ2gxq2YALU7rK3gNCqXuhu6cWzsOQqM7qGbjZiOzxGzrU1deDqZpAod2NEwbA=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "htmlparser2": {
       "version": "8.0.2",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -54,7 +54,7 @@
     "flat": "^5.0.2",
     "focus-trap-react": "^10.2.1",
     "hark": "^1.2.3",
-    "html-to-image": "^1.9.0",
+    "html-to-image": "^1.11.11",
     "immutability-helper": "~2.8.1",
     "langmap": "0.0.16",
     "makeup-screenreader-trap": "0.0.5",


### PR DESCRIPTION
### What does this PR do?

Fix for an issue with latest Google Chrome version where the browser would not request the slide image when "snapshot of current slide" is used - we need to manually replace the image URL with a base64 version.

#### before
![Presentation_random-7893090_2024-11-26T16_55_10 190Z](https://github.com/user-attachments/assets/c606176a-b561-4b10-9716-116c984bcb7f)

#### after

![Presentation_random-7893090_2024-11-26T16_54_40 078Z](https://github.com/user-attachments/assets/f43a84b4-f388-4b54-aee1-80932e4d5b4d)

### Closes Issue(s)
Closes #18739

### How to test
1. join a meeting on latest google chrome (131.0.x)
2. try to use "snapshot of current slide" feature
