### PR TITLE
fix(audio): unreliable LiveKit autoplay handling

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/component.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import Styled from './styles';
+import AudioAutoplayPrompt from '/imports/ui/components/audio/autoplay/component';
+
+const intlMessages = defineMessages({
+  title: {
+    id: 'app.audioModal.autoplayBlockedDesc',
+    description: 'Message for autoplay audio block',
+  },
+});
+
+interface LKAutoplayModalProps {
+  autoplayHandler: () => Promise<void>;
+  isOpen: boolean;
+  onRequestClose: () => void;
+  priority: string;
+  setIsOpen: (isOpen: boolean) => void;
+  isAttemptingAutoplay: boolean;
+}
+
+const LKAutoplayModal: React.FC<LKAutoplayModalProps> = ({
+  autoplayHandler,
+  isOpen,
+  onRequestClose,
+  priority,
+  setIsOpen,
+  isAttemptingAutoplay,
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Styled.LKAutoplayModal
+      onRequestClose={onRequestClose}
+      contentLabel={intl.formatMessage(intlMessages.title)}
+      title={intl.formatMessage(intlMessages.title)}
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      priority={priority}
+      aria-label={intl.formatMessage(intlMessages.title)}
+    >
+      <Styled.LKAutoplayModalContent>
+        <AudioAutoplayPrompt
+          handleAllowAutoplay={autoplayHandler}
+          disabled={isAttemptingAutoplay}
+        />
+      </Styled.LKAutoplayModalContent>
+    </Styled.LKAutoplayModal>
+  );
+};
+
+export default React.memo(LKAutoplayModal);

--- a/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/container.tsx
@@ -1,0 +1,66 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useReactiveVar } from '@apollo/client';
+import { useRoomContext } from '@livekit/components-react';
+import AudioManager from '/imports/ui/services/audio-manager';
+import logger from '/imports/startup/client/logger';
+import LKAutoplayModal from './component';
+import { useAutoplayState } from './hooks';
+
+const LKAutoplayModalContainer: React.FC = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  // @ts-ignore
+  // eslint-disable-next-line no-underscore-dangle
+  const isConnected = useReactiveVar(AudioManager._isConnected.value);
+  const room = useRoomContext();
+  const [autoplayState, handleStartAudio] = useAutoplayState(room);
+
+  const openLKAutoplayModal = useCallback(() => {
+    if (isOpen) return;
+
+    logger.warn({
+      logCode: 'livekit_audio_autoplay_blocked',
+    }, 'LiveKit: audio autoplay blocked');
+    setIsOpen(true);
+  }, [isOpen]);
+
+  const onRequestClose = useCallback(async () => {
+    try {
+      if (!autoplayState.canPlayAudio) {
+        await handleStartAudio();
+      }
+      logger.info({
+        logCode: 'livekit_audio_autoplayed',
+      }, 'LiveKit: audio autoplayed');
+      setIsOpen(false);
+    } catch (error) {
+      logger.error({
+        logCode: 'livekit_audio_autoplay_handle_failed',
+        extraInfo: {
+          errorMessage: (error as Error).message,
+          errorStack: (error as Error).stack,
+        },
+      }, 'LiveKit: failed to handle autoplay');
+    }
+  }, [autoplayState.canPlayAudio, handleStartAudio]);
+
+  useEffect(() => {
+    if (!autoplayState.canPlayAudio && isConnected && !autoplayState.hasAttempted) {
+      openLKAutoplayModal();
+    }
+  }, [autoplayState.canPlayAudio, isConnected, autoplayState.hasAttempted]);
+
+  if (!isConnected || autoplayState.canPlayAudio) return null;
+
+  return (
+    <LKAutoplayModal
+      autoplayHandler={handleStartAudio}
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      priority="medium"
+      setIsOpen={setIsOpen}
+      isAttemptingAutoplay={autoplayState.isAttempting}
+    />
+  );
+};
+
+export default React.memo(LKAutoplayModalContainer);

