### PR TITLE
refactor (bbb-web): Rename endpoint `/ping` to `/rtt-check` to clarify its purpose

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -30,7 +30,7 @@ const ConnectionStatus = () => {
   const handleUpdateConnectionAliveAt = () => {
     const startTime = performance.now();
     fetch(
-      `${getBaseUrl()}/ping`,
+      `${getBaseUrl()}/rtt-check`,
       { signal: AbortSignal.timeout(STATS_INTERVAL) },
     )
       .then((res) => {

--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -159,7 +159,7 @@
             proxy_set_header        X-Original-URI $request_uri;
         }
 
-        location /bigbluebutton/ping {
+        location /bigbluebutton/rtt-check {
             default_type text/plain;
             add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
             add_header Pragma "no-cache";


### PR DESCRIPTION
The client periodically requests a static endpoint to measure its round-trip time (RTT) with the server. Currently, this endpoint is named `/ping`, which can be misleading, as it might be mistaken for a keep-alive request or confused with the periodic GraphQL "ping" used to check if the client is still connected.

This PR renames the endpoint to `/rtt-check` to clearly indicate its purpose: measuring the client’s RTT to the server.


![image](https://github.com/user-attachments/assets/071251c5-afc4-4488-af81-67581351d660)
