### PR TITLE
fix(whiteboard): Add missing tldraw arrow-left icon

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -320,6 +320,7 @@ const getCustomAssetUrls = () => {
       'geo-arrow-right': `${TL_ICON_PATHS}/geo-arrow-right.svg`,
       'align-left': `${TL_ICON_PATHS}/align-left.svg`,
       'align-top': `${TL_ICON_PATHS}/align-top.svg`,
+      'arrow-left': `${TL_ICON_PATHS}/arrow-left.svg`,
       'align-right': `${TL_ICON_PATHS}/align-right.svg`,
       'align-center-horizontal': `${TL_ICON_PATHS}/align-center-horizontal.svg`,
       'align-bottom': `${TL_ICON_PATHS}/align-bottom.svg`,

--- a/bigbluebutton-html5/public/svgs/tldraw/arrow-left.svg
+++ b/bigbluebutton-html5/public/svgs/tldraw/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.4996 21.5001L5.99963 15.0001M5.99963 15.0001L12.4996 8.50012M5.99963 15.0001L23.9999 15.0001" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
### What does this PR do?
This PR adds the missing tldraw icon for arrow-left, resolving the issue where the icon was not found.

### Motivation
The absence of the arrow-left icon caused a console error when it was referenced.

![image](https://github.com/user-attachments/assets/c0da03c2-8884-4a13-be26-8b5b982dc3a3)

