### PR TITLE
refactor: Copy/Save chat needs to drop the Welcome message

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
@@ -75,7 +75,6 @@ const ChatActions: React.FC = () => {
     if (dataHistory) {
       const exportedString = generateExportedMessages(
         dataHistory.chat_message_public,
-        dataHistory.user_welcomeMsgs[0],
         intl,
       );
       if (downloadOrCopyRef.current === 'download') {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
@@ -6,7 +6,6 @@ import { Message } from '/imports/ui/Types/message';
 export type getChatMessageHistory = {
   chat_message_public: Array<Message>
   meeting: Array<Meeting>;
-  user_welcomeMsgs: Array<{welcomeMsg: string, welcomeMsgForModerators: string | null}>;
 };
 
 export const GET_CHAT_MESSAGE_HISTORY = gql`
@@ -30,10 +29,6 @@ query getChatMessageHistory {
   }
   meeting {
     name
-  }
-  user_welcomeMsgs {
-    welcomeMsg
-    welcomeMsgForModerators
   }
 }
 `;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -25,6 +25,14 @@ const intlMessages = defineMessages({
     id: 'app.chat.deleteMessage',
     description: '',
   },
+  userIsPresenter: {
+    id: 'app.chat.isPresenter',
+    description: 'message when user is set presenter',
+  },
+  userIsPresenterSetBy: {
+    id: 'app.chat.isPresenterSetBy',
+    description: 'message when user is set presenter by someone else',
+  },
 });
 
 export const htmlDecode = (input: string) => {
@@ -34,15 +42,8 @@ export const htmlDecode = (input: string) => {
 
 export const generateExportedMessages = (
   messages: Array<Message>,
-  welcomeSettings: { welcomeMsg: string, welcomeMsgForModerators: string | null },
   intl: IntlShape,
 ): string => {
-  const welcomeMessage = htmlDecode(welcomeSettings.welcomeMsg);
-  const welcomeMsgForModerators = welcomeSettings.welcomeMsgForModerators
-      && htmlDecode(welcomeSettings.welcomeMsgForModerators);
-  const systemMessages = `${welcomeMessage ? `system: ${welcomeMessage}` : ''}\n 
-  ${welcomeMsgForModerators ? `system: ${welcomeMsgForModerators}` : ''}\n`;
-
   const text = messages.reduce((acc, message) => {
     const date = new Date(message.createdAt);
     const hour = date.getHours().toString().padStart(2, '0');
@@ -64,6 +65,14 @@ export const generateExportedMessages = (
         messageText = pollText.slice(0, -1);
         break;
       }
+      case ChatMessageType.USER_IS_PRESENTER_MSG: {
+        const { assignedBy } = JSON.parse(message.messageMetadata);
+
+        messageText = (assignedBy)
+          ? `${intl.formatMessage(intlMessages.userIsPresenterSetBy, { 0: message.senderName, 1: assignedBy })}`
+          : `${intl.formatMessage(intlMessages.userIsPresenter, { 0: message.senderName })}`;
+        break;
+      }
       case ChatMessageType.USER_AWAY_STATUS_MSG: {
         const { away } = JSON.parse(message.messageMetadata);
 
@@ -80,7 +89,7 @@ export const generateExportedMessages = (
         break;
     }
     return `${acc}${hourMin} ${userName}${messageText}\n`;
-  }, welcomeMessage ? systemMessages : '');
+  }, '');
   return text;
 };
 

--- a/bigbluebutton-tests/playwright/chat/chat.js
+++ b/bigbluebutton-tests/playwright/chat/chat.js
@@ -86,8 +86,10 @@ class Chat extends MultiUsers {
     await this.modPage.waitAndClick(e.chatCopy);
     // enable access to browser context clipboard
     const copiedText = await this.modPage.getCopiedText(this.modPage.context);
-    const check = copiedText.includes(`${p.fullName}: ${e.message}`);
-    await expect(check, 'should display on the copied chat the same message that was sent on the public chat').toBeTruthy();
+    await expect(
+      copiedText,
+      'should display on the copied chat the same message that was sent on the public chat',
+    ).toContain(`[${this.modPage.username} : MODERATOR]: ${e.message}`);
   }
 
   async saveChat(testInfo) {
@@ -103,11 +105,10 @@ class Chat extends MultiUsers {
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(e.chatUserMessageText, 'should display the message sent by the moderator on the public chat');
     await this.modPage.waitAndClick(e.chatOptions);
+
     const chatSaveLocator = this.modPage.getLocator(e.chatSave);
     const { content } = await this.modPage.handleDownload(chatSaveLocator, testInfo);
-
     const dataToCheck = [
-      this.modPage.meetingId,
       this.modPage.username,
       e.message,
     ];
@@ -319,7 +320,7 @@ class Chat extends MultiUsers {
     await this.modPage.waitAndClick(e.chatCopy);
 
     const copiedText = await this.modPage.getCopiedText(context);
-    const check = copiedText.includes(`${p.fullName}: ${e.convertedEmojiMessage}`);
+    const check = copiedText.includes(`${this.modPage.username}: ${e.convertedEmojiMessage}`);
     await expect(check).toBeTruthy();
   }
 


### PR DESCRIPTION
### What does this PR do?

- removes welcome message from chat copy/save
- fix "user X is now the presenter" messages when chat is saved

### Closes Issue(s)
Closes #22036

### How to test
1. Start a session
2. Save the public chat (before posting anything) via the three dots menu -> Save
3. Copy+Paste the public chat via the three dots menu -> Copy