### PR TITLE
feat(recording): livekit track-based audio processing

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -31,12 +31,19 @@ module BigBlueButton
         edl.each do |entry|
           BigBlueButton.logger.debug "---"
           BigBlueButton.logger.debug "  Timestamp: #{entry[:timestamp]}"
-          BigBlueButton.logger.debug "  Audio:"
+          BigBlueButton.logger.debug "  Audio(s):"
           audio = entry[:audio]
           if audio
             BigBlueButton.logger.debug "    #{audio[:filename]} at #{audio[:timestamp]}"
           else
-            BigBlueButton.logger.debug "    silence"
+            audios = entry[:audios]
+            if audios
+              audios.each do |entry|
+                BigBlueButton.logger.debug "    #{entry[:filename]} at #{entry[:timestamp]}"
+              end
+            else
+              BigBlueButton.logger.debug "    silence"
+            end
           end
         end
       end
@@ -66,15 +73,21 @@ module BigBlueButton
         corrupt_audios = Set.new
 
         BigBlueButton.logger.info "Pre-processing EDL"
-        for i in 0...(edl.length - 1)
-          # The render scripts use this to calculate cut lengths
+        # The render scripts use this to calculate cut lengths
+        (0...(edl.length - 1)).each do |i|
           edl[i][:next_timestamp] = edl[i+1][:timestamp]
-          # Build a list of audio files to read information from
-          if edl[i][:audio]
-            audioinfo[edl[i][:audio][:filename]] = {}
+        end
+      
+        # Build a list of audio files to read information from
+        edl.each do |entry|
+          if entry[:audio]
+            audioinfo[entry[:audio][:filename]] ||= {}
+          elsif entry[:audios]
+            entry[:audios].each { |a| audioinfo[a[:filename]] ||= {} }
           end
         end
-
+      
+        # Read audio metadata
         BigBlueButton.logger.info "Reading source audio information"
         audioinfo.keys.each do |audiofile|
           BigBlueButton.logger.debug "  #{audiofile}"
@@ -82,49 +95,110 @@ module BigBlueButton
           if !info[:audio] || !info[:duration]
             BigBlueButton.logger.warn "    This audio file is corrupt! It will be removed from the output."
             corrupt_audios << audiofile
-            next
+          else
+            BigBlueButton.logger.debug "    format: #{info[:format][:format_name]}, codec: #{info[:audio][:codec_name]}"
+            BigBlueButton.logger.debug "    sample rate: #{info[:sample_rate]}, duration: #{info[:duration]}"
+            audioinfo[audiofile] = info
           end
-
-          BigBlueButton.logger.debug "    format: #{info[:format][:format_name]}, codec: #{info[:audio][:codec_name]}"
-          BigBlueButton.logger.debug "    sample rate: #{info[:sample_rate]}, duration: #{info[:duration]}"
-
-          audioinfo[audiofile] = info
         end
 
-        if corrupt_audios.length > 0
+        if corrupt_audios.any?
           BigBlueButton.logger.info "Removing corrupt audio files from EDL"
           edl.each do |event|
+            # single :audio
             if event[:audio] && corrupt_audios.include?(event[:audio][:filename])
               event[:audio] = nil
             end
+            # multi :audios
+            if event[:audios]
+              event[:audios].reject! { |a| corrupt_audios.include?(a[:filename]) }
+              event[:audios] = nil if event[:audios].empty?
+            end
           end
-
           dump(edl)
         end
 
         ffmpeg_inputs = []
-        ffmpeg_filter = ''
+        filter_lines  = []
+      
+        # Keep an array of final segment labels for later concat
+        segment_labels = []
+      
         BigBlueButton.logger.info "Generating ffmpeg command"
-        for i in 0...(edl.length - 1)
+        # Build one chain per segment
+        (0...(edl.length - 1)).each do |i|
           entry = edl[i]
