### PR TITLE
fix(notification): add guest user name to notification

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -10,6 +10,7 @@ import {
   userJoinPushAlert,
   userLeavePushAlert,
 } from './service';
+import Styled from './styles';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 
@@ -67,16 +68,35 @@ const Notifications: React.FC = () => {
   });
 
   const notifier = (notification: Notification) => {
-    notify(
-      <FormattedMessage
-        id={notification.messageId}
-        // @ts-ignore - JS code
-        values={notification.messageValues}
-        description={notification.messageDescription}
-      />,
-      notification.notificationType,
-      notification.icon,
-    );
+    // special guest alert notification, with user name as title
+    if (notification.messageId === 'app.userList.guest.pendingGuestAlert') {
+      notify(
+        <Styled.TitleMessage>{notification.messageValues[0]}</Styled.TitleMessage>,
+        notification.notificationType,
+        notification.icon,
+        null,
+        <Styled.ContentMessage>
+          <FormattedMessage
+            id={notification.messageId}
+            // @ts-ignore - JS code
+            values={notification.messageValues}
+            description={notification.messageDescription}
+          />
+        </Styled.ContentMessage>,
+        true,
+      );
+    } else {
+      notify(
+        <FormattedMessage
+          id={notification.messageId}
+          // @ts-ignore - JS code
+          values={notification.messageValues}
+          description={notification.messageDescription}
+        />,
+        notification.notificationType,
+        notification.icon,
+      );
+    }
   };
 
   useEffect(() => {

--- a/bigbluebutton-html5/imports/ui/components/notifications/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
+
+const TitleMessage = styled.div`
+  font-weight: bold;
+  font-size: ${fontSizeBase};
+`;
+
+const ContentMessage = styled.div`
+  margin-top: 0.5rem;
+`;
+
+export default {
+  TitleMessage,
+  ContentMessage,
+};


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Adds the name of the waiting user to the notification title (like it was on 2.7).

Before:
![guest_notif_before](https://github.com/user-attachments/assets/9c1df91c-25af-4fcc-aee9-cbfc71f5ceb6)


After:
![guest_notif_after](https://github.com/user-attachments/assets/307e9500-0b22-4c33-acd7-2bfc92b5394d)


### How to test
Set "Ask moderator" as guest policy, join with a guest and see notification for moderator.

