### PR TITLE
fix (ci): Undo "Remove apt-updates of bbb-install (on retry)"

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -330,9 +330,6 @@ jobs:
             echo "Check if there is some process still locking:2"
             ps aux | grep -E 'dpkg|apt'
 
-            #remove all apt-update to make the install faster
-            sed -i 's/apt-get update/#apt-get update/g' bbb-install.sh
-
             RETRY_COUNT=$((RETRY_COUNT + 1))
           done
 


### PR DESCRIPTION
The removal of `apt-updates` in the second attempt was introduced when the ci was running slowly.
It is not necessary anymore since #21612

This step was sometimes causing this problem:

![image](https://github.com/user-attachments/assets/7766f704-eab1-4577-9836-e58166e1062d)
