### PR TITLE
fix (gql-middleware): Introducing synchronous graphql reconnection endpoint to resolve race condition issues

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -18,6 +18,9 @@ trait SystemConfiguration {
   lazy val bbbWebViewerPassword = Try(config.getString("services.viewerPassword")).getOrElse("changeme")
   lazy val keysExpiresInSec = Try(config.getInt("redis.keyExpiry")).getOrElse(14 * 86400) // 14 days
 
+  // Graphql Middleware API url
+  lazy val graphqlMiddlewareAPI = Try(config.getString("services.graphqlMiddlewareAPI")).getOrElse("http://127.0.0.1:8378")
+
   lazy val expireLastUserLeft = Try(config.getInt("expire.lastUserLeft")).getOrElse(60) // 1 minute
   lazy val expireNeverJoined = Try(config.getInt("expire.neverJoined")).getOrElse(5 * 60) // 5 minutes
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ExternalVideoModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ExternalVideoModel.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.apps
 
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 object ExternalVideoModel {
   def setURL(externalVideoModel: ExternalVideoModel, externalVideoUrl: String) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/PermissionCheck.scala
@@ -2,9 +2,9 @@ package org.bigbluebutton.core.apps
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.core.apps.users.UsersApp
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.Sender
 
 trait RightsManagementTrait extends SystemConfiguration {
   /**
@@ -92,7 +92,7 @@ object PermissionCheck extends SystemConfiguration {
       for {
         regUser <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
       } yield {
-        Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, reason, outGW)
+        GraphqlMiddleware.requestGraphqlReconnection(regUser.sessionToken, reason)
       }
     } else {
       // TODO: get this object a context so it can use the akka logging system

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.core.apps
 
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 object ScreenshareModel {
   def resetDesktopSharingParams(status: ScreenshareModel) = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EjectUserFromBreakoutInternalMsgHdlr.scala
@@ -2,10 +2,10 @@ package org.bigbluebutton.core.apps.breakout
 
 import org.bigbluebutton.core.api.EjectUserFromBreakoutInternalMsg
 import org.bigbluebutton.core.apps.users.UsersApp
-import org.bigbluebutton.core.db.{ BreakoutRoomUserDAO, UserDAO }
+import org.bigbluebutton.core.db.UserDAO
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models.RegisteredUsers
 import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.Sender
 
 trait EjectUserFromBreakoutInternalMsgHdlr {
   this: MeetingActor =>
@@ -33,7 +33,7 @@ trait EjectUserFromBreakoutInternalMsgHdlr {
       UserDAO.softDelete(registeredUser.meetingId, registeredUser.id)
 
       // Force reconnection with graphql to refresh permissions
-      Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, msg.reasonCode, outGW)
+      GraphqlMiddleware.requestGraphqlReconnection(registeredUser.sessionToken, msg.reasonCode)
 
       //send users update to parent meeting
       BreakoutHdlrHelpers.updateParentMeetingWithUsers(liveMeeting, eventBus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/UpdateBreakoutRoomsTimeMsgHdlr.scala
@@ -7,7 +7,7 @@ import org.bigbluebutton.core.bus.BigBlueButtonEvent
 import org.bigbluebutton.core.db.{ BreakoutRoomDAO, MeetingDAO, NotificationDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 import org.bigbluebutton.core.util.TimeUtil
 
 trait UpdateBreakoutRoomsTimeMsgHdlr extends RightsManagementTrait {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
@@ -5,7 +5,6 @@ import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.apps.ScreenshareModel.getRTMPBroadcastingUrl
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core2.message.senders.MsgBuilder
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.broadcastStopped
 import org.bigbluebutton.core.db.ScreenshareDAO
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -11,6 +11,7 @@ import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.requestBroadcastStop
 import org.bigbluebutton.core.db.ChatMessageDAO
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core2.message.senders.Sender
 
 trait AssignPresenterReqMsgHdlr extends RightsManagementTrait {
@@ -88,7 +89,7 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
           for {
             u <- RegisteredUsers.findWithUserId(oldPres.intId, liveMeeting.registeredUsers)
           } yield {
-            Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, oldPres.intId, u.sessionToken, "role_changed", outGW)
+            GraphqlMiddleware.requestGraphqlReconnection(u.sessionToken, "assigned_presenter")
           }
         }
       }
@@ -103,7 +104,7 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
         for {
           u <- RegisteredUsers.findWithUserId(newPres.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, newPres.intId, u.sessionToken, "role_changed", outGW)
+          GraphqlMiddleware.requestGraphqlReconnection(u.sessionToken, "assigned_presenter")
         }
 
         //Chat message to announce new presenter

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -4,12 +4,13 @@ import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.db.{ MeetingLockSettingsDAO, NotificationDAO }
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.OutMsgRouter
 import org.bigbluebutton.core.running.MeetingActor
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.Permissions
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -257,7 +258,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
           if user.role == Roles.VIEWER_ROLE
           regUser <- RegisteredUsers.findWithUserId(user.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "lockSettings_changed", outGW)
+          GraphqlMiddleware.requestGraphqlReconnection(regUser.sessionToken, "lockSettings_changed")
         }
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -7,7 +7,6 @@ import org.bigbluebutton.core.db.ChatMessageDAO
 import org.bigbluebutton.core.models.{ GroupChatFactory, GroupChatMessage, Roles, UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRaiseHandReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRaiseHandReqMsgHdlr.scala
@@ -4,7 +4,6 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.models.{ UserState, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait ChangeUserRaiseHandReqMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -6,7 +6,8 @@ import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.LockSettingsUtil
 import org.bigbluebutton.core.db.NotificationDAO
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>
@@ -76,7 +77,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
         for {
           u <- RegisteredUsers.findWithUserId(uvo.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, uvo.intId, u.sessionToken, "role_changed", outGW)
+          GraphqlMiddleware.requestGraphqlReconnection(u.sessionToken, "role_changed")
         }
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/EjectUserFromMeetingCmdMsgHdlr.scala
@@ -1,12 +1,12 @@
 package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.api.{ EjectUserFromBreakoutInternalMsg }
+import org.bigbluebutton.core.api.EjectUserFromBreakoutInternalMsg
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.Sender
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.BigBlueButtonEvent
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models.{ EjectReasonCode, RegisteredUsers }
 
 trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
@@ -71,7 +71,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
             log.info("Eject user {} userId={} by {} and ban=" + banUser + " in meeting {}", registeredUser.name, userId, ejectedBy, meetingId)
 
             // Force reconnection with graphql to refresh permissions
-            Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, EjectReasonCode.EJECT_USER, outGW)
+            GraphqlMiddleware.requestGraphqlReconnection(registeredUser.sessionToken, EjectReasonCode.EJECT_USER)
           }
         } else {
           // User is ejecting self, so just eject this userid not all sessions if joined using multiple
@@ -88,7 +88,7 @@ trait EjectUserFromMeetingCmdMsgHdlr extends RightsManagementTrait {
           )
 
           // Force reconnection with graphql to refresh permissions
-          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, registeredUser.id, registeredUser.sessionToken, EjectReasonCode.EJECT_USER, outGW)
+          GraphqlMiddleware.requestGraphqlReconnection(registeredUser.sessionToken, EjectReasonCode.EJECT_USER)
         }
 
       }
@@ -122,7 +122,7 @@ trait EjectUserFromMeetingSysMsgHdlr {
     for {
       regUser <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
     } yield {
-      Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, EjectReasonCode.SYSTEM_EJECT_USER, outGW)
+      GraphqlMiddleware.requestGraphqlReconnection(regUser.sessionToken, EjectReasonCode.SYSTEM_EJECT_USER)
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GenerateLiveKitTokenRespMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GenerateLiveKitTokenRespMsgHdlr.scala
@@ -4,7 +4,6 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.models.{ RegisteredUsers, Users2x }
-import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GenerateLiveKitTokenRespMsgHdlr {
   this: BaseMeetingActor =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LockUserInMeetingCmdMsgHdlr.scala
@@ -5,7 +5,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models.{ RegisteredUsers, Users2x, VoiceUsers }
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
-import org.bigbluebutton.core2.message.senders.Sender
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 
 trait LockUserInMeetingCmdMsgHdlr extends RightsManagementTrait {
   this: MeetingActor =>
@@ -44,7 +44,7 @@ trait LockUserInMeetingCmdMsgHdlr extends RightsManagementTrait {
         for {
           u <- RegisteredUsers.findWithUserId(uvo.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, uvo.intId, u.sessionToken, "lock_user_changed", outGW)
+          GraphqlMiddleware.requestGraphqlReconnection(u.sessionToken, "lock_user_changed")
         }
 
         log.info("Lock user.  meetingId=" + props.meetingProp.intId + " userId=" + uvo.intId + " locked=" + uvo.locked)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/MuteUserCmdMsgHdlr.scala
@@ -6,7 +6,6 @@ import org.bigbluebutton.core.apps.voice.VoiceApp
 import org.bigbluebutton.core.models.{ Roles, Users2x, VoiceUsers }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait MuteUserCmdMsgHdlr extends RightsManagementTrait {
   this: UsersApp =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/RegisterUserReqMsgHdlr.scala
@@ -2,10 +2,11 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.db.NotificationDAO
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.util.ColorPicker
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait RegisterUserReqMsgHdlr {
   this: UsersApp =>
@@ -48,7 +49,7 @@ trait RegisterUserReqMsgHdlr {
                 UsersApp.ejectUserFromMeeting(outGW, liveMeeting, userToRemove.id, SystemUser.ID, reason, EjectReasonCode.DUPLICATE_USER, ban = false)
 
                 // Force reconnection with graphql to refresh permissions
-                Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, userToRemove.id, userToRemove.sessionToken, EjectReasonCode.DUPLICATE_USER, outGW)
+                GraphqlMiddleware.requestGraphqlReconnection(userToRemove.sessionToken, EjectReasonCode.DUPLICATE_USER)
               }
           }
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -2,8 +2,9 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserJoinMeetingReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
-import org.bigbluebutton.core.db.{ NotificationDAO, UserDAO, UserStateDAO }
+import org.bigbluebutton.core.db.{NotificationDAO, UserDAO, UserStateDAO}
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running._
 import org.bigbluebutton.core2.message.senders._
@@ -179,7 +180,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
     UserStateDAO.updateExpired(regUser.meetingId, regUser.id, expired = false)
 
   private def forceUserGraphqlReconnection(regUser: RegisteredUser) = {
-    Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "user_joined", outGW)
+    GraphqlMiddleware.requestGraphqlReconnection(regUser.sessionToken, "user_joined")
   }
 
   private def updateGraphqlDatabase(regUser: RegisteredUser) = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserLeaveReqMsgHdlr.scala
@@ -1,11 +1,11 @@
 package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserLeaveReqMsg
-import org.bigbluebutton.core.api.{ UserClosedAllGraphqlConnectionsInternalMsg }
+import org.bigbluebutton.core.api.UserClosedAllGraphqlConnectionsInternalMsg
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models.{ RegisteredUsers, Users2x }
 import org.bigbluebutton.core.running.{ HandlerHelpers, MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.Sender
 
 trait UserLeaveReqMsgHdlr extends HandlerHelpers {
   this: MeetingActor =>
@@ -48,7 +48,7 @@ trait UserLeaveReqMsgHdlr extends HandlerHelpers {
             ru <- RegisteredUsers.findWithUserId(userId, liveMeeting.registeredUsers)
           } yield {
             RegisteredUsers.setUserLoggedOutFlag(liveMeeting.registeredUsers, ru)
-            Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, ru.id, ru.sessionToken, "user_loggedout", outGW)
+            GraphqlMiddleware.requestGraphqlReconnection(ru.sessionToken, "user_loggedout")
           }
         }
         state

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UpdateWebcamsOnlyForModeratorCmdMsgHdlr.scala
@@ -6,7 +6,8 @@ import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.db.{ MeetingUsersPoliciesDAO, NotificationDAO }
 import org.bigbluebutton.core.models.{ RegisteredUsers, Roles, Users2x }
 import org.bigbluebutton.core.running.LiveMeeting
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder, Sender }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 
 trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
   this: WebcamApp2x =>
@@ -87,7 +88,7 @@ trait UpdateWebcamsOnlyForModeratorCmdMsgHdlr {
               if user.role == Roles.VIEWER_ROLE
               regUser <- RegisteredUsers.findWithUserId(user.intId, liveMeeting.registeredUsers)
             } yield {
-              Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, "webcamOnlyForMod_changed", bus.outGW)
+              GraphqlMiddleware.requestGraphqlReconnection(regUser.sessionToken, "webcamOnlyForMod_changed")
             }
           }
           case _ =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/graphql/GraphqlMiddleware.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/graphql/GraphqlMiddleware.scala
@@ -1,0 +1,26 @@
+package org.bigbluebutton.core.graphql
+
+import org.bigbluebutton.SystemConfiguration
+import java.net.URI
+import java.net.http.{ HttpClient, HttpRequest, HttpResponse }
+
+object GraphqlMiddleware extends SystemConfiguration {
+  def requestGraphqlReconnection(sessionTokens: Vector[String], reason: String): Unit = {
+    for {
+      sessionToken <- sessionTokens
+    } yield {
+      val url = s"${graphqlMiddlewareAPI}/graphql-reconnection?sessionToken=$sessionToken&reason=${reason}"
+
+      val client = HttpClient.newHttpClient()
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .GET()
+        .build()
+
+      val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+      if (response.statusCode() != 200) {
+        println(s"Error on requesting graphql reconnection for ${sessionToken}. Response Code: ${response.statusCode()}")
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -36,11 +36,13 @@ import org.apache.pekko.actor.Props
 import org.apache.pekko.actor.OneForOneStrategy
 import org.bigbluebutton.ClientSettings.{ getConfigPropertyValueByPathAsBooleanOrElse, getConfigPropertyValueByPathAsIntOrElse, getConfigPropertyValueByPathAsStringOrElse }
 import org.bigbluebutton.common2.msgs
+
 import scala.concurrent.duration._
 import org.bigbluebutton.core.apps.layout.LayoutApp2x
 import org.bigbluebutton.core.apps.plugin.PluginHdlrs
 import org.bigbluebutton.core.apps.users.ChangeLockSettingsInMeetingCmdMsgHdlr
 import org.bigbluebutton.core.db.{ MeetingDAO, NotificationDAO, TimerDAO, UserStateDAO }
+import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models.VoiceUsers.{ findAllFreeswitchCallers, findAllListenOnlyVoiceUsers }
 import org.bigbluebutton.core.models.Webcams.findAll
 import org.bigbluebutton.core2.MeetingStatus2x.hasAuthedUserJoined
@@ -1175,7 +1177,7 @@ class MeetingActor(
         for {
           regUser <- RegisteredUsers.findWithUserId(u.intId, liveMeeting.registeredUsers)
         } yield {
-          Sender.sendForceUserGraphqlReconnectionSysMsg(liveMeeting.props.meetingProp.intId, regUser.id, regUser.sessionToken, EjectReasonCode.USER_INACTIVITY, outGW)
+          GraphqlMiddleware.requestGraphqlReconnection(regUser.sessionToken, EjectReasonCode.USER_INACTIVITY)
         }
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GetGuestsWaitingApprovalReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/guests/GetGuestsWaitingApprovalReqMsgHdlr.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core2.message.handlers.guests
 import org.bigbluebutton.common2.msgs.GetGuestsWaitingApprovalReqMsg
 import org.bigbluebutton.core.models.GuestsWaiting
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetGuestsWaitingApprovalReqMsgHdlr extends HandlerHelpers {
   this: BaseMeetingActor =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -56,7 +56,7 @@ object FakeUserGenerator {
     val webcamBackgroundURL = "https://www." + RandomStringGenerator.randomAlphanumericString(32) + ".com/" +
       RandomStringGenerator.randomAlphanumericString(10) + ".jpg"
     val color = "#ff6242"
-     val logoutUrlFormats = Seq(
+    val logoutUrlFormats = Seq(
       s"https://www.${RandomStringGenerator.randomAlphanumericString(32)}.com/logout?user=${RandomStringGenerator.randomAlphanumericString(8)}#section",
       s"http://localhost:8080/logout/${RandomStringGenerator.randomAlphanumericString(8)}",
       s"https://example.com/logout?redirect=${java.net.URLEncoder.encode("https://another-site.com", "UTF-8")}"

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -66,6 +66,7 @@ services {
   bbbWebAPI = "https://192.168.23.33/bigbluebutton/api"
   sharedSecret = "changeme"
   checkSumAlgorithmForBreakouts = "sha256"
+  graphqlMiddlewareAPI = "http://127.0.0.1:8378"
 }
 
 eventBus {

--- a/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
+++ b/bbb-graphql-middleware/cmd/bbb-graphql-middleware/main.go
@@ -44,7 +44,7 @@ func main() {
 	go websrv.InvalidateIdleBrowserConnectionsRoutine()
 
 	// Websocket listener
-	
+
 	rateLimiter := common.NewCustomRateLimiter(cfg.Server.MaxConnectionsPerSecond)
 	http.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
 		ctx, cancel := context.WithTimeout(r.Context(), 120*time.Second)
@@ -64,6 +64,8 @@ func main() {
 
 		websrv.ConnectionHandler(w, r)
 	})
+
+	http.HandleFunc("/graphql-reconnection", websrv.ReconnectionHandler)
 
 	// Add Prometheus metrics endpoint
 	http.Handle("/metrics", promhttp.Handler())

--- a/bbb-graphql-middleware/internal/websrv/reconnectionHandler.go
+++ b/bbb-graphql-middleware/internal/websrv/reconnectionHandler.go
@@ -1,0 +1,25 @@
+package websrv
+
+import (
+	log "github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func ReconnectionHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	sessionToken := r.URL.Query().Get("sessionToken")
+	if sessionToken == "" {
+		http.Error(w, "Missing 'sessionToken' parameter", http.StatusBadRequest)
+		return
+	}
+
+	reason := r.URL.Query().Get("reason")
+
+	log.Debugf("Reconnection request received for sessionToken: %s, reason: %s", sessionToken, reason)
+
+	go InvalidateSessionTokenHasuraConnections(sessionToken)
+}


### PR DESCRIPTION
Currently, when a user joins, changes roles, becomes a presenter, or leaves, Akka-Apps:
1. Updates the database.
2. Sends a Redis message to `graphql-middleware` to invalidate and restart the GraphQL connection with Hasura.  
   
This ensures the connection reflects the new session variables (e.g., role changes). However, the current approach is asynchronous and does not guarantee that the GraphQL connection will restart before the client receives the new status and begins sending queries with expectations of the updated role.  

In cases where the server is slow, this creates a race condition where the client queries using outdated session variables.

#### Solution
This PR introduces a new synchronous HTTP endpoint in `graphql-middleware` to manage GraphQL reconnections. The new flow ensures Akka-Apps can:
1. Request `graphql-middleware` to restart the GraphQL connection via the HTTP endpoint.
2. Wait for confirmation of the connection restart.
3. Update the database and notify the client of the new status/role.

The synchronous nature of HTTP requests resolves the race condition issue because it guarantees the GraphQL connection is updated before the client acts on the new status.

#### Implementation
- **New Endpoint**:  
  URL: `http://127.0.0.1:8378/graphql-reconnection`  
  Parameters:  
  - `sessionToken`: Identifies the session to reconnect.
  - `reason`: Explains why the reconnection is required (e.g., `user_joined`).

#### Example Request
```http
GET http://127.0.0.1:8378/graphql-reconnection?sessionToken=123&reason=user_joined
```

----
This change mainly addresses the `/join` flow and resolves the race condition issue highlighted during stress tests conducted by @schrd and @TiagoJacobs.