### PR TITLE
fix: Add access key for leave meeting dropdown menu

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -216,6 +216,7 @@ export interface DataSaving {
 export interface Shortcuts {
   openOptions: OpenOptions
   toggleUserList: ToggleUserList
+  openLeaveMenu: OpenLeaveMenu
   toggleMute: ToggleMute
   joinAudio: JoinAudio
   leaveAudio: LeaveAudio
@@ -233,6 +234,11 @@ export interface OpenOptions {
 }
 
 export interface ToggleUserList {
+  accesskey: string
+  descId: string
+}
+
+export interface OpenLeaveMenu {
   accesskey: string
   descId: string
 }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -44,6 +44,7 @@ const propTypes = {
   isDropdownOpen: PropTypes.bool,
   ismobile: PropTypes.bool.isRequired,
   userLeaveMeeting: PropTypes.func.isRequired,
+  openLeaveMenu: PropTypes.string,
 };
 
 const defaultProps = {
@@ -151,6 +152,7 @@ class LeaveMeetingButton extends PureComponent {
       isDropdownOpen,
       ismobile,
       isRTL,
+      openLeaveMenu,
     } = this.props;
 
     const { isEndMeetingConfirmationModalOpen } = this.state;
@@ -165,6 +167,7 @@ class LeaveMeetingButton extends PureComponent {
             <Styled.LeaveButton
               state={isDropdownOpen ? 'open' : 'closed'}
               ismobile={ismobile.toString()}
+              accessKey={openLeaveMenu}
               aria-label={intl.formatMessage(intlMessages.leaveMeetingBtnLabel)}
               label={intl.formatMessage(intlMessages.leaveMeetingBtnLabel)}
               tooltipLabel={intl.formatMessage(intlMessages.leaveMeetingBtnLabel)}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/container.jsx
@@ -9,6 +9,7 @@ import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 
 const LeaveMeetingButtonContainer = (props) => {
   const {
@@ -28,6 +29,8 @@ const LeaveMeetingButtonContainer = (props) => {
   const [userLeaveMeeting] = useMutation(USER_LEAVE_MEETING);
   const isDropdownOpen = useStorageKey('dropdownOpen');
 
+  const openLeaveMenu = useShortcut('openLeaveMenu');
+
   const connected = useReactiveVar(connectionStatus.getConnectedStatusVar());
   const amIModerator = currentUser?.isModerator;
   const isBreakoutRoom = meeting?.isBreakout;
@@ -41,6 +44,7 @@ const LeaveMeetingButtonContainer = (props) => {
         amIModerator,
         connected,
         isBreakoutRoom,
+        openLeaveMenu,
         ...props,
       }
     }

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -47,6 +47,10 @@ const intlMessages = defineMessages({
     id: 'app.shortcut-help.toggleUserList',
     description: 'describes the toggle userlist shortcut',
   },
+  openLeaveMenu: {
+    id: 'app.shortcut-help.openLeaveMenu',
+    description: 'describes the open leave menu shortcut',
+  },
   togglemute: {
     id: 'app.shortcut-help.toggleMute',
     description: 'describes the toggle mute shortcut',

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -157,6 +157,10 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           accesskey: 'U',
           descId: 'toggleUserList',
         },
+        openLeaveMenu: {
+          accesskey: 'X',
+          descId: 'openLeaveMenu',
+        },
         toggleMute: {
           accesskey: 'M',
           descId: 'toggleMute',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -258,6 +258,9 @@ public:
       toggleUserList:
         accesskey: U
         descId: toggleUserList
+      openLeaveMenu:
+        accessKey: X
+        descId: openLeaveMenu
       toggleMute:
         accesskey: M
         descId: toggleMute

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -259,7 +259,7 @@ public:
         accesskey: U
         descId: toggleUserList
       openLeaveMenu:
-        accessKey: X
+        accesskey: X
         descId: openLeaveMenu
       toggleMute:
         accesskey: M

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1031,6 +1031,7 @@
     "app.shortcut-help.closeDesc": "Closes keyboard shortcuts modal",
     "app.shortcut-help.openOptions": "Open Options",
     "app.shortcut-help.toggleUserList": "Toggle UserList",
+    "app.shortcut-help.openLeaveMenu": "Open leave meeting menu",
     "app.shortcut-help.toggleMute": "Mute / Unmute",
     "app.shortcut-help.togglePublicChat": "Toggle Public Chat (User list must be open)",
     "app.shortcut-help.hidePrivateChat": "Hide private chat",


### PR DESCRIPTION
### What does this PR do?
This PR adds an **access key shortcut (`X`)** to the **Leave Meeting dropdown menu**, making it easier for **screen reader users** to access the options.

### Closes Issue(s)
Closes #22097 
