### PR TITLE
fix(whiteboard): Add touch gesture support for undo and redo

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -250,7 +250,15 @@ const intlMessages = defineMessages({
   pushToTalkDesc: {
     id: 'app.shortcut-help.pushToTalk',
     description: 'describes the push-to-talk shortcut',
-  }
+  },
+  gesture: {
+    id: 'app.shortcut-help.gesture',
+    description: 'label for gesture tab',
+  },
+  fingerTap: {
+    id: 'app.shortcut-help.fingerTap',
+    description: 'label for tap shotcut',
+  },
 });
 
 
@@ -335,6 +343,12 @@ const ShortcutHelpComponent = ({
   shortcutItems.push(renderItem(intl.formatMessage(intlMessages.previousSlideDesc),
    intl.formatMessage(intlMessages.previousSlideKey)));
 
+  const gestureItems = [];
+  gestureItems.push(renderItem(intl.formatMessage(intlMessages.undo),
+   `2-${intl.formatMessage(intlMessages.fingerTap)}`));
+  gestureItems.push(renderItem(intl.formatMessage(intlMessages.redo),
+   `3-${intl.formatMessage(intlMessages.fingerTap)}`));
+
   const whiteboardShortcutItems = [];
   //tools
   whiteboardShortcutItems.push(renderItemWhiteBoard(intl.formatMessage(intlMessages.select), '1', 'V'));
@@ -404,6 +418,11 @@ const ShortcutHelpComponent = ({
             <StyledSettings.SettingsIcon iconName="whiteboard" />
             <span id="whiteboardTab">{intl.formatMessage(intlMessages.whiteboard)}</span>
           </StyledSettings.SettingsTabSelector>
+
+          <StyledSettings.SettingsTabSelector selectedClassName="is-selected">
+            <StyledSettings.SettingsIcon iconName="whiteboard" />
+            <span id="gestureTab">{intl.formatMessage(intlMessages.gesture)}</span>
+          </StyledSettings.SettingsTabSelector>
         </StyledSettings.SettingsTabList>
 
         <Styled.TabPanel selectedClassName="is-selected">
@@ -446,6 +465,20 @@ const ShortcutHelpComponent = ({
                   <th>{intl.formatMessage(intlMessages.alternativeLabel)}</th>
                 </tr>
                 {whiteboardShortcutItems}
+              </tbody>
+            </Styled.ShortcutTable>
+          </Styled.TableWrapper>
+        </Styled.TabPanel>
+
+        <Styled.TabPanel selectedClassName="is-selected">
+          <Styled.TableWrapper>
+            <Styled.ShortcutTable>
+              <tbody>
+                <tr>
+                  <th>{intl.formatMessage(intlMessages.functionLabel)}</th>
+                  <th>{intl.formatMessage(intlMessages.comboLabel)}</th>
+                </tr>
+                {gestureItems}
               </tbody>
             </Styled.ShortcutTable>
           </Styled.TableWrapper>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -218,6 +218,9 @@ const useMouseEvents = ({
   const handleTouchEnd = (event) => {
     if (event.touches.length === 0) {
       const count = fingerCountRef.current;
+
+      if (!hasWBAccess) return;
+
       if (count === 2) {
         if (!isPinchingRef.current) {
           tlEditorRef.current?.undo();

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1079,6 +1079,8 @@
     "app.shortcut-help.selectAll": "Select All",
     "app.shortcut-help.delete": "Delete",
     "app.shortcut-help.duplicate": "Duplicate",
+    "app.shortcut-help.gesture": "Gestures",
+    "app.shortcut-help.fingerTap": "finger tap",
     "app.lock-viewers.title": "Lock viewers",
     "app.lock-viewers.description": "These options enable you to restrict viewers from using specific features.",
     "app.lock-viewers.featuresLable": "Feature",


### PR DESCRIPTION
### What does this PR do?
Adds touch gesture support for undo and redo functionality on the whiteboard:

- Two-finger tap for undo.
- Three-finger tap for redo.

**Note**: Users must not have the pencil tool selected when performing a redo action.


### Motivation
The undo and redo UI buttons were removed from the interface in favor of keyboard shortcuts. However, mobile users without keyboards needed an alternative way to perform undo and redo actions. This PR introduces touch gestures to address this.