### PR TITLE
fix (bbb-web/akka): Fix a few Learning Analytic Dashboard related issues

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -760,7 +760,7 @@ class LearningDashboardActor(
 
     //Avoid send repeated activity jsons
     val activityJsonHash : String = MessageDigest.getInstance("MD5").digest(activityJson.getBytes).mkString
-    if(!meetingsLastJsonHash.contains(meeting.intId) || meetingsLastJsonHash.get(meeting.intId).getOrElse("") != activityJsonHash) {
+    if(!meetingsLastJsonHash.contains(meeting.intId) || meetingsLastJsonHash.getOrElse(meeting.intId, "") != activityJsonHash) {
       for {
         learningDashboardAccessToken <- meetingAccessTokens.get(meeting.intId)
       } yield {
@@ -768,16 +768,7 @@ class LearningDashboardActor(
         outGW.send(event)
         meetingsLastJsonHash += (meeting.intId -> activityJsonHash)
 
-        for {
-          learningDashboardAccessToken <- meetingAccessTokens.get(meeting.intId)
-        } yield {
-          val event = MsgBuilder.buildLearningDashboardEvtMsg(meeting.intId, learningDashboardAccessToken, activityJson)
-          outGW.send(event)
-
-          meetingsLastJsonHash += (meeting.intId -> activityJsonHash)
-
-          log.info("Learning Dashboard data sent for meeting {}", meeting.intId)
-        }
+        log.info("Learning Dashboard data sent for meeting {}", meeting.intId)
       }
     }
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -22,7 +22,9 @@ package org.bigbluebutton.api;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Calendar;
 
 public class LearningDashboardService {
@@ -38,23 +40,30 @@ public class LearningDashboardService {
     }
 
     public void writeJsonDataFile(String meetingId, String learningDashboardAccessToken, String activityJson) {
-
+        FileOutputStream fileOutput = null;
         try {
-            if(learningDashboardAccessToken.length() == 0) {
+            if(learningDashboardAccessToken.isEmpty()) {
                 log.error("LearningDashboard AccessToken not found. JSON file will not be saved for meeting {}.",meetingId);
                 return;
             }
 
             File jsonFile = this.getJsonDataFile(meetingId,learningDashboardAccessToken);
 
-            FileOutputStream fileOutput = new FileOutputStream(jsonFile);
+            fileOutput = new FileOutputStream(jsonFile);
             fileOutput.write(activityJson.getBytes("UTF-8"));
-
-            fileOutput.close();
 
             log.info("Learning Dashboard ({}) updated for meeting {}.",jsonFile.getAbsolutePath(),meetingId);
         } catch(Exception e) {
-            System.out.println(e);
+            log.error("Error on updating Learning Dashboard file for meeting [{}]: {}",meetingId, e.getMessage());
+        } finally {
+            // Ensure the file is closed
+            if (fileOutput != null) {
+                try {
+                    fileOutput.close();
+                } catch (IOException e) {
+                    log.error("Error on closing Learning Dashboard file for meeting [{}]: {}",meetingId, e.getMessage());
+                }
+            }
         }
     }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 
 public class LearningDashboardService {
@@ -50,7 +51,7 @@ public class LearningDashboardService {
             File jsonFile = this.getJsonDataFile(meetingId,learningDashboardAccessToken);
 
             fileOutput = new FileOutputStream(jsonFile);
-            fileOutput.write(activityJson.getBytes("UTF-8"));
+            fileOutput.write(activityJson.getBytes(StandardCharsets.UTF_8));
 
             log.info("Learning Dashboard ({}) updated for meeting {}.",jsonFile.getAbsolutePath(),meetingId);
         } catch(Exception e) {


### PR DESCRIPTION
Fix a few issues reported by @ritzalam 

- LAD data file is being written twice every time.
![image](https://github.com/user-attachments/assets/078f2718-cfb4-4c02-a978-f88e3f5f7632)

- Errors on saving the LAD file is not being captured by journal logs (cause it is a `System.out`).

- In case of error on saving the LAD file, it would not close the `FileOutputStream` properly.