### PR TITLE
api/docs: Removes a few deprecated params

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -87,7 +87,6 @@ public class ApiParams {
     public static final String BREAKOUT_ROOMS_CAPTURE_NOTES  = "breakoutRoomsCaptureNotes";
     public static final String BREAKOUT_ROOMS_CAPTURE_SLIDES_FILENAME = "breakoutRoomsCaptureSlidesFilename";
     public static final String BREAKOUT_ROOMS_CAPTURE_NOTES_FILENAME = "breakoutRoomsCaptureNotesFilename";
-    public static final String BREAKOUT_ROOMS_ENABLED = "breakoutRoomsEnabled";
     public static final String BREAKOUT_ROOMS_RECORD = "breakoutRoomsRecord";
     public static final String BREAKOUT_ROOMS_PRIVATE_CHAT_ENABLED = "breakoutRoomsPrivateChatEnabled";
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -64,7 +64,6 @@ public class ApiParams {
     public static final String VOICE_BRIDGE = "voiceBridge";
     public static final String WEB_VOICE = "webVoice";
     public static final String LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES = "learningDashboardCleanupDelayInMinutes";
-    public static final String VIRTUAL_BACKGROUNDS_DISABLED = "virtualBackgroundsDisabled";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";
     public static final String MEETING_CAMERA_CAP = "meetingCameraCap";
     public static final String USER_CAMERA_CAP = "userCameraCap";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -63,7 +63,6 @@ public class ApiParams {
     public static final String SEQUENCE = "sequence";
     public static final String VOICE_BRIDGE = "voiceBridge";
     public static final String WEB_VOICE = "webVoice";
-    public static final String LEARNING_DASHBOARD_ENABLED = "learningDashboardEnabled";
     public static final String LEARNING_DASHBOARD_CLEANUP_DELAY_IN_MINUTES = "learningDashboardCleanupDelayInMinutes";
     public static final String VIRTUAL_BACKGROUNDS_DISABLED = "virtualBackgroundsDisabled";
     public static final String WEBCAMS_ONLY_FOR_MODERATOR = "webcamsOnlyForModerator";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -90,7 +90,6 @@ public class ParamsProcessorUtil {
     private boolean autoStartRecording;
     private boolean allowStartStopRecording;
     private boolean recordFullDurationMedia;
-    private boolean learningDashboardEnabled = true;
     private int learningDashboardCleanupDelayInMinutes;
     private boolean webcamsOnlyForModerator;
     private Integer defaultMeetingCameraCap = 0;
@@ -599,19 +598,6 @@ public class ParamsProcessorUtil {
                 log.warn("[DEPRECATION] use disabledFeatures=virtualBackgrounds instead of virtualBackgroundsDisabled=true");
                 listOfDisabledFeatures.add("virtualBackgrounds");
             }
-        }
-
-        boolean learningDashboardEn = learningDashboardEnabled;
-        if (!StringUtils.isEmpty(params.get(ApiParams.LEARNING_DASHBOARD_ENABLED))) {
-            try {
-                learningDashboardEn = Boolean.parseBoolean(params.get(ApiParams.LEARNING_DASHBOARD_ENABLED));
-            } catch (Exception ex) {
-                log.warn("Invalid param [learningDashboardEnabled] for meeting=[{}]",internalMeetingId);
-            }
-        }
-        if(learningDashboardEn == false && !listOfDisabledFeatures.contains("learningDashboard")) {
-            log.warn("[DEPRECATION] use disabledFeatures=learningDashboard instead of learningDashboardEnabled=false");
-            listOfDisabledFeatures.add("learningDashboard");
         }
 
         // Learning Dashboard not allowed for Breakout Rooms
@@ -1374,10 +1360,6 @@ public class ParamsProcessorUtil {
 
     public void setRecordFullDurationMedia(boolean recordFullDurationMedia) {
         this.recordFullDurationMedia = recordFullDurationMedia;
-    }
-
-    public void setLearningDashboardEnabled(boolean learningDashboardEnabled) {
-        this.learningDashboardEnabled = learningDashboardEnabled;
     }
 
     public void setLearningDashboardCleanupDelayInMinutes(int learningDashboardCleanupDelayInMinutes) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -591,15 +591,6 @@ public class ParamsProcessorUtil {
             }
         }
 
-        // Check if VirtualBackgrounds is disabled
-        if (!StringUtils.isEmpty(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED))) {
-            boolean virtualBackgroundsDisabled = Boolean.valueOf(params.get(ApiParams.VIRTUAL_BACKGROUNDS_DISABLED));
-            if(virtualBackgroundsDisabled == true && !listOfDisabledFeatures.contains("virtualBackgrounds")) {
-                log.warn("[DEPRECATION] use disabledFeatures=virtualBackgrounds instead of virtualBackgroundsDisabled=true");
-                listOfDisabledFeatures.add("virtualBackgrounds");
-            }
-        }
-
         // Learning Dashboard not allowed for Breakout Rooms
         if(isBreakout) {
 		listOfDisabledFeatures.add("learningDashboard");

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -113,7 +113,6 @@ public class ParamsProcessorUtil {
     private String defaultPresentationUploadExternalDescription = "";
     private String defaultPresentationUploadExternalUrl = "";
 
-		private boolean defaultBreakoutRoomsEnabled = true;
 		private boolean defaultBreakoutRoomsRecord;
         private boolean defaultBreakoutRoomsCaptureSlides = false;
         private boolean defaultBreakoutRoomsCaptureNotes = false;
@@ -763,16 +762,6 @@ public class ParamsProcessorUtil {
 
         if (!StringUtils.isEmpty(params.get(ApiParams.MEETING_LAYOUT))) {
             meetingLayout = params.get(ApiParams.MEETING_LAYOUT);
-        }
-
-        Boolean breakoutRoomsEnabled = defaultBreakoutRoomsEnabled;
-        String breakoutRoomsEnabledParam = params.get(ApiParams.BREAKOUT_ROOMS_ENABLED);
-        if (!StringUtils.isEmpty(breakoutRoomsEnabledParam)) {
-            breakoutRoomsEnabled = Boolean.parseBoolean(breakoutRoomsEnabledParam);
-        }
-        if(breakoutRoomsEnabled == false && !listOfDisabledFeatures.contains("breakoutRooms")) {
-            log.warn("[DEPRECATION] use disabledFeatures=breakoutRooms instead of breakoutRoomsEnabled=false");
-            listOfDisabledFeatures.add("breakoutRooms");
         }
 
         BreakoutRoomsParams breakoutParams = processBreakoutRoomsParams(params);
@@ -1601,10 +1590,6 @@ public class ParamsProcessorUtil {
 
         return filters;
     }
-
-	public void setBreakoutRoomsEnabled(Boolean breakoutRoomsEnabled) {
-		this.defaultBreakoutRoomsEnabled = breakoutRoomsEnabled;
-	}
 
 	public void setBreakoutRoomsRecord(Boolean breakoutRoomsRecord) {
 		this.defaultBreakoutRoomsRecord = breakoutRoomsRecord;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -517,9 +517,6 @@ allowRevealOfBBBVersion=false
 # legacy method for disabling of the learning analytics dashboard; please use disabledFeatures=learningDashboard
 learningDashboardEnabled=true
 
-# legacy method for disabling of the breakout rooms; please use disabledFeatures=breakoutRooms
-breakoutRoomsEnabled=true
-
 # legacy, please use maxUserConcurrentAccesses instead
 allowDuplicateExtUserid=true
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -514,9 +514,6 @@ notifyRecordingIsOn=false
 # Allow endpoint with current BigBlueButton version
 allowRevealOfBBBVersion=false
 
-# legacy method for disabling of the learning analytics dashboard; please use disabledFeatures=learningDashboard
-learningDashboardEnabled=true
-
 # legacy, please use maxUserConcurrentAccesses instead
 allowDuplicateExtUserid=true
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -186,7 +186,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="audioBridge" value="${audioBridge}"/>
         <property name="allowModsToUnmuteUsers" value="${allowModsToUnmuteUsers}"/>
         <property name="allowModsToEjectCameras" value="${allowModsToEjectCameras}"/>
-        <property name="breakoutRoomsEnabled" value="${breakoutRoomsEnabled}"/>
         <property name="breakoutRoomsRecord" value="${breakoutRoomsRecord}"/>
         <property name="breakoutRoomsPrivateChatEnabled" value="${breakoutRoomsPrivateChatEnabled}"/>
         <property name="lockSettingsDisableCam" value="${lockSettingsDisableCam}"/>

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -157,7 +157,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="autoStartRecording" value="${autoStartRecording}"/>
         <property name="allowStartStopRecording" value="${allowStartStopRecording}"/>
         <property name="recordFullDurationMedia" value="${recordFullDurationMedia}"/>
-        <property name="learningDashboardEnabled" value="${learningDashboardEnabled}"/>
         <property name="learningDashboardCleanupDelayInMinutes" value="${learningDashboardCleanupDelayInMinutes}"/>
         <property name="webcamsOnlyForModerator" value="${webcamsOnlyForModerator}"/>
         <property name="defaultMeetingCameraCap" value="${meetingCameraCap}"/>

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -98,13 +98,6 @@ const createEndpointTableData = [
     "description": (<>If set to true, the client will give the user the choice to choose the breakout rooms he wants to join.</>)
   },
   {
-    "name": "breakoutRoomsEnabled",
-    "required": "Optional(Breakout Room)",
-    "type": "Boolean",
-    "default": "true",
-    "description": (<><b>[DEPRECATED]</b> Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />If set to false, breakout rooms will be disabled.</>)
-  },
-  {
     "name": "breakoutRoomsPrivateChatEnabled",
     "required": "Optional(Breakout Room)",
     "type": "Boolean",
@@ -244,12 +237,6 @@ const createEndpointTableData = [
     "description": (<>Will set the guest policy for the meeting. The guest policy determines whether or not users who send a join request with <code className="language-plaintext highlighter-rouge">guest=true</code> will be allowed to join the meeting. Possible values are ALWAYS_ACCEPT, ALWAYS_DENY, and ASK_MODERATOR.</>)
   },
   {
-    "name": "keepEvents",
-    "type": "Boolean",
-    "deprecated": true,
-    "description": (<>Removed in 2.3 in favor of <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> and bigbluebutton.properties <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>.</>)
-  },
-  {
     "name": "meetingKeepEvents",
     "type": "Boolean",
     "default": "false",
@@ -274,12 +261,6 @@ const createEndpointTableData = [
     "description": (<>Will set the default layout for the meeting. Possible values are: CUSTOM_LAYOUT, SMART_LAYOUT, PRESENTATION_FOCUS, VIDEO_FOCUS. (added 2.4) In version 3.0 a few more possible options were added: CAMERAS_ONLY, PRESENTATION_ONLY, PARTICIPANTS_AND_CHAT_ONLY</>)
   },
   {
-    "name": "learningDashboardEnabled",
-    "type": "Boolean",
-    "default": "true",
-    "description": (<><b>[DEPRECATED]</b> Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />Default <code className="language-plaintext highlighter-rouge">learningDashboardEnabled=true</code>. When this option is enabled BigBlueButton generates a Dashboard where moderators can view a summary of the activities of the meeting. (added 2.4)</>)
-  },
-  {
     "name": "learningDashboardCleanupDelayInMinutes",
     "type": "Number",
     "default": "2",
@@ -298,13 +279,6 @@ const createEndpointTableData = [
     "type": "Boolean",
     "default": "false",
     "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will allow users to join meetings without session cookie's validation. (added 2.4.3)</>)
-  },
-  {
-    "name": "virtualBackgroundsDisabled",
-    "required": false,
-    "type": "Boolean",
-    "default": "false",
-    "description": (<><b>[DEPRECATED]</b> Removed in 2.5, temporarily still handled, please transition to disabledFeatures.<br /><br />Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable Virtual Backgrounds for all users in the meeting. (added 2.4.3)</>)
   },
   {
     "name": "userCameraCap",

--- a/docs/docs/data/join.tsx
+++ b/docs/docs/data/join.tsx
@@ -74,13 +74,6 @@ const joinEndpointTableData = [
     "description": (<>A custom URL to redirect client when the user click on OK button in the meeting ended screen. By default users are redirected to the meeting's default logout URL.</>)
   },
   {
-    "name": "joinViaHtml5",
-    "required": false,
-    "type": "String",
-    "description": (<><b>[DEPRECATED]</b>Set to “true” to force the HTML5 client to load for the user. (removed in 2.3 since HTML5 is the only client)</>),
-    "deprecated": true
-  },
-  {
     "name": "guest",
     "required": false,
     "type": "String",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -111,7 +111,7 @@ Updated in 2.7:
 
 Updated in 3.0:
 
-- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`;
+- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`. **Removed:** `breakoutRoomsEnabled`, `learningDashboardEnabled`, `virtualBackgroundsDisabled`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`;
 - **join** - **Added:** `enforceLayout`, `logoutURL`, `userdata-bbb_default_layout`, `userdata-bbb_skip_echotest_if_previous_device`, `userdata-bbb_prefer_dark_theme`. **Removed:** `defaultLayout` (replaced by `userdata-bbb_default_layout`) and removed support for all HTTP request methods except GET.
 - **sendChatMessage** endpoint was first introduced.
 - **enter** endpoint was removed. It was only used internally, never part of the api documentation.


### PR DESCRIPTION
Removes:

API Params (`/create`):
- `learningDashboardEnabled` (replaced by `disabledFeatures=learningDashboard`)
- `virtualBackgroundsDisabled` (replaced by `disabledFeatures=virtualBackgrounds`)
- `breakoutRoomsEnabled` (replaced by `disabledFeatures=breakoutRooms`)

Configs (`bigbluebutton.properties`)
- `learningDashboardEnabled` (replaced by `disabledFeatures=learningDashboard`)
- `breakoutRoomsEnabled` (replaced by `disabledFeatures=virtualBackgrounds`)

Docs:
- `/join joinViaHtml5` (param no longer exists)
- `/create keepEvents` (param no longer exists)
- And removes info about params removed in this PR
