### PR TITLE
style(nav-bar/leave-meeting-button): Update button styles for better visibility and accessibility.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -3,9 +3,10 @@ import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import EndMeetingConfirmationContainer from '/imports/ui/components/end-meeting-confirmation/container';
 import BBBMenu from '/imports/ui/components/common/menu/component';
-import { colorDanger, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
 import Styled from './styles';
 import Session from '/imports/ui/services/storage/in-memory';
+import { fontWeight } from '@mui/system';
 
 const intlMessages = defineMessages({
   leaveMeetingBtnLabel: {
@@ -93,6 +94,7 @@ class LeaveMeetingButton extends PureComponent {
     this.menuItems = [];
 
     if (allowLogoutSetting && connected) {
+      const customStyles = { fontWeight: 'bold' };
       this.menuItems.push(
         {
           key: 'list-item-logout',
@@ -100,13 +102,14 @@ class LeaveMeetingButton extends PureComponent {
           icon: 'logout',
           label: intl.formatMessage(intlMessages.leaveSessionLabel),
           description: intl.formatMessage(intlMessages.leaveSessionDesc),
+          customStyles,
           onClick: () => this.leaveSession(),
         },
       );
     }
 
     if (allowedToEndMeeting && connected) {
-      const customStyles = { background: colorDanger, color: colorWhite };
+      const customStyles = { background: 'inherit', color: colorBlack };
 
       this.menuItems.push(
         {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -3,10 +3,8 @@ import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import EndMeetingConfirmationContainer from '/imports/ui/components/end-meeting-confirmation/container';
 import BBBMenu from '/imports/ui/components/common/menu/component';
-import { colorBlack } from '/imports/ui/stylesheets/styled-components/palette';
 import Styled from './styles';
 import Session from '/imports/ui/services/storage/in-memory';
-import { fontWeight } from '@mui/system';
 
 const intlMessages = defineMessages({
   leaveMeetingBtnLabel: {
@@ -94,7 +92,6 @@ class LeaveMeetingButton extends PureComponent {
     this.menuItems = [];
 
     if (allowLogoutSetting && connected) {
-      const customStyles = { fontWeight: 'bold' };
       this.menuItems.push(
         {
           key: 'list-item-logout',
@@ -102,15 +99,12 @@ class LeaveMeetingButton extends PureComponent {
           icon: 'logout',
           label: intl.formatMessage(intlMessages.leaveSessionLabel),
           description: intl.formatMessage(intlMessages.leaveSessionDesc),
-          customStyles,
           onClick: () => this.leaveSession(),
         },
       );
     }
 
     if (allowedToEndMeeting && connected) {
-      const customStyles = { background: 'inherit', color: colorBlack };
-
       this.menuItems.push(
         {
           key: 'list-item-end-meeting',
@@ -118,7 +112,6 @@ class LeaveMeetingButton extends PureComponent {
           icon: 'close',
           label: intl.formatMessage(intlMessages.endMeetingLabel),
           description: intl.formatMessage(intlMessages.endMeetingDesc),
-          customStyles,
           onClick: () => this.setEndMeetingConfirmationModalIsOpen(true),
         },
       );


### PR DESCRIPTION
### What does this PR do?

This PR alters the leave meeting button and the end meeting button style - so the users don't accidentally click the end meeting by mistake.

### Closes Issue(s)

Closes #20908 

### How to test

Start a meeting and observe the end/leave meeting buttons on nav-bar area.


### More
Before

![image](https://github.com/user-attachments/assets/ccd8cb29-11a1-4073-88d4-a6e80209fa0f)

After

![image](https://github.com/user-attachments/assets/45b72b7d-3cef-4e5d-ba80-2b4bdc26130c)