-          audio = entry[:audio]
-          duration = entry[:next_timestamp] - entry[:timestamp]
+          seg_duration = entry[:next_timestamp] - entry[:timestamp]
+      
+          # label the final output of this segment as [segX]
+          seg_label = "seg#{i}"
+      
+          # Grab multiple or single audio references
+          audios = entry[:audios]
+          single = entry[:audio]
+      
+          if audios && !audios.empty?
+            # ------------------------------------------------------
+            # MULTIPLE AUDIOS => amix
+            # ------------------------------------------------------
+            track_labels = []
+      
+            audios.each_with_index do |audio_data, idx|
+              filename = audio_data[:filename]
+              seek     = audio_data[:timestamp]
+              info     = audioinfo[filename]
+              speed    = 1.0
+              
+              if seek < (info[:duration].to_f * speed)
+                input_index = ffmpeg_inputs.size
+                ffmpeg_inputs << { filename: filename, seek: seek }
+      
+                # Build track label
+                track_label = "t#{i}_#{idx}"
+                line = "[#{input_index}]#{FFMPEG_AFORMAT},apad,asetpts=N"
+                line << ",atempo=#{speed}" if speed != 1.0
+                line << "[#{track_label}];"
+                filter_lines << line
+                track_labels << "[#{track_label}]"
+              else
+                # If we're seeking past the file end => silence
+                track_label = "t#{i}_silence#{idx}"
+                line = "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},asetpts=N[#{track_label}];"
+                filter_lines << line
+                track_labels << "[#{track_label}]"
+              end
+            end
+      
+            # Now we mix them
+            if track_labels.size > 1
+              # e.g.: [t0_0][t0_1]amix=inputs=2[seg0]
+              line = track_labels.join
+              line << "amix=inputs=#{track_labels.size}:dropout_transition=0[#{seg_label}];"
+              filter_lines << line
+            else
+              # Only one track => rename it to [segX] (via anull or direct rename)
+              line = "#{track_labels.first}anull[#{seg_label}];"
+              filter_lines << line
+            end
+      
+          elsif single
+            # ------------------------------------------------------
+            # SINGLE AUDIO
+            # ------------------------------------------------------
+            filename = single[:filename]
+            seek     = single[:timestamp]
+            info     = audioinfo[filename]
+            speed    = 1.0
 
-          ffmpeg_filter << "[a_edl#{i}_prev];\n" if i > 0
-
-          if audio
-            BigBlueButton.logger.info "  Using input #{audio[:filename]}"
-
-            speed = 1
-            seek = audio[:timestamp]
+            BigBlueButton.logger.info "  Using input #{filename}"
 
             # Check for and handle audio files with mismatched lengths (generated
             # by buggy versions of freeswitch in old BigBlueButton
