### PR TITLE
fix(HTML5): Restore back 2.7 behaviours for presentation uploader

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/presentation.ts
+++ b/bigbluebutton-html5/imports/ui/Types/presentation.ts
@@ -20,3 +20,25 @@ export interface CurrentPresentation {
     presentationId: string;
     pages: CurrentPage[];
 }
+
+export interface PresPresentation {
+    uploadTemporaryId?: string;
+    uploadInProgress: boolean;
+    current: boolean;
+    downloadFileUri: string;
+    downloadable: boolean;
+    uploadErrorDetailsJson?: object;
+    uploadErrorMsgKey?: string;
+    filenameConverted?: string;
+    isDefault: boolean;
+    name: string;
+    totalPages: number;
+    totalPagesUploaded: number;
+    presentationId: string;
+    removable: boolean;
+    uploadCompleted: boolean;
+    exportToChatInProgress?: boolean;
+    exportToChatStatus?: string;
+    exportToChatCurrentPage?: number;
+    exportToChatHasError?: boolean;
+}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/container.jsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { PresentationUploaderToast } from './component';
 
 import {
   EXPORTING_PRESENTATIONS_SUBSCRIPTION,
 } from '/imports/ui/components/whiteboard/queries';
+import { useStatePreviousValue } from '/imports/ui/hooks/usePreviousValue';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import checkSamePresentation from './utils';
 
 const PresentationUploaderToastContainer = (props) => {
   const {
@@ -15,8 +17,29 @@ const PresentationUploaderToastContainer = (props) => {
   );
   const presentations = presentationData?.pres_presentation || [];
 
+  const [presentationIdsYetToSee, setPresentationIdsYetToSee] = useState(new Set());
+  const previousPresentations = useStatePreviousValue(presentations);
+
+  useEffect(() => {
+    const idsYetToSee = presentations.filter(
+      (p) => !previousPresentations.some(
+        (presentation) => checkSamePresentation(p, presentation),
+      ),
+    );
+    if (idsYetToSee.length > 0) {
+      idsYetToSee.forEach((p) => {
+        presentationIdsYetToSee.add(p.presentationId);
+      });
+      setPresentationIdsYetToSee(presentationIdsYetToSee);
+    }
+  }, [presentationData]);
+
   const convertingPresentations = presentations.filter(
     (p) => (!p.uploadCompleted || !!p.uploadErrorMsgKey),
+  );
+
+  const presentationsToBeShowed = presentations.filter(
+    (p) => (presentationIdsYetToSee.has(p.presentationId)),
   );
 
   if (presentationLoading) return null;
@@ -28,6 +51,8 @@ const PresentationUploaderToastContainer = (props) => {
       ...{
         presentations: presentations.filter((p) => p),
         convertingPresentations,
+        setPresentationIdsYetToSee,
+        presentationsToBeShowed,
         ...props,
       }
       }

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/utils.ts
@@ -1,0 +1,10 @@
+import { PresPresentation } from '/imports/ui/Types/presentation';
+
+function checkSamePresentation(pres1: PresPresentation, pres2: PresPresentation) {
+  return pres1.presentationId === pres2.presentationId
+    || (pres1.uploadTemporaryId
+      && pres2.uploadTemporaryId
+      && pres1.uploadTemporaryId === pres2.uploadTemporaryId);
+}
+
+export default checkSamePresentation;

--- a/bigbluebutton-html5/imports/ui/hooks/usePreviousValue.ts
+++ b/bigbluebutton-html5/imports/ui/hooks/usePreviousValue.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Custom hook to get previous value. It can be used,
@@ -12,6 +12,21 @@ export const usePreviousValue = <T = unknown>(value: T) => {
     ref.current = value;
   });
   return ref.current;
+};
+
+/**
+ * Custom hook to get previous value with state. It can be used,
+ * for example, to get previous props or state. So that every time it changes,
+ * it will force another render.
+ * @param {*} value Value to be tracked
+ * @returns The previous value.
+ */
+export const useStatePreviousValue = <T = unknown>(value: T) => {
+  const [state, setState] = useState<T>();
+  useEffect(() => {
+    setState(value);
+  });
+  return state;
 };
 
 export default usePreviousValue;


### PR DESCRIPTION
### What does this PR do?

It basically:

- Restores the check icon that appeared in the toast whenever a presentation was done uploading;
- Restore the clear error button behaviour (it wasn't necessary to confirm to remove presentation with errors);
- Fix an export problem related to latest changes in the presentation uploader component.

### Closes Issue(s)

Closes #22038

### How to test

I recommend one to test all possible scenarios of uploading presentations:
- Add multiple presentations;
- Add multiple presentations and remove one;
- Add presentations with Error;
- ...

Also, there is 2 other ways of uploading presentation client side:
- Convert shared-notes to presentation;
- And select option to save whiteboard and shared notes in breakouts creation;

If you think of any way of triggering the presentation toast, feel free to test it.

### More

Here is a demo of the behaviour now:

https://github.com/user-attachments/assets/990c4926-3952-4789-ad68-5745aba2c08b




