### PR TITLE
fix(whiteboard): Prevent null error crash during session join

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -246,7 +246,7 @@ const Whiteboard = React.memo((props) => {
       prevShapesRef.current = shapes;
       tlEditorRef.current?.store.mergeRemoteChanges(() => {
         const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
-        editor.store.put(remoteShapesArray);
+        tlEditorRef.current.store.put(remoteShapesArray);
       });
     }
   }, [shapes]);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -244,9 +244,9 @@ const Whiteboard = React.memo((props) => {
   React.useEffect(() => {
     if (shapes && Object.keys(shapes).length > 0) {
       prevShapesRef.current = shapes;
+      const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
       tlEditorRef.current?.store.mergeRemoteChanges(() => {
-        const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
-        tlEditorRef.current.store.put(remoteShapesArray);
+        tlEditorRef.current?.store.put(remoteShapesArray);
       });
     }
   }, [shapes]);
@@ -778,14 +778,18 @@ const Whiteboard = React.memo((props) => {
         },
       ];
 
+      const hasShapes = shapes && Object.keys(shapes).length > 0;
+      const remoteShapesArray = hasShapes 
+        ? Object.values(shapes).map((shape) => sanitizeShape(shape))
+        : [];
+
       editor.store.mergeRemoteChanges(() => {
         editor.batch(() => {
           editor.store.put(pages);
           editor.store.put(assets);
           editor.setCurrentPage(`page:${curPageIdRef.current}`);
           editor.store.put(bgShape);
-          if (shapes && Object.keys(shapes).length > 0) {
-            const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
+          if (hasShapes) {
             editor.store.put(remoteShapesArray);
           }
           editor.history.clear();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -242,11 +242,11 @@ const Whiteboard = React.memo((props) => {
   }, [fitToWidth]);
 
   React.useEffect(() => {
-    if (shapes && !isEqual(prevShapesRef.current, shapes)) {
+    if (shapes && Object.keys(shapes).length > 0) {
       prevShapesRef.current = shapes;
       tlEditorRef.current?.store.mergeRemoteChanges(() => {
-        const shapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
-        tlEditorRef.current?.store?.put(shapesArray);
+        const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
+        editor.store.put(remoteShapesArray);
       });
     }
   }, [shapes]);
@@ -784,15 +784,12 @@ const Whiteboard = React.memo((props) => {
           editor.store.put(assets);
           editor.setCurrentPage(`page:${curPageIdRef.current}`);
           editor.store.put(bgShape);
+          if (shapes && Object.keys(shapes).length > 0) {
+            const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
+            editor.store.put(remoteShapesArray);
+          }
           editor.history.clear();
         });
-      });
-
-      editor.store.mergeRemoteChanges(() => {
-        if (shapes) {
-          const remoteShapesArray = Object.values(shapes).map((shape) => sanitizeShape(shape));
-          editor.store.put(remoteShapesArray);
-        }
       });
 
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
### What does this PR do?
This PR attempts to fix a null error crash in the whiteboard component that occurred under specific conditions when joining sessions.

### Motivation
This error was happening in some cases on join

![image](https://github.com/user-attachments/assets/a895e53b-2d78-422a-a00e-08b6bdec93c8)
