### PR TITLE
feat: introduce showSessionDetailsOnJoin parameter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -152,7 +152,7 @@ class NavBar extends Component {
     this.splitPluginItems = this.splitPluginItems.bind(this);
 
     this.state = {
-      isModalOpen: false,
+      isModalOpen: props.showSessionDetailsOnJoin,
     };
   }
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -60,6 +60,10 @@ const NavBarContainer = ({ children, ...props }) => {
     'bbb_direct_leave_button',
     PUBLIC_CONFIG.app.defaultSettings.application.directLeaveButton,
   );
+  const SHOW_SESSION_DETAILS_ON_JOIN = getFromUserSettings(
+    'bbb_show_session_details_on_join',
+    PUBLIC_CONFIG.layout.showSessionDetailsOnJoin,
+  );
 
   let meetingTitle;
   let breakoutNum;
@@ -122,6 +126,7 @@ const NavBarContainer = ({ children, ...props }) => {
         // TODO: Remove/Replace
         isMeteorConnected: true,
         hideTopRow: navBar.hideTopRow,
+        showSessionDetailsOnJoin: SHOW_SESSION_DETAILS_ON_JOIN,
         ...props,
       }}
       style={{ ...navBar }}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -800,7 +800,7 @@ public:
     showParticipantsOnLogin: true
     showPushLayoutButton: true
     showPushLayoutToggle: true
-    showSessionDetailsOnJoin: false
+    showSessionDetailsOnJoin: true
   pads:
     url: ETHERPAD_HOST
   media:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -800,6 +800,7 @@ public:
     showParticipantsOnLogin: true
     showPushLayoutButton: true
     showPushLayoutToggle: true
+    showSessionDetailsOnJoin: false
   pads:
     url: ETHERPAD_HOST
   media:

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1427,7 +1427,7 @@ Useful tools for development:
 | `userdata-bbb_parent_room_moderator=` | (Introduced in BigBlueButton 3.0) Only used in breakouts: if set to `true`, user will have permission to kick other users inside the breakout | `false`                                                                      
 | `userdata-bbb_record_permission=` | (Introduced in BigBlueButton 3.0) If set to `true`, the user will be able to control the recording start/stop. If set to `false`, the user will not be allowed to control the recording start/stop even if their role is moderator. Otherwise only moderators will have the control (default).                                                                                                                   | `null`        |
 | `userdata-bbb_record_permission_tooltip=` | (Introduced in BigBlueButton 3.0) If set, the tooltip of the recording indicator shown when the user don't have permission to record will be replaced by its content.                                                                                                                   | `null`        |
-| `userdata-bbb_show_session_details_on_join=` | (Introduced in BigBlueButton 3.0) If set to `true` , the session details window will be displayed when a user joins the session.                                                                                                                   | `null`        |
+| `userdata-bbb_show_session_details_on_join=` | (Introduced in BigBlueButton 3.0) If set to `false` , the session details window will not be displayed when a user joins the session.                                                                                                                   | `null`        |
 
 #### Branding parameters
 

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1427,6 +1427,7 @@ Useful tools for development:
 | `userdata-bbb_parent_room_moderator=` | (Introduced in BigBlueButton 3.0) Only used in breakouts: if set to `true`, user will have permission to kick other users inside the breakout | `false`                                                                      
 | `userdata-bbb_record_permission=` | (Introduced in BigBlueButton 3.0) If set to `true`, the user will be able to control the recording start/stop. If set to `false`, the user will not be allowed to control the recording start/stop even if their role is moderator. Otherwise only moderators will have the control (default).                                                                                                                   | `null`        |
 | `userdata-bbb_record_permission_tooltip=` | (Introduced in BigBlueButton 3.0) If set, the tooltip of the recording indicator shown when the user don't have permission to record will be replaced by its content.                                                                                                                   | `null`        |
+| `userdata-bbb_show_session_details_on_join=` | (Introduced in BigBlueButton 3.0) If set to `true` , the session details window will be displayed when a user joins the session.                                                                                                                   | `null`        |
 
 #### Branding parameters
 


### PR DESCRIPTION
### What does this PR do?

introduces **showSessionDetailsOnJoin** parameter, making it possible to change the session details modal initial state when joining a meeting

### Closes Issue(s)
Closes #21886

### Motivation
https://github.com/bigbluebutton/bigbluebutton/issues/21886#issuecomment-2552108002

### How to test
1. set `public.layout.showSessionDetailsOnJoin` as `true` in the settings file or use the join parameter `userdata-bbb_show_session_details_on_join=true`
2. join the meeting and the session details modal should open