### PR TITLE
gql-server: Allow aggregation queries for graphql Type `user_session`

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session.yaml
@@ -20,4 +20,5 @@ select_permissions:
               _eq: X-Hasura-MeetingId
           - userId:
               _eq: X-Hasura-UserId
+      allow_aggregations: true
     comment: ""


### PR DESCRIPTION
Add aggregate permission for Type `user_session`, that was missing on #21836 .


```gql
subscription {
  user_session_aggregate(where: {connectionsAlive: {_gt: "0"}}) {
    aggregate {
      count
    }
  }
}
```

```json
{
  "data": {
    "user_session_aggregate": {
      "aggregate": {
        "count": 2
      }
    }
  }
}
```