### PR TITLE
refactor (bbb-web) Speed up upload of presentations by removing a fixed delay

### DIFF
--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -83,6 +83,7 @@ class PresentationService {
 	}
 
 	def processUploadedPresentation = { uploadedPres ->
+		// Run conversion on another thread to allow multiple conversions to run simultaneously
 		def scheduler = Executors.newSingleThreadScheduledExecutor()
 		def startTime = System.currentTimeMillis()
 		def timeout = 10000 // 10 secs


### PR DESCRIPTION
This PR modifies the logic for handling presentation uploads to improve the process of waiting for the meeting to be created. Previously, the system waited for a fixed delay of **5 seconds** before proceeding with the presentation conversion. Now, the logic has been updated to **check every 1 second** if the meeting has been created and is running, allowing the process to start sooner if the meeting becomes available.

This change is particularly beneficial for uploads during an ongoing meeting, as the meeting is already created, and the process can start immediately without waiting.

<table>

<tr>
<td>Before (8 seconds):</td>
<td>After (2 seconds):</td>
</tr>

<tr>
<td>

[Screencast from 2025-01-27 09-32-39.webm](https://github.com/user-attachments/assets/323ad504-577f-4bc2-95a7-4546e4f00221)

</td>
<td>

[Screencast from 2025-01-27 09-31-14.webm](https://github.com/user-attachments/assets/5044735a-0959-40d0-b6a2-19ad77e11ebe)

</td>
</tr>

</table>


Motivation of the old delay for reference: https://github.com/bigbluebutton/bigbluebutton/commit/d0343b40d2853be7b0235f52e818316380749208