### PR TITLE
ci (automated tests): Install Sipp (for future dial-in user tests)

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -255,7 +255,7 @@ jobs:
         run: |
           sudo sh -c '
           apt --purge -y remove apache2-bin
-          apt-mark hold firefox #hold ff once bbb-install frequently stuck at `Installing the firefox snap`
+          apt-mark hold firefox #hold ff as bbb-install frequently stuck at `Installing the firefox snap`
 
           #bbb-webrtc-sfu: removes the special scheduling policies
           mkdir -p /etc/systemd/system/bbb-webrtc-sfu.service.d/
@@ -265,6 +265,30 @@ jobs:
           Nice=19
           EOL
           systemctl daemon-reload
+
+          #Install Sipp for dial-in tests
+          apt install -y pkg-config dh-autoreconf ncurses-dev build-essential libssl-dev libpcap-dev libncurses5-dev libsctp-dev lksctp-tools cmake
+          git clone --recurse-submodules https://github.com/SIPp/sipp.git /opt/sipp
+          cd /opt/sipp
+          git checkout 4682fdba2b63007f13a632c6eb06f0ece84cb7df #Set an old commit as the current code is not working
+          cmake . -DUSE_SSL=1 -DUSE_SCTP=1 -DUSE_PCAP=1 -DUSE_GSL=1
+          make
+          sudo make install
+          rm -r /opt/sipp/gtest
+          rm -r /opt/sipp/src
+
+          # Set dial plan for internal calls
+          mkdir -p /opt/freeswitch/conf/dialplan/public/
+          cat << EOF > "/opt/freeswitch/conf/dialplan/public/bbb_sip.xml"
+          <include>
+            <extension name="bbb_sp_call" continue="true">
+                <condition field="network_addr" expression="\${domain}" break="on-false">
+                    <action application="set" data="bbb_authorized=true"/>
+                    <action application="transfer" data="\${destination_number} XML default"/>
+                </condition>
+            </extension>
+          </include>
+          EOF
           '
       - name: Install BBB
         env:


### PR DESCRIPTION
Installs Sipp in CI server as it enable to run tests for dial-in users.

With sipp installed it is possible to simulate a dial-in user by running:
```
VOICE_BRIDGE=76034
cd /opt/sipp
sudo sipp -sn uac_pcap -m 1 -aa -d 30000 -s $VOICE_BRIDGE "$(hostname -I | awk '{print $1}')":5060
```
Replacing the VOICE_BRIDGE with the same number used during `/create` of the meeting.


More info: https://github.com/SIPp/sipp.git