### PR TITLE
fix(API): Remove commas from numeric fields in API responses

### DIFF
--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
@@ -28,12 +28,12 @@
         <hasBeenForciblyEnded>${meeting.isForciblyEnded()?c}</hasBeenForciblyEnded>
         <startTime>${meeting.getStartTime()?c}</startTime>
         <endTime>${meeting.getEndTime()?c}</endTime>
-        <participantCount>${meeting.getNumUsersOnline()}</participantCount>
-        <listenerCount>${meeting.getNumListenOnly()}</listenerCount>
-        <voiceParticipantCount>${meeting.getNumVoiceJoined()}</voiceParticipantCount>
-        <videoCount>${meeting.getNumVideos()}</videoCount>
+        <participantCount>${meeting.getNumUsersOnline()?c}</participantCount>
+        <listenerCount>${meeting.getNumListenOnly()?c}</listenerCount>
+        <voiceParticipantCount>${meeting.getNumVoiceJoined()?c}</voiceParticipantCount>
+        <videoCount>${meeting.getNumVideos()?c}</videoCount>
         <maxUsers>${meeting.getMaxUsers()?c}</maxUsers>
-        <moderatorCount>${meeting.getNumModerators()}</moderatorCount>
+        <moderatorCount>${meeting.getNumModerators()?c}</moderatorCount>
         <attendees>
         <#list meetingDetail.meeting.getUsers() as att>
           <attendee>

--- a/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
+++ b/bigbluebutton-web/src/main/webapp/WEB-INF/freemarker/get-meetings.ftlx
@@ -68,7 +68,7 @@
 
         <#if meetingDetail.meeting.isBreakout()>
            <parentMeetingID>${meetingDetail.meeting.getParentMeetingId()}</parentMeetingID>
-           <sequence>${meetingDetail.meeting.getSequence()}</sequence>
+           <sequence>${meetingDetail.meeting.getSequence()?c}</sequence>
            <freeJoin>${meetingDetail.meeting.isFreeJoin()?c}</freeJoin>
         </#if>
 


### PR DESCRIPTION
### What does this PR do?

Uses computer format for numeric fields in the Freemarker `getMeetings` response so that numbers greater than 1,000 do not contain commas.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22102


### How to test

Either join a meeting with at least 1,000 users or override the number of users returned [here](https://github.com/bigbluebutton/bigbluebutton/blob/c14393519b987e13ba8fbadcde9fb792b0b20a67/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java#L794) and then call `getMeetings` and look at the numeric fields, specifically `participantCount`. 
