### PR TITLE
Fix(breakout-room): Add subscription for last breakout room data and automatically move users to last breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
@@ -75,7 +75,6 @@ subscription {
     lastBreakoutRoom {
       breakoutRoomId
       currentlyInRoom
-      isDefaultName
       sequence
       shortName
       userId

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
@@ -69,7 +69,23 @@ export const getBreakoutCount = gql`
   }
 `;
 
+export const getLastBreakout = gql`
+subscription {
+  user {
+    lastBreakoutRoom {
+      breakoutRoomId
+      currentlyInRoom
+      isDefaultName
+      sequence
+      shortName
+      userId
+    }
+  }
+}
+`;
+
 export default {
   getUser,
   getBreakouts,
+  getLastBreakout,
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
@@ -184,7 +184,7 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
       const usersToMove: string[] = [];
       const toRooms: number[] = [];
 
-      if (runningRooms) return;
+      if (runningRooms?.length && runningRooms.length > 0) return;
 
       lastBreakoutData.user.forEach((user: lastBreakoutRoomUser) => {
         if (user.lastBreakoutRoom?.sequence) {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
@@ -184,6 +184,8 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
       const usersToMove: string[] = [];
       const toRooms: number[] = [];
 
+      if (runningRooms) return;
+
       lastBreakoutData.user.forEach((user: lastBreakoutRoomUser) => {
         if (user.lastBreakoutRoom?.sequence) {
           const roomSequence = Number(user.lastBreakoutRoom.sequence);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/types.ts
@@ -17,6 +17,19 @@ export interface moveUserRegistery {
   }
 }
 
+export interface lastBreakoutRoomUser {
+  lastBreakoutRoom: {
+    breakoutRoomId: string;
+    currentlyInRoom: boolean;
+    isDefaultName: boolean;
+    sequence: string;
+    shortName: string;
+    userId: string;
+    __typename: string;
+  } | null;
+  __typename: string;
+}
+
 export type RoomToWithSettings = {
   name: string;
   users: string[];


### PR DESCRIPTION
### What does this PR do?

This PR ports the behavior from 27 breakouts, making the users go back to the same breakout they were (if they were) previously.

### How to test

Create a meeting with breakout rooms, populate this breakouts, and then end it and start a new one, users should automatically go to the previous rooms.