-            if ((audioinfo[audio[:filename]][:format][:format_name] == 'wav' ||
-                 audioinfo[audio[:filename]][:audio][:codec_name] == 'vorbis') &&
+            if ((info[:format][:format_name] == 'wav' ||
+              info[:audio][:codec_name] == 'vorbis') &&
                  entry[:original_duration] &&
-                 (audioinfo[audio[:filename]][:duration].to_f / entry[:original_duration]) < 0.997 &&
-                 ((entry[:original_duration] - audioinfo[audio[:filename]][:duration]).to_f /
+                 (info[:duration].to_f / entry[:original_duration]) < 0.997 &&
+                 ((entry[:original_duration] - info[:duration]).to_f /
                    entry[:original_duration]).abs < 0.05)
 
               speed = audioinfo[audio[:filename]][:duration].to_f / entry[:original_duration]
@@ -133,57 +207,73 @@ module BigBlueButton
             end
 
             # Skip this input and generate silence if the seekpoint is past the end of the audio, which can happen
-            # if events are slightly misaligned and you get unlucky with a start/stop or chapter break.
-            if audio[:timestamp] < (audioinfo[audio[:filename]][:duration] * speed)
-              input_index = ffmpeg_inputs.length
-              ffmpeg_inputs << {
-                filename: audio[:filename],
-                seek: seek
-              }
-              ffmpeg_filter << "[#{input_index}]#{FFMPEG_AFORMAT},apad"
+            # if events are slightly misaligned and you get unlucky with a start/stop or chapter break.      
+            if seek < (info[:duration] * speed)
+              input_index = ffmpeg_inputs.size
+              ffmpeg_inputs << { filename: filename, seek: seek }
+              line = "[#{input_index}]#{FFMPEG_AFORMAT},apad,asetpts=N"
+              line << ",atempo=#{speed}" if speed != 1.0
+              line << "[#{seg_label}];"
+              filter_lines << line
             else
-              ffmpeg_filter << "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT}"
+              # Past file => silence
+              line = "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},asetpts=N[#{seg_label}];"
+              filter_lines << line
             end
-
-            ffmpeg_filter << ',asetpts=N'
-
-            ffmpeg_filter << ",atempo=#{speed},atrim=start=#{ms_to_s(audio[:timestamp])}" if speed != 1
+      
           else
+            # ------------------------------------------------------
+            # NO AUDIO => SILENCE
+            # ------------------------------------------------------
             BigBlueButton.logger.info "  Generating silence"
-
-            ffmpeg_filter << "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT}"
+            line = "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},asetpts=N[#{seg_label}];"
+            filter_lines << line
           end
-
-          if i > 0
-            ffmpeg_filter << "[a_edl#{i}];\n"
-            ffmpeg_filter << "[a_edl#{i}_prev][a_edl#{i}]concat=n=2:a=1:v=0"
-          end
-
-          ffmpeg_filter << ",atrim=end=#{ms_to_s(entry[:next_timestamp])}"
+      
+          # Now trim this segment to seg_duration
+          trim_line = "[#{seg_label}]atrim=end=#{ms_to_s(seg_duration)}[#{seg_label}];"
+          filter_lines << trim_line
+      
+          # Collect the segment’s final label for the eventual concat
+          segment_labels << "[#{seg_label}]"
         end
-
+      
+        # Build the final concat line if we have at least one segment
+        if segment_labels.any?
+          # e.g.: [seg0][seg1][seg2]concat=n=3:a=1:v=0
+          line = segment_labels.join
+          line << "concat=n=#{segment_labels.size}:a=1:v=0"
+          filter_lines << line
+        end
+      
+        #-------------------------------------
+        # Build the ffmpeg command
+        #-------------------------------------
         ffmpeg_cmd = [*FFMPEG]
         ffmpeg_inputs.each do |input|
-          ffmpeg_cmd += ['-ss', ms_to_s(input[:seek])]
+          # Seek
+          if input[:seek].positive?
+            ffmpeg_cmd += ['-ss', ms_to_s(input[:seek])]
+          end
           # Ensure that the entire contents of freeswitch wav files are read
-          if audioinfo[input[:filename]][:format][:format_name] == 'wav'
+          info = audioinfo[input[:filename]]
+          if info && info[:format][:format_name] == 'wav'
             ffmpeg_cmd += ['-ignore_length', '1']
           end
           # Prefer using the libopus decoder for opus files, it handles discontinuities better
-          if audioinfo[input[:filename]][:audio][:codec_name] == 'opus'
+          if info && info[:audio][:codec_name] == 'opus'
             ffmpeg_cmd << '-c:a' << 'libopus'
           end
           ffmpeg_cmd += ['-i', input[:filename]]
         end
 
+        # Write filter script
+        filter_script = "#{output_basename}.filter"
+        filter_content = filter_lines.join("\n")
         BigBlueButton.logger.debug('  ffmpeg filter_complex_script:')
-        BigBlueButton.logger.debug(ffmpeg_filter)
-        filter_complex_script = "#{output_basename}.filter"
-        File.open(filter_complex_script, 'w') do |io|
-          io.write(ffmpeg_filter)
-        end
-
-        ffmpeg_cmd << '-filter_complex_script' << filter_complex_script
+        BigBlueButton.logger.debug(filter_content)
+        File.open(filter_script, 'w') { |f| f.write(filter_content) }
+        ffmpeg_cmd << '-filter_complex_script' << filter_script
 
         output = "#{output_basename}.#{WF_EXT}"
         ffmpeg_cmd += ['-vn', *FFMPEG_WF_ARGS, output]

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -100,7 +100,6 @@ module BigBlueButton
           edl.each do |event|
             if event[:audios]
               event[:audios].reject! { |a| corrupt_audios.include?(a[:filename]) }
-              event[:audios] = nil if event[:audios].empty?
             end
           end
           dump(edl)
@@ -206,9 +205,7 @@ module BigBlueButton
         ffmpeg_cmd = [*FFMPEG]
         ffmpeg_inputs.each do |input|
           # Seek
-          if input[:seek].positive?
-            ffmpeg_cmd += ['-ss', ms_to_s(input[:seek])]
-          end
+          ffmpeg_cmd += ['-ss', ms_to_s(input[:seek])]
           # Ensure that the entire contents of freeswitch wav files are read
           info = audioinfo[input[:filename]]
           if info && info[:format][:format_name] == 'wav'

--- a/record-and-playback/core/lib/recordandplayback/generators/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio.rb
@@ -40,7 +40,7 @@ module BigBlueButton
       # Initially start with silence
       audio_edl << {
         :timestamp => 0,
-        :audios => nil
+        :audios => []
       }
 
       # Add events for recording start/stop
@@ -57,11 +57,11 @@ module BigBlueButton
         when 'StopRecordingEvent'
           filename = event.at_xpath('filename').text
           filename = "#{audio_dir}/#{File.basename(filename)}"
-          if audio_edl.last[:audios] && audio_edl.last[:audios][0][:filename] == filename
+          if audio_edl.last.dig(:audios, 0, :filename) == filename
             audio_edl.last[:original_duration] = timestamp - audio_edl.last[:timestamp]
             audio_edl << {
               :timestamp => timestamp,
-              :audios => nil
+              :audios => []
             }
           end
         when 'AudioTrackPublishedEvent'
@@ -100,7 +100,7 @@ module BigBlueButton
 
       audio_edl << {
         :timestamp => final_timestamp - initial_timestamp,
-        :audios => nil
+        :audios => []
       }
 
       return audio_edl
@@ -116,7 +116,7 @@ module BigBlueButton
       # Initially start with silence
       audio_edl << {
         :timestamp => 0,
-        :audios => nil
+        :audios => []
       }
 
       events.xpath('/recording/event[@module="bbb-webrtc-sfu" and (@eventname="StartWebRTCDesktopShareEvent" or @eventname="StopWebRTCDesktopShareEvent")]').each do |event|
@@ -140,7 +140,7 @@ module BigBlueButton
               :audios => [{ :filename => filename, :timestamp => 0 }]
             }
           when 'StopWebRTCDesktopShareEvent'
-            if audio_edl.last[:audios] && audio_edl.last[:audios][0][:filename] == filename
+            if audio_edl.last.dig(:audios, 0, :filename) == filename
               # Fill in the original/expected audo duration when available
               duration = event.at_xpath('duration')
               if !duration.nil?
@@ -151,7 +151,7 @@ module BigBlueButton
               end
               audio_edl << {
                 :timestamp => timestamp,
-                :audios => nil
+                :audios => []
               }
             end
           end
@@ -162,7 +162,7 @@ module BigBlueButton
 
       audio_edl << {
         :timestamp => final_timestamp - initial_timestamp,
-        :audios => nil
+        :audios => []
       }
 
       return audio_edl

--- a/record-and-playback/core/lib/recordandplayback/generators/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio.rb
@@ -40,7 +40,7 @@ module BigBlueButton
       # Initially start with silence
       audio_edl << {
         :timestamp => 0,
-        :audio => nil
+        :audios => nil
       }
 
       # Add events for recording start/stop
@@ -52,16 +52,16 @@ module BigBlueButton
           filename = "#{audio_dir}/#{File.basename(filename)}"
           audio_edl << {
             :timestamp => timestamp,
-            :audio => { :filename => filename, :timestamp => 0 }
+            :audios => [{ :filename => filename, :timestamp => 0 }]
           }
         when 'StopRecordingEvent'
           filename = event.at_xpath('filename').text
           filename = "#{audio_dir}/#{File.basename(filename)}"
-          if audio_edl.last[:audio] && audio_edl.last[:audio][:filename] == filename
+          if audio_edl.last[:audios] && audio_edl.last[:audios][0][:filename] == filename
             audio_edl.last[:original_duration] = timestamp - audio_edl.last[:timestamp]
             audio_edl << {
               :timestamp => timestamp,
-              :audio => nil
+              :audios => nil
             }
           end
         when 'AudioTrackPublishedEvent'
@@ -100,7 +100,7 @@ module BigBlueButton
 
       audio_edl << {
         :timestamp => final_timestamp - initial_timestamp,
-        :audio => nil
+        :audios => nil
       }
 
       return audio_edl
@@ -116,7 +116,7 @@ module BigBlueButton
       # Initially start with silence
       audio_edl << {
         :timestamp => 0,
-        :audio => nil
+        :audios => nil
       }
 
       events.xpath('/recording/event[@module="bbb-webrtc-sfu" and (@eventname="StartWebRTCDesktopShareEvent" or @eventname="StopWebRTCDesktopShareEvent")]').each do |event|
@@ -137,10 +137,10 @@ module BigBlueButton
           when 'StartWebRTCDesktopShareEvent'
             audio_edl << {
               :timestamp => timestamp,
-              :audio => { :filename => filename, :timestamp => 0 }
+              :audios => [{ :filename => filename, :timestamp => 0 }]
             }
           when 'StopWebRTCDesktopShareEvent'
-            if audio_edl.last[:audio] && audio_edl.last[:audio][:filename] == filename
+            if audio_edl.last[:audios] && audio_edl.last[:audios][0][:filename] == filename
               # Fill in the original/expected audo duration when available
               duration = event.at_xpath('duration')
               if !duration.nil?
@@ -151,7 +151,7 @@ module BigBlueButton
               end
               audio_edl << {
                 :timestamp => timestamp,
-                :audio => nil
+                :audios => nil
               }
             end
           end
@@ -162,7 +162,7 @@ module BigBlueButton
 
       audio_edl << {
         :timestamp => final_timestamp - initial_timestamp,
-        :audio => nil
+        :audios => nil
       }
 
       return audio_edl

--- a/record-and-playback/core/lib/recordandplayback/generators/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio.rb
@@ -65,12 +65,10 @@ module BigBlueButton
             }
           end
         when 'AudioTrackPublishedEvent'
