### PR TITLE
fix(whiteboard): Prevent zoom carry-over between slides

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useState } from 'react';
 import { isEqual } from 'radash';
 import {
   Tldraw,
@@ -155,12 +155,22 @@ const Whiteboard = React.memo((props) => {
   const lastVisibilityStateRef = React.useRef('');
   const mountedTimeoutIdRef = useRef(null);
 
+  const [pageZoomMap, setPageZoomMap] = useState(() => {
+    try {
+      const saved = localStorage.getItem('pageZoomMap');
+      return saved ? JSON.parse(saved) : {};
+    } catch {
+      return {};
+    }
+  });
+
   const CAMERA_UPDATE_DELAY = 650;
   const MOUNTED_CAMERA_DELAY = 500;
 
   const customTools = [NoopTool];
 
   const presenterChanged = usePrevious(isPresenter) !== isPresenter;
+  const pageChanged = usePrevious(curPageId) !== curPageId;
 
   let clipboardContent = null;
   let isPasting = false;
@@ -186,6 +196,10 @@ const Whiteboard = React.memo((props) => {
       ...rest,
     };
   };
+
+  React.useEffect(() => {
+    localStorage.setItem('pageZoomMap', JSON.stringify(pageZoomMap));
+  }, [pageZoomMap]);
 
   React.useEffect(() => {
     currentPresentationPageRef.current = currentPresentationPage;
@@ -752,15 +766,15 @@ const Whiteboard = React.memo((props) => {
     );
 
     if (editor && curPageIdRef.current) {
-      const pages = [
-        {
-          meta: {},
-          id: `page:${curPageIdRef.current}`,
-          name: `Slide ${curPageIdRef.current}`,
-          index: 'a1',
-          typeName: 'page',
-        },
-      ];
+      const page = [];
+      const formattedPageId = parseInt(curPageIdRef.current, 10);
+      const currentPageId = `page:${formattedPageId}`;
+      const currPageExists = tlEditorRef.current?.getPage(currentPageId);
+
+      if (!currPageExists) {
+        const currentPage = createPage(currentPageId);
+        page.push(...currentPage);
+      }
 
       const hasShapes = shapes && Object.keys(shapes).length > 0;
       const remoteShapesArray = hasShapes 
@@ -769,7 +783,7 @@ const Whiteboard = React.memo((props) => {
 
       editor.store.mergeRemoteChanges(() => {
         editor.batch(() => {
-          editor.store.put(pages);
+          editor.store.put(page);
           editor.store.put(assets);
           editor.setCurrentPage(`page:${curPageIdRef.current}`);
           editor.store.put(bgShape);
@@ -1013,6 +1027,10 @@ const Whiteboard = React.memo((props) => {
   React.useEffect(() => {
     zoomValueRef.current = zoomValue;
     let timeoutId = null;
+    setPageZoomMap(prev => ({
+      ...prev,
+      [curPageIdRef.current]: zoomValue,
+    }));
 
     if (
       tlEditorRef.current &&
@@ -1021,6 +1039,10 @@ const Whiteboard = React.memo((props) => {
       isPresenter &&
       !isWheelZoomRef.current
     ) {
+      if (pageChanged) {
+        return zoomChanger(pageZoomMap[curPageIdRef.current]||HUNDRED_PERCENT);
+      }
+
       const zoomLevelForReset =
         fitToWidthRef.current || !initialZoomRef.current
           ? calculateZoomValue(
@@ -1240,14 +1262,7 @@ const Whiteboard = React.memo((props) => {
             ...camera,
             z: adjustedZoom,
           };
-
-          let cameras = [
-            createCamera(formattedPageId - 1, zoomToApply),
-            updatedCurrentCam,
-            createCamera(formattedPageId + 1, zoomToApply),
-          ];
-          cameras = cameras.filter((cam) => cam.id !== 'camera:page:0');
-          tlEditorRef.current.store.put(cameras);
+          tlEditorRef.current.store.put([updatedCurrentCam]);
         } else {
           // Viewer logic
           const newZoom = calculateZoomValue(
@@ -1261,14 +1276,7 @@ const Whiteboard = React.memo((props) => {
             ...camera,
             z: newZoom,
           };
-
-          let cameras = [
-            createCamera(formattedPageId - 1, newZoom),
-            updatedCurrentCam,
-            createCamera(formattedPageId + 1, newZoom),
-          ];
-          cameras = cameras.filter((cam) => cam.id !== 'camera:page:0');
-          tlEditorRef.current.store.put(cameras);
+          tlEditorRef.current.store.put([updatedCurrentCam]);
         }
       }
     };
@@ -1451,14 +1459,22 @@ const Whiteboard = React.memo((props) => {
   React.useEffect(() => {
     const formattedPageId = parseInt(curPageIdRef.current, 10);
     if (tlEditorRef.current && formattedPageId !== 0) {
-      const currentPageId = `page:${formattedPageId}`;
-      const tlZ = tlEditorRef.current.getCamera()?.z;
-
-      const pages = createPage(currentPageId);
-      const cameras = createCameras(formattedPageId, tlZ);
-
       tlEditorRef.current.store.mergeRemoteChanges(() => {
         tlEditorRef.current.batch(() => {
+          const currentPageId = `page:${formattedPageId}`;
+          const tlZ = tlEditorRef.current.getCamera()?.z;
+          const cameras = [];
+          const pages = [];
+          const currPageExists = tlEditorRef.current?.getPage(currentPageId);
+          if (!currPageExists) {
+            const currentPage = createPage(currentPageId);
+            pages.push(...currentPage);
+          }
+          const allRecords = tlEditorRef.current.store.allRecords();
+          const cameraRecords = allRecords.filter(record => record.typeName === "camera" && record.id?.split(':').pop() == formattedPageId);
+          if (cameraRecords?.length < 1) {
+            cameras.push(createCamera(formattedPageId, tlZ));
+          }
           cleanupStore(currentPageId);
           updateStore(pages, cameras);
           tlEditorRef.current.setCurrentPage(currentPageId);
@@ -1473,10 +1489,12 @@ const Whiteboard = React.memo((props) => {
 
   React.useEffect(() => {
     setTldrawIsMounting(true);
+    isPresenterRef?.current && zoomChanger(HUNDRED_PERCENT);
     return () => {
       isMountedRef.current = false;
       localStorage.removeItem('initialViewBoxWidth');
       localStorage.removeItem('initialViewBoxHeight');
+      localStorage.removeItem('pageZoomMap');
       if (mountedTimeoutIdRef.current) {
         clearTimeout(mountedTimeoutIdRef.current);
       }


### PR DESCRIPTION
### What does this PR do?
This PR prevents the zoom being carried over from the previous slide.

before:
![zoom-carry-over-bug](https://github.com/user-attachments/assets/3982389e-1ee5-4208-8e68-4f45cd70bd3a)

after:
![zoom-carry-over-fix](https://github.com/user-attachments/assets/e34557d6-58d3-47f5-a206-69e2048ce217)


### Closes Issue(s)
Closes #21874 
