### PR TITLE
Change userlist label when user is locked

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -158,6 +158,7 @@
     "app.user.activityCheck.label": "Check if user is still in session ({0})",
     "app.user.activityCheck.check": "Check",
     "app.userList.usersTitle": "Users ({0})",
+    "app.userList.lockedUsersTitle": "Moderators ({0})",
     "app.userList.participantsTitle": "Participants",
     "app.userList.messagesTitle": "Messages",
     "app.userList.notesTitle": "Notes",


### PR DESCRIPTION
### What does this PR do?

Adds a new localization string "Moderators" to be displayed in the userlist instead of "Users" when a user lock for "See other viewers in the users list" is active

#### unlocked
![unlocked](https://github.com/user-attachments/assets/0a867ce6-0def-4810-afc3-a463f610f501)

#### locked
![locked](https://github.com/user-attachments/assets/a1e36e25-e993-4227-b9c8-706c3dc6dcf5)

### Motivation
When the lock is active, a locked viewer will only see the moderators in the users list

### How to test
1. join a meeting with a moderator and a viewer
2. change lock settings for "See other viewers in the users list"
3. see the userlist label change for the locked user