### PR TITLE
chore: swap positions of thumbs up/down

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -785,10 +785,10 @@ public:
         native: '😐'
       - id: 'slightly_frowning_face'
         native: '🙁'
-      - id: '+1'
-        native: '👍'
       - id: '-1'
         native: '👎'
+      - id: '+1'
+        native: '👍'
       - id: 'clap'
         native: '👏'
   notes:


### PR DESCRIPTION
Thumbs down was between thumbs up and clapping, leading to unintentional misclicks being harsh

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none open.

### Motivation
<!-- What inspired you to submit this pull request? -->
@GuiLeme reported that a mouse slip resulted in clicking :-1: instead of :clap: 
It woube be better to place the :+1: beside the :clap: instead.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

before:
![image](https://github.com/user-attachments/assets/f5ced704-6234-4366-b1bb-990f077331c6)


after:
![Screenshot from 2024-12-03 12-05-56](https://github.com/user-attachments/assets/6f7ec1e2-80cb-4ce4-9453-9743a1eed162)
