### PR TITLE
fix(breakout-room/create-breakout-room): Refactor initial state for number of rooms in `CreateBreakoutRoom` component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -231,6 +231,8 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   const { isMobile } = deviceInfo;
   const intl = useIntl();
 
+  const initialNumberOfRooms = runningRooms.length > 0 ? runningRooms.length : MIN_BREAKOUT_ROOMS;
+
   const [numberOfRoomsIsValid, setNumberOfRoomsIsValid] = React.useState(true);
   const [durationIsValid, setDurationIsValid] = React.useState(true);
   const [freeJoin, setFreeJoin] = React.useState(false);
@@ -239,7 +241,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   const [leastOneUserIsValid, setLeastOneUserIsValid] = React.useState(false);
   const [captureNotes, setCaptureNotes] = React.useState(false);
   const [inviteMods, setInviteMods] = React.useState(false);
-  const [numberOfRooms, setNumberOfRooms] = React.useState(MIN_BREAKOUT_ROOMS);
+  const [numberOfRooms, setNumberOfRooms] = React.useState(initialNumberOfRooms);
   const [durationTime, setDurationTime] = React.useState(DEFAULT_BREAKOUT_TIME);
   const isImportPresentationWithAnnotationsEnabled = useIsImportPresentationWithAnnotationsFromBreakoutRoomsEnabled();
   const isImportSharedNotesEnabled = useIsImportSharedNotesFromBreakoutRoomsEnabled();


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the user would create more than 2 breakout rooms and when updating those rooms, would be able to update only room  1 and 2.

### Closes Issue(s)

Closes #21760 

### How to test

Start a meeting, play around with creating and updating breakout rooms.

### More

Before

![image](https://github.com/user-attachments/assets/011eb24a-841e-45fa-8999-ffdb0a50bfe2)

After

![image](https://github.com/user-attachments/assets/8be8570b-bce9-4285-a8c0-816e8ba8bde9)
