### PR TITLE
feat(livekit): make room options configurable, enable adaptiveStream

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -1,4 +1,7 @@
-import type { TrackPublishOptions } from 'livekit-client';
+import type {
+  InternalRoomOptions,
+  TrackPublishOptions,
+} from 'livekit-client';
 
 export interface MeetingClientSettings {
   public: Public
@@ -630,6 +633,7 @@ export interface LiveKitAudioSettings {
 export interface LiveKitSettings {
   url?: string
   selectiveSubscription?: boolean
+  roomOptions?: Partial<InternalRoomOptions>
   audio?: LiveKitAudioSettings
   camera?: LiveKitCameraSettings
   screenshare?: LiveKitScreenShareSettings

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -10,6 +10,7 @@ import {
 import {
   ConnectionState,
   type Room,
+  type InternalRoomOptions,
   type RoomConnectOptions,
 } from 'livekit-client';
 import Auth from '/imports/ui/services/auth';
@@ -28,6 +29,7 @@ import LKAutoplayModalContainer from '/imports/ui/components/livekit/autoplay-mo
 interface BBBLiveKitRoomProps {
   url?: string;
   token?: string;
+  roomOptions: Partial<InternalRoomOptions>;
   bbbSessionToken: string;
   usingAudio: boolean;
   usingScreenShare: boolean;
@@ -100,6 +102,7 @@ const LiveKitObserver = ({
 const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   url,
   token,
+  roomOptions,
   bbbSessionToken,
   usingAudio,
   usingScreenShare,
@@ -118,6 +121,7 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       },
     };
 
+    liveKitRoom.options = { ...liveKitRoom.options, ...roomOptions };
     liveKitRoom.connect(url, token, connectOptions).catch((error) => {
       logger.error({
         logCode: 'livekit_connect_error',
@@ -172,6 +176,11 @@ const BBBLiveKitRoomContainer: React.FC = () => {
   const [meetingSettings] = useMeetingSettings();
   const url = meetingSettings.public.media?.livekit?.url
     || `wss://${window.location.hostname}/livekit`;
+  const roomOptions = meetingSettings.public.media?.livekit?.roomOptions ?? {
+    adaptiveStream: true,
+    dynacast: true,
+    stopLocalTrackOnUnpublish: false,
+  };
   const { data: bridges } = useMeeting((m) => ({
     cameraBridge: m.cameraBridge,
     screenShareBridge: m.screenShareBridge,
@@ -187,6 +196,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
     <BBBLiveKitRoom
       token={currentUserData?.livekit?.livekitToken}
       url={url}
+      roomOptions={roomOptions}
       bbbSessionToken={Auth.sessionToken as string}
       usingAudio={bridges?.audioBridge === 'livekit'}
       usingScreenShare={bridges?.screenShareBridge === 'livekit'}

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -667,6 +667,11 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       livekit: {
         url: `wss://${window.location.hostname}/livekit`,
         selectiveSubscription: false,
+        roomOptions: {
+          adaptiveStream: true,
+          dynacast: true,
+          stopLocalTrackOnUnpublish: false,
+        },
         audio: {
           publishOptions: {
             audioPreset: AudioPresets.speech,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -932,6 +932,10 @@ public:
       # applicable track sources. Default value is false. This overrides autoSubscribe
       # when set to true and in effect (conditional to client behavior).
       selectiveSubscription: false
+      roomOptions:
+        adaptiveStream: true
+        dynacast: true
+        stopLocalTrackOnUnpublish: false
       audio:
         # publishOptions: see https://docs.livekit.io/client-sdk-js/interfaces/TrackPublishOptions.html
         publishOptions:


### PR DESCRIPTION
### What does this PR do?

- [feat(livekit): make room options configurable, enable adaptiveStream](https://github.com/bigbluebutton/bigbluebutton/commit/1bb9c2b8bf124bfdc77bef64bba821d3a268e3ae) 
  - Make LiveKit's room options configurable via the client's configuration.
  Additionally, enable adaptiveStream by default (as well as dynacast,
  even though that it largely unsupported in our VP8-only scenario).

### Closes Issue(s)

None
Ref #21059