### PR TITLE
change audio and video modal priority level to medium

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -262,7 +262,7 @@ const AudioContainer = (props) => {
       {isAudioModalOpen ? (
         <AudioModalContainer
           {...{
-            priority: 'low',
+            priority: 'medium',
             setIsOpen: setAudioModalIsOpen,
             isOpen: isAudioModalOpen,
           }}
@@ -274,7 +274,7 @@ const AudioContainer = (props) => {
             callbackToClose: () => {
               setVideoPreviewModalIsOpen(false);
             },
-            priority: 'low',
+            priority: 'medium',
             setIsOpen: setVideoPreviewModalIsOpen,
             isOpen: isVideoPreviewModalOpen,
           }}


### PR DESCRIPTION

### What does this PR do?
updates audio and video modal priority level to "medium", so they always appear before the session details modal

### Motivation
session details modal had the same priority level as audio and video modals, making the order of appearance unpredictable