### PR TITLE
fix: locale not updating in chat dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
@@ -142,7 +142,7 @@ const ChatActions: React.FC = () => {
       },
     ];
     return dropdownActions.filter((action) => action.enable);
-  }, [userIsModerator, meetingIsBreakout, currentUserLoading, meetingLoading]);
+  }, [userIsModerator, meetingIsBreakout, currentUserLoading, meetingLoading, intl.locale]);
   if (errorHistory) {
     return (
       <p>


### PR DESCRIPTION
### What does this PR do?

fix issue where the chat dropdown options would be displayed in the wrong language after switching locales

### How to test
1. join a meeting
2. change language in settings menu
3. save settings
4. see chat dropdown options