### PR TITLE
feat (gql-server): Introduces new prop `layout.screenshareAsContent`

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/LayoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/LayoutApp2x.scala
@@ -6,6 +6,7 @@ import org.bigbluebutton.core.running.MeetingActor
 trait LayoutApp2x
   extends BroadcastLayoutMsgHdlr
   with BroadcastPushLayoutMsgHdlr
+  with SetScreenshareAsContentReqMsgHdlr
   with GetCurrentLayoutReqMsgHdlr {
 
   this: MeetingActor =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/SetScreenshareAsContentReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/SetScreenshareAsContentReqMsgHdlr.scala
@@ -1,0 +1,44 @@
+package org.bigbluebutton.core.apps.layout
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.db.LayoutDAO
+import org.bigbluebutton.core.models.Layouts
+import org.bigbluebutton.core.running.OutMsgRouter
+
+trait SetScreenshareAsContentReqMsgHdlr extends RightsManagementTrait {
+  this: LayoutApp2x =>
+
+  val outGW: OutMsgRouter
+
+  def handleSetScreenshareAsContentReqMsg(msg: SetScreenshareAsContentReqMsg): Unit = {
+
+    if (liveMeeting.props.meetingProp.disabledFeatures.contains("screenshare")) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "Screenshare is disabled for this meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+    } else if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to set screenshare as content."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+    } else {
+      Layouts.setScreenshareAsContent(liveMeeting.layouts, msg.body.screenshareAsContent)
+      LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
+      sendSetScreenshareAsContentEvtMsg(msg.header.userId)
+    }
+  }
+
+  def sendSetScreenshareAsContentEvtMsg(fromUserId: String): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, fromUserId)
+    val envelope = BbbCoreEnvelope(SetScreenshareAsContentEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(SetScreenshareAsContentEvtMsg.NAME, liveMeeting.props.meetingProp.intId, fromUserId)
+
+    val body = SetScreenshareAsContentEvtMsgBody(
+      Layouts.getScreenshareAsContent(liveMeeting.layouts),
+    )
+    val event = SetScreenshareAsContentEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+    outGW.send(msgEvent)
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/LayoutDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/LayoutDAO.scala
@@ -1,19 +1,20 @@
 package org.bigbluebutton.core.db
 
 import org.bigbluebutton.core.models.Layouts
-import org.bigbluebutton.core.models.Layouts.{getCameraDockIsResizing, getCameraPosition, getCurrentLayout, getFocusedCamera, getPresentationIsOpen, getPresentationVideoRate, getPushLayout, setCurrentLayout}
+import org.bigbluebutton.core.models.Layouts.{getCameraDockIsResizing, getCameraPosition, getCurrentLayout, getFocusedCamera, getPresentationIsOpen, getPresentationVideoRate, getPushLayout, getScreenshareAsContent, setCurrentLayout}
 import slick.jdbc.PostgresProfile.api._
 
 case class LayoutDbModel(
-    meetingId:        String,
-    currentLayoutType:        String,
-    presentationMinimized:          Boolean,
-    cameraDockIsResizing:           Boolean,
-    cameraDockPlacement:             String,
-    cameraDockAspectRatio:      Double,
+    meetingId:              String,
+    currentLayoutType:      String,
+    presentationMinimized:  Boolean,
+    cameraDockIsResizing:   Boolean,
+    cameraDockPlacement:    String,
+    cameraDockAspectRatio:  Double,
     cameraWithFocus:        String,
-    propagateLayout:          Boolean,
-    updatedAt:        java.sql.Timestamp,
+    propagateLayout:        Boolean,
+    screenshareAsContent:   Boolean,
+    updatedAt:              java.sql.Timestamp,
 )
 
 class LayoutDbTableDef(tag: Tag) extends Table[LayoutDbModel](tag, None, "layout") {
@@ -25,8 +26,12 @@ class LayoutDbTableDef(tag: Tag) extends Table[LayoutDbModel](tag, None, "layout
   val cameraDockAspectRatio = column[Double]("cameraDockAspectRatio")
   val cameraWithFocus = column[String]("cameraWithFocus")
   val propagateLayout = column[Boolean]("propagateLayout")
+  val screenshareAsContent = column[Boolean]("screenshareAsContent")
   val updatedAt = column[java.sql.Timestamp]("updatedAt")
-  override def * = (meetingId, currentLayoutType, presentationMinimized, cameraDockIsResizing, cameraDockPlacement, cameraDockAspectRatio, cameraWithFocus, propagateLayout, updatedAt) <> (LayoutDbModel.tupled, LayoutDbModel.unapply)
+  override def * = (
+    meetingId, currentLayoutType, presentationMinimized, cameraDockIsResizing, cameraDockPlacement,
+    cameraDockAspectRatio, cameraWithFocus, propagateLayout, screenshareAsContent, updatedAt
+  ) <> (LayoutDbModel.tupled, LayoutDbModel.unapply)
 }
 
 object LayoutDAO {
@@ -49,6 +54,7 @@ object LayoutDAO {
           cameraDockAspectRatio = getPresentationVideoRate(layout),
           cameraWithFocus = getFocusedCamera(layout),
           propagateLayout = getPushLayout(layout),
+          screenshareAsContent = getScreenshareAsContent(layout),
           updatedAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Layouts.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Layouts.scala
@@ -59,6 +59,14 @@ object Layouts {
     instance.presentationVideoRate
   }
 
+  def setScreenshareAsContent(instance: Layouts, screenshareAsContent: Boolean) = {
+    instance.screenshareAsContent = screenshareAsContent
+  }
+
+  def getScreenshareAsContent(instance: Layouts): Boolean = {
+    instance.screenshareAsContent
+  }
+
   def setRequestedBy(instance: Layouts, setBy: String) = {
     instance.setByUser = setBy;
   }
@@ -77,6 +85,7 @@ class Layouts {
   private var cameraPosition: String = "contentTop";
   private var focusedCamera: String = "none";
   private var presentationVideoRate: Double = 0;
+  private var screenshareAsContent: Boolean = true;
 }
 
 object LayoutsType {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -255,6 +255,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[BroadcastLayoutMsg](envelope, jsonNode)
       case BroadcastPushLayoutMsg.NAME =>
         routeGenericMsg[BroadcastPushLayoutMsg](envelope, jsonNode)
+      case SetScreenshareAsContentReqMsg.NAME =>
+        routeGenericMsg[SetScreenshareAsContentReqMsg](envelope, jsonNode)
 
       case UserLeaveReqMsg.NAME =>
         routeGenericMsg[UserLeaveReqMsg](envelope, jsonNode)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -568,17 +568,18 @@ class MeetingActor(
         handleListenOnlyModeToggledInSfuEvtMsg(m)
 
       // Layout
-      case m: GetCurrentLayoutReqMsg  => handleGetCurrentLayoutReqMsg(m)
-      case m: BroadcastLayoutMsg      => handleBroadcastLayoutMsg(m)
-      case m: BroadcastPushLayoutMsg  => handleBroadcastPushLayoutMsg(m)
+      case m: GetCurrentLayoutReqMsg        => handleGetCurrentLayoutReqMsg(m)
+      case m: BroadcastLayoutMsg            => handleBroadcastLayoutMsg(m)
+      case m: BroadcastPushLayoutMsg        => handleBroadcastPushLayoutMsg(m)
+      case m: SetScreenshareAsContentReqMsg => handleSetScreenshareAsContentReqMsg(m)
 
       // Pads
-      case m: PadGroupCreatedEvtMsg   => padsApp2x.handle(m, liveMeeting, msgBus)
-      case m: PadCreateReqMsg         => padsApp2x.handle(m, liveMeeting, msgBus)
-      case m: PadCreatedEvtMsg        => padsApp2x.handle(m, liveMeeting, msgBus)
-      case m: PadCreateSessionReqMsg  => padsApp2x.handle(m, liveMeeting, msgBus)
-      case m: PadSessionCreatedEvtMsg => padsApp2x.handle(m, liveMeeting, msgBus)
-      case m: PadSessionDeletedSysMsg => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: PadGroupCreatedEvtMsg         => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: PadCreateReqMsg               => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: PadCreatedEvtMsg              => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: PadCreateSessionReqMsg        => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: PadSessionCreatedEvtMsg       => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: PadSessionDeletedSysMsg       => padsApp2x.handle(m, liveMeeting, msgBus)
       case m: PadUpdatedSysMsg =>
         padsApp2x.handle(m, liveMeeting, msgBus)
         updateUserLastActivity(m.body.userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -56,7 +56,7 @@ object FakeUserGenerator {
     val webcamBackgroundURL = "https://www." + RandomStringGenerator.randomAlphanumericString(32) + ".com/" +
       RandomStringGenerator.randomAlphanumericString(10) + ".jpg"
     val color = "#ff6242"
-     val logoutUrlFormats = Seq(
+    val logoutUrlFormats = Seq(
       s"https://www.${RandomStringGenerator.randomAlphanumericString(32)}.com/logout?user=${RandomStringGenerator.randomAlphanumericString(8)}#section",
       s"http://localhost:8080/logout/${RandomStringGenerator.randomAlphanumericString(8)}",
       s"https://example.com/logout?redirect=${java.net.URLEncoder.encode("https://another-site.com", "UTF-8")}"

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LayoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LayoutMsgs.scala
@@ -1,27 +1,33 @@
 package org.bigbluebutton.common2.msgs
 
-// In messages
 object GetCurrentLayoutReqMsg { val NAME = "GetCurrentLayoutReqMsg" }
 case class GetCurrentLayoutReqMsg(header: BbbClientMsgHeader, body: GetCurrentLayoutReqMsgBody) extends StandardMsg
 case class GetCurrentLayoutReqMsgBody()
+
+object GetCurrentLayoutRespMsg { val NAME = "GetCurrentLayoutRespMsg" }
+case class GetCurrentLayoutRespMsg(header: BbbClientMsgHeader, body: GetCurrentLayoutRespMsgBody) extends BbbCoreMsg
+case class GetCurrentLayoutRespMsgBody(layout: String, setByUserId: String)
 
 object BroadcastLayoutMsg { val NAME = "BroadcastLayoutMsg" }
 case class BroadcastLayoutMsg(header: BbbClientMsgHeader, body: BroadcastLayoutMsgBody) extends StandardMsg
 case class BroadcastLayoutMsgBody(layout: String, pushLayout: Boolean, presentationIsOpen: Boolean, isResizing: Boolean, cameraPosition: String, focusedCamera: String, presentationVideoRate: Double)
 
-object BroadcastPushLayoutMsg { val NAME = "BroadcastPushLayoutMsg" }
-case class BroadcastPushLayoutMsg(header: BbbClientMsgHeader, body: BroadcastPushLayoutMsgBody) extends StandardMsg
-case class BroadcastPushLayoutMsgBody(pushLayout: Boolean)
-
-// Out messages
-object GetCurrentLayoutRespMsg { val NAME = "GetCurrentLayoutRespMsg" }
-case class GetCurrentLayoutRespMsg(header: BbbClientMsgHeader, body: GetCurrentLayoutRespMsgBody) extends BbbCoreMsg
-case class GetCurrentLayoutRespMsgBody(layout: String, setByUserId: String)
-
 object BroadcastLayoutEvtMsg { val NAME = "BroadcastLayoutEvtMsg" }
 case class BroadcastLayoutEvtMsg(header: BbbClientMsgHeader, body: BroadcastLayoutEvtMsgBody) extends BbbCoreMsg
 case class BroadcastLayoutEvtMsgBody(layout: String, pushLayout: Boolean, presentationIsOpen: Boolean, isResizing: Boolean, cameraPosition: String, focusedCamera: String, presentationVideoRate: Double, setByUserId: String)
 
+object BroadcastPushLayoutMsg { val NAME = "BroadcastPushLayoutMsg" }
+case class BroadcastPushLayoutMsg(header: BbbClientMsgHeader, body: BroadcastPushLayoutMsgBody) extends StandardMsg
+case class BroadcastPushLayoutMsgBody(pushLayout: Boolean)
+
 object BroadcastPushLayoutEvtMsg { val NAME = "BroadcastPushLayoutEvtMsg" }
 case class BroadcastPushLayoutEvtMsg(header: BbbClientMsgHeader, body: BroadcastPushLayoutEvtMsgBody) extends BbbCoreMsg
 case class BroadcastPushLayoutEvtMsgBody(pushLayout: Boolean, setByUserId: String)
+
+object SetScreenshareAsContentReqMsg { val NAME = "SetScreenshareAsContentReqMsg" }
+case class SetScreenshareAsContentReqMsg(header: BbbClientMsgHeader, body: SetScreenshareAsContentReqMsgBody) extends StandardMsg
+case class SetScreenshareAsContentReqMsgBody(screenshareAsContent: Boolean)
+
+object SetScreenshareAsContentEvtMsg { val NAME = "SetScreenshareAsContentEvtMsg" }
+case class SetScreenshareAsContentEvtMsg(header: BbbClientMsgHeader, body: SetScreenshareAsContentEvtMsgBody) extends StandardMsg
+case class SetScreenshareAsContentEvtMsgBody(screenshareAsContent: Boolean)

--- a/bbb-graphql-actions/src/actions/meetingLayoutSetScreenshareAsContent.ts
+++ b/bbb-graphql-actions/src/actions/meetingLayoutSetScreenshareAsContent.ts
@@ -1,0 +1,30 @@
+import { RedisMessage } from '../types';
+import {throwErrorIfInvalidInput, throwErrorIfNotPresenter} from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input,
+      [
+        {name: 'screenshareAsContent', type: 'boolean', required: true},
+      ]
+  )
+
+  const eventName = 'SetScreenshareAsContentReqMsg';
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId
+  };
+
+  const body = {
+    screenshareAsContent: input.screenshareAsContent
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2086,6 +2086,7 @@ CREATE TABLE "layout" (
 	"cameraDockAspectRatio" numeric,
 	"cameraWithFocus" 		varchar(100),
 	"propagateLayout" 		boolean,
+	"screenshareAsContent" 	boolean,
 	"updatedAt" 			timestamp with time zone
 );
 
@@ -2221,6 +2222,13 @@ select "meeting"."meetingId",
             where "v_screenshare"."meetingId" = "meeting"."meetingId"
             and "contentType" = 'screenshare'
         ) as "hasScreenshare",
+        exists (
+            select 1
+            from "v_screenshare"
+            join "v_layout" on "v_layout"."meetingId" = "v_screenshare"."meetingId" and "v_layout"."screenshareAsContent" is true
+            where "v_screenshare"."meetingId" = "meeting"."meetingId"
+            and "contentType" = 'screenshare'
+        ) as "hasScreenshareAsContent",
         exists (
             select 1
             from "v_screenshare"

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -235,6 +235,12 @@ type Mutation {
 }
 
 type Mutation {
+  meetingLayoutSetScreenshareAsContent(
+    screenshareAsContent: Boolean!
+  ): Boolean
+}
+
+type Mutation {
   meetingLayoutSetSyncWithPresenterLayout(
     syncWithPresenterLayout: Boolean!
   ): Boolean

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -215,6 +215,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: meetingLayoutSetScreenshareAsContent
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: meetingLayoutSetSyncWithPresenterLayout
     definition:
       kind: synchronous

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_layout.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_layout.yaml
@@ -17,6 +17,7 @@ select_permissions:
         - currentLayoutType
         - presentationMinimized
         - propagateLayout
+        - screenshareAsContent
         - updatedAt
       filter:
         meetingId:


### PR DESCRIPTION
This PR implements the backend portion of a task that @Tainan404 will work during the Summit in Berlin.
It creates a new flag `layout.screenshareAsContent` which will be used to indicate whether screen share should be shown in presentation area or not.

Mutation (requires presenter status):
```gql
mutation($screenshareAsContent: Boolean!) {
  meetingLayoutSetScreenshareAsContent(screenshareAsContent: $screenshareAsContent)
}
```

Subscriptions:
```gql
subscription {
  layout {
    screenshareAsContent
  }
}
```

```gql
subscription {
  meeting_componentFlags {
    hasScreenshare
    hasScreenshareAsContent
  }
}
```

- `hasScreenshare`: Indicate whether there is some screen share running
- `hasScreenshareAsContent`: Indicate whether there is some screen share running AND the flag `layout.screenshareAsContent` is `true`