### PR TITLE
fix: locale not updating in shared notes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
@@ -51,7 +51,7 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
       return;
     }
     setPadURL(Service.buildPadURL(padId, sessionIds));
-  }, [isRTL, hasSession]);
+  }, [isRTL, hasSession, intl.locale]);
 
   if (!hasSession) {
     return <PadContent externalId={externalId} />;


### PR DESCRIPTION
### What does this PR do?

fix issue where the shared notes buttons tooltips would be displayed in the wrong language after switching locales

![2025-01-23_10-16](https://github.com/user-attachments/assets/3e7124b3-73aa-4218-a316-9d897aee1af3)

### How to test
1. join a meeting
2. open shared notes
3. change language in settings menu
4. save settings
5. see shared notes buttons