### PR TITLE
fix: transcription warning font rendering issue

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
@@ -82,7 +82,6 @@ const AudioCaptionsSelect: React.FC<AudioCaptionsSelectProps> = ({
       <div
         data-test="speechRecognitionUnsupported"
         style={{
-          fontSize: '.75rem',
           padding: '1rem 0',
         }}
       >


### PR DESCRIPTION
### What does this PR do?

Fix font rendering issue on message about lack of speech recognition support (issue only happens on chromium browser) by adjusting font-size of element.

![font-before](https://github.com/user-attachments/assets/b0abe339-1979-4ed4-bd0d-aa5cc1ac62f8)

![2025-01-29_13-44](https://github.com/user-attachments/assets/c298870b-9b77-4686-8d6c-d8494753f78d)


### How to test
1. enable audioCaptions
2. join a meeting on chromium (not chrome)
3. open audio modal