### PR TITLE
test: Replace closing toast for its related function

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -161,10 +161,7 @@ class Join extends Create {
 
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
     await this.modPage.waitAndClick(e.breakoutOptionsMenu);
-    // close all notifications displayed before ending rooms
-    for (const closeButton of await this.modPage.getLocator(e.closeToastBtn).all()) {
-      await closeButton.click();
-    }
+    await this.modPage.closeAllToastNotifications();
     await this.modPage.waitAndClick(e.endAllBreakouts);
 
     await this.modPage.hasElement(e.presentationUploadProgressToast, 'should display the presentation upload progress toast');
@@ -208,10 +205,7 @@ class Join extends Create {
 
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
     await this.modPage.waitAndClick(e.breakoutOptionsMenu);
-    // close all notifications displayed before ending rooms
-    for (const closeButton of await this.modPage.getLocator(e.closeToastBtn).all()) {
-      await closeButton.click();
-    }
+    await this.modPage.closeAllToastNotifications();
     await this.modPage.waitAndClick(e.endAllBreakouts);
 
     await this.modPage.hasElement(e.presentationUploadProgressToast, 'should display the presentation upload progress toast', ELEMENT_WAIT_LONGER_TIME);

--- a/bigbluebutton-tests/playwright/presentation/presentation.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.js
@@ -39,10 +39,7 @@ class Presentation extends MultiUsers {
     await this.modPage.hasElement(e.webcamMirroredVideoPreview, 'should display the camera preview when sharing camera as content');
     await this.modPage.waitAndClick(e.startSharingWebcam);
     await this.modPage.hasElement(e.screenShareVideo);
-    // close all notifications displayed before comparing screenshots
-    for (const closeButton of await this.modPage.getLocator(e.closeToastBtn).all()) {
-      await closeButton.click();
-    }
+    await this.modPage.closeAllToastNotifications();
     const modWhiteboardLocator = this.modPage.getLocator(e.screenShareVideo);
     await expect(modWhiteboardLocator, 'should display the same screenshot as taken before').toHaveScreenshot('moderator-share-camera-as-content.png', {
       maxDiffPixels: 1000,
@@ -50,10 +47,7 @@ class Presentation extends MultiUsers {
 
     await this.userPage.wasRemoved(e.screenshareConnecting);
     await this.userPage.hasElement(e.screenShareVideo);
-    // close all notifications displayed before comparing screenshots
-    for (const closeButton of await this.userPage.getLocator(e.closeToastBtn).all()) {
-      await closeButton.click();
-    }
+    await this.modPage.closeAllToastNotifications();
     const viewerWhiteboardLocator = this.userPage.getLocator(e.screenShareVideo);
     await expect(viewerWhiteboardLocator).toHaveScreenshot('viewer-share-camera-as-content.png', {
       maxDiffPixels: 1000,


### PR DESCRIPTION
### What does this PR do?
Replaces all actions of closing toast notification for its related function, so the action will be the same in every case

### Motivation
There were some CI failures due to missing timeout, which got PW stuck into the closing toast action
![image](https://github.com/user-attachments/assets/085c262a-2c0c-4a06-8b42-63743297bf83)

