### PR TITLE
fix(middleware): check browser connection before using it

### DIFF
--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -69,10 +69,10 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	browserWsConn, err := websocket.Accept(w, r, &acceptOptions)
-	browserWsConn.SetReadLimit(9999999) //10MB
 	if err != nil {
 		connectionLogger.Errorf("error: %v", err)
 	}
+	browserWsConn.SetReadLimit(9999999) //10MB
 
 	if common.HasReachedMaxGlobalConnections() {
 		common.WsConnectionRejectedCounter.With(prometheus.Labels{"reason": "limit of server connections exceeded"}).Inc()


### PR DESCRIPTION

### What does this PR do?

If a connection does not supply the expected CORS headers, the websocket will not return a connection. So that would leave a stack trace in the logs without indication for the reason.


### Closes Issue(s)

Not reported as issue yet.