### PR TITLE
refactor (bbb-web): Use `identify` (ImageMagick) for image resolution in presentation uploads

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ImageResolution.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ImageResolution.java
@@ -1,0 +1,22 @@
+package org.bigbluebutton.presentation;
+
+public class ImageResolution {
+
+	private final int width;
+	private final int height;
+
+	public ImageResolution(int width, int height) {
+		this.width = width;
+		this.height = height;
+	}
+	
+	public int getWidth() {
+		return width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+	
+	 
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/ImageResolutionServiceHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/ImageResolutionServiceHandler.java
@@ -54,7 +54,7 @@ public class ImageResolutionServiceHandler extends AbstractCommandHandler {
         try {
             return Integer.parseInt(outputParts[1]);
         } catch (NumberFormatException e) {
-            log.error("Received height is not an integer {}", outputParts[0]);
+            log.error("Received height is not an integer {}", outputParts[1]);
         }
       }
     } catch (Exception e) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/ImageResolutionServiceHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/ImageResolutionServiceHandler.java
@@ -1,0 +1,65 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * 
+ * Copyright (c) 2017 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * 
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package org.bigbluebutton.presentation.handlers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ImageResolutionServiceHandler extends AbstractCommandHandler {
+
+  private static Logger log = LoggerFactory
+      .getLogger(ImageResolutionServiceHandler.class);
+
+  /**
+   * @return The number of pages inside the scanned PDF document
+   */
+  public int getWidth() {
+    try {
+      String[] outputParts = stdoutBuilder.toString().split(" ");
+
+      if(outputParts.length == 2) {
+        try {
+            return Integer.parseInt(outputParts[0]);
+        } catch (NumberFormatException e) {
+            log.error("Received width is not an integer {}", outputParts[0]);
+        }
+      }
+    } catch (Exception e) {
+      log.error("Exception identifying width of the image", e);
+    }
+    return 0;
+  }
+
+  public int getHeight() {
+    try {
+      String[] outputParts = stdoutBuilder.toString().split(" ");
+
+      if(outputParts.length == 2) {
+        try {
+            return Integer.parseInt(outputParts[1]);
+        } catch (NumberFormatException e) {
+            log.error("Received height is not an integer {}", outputParts[0]);
+        }
+      }
+    } catch (Exception e) {
+      log.error("Exception identifying height of the image", e);
+    }
+    return 0;
+  }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/ImageResolutionServiceHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/ImageResolutionServiceHandler.java
@@ -27,7 +27,7 @@ public class ImageResolutionServiceHandler extends AbstractCommandHandler {
       .getLogger(ImageResolutionServiceHandler.class);
 
   /**
-   * @return The number of pages inside the scanned PDF document
+   * @return The resolution of the provided image
    */
   public int getWidth() {
     try {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -1,0 +1,58 @@
+/**
+* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+* 
+* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+*
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License as published by the Free Software
+* Foundation; either version 3.0 of the License, or (at your option) any later
+* version.
+* 
+* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along
+* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+package org.bigbluebutton.presentation.imp;
+
+import com.zaxxer.nuprocess.NuProcess;
+import com.zaxxer.nuprocess.NuProcessBuilder;
+import org.bigbluebutton.presentation.ImageResolution;
+import org.bigbluebutton.presentation.handlers.ImageResolutionServiceHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+public class ImageResolutionService {
+  private static Logger log = LoggerFactory.getLogger(ImageResolutionService.class);
+
+  private int wait = 5;
+
+  public ImageResolution identifyImageResolution(File presentationFile) {
+
+    NuProcessBuilder imageResolution = new NuProcessBuilder(
+        Arrays.asList("identify", "-format","%w %h", presentationFile.getAbsolutePath()));
+
+    ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler();
+    imageResolution.setProcessListener(imgResHandler);
+
+    NuProcess process = imageResolution.start();
+    try {
+      process.waitFor(wait, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      log.error("InterruptedException while identifying image resolution {}", presentationFile.getName(), e);
+    }
+
+    return new ImageResolution(imgResHandler.getWidth(), imgResHandler.getHeight());
+  }
+
+  public void setWait(int wait) {
+    this.wait = wait;
+  }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
@@ -19,21 +19,13 @@
 
 package org.bigbluebutton.presentation.imp;
 
-import java.awt.image.BufferedImage;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
-import org.bigbluebutton.presentation.ImageResizer;
-import org.bigbluebutton.presentation.PngCreator;
-import org.bigbluebutton.presentation.SvgImageCreator;
-import org.bigbluebutton.presentation.TextFileCreator;
-import org.bigbluebutton.presentation.ThumbnailCreator;
-import org.bigbluebutton.presentation.UploadedPresentation;
+import org.bigbluebutton.presentation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.imageio.ImageIO;
 
 public class ImageSlidesGenerationService {
 	private static Logger log = LoggerFactory.getLogger(ImageSlidesGenerationService.class);
@@ -101,8 +93,12 @@ public class ImageSlidesGenerationService {
 		log.debug("Creating SVG images.");
 
 		try {
-			BufferedImage bimg = ImageIO.read(pres.getUploadedFile());
-			if(bimg.getWidth() > maxImageWidth || bimg.getHeight() > maxImageHeight) {
+			ImageResolutionService imgResService = new ImageResolutionService();
+			ImageResolution imageResolution = imgResService.identifyImageResolution(pres.getUploadedFile());
+
+			log.debug("Identified image {} width={} and height={}", pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
+
+			if(imageResolution.getWidth() > maxImageWidth || imageResolution.getHeight() > maxImageHeight) {
 				log.info("The image exceeds max dimension allowed, it will be resized.");
 				resizeImage(pres, maxImageWidth + "x" + maxImageHeight);
 			}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -1,6 +1,5 @@
 package org.bigbluebutton.presentation.imp;
 
-import java.awt.image.BufferedImage;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -8,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
+import org.bigbluebutton.presentation.ImageResolution;
 import org.bigbluebutton.presentation.SupportedFileTypes;
 import org.bigbluebutton.presentation.SvgImageCreator;
 import org.bigbluebutton.presentation.UploadedPresentation;
@@ -22,8 +22,6 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.zaxxer.nuprocess.NuProcess;
 import com.zaxxer.nuprocess.NuProcessBuilder;
-
-import javax.imageio.ImageIO;
 
 public class SvgImageCreatorImp implements SvgImageCreator {
     private static Logger log = LoggerFactory.getLogger(SvgImageCreatorImp.class);
@@ -254,10 +252,13 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                         int width = 500;
                         int height = 500;
 
-                        BufferedImage img = ImageIO.read(tempPng);
-                        if (img != null) {
-                            width = img.getWidth();
-                            height = img.getHeight();
+                        ImageResolutionService imgResService = new ImageResolutionService();
+                        ImageResolution imageResolution = imgResService.identifyImageResolution(pres.getUploadedFile());
+                        log.debug("Identified image {} width={} and height={}", pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
+
+                        if (imageResolution.getWidth() != 0 && imageResolution.getHeight() != 0) {
+                            width = imageResolution.getWidth();
+                            height = imageResolution.getHeight();
                         }
 
                         String svg = createSvgWithEmbeddedPng(base64encodedPng, width, height);


### PR DESCRIPTION
This PR updates the method for obtaining the resolution of image files during presentation uploads. Instead of using `ImageIO.read`, the system now relies on the `identify` command from ImageMagick.  

### Why  
`ImageIO.read` was causing `java.lang.OutOfMemoryError: Java heap space` when attempting to read large image files. Switching to `identify` resolves this issue by offloading the resolution detection to an external, memory-efficient tool. 