### PR TITLE
fix: audio rejoin after breakout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -409,7 +409,7 @@ const AudioModal = ({
     setDisableActions(true);
     setErrorInfo(null);
 
-    joinMicrophone({ muted: true }).then(() => {
+    joinMicrophone().then(() => {
       setDisableActions(false);
     }).catch((err) => {
       handleJoinAudioError(err);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -409,7 +409,7 @@ const AudioModal = ({
     setDisableActions(true);
     setErrorInfo(null);
 
-    joinMicrophone().then(() => {
+    joinMicrophone({ muted: true }).then(() => {
       setDisableActions(false);
     }).catch((err) => {
       handleJoinAudioError(err);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/service.ts
@@ -37,7 +37,7 @@ const logUserCouldNotRejoinAudio = () => {
 
 export const rejoinAudio = () => {
   if (didUserSelectedMicrophone()) {
-    AudioManager.joinMicrophone().catch(() => {
+    AudioManager.joinMicrophone({ muted: true }).catch(() => {
       logUserCouldNotRejoinAudio();
     });
   } else if (didUserSelectedListenOnly()) {


### PR DESCRIPTION
### What does this PR do?

Adds missing parameter in joinMicrophone method, that was causing an error when leaving a breakout room

### How to test

1. join a meeting
2. join with audio in the main room
3. join in a breakout room
4. click to leave the breakout room
5. see error in the main room