### PR TITLE
build(bbb-webrtc-sfu): v2.17.0-beta.1

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v2.17.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.17.0-beta.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webrtc-sfu): v2.17.0-beta.1](https://github.com/bigbluebutton/bigbluebutton/commit/0c3d24951d92d3c5ebeba951361d15c40d77b1b2) 
  * fix(livekit): ignore participants other than STANDARD and SIP
  * fix(livekit): do not send audio events to BBB if bridge is unused
  * fix(livekit): clean up rooms on meeting end
  * fix(livekit): add error handling to ParticipantLeft callback

### Closes Issue(s)

None