### PR TITLE
fix(presentation-menu): Refactor toast notification to use the correct method for displaying info.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -286,7 +286,7 @@ const PresentationMenu = (props) => {
               hasError: false,
             });
 
-            toast.info(renderToastContent(), {
+            toast(renderToastContent(), {
               hideProgressBar: true,
               autoClose: false,
               newestOnTop: true,

--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -52,7 +52,6 @@ export function notify(message, type = 'default', icon, options, content, small)
         {
           render: <div role="alert"><Toast {...toastProps} /></div>,
           autoClose: options.autoClose,
-          ...toastProps,
         },
       );
     } else {


### PR DESCRIPTION
### What does this PR do?

This PR fixes an error that made the snapshot of the current slide show a blank card instead of the toast.

### Closes Issue(s)

Closes #21872 


### How to test

Start a meeting and snapshot a slide.
