### PR TITLE
Remove: Side effects from error screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -111,9 +111,7 @@ class ErrorScreen extends PureComponent {
   componentDidMount() {
     const { callback, endedReason } = this.props;
     // stop audio
-    window.dispatchEvent(new Event('StopAudioTracks'));
     callback(endedReason, () => {});
-    console.error({ logCode: 'startup_client_usercouldnotlogin_error' }, 'User could not log in HTML5');
   }
 
   render() {


### PR DESCRIPTION
### What does this PR do?
The original purpose of the error screen was to display issues occurring on the server side, such as unauthorized access or network problems, which prevented the client from communicating successfully. However, it’s now also being used by several components within the client itself whenever a component crashes. In these cases, it doesn’t make sense to stop the audio or display a login error. Therefore, it’s better to remove those behaviors from the error screen and let it simply serve as a display, while leaving error handling to error boundaries (as is currently done).
