### PR TITLE
fix(bbb-html5): fix inverted away state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -302,7 +302,7 @@ class OptionsDropdown extends PureComponent {
             <Styled.AFKLabel>{ToggleAFKLabel()}</Styled.AFKLabel>
             <Toggle
               icons={false}
-              checked={away}
+              checked={!away}
               onChange={handleToggleAFK}
               ariaLabel={ToggleAFKLabel()}
               showToggleLabel={false}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
The state of the presence slider was confusing. This is due to an inverted state. Before the fix the behaviour was:

User present: Text active, color red, slider left
User away: Text away, color green, slider right

This was unexpected behaviour for all users I spoke with. This patch changes the behaviour to

User present: Text active, color green, slider right
User away: Text away, color red, slider left

Previous behaviour:

[Bildschirmaufzeichnung vom 2025-01-27, 08-41-16.webm](https://github.com/user-attachments/assets/74af33cb-e1ee-4f1a-a9fe-a138950b817e)

Fixed behaviour:

[Bildschirmaufzeichnung vom 2025-01-27, 08-39-32.webm](https://github.com/user-attachments/assets/78957620-a23d-4294-90db-96ac5239b7dd)
