### PR TITLE
fix: adjust virtual background upload toast styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/file-reader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/file-reader/component.jsx
@@ -105,7 +105,7 @@ const withFileReader = (
       toast.dismiss(toastId.current);
     }
 
-    toastId.current = toast.info(renderToastContent(text, status), {
+    toastId.current = toast(renderToastContent(text, status), {
       hideProgressBar: status === STATUS.DONE ? false : true,
       autoClose: status === STATUS.DONE ? 5000 : false,
       newestOnTop: true,


### PR DESCRIPTION
### What does this PR do?

Adjusts virtual background upload toast to work after #21695

#### before
![Screenshot from 2024-11-28 09-33-45](https://github.com/user-attachments/assets/f56e90bd-ac6f-4bdd-841d-5860371d9017)


#### after
![Screenshot from 2024-11-28 09-33-23](https://github.com/user-attachments/assets/459f6c34-b368-4d90-9d81-540282e1805f)

### Closes Issue(s)
Closes #21346