### PR TITLE
fix: typo in fallback LiveKit URL, log improvements

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -47,6 +47,7 @@ export default class KurentoScreenshareBridge {
     this._restartIntervalMs = null;
     this.startedOnce = false;
     this.outputDeviceId = null;
+    this.bridgeName = BRIDGE_NAME;
   }
 
   get restartIntervalMs() {

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -31,9 +31,10 @@ interface BBBLiveKitRoomProps {
 
 interface ObserverProps {
   room: Room;
+  url?: string;
 }
 
-const LiveKitObserver = ({ room }: ObserverProps) => {
+const LiveKitObserver = ({ room, url }: ObserverProps) => {
   const { localParticipant } = useLocalParticipant();
   const [setUserTalking] = useMutation(USER_SET_TALKING);
   const isSpeaking = useIsSpeaking(localParticipant);
@@ -47,7 +48,7 @@ const LiveKitObserver = ({ room }: ObserverProps) => {
       logCode: 'livekit_conn_state_changed',
       extraInfo: {
         connectionState,
-        serverInfo: room.serverInfo,
+        url,
       },
     }, `LiveKit conn state changed: ${connectionState}`);
   }, [connectionState]);
@@ -120,8 +121,8 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = (props) => {
       room={liveKitRoom}
       style={{ zIndex: 0, height: 'initial', width: 'initial' }}
     >
+      <LiveKitObserver room={liveKitRoom} url={url} />
       <RoomAudioRenderer />
-      <LiveKitObserver room={liveKitRoom} />
     </LiveKitRoom>
   );
 };
@@ -131,9 +132,8 @@ const BBBLiveKitRoomContainer: React.FC = () => {
     livekit: u.livekit,
   }));
   const [meetingSettings] = useMeetingSettings();
-  const { url } = meetingSettings.public.media.livekit || {
-    url: `wss://${window.location.hostname}/livekit`,
-  };
+  const url = meetingSettings.public.media?.livekit?.url
+    || `wss://${window.location.hostname}/livekit`;
   const { data: bridges } = useMeeting((m) => ({
     cameraBridge: m.cameraBridge,
     screenShareBridge: m.screenShareBridge,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -38,9 +38,9 @@ export const setBridge = (bridgeName) => {
     logCode: 'screenshare_bridge_set',
     extraInfo: {
       targetBridge: bridgeName,
-      bridge: screenShareBridge?.constructor?.name,
+      bridge: screenShareBridge?.bridgeName,
     },
-  }, `Screenshare bridge set to ${screenShareBridge?.constructor?.name}`);
+  }, `Screenshare bridge set to ${screenShareBridge?.bridgeName}`);
 
   return screenShareBridge;
 };


### PR DESCRIPTION
### What does this PR do?

- [fix: typo in fallback LiveKit URL](https://github.com/bigbluebutton/bigbluebutton/commit/ced120c15f36720724e0312ee47a2f905171bd10) 
  - There's a typo in the fallback LiveKit URL generation when parsing the
client's setting which would made the URL be nil if the livekit config
object was unset.
- [refactor(livekit): add additional debug logging](https://github.com/bigbluebutton/bigbluebutton/commit/9e837f88f3a23673c627a27704674efcd2be853c) 
  - Add additional debug logging to LiveKit based A/V/screen share to be
able to capture more information on testing phases.
Take the oportunity to standardize messages with a `LiveKit` prefix and
logCodecs with a `livekit_` prefix.

### Closes Issue(s)

None