### PR TITLE
fix: Button behind userList toggle on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -117,7 +117,7 @@ const PushLayoutEngine = (props) => {
     let { selectedLayout: actualLayout } = Settings.application;
     if (isMobile()) {
       actualLayout = actualLayout === 'custom' ? 'smart' : actualLayout;
-      Settings.application.actualLayout = actualLayout;
+      Settings.application.selectedLayout = actualLayout;
     }
     Session.setItem('isGridEnabled', actualLayout === LAYOUT_TYPE.VIDEO_FOCUS);
 


### PR DESCRIPTION
### What does this PR do?

Adjusts layout being incorrectly set on mobile

### Closes Issue(s)
Closes #22053

### How to test
1. Create a meeting
2. Join with three different users and then turn on their webcams
3. Join with another one on mobile
4. See the blue button