### PR TITLE
refactor: adjust session details modal text

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/session-details/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/session-details/component.tsx
@@ -200,7 +200,6 @@ const SessionDetailsContainer: React.FC<SessionDetailsContainerProps> = ({
     isModerator: user.isModerator,
   }));
 
-
   if (welcomeLoading) return null;
   if (welcomeError) return <div>{JSON.stringify(welcomeError)}</div>;
   if (!welcomeData || loading || !currentMeeting) return null;

--- a/bigbluebutton-html5/imports/ui/components/session-details/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/session-details/component.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 import { useQuery } from '@apollo/client';
 import { GET_WELCOME_MESSAGE, WelcomeMsgsResponse } from './queries';
@@ -195,6 +196,11 @@ const SessionDetailsContainer: React.FC<SessionDetailsContainerProps> = ({
     };
   });
 
+  const { data: currentUserData } = useCurrentUser((user) => ({
+    isModerator: user.isModerator,
+  }));
+
+
   if (welcomeLoading) return null;
   if (welcomeError) return <div>{JSON.stringify(welcomeError)}</div>;
   if (!welcomeData || loading || !currentMeeting) return null;
@@ -214,13 +220,21 @@ const SessionDetailsContainer: React.FC<SessionDetailsContainerProps> = ({
 
   const anchorElement = document.getElementById('presentationTitle') as HTMLElement;
 
+  // login url should only be displayed for moderators
+  let loginUrl = currentMeeting.loginUrl ?? '';
+  const isModerator = currentUserData?.isModerator;
+
+  if (!isModerator) {
+    loginUrl = '';
+  }
+
   return (
     <SessionDetails
       isOpen={isOpen}
       onRequestClose={onRequestClose}
       priority={priority}
       meetingName={currentMeeting.name ?? ''}
-      loginUrl={currentMeeting.loginUrl ?? ''}
+      loginUrl={loginUrl}
       welcomeMessage={welcomeData.user_welcomeMsgs[0]?.welcomeMsg ?? ''}
       welcomeMsgForModerators={welcomeData.user_welcomeMsgs[0]?.welcomeMsgForModerators ?? ''}
       formattedDialNum={formattedDialNum}

--- a/bigbluebutton-html5/imports/ui/components/session-details/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/session-details/styles.ts
@@ -23,6 +23,8 @@ const Container = styled.div<{ isFullWidth: boolean }>`
     flex: ${({ isFullWidth }) => (isFullWidth ? '1 1 100%' : '1 1 50%')};
     box-sizing: border-box;
     padding: 10px;
+    overflow: auto;
+    overflow-wrap: break-word;
   }
 
   & div p {


### PR DESCRIPTION
### What does this PR do?

adjusts session details modal to:
- correctly break text when displaying 2 columns
- only display login url for moderators