### PR TITLE
feat(livekit): add connection status tracking and data

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -21,7 +21,7 @@ import {
   filterSupportedConstraints,
   doGUM,
 } from '/imports/api/audio/client/bridge/service';
-import { liveKitRoom } from '/imports/ui/services/livekit';
+import { liveKitRoom, getLKStats } from '/imports/ui/services/livekit';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 
 const BRIDGE_NAME = 'livekit';
@@ -534,6 +534,16 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
       this.liveKitRoom.once(RoomEvent.Connected, onRoomConnected);
     });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getPeerConnection(): RTCPeerConnection | null {
+    return null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getStats(): Promise<Map<string, unknown>> {
+    return getLKStats();
   }
 
   async joinAudio(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -20,6 +20,7 @@ import {
 } from 'livekit-client';
 import {
   liveKitRoom,
+  getLKStats,
 } from '/imports/ui/services/livekit';
 
 const BRIDGE_NAME = 'livekit';
@@ -337,9 +338,13 @@ export default class LiveKitScreenshareBridge {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  getPeerConnection(): void {
-    // eslint-disable-next-line no-console
-    console.error('The Bridge must implement getPeerConnection');
+  getPeerConnection() {
+    return null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getStats(): Promise<Map<string, unknown>> {
+    return getLKStats();
   }
 
   setVolume(volume: number): number {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/container.jsx
@@ -7,9 +7,14 @@ import { getWorstStatus } from '../service';
 const ConnectionStatusButtonContainer = (props) => {
   const connected = useReactiveVar(connectionStatus.getConnectedStatusVar());
   const rttStatus = useReactiveVar(connectionStatus.getRttStatusVar());
+  const liveKitStatus = useReactiveVar(connectionStatus.getLiveKitConnectionStatusVar());
   const packetLossStatus = useReactiveVar(connectionStatus.getPacketLossStatusVar());
 
-  const myCurrentStatus = getWorstStatus([rttStatus, packetLossStatus]);
+  const myCurrentStatus = getWorstStatus([
+    rttStatus,
+    packetLossStatus,
+    liveKitStatus,
+  ]);
 
   return (
     <ConnectionStatusButtonComponent

--- a/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
@@ -117,7 +117,13 @@ class ConnectionStatusIcon extends PureComponent {
 const WrapConnectionStatus = (props) => {
   const rttStatus = useReactiveVar(connectionStatus.getRttStatusVar());
   const packetLossStatus = useReactiveVar(connectionStatus.getPacketLossStatusVar());
-  const status = getWorstStatus([rttStatus, packetLossStatus]);
+  const liveKitConnQuality = useReactiveVar(connectionStatus.getLiveKitConnectionStatusVar());
+  const status = getWorstStatus([
+    rttStatus,
+    packetLossStatus,
+    liveKitConnQuality,
+  ]);
+
   return (
     <ConnectionStatusIcon
       {...props}

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -373,14 +373,22 @@ export const screenShareEndAlert = () => AudioService
    */
 export const getStats = async (statsTypes = DEFAULT_SCREENSHARE_STATS_TYPES) => {
   const screenshareStats = {};
-  const peer = screenShareBridge.getPeerConnection();
+  let stats = null;
 
-  if (!peer) return null;
+  if (typeof screenShareBridge.getStats === 'function') {
+    stats = await screenShareBridge.getStats();
+  } else {
+    const peer = screenShareBridge.getPeerConnection();
 
-  const peerStats = await peer.getStats();
+    if (!peer) return null;
 
-  peerStats.forEach((stat) => {
-    if (statsTypes.includes(stat.type)) {
+    stats = await peer.getStats();
+  }
+
+  if (!stats) return null;
+
+  stats.forEach((stat) => {
+    if (statsTypes.includes(stat.type) && (!stat.kind || stat.kind === 'video')) {
       screenshareStats[stat.type] = stat;
     }
   });

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -18,6 +18,15 @@ type NetworkData = {
     videoCurrentDownloadRate: number,
   }
 };
+
+export enum MetricStatus {
+  Unknown = 'unknown',
+  Normal = 'normal',
+  Warning = 'warning',
+  Danger = 'danger',
+  Critical = 'critical',
+}
+
 class ConnectionStatus {
   private connected = makeVar(false);
 
@@ -56,6 +65,25 @@ class ConnectionStatus {
     lastUnstableStatusAt: Date | number,
     clientNotResponding?: boolean,
   }>>([]);
+
+  private liveKitConnectionStatus = makeVar(MetricStatus.Unknown);
+
+  public setLiveKitConnectionStatus(status: MetricStatus): void {
+    if (this.liveKitConnectionStatus() !== status) {
+      logger.info({
+        logCode: 'stats_livekit_conn_state',
+      }, `LiveKit connection status changed to ${status}`);
+      this.liveKitConnectionStatus(status);
+    }
+  }
+
+  public getLiveKitConnectionStatus() {
+    return this.liveKitConnectionStatus();
+  }
+
+  public getLiveKitConnectionStatusVar() {
+    return this.liveKitConnectionStatus;
+  }
 
   private packetLossFraction = makeVar(0);
 

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1372,16 +1372,25 @@ class AudioManager {
   async getStats() {
     if (!this.bridge) return null;
 
-    const peer = this.bridge.getPeerConnection();
+    let stats = null;
 
-    if (!peer) return null;
+    if (typeof this.bridge.getStats === 'function') {
+      stats = await this.bridge.getStats();
+    } else {
+      const peer = this.bridge.getPeerConnection();
 
-    const peerStats = await peer.getStats();
+      if (!peer) return null;
+
+      stats = await peer.getStats();
+    }
+
+    if (!stats) return null;
 
     const audioStats = {};
 
-    peerStats.forEach((stat) => {
-      if (FILTER_AUDIO_STATS.includes(stat.type)) {
+    stats.forEach((stat) => {
+      if (FILTER_AUDIO_STATS.includes(stat.type)
+        && (!stat.kind || stat.kind === 'audio')) {
         audioStats[stat.id] = stat;
       }
     });

--- a/bigbluebutton-html5/imports/ui/services/livekit/index.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/index.ts
@@ -4,6 +4,29 @@ import {
 
 export const liveKitRoom: Room = new Room();
 
+export const getLKStats = async (): Promise<Map<string, unknown>> => {
+  const { localParticipant } = liveKitRoom;
+
+  const statsMap: Map<string, unknown> = new Map();
+
+  if (localParticipant?.engine?.pcManager?.publisher) {
+    const senderStats = await localParticipant.engine.pcManager.publisher.getStats();
+    senderStats.forEach((stat) => {
+      statsMap.set(stat.id, stat);
+    });
+  }
+
+  if (localParticipant?.engine?.pcManager?.subscriber) {
+    const receiverStats = await localParticipant.engine.pcManager.subscriber.getStats();
+    receiverStats.forEach((stat) => {
+      statsMap.set(stat.id, stat);
+    });
+  }
+
+  return statsMap;
+};
+
 export default {
   liveKitRoom,
+  getLKStats,
 };

--- a/bigbluebutton-html5/imports/utils/stats.js
+++ b/bigbluebutton-html5/imports/utils/stats.js
@@ -1,145 +1,10 @@
 import logger from '/imports/startup/client/logger';
+import AudioManager from '/imports/ui/services/audio-manager';
+
+let probingTimeout;
 
 // Probes done in an interval
 const PROBES = 5;
-
-const stop = callback => {
-  logger.debug(
-    { logCode: 'stats_stop_monitor' },
-    'Lost peer connection. Stopping monitor'
-  );
-  callback(clearResult());
-  return;
-};
-
-const isActive = conn => {
-  let active = false;
-
-  if (conn) {
-    const { connectionState } = conn;
-    const logCode = 'stats_connection_state';
-
-    switch (connectionState) {
-      case 'new':
-      case 'connecting':
-      case 'connected':
-      case 'disconnected':
-        active = true;
-        break;
-      case 'failed':
-      case 'closed':
-      default:
-        logger.warn({ logCode }, connectionState);
-    }
-  } else {
-    logger.error(
-      { logCode: 'stats_missing_connection' },
-      'Missing connection'
-    );
-  }
-
-  return active;
-};
-
-const collect = (conn, callback) => {
-  const INTERVAL = window.meetingClientSettings.public.stats.interval / PROBES;
-  let stats = [];
-
-  const monitor = (conn, stats) => {
-    if (!isActive(conn)) return stop(callback);
-
-    conn.getStats().then(results => {
-      if (!results) return stop(callback);
-
-      let inboundRTP;
-      let remoteInboundRTP;
-
-      results.forEach(res => {
-        switch (res.type) {
-          case 'inbound-rtp':
-            inboundRTP = res;
-            break;
-          case 'remote-inbound-rtp':
-            remoteInboundRTP = res;
-            break;
-          default:
-        }
-      });
-
-      if (inboundRTP || remoteInboundRTP) {
-        if (!inboundRTP) {
-          logger.debug(
-            { logCode: 'stats_missing_inbound_rtc' },
-            'Missing local inbound RTC. Using remote instead'
-          );
-        }
-
-        stats.push(buildData(inboundRTP || remoteInboundRTP));
-        while (stats.length > PROBES) stats.shift();
-
-        const interval = calculateInterval(stats);
-        callback(buildResult(interval));
-      }
-
-      setTimeout(monitor, INTERVAL, conn, stats);
-    }).catch(error => {
-      logger.debug(
-        {
-          logCode: 'stats_get_stats_error',
-          extraInfo: { error }
-        },
-        'WebRTC stats not available'
-      );
-    });
-  };
-  monitor(conn, stats);
-};
-
-const buildData = inboundRTP => {
-  return {
-    packets: {
-      received: inboundRTP.packetsReceived,
-      lost: inboundRTP.packetsLost
-    },
-    bytes: {
-      received: inboundRTP.bytesReceived
-    },
-    jitter: inboundRTP.jitter
-  };
-};
-
-const buildResult = (interval) => {
-  const rate = calculateRate(interval.packets);
-  return {
-    packets: {
-      received: interval.packets.received,
-      lost: interval.packets.lost
-    },
-    bytes: {
-      received: interval.bytes.received
-    },
-    jitter: interval.jitter,
-    rate: rate,
-    loss: calculateLoss(rate),
-    MOS: calculateMOS(rate)
-  };
-};
-
-const clearResult = () => {
-  return {
-    packets: {
-      received: 0,
-      lost: 0
-    },
-    bytes: {
-      received: 0
-    },
-    jitter: 0,
-    rate: 0,
-    loss: 0,
-    MOS: 0
-  };
-};
 
 const diff = (single, first, last) => Math.abs((single ? 0 : last) - first);
 
@@ -150,12 +15,12 @@ const calculateInterval = (stats) => {
   return {
     packets: {
       received: diff(single, first.packets.received, last.packets.received),
-      lost: diff(single, first.packets.lost, last.packets.lost)
+      lost: diff(single, first.packets.lost, last.packets.lost),
     },
     bytes: {
-      received: diff(single, first.bytes.received, last.bytes.received)
+      received: diff(single, first.bytes.received, last.bytes.received),
     },
-    jitter: Math.max.apply(Math, stats.map(s => s.jitter))
+    jitter: Math.max(...stats.map((s) => s.jitter)),
   };
 };
 
@@ -166,28 +31,139 @@ const calculateRate = (packets) => {
   return rate;
 };
 
-const calculateLoss = (rate) => {
-  return 1 - (rate / 100);
+const calculateLoss = (rate) => 1 - (rate / 100);
+
+const calculateMOS = (rate) => 1 + (0.035) * rate + (0.000007) * rate * (rate - 60) * (100 - rate);
+const buildData = (inboundRTP) => {
+  const builtData = {
+    packets: {
+      received: inboundRTP.packetsReceived,
+      lost: inboundRTP.packetsLost,
+    },
+    bytes: {
+      received: inboundRTP.bytesReceived,
+    },
+    jitter: inboundRTP.jitter,
+  };
+
+  return builtData;
 };
 
-const calculateMOS = (rate) => {
-  return 1 + (0.035) * rate + (0.000007) * rate * (rate - 60) * (100 - rate);
+const buildResult = (interval) => {
+  const rate = calculateRate(interval.packets);
+  return {
+    packets: {
+      received: interval.packets.received,
+      lost: interval.packets.lost,
+    },
+    bytes: {
+      received: interval.bytes.received,
+    },
+    jitter: interval.jitter,
+    rate,
+    loss: calculateLoss(rate),
+    MOS: calculateMOS(rate),
+  };
 };
 
-const monitorAudioConnection = conn => {
-  if (!conn) return;
+const clearResult = () => {
+  const cleanStats = {
+    packets: {
+      received: 0,
+      lost: 0,
+    },
+    bytes: {
+      received: 0,
+    },
+    jitter: 0,
+    rate: 0,
+    loss: 0,
+    MOS: 0,
+  };
 
+  return cleanStats;
+};
+
+const stop = (callback) => {
+  logger.debug(
+    { logCode: 'stats_stop_monitor' },
+    'Lost peer connection. Stopping monitor',
+  );
+  if (probingTimeout) {
+    clearTimeout(probingTimeout);
+    probingTimeout = null;
+  }
+
+  callback(clearResult());
+};
+
+const collect = (callback) => {
+  const INTERVAL = window.meetingClientSettings.public.stats.interval / PROBES;
+
+  const monitor = (statsRed) => {
+    AudioManager.getStats().then((results) => {
+      if (results) {
+        let inboundRTP;
+        let remoteInboundRTP;
+
+        Object.values(results).forEach((res) => {
+          switch (res.type) {
+            case 'inbound-rtp':
+              inboundRTP = res;
+              break;
+            case 'remote-inbound-rtp':
+              remoteInboundRTP = res;
+              break;
+            default:
+          }
+        });
+
+        if (inboundRTP || remoteInboundRTP) {
+          if (!inboundRTP) {
+            logger.debug(
+              { logCode: 'stats_missing_inbound_rtc' },
+              'Missing local inbound RTC. Using remote instead',
+            );
+          }
+
+          statsRed.push(buildData(inboundRTP || remoteInboundRTP));
+          while (statsRed.length > PROBES) statsRed.shift();
+
+          const interval = calculateInterval(statsRed);
+          callback(buildResult(interval));
+        }
+      }
+    }).catch((error) => {
+      logger.debug({
+        logCode: 'stats_get_stats_error',
+        extraInfo: {
+          errorMessage: error.message,
+          errorName: error.name,
+        },
+      }, 'WebRTC stats not available');
+    }).finally(() => {
+      probingTimeout = setTimeout(monitor, INTERVAL, statsRed);
+    });
+  };
+
+  monitor([]);
+};
+
+export const monitorAudioConnection = () => {
   logger.debug(
     { logCode: 'stats_audio_monitor' },
-    'Starting to monitor audio connection'
+    'Starting to monitor audio connection',
   );
-
-  collect(conn, (result) => {
+  const callback = (result) => {
     const event = new CustomEvent('audiostats', { detail: result });
     window.dispatchEvent(event);
-  });
+  };
+
+  if (probingTimeout) stop(callback);
+
+  collect(callback);
 };
 
-export {
+export default {
   monitorAudioConnection,
 };


### PR DESCRIPTION
### What does this PR do?

- [feat(livekit): add connection status tracking and data](https://github.com/bigbluebutton/bigbluebutton/commit/c38539e09141134fa2065026d08da2fbc2bf71d3) 
  - Implement audio stats tracking (i.e.: loss %) for LiveKit audio as well as
populate the connection status modal with the necessary network data for
all LiveKit components. Additionally:
    - Add a LiveKit connection quality metric to the set of connection
    status metrics
    - Refurbish stats.js so that it pulls stats directly from AudioManager
    rather than dealing with peer connections directly

### Closes Issue(s)

None
Ref #21059 