### PR TITLE
style: restyle audio devices dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -156,14 +156,11 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
       {
         key: `audioDeviceList-${deviceKind}`,
         label: title,
-        iconRight: (deviceKind === 'audioinput') ? 'unmute' : 'volume_level_2',
+        icon: (deviceKind === 'audioinput') ? 'unmute' : 'listen',
         disabled: true,
         customStyles: Styled.DisabledLabel,
+        onClick: () => {},
       } as MenuOptionItemType,
-      {
-        key: 'separator-01',
-        isSeparator: true,
-      } as MenuSeparatorItemType,
     ];
 
     let deviceList: MenuOptionItemType[] = [];
@@ -182,7 +179,8 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
           key: `${device.deviceId}-${deviceKind}`,
           dataTest: `${deviceKind}-${index + 1}`,
           label: truncateDeviceName(device.label || getFallbackLabel(device, index + 1)),
-          customStyles: isCurrentDevice ? Styled.SelectedLabel : null,
+          customStyles: isCurrentDevice ? Styled.SelectedLabel : Styled.DeviceLabel,
+          iconStyles: isCurrentDevice ? Styled.SelectedLabelIcon : null,
           iconRight: isCurrentDevice ? 'check' : null,
           onClick: () => onDeviceListClick(device.deviceId, deviceKind, callback),
         } as MenuOptionItemType;
@@ -219,7 +217,8 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
         key: `listenOnly-${deviceKind}`,
         dataTest: `${deviceKind}-listenOnly`,
         label: intl.formatMessage(intlMessages.noMicListenOnlyLabel),
-        customStyles: listenOnly && Styled.SelectedLabel,
+        customStyles: listenOnly ? Styled.SelectedLabel : Styled.DeviceLabel,
+        iconStyles: listenOnly ? Styled.SelectedLabelIcon : null,
         iconRight: listenOnly ? 'check' : null,
         onClick: () => onDeviceListClick('listen-only', deviceKind, callback),
       } as MenuOptionItemType);
@@ -289,11 +288,15 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
     onClick: () => handleLeaveAudio(meetingIsBreakout),
   };
   const dropdownListComplete = inputDeviceList
+    .concat({
+      key: 'separator-01',
+      isSeparator: true,
+    } as MenuOptionItemType)
     .concat(outputDeviceList)
     .concat({
       key: 'separator-02',
       isSeparator: true,
-    });
+    } as MenuOptionItemType);
   if (shouldTreatAsMicrophone()) dropdownListComplete.push(audioSettingsOption);
   dropdownListComplete.push(leaveAudioOption);
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -291,12 +291,12 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
     .concat({
       key: 'separator-01',
       isSeparator: true,
-    } as MenuOptionItemType)
+    } as MenuSeparatorItemType)
     .concat(outputDeviceList)
     .concat({
       key: 'separator-02',
       isSeparator: true,
-    } as MenuOptionItemType);
+    } as MenuSeparatorItemType);
   if (shouldTreatAsMicrophone()) dropdownListComplete.push(audioSettingsOption);
   dropdownListComplete.push(leaveAudioOption);
 
@@ -318,7 +318,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
         dropdownListComplete.push({
           isSeparator: true,
           key: audioSettingsDropdownSeparator.id,
-        });
+        } as MenuSeparatorItemType);
         break;
       }
       default:

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
@@ -8,6 +8,7 @@ import {
   colorGrayDark,
   colorOffWhite,
   colorWhite,
+  colorSuccess,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { smPaddingY, smPadding } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
@@ -70,6 +71,7 @@ export const DisabledLabel = {
   color: colorGrayDark,
   fontWeight: 'bold',
   opacity: 1,
+  fontSize: '1rem',
 };
 
 export const AudioSettingsOption = {
@@ -79,6 +81,17 @@ export const AudioSettingsOption = {
 export const SelectedLabel = {
   color: colorPrimary,
   backgroundColor: colorOffWhite,
+  fontWeight: 'bold',
+  paddingLeft: '2.6rem',
+};
+
+export const DeviceLabel = {
+  paddingLeft: '2.6rem',
+};
+
+export const SelectedLabelIcon = {
+  color: colorSuccess,
+  fontSize: '1.2rem',
 };
 
 export const DangerColor = {
@@ -99,7 +112,9 @@ export const AudioDropdown = styled(ButtonEmoji)`
 export default {
   MuteToggleButton,
   DisabledLabel,
+  DeviceLabel,
   SelectedLabel,
+  SelectedLabelIcon,
   AudioSettingsOption,
   DangerColor,
   AudioDropdown,

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -118,8 +118,14 @@ class BBBMenu extends React.Component {
         marginRight: '0px',
       };
 
+      let iconStyles = {};
+
       if (a.customStyles) {
         customStyles = { ...customStyles, ...a.customStyles };
+      }
+
+      if (a.iconStyles) {
+        iconStyles = { ...iconStyles, ...a.iconStyles };
       }
 
       if (loading) {
@@ -155,7 +161,7 @@ class BBBMenu extends React.Component {
               {a.icon ? <Icon iconName={a.icon} key="icon" /> : null}
               <Styled.Option hasIcon={!!(a.icon)} isHorizontal={isHorizontal} isMobile={isMobile} aria-describedby={`${key}-option-desc`} $isToggle={isToggle}>{label}</Styled.Option>
               {description && <div className="sr-only" id={`${key}-option-desc`}>{`${description}${selected ? ` - ${intl.formatMessage(intlMessages.active)}` : ''}`}</div>}
-              {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" /> : null}
+              {a.iconRight ? <Styled.IconRight iconName={a.iconRight} key="iconRight" style={iconStyles} /> : null}
             </Styled.MenuItemWrapper>
           </Styled.BBBMenuItem>
         ),

--- a/bigbluebutton-html5/imports/ui/components/common/menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/styles.js
@@ -143,7 +143,7 @@ const BBBMenuItem = styled(MenuItem)`
   &:focus,
   &:hover {
     i { 
-      color: #FFF;
+      color: #FFF !important;
     }
     color: #FFF !important;
     background-color: ${colorPrimary} !important;

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -805,7 +805,7 @@
     "app.audio.stopAudioFeedback": "Stop audio feedback",
     "app.audio.backLabel": "Back",
     "app.audio.loading": "Loading",
-    "app.audio.microphones": "Microphones",
+    "app.audio.microphones": "Microphone",
     "app.audio.speakers": "Speakers",
     "app.audio.noDeviceFound": "No device found (listen only)",
     "app.audio.audioSettings.titleLabel": "Your audio settings",


### PR DESCRIPTION
### What does this PR do?

applies the following changes to the audio devices dropdown:
- adjusts titles ("Microphone" and "Speakers" text) font-weight to bold  
- removes separator (hr element) between titles and devices
- switch title icon to the left
- align available devices text with titles
- adjust current devices font-weight to bold
- increase the "current device" icon size and change color to green

### Closes Issue(s)
Closes #22080

#### before
![audio-before](https://github.com/user-attachments/assets/3039bd49-4306-4db1-8546-11497566a5d4)

#### after
![audio-after](https://github.com/user-attachments/assets/740f19e5-aa12-4e02-96a3-b98b054febc7)


### How to test
1. join a meeting
2. open audio devices dropdown