### PR TITLE
fix (html5): Store API URL In-Memory to avoid Session Storage caching issues

### DIFF
--- a/bigbluebutton-html5/imports/api/bbb-web-api/index.ts
+++ b/bigbluebutton-html5/imports/api/bbb-web-api/index.ts
@@ -1,15 +1,13 @@
-import Session from '/imports/ui/services/storage/session';
 import { IndexResponse } from './types';
 
 class BBBWebApi {
-  private cachePrefix = 'bbbWebApi';
+  private lastResponse : IndexResponse['response'] | null = null;
 
   private routes = {
     index: {
       // this needs to be a relative path because it may be mounted as a subpath
       // for example in cluster setups
       path: 'bigbluebutton/api',
-      cacheKey: `${this.cachePrefix}_index`,
     },
   };
 
@@ -25,10 +23,9 @@ class BBBWebApi {
     data: IndexResponse['response'],
     response?: Response,
   }> {
-    const cache = Session.getItem(this.routes.index.cacheKey);
-    if (cache) {
+    if (this.lastResponse != null) {
       return {
-        data: cache as IndexResponse['response'],
+        data: this.lastResponse as IndexResponse['response'],
       };
     }
 
@@ -40,7 +37,7 @@ class BBBWebApi {
     });
 
     const body: IndexResponse = await response.json();
-    Session.setItem(this.routes.index.cacheKey, body.response);
+    this.lastResponse = body.response;
 
     return {
       response,


### PR DESCRIPTION
The Html5 Client retrieves the API URL from `/bigbluebutton/api` and stores it in session storage. If the API URL changes, the client may continue using the outdated URL from the cache.

**Solution:**  
- **Remove Session Storage:** Eliminate caching the API URL in session storage.
- **Use In-Memory Singleton:** Store the API URL in a singleton in-memory object, ensuring it only persists until the browser is refreshed.

Closes #21927