### PR TITLE
fix: Tab stops on recording button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -194,7 +194,9 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
         recordingToggle(micUser, recording);
       }}
       onKeyDown={(ev) => {
-        ev.preventDefault();
+        if (ev.key !== 'Tab') {
+          ev.preventDefault();
+        }
         if (ev.key === 'Enter') {
           recordingToggle(micUser, recording);
         }


### PR DESCRIPTION
### What does this PR do?

Restores keyboard navigation using tab on recording button.

### Closes Issue(s)
Closes #21984

### How to test
1. Create a meeting
2. Try to navigate with tab past the recording button