### PR TITLE
fix (html5): Avoid reloading whiteboard due to a harmless error caused by React Dev Tools

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -1,7 +1,11 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useState, useEffect, useRef, useCallback,
+} from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import logger from '/imports/startup/client/logger';
-import { ErrorContainer, Message, Spinner, ReloadButton } from './styles';
+import {
+  ErrorContainer, Message, Spinner, ReloadButton,
+} from './styles';
 
 const intlMessages = defineMessages({
   attemptingToRecover: {
@@ -60,11 +64,16 @@ const ErrorBoundaryWithReload = ({ children }) => {
           errorStack: event.error?.stack,
         },
       }, 'Global error caught by ErrorBoundaryWithReload');
-    
+
       triggerError();
     };
 
     const handleUnhandledRejection = (event) => {
+      // Ignore error caused by ReactDevTools (chrome-extension://fmkadmapgofadopljbjfkapdkoienihi/build/installHook.js)
+      if (event.reason?.stack.toString().indexOf('fmkadmapgofadopljbjfkapdkoienihi') !== false) {
+        return;
+      }
+
       logger.error({
         logCode: 'ErrorBoundaryWithReload.UnhandledRejection',
         extraInfo: {
@@ -72,7 +81,7 @@ const ErrorBoundaryWithReload = ({ children }) => {
           errorStack: event.reason?.stack,
         },
       }, 'Unhandled promise rejection caught by ErrorBoundaryWithReload');
-    
+
       triggerError();
     };
 


### PR DESCRIPTION
Closes #22066

I identified the error is caused by React Dev Tools and we force the reload of Tldraw unnecessarily.
So my approach to fix is to ignore the error when we know it was caused by the extension `fmkadmapgofadopljbjfkapdkoienihi`.

```
TypeError: Cannot read properties of null (reading 'values')
     at console.overrideMethod [as warn] (chrome-extension://fmkadmapgofadopljbjfkapdkoienihi/build/installHook.js:1:146012)
     at https://bbb30.bbb.imdt.dev/html5client/bundle.bfa4f567775e16d6a866.js:85:159225
     at async https://bbb30.bbb.imdt.dev/html5client/bundle.bfa4f567775e16d6a866.js:85:159136

```