### PR TITLE
fix: chat does not open on mobile devices

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -295,7 +295,7 @@ const LayoutEngine = () => {
     left = !isRTL ? left : null;
     right = isRTL ? right : null;
 
-    const zIndex = isMobile ? 11 : 1;
+    const zIndex = isMobile ? 11 : 2;
 
     return {
       top,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.jsx
@@ -116,7 +116,7 @@ const SidebarContent = (props) => {
         top,
         left,
         right,
-        zIndex: '2',
+        zIndex,
         width,
         height,
       }}


### PR DESCRIPTION
### What does this PR do?
Adjusts sidebar styles so the chat and other types of content appear correctly on mobile devices.

### Closes Issue(s)
Closes #21930

### How to test
1. Start meeting
2. Enter meeting on a mobile device
3. Try to open chat or public note
