### PR TITLE
fix(client): Connection status function accepting 2 params, meant to improve log readability

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -45,7 +45,7 @@ const ConnectionStatus = () => {
             },
           });
           const rttStatus = getStatus(rttLevels, networkRtt);
-          connectionStatus.setConnectedStatus(networkRtt, rttStatus);
+          connectionStatus.setConnectionStatus(networkRtt, rttStatus);
           connectionStatus.setLastRttRequestSuccess(true);
 
           if (Object.keys(rttLevels).includes(rttStatus)) {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -45,8 +45,7 @@ const ConnectionStatus = () => {
             },
           });
           const rttStatus = getStatus(rttLevels, networkRtt);
-          connectionStatus.setRttValue(networkRtt);
-          connectionStatus.setRttStatus(rttStatus);
+          connectionStatus.setConnectedStatus(networkRtt, rttStatus);
           connectionStatus.setLastRttRequestSuccess(true);
 
           if (Object.keys(rttLevels).includes(rttStatus)) {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -60,7 +60,7 @@ const ConnectionStatus = () => {
       .catch(() => {
         connectionStatus.setLastRttRequestSuccess(false);
         // gets the worst status
-        connectionStatus.setRttStatus('critical');
+        connectionStatus.setConnectionStatus(2000, 'critical');
       })
       .finally(() => {
         if (timeoutRef.current) {

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -1,7 +1,6 @@
 import { makeVar, ReactiveVar } from '@apollo/client';
 import logger from '/imports/startup/client/logger';
 import { User } from '/imports/ui/Types/user';
-import getStatus from '/imports/ui/core/utils/getStatus';
 
 type NetworkData = {
   ready: boolean;
@@ -245,6 +244,5 @@ class ConnectionStatus {
 }
 
 const connectionsStatusSingleton = new ConnectionStatus();
-
 
 export default connectionsStatusSingleton;

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -140,7 +140,11 @@ class ConnectionStatus {
 
   public setLastRttRequestSuccess(value: boolean): void {
     if (value !== this.lastRttRequestSuccess()) {
-      logger.info({ logCode: 'stats_rtt_success_state' }, `Last RTT request changed to ${value}`);
+      if (value === false) {
+        logger.warn({ logCode: 'stats_rtt_success_state' }, `Last RTT request failed (rtt_success=${value})`);
+      } else {
+        logger.debug({ logCode: 'stats_rtt_success_state' }, `Last RTT request succeeded (rtt_success=${value})`);
+      }
       this.lastRttRequestSuccess(value);
     }
   }
@@ -241,5 +245,7 @@ class ConnectionStatus {
 }
 
 const connectionsStatusSingleton = new ConnectionStatus();
+
+window.teste = connectionsStatusSingleton;
 
 export default connectionsStatusSingleton;

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -248,6 +248,5 @@ class ConnectionStatus {
 
 const connectionsStatusSingleton = new ConnectionStatus();
 
-window.teste = connectionsStatusSingleton;
 
 export default connectionsStatusSingleton;

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -246,6 +246,5 @@ class ConnectionStatus {
 
 const connectionsStatusSingleton = new ConnectionStatus();
 
-window.teste = connectionsStatusSingleton;
 
 export default connectionsStatusSingleton;

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -104,21 +104,24 @@ class ConnectionStatus {
     return this.networkData;
   }
 
-  public setConnectionStatus(rtt: number, status: string): void {
-    if (rtt !== this.rttValue() || status !== this.rttStatus()) {
-      const warnLevels = ['danger', 'critical'];
-      if (
-        warnLevels.includes(status)
-        // Emit warning if the status changed to a warn level or if the status recovered from a warn level
-        || (warnLevels.includes(this.rttStatus()) && !warnLevels.includes(status))
-      ) {
-        logger.warn({ logCode: 'stats_rtt_state' }, `Connection status changed to ${status} (rtt > ${rtt}ms)`);
-      } else {
-        logger.debug({ logCode: 'stats_rtt_state' }, `Connection status changed to ${status} (rtt > ${rtt}ms)`);
+  public setConnectionStatus(newRttValue: number, newRttStatus: string): void {
+    if (newRttValue !== this.rttValue() || newRttStatus !== this.rttStatus()) {
+      switch (newRttStatus) {
+        case 'critical':
+          logger.warn({ logCode: 'stats_rtt_state' }, `Connection status changed to critical(rtt > ${newRttValue}ms)`);
+          break;
+        case 'danger':
+          logger.warn({ logCode: 'stats_rtt_state' }, `Connection status changed to danger (rtt = ${newRttValue}ms)`);
+          break;
+        case 'warning':
+        case 'normal':
+          logger.debug({ logCode: 'stats_rtt_state' }, `Connection status changed to ${newRttStatus} (rtt = ${newRttValue}ms)`);
+          break;
+        default:
       }
 
-      this.setRttValue(rtt);
-      this.setRttStatus(status);
+      this.setRttValue(newRttValue);
+      this.setRttStatus(newRttStatus);
     }
   }
 
@@ -244,5 +247,7 @@ class ConnectionStatus {
 }
 
 const connectionsStatusSingleton = new ConnectionStatus();
+
+window.teste = connectionsStatusSingleton;
 
 export default connectionsStatusSingleton;

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -248,5 +248,4 @@ class ConnectionStatus {
 
 const connectionsStatusSingleton = new ConnectionStatus();
 
-
 export default connectionsStatusSingleton;

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -112,9 +112,9 @@ class ConnectionStatus {
         // Emit warning if the status changed to a warn level or if the status recovered from a warn level
         || (warnLevels.includes(this.rttStatus()) && !warnLevels.includes(status))
       ) {
-        logger.warn({ logCode: 'stats_rtt_state' }, `Connection status changed to ${status} (rtt=${rtt}ms)`);
+        logger.warn({ logCode: 'stats_rtt_state' }, `Connection status changed to ${status} (rtt > ${rtt}ms)`);
       } else {
-        logger.debug({ logCode: 'stats_rtt_state' }, `Connection status changed to ${status} (rtt=${rtt}ms)`);
+        logger.debug({ logCode: 'stats_rtt_state' }, `Connection status changed to ${status} (rtt > ${rtt}ms)`);
       }
 
       this.setRttValue(rtt);

--- a/bigbluebutton-html5/imports/ui/core/utils/getStatus.js
+++ b/bigbluebutton-html5/imports/ui/core/utils/getStatus.js
@@ -4,11 +4,8 @@ export default function getStatus(levels, value) {
     .sort((a, b) => a[1] - b[1]);
 
   for (let i = 0; i < sortedLevels.length; i += 1) {
-    if (value < sortedLevels[i][1]) {
+    if (value <= sortedLevels[i][1]) {
       return i === 0 ? 'normal' : sortedLevels[i - 1][0];
-    }
-    if (i === sortedLevels.length - 1) {
-      return sortedLevels[i][0];
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR improves RTT logs by combining the setRttValue and setRttStatus functions into one. Previously, misunderstandings arose because these values could become unsynchronized. By consolidating both setters, we ensure that the logs always use the most up-to-date data, thereby displaying the correct values. 

### Closes Issue(s)
Closes #22065
