### PR TITLE
feat(actions-bar/raise-hand-button): Add dropdown functionality to Raise Hand button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/styles.js
@@ -3,19 +3,56 @@ import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import Button from '/imports/ui/components/common/button/component';
 
 const RaiseHandButton = styled(Button)`
-${({ ghost }) => ghost && `
-  & > span {
-    box-shadow: none;
-    background-color: transparent !important;
-    border-color: ${colorWhite} !important;
-  }
-   `}
-   
-   & span i {
+  ${({ ghost }) => ghost && `
+    & > span {
+      box-shadow: none;
+      background-color: transparent !important;
+      border-color: ${colorWhite} !important;
+    }
+  `}
+  
+  & span i {
     left: -.05rem;
-   }
+  }
+`;
+
+const Dropdown = styled.ul`
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  transform: translateY(-0.5rem);
+  margin: 0;
+  padding: 0.5rem;
+  list-style: none;
+  background-color: ${colorWhite};
+  border: 1px solid #ccc;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  white-space: nowrap;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s ease-in-out;
+  &:hover {
+    background-color: #0F70D7;
+  }
+`;
+
+const DropdownItem = styled.li`
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  background-color: #f9f9f9;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-radius: 0.25rem;
+  transition: background-color 0.2s ease-in-out;
+
+  &:hover {
+    background-color: #0F70D7;
+    color: ${colorWhite};
+  }
 `;
 
 export default {
   RaiseHandButton,
+  Dropdown,
+  DropdownItem,
 };


### PR DESCRIPTION
### What does this PR do?

This PR adds both a dropdown to confirm raising hands and a parameter to pass to enable this feature.

### Motivation

Avoid the user's unintentional click on raise hand.

### How to test

Create a meeting with the `userdata-bbb_open_dropdown_on_raise_hand=true`  and play around with raise hands.


### More
  `userdata-bbb_open_dropdown_on_raise_hand=true`
![image](https://github.com/user-attachments/assets/580b45a0-9881-4f76-92d0-f857cd4b75ed)
