### PR TITLE
refactor: remove loading steps text from guest lobby

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -176,7 +176,6 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
   return (
     <Styled.Container>
       <Styled.Content id="content">
-        <Styled.Heading as="h2">3/5</Styled.Heading>
         <Styled.Heading id="heading">{intl.formatMessage(intlMessages.windowTitle)}</Styled.Heading>
         {animate && (
           <Styled.Spinner>


### PR DESCRIPTION
### What does this PR do?
removes `3/5` text from guest lobby

#### before

![Screenshot from 2024-12-09 14-56-37](https://github.com/user-attachments/assets/6c56f99d-9058-4f4c-93df-d80cd68a6354)

#### after

![Screenshot from 2024-12-09 14-56-22](https://github.com/user-attachments/assets/1a412375-727a-42da-bb22-c59a66945c63)


### More
#21709

