### PR TITLE
build: fix config file permissions

### DIFF
--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -38,6 +38,7 @@ chmod -R a+rX staging/usr/share/bbb-graphql-server
 POSTGRES_MAJOR_VERSION=14
 mkdir -p staging/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/conf.d
 cp bbb-pg.conf staging/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/conf.d
+chmod 644 staging/etc/postgresql/$POSTGRES_MAJOR_VERSION/main/conf.d/bbb-pg.conf
 
 cp bbb-graphql-server.service staging/lib/systemd/system/bbb-graphql-server.service
 cp bbb-graphql-server@.service staging/lib/systemd/system/bbb-graphql-server@.service

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -29,6 +29,7 @@ cp livekit-server.service livekit-sip.service $DESTDIR/lib/systemd/system
 
 mkdir -p $DESTDIR/usr/share/livekit-server
 cp livekit.yaml livekit-sip.yaml $DESTDIR/usr/share/livekit-server
+chmod 644 $DESTDIR/usr/share/livekit-server/livekit*.yaml
 
 mkdir -p $DESTDIR/usr/bin
 

--- a/build/packages-template/bbb-webrtc-recorder/build.sh
+++ b/build/packages-template/bbb-webrtc-recorder/build.sh
@@ -33,6 +33,7 @@ go build -o ./build/bbb-webrtc-recorder \
 cp ./build/bbb-webrtc-recorder staging/usr/bin
 cp ./build/env staging/etc/default/bbb-webrtc-recorder
 cp ./config/bbb-webrtc-recorder.yml staging/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml
+chmod 644 staging/etc/bbb-webrtc-recorder/bbb-webrtc-recorder.yml
 cp bbb-webrtc-recorder.service staging/usr/lib/systemd/system
 
 . ./opts-$DISTRO.sh


### PR DESCRIPTION
### What does this PR do?

If the packages are built with umask 0077 on the build system, the config files deployed by packages are not readable by the services. This fixes some new spotted places.
