### PR TITLE
bbb-web: Improve `getJoinUrl` by supporting `enforceLayout` and `userdata-*` params

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetUserApiMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetUserApiMsgHdlr.scala
@@ -16,14 +16,14 @@ trait GetUserApiMsgHdlr extends HandlerHelpers {
     RegisteredUsers.findWithSessionToken(msg.sessionToken, liveMeeting.registeredUsers) match {
       case Some(regUser) =>
         log.debug("replying GetUserApiMsg with success")
-        actorRef ! ApiResponseSuccess("User found!", UserInfosApiMsg(getUserInfoResponse(regUser)))
+        actorRef ! ApiResponseSuccess("User found!", UserInfosApiMsg(getUserInfoResponse(regUser, msg.sessionToken)))
       case None =>
         log.debug("User not found, sending failure message")
         actorRef ! ApiResponseFailure("User not found", "user_not_found", Map())
     }
   }
 
-  private def getUserInfoResponse(regUser: RegisteredUser): Map[String, Any] = {
+  private def getUserInfoResponse(regUser: RegisteredUser, sessionToken: String): Map[String, Any] = {
     val isModerator = (regUser.role == Roles.MODERATOR_ROLE)
     val isLocked = Users2x.findWithIntId(liveMeeting.users2x, regUser.id).exists(u => u.locked)
     val userStateExists = Users2x.findWithIntId(liveMeeting.users2x, regUser.id).nonEmpty
@@ -40,7 +40,7 @@ trait GetUserApiMsgHdlr extends HandlerHelpers {
     userInfos += ("internalUserID" -> regUser.id)
     userInfos += ("currentlyInMeeting" -> currentlyInMeeting)
     userInfos += ("authToken" -> regUser.authToken)
-    userInfos += ("sessionToken" -> regUser.sessionToken)
+    userInfos += ("sessionToken" -> sessionToken)
     userInfos += ("role" -> regUser.role)
     userInfos += ("guest" -> regUser.guest)
     userInfos += ("guestStatus" -> regUser.guestStatus)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -92,11 +92,11 @@ object UserDAO {
     )
 
     UserConnectionStatusDAO.insert(meetingId, regUser.id)
-    UserMetadataDAO.insert(meetingId, regUser.id, regUser.userMetadata)
+    UserMetadataDAO.insert(meetingId, regUser.id, "", regUser.userMetadata)
     UserLockSettingsDAO.insertOrUpdate(meetingId, regUser.id, UserLockSettings())
     UserClientSettingsDAO.insertOrUpdate(meetingId, regUser.id, JsonUtils.stringToJson("{}"))
     ChatUserDAO.insertUserPublicChat(meetingId, regUser.id)
-    UserSessionTokenDAO.insert(regUser.meetingId, regUser.id, regUser.sessionToken.head, enforceLayout = "")
+    UserSessionTokenDAO.insert(regUser.meetingId, regUser.id, regUser.sessionToken.head, sessionName = "", regUser.enforceLayout)
   }
 
   def update(regUser: RegisteredUser) = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserMetadata.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserMetadata.scala
@@ -4,23 +4,25 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{ ProvenShape }
 
 case class UserMetadataDbModel(
-    meetingId: String,
-    userId:    String,
-    parameter: String,
-    value:     String
+    meetingId:    String,
+    userId:       String,
+    sessionToken: String,
+    parameter:    String,
+    value:        String
 )
 
 class UserMetadataDbTableDef(tag: Tag) extends Table[UserMetadataDbModel](tag, "user_metadata") {
   val meetingId = column[String]("meetingId", O.PrimaryKey)
   val userId = column[String]("userId", O.PrimaryKey)
+  val sessionToken = column[String]("sessionToken", O.PrimaryKey)
   val parameter = column[String]("parameter", O.PrimaryKey)
   val value = column[String]("value")
 
-  override def * : ProvenShape[UserMetadataDbModel] = (meetingId, userId, parameter, value) <> (UserMetadataDbModel.tupled, UserMetadataDbModel.unapply)
+  override def * : ProvenShape[UserMetadataDbModel] = (meetingId, userId, sessionToken, parameter, value) <> (UserMetadataDbModel.tupled, UserMetadataDbModel.unapply)
 }
 
 object UserMetadataDAO {
-  def insert(meetingId: String, userId: String, userMetadata: Map[String, String]) = {
+  def insert(meetingId: String, userId: String, sessionToken: String, userMetadata: Map[String, String]) = {
     DatabaseConnection.enqueue(DBIO.sequence(
       for {
         metadata <- userMetadata
@@ -29,6 +31,7 @@ object UserMetadataDAO {
           UserMetadataDbModel(
             meetingId = meetingId,
             userId = userId,
+            sessionToken = sessionToken,
             parameter = metadata._1,
             value = metadata._2
           )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserSessionTokenDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserSessionTokenDAO.scala
@@ -5,6 +5,7 @@ case class UserSessionTokenDbModel (
                                      meetingId:               String,
                                      userId:                  String,
                                      sessionToken:            String,
+                                     sessionName:             Option[String],
                                      enforceLayout:           Option[String],
                                      createdAt:               java.sql.Timestamp,
                                      removedAt:               Option[java.sql.Timestamp],
@@ -12,24 +13,29 @@ case class UserSessionTokenDbModel (
 
 class UserSessionTokenDbTableDef(tag: Tag) extends Table[UserSessionTokenDbModel](tag, None, "user_sessionToken") {
   override def * = (
-    meetingId, userId, sessionToken, enforceLayout, createdAt, removedAt
+    meetingId, userId, sessionToken, sessionName, enforceLayout, createdAt, removedAt
   ) <> (UserSessionTokenDbModel.tupled, UserSessionTokenDbModel.unapply)
   val meetingId = column[String]("meetingId", O.PrimaryKey)
   val userId = column[String]("userId", O.PrimaryKey)
   val sessionToken = column[String]("sessionToken", O.PrimaryKey)
+  val sessionName = column[Option[String]]("sessionName")
   val enforceLayout = column[Option[String]]("enforceLayout")
   val createdAt = column[java.sql.Timestamp]("createdAt")
   val removedAt = column[Option[java.sql.Timestamp]]("removedAt")
 }
 
 object UserSessionTokenDAO {
-  def insert(meetingId: String, userId: String, sessionToken: String, enforceLayout: String) = {
+  def insert(meetingId: String, userId: String, sessionToken: String, sessionName: String, enforceLayout: String) = {
     DatabaseConnection.enqueue(
       TableQuery[UserSessionTokenDbTableDef].insertOrUpdate(
         UserSessionTokenDbModel(
           meetingId = meetingId,
           userId = userId,
           sessionToken = sessionToken,
+          sessionName = sessionName match {
+            case "" => None
+            case sessionName => Some(sessionName)
+          },
           enforceLayout = enforceLayout match {
             case "" => None
             case enforceLayout => Some(enforceLayout)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -220,10 +220,11 @@ object RegisteredUsers {
     u
   }
 
-  def addUserSessionToken(users: RegisteredUsers, user: RegisteredUser, newSessionToken: String, enforceLayout: String): RegisteredUser = {
+  def addUserSessionToken(users: RegisteredUsers, user: RegisteredUser, newSessionToken: String, newSessionName: String,
+                          enforceLayout: String): RegisteredUser = {
     val u = user.copy(sessionToken = user.sessionToken :+ newSessionToken)
     users.save(u)
-    UserSessionTokenDAO.insert(u.meetingId, u.id, newSessionToken, enforceLayout)
+    UserSessionTokenDAO.insert(u.meetingId, u.id, newSessionToken, newSessionName, enforceLayout)
     u
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/UserInfoService.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/service/UserInfoService.scala
@@ -33,6 +33,7 @@ class UserInfoService(system: ActorSystem, bbbActor: ActorRef) {
     val infos = userInfos.infos
     val meetingID = infos.getOrElse("meetingID", "").toString
     val userId = infos.getOrElse("internalUserID", "").toString
+    val sessionToken = infos.getOrElse("sessionToken", "").toString
 
     def conditionalValue(key: String, defaultValueTrue: String, defaultValueFalse: String): String = {
       infos.get(key) match {
@@ -49,6 +50,7 @@ class UserInfoService(system: ActorSystem, bbbActor: ActorRef) {
         "X-Hasura-PresenterInMeeting" -> conditionalValue("presenter", meetingID, ""),
         "X-Hasura-UserId" -> userId,
         "X-Hasura-MeetingId" -> meetingID,
+        "X-Hasura-SessionToken" -> sessionToken,
         "X-Hasura-CursorNotLockedInMeeting" -> conditionalValue("hideViewersCursor", "", meetingID),
         "X-Hasura-CursorLockedUserId" -> conditionalValue("hideViewersCursor", userId, ""),
         "X-Hasura-AnnotationsNotLockedInMeeting" -> conditionalValue("hideViewersAnnotation", "", meetingID),
@@ -65,6 +67,7 @@ class UserInfoService(system: ActorSystem, bbbActor: ActorRef) {
         "X-Hasura-PresenterInMeeting" -> conditionalValue("presenter", meetingID, ""),
         "X-Hasura-UserId" -> userId,
         "X-Hasura-MeetingId" -> meetingID,
+        "X-Hasura-SessionToken" -> sessionToken,
       )
     }
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -28,6 +28,7 @@ case class RegisterUserSessionTokenReqMsgBody(
     meetingId:           String,
     userId:              String,
     sessionToken:        String,
+    sessionName:         String,
     replaceSessionToken: String,
     enforceLayout:       String,
     userSessionMetadata: Map[String, String]

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -154,12 +154,14 @@ public class MeetingService implements MessageListener {
           String meetingID,
           String internalUserId,
           String sessionToken,
+          String sessionName,
           String replaceSessionToken,
           String enforceLayout,
           Map<String, String> userSessionMetadata
   ) {
     handle(
-            new RegisterUserSessionToken(meetingID, internalUserId, sessionToken, replaceSessionToken, enforceLayout, userSessionMetadata)
+            new RegisterUserSessionToken(meetingID, internalUserId, sessionToken, sessionName,
+                    replaceSessionToken, enforceLayout, userSessionMetadata)
     );
   }
 
@@ -605,7 +607,7 @@ public class MeetingService implements MessageListener {
   }
 
   private void processRegisterUserSessionToken(RegisterUserSessionToken message) {
-    gw.registerUserSessionToken(message.meetingID, message.internalUserId, message.sessionToken,
+    gw.registerUserSessionToken(message.meetingID, message.internalUserId, message.sessionToken, message.sessionName,
             message.replaceSessionToken, message.enforceLayout, message.userSessionMetadata);
   }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSession.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/UserSession.java
@@ -43,6 +43,7 @@ public class UserSession {
   public String logoutUrl = null;
   public String defaultLayout = "NOLAYOUT";
   public String enforceLayout = "";
+  public String sessionName = "";
   public String avatarURL;
   public String webcamBackgroundURL;
   public String guestStatus = GuestPolicy.ALLOW;
@@ -135,6 +136,10 @@ public class UserSession {
 
   public String getEnforceLayout() {
     return enforceLayout;
+  }
+
+  public String getSessionName() {
+    return sessionName;
   }
 
   public String getAvatarURL() {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/RegisterUserSessionToken.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/RegisterUserSessionToken.java
@@ -7,6 +7,7 @@ public class RegisterUserSessionToken implements IMessage {
     public final String meetingID;
     public final String internalUserId;
     public final String sessionToken;
+    public final String sessionName;
     public final String replaceSessionToken;
     public final String enforceLayout;
     public final Map<String, String> userSessionMetadata;
@@ -14,6 +15,7 @@ public class RegisterUserSessionToken implements IMessage {
     public RegisterUserSessionToken(String meetingID,
                                     String internalUserId,
                                     String sessionToken,
+                                    String sessionName,
                                     String replaceSessionToken,
                                     String enforceLayout,
                                     Map<String, String> userSessionMetadata
@@ -21,6 +23,7 @@ public class RegisterUserSessionToken implements IMessage {
         this.meetingID = meetingID;
         this.internalUserId = internalUserId;
         this.sessionToken = sessionToken;
+        this.sessionName = sessionName;
         this.replaceSessionToken = replaceSessionToken;
         this.enforceLayout = enforceLayout;
         this.userSessionMetadata = userSessionMetadata;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -79,7 +79,7 @@ public interface IBbbWebApiGWApp {
                     String externUserID, String authToken, String sessionToken, String avatarURL, String webcamBackgroundURL,
                     Boolean bot, Boolean guest, Boolean authed, String guestStatus, Boolean excludeFromDashboard,
                     String enforceLayout, String logoutUrl, Map<String, String> userMetadata);
-  void registerUserSessionToken(String meetingID, String internalUserId, String sessionToken,
+  void registerUserSessionToken(String meetingID, String internalUserId, String sessionToken, String sessionName,
                                 String replaceSessionToken, String enforceLayout, Map<String, String> userSessionMetadata);
 
   void destroyMeeting(DestroyMeetingMessage msg);

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -318,10 +318,18 @@ class BbbWebApiGWApp(
     msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))
   }
 
-  def registerUserSessionToken(meetingId: String, intUserId: String, sessionToken: String, replaceSessionToken: String,
-                               enforceLayout: String, userSessionMetadata: java.util.Map[String, String]): Unit = {
-    val regUserSessionToken = new RegisterUserSessionToken(meetingId, intUserId, sessionToken, replaceSessionToken,
-                                                            enforceLayout, userSessionMetadata)
+  def registerUserSessionToken(meetingId: String, intUserId: String, sessionToken: String, sessionName: String,
+                               replaceSessionToken: String, enforceLayout: String,
+                               userSessionMetadata: java.util.Map[String, String]): Unit = {
+    val regUserSessionToken = new RegisterUserSessionToken(
+      meetingId,
+      intUserId,
+      sessionToken,
+      sessionName,
+      replaceSessionToken,
+      enforceLayout,
+      userSessionMetadata
+    )
 
     val event = MsgBuilder.buildRegisterUserSessionTokenRequestToAkkaApps(regUserSessionToken)
     msgToAkkaAppsEventBus.publish(MsgToAkkaApps(toAkkaAppsChannel, event))

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -72,6 +72,7 @@ object MsgBuilder {
       meetingId = msg.meetingID,
       userId = msg.internalUserId,
       sessionToken = msg.sessionToken,
+      sessionName = msg.sessionName,
       replaceSessionToken = msg.replaceSessionToken,
       enforceLayout = msg.enforceLayout,
       userSessionMetadata = msg.userSessionMetadata.asScala.toMap

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -573,19 +573,72 @@ AS SELECT
 FROM "user"
 where "firstJoinedAt" is not null;
 
+CREATE TABLE "user_sessionToken" (
+	"meetingId" varchar(100),
+	"userId" varchar(50),
+	"sessionToken" varchar(16),
+	"sessionName" varchar(255),
+	"enforceLayout" varchar(50),
+	"createdAt" timestamp with time zone not null default current_timestamp,
+	"removedAt" timestamp with time zone,
+	CONSTRAINT "user_sessionToken_pk" PRIMARY KEY ("meetingId", "userId","sessionToken"),
+	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
+);
+
+CREATE INDEX "idx_user_sessionToken_stk" ON "user_sessionToken"("sessionToken");
+
+create view "v_user_sessionToken" as select * from "user_sessionToken";
+create view "v_user_session_current" as select * from "user_sessionToken";
+
+CREATE TABLE "user_graphqlConnection" (
+	"graphqlConnectionId" serial PRIMARY KEY,
+	"sessionToken" varchar(16),
+	"clientSessionUUID" varchar(36),
+	"clientType" varchar(50),
+	"clientIsMobile" bool,
+	"middlewareUID" varchar(36),
+	"middlewareConnectionId" varchar(12),
+	"establishedAt" timestamp with time zone,
+	"closedAt" timestamp with time zone
+);
+
+CREATE INDEX "idx_user_graphqlConnectionSessionToken" ON "user_graphqlConnection"("sessionToken");
+
+create view "v_user_session" as
+select ust."meetingId", ust."userId", ust."sessionToken", ust."sessionName", ust."enforceLayout", count(ugc."graphqlConnectionId") as "connectionsAlive"
+from "user_sessionToken" ust
+left join "user_graphqlConnection" ugc on ugc."sessionToken" = ust."sessionToken" and ugc."closedAt" is null
+where ust."removedAt" is null
+group by ust."meetingId", ust."userId", ust."sessionToken", ust."sessionName", ust."enforceLayout";
+
+--TODO create indexes for this view
+
 create table "user_metadata"(
     "meetingId" varchar(100),
     "userId" varchar(50),
+    "sessionToken" varchar(16),
 	"parameter" varchar(255),
 	"value" varchar(1000),
-	CONSTRAINT "user_metadata_pkey" PRIMARY KEY ("meetingId", "userId","parameter"),
+	CONSTRAINT "user_metadata_pkey" PRIMARY KEY ("meetingId", "userId", "sessionToken", "parameter"),
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 create index "idx_user_metadata_pk_reverse" on "user_metadata" ("userId", "meetingId");
+create index "idx_user_metadata_sessionToken" on "user_metadata" ("meetingId", "userId", "sessionToken");
 
 CREATE VIEW "v_user_metadata" AS
-SELECT *
-FROM "user_metadata";
+SELECT DISTINCT ON (ust."sessionToken", ust."meetingId", ust."userId", umd."parameter")
+    ust."sessionToken",
+    ust."meetingId",
+    ust."userId",
+    umd."parameter",
+    umd."value"
+FROM "user_sessionToken" ust
+JOIN "user_metadata" umd
+    ON umd."meetingId" = ust."meetingId"
+    AND umd."userId" = ust."userId"
+    AND (umd."sessionToken" = '' OR umd."sessionToken" = ust."sessionToken")
+    --show params specific for a sessionToken first and generic (with empty sessionToken) last
+ORDER BY ust."sessionToken", ust."meetingId", ust."userId", umd."parameter", umd."sessionToken" = '';
 
 CREATE VIEW "v_user_welcomeMsgs" AS
 SELECT
@@ -846,34 +899,6 @@ LEFT JOIN "user_connectionStatusMetrics" csm ON csm."meetingId" = u."meetingId" 
 GROUP BY u."meetingId", u."userId";
 
 CREATE INDEX "idx_user_connectionStatusMetrics_UnstableReport" ON "user_connectionStatusMetrics" ("meetingId", "userId") WHERE "status" != 'normal';
-
-CREATE TABLE "user_sessionToken" (
-	"meetingId" varchar(100),
-	"userId" varchar(50),
-	"sessionToken" varchar(16),
-	"enforceLayout" varchar(50),
-	"createdAt" timestamp with time zone not null default current_timestamp,
-	"removedAt" timestamp with time zone,
-	CONSTRAINT "user_sessionToken_pk" PRIMARY KEY ("meetingId", "userId","sessionToken"),
-	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
-);
-
-CREATE INDEX "idx_user_sessionToken_stk" ON "user_sessionToken"("sessionToken");
-create view "v_user_sessionToken" as select * from "user_sessionToken";
-
-CREATE TABLE "user_graphqlConnection" (
-	"graphqlConnectionId" serial PRIMARY KEY,
-	"sessionToken" varchar(16),
-	"clientSessionUUID" varchar(36),
-	"clientType" varchar(50),
-	"clientIsMobile" bool,
-	"middlewareUID" varchar(36),
-	"middlewareConnectionId" varchar(12),
-	"establishedAt" timestamp with time zone,
-	"closedAt" timestamp with time zone
-);
-
-CREATE INDEX "idx_user_graphqlConnectionSessionToken" ON "user_graphqlConnection"("sessionToken");
 
 --ALTER TABLE "user_connectionStatus" ADD COLUMN "applicationRttInMs" NUMERIC GENERATED ALWAYS AS
 --(CASE WHEN  "connectionAliveAt" IS NULL OR "userClientResponseAt" IS NULL THEN NULL

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -52,6 +52,16 @@ object_relationships:
         remote_table:
           name: v_meeting
           schema: public
+  - name: sessionCurrent
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_session_current
+          schema: public
   - name: sharedNotesSession
     using:
       manual_configuration:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session.yaml
@@ -1,0 +1,23 @@
+table:
+  name: v_user_session
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_session
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - connectionsAlive
+        - enforceLayout
+        - sessionName
+        - sessionToken
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - userId:
+              _eq: X-Hasura-UserId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session_current.yaml
@@ -1,17 +1,18 @@
 table:
-  name: v_user_metadata
+  name: v_user_session_current
   schema: public
 configuration:
   column_config: {}
   custom_column_names: {}
-  custom_name: user_metadata
+  custom_name: user_session_current
   custom_root_fields: {}
 select_permissions:
   - role: bbb_client
     permission:
       columns:
-        - parameter
-        - value
+        - enforceLayout
+        - sessionName
+        - sessionToken
       filter:
         _and:
           - meetingId:
@@ -20,15 +21,4 @@ select_permissions:
               _eq: X-Hasura-UserId
           - sessionToken:
               _eq: X-Hasura-SessionToken
-  - role: bbb_client_not_in_meeting
-    permission:
-      columns:
-        - parameter
-        - value
-      filter:
-        _and:
-          - meetingId:
-              _eq: X-Hasura-MeetingId
-          - userId:
-              _eq: X-Hasura-UserId
     comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -60,6 +60,8 @@
 - "!include public_v_user_presenceLog.yaml"
 - "!include public_v_user_reaction.yaml"
 - "!include public_v_user_ref.yaml"
+- "!include public_v_user_session.yaml"
+- "!include public_v_user_session_current.yaml"
 - "!include public_v_user_transcriptionError.yaml"
 - "!include public_v_user_typing_private.yaml"
 - "!include public_v_user_typing_public.yaml"

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -68,6 +68,10 @@ export interface userLockSettings {
   disablePublicChat: boolean;
 }
 
+export interface sessionCurrent {
+  enforceLayout: boolean;
+}
+
 export interface Livekit {
   livekitToken: string;
 }
@@ -85,7 +89,6 @@ export interface User {
   ejectReason: string;
   ejectReasonCode: string;
   ejected: boolean;
-  enforceLayout: boolean;
   role: string;
   color: string;
   avatar: string;
@@ -119,5 +122,6 @@ export interface User {
   raiseHand: boolean;
   breakoutRooms: BreakoutRooms;
   userLockSettings: userLockSettings;
+  sessionCurrent: sessionCurrent;
   livekit?: Livekit;
 }

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -358,7 +358,7 @@ const PushLayoutEngineContainer = (props) => {
   const { isOpen: presentationIsOpen } = presentationInput;
 
   const { data: currentUserData } = useCurrentUser((user) => ({
-    enforceLayout: user.enforceLayout,
+    enforceLayout: user.sessionCurrent.enforceLayout,
     isModerator: user.isModerator,
     presenter: user.presenter,
   }));

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -13,7 +13,6 @@ subscription userCurrentSubscription {
     ejectReasonCode
     ejected
     reactionEmoji
-    enforceLayout
     extId
     guest
     guestStatus
@@ -73,6 +72,9 @@ subscription userCurrentSubscription {
     }
     userLockSettings {
       disablePublicChat
+    }
+    sessionCurrent {
+      enforceLayout
     }
     livekit {
       livekitToken

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -630,20 +630,24 @@ class ApiController {
       us.enforceLayout = params.enforceLayout;
     }
 
+    if (!StringUtils.isEmpty(params.sessionName)) {
+      us.sessionName = params.sessionName;
+    }
+
     //used to drop the previous session of the user
     String replaceSessionToken = ""
     if (!StringUtils.isEmpty(params.replaceSessionToken)) {
       replaceSessionToken = params.replaceSessionToken;
     }
 
-    //TODO parse user-session-metadata
-    Map<String, String> userSessionCustomData = new LinkedHashMap<String, String>()
+    Map<String, String> userSessionCustomData = paramsProcessorUtil.getUserCustomData(params)
 
     // Register a new session token to the user
     meetingService.registerUserSession(
             us.meetingID,
             us.internalUserId,
             sessionToken,
+            us.sessionName,
             replaceSessionToken,
             us.enforceLayout,
             userSessionCustomData
@@ -1193,12 +1197,18 @@ class ApiController {
         queryParameters.put("redirect", "true");
         queryParameters.put("existingUserID", us.getInternalUserId());
 
-        // revokePreviousSession: If this link is intended to replace the previous session of the user
+        // replaceSession: If this link is intended to replace the previous session of the user
         if (!StringUtils.isEmpty(params.replaceSession) && Boolean.parseBoolean(params.replaceSession)) {
           queryParameters.put("replaceSessionToken", sessionToken);
         }
 
-        // TODO allow to specify enforceLayout and user-session-data
+        // If the user calling getJoinUrl is a moderator (except in breakout rooms), allow to specify additional parameters
+        if (us.role.equals(ROLE_MODERATOR) && !meeting.isBreakout()) {
+          request.getParameterMap()
+                  .findAll { key, value -> ["enforceLayout","sessionName"].contains(key) || key.startsWith("userdata-") }
+                  .findAll { key, value -> !StringUtils.isEmpty(value[-1]) }
+                  .each { key, value -> queryParameters.put(key, value[-1]) };
+        }
 
         String httpQueryString = "";
         for(String parameterName : queryParameters.keySet()) {


### PR DESCRIPTION
This PR adds new parameters to the `/getJoinUrl` API, restoring some functionality from the previous 2.7 version. 

Previously, certain user properties could be adjusted via `getJoinUrl`. However, after internal discussions, we decided on a different approach. Instead of altering user properties like name directly, users can now "clone" themselves by generating a new `sessionToken` associated with the same `userId`. This ensures that the new session will appear as the same user in the user list, maintaining the correct user count. As a result, it's no longer possible to change the user’s properties after the session is created.

With this PR, the following parameters can be passed to `/getJoinUrl` for a specific session:

- `enforceLayout`
- Any parameter prefixed with `userdata-*`
- `sessionName`: This helps specify the purpose of a particular session, enabling plugins to differentiate between multiple sessions owned by the same user.

_PS: Parameters supported only for moderators_


## Graphql subscriptions:

### Now the enforce layout is part of the session:
```gql
subscription {
  user_current {
    name 
    sessionCurrent {
      enforceLayout
    }
  }
}
```

```json
{
  "data": {
    "user_current": [
      {
        "name": "teacher 1",
        "sessionCurrent": {
          "enforceLayout": "CUSTOM_LAYOUT"
        }
      }
    ]
  }
}
```

### List the sessions of the user
```gql
subscription {
  user_session {
    connectionsAlive
    enforceLayout
    sessionName
    sessionToken
  }
}
```

```json
{
  "data": {
    "user_session": [
      {
        "connectionsAlive": 1,
        "enforceLayout": "CUSTOM_LAYOUT",
        "sessionName": "Session with custom layout",
        "sessionToken": "3c5y78inv65hfdbq"
      },
      {
        "connectionsAlive": 1,
        "enforceLayout": "PRESENTATION_ONLY",
        "sessionName": null,
        "sessionToken": "7ir52gn4vjkbl64a"
      },
      {
        "connectionsAlive": 1,
        "enforceLayout": "VIDEO_FOCUS",
        "sessionName": "Session with focus on video",
        "sessionToken": "dnvjlmcti0cfbplv"
      },
      {
        "connectionsAlive": 1,
        "enforceLayout": "PRESENTATION_ONLY",
        "sessionName": "Session with focus on presention",
        "sessionToken": "p3qbrm4ofciog1db"
      }
    ]
  }
}
```

### Count number of active sessions 
Aim to replace https://github.com/bigbluebutton/bigbluebutton-room-media-connector/blob/main/appliance-application/packages/main/src/bbb-meeting.ts#L56
```gql
subscription {
  user_session_aggregate(where: {connectionsAlive: {_gt: "0"}}) {
    aggregate {
      count
    }
  }
}
```

```json
{
  "data": {
    "user_session_aggregate": {
      "aggregate": {
        "count": 2
      }
    }
  }
}
```

[Screencast from 2024-12-05 22-34-25.webm](https://github.com/user-attachments/assets/5f90a76a-8cfc-4897-be42-6ee4198ebfd6)


Related: #21102
Closes: #21831

A subsequent PR will include the Docs for this endpoint.