### PR TITLE
fix(whiteboard): Fix whiteboard crash on reload

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -240,7 +240,7 @@ const WhiteboardContainer = (props) => {
   const { data: annotationStreamData } = useSubscription(ANNOTATION_HISTORY_STREAM, {
     variables: { updatedAt: lastUpdatedAt },
     skip: !curPageId || !lastUpdatedAt,
-    onSubscriptionData: ({ subscriptionData }) => {
+    onData: ({ data: subscriptionData }) => {
       const annotationStream =
         subscriptionData.data?.pres_annotation_history_curr_stream || [];
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Replaces Apollo's deprecated callback `onSubscriptionData` with the recommended `onData`. See https://www.apollographql.com/docs/react/api/react/hooks#onsubscriptiondataoptional.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21997

### Motivation

The abovementioned issue is caused when the client browser has [React Dev Tools](https://react.dev/learn/react-developer-tools) installed on it. For some reason, React Dev Tools runs some kind of overriding on the [Console](https://developer.mozilla.org/en-US/docs/Web/API/console) interface, which by itself alone can be problematic.

It turns out that the Apollo's `useSubscription` hook also runs some kind of overriding on the same interface for its log system, which is triggered when using a deprecated `useSubscription` option in production.

Both may be conflicting with each other when overriding the Console interface.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Uninstall React Dev Tools from your browser.
2. Open a session.
3. Reload the page.