### PR TITLE
docs: add note on LiveKit + Node.js 22

### DIFF
--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -192,6 +192,10 @@ To enable support for LiveKit:
   - Install bbb-livekit: `$ sudo apt-get install bbb-livekit`
   - Enable the LiveKit controller module in bbb-webrtc-sfu: `$ sudo yq -i '.livekit.enabled = true' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
   - Restart bbb-webrtc-sfu: `$ sudo systemctl restart bbb-webrtc-sfu`
+  - Guarantee that Node.js 22 is installed in your server: `$ node -v`
+    - Older 3.0 installations might still be using Node.js 18. If that's the case,
+      re-run bbb-install or correct any custom installation scripts to ensure
+      Node.js 22 is installed.
 
 Once enabled, LiveKit still won't be used by default. There are two ways to make
 use of it in meetings:


### PR DESCRIPTION
### What does this PR do?

- [docs: add note on LiveKit + Node.js 22](https://github.com/bigbluebutton/bigbluebutton/commit/6dd7f874a11920ade7096cbfd491f4e8d1729541) 
  - Older 3.0 installations might still be using Node.js 18. LiveKit's
    controller module requires Node.js 22. Add an extra step to remind users
    to check their Node.js version before trying out LiveKit.

### Closes Issue(s)

None