### PR TITLE
documentation: hint in turn configuration about a coturn bug in internal log rotation

### DIFF
--- a/docs/docs/administration/turn-server.md
+++ b/docs/docs/administration/turn-server.md
@@ -241,6 +241,8 @@ $ sudo mkdir -p /var/log/turnserver
 $ sudo chown turnserver:turnserver /var/log/turnserver
 ```
 
+It is strongly recommended that you use the logging configuration described. There seems to be a bug in coturn's internal log rotation that causes connection problems.
+
 ### Restart coturn
 
 With the above steps completed, restart the TURN server


### PR DESCRIPTION
### What does this PR do?

Hint in documentation about turn configuration is added, which warns about a bug in coturn's internal log rotation.

### Motivation

The bug seems to be the reason for connectivity issues experienced in the past.