-          source = event.at_xpath('source').text
-          next if source != 'microphone'
           filename = event.at_xpath('filename').text
           filename = "#{audio_dir}/#{File.basename(filename)}"
           audios[filename] = { :timestamp => timestamp }
-          active_audios << filename;
+          active_audios << filename
           edl_entry = {
             :timestamp => timestamp,
             :audios => []
@@ -83,8 +81,6 @@ module BigBlueButton
           end
           audio_edl << edl_entry
         when 'AudioTrackUnpublishedEvent'
-          source = event.at_xpath('source').text
-          next if source != 'microphone'
           filename = event.at_xpath('filename').text
           filename = "#{audio_dir}/#{File.basename(filename)}"
           active_audios.delete(filename)
@@ -123,16 +119,11 @@ module BigBlueButton
         :audio => nil
       }
 
-      events.xpath('/recording/event[@module="bbb-webrtc-sfu" and (@eventname="StartWebRTCDesktopShareEvent" or @eventname="StopWebRTCDesktopShareEvent" or @eventname="AudioTrackPublishedEvent" or @eventname="AudioTrackUnpublishedEvent")]').each do |event|
+      events.xpath('/recording/event[@module="bbb-webrtc-sfu" and (@eventname="StartWebRTCDesktopShareEvent" or @eventname="StopWebRTCDesktopShareEvent")]').each do |event|
         filename = event.at_xpath('filename').text
         # Determine the audio filename
         case event['eventname']
         when 'StartWebRTCDesktopShareEvent', 'StopWebRTCDesktopShareEvent'
