### PR TITLE
fix(webcam): broken pagination when using LiveKit

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useEffect, useRef, useCallback } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import {
@@ -213,10 +212,10 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
         }
       });
       delete streamRefs.current.localTracks[stream];
+      delete streamRefs.current.localVideoStreams[stream];
     } else {
       const track = streamRefs.current.remoteTracks[stream];
       if (track) track.detach();
-      delete streamRefs.current.remoteTracks[stream];
     }
   }, [isCameraSource]);
 
@@ -261,7 +260,11 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       name: stream,
     };
 
-    if (!isLocal || !bbbVideoStream) return;
+    if (!isLocal || !bbbVideoStream) {
+      attachLiveKitStream(stream);
+      notifyStreamStateChange(stream, 'completed');
+      return;
+    }
 
     streamRefs.current.connectingStreams[stream] = true;
 
@@ -357,6 +360,8 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
         trackSid: publication.trackSid,
       },
     }, `LiveKit: camera unsubscribed - ${trackSid}`);
+
+    delete streamRefs.current.remoteTracks[stream];
   }, [isCameraSource]);
 
   const handleTrackPublished = useCallback((publication: RemoteTrackPublication) => {


### PR DESCRIPTION
### What does this PR do?

- [fix(webcam): broken pagination when using LiveKit](https://github.com/bigbluebutton/bigbluebutton/commit/6718ab97bb0747914d8bbd9ea768e0188ecd78c3) 
  - Restructuring of how LiveKit's camera bridge works broke the pagination
    feature due to a couple of reasons:
    - Stale remote track references when they were either
      paginated out or unsubscribed from
    - a missing failover stream attachment for when subscriptions happened
      before the bridge component picked the states up

### Closes Issue(s)

None (reported internally)