### PR TITLE
docs: Add docs for `disabledFeatures` options of new chat features

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -512,7 +512,8 @@ endWhenNoModeratorDelayInMinutes=1
 # List of features to disable (comma-separated)
 # https://docs.bigbluebutton.org/3.0/development/api/#create
 # Available options:
-# chat, privateChat, sharedNotes, polls, screenshare, externalVideos, layouts, captions, liveTranscription,
+# sharedNotes, polls, screenshare, externalVideos, layouts, captions, liveTranscription,
+# chat, privateChat, deleteChatMessage, editChatMessage, replyChatMessage, chatMessageReactions
 # breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms,
 # presentation, downloadPresentationWithAnnotations, downloadPresentationOriginalFile, downloadPresentationConvertedToPdf,
 # learningDashboard, learningDashboardDownloadSessionData,

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -345,7 +345,7 @@ const createEndpointTableData = [
               <code className="language-plaintext highlighter-rouge">privateChat</code> - <b>Private Chat</b>
             </li>
             <li>
-              <code className="language-plaintext highlighter-rouge">deleteChatMessage</code> - <b>Delete a Chat Message (moderators or owner)</b>
+              <code className="language-plaintext highlighter-rouge">deleteChatMessage</code> - <b>Delete a Chat Message (moderators or author)</b>
             </li>
             <li>
               <code className="language-plaintext highlighter-rouge">editChatMessage</code> - <b>Edit a Chat Message (only owner)</b>

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -326,7 +326,7 @@ const createEndpointTableData = [
     "type": "String",
     "description": (
         <>
-          List (comma-separated) of features to disable in a particular meeting. (added 2.5)
+          List (comma-separated) of features to disable in a particular meeting.
           <br />
           <br />
           Available options to disable:

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -321,10 +321,10 @@ const createEndpointTableData = [
     "description": (<>Pass a URL to an image which will then be visible in the area above the participants list if <code>displayBrandingArea</code> is set to <code>true</code> in bbb-html5's configuration</>)
   },
   {
-    name: "disabledFeatures",
-    required: false,
-    type: "String",
-    description: (
+    "name": "disabledFeatures",
+    "required": false,
+    "type": "String",
+    "description": (
         <>
           List (comma-separated) of features to disable in a particular meeting. (added 2.5)
           <br />
@@ -418,29 +418,16 @@ const createEndpointTableData = [
             </li>
           </ul>
         </>
-),
-},
-{
-"name"
-:
-"disabledFeaturesExclude",
-    "required"
-:
-false,
-    "type"
-:
-"String",
-    "description"
-:
-(<>List (comma-separated) of features to no longer disable in a particular meeting. This is particularly useful if you
-  disabled a list of features on a per-server basis but want to allow one of two of these features for a specific
-  meeting. (added 2.6.9)<br/><br/>The available options to exclude are exactly the same as for <code
-      className="language-plaintext highlighter-rouge">disabledFeatures</code></>)
-},
-{
-"name"
-:
-"preUploadedPresentationOverrideDefault",
+    ),
+  },
+  {
+    "name":"disabledFeaturesExclude",
+    "required":false,
+    "type":"String",
+    "description": (<>List (comma-separated) of features to no longer disable in a particular meeting. This is particularly useful if you disabled a list of features on a per-server basis but want to allow one of two of these features for a specific meeting. (added 2.6.9)<br/><br/>The available options to exclude are exactly the same as for <code className="language-plaintext highlighter-rouge">disabledFeatures</code></>)
+  },
+  {
+    "name":"preUploadedPresentationOverrideDefault",
     "required": false,
     "type": "Boolean",
     "default": "true",

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -348,7 +348,7 @@ const createEndpointTableData = [
               <code className="language-plaintext highlighter-rouge">deleteChatMessage</code> - <b>Delete a Chat Message (moderators or author)</b>
             </li>
             <li>
-              <code className="language-plaintext highlighter-rouge">editChatMessage</code> - <b>Edit a Chat Message (only owner)</b>
+              <code className="language-plaintext highlighter-rouge">editChatMessage</code> - <b>Edit a Chat Message (only author)</b>
             </li>
             <li>
               <code className="language-plaintext highlighter-rouge">replyChatMessage</code> - <b>Reply to a Chat Message</b>

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -321,19 +321,126 @@ const createEndpointTableData = [
     "description": (<>Pass a URL to an image which will then be visible in the area above the participants list if <code>displayBrandingArea</code> is set to <code>true</code> in bbb-html5's configuration</>)
   },
   {
-    "name": "disabledFeatures",
-    "required": false,
-    "type": "String",
-    "description": (<>List (comma-separated) of features to disable in a particular meeting. (added 2.5)<br /><br />Available options to disable:<br /><ul><li><code className="language-plaintext highlighter-rouge">breakoutRooms</code>- <b>Breakout Rooms</b> </li><li><code className="language-plaintext highlighter-rouge">captions</code>- <b>Closed Caption</b> </li><li><code className="language-plaintext highlighter-rouge">chat</code>- <b>Chat</b></li><li><code className="language-plaintext highlighter-rouge">privateChat</code>- <b>Private Chat</b></li><li><code className="language-plaintext highlighter-rouge">downloadPresentationWithAnnotations</code>- <b>Annotated presentation download</b></li><li><code className="language-plaintext highlighter-rouge">downloadPresentationConvertedToPdf</code>- <b>Converted presentation download (if BigBlueButton had to convert to PDF)</b></li><li><code className="language-plaintext highlighter-rouge">downloadPresentationOriginalFile</code>- <b>Original presentation download</b></li><li><code className="language-plaintext highlighter-rouge">snapshotOfCurrentSlide</code>- <b>Allow snapshot of the current slide</b></li><li><code className="language-plaintext highlighter-rouge">externalVideos</code>- <b>Share an external video</b> </li><li><code className="language-plaintext highlighter-rouge">importPresentationWithAnnotationsFromBreakoutRooms</code>- <b>Capture breakout presentation</b></li><li><code className="language-plaintext highlighter-rouge">importSharedNotesFromBreakoutRooms</code>- <b>Capture breakout shared notes</b></li><li><code className="language-plaintext highlighter-rouge">layouts</code>- <b>Layouts</b> (allow only default layout)</li><li><code className="language-plaintext highlighter-rouge">learningDashboard</code>- <b>Learning Analytics Dashboard</b></li><li><code className="language-plaintext highlighter-rouge">learningDashboardDownloadSessionData</code>- <b>Learning Analytics Dashboard Download Session Data (prevents the option to download)</b></li><li><code className="language-plaintext highlighter-rouge">polls</code>- <b>Polls</b> </li><li><code className="language-plaintext highlighter-rouge">screenshare</code>- <b>Screen Sharing</b></li><li><code className="language-plaintext highlighter-rouge">sharedNotes</code>- <b>Shared Notes</b></li><li><code className="language-plaintext highlighter-rouge">virtualBackgrounds</code>- <b>Virtual Backgrounds</b></li><li><code className="language-plaintext highlighter-rouge">customVirtualBackgrounds</code>- <b>Virtual Backgrounds Upload</b></li><li><code className="language-plaintext highlighter-rouge">liveTranscription</code>- <b>Live Transcription</b></li><li><code className="language-plaintext highlighter-rouge">presentation</code>- <b>Presentation</b></li><li><code className="language-plaintext highlighter-rouge">cameraAsContent</code>-<b>Enables/Disables camera as a content</b></li><li><code className="language-plaintext highlighter-rouge">timer</code>- <b>disables timer</b></li><li><code className="language-plaintext highlighter-rouge">infiniteWhiteboard</code>- <b>Infinite Whiteboard (added in BigBlueButton 3.0)</b></li></ul></>)
-  },
-  {
-    "name": "disabledFeaturesExclude",
-    "required": false,
-    "type": "String",
-    "description": (<>List (comma-separated) of features to no longer disable in a particular meeting. This is particularly useful if you disabled a list of features on a per-server basis but want to allow one of two of these features for a specific meeting. (added 2.6.9)<br /><br />The available options to exclude are exactly the same as for <code className="language-plaintext highlighter-rouge">disabledFeatures</code></>)
-  },
-  {
-    "name": "preUploadedPresentationOverrideDefault",
+    name: "disabledFeatures",
+    required: false,
+    type: "String",
+    description: (
+        <>
+          List (comma-separated) of features to disable in a particular meeting. (added 2.5)
+          <br />
+          <br />
+          Available options to disable:
+          <br />
+          <ul>
+            <li>
+              <code className="language-plaintext highlighter-rouge">breakoutRooms</code> - <b>Breakout Rooms</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">captions</code> - <b>Closed Caption</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">chat</code> - <b>Chat (Public and Private)</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">privateChat</code> - <b>Private Chat</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">deleteChatMessage</code> - <b>Delete a Chat Message (moderators or owner)</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">editChatMessage</code> - <b>Edit a Chat Message (only owner)</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">replyChatMessage</code> - <b>Reply to a Chat Message</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">chatMessageReactions</code> - <b>Send Reactions to a chat message</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">downloadPresentationWithAnnotations</code> - <b>Annotated presentation download</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">downloadPresentationConvertedToPdf</code> - <b>Converted presentation download (if BigBlueButton had to convert to PDF)</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">downloadPresentationOriginalFile</code> - <b>Original presentation download</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">snapshotOfCurrentSlide</code> - <b>Allow snapshot of the current slide</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">externalVideos</code> - <b>Share an external video</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">importPresentationWithAnnotationsFromBreakoutRooms</code> - <b>Capture breakout presentation</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">importSharedNotesFromBreakoutRooms</code> - <b>Capture breakout shared notes</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">layouts</code> - <b>Layouts</b> (allow only default layout)
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">learningDashboard</code> - <b>Learning Analytics Dashboard</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">learningDashboardDownloadSessionData</code> - <b>Learning Analytics Dashboard Download Session Data (prevents the option to download)</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">polls</code> - <b>Polls</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">screenshare</code> - <b>Screen Sharing</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">sharedNotes</code> - <b>Shared Notes</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">virtualBackgrounds</code> - <b>Virtual Backgrounds</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">customVirtualBackgrounds</code> - <b>Virtual Backgrounds Upload</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">liveTranscription</code> - <b>Live Transcription</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">presentation</code> - <b>Presentation</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">cameraAsContent</code> - <b>Enables/Disables camera as a content</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">timer</code> - <b>Disables timer</b>
+            </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">infiniteWhiteboard</code> - <b>Infinite Whiteboard (added in BigBlueButton 3.0)</b>
+            </li>
+          </ul>
+        </>
+),
+},
+{
+"name"
+:
+"disabledFeaturesExclude",
+    "required"
+:
+false,
+    "type"
+:
+"String",
+    "description"
+:
+(<>List (comma-separated) of features to no longer disable in a particular meeting. This is particularly useful if you
+  disabled a list of features on a per-server basis but want to allow one of two of these features for a specific
+  meeting. (added 2.6.9)<br/><br/>The available options to exclude are exactly the same as for <code
+      className="language-plaintext highlighter-rouge">disabledFeatures</code></>)
+},
+{
+"name"
+:
+"preUploadedPresentationOverrideDefault",
     "required": false,
     "type": "Boolean",
     "default": "true",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -112,7 +112,7 @@ Updated in 2.7:
 
 Updated in 3.0:
 
-- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`. **Removed:** `breakoutRoomsEnabled`, `learningDashboardEnabled`, `virtualBackgroundsDisabled`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`;
+- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`. **Removed:** `breakoutRoomsEnabled`, `learningDashboardEnabled`, `virtualBackgroundsDisabled`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`, `deleteChatMessage`, `editChatMessage`, `replyChatMessage`, `chatMessageReactions`;
 - **join** - **Added:** `enforceLayout`, `logoutURL`, `userdata-bbb_default_layout`, `userdata-bbb_skip_echotest_if_previous_device`, `userdata-bbb_prefer_dark_theme`. **Removed:** `defaultLayout` (replaced by `userdata-bbb_default_layout`) and removed support for all HTTP request methods except GET.
 - **sendChatMessage** endpoint was first introduced.
 - **getJoinUrl** endpoint was first introduced.


### PR DESCRIPTION
Adds the following samples in `bigbluebutton.properties`:
```
disabledFeatures=deleteChatMessage, editChatMessage, replyChatMessage, chatMessageReactions
```

And adds the following docs:

![image](https://github.com/user-attachments/assets/d6b49064-3c07-4664-a6c1-93363ede26bb)

---

![image](https://github.com/user-attachments/assets/f61aced7-9a42-49e5-bcb8-b07d23660b00)
