### PR TITLE
fix: Enhance link detection to avoid mistakenly identifying strings that are not intended to be links

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/service.ts
@@ -4,33 +4,21 @@ export const textToMarkdown = (message: string) => {
   const CODE_BLOCK_REGEX = /```([\s\S]*?)```/g;
   const isCode = parsedMessage.search(CODE_BLOCK_REGEX);
 
+  const IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]*)\)/g;
+  const isImage = parsedMessage.search(IMAGE_REGEX);
+
   // regular expression to match urls
-  const urlRegex = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
-
-  // regular expression to match URLs with IP addresses
-  const ipUrlRegex = /\b(?:https?:\/\/)?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?::\d{1,5})?(?:\/\S*)?\b/g;
-
-  // regular expression to match Markdown links
-  const mdRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  const urlRegex = /(http(s)?:\/\/)[-a-zA-Z0-9@:%._+~#=,ß]{2,256}\.[a-z0-9]{2,6}\b([-a-zA-Z0-9@:%_+.~#!?&//=,ß]*)?/g;
 
   // regular expression to match new lines
   const newLineRegex = /\n\r?/g;
 
-  // append https:// to URLs that don't have it
-  const appendHttps = (match: string, text: string, url: string) => {
-    if (!/^https?:\/\//.test(url)) {
-      return `[${text}](https://${url})`;
-    }
-    return match;
-  };
-  if (isCode !== -1) {
+  if (isCode !== -1 || isImage !== -1) {
     return parsedMessage.trim();
   }
   return parsedMessage
     .trim()
     .replace(urlRegex, '[$&]($&)')
-    .replace(ipUrlRegex, '[$&]($&)')
-    .replace(mdRegex, appendHttps)
     .replace(newLineRegex, '  \n');
 };
 


### PR DESCRIPTION
### What does this PR do?

updates chat regex to allow images and do not allow links that do not start with http:// or https://

### Closes Issue(s)
Closes #21751

### How to test

join a session and send messages with links in the chat