### PR TITLE
fix(chat): Add emoji shortcodes to message reaction labels

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/component.tsx
@@ -1,0 +1,96 @@
+import React, { useId } from 'react';
+import { capitalize } from 'radash';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
+import { defineMessages, useIntl } from 'react-intl';
+import Styled from './styles';
+
+const intlMessages = defineMessages({
+  reactionLabel: {
+    id: 'app.chat.toolbar.reactions.reactionLabel',
+  },
+  you: {
+    id: 'app.chat.toolbar.reactions.youLabel',
+  },
+  and: {
+    id: 'app.chat.toolbar.reactions.andLabel',
+  },
+});
+
+interface ReactionItemProps {
+  count: number;
+  userNames: string[];
+  reactedByMe: boolean;
+  reactionEmoji: string;
+  reactionEmojiId: string;
+  shortcodes: string;
+  sendReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  deleteReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  chatId: string;
+  messageId: string;
+}
+
+const ReactionItem: React.FC<ReactionItemProps> = (props) => {
+  const {
+    count,
+    reactedByMe,
+    reactionEmoji,
+    reactionEmojiId,
+    userNames,
+    shortcodes,
+    chatId,
+    messageId,
+    deleteReaction,
+    sendReaction,
+  } = props;
+
+  const intl = useIntl();
+  const id = useId();
+
+  let usersLabel = '';
+  if (userNames.length) {
+    const users = userNames.join(', ');
+    usersLabel += users;
+
+    if (reactedByMe) {
+      usersLabel += ` ${intl.formatMessage(intlMessages.and)} ${intl.formatMessage(intlMessages.you)}`;
+    }
+  } else if (reactedByMe) {
+    usersLabel += capitalize(intl.formatMessage(intlMessages.you));
+  }
+
+  const label = intl.formatMessage(intlMessages.reactionLabel, {
+    0: usersLabel,
+    1: shortcodes,
+  });
+
+  return (
+    <TooltipContainer title={label} key={reactionEmojiId}>
+      <Styled.EmojiWrapper
+        aria-describedby={id}
+        highlighted={reactedByMe}
+        onClick={() => {
+          if (reactedByMe) {
+            deleteReaction(reactionEmoji, reactionEmojiId, chatId, messageId);
+          } else {
+            sendReaction(reactionEmoji, reactionEmojiId, chatId, messageId);
+          }
+        }}
+      >
+        <em-emoji
+          size={parseFloat(
+            window.getComputedStyle(document.documentElement).fontSize,
+          )}
+          emoji={{
+            id: reactionEmojiId,
+            native: reactionEmoji,
+          }}
+          native={reactionEmoji}
+        />
+        <span>{count}</span>
+        <span className="sr-only" id={id}>{label}</span>
+      </Styled.EmojiWrapper>
+    </TooltipContainer>
+  );
+};
+
+export default ReactionItem;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/styles.tsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+import { colorGrayLightest, colorOffWhite, colorGrayLighter } from '/imports/ui/stylesheets/styled-components/palette';
+
+const EmojiWrapper = styled.button<{ highlighted: boolean }>`
+  background: none;
+  border-radius: 1rem;
+  padding: 0.375rem 1rem;
+  line-height: 1;
+  display: flex;
+  flex-wrap: nowrap;
+  border: 1px solid ${colorGrayLightest};
+  cursor: pointer;
+
+  ${({ highlighted }) => highlighted && `
+    background-color: ${colorOffWhite};
+  `}
+
+  em-emoji {
+    [dir='ltr'] & {
+      margin-right: 0.25rem;
+    }
+
+    [dir='rtl'] & {
+      margin-left: 0.25rem;
+    }
+  }
+
+  &:hover {
+    border: 1px solid ${colorGrayLighter};
+  }
+`;
+
+export default {
+  EmojiWrapper,
+};

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/styles.ts
@@ -1,36 +1,4 @@
 import styled from 'styled-components';
-import {
-  colorGrayLighter, colorGrayLightest, colorOffWhite,
-} from '/imports/ui/stylesheets/styled-components/palette';
-
-const EmojiWrapper = styled.button<{ highlighted: boolean }>`
-  background: none;
-  border-radius: 1rem;
-  padding: 0.375rem 1rem;
-  line-height: 1;
-  display: flex;
-  flex-wrap: nowrap;
-  border: 1px solid ${colorGrayLightest};
-  cursor: pointer;
-
-  ${({ highlighted }) => highlighted && `
-    background-color: ${colorOffWhite};
-  `}
-
-  em-emoji {
-    [dir='ltr'] & {
-      margin-right: 0.25rem;
-    }
-
-    [dir='rtl'] & {
-      margin-left: 0.25rem;
-    }
-  }
-
-  &:hover {
-    border: 1px solid ${colorGrayLighter};
-  }
-`;
 
 const ReactionsWrapper = styled.div`
   display: flex;
@@ -40,6 +8,5 @@ const ReactionsWrapper = styled.div`
 `;
 
 export default {
-  EmojiWrapper,
   ReactionsWrapper,
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -47,7 +47,7 @@
     "app.chat.toolbar.reply": "Reply to message {0}",
     "app.chat.toolbar.edit": "Edit",
     "app.chat.toolbar.delete": "Delete",
-    "app.chat.toolbar.reactions.reactedByLabel": "Reacted by",
+    "app.chat.toolbar.reactions.reactionLabel": "{0} reacted with {1}",
     "app.chat.toolbar.reactions.youLabel": "you",
     "app.chat.toolbar.reactions.andLabel": "and",
     "app.chat.toolbar.reactions.findReactionButtonLabel": "Find a reaction",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Add reaction emoji shortcodes to the reaction tooltip label.
Add reaction item accessibility string.
Extract reaction item in its own component.

![Screenshot from 2024-11-29 13-18-45](https://github.com/user-attachments/assets/7aa4c915-3b3e-4150-bb90-070297ecb9bc)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
n/a