### PR TITLE
ci: Specify ubuntu version on upload-report step

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -468,7 +468,7 @@ jobs:
   upload-report:
     if: always() && !contains(github.event.head_commit.message, 'Merge pull request')
     needs: install-and-run-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       hasReportData: ${{ needs.install-and-run-tests.result == 'success' || needs.install-and-run-tests.result == 'failure' }}
     steps:


### PR DESCRIPTION
### What does this PR do?
This PR sets the same ubuntu version as the other steps, also to avoid the following warning
![image](https://github.com/user-attachments/assets/e45864ce-cc51-46b6-89e1-1108f5b53fe1)
