### PR TITLE
fix (gql-middleware): Implement reference-counted locks to resolve concurrency issues in global cache

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -56,7 +56,7 @@ object FakeUserGenerator {
     val webcamBackgroundURL = "https://www." + RandomStringGenerator.randomAlphanumericString(32) + ".com/" +
       RandomStringGenerator.randomAlphanumericString(10) + ".jpg"
     val color = "#ff6242"
-    val logoutUrlFormats = Seq(
+     val logoutUrlFormats = Seq(
       s"https://www.${RandomStringGenerator.randomAlphanumericString(32)}.com/logout?user=${RandomStringGenerator.randomAlphanumericString(8)}#section",
       s"http://localhost:8080/logout/${RandomStringGenerator.randomAlphanumericString(8)}",
       s"https://example.com/logout?redirect=${java.net.URLEncoder.encode("https://another-site.com", "UTF-8")}"

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -56,7 +56,7 @@ object FakeUserGenerator {
     val webcamBackgroundURL = "https://www." + RandomStringGenerator.randomAlphanumericString(32) + ".com/" +
       RandomStringGenerator.randomAlphanumericString(10) + ".jpg"
     val color = "#ff6242"
-     val logoutUrlFormats = Seq(
+    val logoutUrlFormats = Seq(
       s"https://www.${RandomStringGenerator.randomAlphanumericString(32)}.com/logout?user=${RandomStringGenerator.randomAlphanumericString(8)}#section",
       s"http://localhost:8080/logout/${RandomStringGenerator.randomAlphanumericString(8)}",
       s"https://example.com/logout?redirect=${java.net.URLEncoder.encode("https://another-site.com", "UTF-8")}"

--- a/bbb-graphql-middleware/internal/common/CustomCache.go
+++ b/bbb-graphql-middleware/internal/common/CustomCache.go
@@ -2,48 +2,63 @@ package common
 
 import (
 	"sync"
-	"time"
 )
 
 var GlobalCacheLocks = NewCacheLocks()
 
+type refMutex struct {
+	mutex    *sync.Mutex
+	refCount int
+}
+
 type CacheLocks struct {
-	locks map[uint32]*sync.Mutex
+	locks map[uint32]*refMutex
 	mutex sync.Mutex // Protects the 'locks' map
 }
 
 func NewCacheLocks() *CacheLocks {
 	return &CacheLocks{
-		locks: make(map[uint32]*sync.Mutex),
+		locks: make(map[uint32]*refMutex),
 	}
 }
 
 func (c *CacheLocks) Lock(id uint32) {
+	var rm *refMutex
+
 	c.mutex.Lock()
-	if _, exists := c.locks[id]; !exists {
-		c.locks[id] = &sync.Mutex{}
+	if existingRm, exists := c.locks[id]; !exists {
+		rm = &refMutex{
+			mutex:    &sync.Mutex{},
+			refCount: 1,
+		}
+		c.locks[id] = rm
+	} else {
+		rm = existingRm
+		rm.refCount++
 	}
-	mtx := c.locks[id]
 	c.mutex.Unlock()
 
-	mtx.Lock() // Lock the specific ID mutex
+	// Lock rm.mutex outside of c.mutex to avoid deadlocks
+	rm.mutex.Lock()
 }
 
 func (c *CacheLocks) Unlock(id uint32) {
-	c.mutex.Lock()
-	if mtx, exists := c.locks[id]; exists {
-		mtx.Unlock()
-		go c.RemoveLockId(id, 30)
-	}
-	c.mutex.Unlock()
-}
-
-func (c *CacheLocks) RemoveLockId(id uint32, delayInSecs time.Duration) {
-	time.Sleep(delayInSecs * time.Second)
+	var rm *refMutex
 
 	c.mutex.Lock()
-	if _, exists := c.locks[id]; exists {
-		delete(c.locks, id)
+	if existingRm, exists := c.locks[id]; exists {
+		rm = existingRm
+		rm.refCount--
+		if rm.refCount == 0 {
+			delete(c.locks, id)
+		}
+	} else {
+		// Handle the case where Unlock is called without a corresponding Lock
+		c.mutex.Unlock()
+		return
 	}
 	c.mutex.Unlock()
+
+	// Unlock rm.mutex outside of c.mutex to avoid deadlocks
+	rm.mutex.Unlock()
 }


### PR DESCRIPTION
We have a global lock mechanism to prevent processing the same message multiple times #19964. Initially, the cache of locks was expected to be needed for at most 30 seconds. However, in high-access scenarios, some messages are taking longer than 30 seconds to arrive and be processed.

This led to a situation where a routine could acquire a lock on an ID at, say, the 30th second and attempt to unlock it later, but the lock would no longer exist because it was removed from the cache after 30 seconds. This caused errors and inconsistent behavior.

**Solution:**

This PR implements a reference counter for each lock to track how many routines are currently using it. Instead of removing locks based on a time threshold, a lock will now only be removed from the cache when all routines have released it. This ensures that locks persist as long as they are needed, preventing premature removal and fixing the issues caused by locks disappearing while still in use.

Fix an issue reported by @schrd:
```
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: fatal error: sync: unlock of unlocked mutex
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: goroutine 118741 [running]:
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: sync.fatal({0x933a7a?, 0x0?})
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]:         /go/src/runtime/panic.go:1007 +0x18
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: sync.(*Mutex).unlockSlow(0xc01ac08788, 0xffffffff)
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]:         /go/src/sync/mutex.go:229 +0x35
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: sync.(*Mutex).Unlock(...)
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]:         /go/src/sync/mutex.go:223
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: bbb-graphql-middleware/internal/common.(*CacheLocks).Unlock(0xce7850, 0x906f9f4)
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]:         /tmp/build/bbb-graphql-middleware_3.0.0~beta.6+20241129T111629-git.local-build-deadc1310b_jammy/internal/common/CustomCache.go:35 +0x85
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: bbb-graphql-middleware/internal/common.GetLastStreamCursorValueFromReceivedMessage({0xc01a2fb800, 0xf5, 0xf5}, {0xc0004a1142, 0xd})
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]:         /tmp/build/bbb-graphql-middleware_3.0.0~beta.6+20241129T111629-git.local-build-deadc1310b_jammy/internal/common/StreamCursorUtils.go:41 +0x235
Dec 03 16:56:33 davis.hrz.tu-chemnitz.de bbb-graphql-middleware[124097]: bbb-graphql-middleware/internal/hasura/conn/reader.handleStreamingMessage(0xc00b8eed40, {0xc01a2fb800?, 0xc004d66380?, 0xc002867cb0?}, {{0xc012ee7a10, 0x24}, {0xc00c1fa3c0, 0x1d1, 0x1e0}, {0x928424, ...}, ...}, ...)
```