### PR TITLE
[3.0]chore(sec): bump embedded tomcat to 9.0.96

### DIFF
--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -3,5 +3,5 @@ gormVersion=7.3.1
 gradleWrapperVersion=7.6.3
 grailsGradlePluginVersion=6.1.0
 groovyVersion=3.0.19
-tomcatEmbedVersion=9.0.90
+tomcatEmbedVersion=9.0.96
 springVersion=2.7.17


### PR DESCRIPTION
Porting https://github.com/bigbluebutton/bigbluebutton/pull/21824 to BBB 3.0+