### PR TITLE
fix: Avoid reloading whiteboard due to permission error

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -82,6 +82,11 @@ const ErrorBoundaryWithReload = ({ children }) => {
         return;
       }
 
+      // Ignore errors caused by missing permissions on graphql
+      if (event.reason?.message?.toString().indexOf('Permission Denied') !== -1) {
+        return;
+      }
+
       triggerError();
     };
 


### PR DESCRIPTION
### What does this PR do?
similar to #22067, the whiteboard should not crash if a user tries to call an action and does not have permission for it.

### Motivation
if presenter is changed as soon as the client loads, the client will try to set the presentation zoom and fail due to the user not having presenter status anymore - this should not have side effects, and fail silently.


### How to test
1. join a meeting with 2 users
2. change presenter as soon as the whiteboard loads
3. whiteboard should not crash and reload