### PR TITLE
[3.1] fix(sidebar-content): new chat buttons behavior and padding correction

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -44,6 +44,7 @@ interface ChatProps {
   privateUnreadMessages: boolean;
   chatId: string;
   participantName: string;
+  filteredPrivateChats: Partial<ChatType>[];
 }
 
 const Chat: React.FC<ChatProps> = ({
@@ -51,13 +52,14 @@ const Chat: React.FC<ChatProps> = ({
   privateUnreadMessages,
   chatId,
   participantName,
+  filteredPrivateChats,
 }) => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
 
   const isEditingMessage = useRef(false);
   const [showMessages, setShowMessages] = useState(chatId === PUBLIC_GROUP_CHAT_ID);
-  const [privateList, setPrivateList] = useState(false); // novo estado
+  const [privateList, setPrivateList] = useState(false);
   const layoutContextDispatch = layoutDispatch();
   const intl = useIntl();
 
@@ -127,73 +129,78 @@ const Chat: React.FC<ChatProps> = ({
       <ChatHeader />
       <Styled.Separator />
       <Styled.ContentWrapper>
-        <Styled.ButtonsWrapper>
-          <Button
-            variant={showMessages ? 'contained' : 'outlined'}
-            color="primary"
-            size="medium"
-            sx={{
-              position: 'relative',
-              borderRadius: '16px',
-              width: '100%',
-              marginRight: '8px',
-              padding: '8px 16px',
-              textTransform: 'none',
-              backgroundColor: showMessages ? btnPrimaryBg : colorOffWhite,
-              color: showMessages ? colorWhite : colorGrayLight,
-              border: `1px solid ${btnPrimaryBg}`,
-            }}
-            onClick={() => handleClickSelectChat(true)}
-          >
-            {intl.formatMessage(intlMessages.titlePublic)}
-            {publicUnreadMessages && (
-              <span
-                style={{
-                  position: 'absolute',
-                  bottom: '8px',
-                  right: '8px',
-                  width: '8px',
-                  height: '8px',
-                  backgroundColor: colorDanger,
-                  borderRadius: '50%',
-                }}
-              />
-            )}
-          </Button>
-          <Button
-            variant={!showMessages ? 'contained' : 'outlined'}
-            color="primary"
-            size="medium"
-            sx={{
-              position: 'relative',
-              borderRadius: '16px',
-              width: '100%',
-              padding: '8px 16px',
-              textTransform: 'none',
-              backgroundColor: !showMessages ? btnPrimaryBg : colorOffWhite,
-              color: !showMessages ? colorWhite : colorGrayLight,
-              border: `1px solid ${btnPrimaryBg}`,
-            }}
-            onClick={() => handleClickSelectChat(false)}
-          >
-            {intl.formatMessage(intlMessages.titlePrivate)}
-            {privateUnreadMessages && (
-              <span
-                style={{
-                  position: 'absolute',
-                  bottom: '8px',
-                  right: '8px',
-                  width: '8px',
-                  height: '8px',
-                  backgroundColor: colorDanger,
-                  borderRadius: '50%',
-                }}
-              />
-            )}
-          </Button>
-        </Styled.ButtonsWrapper>
+        {filteredPrivateChats.length > 0 ? (
+          <Styled.ButtonsWrapper>
+            <Button
+              variant={showMessages ? 'contained' : 'outlined'}
+              color="primary"
+              size="medium"
+              sx={{
+                position: 'relative',
+                borderRadius: '16px',
+                width: '100%',
+                marginRight: '8px',
+                padding: '8px 16px',
+                textTransform: 'none',
+                backgroundColor: showMessages ? btnPrimaryBg : colorOffWhite,
+                color: showMessages ? colorWhite : colorGrayLight,
+                border: `1px solid ${btnPrimaryBg}`,
+              }}
+              onClick={() => handleClickSelectChat(true)}
+            >
+              {intl.formatMessage(intlMessages.titlePublic)}
+              {publicUnreadMessages && (
+                <span
+                  style={{
+                    position: 'absolute',
+                    bottom: '8px',
+                    right: '8px',
+                    width: '8px',
+                    height: '8px',
+                    backgroundColor: colorDanger,
+                    borderRadius: '50%',
+                  }}
+                />
+              )}
+            </Button>
+            <Button
+              variant={!showMessages ? 'contained' : 'outlined'}
+              color="primary"
+              size="medium"
+              sx={{
+                position: 'relative',
+                borderRadius: '16px',
+                width: '100%',
+                padding: '8px 16px',
+                textTransform: 'none',
+                backgroundColor: !showMessages ? btnPrimaryBg : colorOffWhite,
+                color: !showMessages ? colorWhite : colorGrayLight,
+                border: `1px solid ${btnPrimaryBg}`,
+              }}
+              onClick={() => handleClickSelectChat(false)}
+            >
+              {intl.formatMessage(intlMessages.titlePrivate)}
+              {privateUnreadMessages && (
+                <span
+                  style={{
+                    position: 'absolute',
+                    bottom: '8px',
+                    right: '8px',
+                    width: '8px',
+                    height: '8px',
+                    backgroundColor: colorDanger,
+                    borderRadius: '50%',
+                  }}
+                />
+              )}
+            </Button>
+          </Styled.ButtonsWrapper>
+        ) : null}
         {privateList ? (
-          <PrivateChatListContainer privateChatSelectedCallback={() => setPrivateList(false)} />
+          <PrivateChatListContainer
+            privateChatSelectedCallback={() => setPrivateList(false)}
+            chats={filteredPrivateChats}
+          />
         ) : (
           <>
             {!showMessages && !privateList && (
@@ -221,6 +228,8 @@ const ChatContainer: React.FC = () => {
       chatId: chat.chatId,
       participant: chat.participant,
       totalUnread: chat.totalUnread,
+      public: chat.public,
+      totalMessages: chat.totalMessages,
     };
   }) as GraphqlDataHookSubscriptionResponse<Partial<ChatType>[]>;
 
@@ -237,6 +246,9 @@ const ChatContainer: React.FC = () => {
     && chat?.totalUnread
     && chat.totalUnread > 0
   ));
+  const filteredPrivateChats = (chats || []).filter(
+    (chat) => !chat.public && chat.totalMessages !== 0,
+  );
 
   let participantName = '';
   const currentChat = chats?.find((chat) => chat.chatId === idChatOpen);
@@ -266,6 +278,7 @@ const ChatContainer: React.FC = () => {
       privateUnreadMessages={privateUnreadMessages}
       participantName={participantName}
       chatId={idChatOpen}
+      filteredPrivateChats={filteredPrivateChats}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/component.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Styled from './styles';
 import PrivateChatListItem from './chat-list-item/component';
-import useChat from '/imports/ui/core/hooks/useChat';
 import { Chat } from '/imports/ui/Types/chat';
 import Service from '/imports/ui/components/user-list/service';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
@@ -72,12 +71,10 @@ const PrivateChatList: React.FC<ChatListProps> = ({ chats, privateChatSelectedCa
 
 interface PrivateChatListContainerProps {
   privateChatSelectedCallback: () => void;
+  chats: Partial<ChatType>[];
 }
 
-const PrivateChatListContainer: React.FC<PrivateChatListContainerProps> = ({ privateChatSelectedCallback }) => {
-  const { data } = useChat((chat) => chat) as GraphqlDataHookSubscriptionResponse<Chat[]>;
-  const chats = (data || []).filter((chat) => !chat.public && chat.totalMessages !== 0);
-
+const PrivateChatListContainer: React.FC<PrivateChatListContainerProps> = ({ privateChatSelectedCallback, chats }) => {
   return (
     <PrivateChatList chats={chats} privateChatSelectedCallback={privateChatSelectedCallback} />
   );

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
@@ -1,10 +1,11 @@
 import styled, { css, keyframes } from 'styled-components';
 import {
-  colorWhite, colorText, colorPrimary, colorGrayLightest,
+  colorWhite, colorText, colorPrimary, colorGrayLightest, colorGrayLighter,
   colorGrayDark, colorLink, listItemBgHover,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPadding,
+  contentSidebarGap,
   contentSidebarPadding,
   contentSidebarBottomScrollPadding,
   contentSidebarBorderRadius,
@@ -40,7 +41,7 @@ const ProfileSettings = styled(ScrollboxVertical)`
   padding: ${contentSidebarPadding} 0 ${contentSidebarBottomScrollPadding} 0;
   margin: 0 ${smPadding} 0;
   flex-direction: column;
-  gap: ${contentSidebarPadding};
+  gap: ${contentSidebarGap};
   border-radius: ${contentSidebarBorderRadius};
   background: ${colorWhite};
   overflow-y: auto;
@@ -165,7 +166,7 @@ const UserPresenceContainer = styled.div`
   align-items: center;
   gap: 1rem;
   border-radius: 1rem;
-  border: 1px solid ${colorGrayLightest};
+  border: 1px solid ${colorGrayLighter};
 `;
 
 const UserPresenceButton = styled(SimpleButton)<{ active?: boolean }>`

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
@@ -104,7 +104,7 @@ export const SidebarContentPanel = styled.div<SidebarContentPanelProps>`
 
 export const HeaderContainer = styled(Header)`
   padding: ${contentSidebarPadding};
-  padding-bottom: 0.5rem;
+  padding-bottom: 0;
 `;
 
 export const Separator = styled.hr`

--- a/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/styles.ts
@@ -9,7 +9,7 @@ import { ActionButtonProps } from './types';
 
 const ActionButtonsWrapper = styled.div`
   display: flex;
-  padding: 1.5rem;
+  padding: 1rem;
   align-items: flex-end;
   gap: 1.5rem;
 `;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/styles.ts
@@ -32,7 +32,7 @@ interface UserItemContentsProps {
 
 const UserItemContents = styled.div<UserItemContentsProps>`
   position: static;
-  padding: .45rem;
+  padding-right: 0.5rem;
   width: 100%;
 
   ${({ selected }) => selected && `

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
@@ -85,7 +85,7 @@ const UserListColumn = styled.div`
   flex-flow: column;
   min-height: 0;
   flex-grow: 1;
-  padding: ${contentSidebarPadding} ${contentSidebarPadding} ${contentSidebarBottomScrollPadding};
+  padding: 0.5rem 0rem 0rem ${contentSidebarPadding};
 `;
 
 const pulse = (color: string) => keyframes`

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -23,7 +23,8 @@ const $3xlPadding = '1.25rem';
 const whiteboardToolbarPadding = '.5rem';
 const whiteboardToolbarMargin = '.5rem';
 const whiteboardToolbarPaddingSm = '.3rem';
-const contentSidebarPadding = '1.5rem';
+const contentSidebarGap = '0.5rem';
+const contentSidebarPadding = '1rem';
 const contentSidebarBottomScrollPadding = '2rem';
 const contentSidebarHeight = '86%';
 const contentSidebarBorderRadius = '1rem';
@@ -213,6 +214,7 @@ export {
   $3xlPadding,
   xlPadding,
   xsPadding,
+  contentSidebarGap,
   contentSidebarPadding,
   contentSidebarBottomScrollPadding,
   contentSidebarHeight,


### PR DESCRIPTION
### What does this PR do?
Chats buttons only appers when has a active private conversation. Correction of padding, gap and colors in the sidebar contents.

### More
Whitout private conversations
![406170719-022680ef-ff0b-43a2-a279-98613a1468f2](https://github.com/user-attachments/assets/08c45f33-25ad-4e52-99af-aa77de461490)
![406170992-7ce15dd5-4ef1-4c6c-8fc1-8ad1d5be8f96](https://github.com/user-attachments/assets/75c133e8-69d4-41a3-87b0-88f099faa9d8)
![406171175-07059357-ce65-4a2d-a0d6-fa05e9633cc0](https://github.com/user-attachments/assets/bd0c94c0-b7ba-40a4-b111-e0cbf1f8b9ba)




