### PR TITLE
impr(bbb-record): Clarify recording status output

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -508,11 +508,11 @@ if [ $LIST ]; then
    #
 
    if [ $WITHDESC ]; then
-      echo "Internal MeetingID                                               Time                APVD APVDE RAS Slides Processed            Published           External MeetingID  Description"
-      echo "------------------------------------------------------  ---------------------------- ---- ----- --- ------ -------------------- ------------------  ------------------- -----------"
+      echo "Internal MeetingID                                      Time                            APVD APVDE RAS Slides Processed            Published           External MeetingID  Description"
+      echo "------------------------------------------------------  ------------------------------- ---- ----- --- ------ -------------------- ------------------  ------------------- -----------"
    else
-      echo "Internal MeetingID                                               Time                APVD APVDE RAS Slides Processed            Published           External MeetingID"
-      echo "------------------------------------------------------  ---------------------------- ---- ----- --- ------ -------------------- ------------------  -------------------"
+      echo "Internal MeetingID                                      Time                            APVD APVDE RAS Slides Processed            Published           External MeetingID"
+      echo "------------------------------------------------------  ------------------------------- ---- ----- --- ------ -------------------- ------------------  -------------------"
    fi
 
    if [ -z $HEAD ]; then

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -508,11 +508,11 @@ if [ $LIST ]; then
    #
 
    if [ $WITHDESC ]; then
-      echo "Internal MeetingID                                      Time                            APVD APVDE RAS Slides Processed            Published           External MeetingID  Description"
-      echo "------------------------------------------------------  ------------------------------- ---- ----- --- ------ -------------------- ------------------  ------------------- -----------"
+      echo "Internal MeetingID                                      Time                         APVD APVDE RAS Slides Processed            Published           External MeetingID  Description"
+      echo "------------------------------------------------------  ---------------------------- ---- ----- --- ------ -------------------- ------------------  ------------------- -----------"
    else
-      echo "Internal MeetingID                                      Time                            APVD APVDE RAS Slides Processed            Published           External MeetingID"
-      echo "------------------------------------------------------  ------------------------------- ---- ----- --- ------ -------------------- ------------------  -------------------"
+      echo "Internal MeetingID                                      Time                         APVD APVDE RAS Slides Processed            Published           External MeetingID"
+      echo "------------------------------------------------------  ---------------------------- ---- ----- --- ------ -------------------- ------------------  -------------------"
    fi
 
    if [ -z $HEAD ]; then

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -539,21 +539,21 @@ if [ $LIST ]; then
       #
       # Check if there is any recorded audio
       if ls -A "$RAW_AUDIO_SRC"/"$meeting"-*.wav &> /dev/null; then
-         echo -n "X"
+         echo -n "A"
       else
-         echo -n " "
+         echo -n "."
       fi
 
       #
       # Check if there is any uploaded presentations
       if [ -d "$RAW_PRESENTATION_SRC"/"$meeting"/"$meeting" ]; then
          if [ "$(ls -A "$RAW_PRESENTATION_SRC"/"$meeting"/"$meeting")" ]; then
-            echo -n "X"
+            echo -n "P"
          else
-            echo -n " "
+            echo -n "."
          fi
       else
-         echo -n " "
+         echo -n "."
       fi
 
 
@@ -561,12 +561,12 @@ if [ $LIST ]; then
       # Check if there is any recorded videos
       if [ -d "$RAW_VIDEO_SRC"/"$meeting" ]; then
          if [ "$(ls -A "$RAW_VIDEO_SRC"/"$meeting")" ]; then
-            echo -n "X"
+            echo -n "V"
          else
-            echo -n " "
+            echo -n "."
          fi
       else
-         echo -n " "
+         echo -n "."
       fi
 
       #echo "## $RAW_SCREENSHARE_SRC/$meeting-*.flv"
