### PR TITLE
fix: missing locale string

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -51,6 +51,10 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.actionsDropdown.lockedDesktopShareDesc',
     description: 'Desktop locked Share option desc',
   },
+  lockedDesktopShareLabel: {
+    id: 'app.actionsBar.actionsDropdown.lockedDesktopShareLabel',
+    description: 'Desktop locked Share option label',
+  },
   notPresenterDesktopShareLabel: {
     id: 'app.actionsBar.actionsDropdown.notPresenterDesktopShareLabel',
     description: 'You are not the presenter label',

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -682,6 +682,7 @@
     "app.actionsBar.actionsDropdown.presentationLabel": "Upload/Manage presentations",
     "app.actionsBar.actionsDropdown.initPollLabel": "Initiate a poll",
     "app.actionsBar.actionsDropdown.desktopShareLabel": "Share your screen",
+    "app.actionsBar.actionsDropdown.lockedDesktopShareLabel": "Screenshare locked",
     "app.actionsBar.actionsDropdown.lockedDesktopShareDesc": "Screenshare locked",
     "app.actionsBar.actionsDropdown.notPresenterDesktopShareLabel": "You must be a presenter to share your screen",
     "app.actionsBar.actionsDropdown.notPresenterDesktopShareDesc": "You must be a presenter to share your screen",


### PR DESCRIPTION
### What does this PR do?
Adds missing string locale in screenshare button

### How to test
disable "enable other participants desktop sharing" and make user presenter