-          uri = event.at_xpath('filename').text
-          filename = "#{deskshare_dir}/#{File.basename(uri)}"
-        when 'AudioTrackPublishedEvent', 'AudioTrackUnpublishedEvent'
-          source = event.at_xpath('source').text
-          next if source != 'screen_share_audio'
           uri = event.at_xpath('filename').text
           filename = "#{deskshare_dir}/#{File.basename(uri)}"
         end
@@ -143,12 +134,12 @@ module BigBlueButton
           timestamp = event['timestamp'].to_i - initial_timestamp
           # Add the audio to the EDL
           case event['eventname']
-          when 'StartWebRTCDesktopShareEvent', 'AudioTrackPublishedEvent'
+          when 'StartWebRTCDesktopShareEvent'
             audio_edl << {
               :timestamp => timestamp,
               :audio => { :filename => filename, :timestamp => 0 }
             }
-          when 'StopWebRTCDesktopShareEvent', 'AudioTrackUnpublishedEvent'
+          when 'StopWebRTCDesktopShareEvent'
             if audio_edl.last[:audio] && audio_edl.last[:audio][:filename] == filename
               # Fill in the original/expected audo duration when available
               duration = event.at_xpath('duration')

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -530,9 +530,8 @@ module BigBlueButton
 
     def self.edl_entry_offset_audio
       return Proc.new do |edl_entry, offset|
