### PR TITLE
test: Flag recent CI test failures as flaky

### DIFF
--- a/bigbluebutton-tests/playwright/audio/audio.spec.js
+++ b/bigbluebutton-tests/playwright/audio/audio.spec.js
@@ -26,7 +26,8 @@ test.describe('Audio', { tag: '@ci' }, () => {
   });
 
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#muteunmute
-  test('Mute yourself by clicking the mute button', async () => {
+  // Ci failure: not being muted when clicking the mute button (isTalking element keep displayed)
+  test('Mute yourself by clicking the mute button', { tag: '@flaky' }, async () => {
     await audio.muteYourselfByButton();
   });
 

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.js
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.js
@@ -469,7 +469,8 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
       await customParam.hidePresentationOnJoin();
     });
 
-    test('Force restore presentation on new events', async ({ browser, context, page }) => {
+    // not restoring presentation after zooming in
+    test('Force restore presentation on new events', { tag: '@flaky' }, async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
       await customParam.initModPage(page);
       await customParam.initUserPage(true, context, { useModMeetingId: true, joinParameter: c.forceRestorePresentationOnNewEvents });

--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
@@ -39,7 +39,10 @@ test.describe('Shared Notes', { tag: '@ci' }, () => {
     await sharedNotes.seeNotesWithoutEditPermission();
   });
 
-  test('Pin and unpin notes onto whiteboard', async () => {
+  // different failures in CI and local
+  // local: not able to click on "unpin" button
+  // CI: not restoring presentation for viewer after unpinning notes
+  test('Pin and unpin notes onto whiteboard', { tag: '@flaky' }, async () => {
     await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -140,8 +140,9 @@ class MultiUsers {
   async raiseAndLowerHand() {
     await this.modPage.waitForSelector(e.whiteboard);
     await this.initUserPage();
+    await this.userPage.waitForSelector(e.whiteboard);
     await this.userPage.waitAndClick(e.raiseHandBtn);
-    await this.userPage.hasElement(e.raiseHandBtn);
+    await this.userPage.hasElement(e.lowerHandBtn, 'should display the lower hand button after raising the hand');
     await this.modPage.comparingSelectorsBackgroundColor(e.avatarsWrapperAvatar, `${e.userListItem} div:first-child`);
     await sleep(1000);
     await this.userPage.waitAndClick(e.lowerHandBtn);


### PR DESCRIPTION
### What does this PR do?
Adds flaky flags on 3 tests failing in recent CI runs:
- `Force restore presentation on new events`: not restoring presentation after zooming in;
- `Pin and unpin notes onto whiteboard`: not restoring presentation after unpinning notes;
- `Mute yourself by clicking the mute button`: looks like it's not unmuting/muting correctly - mic button keeps in current state

### More:
- `Raise and lower Hand` test step fixed, also failed in recent CI runs
