### PR TITLE
test: Add cooldown before mute/unmute mic step to avoid debounce time failure

### DIFF
--- a/bigbluebutton-tests/playwright/audio/util.js
+++ b/bigbluebutton-tests/playwright/audio/util.js
@@ -7,10 +7,11 @@ async function connectMicrophone(testPage) {
     autoJoinAudioModal,
     skipEchoTest,
     skipEchoTestOnJoin,
+    listenOnlyMode,
   } = testPage.settings;
 
   if (!autoJoinAudioModal) await testPage.waitAndClick(e.joinAudio);
-  await testPage.waitAndClick(e.microphoneButton);
+  if (listenOnlyMode) await testPage.waitAndClick(e.microphoneButton);
   const shouldSkipEchoTest = skipEchoTest || skipEchoTestOnJoin;
   if (!shouldSkipEchoTest) {
     await testPage.waitForSelector(e.stopHearingButton);


### PR DESCRIPTION
### What does this PR do?
This PR adds a timeout between muting/unmuting steps to avoid failure due to its debounce time

### Motivation
CI has recently reported a few failures after clicking to mute/unmute in different test cases, expecting the opposite state's elements:
![image](https://github.com/user-attachments/assets/9f00269b-f4ac-424c-9705-6c01709a9135)

Not easily reproducible locally, I've found out that when tested without the assertions in between mute and unmute steps it fails with the same log:
![2025-01-27_15-16](https://github.com/user-attachments/assets/c4e00743-8df7-4b92-9908-50ef5f383efa)

Once I've added a reasonable timeout, it no longer failed:
![image](https://github.com/user-attachments/assets/7f67e457-b663-4d7c-9b4f-0273e2d4032e)


