### PR TITLE
fix: Apostrophe character not displayed correctly in guest panel [2.7]

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/component.jsx
@@ -350,7 +350,8 @@ const WaitingUsers = (props) => {
                 &quot;
                 {
                 guestLobbyMessage.length > 0
-                  ? guestLobbyMessage
+                  // eslint-disable-next-line react/no-danger
+                  ? <span dangerouslySetInnerHTML={{ __html: guestLobbyMessage }} />
                   : intl.formatMessage(intlMessages.emptyMessage)
               }
                 &quot;


### PR DESCRIPTION
### What does this PR do?

fix character escape in guest management panel

#### before
![Screenshot from 2024-12-09 14-10-02](https://github.com/user-attachments/assets/7275c36c-3c02-4d05-b211-e85f122603df)

#### after
![Screenshot from 2024-12-09 14-09-48](https://github.com/user-attachments/assets/8eede44d-6a87-4c36-a0a6-e29383d165e9)


### Closes Issue(s)
Closes #21852

### How to test
1. Join a session as moderator
2. Switch the guest policy (from gear icon menu) to Always ask
3. Join as a viewer (waiting in the lobby)
4. Have the moderator send a message to the lobby which includes ', for example `I'm your father`
5. Check message in guest management panel
