### PR TITLE
fix(html5): Presentation uploader causing error on presenter change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -369,19 +369,19 @@ class PresentationUploader extends Component {
 
       const modPresentation = presentation;
       if (currentPropPres?.current !== prevPropPres?.current) {
-        modPresentation.current = currentPropPres.current;
+        modPresentation.current = currentPropPres?.current;
         shouldUpdateState = true;
       }
 
       if (currentPropPres?.totalPagesUploaded !== prevPropPres?.totalPagesUploaded
         || presentation.totalPagesUploaded !== currentPropPres?.totalPagesUploaded) {
-        modPresentation.totalPagesUploaded = currentPropPres.totalPagesUploaded;
+        modPresentation.totalPagesUploaded = currentPropPres?.totalPagesUploaded;
         shouldUpdateState = true;
       }
 
       if (currentPropPres?.uploadCompleted !== prevPropPres?.uploadCompleted
         || presentation.uploadCompleted !== currentPropPres?.uploadCompleted) {
-        modPresentation.uploadCompleted = currentPropPres.uploadCompleted;
+        modPresentation.uploadCompleted = currentPropPres?.uploadCompleted;
         shouldUpdateState = true;
       }
 
@@ -389,29 +389,29 @@ class PresentationUploader extends Component {
         currentPropPres?.uploadErrorMsgKey !== prevPropPres?.uploadErrorMsgKey
         && currentPropPres?.uploadErrorDetailsJson !== prevPropPres?.uploadErrorDetailsJson
       ) {
-        modPresentation.uploadErrorMsgKey = currentPropPres.uploadErrorMsgKey;
-        modPresentation.uploadErrorDetailsJson = currentPropPres.uploadErrorDetailsJson;
+        modPresentation.uploadErrorMsgKey = currentPropPres?.uploadErrorMsgKey;
+        modPresentation.uploadErrorDetailsJson = currentPropPres?.uploadErrorDetailsJson;
         shouldUpdateState = true;
       }
 
       if (currentPropPres?.totalPages !== prevPropPres?.totalPages
         || presentation.totalPages !== currentPropPres?.totalPages) {
-        modPresentation.totalPages = currentPropPres.totalPages;
+        modPresentation.totalPages = currentPropPres?.totalPages;
         shouldUpdateState = true;
       }
 
       if (currentPropPres?.downloadable !== prevPropPres?.downloadable) {
-        modPresentation.downloadable = currentPropPres.downloadable;
+        modPresentation.downloadable = currentPropPres?.downloadable;
         shouldUpdateState = true;
       }
 
       if (currentPropPres?.downloadFileUri !== prevPropPres?.downloadFileUri) {
-        modPresentation.downloadFileUri = currentPropPres.downloadFileUri;
+        modPresentation.downloadFileUri = currentPropPres?.downloadFileUri;
         shouldUpdateState = true;
       }
 
       if (currentPropPres?.filenameConverted !== prevPropPres?.filenameConverted) {
-        modPresentation.filenameConverted = currentPropPres.filenameConverted;
+        modPresentation.filenameConverted = currentPropPres?.filenameConverted;
         shouldUpdateState = true;
       }
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the whiteboard would reload incorrectly due to an error in the presentation uploader when switching presenters

before:
![presenter-change-crashing-wb](https://github.com/user-attachments/assets/63d716d7-f3b0-442f-9964-50708abb0f14)

after:
![presenter-change-crashing-wb-fix](https://github.com/user-attachments/assets/2f063143-45cd-45b1-b1b2-0f2a768c910c)


### Motivation
related to #22119
