### PR TITLE
improvement (html5): Automatically fetch locales from project directory in development environment

### DIFF
--- a/bigbluebutton-html5/run-prod.sh
+++ b/bigbluebutton-html5/run-prod.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sudo ln -sf /usr/share/bigbluebutton/nginx/bbb-html5.nginx.static /usr/share/bigbluebutton/nginx/bbb-html5.nginx
+sudo systemctl restart nginx

--- a/build/packages-template/bbb-html5/bbb-html5.nginx.dev
+++ b/build/packages-template/bbb-html5/bbb-html5.nginx.dev
@@ -9,7 +9,21 @@ location /html5client/ {
 }
 
 location /html5client/locales {
-  alias /usr/share/bigbluebutton/html5-client/locales;
+  # try path of locales in docker dev first
+  set $locales_dir /home/bigbluebutton/src/bigbluebutton-html5/public/locales;
+
+  if (!-d $locales_dir) {
+    # as fallback use the production path
+    set $locales_dir /usr/share/bigbluebutton/html5-client/locales;
+  }
+
+  alias $locales_dir;
+
   autoindex on;
   autoindex_format json;
+
+  # Prevent browsers from caching
+  add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+  add_header Pragma "no-cache";
+  add_header Expires 0;
 }


### PR DESCRIPTION
This PR simplifies the process of updating labels in the HTML5 project by ensuring that browsers automatically recognize and display the latest label changes without manual intervention.

1. **Dynamic Locale Directory:**  
   Nginx will now attempt to load locale files from `/home/bigbluebutton/src/bigbluebutton-html5/public/locales`, which is the default directory in a Docker development environment. If that directory is not available (e.g., in production), it will gracefully fall back to using `/usr/share/bigbluebutton/html5-client/locales`.

2. **No-Caching Headers for Locales:**  
   To avoid issues with stale labels, this PR adds HTTP headers that prevent browsers from caching the locale files. As a result, any changes to labels are reflected immediately, with no need to clear browser caches or take additional steps.

3. **New `run-prod.sh` Script:**  
   Alongside the existing `run-dev.sh` script, a new `run-prod.sh` script is introduced. Running `run-prod.sh` reverts the setup made by `run-dev.sh` so that Nginx once again serves static files and locales from their original production paths.

These improvements streamline the development workflow, making label updates straightforward and reducing the time spent troubleshooting browser caching issues.