-        new_entry = { audios: nil }
+        new_entry = { audios: [] }
         if edl_entry[:audios]
-          new_entry[:audios] = []
           edl_entry[:audios].each do |audio|
             new_entry[:audios] << {
               filename: audio[:filename],

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -537,6 +537,15 @@ module BigBlueButton
             timestamp: edl_entry[:audio][:timestamp] + offset
           }
         end
+        if edl_entry[:audios]
+          new_entry[:audios] = []
+          edl_entry[:audios].each do |audio|
+            new_entry[:audios] << {
+              filename: audio[:filename],
+              timestamp: audio[:timestamp] + offset
+            }
+          end
+        end
         if edl_entry[:original_duration]
           new_entry[:original_duration] = edl_entry[:original_duration]
         end
@@ -1159,6 +1168,12 @@ module BigBlueButton
         filename = "#{deskshare_dir}/#{File.basename(filename)}"
         fileHasAudio = !BigBlueButton::EDL::Audio.audio_info(filename)[:audio].nil?
         if fileHasAudio
+          return true
+        end
+      end
+      events.xpath('/recording/event[@eventname="AudioTrackPublishedEvent"]').each do |event|
+        source = event.at_xpath('source').text
+        if source == 'screen_share_audio'
           return true
         end
       end

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -530,13 +530,7 @@ module BigBlueButton
 
     def self.edl_entry_offset_audio
       return Proc.new do |edl_entry, offset|
-        new_entry = { audio: nil }
-        if edl_entry[:audio]
-          new_entry[:audio] = {
-            filename: edl_entry[:audio][:filename],
-            timestamp: edl_entry[:audio][:timestamp] + offset
-          }
-        end
+        new_entry = { audios: nil }
         if edl_entry[:audios]
           new_entry[:audios] = []
           edl_entry[:audios].each do |audio|

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1171,12 +1171,6 @@ module BigBlueButton
           return true
         end
       end
