### PR TITLE
fix: Breakout defaults from bbb-html5.yml not respected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -233,18 +233,29 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
 
   const initialNumberOfRooms = runningRooms.length > 0 ? runningRooms.length : MIN_BREAKOUT_ROOMS;
 
-  const [numberOfRoomsIsValid, setNumberOfRoomsIsValid] = React.useState(true);
-  const [durationIsValid, setDurationIsValid] = React.useState(true);
-  const [freeJoin, setFreeJoin] = React.useState(false);
-  const [record, setRecord] = React.useState(false);
-  const [captureSlides, setCaptureSlides] = React.useState(false);
-  const [leastOneUserIsValid, setLeastOneUserIsValid] = React.useState(false);
-  const [captureNotes, setCaptureNotes] = React.useState(false);
-  const [inviteMods, setInviteMods] = React.useState(false);
-  const [numberOfRooms, setNumberOfRooms] = React.useState(initialNumberOfRooms);
-  const [durationTime, setDurationTime] = React.useState(DEFAULT_BREAKOUT_TIME);
   const isImportPresentationWithAnnotationsEnabled = useIsImportPresentationWithAnnotationsFromBreakoutRoomsEnabled();
   const isImportSharedNotesEnabled = useIsImportSharedNotesFromBreakoutRoomsEnabled();
+
+  // @ts-ignore
+  const BREAKOUT_SETTINGS = window.meetingClientSettings.public.app.breakouts;
+
+  const { allowUserChooseRoomByDefault } = BREAKOUT_SETTINGS;
+  const captureWhiteboardByDefault = BREAKOUT_SETTINGS.captureWhiteboardByDefault
+                                    && isImportPresentationWithAnnotationsEnabled;
+  const captureSharedNotesByDefault = BREAKOUT_SETTINGS.captureSharedNotesByDefault
+                                    && isImportPresentationWithAnnotationsEnabled;
+  const inviteModsByDefault = BREAKOUT_SETTINGS.sendInvitationToAssignedModeratorsByDefault;
+
+  const [numberOfRoomsIsValid, setNumberOfRoomsIsValid] = React.useState(true);
+  const [durationIsValid, setDurationIsValid] = React.useState(true);
+  const [freeJoin, setFreeJoin] = React.useState(allowUserChooseRoomByDefault);
+  const [record, setRecord] = React.useState(false);
+  const [captureSlides, setCaptureSlides] = React.useState(captureWhiteboardByDefault);
+  const [leastOneUserIsValid, setLeastOneUserIsValid] = React.useState(false);
+  const [captureNotes, setCaptureNotes] = React.useState(captureSharedNotesByDefault);
+  const [inviteMods, setInviteMods] = React.useState(inviteModsByDefault);
+  const [numberOfRooms, setNumberOfRooms] = React.useState(initialNumberOfRooms);
+  const [durationTime, setDurationTime] = React.useState(DEFAULT_BREAKOUT_TIME);
   const [roomPresentations, setRoomPresentations] = React.useState<RoomPresentations>([]);
 
   const [createBreakoutRoom] = useMutation(BREAKOUT_ROOM_CREATE);
@@ -356,6 +367,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
     return [
       {
         allowed: true,
+        checked: freeJoin,
         htmlFor: 'freeJoinCheckbox',
         key: 'free-join-breakouts',
         id: 'freeJoinCheckbox',
@@ -367,6 +379,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
       },
       {
         allowed: isBreakoutRecordable,
+        checked: record,
         htmlFor: 'recordBreakoutCheckbox',
         key: 'record-breakouts',
         id: 'recordBreakoutCheckbox',
@@ -375,6 +388,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
       },
       {
         allowed: isImportPresentationWithAnnotationsEnabled,
+        checked: captureSlides,
         htmlFor: 'captureSlidesBreakoutCheckbox',
         key: 'capture-slides-breakouts',
         id: 'captureSlidesBreakoutCheckbox',
@@ -383,6 +397,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
       },
       {
         allowed: isImportSharedNotesEnabled,
+        checked: captureNotes,
         htmlFor: 'captureNotesBreakoutCheckbox',
         key: 'capture-notes-breakouts',
         id: 'captureNotesBreakoutCheckbox',
@@ -391,6 +406,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
       },
       {
         allowed: true,
+        checked: inviteMods,
         htmlFor: 'sendInvitationToAssignedModeratorsCheckbox',
         key: 'send-invitation-to-assigned-moderators-breakouts',
         id: 'sendInvitationToAssignedModeratorsCheckbox',
@@ -398,11 +414,21 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         label: intl.formatMessage(intlMessages.sendInvitationToMods),
       },
     ];
-  }, [isBreakoutRecordable, isImportPresentationWithAnnotationsEnabled, isImportSharedNotesEnabled]);
+  }, [
+    isBreakoutRecordable,
+    isImportPresentationWithAnnotationsEnabled,
+    isImportSharedNotesEnabled,
+    freeJoin,
+    record,
+    captureSlides,
+    captureNotes,
+    inviteMods,
+  ]);
 
   const form = useMemo(() => {
     if (isUpdate) return null;
 
+    // @ts-ignore
     const BREAKOUT_LIM = window.meetingClientSettings.public.app.breakouts.breakoutRoomLimit;
     const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
 
@@ -474,6 +500,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
                     id={item.id}
                     onChange={item.onChange}
                     aria-label={item.label}
+                    checked={item.checked}
                   />
                   <span aria-hidden>{item.label}</span>
                 </Styled.FreeJoinLabel>
@@ -492,6 +519,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   }, [
     durationTime, durationIsValid, numberOfRooms, numberOfRoomsIsValid,
     isImportPresentationWithAnnotationsEnabled, isImportSharedNotesEnabled,
+    checkboxesInfo,
   ]);
 
   return (


### PR DESCRIPTION
### What does this PR do?

Adjusts breakout creation modal so the checkboxes use default value from settings file

### Closes Issue(s)
Closes #21950

### How to test
1. change any (or all) setting related to the breakout checkboxes default value (`public.app.breakouts.allowUserChooseRoomByDefault`,`public.app.breakouts.captureWhiteboardByDefault`,`public.app.breakouts.captureSharedNotesByDefault`,`public.app.breakouts.sendInvitationToAssignedModeratorsByDefault`, )
2. join a meeting
3. open "create breakout rooms" modal
4. verify if the checkboxes with default values set as `true` are checked

![2025-01-15_09-15](https://github.com/user-attachments/assets/5b688cc7-90dc-42f3-8f8a-c5fd6d72c27c)
