### PR TITLE
fix: Apostrophe character not displayed correctly in guest lobby [3.0]

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -185,9 +185,12 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
             <Styled.Bounce />
           </Styled.Spinner>
         )}
-        <p aria-live="polite" data-test="guestMessage">
-          {message}
-        </p>
+        <p
+          aria-live="polite"
+          data-test="guestMessage"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: message }}
+        />
         <Styled.Position id="positionInWaitingQueue">
           <p aria-live="polite">{positionMessage}</p>
         </Styled.Position>


### PR DESCRIPTION
### What does this PR do?
fix character escape in guest lobby

### Closes Issue(s)
partially #21852

#### before
![Screenshot from 2024-12-09 13-54-59](https://github.com/user-attachments/assets/b03d7285-5fed-4349-a794-95dea1a76709)

#### after
![Screenshot from 2024-12-09 13-54-27](https://github.com/user-attachments/assets/74bfb7e3-7cb2-4a82-9155-b99afc59aa0f)


### How to test
1. Join a session as moderator
2. Switch the guest policy (from gear icon menu) to Always ask
3. Join as a viewer (waiting in the lobby)
4. Have the moderator send a message to the lobby which includes ', for example `I'm your father`
5. Check message for guest