### PR TITLE
Update BBB 3.0 cluster proxy config for LiveKit

### DIFF
--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -118,6 +118,8 @@ public:
   media:
     stunTurnServersFetchAddress: 'https://bbb-01.example.com/bigbluebutton/api/stuns'
     sip_ws_host: 'bbb-01.example.com'
+    livekit:
+      url: wss://bbb-01.example.com/livekit
   kurento:
     wsUrl: wss://bbb-01.example.com/bbb-webrtc-sfu
   presentation:


### PR DESCRIPTION
### What does this PR do?
Updates the documentation on cluster proxy setup for BBB 3.0 such that it works when LiveKit is used.

When the `public.media.livekit.url` is not set, the websocket connection will be attempted towards  `wss://{window.location.hostname}/livekit`, where `window.location.hostname` will be the proxy FQDN in case of a cluster proxy setup. Thus, `public.media.livekit.url` needs to be correctly set.