### PR TITLE
gql: Add flags `hasCurrentPresentation` and `isSharedNotedPinned` for `componentsFlags`

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2272,7 +2272,18 @@ select "meeting"."meetingId",
             select 1
             from "v_caption_activeLocales"
             where "v_caption_activeLocales"."meetingId" = "meeting"."meetingId"
-        ) as "hasCaption"
+        ) as "hasCaption",
+        exists (
+            select 1
+            from "sharedNotes"
+            where "sharedNotes"."meetingId" = "meeting"."meetingId"
+            and "sharedNotes"."pinned" is true
+        ) as "isSharedNotedPinned",
+        exists (
+            select 1
+            from "v_pres_page_curr"
+            where "v_pres_page_curr"."meetingId" = "meeting"."meetingId"
+        ) as "hasCurrentPresentation"
 from "meeting";
 
 ------------------------

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
@@ -11,12 +11,14 @@ select_permissions:
     permission:
       columns:
         - hasBreakoutRoom
+        - hasCameraAsContent
         - hasCaption
+        - hasCurrentPresentation
         - hasExternalVideo
         - hasPoll
         - hasScreenshare
-        - hasCameraAsContent
         - hasTimer
+        - isSharedNotedPinned
         - showRemainingTime
       filter:
         meetingId:


### PR DESCRIPTION
Introduces two components flags suggested by @Tainan404.
Using these flags allows the client to easily decide which components to render without needing to create a separate subscription for this validation.

```gql
subscription {
  meeting_componentFlags {
    hasCurrentPresentation
    isSharedNotedPinned
  }
}
```