### PR TITLE
chore(etherpad): change ep_cursortrace to mconf's fork

### DIFF
--- a/build/packages-template/bbb-etherpad/build.sh
+++ b/build/packages-template/bbb-etherpad/build.sh
@@ -47,7 +47,11 @@ git clone https://github.com/mconf/ep_redis_publisher.git
 npm pack ./ep_redis_publisher
 npm install ./ep_redis_publisher-*.tgz
 
-npm install ep_cursortrace
+rm -rf ep_cursortrace
+git clone https://github.com/mconf/ep_cursortrace.git
+npm pack ./ep_cursortrace
+npm install ./ep_cursortrace-*.tgz
+
 npm install ep_disable_chat
 npm install --no-save --legacy-peer-deps ep_auth_session
 


### PR DESCRIPTION
### What does this PR do?
Change `ep_cursortrace` plugin to mconf custom fork, it includes https://github.com/mconf/ep_cursortrace/pull/2, which fixes client slowing down when there's too many edits in shared notes in short time.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/21959




### How to test
Join with two users, open shared nodes. Start typing as fast as you can in shared notes (or just keep a key pressed), see if client don't slow down.

