### PR TITLE
fix(whiteboard): Delay rendering of error boundary children until listeners attach

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -25,6 +25,7 @@ const ErrorBoundaryWithReload = ({ children }) => {
   const [hasError, setHasError] = useState(false);
   const [errorKey, setErrorKey] = useState(0);
   const [errorCount, setErrorCount] = useState(0);
+  const [isReady, setIsReady] = useState(false);
   const resetTimeout = useRef(null);
 
   const handleReset = useCallback(() => {
@@ -78,12 +79,16 @@ const ErrorBoundaryWithReload = ({ children }) => {
     window.addEventListener('error', handleGlobalError);
     window.addEventListener('unhandledrejection', handleUnhandledRejection);
 
+    setIsReady(true);
+
     return () => {
       if (resetTimeout.current) clearTimeout(resetTimeout.current);
       window.removeEventListener('error', handleGlobalError);
       window.removeEventListener('unhandledrejection', handleUnhandledRejection);
     };
   }, [triggerError]);
+
+  if (!isReady) return null;
 
   if (hasError && errorCount <= MAX_RETRIES) {
     return (

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -122,7 +122,6 @@ const Whiteboard = React.memo((props) => {
 
   clearTldrawCache();
 
-  const [tlEditor, setTlEditor] = React.useState(null);
   const [isMounting, setIsMounting] = React.useState(true);
   const [isTabVisible, setIsTabVisible] = React.useState(document.visibilityState === 'visible');
 
@@ -148,7 +147,7 @@ const Whiteboard = React.memo((props) => {
   const whiteboardRef = React.useRef(null);
   const zoomValueRef = React.useRef(null);
   const prevShapesRef = React.useRef(shapes);
-  const tlEditorRef = React.useRef(tlEditor);
+  const tlEditorRef = React.useRef(null);
   const slideChanged = React.useRef(false);
   const slideNext = React.useRef(null);
   const prevZoomValueRef = React.useRef(null);
@@ -589,7 +588,7 @@ const Whiteboard = React.memo((props) => {
   };
 
   const handleTldrawMount = (editor) => {
-    setTlEditor(editor);
+    tlEditorRef.current = editor;
     setTldrawAPI(editor);
     setEditor(editor);
 
@@ -968,10 +967,6 @@ const Whiteboard = React.memo((props) => {
   );
 
   React.useEffect(() => {
-    tlEditorRef.current = tlEditor;
-  }, [tlEditor]);
-
-  React.useEffect(() => {
     const handleArrowPress = (event) => {
       const currPageNum = parseInt(curPageIdRef.current, 10);
       const shapeSelected = tlEditorRef.current.getSelectedShapes()?.length > 0;
@@ -1035,7 +1030,7 @@ const Whiteboard = React.memo((props) => {
     let timeoutId = null;
 
     if (
-      tlEditor &&
+      tlEditorRef.current &&
       curPageIdRef.current &&
       currentPresentationPage &&
       isPresenter &&
@@ -1128,7 +1123,7 @@ const Whiteboard = React.memo((props) => {
     prevZoomValueRef.current = zoomValue;
     return () => clearTimeout(timeoutId);
   }, [
-    zoomValue, tlEditor, curPageId, isWheelZoomRef.current, fitToWidthRef.current,
+    zoomValue, tlEditorRef.current, curPageId, isWheelZoomRef.current, fitToWidthRef.current,
   ]);
 
   React.useEffect(() => {
@@ -1219,7 +1214,7 @@ const Whiteboard = React.memo((props) => {
       if (
         presentationAreaHeight > 0 &&
         presentationAreaWidth > 0 &&
-        tlEditor &&
+        tlEditorRef.current &&
         currentPresentationPage &&
         currentPresentationPage.scaledWidth > 0 &&
         currentPresentationPage.scaledHeight > 0


### PR DESCRIPTION
### What does this PR do?
This pull request resolves an issue where the error boundary for the whiteboard in breakout rooms fails to recover when a crash occurs. The recovery mechanism does not properly trigger in breakout rooms because the listeners are not yet attached when the error boundary renders its children.

![image](https://github.com/user-attachments/assets/d6da6a36-616e-43b8-b8f7-822e3f8a73f6)



### Closes Issue(s)
Closes #21952
