### PR TITLE
refactor(audio): use LiveKit's event listener removal method

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -234,13 +234,13 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
   private removeLiveKitObservers(): void {
     if (!this.liveKitRoom) return;
-    this.liveKitRoom.removeAllListeners(RoomEvent.TrackSubscribed);
-    this.liveKitRoom.removeAllListeners(RoomEvent.TrackUnsubscribed);
-    this.liveKitRoom.removeAllListeners(RoomEvent.TrackSubscriptionFailed);
-    this.liveKitRoom.localParticipant.removeAllListeners(ParticipantEvent.TrackMuted);
-    this.liveKitRoom.localParticipant.removeAllListeners(ParticipantEvent.TrackUnmuted);
-    this.liveKitRoom.localParticipant.removeAllListeners(ParticipantEvent.LocalTrackPublished);
-    this.liveKitRoom.localParticipant.removeAllListeners(ParticipantEvent.LocalTrackUnpublished);
+    this.liveKitRoom.off(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
+    this.liveKitRoom.off(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
+    this.liveKitRoom.off(RoomEvent.TrackSubscriptionFailed, this.handleTrackSubscriptionFailed);
+    this.liveKitRoom.localParticipant.off(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
+    this.liveKitRoom.localParticipant.off(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
+    this.liveKitRoom.localParticipant.off(ParticipantEvent.LocalTrackPublished, this.handleLocalTrackPublished);
+    this.liveKitRoom.localParticipant.off(ParticipantEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
### What does this PR do?

- [refactor(audio): use LiveKit's event listener removal method](https://github.com/bigbluebutton/bigbluebutton/commit/dd3e7e41e100ea0a83607881e07c9cc250dab01e) 
  - Use LiveKit's own even removal method rather than the generic
remove[All]Listener[s]. Nothing explictly broken here, but for the sake
of consistency.

### Closes Issue(s)

None