### PR TITLE
fix(poll): Wrap overly long poll options

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -4,8 +4,8 @@ import {
 } from 'recharts';
 import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { defineMessages, useIntl } from 'react-intl';
-import deviceInfo from '/imports/utils/deviceInfo';
 import Styled from './styles';
+import CustomizedAxisTick from '/imports/ui/components/poll/components/CustomizedAxisTick';
 
 interface ChatPollContentProps {
   metadata: string;
@@ -96,13 +96,12 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
   });
 
   const useHeight = height || translatedAnswers.length * 50;
-  const useWidth = deviceInfo.isPortrait() ? '100%' : '130%';
   return (
     <Styled.PollWrapper data-test="chatPollMessageText">
       <Styled.PollText>
         {pollData.questionText}
       </Styled.PollText>
-      <ResponsiveContainer width={useWidth} height={useHeight}>
+      <ResponsiveContainer width="100%" height={useHeight}>
         <BarChart
           data={translatedAnswers}
           layout="vertical"
@@ -111,7 +110,7 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
             type="number"
             allowDecimals={false}
           />
-          <YAxis width={80} type="category" dataKey="pollAnswer" />
+          <YAxis width={100} type="category" dataKey="pollAnswer" tick={<CustomizedAxisTick />} />
           <Bar dataKey="numVotes" fill="#0C57A7" />
         </BarChart>
       </ResponsiveContainer>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/styles.ts
@@ -6,14 +6,12 @@ export const PollText = styled.div`
   margin-bottom: 0.5rem;
   font-size: 1.25rem;
   font-weight: 500;
-  margin-left: 2.75rem;
   color: ${colorText};
   word-break: break-word;
 `;
 
 export const PollWrapper = styled.div`
-  width: 90%;
-  margin-left: -50px;
+  width: 100%;
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/poll/components/CustomizedAxisTick.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/CustomizedAxisTick.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+function getAverageCharacterWidth(text: string, font: string) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) return null;
+
+  ctx.font = font;
+
+  const textWidth = ctx.measureText(text).width;
+  const averageAdvance = textWidth / text.length;
+
+  return averageAdvance;
+}
+
+const TICK_SIZE = 6;
+const AVERAGE_CHAR_WIDTH = getAverageCharacterWidth('0', 'Source Sans Pro') ?? 6;
+const ELLIPSIS = '...';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const CustomizedAxisTick = (props: any) => {
+  const { payload, ...restProps } = props;
+  const { width } = restProps;
+  const numberOfChars = Math.floor((width - TICK_SIZE) / AVERAGE_CHAR_WIDTH);
+  const restValue = payload.value.substring(numberOfChars, payload.value.length);
+
+  return (
+    <g>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <text {...restProps}>
+        {payload.value.substring(0, restValue.length > 0 ? numberOfChars - ELLIPSIS.length : numberOfChars)}
+        {restValue.length > 0 && ELLIPSIS}
+      </text>
+    </g>
+  );
+};
+
+export default CustomizedAxisTick;

--- a/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
@@ -18,6 +18,7 @@ import { POLL_CANCEL, POLL_PUBLISH_RESULT } from '../mutations';
 import { layoutDispatch } from '../../layout/context';
 import { ACTIONS, PANELS } from '../../layout/enums';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import CustomizedAxisTick from './CustomizedAxisTick';
 
 const intlMessages = defineMessages({
   usersTitle: {
@@ -122,7 +123,7 @@ const LiveResult: React.FC<LiveResultProps> = ({
             layout="vertical"
           >
             <XAxis type="number" allowDecimals={false} />
-            <YAxis width={70} type="category" dataKey="optionDesc" />
+            <YAxis width={70} type="category" dataKey="optionDesc" tick={<CustomizedAxisTick />} />
             <Bar dataKey="optionResponsesCount" fill="#0C57A7" />
           </BarChart>
         </ResponsiveContainer>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Shorten overly long poll options by wrapping the text and appending `...` (ellipsis) to it.

#### Live Result
![Screenshot from 2025-01-10 13-16-10](https://github.com/user-attachments/assets/f9ce15b0-1d80-42d3-a05e-af1229a682f4)

#### Chat message
![Screenshot from 2025-01-10 13-15-34](https://github.com/user-attachments/assets/80689e0c-cfcc-4496-abc7-5f679eace1f1)

### Currently

#### Chat message

![Screenshot from 2025-01-10 13-22-16](https://github.com/user-attachments/assets/ae057660-c2ab-4752-8c57-9285585e3c1c)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21878

### More

test file for Smart Slides: [long_poll (1).pdf](https://github.com/user-attachments/files/18379794/long_poll.1.pdf)