### PR TITLE
build(bbb-webrtc-sfu): v2.17.0-beta.0

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.17.0-alpha.5 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.17.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webrtc-sfu): v2.17.0-beta.0](https://github.com/bigbluebutton/bigbluebutton/commit/c7f891b8a4a6f7b1328056946f786d7b1c28606d) 
  * fix(livekit): various adjustments to egress handling
  * build: livekit-server-sdk@v2.9.3 (up from v2.6.2)
  * build: @livekit/rtc-node@0.12.1 (up from 0.9.2)
  * build: express@4.21.2 (up from 4.21.1)

### Closes Issue(s)

None