### PR TITLE
feat(livekit): selective subscription in camera bridge

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -629,6 +629,7 @@ export interface LiveKitAudioSettings {
 
 export interface LiveKitSettings {
   url?: string
+  selectiveSubscription?: boolean
   audio?: LiveKitAudioSettings
   camera?: LiveKitCameraSettings
   screenshare?: LiveKitScreenShareSettings

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -476,9 +476,12 @@ export const useExitVideo = (forceExit = false) => {
             return true;
           }).catch((e) => {
             logger.warn({
-              logCode: 'exit_audio',
-              extraInfo: e,
-            }, 'Exiting audio');
+              logCode: 'exit_video_error',
+              extraInfo: {
+                errorMessage: e.message,
+                errorStack: e.stack,
+              },
+            }, `Failed to exit video: ${e.message}`);
             return false;
           });
         }

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -666,6 +666,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       },
       livekit: {
         url: `wss://${window.location.hostname}/livekit`,
+        selectiveSubscription: false,
         audio: {
           publishOptions: {
             audioPreset: AudioPresets.speech,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -922,6 +922,10 @@ public:
     livekit:
       # livekit.url is the URL of the LiveKit server. Default value is 'wss://{window.location.hostname}/livekit'
       #url: wss://LIVEKIT_HOST/livekit
+      # livekit.selectiveSubscription: whether to use selective subscription all
+      # applicable track sources. Default value is false. This overrides autoSubscribe
+      # when set to true and in effect (conditional to client behavior).
+      selectiveSubscription: false
       audio:
         # publishOptions: see https://docs.livekit.io/client-sdk-js/interfaces/TrackPublishOptions.html
         publishOptions:


### PR DESCRIPTION
### What does this PR do?

- [feat(livekit): selective subscription in camera bridge](https://github.com/bigbluebutton/bigbluebutton/commit/662b5dad281c276978723708250e11496565e807) 
  - Use selective subscription in LiveKit's camera bridge if enabled to do
so. This should only subscribe to streams when necessary now, which is more
efficient than the autosubscription approach that was in effect.
  - Additionally, multiple assorted fixes to camera-related features, e.g.
(not exhaustive):
    - Client might get stuck when a share attempt fails
    - Reduce spurious re-renders in the bridge component
    - Properly cleanup camera bridge streams on unmount
  - Config flag is public.media.livekit.selectiveSubscription. Disabled by
default for now.

### Closes Issue(s)

Relates to #21059 