-      events.xpath('/recording/event[@eventname="AudioTrackPublishedEvent"]').each do |event|
-        source = event.at_xpath('source').text
-        if source == 'screen_share_audio'
-          return true
-        end
-      end
       return false
     end
 

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -252,7 +252,7 @@ archive_directory("#{mediasoup_video_dir}/#{meeting_id}", "#{target_dir}/video/#
 # bbb-webrtc-recorder media
 remux_and_archive("#{webrtc_recorder_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
 remux_and_archive("#{webrtc_recorder_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
-archive_directory("#{webrtc_recorder_audio_dir}/#{meeting_id}", "#{target_dir}/audio")
+remux_and_archive("#{webrtc_recorder_audio_dir}/#{meeting_id}", "#{target_dir}/audio")
 
 # If this was the last (or only) segment in a recording, delete the original media files
 if break_timestamp.nil?

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -218,6 +218,7 @@ mediasoup_video_dir = props['mediasoup_video_src']
 mediasoup_screenshare_dir = props['mediasoup_screenshare_src']
 webrtc_recorder_video_dir = props['webrtc_recorder_video_src']
 webrtc_recorder_screenshare_dir = props['webrtc_recorder_screenshare_src']
+webrtc_recorder_audio_dir = props['webrtc_recorder_audio_src']
 log_dir = props['log_dir']
 notes_endpoint = props['notes_endpoint']
 notes_formats = props['notes_formats']
@@ -251,6 +252,7 @@ archive_directory("#{mediasoup_video_dir}/#{meeting_id}", "#{target_dir}/video/#
 # bbb-webrtc-recorder media
 remux_and_archive("#{webrtc_recorder_screenshare_dir}/#{meeting_id}", "#{target_dir}/deskshare")
 remux_and_archive("#{webrtc_recorder_video_dir}/#{meeting_id}", "#{target_dir}/video/#{meeting_id}")
+archive_directory("#{webrtc_recorder_audio_dir}/#{meeting_id}", "#{target_dir}/audio")
 
 # If this was the last (or only) segment in a recording, delete the original media files
 if break_timestamp.nil?
@@ -266,6 +268,7 @@ if break_timestamp.nil?
   # bbb-webrtc-recorder media
   FileUtils.rm_rf("#{webrtc_recorder_screenshare_dir}/#{meeting_id}")
   FileUtils.rm_rf("#{webrtc_recorder_video_dir}/#{meeting_id}")
+  FileUtils.rm_rf("#{webrtc_recorder_audio_dir}/#{meeting_id}")
 end
 
 if not archive_has_recording_marks?(meeting_id, raw_archive_dir, break_timestamp)

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -4,6 +4,7 @@ mediasoup_video_src: /var/mediasoup/recordings
 mediasoup_screenshare_src: /var/mediasoup/screenshare
 webrtc_recorder_video_src: /var/lib/bbb-webrtc-recorder/recordings
 webrtc_recorder_screenshare_src: /var/lib/bbb-webrtc-recorder/screenshare
+webrtc_recorder_audio_src: /var/lib/bbb-webrtc-recorder/audio
 raw_deskshare_src: /var/bigbluebutton/deskshare
 raw_presentation_src: /var/bigbluebutton
 notes_endpoint: http://127.0.0.1:9002/p


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adds support for livekit audio capture events and files.
Basically the audio edl now stores all active audios at each moment and when more than one audio is present they are mixed together in the render method.
Previous behaviour for other events is preserverd.

Sample event por reference:
```
  <event timestamp="3173077711" module="bbb-webrtc-sfu" eventname="AudioTrackPublishedEvent">
    <userId>w_fodi3y98tzex</userId>
    <source>microphone</source>
    <meeting_id>bd86fde4446324b79e3fb3f31ae67e4c67a57405-1736419145593</meeting_id>
    <filename>/var/lib/bbb-webrtc-recorder/audio/bd86fde4446324b79e3fb3f31ae67e4c67a57405-1736419145593/microphone-w_fodi3y98tzex-TR_AMi4Y5RdyzdbNR.ogg</filename>
    <timestampUTC>1736419164951753770</timestampUTC>
  </event>
```

### How to test
Needs a livekit setup with egress to record

1. Record a meeting using audio through livekit
2. Check if the generated recording has audio & it's correctly synced

Related to https://github.com/bigbluebutton/bigbluebutton/issues/21059

