### PR TITLE
fix(chat): Unstable scroll + unable to load previous page

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -301,7 +301,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         return prev;
       });
     }
-  }, [isStartSentinelVisible, followingTail]);
+  }, [isStartSentinelVisible]);
 
   useEffect(() => {
     setter({

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -469,6 +469,16 @@ const ChatMessageList: React.FC<ChatListProps> = ({
                 setShowStartSentinel(userScrolledUp);
               }
             }}
+            onWheel={(e) => {
+              if (e.deltaY < 0 && isStartSentinelVisible) {
+                setUserLoadedBackUntilPage((prev) => {
+                  if (typeof prev === 'number' && prev > 0) {
+                    return prev - 1;
+                  }
+                  return prev;
+                });
+              }
+            }}
             data-test="chatMessages"
             isRTL={isRTL}
             ref={updateRefs}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Fixes a bug where the chat scroll does not stick to the bottom after sending a reply message.
- Fixes a bug where you are unable to load the previous message page by scrolling up if the chat scroll is already stuck at the top.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22018
