### PR TITLE
Add: New log showing the error caught by error Boundary component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
@@ -49,6 +49,8 @@ class ErrorBoundary extends Component {
     const { error, errorInfo } = this.state;
     const { logMetadata: { logCode, logMessage } } = this.props;
     if (error || errorInfo) {
+      console.log('%cErrorBoundary caught an error: ', 'color: red', error);
+      console.log('ErrorInfo: ', errorInfo);
       logger.error({
         logCode,
         extraInfo: {


### PR DESCRIPTION
### What does this PR do?
This PR adds a log in the error boundary showing the stack trace for better debugging of crashes, I've tried to modify the logger to show more info, but the browser bunyan converts the error to string showing the path of the bundle instead the reference to the line like in a normal log.

### How to test
- Deploy the code to production.
- Join as presenter.
- reload the client until the crash happens.

### More
Before:
![Screenshot from 2025-01-09 21-30-58](https://github.com/user-attachments/assets/4e394eeb-959b-40e4-b307-9470093ff243)

After:
![Screenshot from 2025-01-09 21-13-18](https://github.com/user-attachments/assets/d3b49837-97d1-4da3-80cd-c7a2f7e2fb6f)

Demo:
[Screencast from 09-01-2025 21:39:21.webm](https://github.com/user-attachments/assets/1ba47f62-5bbb-44d3-af6a-a468177cea46)


