### PR TITLE
refactor: Reword removal of away status message

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1006,7 +1006,7 @@
     "app.toast.setEmoji.raiseHand": "You have raised your hand",
     "app.toast.setEmoji.lowerHand": "Your hand has been lowered",
     "app.toast.setEmoji.away": "You have set your status to away",
-    "app.toast.setEmoji.notAway": "You removed your away status",
+    "app.toast.setEmoji.notAway": "Your away status was removed",
     "app.toast.promotedLabel": "You have been promoted to Moderator",
     "app.toast.demotedLabel": "You have been demoted to Viewer",
     "app.notification.recordingStart": "This session is now being recorded",


### PR DESCRIPTION
Since it's a system action rather than intentional user action, the notification should not imply it was the user's action.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Rewording the notification displayed when Away state is interrupted

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Suggested by @soheb-somani


