### PR TITLE
fix(bbb-web): Check to see if moderator has left in moderator count

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -731,7 +731,7 @@ public class Meeting {
         int sum = 0;
         for (Map.Entry<String, User> entry : users.entrySet()) {
             User u = entry.getValue();
-            if (u.isModerator())
+            if (!u.hasLeft() && u.isModerator())
                 sum++;
         }
         return sum;


### PR DESCRIPTION
### What does this PR do?

Adds a check when determining the number of moderators in meeting to see if a moderator has left before including them in the total.


### Closes Issue(s)
Closes #21749

### How to test
1. Create meeting
2. Join the meeting as a moderator
3. Call `getMeetingInfo` to see the number of participants and the number of moderators
4. Leave the meeting
5. After 20-30 seconds call `getMeetingInfo` to check that the number of participants and moderators is correct.