--- a/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/hooks.ts
@@ -1,0 +1,51 @@
+import { useState, useCallback } from 'react';
+import { Room } from 'livekit-client';
+import { useAudioPlayback } from '@livekit/components-react';
+import logger from '/imports/startup/client/logger';
+
+export interface AutoplayState {
+  hasAttempted: boolean;
+  isAttempting: boolean;
+  canPlayAudio: boolean;
+}
+
+export const useAutoplayState = (liveKitRoom: Room): [AutoplayState, () => Promise<void>] => {
+  const { canPlayAudio, startAudio } = useAudioPlayback(liveKitRoom);
+  const [state, setState] = useState<AutoplayState>({
+    hasAttempted: false,
+    isAttempting: false,
+    canPlayAudio,
+  });
+
+  const handleStartAudio = useCallback(async () => {
+    setState((prev) => ({ ...prev, isAttempting: true }));
+    try {
+      await startAudio();
+      setState({
+        hasAttempted: true,
+        isAttempting: false,
+        canPlayAudio: true,
+      });
+    } catch (error) {
+      setState({
+        hasAttempted: true,
+        isAttempting: false,
+        canPlayAudio: false,
+      });
+      logger.error({
+        logCode: 'livekit_audio_autoplay_failed',
+        extraInfo: {
+          errorMessage: (error as Error).message,
+          errorStack: (error as Error).stack,
+        },
+      }, 'LiveKit: audio autoplay failed');
+      throw error;
+    }
+  }, [startAudio]);
+
+  return [{ ...state, canPlayAudio }, handleStartAudio];
+};
+
+export default {
+  useAutoplayState,
+};

--- a/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/styles.ts
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import ModalSimple from '/imports/ui/components/common/modal/simple/component';
+import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
+
+const LKAutoplayModal = styled(ModalSimple)`
+  padding: 1rem;
+  min-height: 20rem;
+`;
+
+const LKAutoplayModalContent = styled.div`
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  margin-top: auto;
+  margin-bottom: auto;
+  padding: 0.5rem 0;
+
+  button:first-child {
+    margin: 0 3rem 0 0;
+
+    [dir="rtl"] & {
+      margin: 0 0 0 3rem;
+    }
+
+    @media ${smallOnly} {
+      margin: 0 1rem 0 0;
+
+      [dir="rtl"] & {
+        margin: 0 0 0 1rem;
+      }
+    }
+  }
+
+  button:only-child {
+    margin: inherit 0 inherit inherit;
+
+    [dir="rtl"] & {
+      margin: inherit inherit inherit 0 !important;
+    }
+  }
+`;
+
+export default {
+  LKAutoplayModal,
+  LKAutoplayModalContent,
+};

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -22,12 +22,14 @@ import {
 } from '/imports/ui/services/livekit';
 import { USER_SET_TALKING } from '/imports/ui/components/livekit/mutations';
 import { useIceServers } from '/imports/ui/components/livekit/hooks';
+import LKAutoplayModalContainer from '/imports/ui/components/livekit/autoplay-modal/container';
 
 interface BBBLiveKitRoomProps {
   url?: string;
   token?: string;
   bbbSessionToken: string;
   usingAudio: boolean;
+  usingScreenShare: boolean;
 }
 
 interface ObserverProps {
@@ -77,6 +79,7 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   token,
   bbbSessionToken,
   usingAudio,
+  usingScreenShare,
 }) => {
   const {
     iceServers,
@@ -119,6 +122,9 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
     });
   }, [url]);
 
+  // Screen share requires audio playback as well (Chrome supports it)
+  const withAudioPlayback = usingAudio || usingScreenShare;
+
   return (
     <LiveKitRoom
       video={false}
@@ -130,7 +136,8 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       style={{ zIndex: 0, height: 'initial', width: 'initial' }}
     >
       <LiveKitObserver room={liveKitRoom} url={url} usingAudio={usingAudio} />
-      <RoomAudioRenderer />
+      {withAudioPlayback && <LKAutoplayModalContainer />}
+      {withAudioPlayback && <RoomAudioRenderer />}
     </LiveKitRoom>
   );
 };
@@ -159,6 +166,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
       url={url}
       bbbSessionToken={Auth.sessionToken as string}
       usingAudio={bridges?.audioBridge === 'livekit'}
+      usingScreenShare={bridges?.screenShareBridge === 'livekit'}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): unreliable LiveKit autoplay handling](https://github.com/bigbluebutton/bigbluebutton/commit/98b56f02c312cde2e5182025e90452ddbe226bfe) 
  - The existing autoplay handling for LiveKit has been inconsistent. Previous
attempts to reuse the current autoplay mechanism (`audio-manager` +
`audio-modal`) resulted in issues with the autoplay prompt being omitted
in certain scenarios. See commit log for more info.

### Closes Issue(s)

None 

### Motivation

Ref #21059