### PR TITLE
feat (bbb-web): Introduces S3-based cache for presentation assets

### DIFF
--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
     val gson = "2.8.9"
     val jackson = "2.13.5"
     val freemarker = "2.3.31"
+    val awsSdkS3 = "1.12.779"
     val apacheHttp = "4.5.13"
     val apacheHttpAsync = "4.1.4"
     val jsoup = "1.14.3"
@@ -53,6 +54,7 @@ object Dependencies {
     val jacksonModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson
     val jacksonXml = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % Versions.jackson
     val freemarker = "org.freemarker" % "freemarker" % Versions.freemarker
+    val awsSdkS3 = "com.amazonaws" % "aws-java-sdk-s3" % Versions.awsSdkS3
     val apacheHttp = "org.apache.httpcomponents" % "httpclient" % Versions.apacheHttp
     val apacheHttpAsync = "org.apache.httpcomponents" % "httpasyncclient" % Versions.apacheHttpAsync
     val jsoup = "org.jsoup" % "jsoup" % Versions.jsoup
@@ -93,6 +95,7 @@ object Dependencies {
     Compile.jacksonModule,
     Compile.jacksonXml,
     Compile.freemarker,
+    Compile.awsSdkS3,
     Compile.apacheHttp,
     Compile.apacheHttpAsync,
     Compile.jsoup,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -32,6 +32,7 @@ public final class UploadedPresentation {
   private final boolean uploadFailed;
   private final ArrayList<String> uploadFailReason;
   private File uploadedFile;
+  private String uploadedFileHash;
   private String fileType = "unknown";
   private int numberOfPages = 0;
   private String conversionStatus;
@@ -117,6 +118,14 @@ public final class UploadedPresentation {
 
   public void setUploadedFile(File uploadedFile) {
     this.uploadedFile = uploadedFile;
+  }
+
+  public String getUploadedFileHash() {
+    return uploadedFileHash;
+  }
+
+  public void setUploadedFileHash(String uploadedFileHash) {
+    this.uploadedFileHash = uploadedFileHash;
   }
 
   public String getMeetingId() {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
@@ -49,7 +49,7 @@ public class PdfSlidesGenerationService {
                 pageToConvert.getMeetingId(),
                 new ArrayList<>());
         presentationConversionCompletionService.handle(msg);
-        pageToConvert.getPageFile().delete();
+        // The pdf of the page will be removed after cache storing
       }
     };
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -86,7 +88,12 @@ public class PngCreatorImp implements PngCreator {
 	private boolean generatePng(File pngsDir, UploadedPresentation pres, int page, File pageFile)
 					throws InterruptedException {
 		String source = pageFile.getAbsolutePath();
-		String dest;
+		String dest = pngsDir.getAbsolutePath() + File.separator + "slide-" + page + ".png";
+
+		// Skip processing if the destination file exists, as it was likely restored from the cache
+		if(Files.exists(Paths.get(dest))) {
+			return true;
+		}
 
 		if (SupportedFileTypes.isImageFile(pres.getFileType())) {
 			// Need to create a PDF as intermediate step.

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
@@ -1,5 +1,6 @@
 package org.bigbluebutton.presentation.imp;
 
+import com.amazonaws.services.s3.model.S3Object;
 import com.google.gson.Gson;
 import org.apache.commons.io.FilenameUtils;
 import org.bigbluebutton.api.Util;
@@ -40,6 +41,7 @@ public class PresentationFileProcessor {
     private PresentationConversionCompletionService presentationConversionCompletionService;
     private ImageSlidesGenerationService imageSlidesGenerationService;
     private PdfSlidesGenerationService pdfSlidesGenerationService;
+    private S3FileManager s3FileManager;
 
     private ExecutorService executor;
     private volatile boolean processPresentation = false;
@@ -53,6 +55,20 @@ public class PresentationFileProcessor {
     public synchronized void process(UploadedPresentation pres) {
         if (pres.isDownloadable()) {
             processMakePresentationDownloadableMsg(pres);
+        }
+
+        //Download presentation outputs from cache (if enabled)
+        try {
+            pres.setUploadedFileHash(s3FileManager.generateHash(pres.getUploadedFile()));
+            String remoteFileName = pres.getUploadedFileHash() + ".tar.gz";
+            if(s3FileManager.isPresentationConversionCacheEnabled() && s3FileManager.exists(remoteFileName)) {
+                S3Object s3Object = s3FileManager.download(remoteFileName);
+                File parentDir = new File(pres.getUploadedFile().getParent());
+                TarGzManager.decompress(s3Object, parentDir.getAbsolutePath());
+                log.info("Presentation outputs restored from cache successfully for {}.", pres.getId());
+            }
+        } catch (Exception e) {
+            log.error("Error while downloading presentations outputs from cache: {}", e.getMessage());
         }
 
         Runnable messageProcessor = new Runnable() {
@@ -96,19 +112,21 @@ public class PresentationFileProcessor {
     }
 
     private void extractIntoPages(UploadedPresentation pres) {
+        String presDir = pres.getUploadedFile().getParent();
+
         List<PageToConvert> listOfPagesConverted = new ArrayList<>();
         for (int page = 1; page <= pres.getNumberOfPages(); page++) {
-            String presDir = pres.getUploadedFile().getParent();
             File pageFile = new File(presDir + "/page" + "-" + page + ".pdf");
 
-            File extractedPageFile = extractPage(pres, page);
-
-            if (extractedPageFile.length() > maxBigPdfPageSize) {
-                File downscaledPageFile = downscalePage(pres, extractedPageFile, page);
-                downscaledPageFile.renameTo(pageFile);
-                extractedPageFile.delete();
-            } else {
-                extractedPageFile.renameTo(pageFile);
+            if(!pageFile.exists()) {
+                File extractedPageFile = extractPage(pres, page);
+                if (extractedPageFile.length() > maxBigPdfPageSize) {
+                    File downscaledPageFile = downscalePage(pres, extractedPageFile, page);
+                    downscaledPageFile.renameTo(pageFile);
+                    extractedPageFile.delete();
+                } else {
+                    extractedPageFile.renameTo(pageFile);
+                }
             }
 
             PageToConvert pageToConvert = new PageToConvert(
@@ -340,5 +358,9 @@ public class PresentationFileProcessor {
 
     public void setPdfSlidesGenerationService(PdfSlidesGenerationService s) {
         this.pdfSlidesGenerationService = s;
+    }
+
+    public void setS3FileManager(S3FileManager s3FileManager) {
+        this.s3FileManager = s3FileManager;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/S3FileManager.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/S3FileManager.java
@@ -1,0 +1,142 @@
+package org.bigbluebutton.presentation.imp;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class S3FileManager {
+    private static Logger log = LoggerFactory.getLogger(S3FileManager.class);
+    private boolean presentationConversionCacheEnabled = false;
+    private String accessKeyId = "";
+    private String accessKeySecret = "";
+    private String bucketName = "";
+    private String region = "";
+    private String endpointUrl = "";
+    private boolean pathStyleAccess = false;
+    private AmazonS3 s3Client = null;
+
+    public AmazonS3 getS3Client() {
+        if(s3Client == null && isPresentationConversionCacheEnabled()) {
+            AWSCredentials credentials = new BasicAWSCredentials(accessKeyId, accessKeySecret);
+            s3Client = AmazonS3ClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpointUrl, region))
+                    .withPathStyleAccessEnabled(pathStyleAccess)
+                    .build();
+        }
+
+        return s3Client;
+    }
+
+    public boolean exists(String key) {
+        return getS3Client() != null && getS3Client().doesObjectExist(bucketName, key);
+    }
+
+    public void upload(String key, File file) {
+        if(getS3Client() != null) {
+            getS3Client().putObject(new PutObjectRequest(bucketName, key, file));
+        }
+    }
+
+    public S3Object download(String key) {
+        if(getS3Client() != null) {
+            return getS3Client().getObject(new GetObjectRequest(bucketName, key));
+        } else {
+            return null;
+        }
+    }
+
+    public String generateHash(File file) throws IOException, NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (InputStream is = new FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
+            }
+        }
+        byte[] hashBytes = digest.digest();
+        StringBuilder hashString = new StringBuilder();
+        for (byte b : hashBytes) {
+            hashString.append(String.format("%02x", b));
+        }
+        return hashString.toString();
+    }
+
+
+    public boolean isPresentationConversionCacheEnabled() {
+        return presentationConversionCacheEnabled;
+    }
+
+    public void setPresentationConversionCacheEnabled(boolean presentationConversionCacheEnabled) {
+        if(presentationConversionCacheEnabled) {
+            log.info("S3 cache system enabled");
+        } else {
+            log.info("S3 cache system disabled");
+        }
+        this.presentationConversionCacheEnabled = presentationConversionCacheEnabled;
+    }
+
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    public void setAccessKeyId(String accessKeyId) {
+        this.accessKeyId = accessKeyId;
+    }
+
+    public String getAccessKeySecret() {
+        return accessKeySecret;
+    }
+
+    public void setAccessKeySecret(String accessKeySecret) {
+        this.accessKeySecret = accessKeySecret;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getEndpointUrl() {
+        return endpointUrl;
+    }
+
+    public void setEndpointUrl(String endpointUrl) {
+        this.endpointUrl = endpointUrl;
+    }
+
+    public boolean isPathStyleAccess() {
+        return pathStyleAccess;
+    }
+
+    public void setPathStyleAccess(boolean pathStyleAccess) {
+        this.pathStyleAccess = pathStyleAccess;
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -79,6 +79,13 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             throws InterruptedException, TimeoutException {
         String source = pres.getUploadedFile().getAbsolutePath();
         String dest;
+
+        // Skip processing if the destination file exists, as it was likely restored from the cache
+        File destsvg = new File(imagePresentationDir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
+        if(destsvg.exists()) {
+            return true;
+        }
+
         int countOfTimeOut = 0;
 
         int numSlides = 1;
@@ -137,9 +144,6 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             log.info("Font Type 3 identified on {} page {}, slide will be rasterized.", pres.getName(), page);
             rasterizeCurrSlide = true;
         }
-
-
-        File destsvg = new File(imagePresentationDir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
 
         SvgConversionHandler pHandler = new SvgConversionHandler();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TarGzManager.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TarGzManager.java
@@ -1,0 +1,101 @@
+package org.bigbluebutton.presentation.imp;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+import com.amazonaws.services.s3.model.S3Object;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+public class TarGzManager {
+    private static final List<String> allowedDirs = Collections.unmodifiableList(
+            Arrays.asList("thumbnails", "textfiles", "svgs", "pngs")
+    );
+
+    public static File compress(String sourceDirectory, String outputFileName, Integer numOfPages) throws IOException {
+        File tempTarGzFile = File.createTempFile(outputFileName, ".tar.gz");
+
+        File parentDir = new File(sourceDirectory);
+        File[] directories = parentDir.listFiles(File::isDirectory);
+
+        try (FileOutputStream fos = new FileOutputStream(tempTarGzFile);
+             GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(fos);
+             TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+
+            taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+
+            for (File directory : directories) {
+                if (allowedDirs.contains(directory.getName())) {
+                    addDirectoryToTarGz(taos, directory, "");
+                }
+            }
+
+            for (int page = 1; page <= numOfPages; page++) {
+                File pageFile = new File(sourceDirectory + "/page" + "-" + page + ".pdf");
+                if(pageFile.exists()) {
+                    addFileToTarGz(taos, pageFile, "");
+                }
+            }
+        }
+
+        return tempTarGzFile;
+    }
+
+    public static void decompress(S3Object s3Object, String destinationPath) throws IOException {
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(s3Object.getObjectContent());
+             TarArchiveInputStream tarInputStream = new TarArchiveInputStream(gzipInputStream)) {
+
+            TarArchiveEntry tarEntry;
+            while ((tarEntry = tarInputStream.getNextTarEntry()) != null) {
+                File outputFile = new File(destinationPath, tarEntry.getName());
+
+                if (tarEntry.isDirectory()) {
+                    if (!outputFile.exists() && !outputFile.mkdirs()) {
+                        throw new IOException("Could not create directory: " + outputFile.getAbsolutePath());
+                    }
+                } else {
+                    File parent = outputFile.getParentFile();
+                    if (!parent.exists() && !parent.mkdirs()) {
+                        throw new IOException("Could not create directory: " + parent.getAbsolutePath());
+                    }
+
+                    try (FileOutputStream fos = new FileOutputStream(outputFile)) {
+                        IOUtils.copy(tarInputStream, fos);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void addDirectoryToTarGz(TarArchiveOutputStream taos, File directory, String base) throws IOException {
+        String entryName = base + directory.getName();
+        taos.putArchiveEntry(new TarArchiveEntry(directory, entryName));
+        taos.closeArchiveEntry();
+
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    addDirectoryToTarGz(taos, file, entryName + "/");
+                } else {
+                    addFileToTarGz(taos, file, entryName);
+                }
+            }
+        }
+    }
+
+    private static void addFileToTarGz(TarArchiveOutputStream taos, File file, String path) throws IOException {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            TarArchiveEntry entry = new TarArchiveEntry(file, path + "/" + file.getName());
+            taos.putArchiveEntry(entry);
+            IOUtils.copy(fis, taos);
+            taos.closeArchiveEntry();
+        }
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,8 +68,13 @@ public class TextFileCreatorImp implements TextFileCreator {
       UploadedPresentation pres, int page) throws InterruptedException {
     boolean success = true;
     String source = pres.getUploadedFile().getAbsolutePath();
-    String dest;
+    String dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-" + page + ".txt";
     String COMMAND = "";
+
+    // Skip processing if the destination file exists, as it was likely restored from the cache
+    if(Files.exists(Paths.get(dest))) {
+      return true;
+    }
 
     if (SupportedFileTypes.isImageFile(pres.getFileType())) {
       dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-1.txt";
@@ -91,9 +98,7 @@ public class TextFileCreatorImp implements TextFileCreator {
       }
 
     } else {
-      dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-" + page + ".txt";
       // sudo apt-get install xpdf-utils
-
         COMMAND = "pdftotext -raw -nopgbrk -enc UTF-8 -f " + page + " -l " + page
             + " " + source + " " + dest;
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -21,6 +21,9 @@ package org.bigbluebutton.presentation.imp;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -77,15 +80,20 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
   private boolean generateThumbnail(File thumbsDir, UploadedPresentation pres, int page, File pageFile)
       throws InterruptedException {
     String source = pageFile.getAbsolutePath();
-    String dest;
+    String dest = thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + page + ".png";
     String COMMAND = "";
+
+    // Skip processing if the destination file exists, as it was likely restored from the cache
+    if(Files.exists(Paths.get(dest))) {
+      return true;
+    }
 
     if (SupportedFileTypes.isImageFile(pres.getFileType())) {
       dest = thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + page + ".png";
       COMMAND = IMAGEMAGICK_DIR + File.separatorChar + "convert -thumbnail 150x150 "  + source + " " + dest;
     } else {
-      dest = thumbsDir.getAbsolutePath() + File.separatorChar + TEMP_THUMB_NAME + "-" + page; // the "-x.png" is appended automagically
-      COMMAND = "pdftocairo -png -scale-to 150 -cropbox " + source + " " + dest;
+      String pdftocairoDest = thumbsDir.getAbsolutePath() + File.separatorChar + TEMP_THUMB_NAME + "-" + page; // the "-x.png" is appended automagically
+      COMMAND = "pdftocairo -png -scale-to 150 " + source + " " + pdftocairoDest;
     }
 
     //System.out.println(COMMAND);

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -180,6 +180,17 @@ bigPdfSize=14000000
 # The maximum allowed page size for PDF files exceeding the 'pdfCheckSize' value, 2 MB by default
 maxBigPdfPageSize=2000000
 
+# This functionality stores outputs such as SVGs, PNGs, and text generated from PDFs or document files uploaded as presentations.
+# The processed outputs are cached in an S3-based storage system, keyed by a hash of the presentation file.
+# When the same presentation is uploaded again, the system retrieves the cached outputs, avoiding redundant processing and improving performance.
+presentationConversionCacheEnabled=false
+#presentationConversionCacheS3AccessKeyId=
+#presentationConversionCacheS3AccessKeySecret=
+#presentationConversionCacheS3BucketName=
+#presentationConversionCacheS3Region=
+#presentationConversionCacheS3EndpointURL=
+#presentationConversionCacheS3PathStyle=false
+
 #----------------------------------------------------
 # Default dial access number
 defaultDialAccessNumber=613-555-1234

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -45,6 +45,16 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="presCheckExec" value="${presCheckExec}"/>
     </bean>
 
+    <bean id="s3FileManager" class="org.bigbluebutton.presentation.imp.S3FileManager">
+        <property name="presentationConversionCacheEnabled" value="${presentationConversionCacheEnabled}"/>
+        <property name="accessKeyId" value="${presentationConversionCacheS3AccessKeyId}"/>
+        <property name="accessKeySecret" value="${presentationConversionCacheS3AccessKeySecret}"/>
+        <property name="bucketName" value="${presentationConversionCacheS3BucketName}"/>
+        <property name="region" value="${presentationConversionCacheS3Region}"/>
+        <property name="endpointUrl" value="${presentationConversionCacheS3EndpointURL}"/>
+        <property name="pathStyleAccess" value="${presentationConversionCacheS3PathStyle:false}"/>
+    </bean>
+
     <bean id="officeToPdfConversionService" class="org.bigbluebutton.presentation.imp.OfficeToPdfConversionService">
         <property name="officeDocumentValidator" ref="officeDocumentValidator"/>
         <property name="skipOfficePrecheck" value="${skipOfficePrecheck}"/>
@@ -114,6 +124,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="imageSlidesGenerationService" ref="imageSlidesGenerationService"/>
         <property name="counterService" ref="pageCounterService"/>
         <property name="pdfSlidesGenerationService" ref="pdfSlidesGenerationService"/>
+        <property name="s3FileManager" ref="s3FileManager"/>
     </bean>
 
     <bean id="imageSlidesGenerationService"
@@ -141,6 +152,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           class="org.bigbluebutton.presentation.imp.PresentationConversionCompletionService"
           init-method="start" destroy-method="stop">
         <property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>
+        <property name="s3FileManager" ref="s3FileManager"/>
     </bean>
 
 </beans>

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -975,6 +975,27 @@ public:
 
 and restart BigBlueButton via `sudo bbb-conf --restart`
 
+#### Configure S3-based cache for presentation assets
+
+In BigBlueButton 3.0 we introduced a functionality to store outputs such as SVGs, PNGs, thumbnails and text generated from PDFs or document files uploaded as presentations.
+The processed outputs are cached in an S3-based storage system, keyed by a hash of the presentation file.
+When the same presentation is uploaded again, the system retrieves the cached outputs, avoiding redundant processing and improving performance.
+
+In order to enable this feature, change the file `/etc/bigbluebutton/bbb-web.properties` including the following content:
+
+```
+presentationConversionCacheEnabled=true
+presentationConversionCacheS3AccessKeyId=AAAAAAAAAAAAAAAAAAAA
+presentationConversionCacheS3AccessKeySecret=aaaAAAaaaaaaaaaaaAAAAAAAAAaaaaaaaaaaaaa+aaA
+presentationConversionCacheS3BucketName=my-storage-name
+presentationConversionCacheS3Region=nyc3
+presentationConversionCacheS3EndpointURL=https://nyc3.digitaloceanspaces.com
+presentationConversionCacheS3PathStyle=false
+```
+_This is an example of config for DigitalOcean Spaces S3-Compatible Object Storage._
+
+and restart BigBlueButton via `sudo bbb-conf --restart`
+
 
 ### Frontends
 


### PR DESCRIPTION
This functionality stores outputs such as PDFs (separated per page), SVGs, PNGs, thumbnails and text generated from PDFs or document files uploaded as presentations.
The processed outputs are cached in an S3-based storage system, keyed by a hash of the presentation file.
When the same presentation is uploaded again, the system retrieves the cached outputs, avoiding redundant processing and improving performance.

The configs should be set at `/etc/bigbluebutton/bbb-web.properties`:
```
presentationConversionCacheEnabled=true
presentationConversionCacheS3AccessKeyId=
presentationConversionCacheS3AccessKeySecret=
presentationConversionCacheS3BucketName=
presentationConversionCacheS3Region=
presentationConversionCacheS3EndpointURL=
presentationConversionCacheS3PathStyle=false
```