### PR TITLE
fix(livekit): breakout rooms ignoring media bridge configs

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -106,6 +106,9 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         breakout.captureNotesFilename,
         breakout.captureSlidesFilename,
         pluginProp = filteredPluginProp,
+        liveMeeting.props.meetingProp.audioBridge,
+        liveMeeting.props.meetingProp.cameraBridge,
+        liveMeeting.props.meetingProp.screenShareBridge,
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -59,6 +59,9 @@ case class BreakoutRoomDetail(
     captureNotesFilename:    String,
     captureSlidesFilename:   String,
     pluginProp:              util.Map[String, AnyRef],
+    audioBridge:             String,
+    cameraBridge:            String,
+    screenShareBridge:       String,
 )
 
 /**

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -824,6 +824,9 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.DURATION, message.durationInMinutes.toString());
       params.put(ApiParams.RECORD, message.record.toString());
       params.put(ApiParams.WELCOME, getMeeting(message.parentMeetingId).getWelcomeMessageTemplate());
+      params.put(ApiParams.AUDIO_BRIDGE, message.audioBridge);
+      params.put(ApiParams.CAMERA_BRIDGE, message.cameraBridge);
+      params.put(ApiParams.SCREEN_SHARE_BRIDGE, message.screenShareBridge);
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -26,6 +26,9 @@ public class CreateBreakoutRoom implements IMessage {
     public final String captureNotesFilename;
     public final String captureSlidesFilename;
     public final Map<String, Object> pluginProp;
+    public final String audioBridge;
+    public final String cameraBridge;
+    public final String screenShareBridge;
 
     public CreateBreakoutRoom(String meetingId,
 															String parentMeetingId,
@@ -47,7 +50,10 @@ public class CreateBreakoutRoom implements IMessage {
                                                             Boolean captureSlides,
                                                             String captureNotesFilename,
                                                             String captureSlidesFilename,
-                                                            Map<String, Object> pluginProp) {
+                                                            Map<String, Object> pluginProp,
+                                                            String audioBridge,
+                                                            String cameraBridge,
+                                                            String screenShareBridge) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -69,5 +75,8 @@ public class CreateBreakoutRoom implements IMessage {
         this.captureNotesFilename = captureNotesFilename;
         this.captureSlidesFilename = captureSlidesFilename;
         this.pluginProp = pluginProp;
+        this.audioBridge = audioBridge;
+        this.cameraBridge = cameraBridge;
+        this.screenShareBridge = screenShareBridge;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -128,8 +128,10 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.captureNotesFilename,
       msg.body.room.captureSlidesFilename,
       msg.body.room.pluginProp,
+      msg.body.room.audioBridge,
+      msg.body.room.cameraBridge,
+      msg.body.room.screenShareBridge,
     ))
-    
   }
 
   def handleRecordingStatusChangedEvtMsg(msg: RecordingStatusChangedEvtMsg): Unit = {


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): breakout rooms ignoring media bridge configs](https://github.com/bigbluebutton/bigbluebutton/commit/7c0139a5d34313fcaf3458e8aea1d26fa31690c6) 
  - Breakout rooms are ignoring audioBridge, cameraBridge and
screenShareBridge meeting props since those were not added to the
breakout creation process. Media works since it falls back to default
bridges, but this is incorrect.
  - Properly forward audioBridge, cameraBridge and screenShareBridge meeting
props to the parent meeting to breakouts.

### Closes Issue(s)

Relates to https://github.com/bigbluebutton/bigbluebutton/issues/21059