@@ -574,9 +574,9 @@ if [ $LIST ]; then
       #
       # Check if there is any recorded desktop sharing
       if ls -A "$RAW_SCREENSHARE_SRC"/"$meeting"/*.flv &> /dev/null; then
-         echo -n "X"
+         echo -n "D"
       else
-         echo -n " "
+         echo -n "."
       fi
 
       #
@@ -591,19 +591,19 @@ if [ $LIST ]; then
       for dir in $DIRS; do
          if [ -d "$RAW_DIR"/"$dir" ]; then
             if [ "$(ls -A "$RAW_DIR"/"$dir")" ]; then
-               echo -n "X"
+               echo -n "${dir:0:1}" | tr "a-z" "A-Z"
             else
-               echo -n " "
+               echo -n "."
             fi
          else
-            echo -n " "
+            echo -n "."
          fi
       done
 
       if [ -f "$RAW_DIR"/events.xml ]; then
-         echo -n "X"
+         echo -n "E"
       else
-         echo -n " "
+         echo -n "."
       fi
 
       #
@@ -613,9 +613,9 @@ if [ $LIST ]; then
       DIRS="recorded archived sanity"
       for dir in $DIRS; do
          if [ -f "$STATUS"/"$dir"/"$meeting".done ]; then
-            echo -n "X"
+            echo -n "${dir:0:1}" | tr "a-z" "A-Z"
          else
-            echo -n " "
+            echo -n "."
          fi
       done
 


### PR DESCRIPTION
### What does this PR do?
Using `X` and ` ` to indicate presence / absence of recording components in the output of `bbb-record --list` and `bbb-record --list-recent` is not very helpful in a long table where the header runs out of sight. This patch uses the same letters as the header to indicate presence and `.` to indicate absence of components. This greatly improves readability of the table.
While I was at it, I also fixed the table header.

Before:
```
$ sudo bbb-record --list-recent | head -n16
Internal MeetingID                                               Time                APVD APVDE RAS Slides Processed            Published           External MeetingID
------------------------------------------------------  ---------------------------- ---- ----- --- ------ -------------------- ------------------  -------------------
1fd38817e18530ea66cf72afd419d5b74240b815-1734015156467  Thu 12 Dec 2024 02:52:36 PM UTC  X                  0
87cc7a5cf9f0bf4e589dc652f6c8abce4f46aef7-1734014899314  Thu 12 Dec 2024 02:48:19 PM UTC  X                  0
e0218cf312261ebc5b9bef734b773bd2a1d4f45f-1734014640027  Thu 12 Dec 2024 02:44:00 PM UTC  X                  0
35826833b9405592b1ba924edc8051c670a08d81-1734014383393  Thu 12 Dec 2024 02:39:43 PM UTC  X                  0
e4afd91f3da813d30dad9680ffd4fe31fa8ef44d-1734014126352  Thu 12 Dec 2024 02:35:26 PM UTC  X                  0
ed024bc93ba4cc249ed0504ce5c0a091cf53345e-1734013866491  Thu 12 Dec 2024 02:31:06 PM UTC  X                  0
10ac0df8abab3ca37eda40a042c855b9b148115f-1734013612870  Thu 12 Dec 2024 02:26:52 PM UTC  X                  0
6cfffeebe4e5ac56cb3d7387fd39c2eb4e188462-1734013352590  Thu 12 Dec 2024 02:22:32 PM UTC  X                  0
e9dfa40f5eb7f12d53902dd8e2a176b1bf517204-1734013095422  Thu 12 Dec 2024 02:18:15 PM UTC  X                  0
90c02c7c1a7f3e1d531cbdf8c55f25e681fd5b45-1734012835217  Thu 12 Dec 2024 02:13:55 PM UTC  X                  0
e34be7a4da16a4380089b5fe34dbccc2d0091dca-1733944126747  Wed 11 Dec 2024 07:08:46 PM UTC  X   XXX X  XX     10 podcast,presentation,videopodcast,presentation,video   
80d4e28fbfe6e9f9499e342ce71abdee7d5e9ac9-1733502766199  Fri 06 Dec 2024 04:32:46 PM UTC  X    XX X         10                                          
1d49306493b458703bb5bf30527e1fef849af004-1733413038183  Thu 05 Dec 2024 03:37:18 PM UTC       XX X         10                                          
80d4e28fbfe6e9f9499e342ce71abdee7d5e9ac9-1733245299265  Tue 03 Dec 2024 05:01:39 PM UTC       XX X         10                                          
```

After:
```
$ sudo bbb-record --list-recent | head -n16
Internal MeetingID                                      Time                            APVD APVDE RAS Slides Processed            Published           External MeetingID
------------------------------------------------------  ------------------------------- ---- ----- --- ------ -------------------- ------------------  -------------------
246a8b4ef08d500c4ba3d11b03958ee16795a54b-1734015673807  Thu 12 Dec 2024 03:01:13 PM UTC .P.. ..... ...      0
9411d906590cd81ead3efd9960c042b4e873d703-1734015412373  Thu 12 Dec 2024 02:56:52 PM UTC .P.. ..... ...      0
1fd38817e18530ea66cf72afd419d5b74240b815-1734015156467  Thu 12 Dec 2024 02:52:36 PM UTC .P.. ..... ...      0
87cc7a5cf9f0bf4e589dc652f6c8abce4f46aef7-1734014899314  Thu 12 Dec 2024 02:48:19 PM UTC .P.. ..... ...      0
e0218cf312261ebc5b9bef734b773bd2a1d4f45f-1734014640027  Thu 12 Dec 2024 02:44:00 PM UTC .P.. ..... ...      0
35826833b9405592b1ba924edc8051c670a08d81-1734014383393  Thu 12 Dec 2024 02:39:43 PM UTC .P.. ..... ...      0
e4afd91f3da813d30dad9680ffd4fe31fa8ef44d-1734014126352  Thu 12 Dec 2024 02:35:26 PM UTC .P.. ..... ...      0
ed024bc93ba4cc249ed0504ce5c0a091cf53345e-1734013866491  Thu 12 Dec 2024 02:31:06 PM UTC .P.. ..... ...      0
10ac0df8abab3ca37eda40a042c855b9b148115f-1734013612870  Thu 12 Dec 2024 02:26:52 PM UTC .P.. ..... ...      0
6cfffeebe4e5ac56cb3d7387fd39c2eb4e188462-1734013352590  Thu 12 Dec 2024 02:22:32 PM UTC .P.. ..... ...      0
e34be7a4da16a4380089b5fe34dbccc2d0091dca-1733944126747  Wed 11 Dec 2024 07:08:46 PM UTC .P.. APV.E .AS     10 podcast,presentation,videopodcast,presentation,video   
80d4e28fbfe6e9f9499e342ce71abdee7d5e9ac9-1733502766199  Fri 06 Dec 2024 04:32:46 PM UTC .P.. .PV.E ...     10                                          
1d49306493b458703bb5bf30527e1fef849af004-1733413038183  Thu 05 Dec 2024 03:37:18 PM UTC .... .PV.E ...     10                                          
80d4e28fbfe6e9f9499e342ce71abdee7d5e9ac9-1733245299265  Tue 03 Dec 2024 05:01:39 PM UTC .... .PV.E ...     10               
```

### Closes Issue(s)
None as of now. I you want, I can create one, though.


### Motivation
We were / are using the script from time to time for debugging purposes. Every time we do, we have a hard time figuring out which `X` in the output table means what, so I decided to fix the problem.


### How to test
Roll out, run `sudo bbb-record --list-recent`, rejoice. \o/


### More
--