### PR TITLE
fix(bbb-web): Rasterized pages always blank

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -290,6 +290,8 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                     if (namespaceHandler.isCommandTimeout()) {
                         log.error("Command execution (addNameSpaceToSVG) exceeded the {} secs timeout for {} page {}.", convPdfToSvgTimeout, pres.getName(), page);
                     }
+
+                    done = true;
                 }
             }
 
@@ -297,8 +299,6 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             if(tempPng.exists()) {
                 tempPng.delete();
             }
-
-            done = true;
         }
 
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -253,8 +253,8 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                         int height = 500;
 
                         ImageResolutionService imgResService = new ImageResolutionService();
-                        ImageResolution imageResolution = imgResService.identifyImageResolution(pres.getUploadedFile());
-                        log.debug("Identified image {} width={} and height={}", pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
+                        ImageResolution imageResolution = imgResService.identifyImageResolution(tempPng);
+                        log.debug("Identified page {} image {} width={} and height={}", page, pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
 
                         if (imageResolution.getWidth() != 0 && imageResolution.getHeight() != 0) {
                             width = imageResolution.getWidth();
@@ -297,6 +297,8 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             if(tempPng.exists()) {
                 tempPng.delete();
             }
+
+            done = true;
         }
 
 
@@ -308,14 +310,15 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             return true;
         }
 
-        copyBlankSvgs(imagePresentationDir, pres.getNumberOfPages());
+        copyBlankSvg(destsvg);
 
         Map<String, Object> logData = new HashMap<String, Object>();
         logData.put("meetingId", pres.getMeetingId());
         logData.put("presId", pres.getId());
         logData.put("filename", pres.getName());
+        logData.put("page", page);
         logData.put("logCode", "create_svg_images_failed");
-        logData.put("message", "Failed to create svg images.");
+        logData.put("message", "Failed to create svg image.");
 
         Gson gson = new Gson();
         String logStr = gson.toJson(logData);
@@ -370,6 +373,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
 	private void copyBlankSvg(File svg) {
 		try {
+            log.info("Copying blank SVG to {}", svg);
 			FileUtils.copyFile(new File(BLANK_SVG), svg);
 		} catch (IOException e) {
 			log.error("IOException while copying blank SVG.");


### PR DESCRIPTION
### What does this PR do?

Sets the `done` flag to `true` after rasterization to ensure that a blank SVG is not used for rasterized presentation pages. Also calculates the image resolution to use during rasterization based on the temporary PNG that is generated.

### Motivation

During presentation upload whenever a page needed to be rasterized the `done` flag was not being set to `true` after rasterization. Because of this it was assumed that an error occurred during SVG generation and therefore the default blank SVG would be used for that page.


### How to test

Upload a document with pages that require rasterization. Before these changes any of these pages would be blank. After the pages should be displayed correctly.
