### PR TITLE
fix: Fix raise hand notification CSS with recent updates 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.jsx
@@ -157,7 +157,7 @@ class RaiseHandNotifier extends Component {
     const { raiseHandUsers, intl, lowerUserHands } = this.props;
     const formattedRaisedHands = this.getRaisedHandNames();
     return (
-      <div>
+      <Styled.ToastContentWrapper>
         <Styled.ToastContent>
           <Styled.IconWrapper>
             <Icon iconName="hand" />
@@ -180,7 +180,7 @@ class RaiseHandNotifier extends Component {
           }}
           data-test="raiseHandRejection"
         />
-      </div>
+      </Styled.ToastContentWrapper>
     );
   }
 

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
@@ -130,10 +130,15 @@ const AvatarWrapper = styled.div`
   display: flex;
 `;
 
+const ToastContentWrapper = styled.div`
+  width: 100%;
+`;
+
 const ToastSeparator = styled(ToastStyled.Separator)``;
 
 export default {
   Avatar,
+  ToastContentWrapper,
   AvatarsExtra,
   ToastContent,
   IconWrapper,


### PR DESCRIPTION
### What does this PR do?

Just a fix in the raise hand notification's CSS

### Closes Issue(s)

Closes #22043

### How to test
If one finds it fit, it would be nice to also test the other notifications, since the recent updates in the react-toastify of https://github.com/bigbluebutton/bigbluebutton/pull/22024


### More

See the fixed behaviour in the demo below:

https://github.com/user-attachments/assets/d0191c9e-82b1-46f1-9c2f-e368dbc3aa1c


