### PR TITLE
refactor: Replace tokens in the logout url on the server

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -96,6 +96,11 @@ public class ValidationService {
     }
 
     public boolean isValidURL(String url) {
+        // Replace the tokens because they won't validate correctly. 
+        String newUrl = url;
+        newURL = newURL.replace('%%MEETINGID%%', "123");
+        newURL = newURL.replace('%%USERID%%', "456");
+        newURL = newURL.replace('%%USERNAME%%', "John Doe");
         try {
             new URL(url).toURI();
             return true;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -98,11 +98,11 @@ public class ValidationService {
     public boolean isValidURL(String url) {
         // Replace the tokens because they won't validate correctly. 
         String newUrl = url;
-        newURL = newURL.replace('%%MEETINGID%%', "123");
-        newURL = newURL.replace('%%USERID%%', "456");
-        newURL = newURL.replace('%%USERNAME%%', "John Doe");
+        newUrl = newUrl.replace('%%MEETINGID%%', "123");
+        newUrl = newUrl.replace('%%USERID%%', "456");
+        newUrl = newUrl.replace('%%USERNAME%%', "John Doe");
         try {
-            new URL(url).toURI();
+            new URL(newUrl).toURI();
             return true;
         } catch (MalformedURLException | URISyntaxException e) {
             return false;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/ValidationService.java
@@ -98,9 +98,9 @@ public class ValidationService {
     public boolean isValidURL(String url) {
         // Replace the tokens because they won't validate correctly. 
         String newUrl = url;
-        newUrl = newUrl.replace('%%MEETINGID%%', "123");
-        newUrl = newUrl.replace('%%USERID%%', "456");
-        newUrl = newUrl.replace('%%USERNAME%%', "John Doe");
+        newUrl = newUrl.replace("%%MEETINGID%%", "123");
+        newUrl = newUrl.replace("%%USERID%%", "456");
+        newUrl = newUrl.replace("%%USERNAME%%", "John Doe");
         try {
             new URL(newUrl).toURI();
             return true;

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -271,9 +271,6 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
     if (isBreakout) window.close();
     if (allowRedirect) {
       let redirectTo = logoutUrl;
-      redirectTo = redirectTo.replaceAll('%%USERID%%', userId);
-      redirectTo = redirectTo.replaceAll('%%USERNAME%%', userName);
-      redirectTo = redirectTo.replaceAll('%%MEETINGID%%', meetingId);
       if (isURL(redirectTo)) {
         window.location.href = redirectTo;
       }

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -270,9 +270,8 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
   const confirmRedirect = (isBreakout: boolean, allowRedirect: boolean) => {
     if (isBreakout) window.close();
     if (allowRedirect) {
-      let redirectTo = logoutUrl;
-      if (isURL(redirectTo)) {
-        window.location.href = redirectTo;
+      if (isURL(logoutUrl)) {
+        window.location.href = logoutUrl;
       }
     }
   };

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -416,6 +416,8 @@ class ApiController {
       externUserID = internalUserID
     }
 
+    // Get the logoutUrl, either from the meeting or from the join api.
+    // Also replace the tokens.
     String logoutUrl = meeting.getLogoutUrl()
     if(!StringUtils.isEmpty(params.get(ApiParams.LOGOUT_URL))) {
       String userProvidedUrl = params.get(ApiParams.LOGOUT_URL)
@@ -427,6 +429,7 @@ class ApiController {
         log.debug "The following logout URL is present: " + logoutUrl
       }
     }
+    logoutUrl = subLogoutParams(uriString, us.meetingID, us.internalUserId, us.fullname);
 
     //Return a Map with the user custom data
     Map<String, String> userCustomData = meetingService.getUserCustomData(meeting, externUserID, params);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -429,7 +429,7 @@ class ApiController {
         log.debug "The following logout URL is present: " + logoutUrl
       }
     }
-    logoutUrl = subLogoutParams(uriString, us.meetingID, us.internalUserId, us.fullname);
+    logoutUrl = subLogoutParams(logoutUrl, meeting.getInternalId(), internalUserID, fullName);
 
     //Return a Map with the user custom data
     Map<String, String> userCustomData = meetingService.getUserCustomData(meeting, externUserID, params);


### PR DESCRIPTION
### What does this PR do?

Replace the tokens in the logout Url on the server rather than in the client.  This is possible after the implementation of logout url per user (see #21204 and #20285)

### Closes Issue(s)

This is a follow up PR for #20285 

### Motivation

Promised to do this follow up work in the already merged pr #20285 


### How to test

Join a meeting by api, and set a logout url including tokens such as `%%USERID%%`  or `%%MEETINGID%%` or `%%USERNAME%%`

Observe whether the tokens are replaced as soon as you logout of the meeting.
