### PR TITLE
refactor (build): Stops calling external script to install Hasura CLI

### DIFF
--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -41,8 +41,39 @@ cp bbb-pg.conf staging/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/conf.d
 
 cp bbb-graphql-server.service staging/lib/systemd/system/bbb-graphql-server.service
 
-# Install Hasura CLI
-curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | INSTALL_PATH=staging/usr/bin VERSION=$HASURA_VERSION bash
+# ============= Begin: Install Hasura CLI =============
+# The logic bellow is based on https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh
+
+platform='unknown'
+unamestr=`uname`
+if [ "$unamestr" == 'Linux' ]; then
+    platform='linux'
+elif [ "$unamestr" == 'Darwin' ]; then
+    platform='darwin'
+else
+    echo "Unknown OS platform"
+    exit 1
+fi
+
+arch='unknown'
+archstr=`uname -m`
+if [ "$archstr" == 'x86_64' ]; then
+    arch='amd64'
+elif [ "$archstr" == 'arm64' ] || [ "$archstr" == 'aarch64' ]; then
+    arch='arm64'
+else
+    echo "prebuilt binaries for $(arch) architecture not available"
+    exit 1
+fi
+
+url="https://github.com/hasura/graphql-engine/releases/download/${HASURA_VERSION}/cli-hasura-${platform}-${arch}"
+
+echo "Downloading Hasura CLI from $url"
+
+curl -L -f -o staging/usr/bin/hasura "$url"
+chmod +x staging/usr/bin/hasura
+staging/usr/bin/hasura version --skip-update-check
+# ============= End: Install Hasura CLI =============
 
 
 . ./opts-$DISTRO.sh


### PR DESCRIPTION
Previously, the BBB build process installed the Hasura CLI by calling an external script hosted on:  
<https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh>

This approach was not ideal because it relied on code outside of our control. To address this, this PR replicates the essential logic from that external script directly into our own build process. Ensuring full visibility into the installation steps.

*Suggested by @danimo* https://github.com/bigbluebutton/bigbluebutton/issues/20083#issuecomment-2079352523

**Closes #20083**