### PR TITLE
Fixes issue #21903: [3.0.0-beta6] WEBHOOKS_APP_PORT null in bbb-conf --check

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -741,7 +741,7 @@ check_configuration() {
         fi
 
         WEBHOOKS_PROXY_PORT=$(cat /usr/share/bigbluebutton/nginx/webhooks.nginx | grep -v '#' | grep '^[ \t]*proxy_pass[ \t]*' | sed 's|.*http[s]\?://[^:]*:\([^;]*\);.*|\1|g')
-        WEBHOOKS_APP_PORT=$(yq e '.server.port' $WEBHOOKS_CONF)
+        WEBHOOKS_APP_PORT=$(yq e '.modules."../out/webhooks/index.js".config.api.port' $WEBHOOKS_CONF)
 
         if [ "$WEBHOOKS_PROXY_PORT" != "$WEBHOOKS_APP_PORT" ]; then
             echo "# Warning: Webhooks port mismatch: "


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/bigbluebutton/bigbluebutton/issues/21903
[3.0.0-beta6] WEBHOOKS_APP_PORT null in `bbb-conf --check`.

### Closes Issue(s)
Closes #21903

### Motivation
Fixes the false positive warning I found in bbb-v3-beta-6.

### How to test
Test if the warning in bbb-conf --check is still displayed.