### PR TITLE
Backport of: feat(extensible-areas): add Actions bar generic component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -15,6 +15,7 @@ import ReactionsButtonContainer from '/imports/ui/components/actions-bar/reactio
 import RaiseHandButtonContainer from '/imports/ui/components/actions-bar/raise-hand-button/container';
 import Selector from '/imports/ui/components/common/selector/component';
 import ToggleGroup from '/imports/ui/components/common/toggle-group/component';
+import Separator from '/imports/ui/components/common/separator/component';
 
 const intlMessages = defineMessages({
   actionsBarLabel: {
@@ -55,8 +56,10 @@ class ActionsBar extends PureComponent {
                 break;
               case ActionsBarItemType.SEPARATOR:
                 actionBarItemToReturn = (
-                  <Styled.Separator
+                  <Separator
                     key={`${plugin.type}-${plugin.id}`}
+                    actionsBar
+                    icon={plugin.icon}
                   />
                 );
                 break;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -13,6 +13,8 @@ import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import { LAYOUT_TYPE } from '../layout/enums';
 import ReactionsButtonContainer from '/imports/ui/components/actions-bar/reactions-button/container';
 import RaiseHandButtonContainer from '/imports/ui/components/actions-bar/raise-hand-button/container';
+import Selector from '/imports/ui/components/common/selector/component';
+import ToggleGroup from '/imports/ui/components/common/toggle-group/component';
 
 const intlMessages = defineMessages({
   actionsBarLabel: {
@@ -55,6 +57,28 @@ class ActionsBar extends PureComponent {
                 actionBarItemToReturn = (
                   <Styled.Separator
                     key={`${plugin.type}-${plugin.id}`}
+                  />
+                );
+                break;
+              case ActionsBarItemType.SELECTOR:
+                actionBarItemToReturn = (
+                  <Selector
+                    title={plugin.title}
+                    options={plugin.options}
+                    defaultOption={plugin.defaultOption}
+                    onChange={plugin.onChange}
+                    width={plugin.width}
+                  />
+                );
+                break;
+              case ActionsBarItemType.TOGGLE_GROUP:
+                actionBarItemToReturn = (
+                  <ToggleGroup
+                    title={plugin.title}
+                    options={plugin.options}
+                    defaultOption={plugin.defaultOption}
+                    onChange={plugin.onChange}
+                    exclusive={plugin.exclusive}
                   />
                 );
                 break;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/styles.js
@@ -105,14 +105,6 @@ const Wrapper = styled.div`
   }
 `;
 
-const Separator = styled.div`
-  height: 2.5rem;
-  width: 0;
-  border: 1px solid ${colorWhite};
-  align-self: center;
-  opacity: .75;
-`;
-
 export default {
   ActionsBar,
   Left,
@@ -122,6 +114,5 @@ export default {
   ButtonContainer,
   ReactionsDropdown,
   Wrapper,
-  Separator,
   ActionsBarWrapper,
 };

--- a/bigbluebutton-html5/imports/ui/components/common/selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/selector/component.tsx
@@ -39,14 +39,12 @@ export default function Selector({
   return (
     <Styled.Container>
       <Styled.FormControl sx={{ width }} size="small">
-        {title && <Styled.InputLabel id="selector-input-label">{title}</Styled.InputLabel>}
+        {title && <Styled.Title>{title}</Styled.Title>}
         <Styled.Select
           value={selected}
           onChange={handleChange}
-          autoWidth
           displayEmpty
-          label={title}
-          labelId="selector-input-label"
+          hasTitle={!!title}
         >
           {children}
         </Styled.Select>

--- a/bigbluebutton-html5/imports/ui/components/common/selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/selector/component.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import MenuItem from '@mui/material/MenuItem';
+import { SelectChangeEvent } from '@mui/material/Select';
+import { SelectorProps } from './types';
+import Styled from './styles';
+
+export default function Selector({
+  title = '',
+  options = [],
+  defaultOption = options[0],
+  onChange,
+  width = 140,
+}: SelectorProps): React.ReactNode {
+  const [selected, setSelected] = React.useState<string | number>(defaultOption.value);
+
+  const handleChange = (event: SelectChangeEvent<unknown>) => {
+    const value = event.target.value as string | number;
+    setSelected(value);
+    if (!onChange) return;
+    onChange(value, event);
+  };
+
+  const children = options.map((option) => {
+    const {
+      label,
+      value,
+    } = option;
+
+    return (
+      <MenuItem
+        key={value}
+        value={value}
+      >
+        {label}
+      </MenuItem>
+    );
+  });
+
+  return (
+    <Styled.Container>
+      <Styled.FormControl sx={{ width }} size="small">
+        {title && <Styled.InputLabel id="selector-input-label">{title}</Styled.InputLabel>}
+        <Styled.Select
+          value={selected}
+          onChange={handleChange}
+          autoWidth
+          displayEmpty
+          label={title}
+          labelId="selector-input-label"
+        >
+          {children}
+        </Styled.Select>
+      </Styled.FormControl>
+    </Styled.Container>
+  );
+}

--- a/bigbluebutton-html5/imports/ui/components/common/selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/selector/styles.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import SelectMui from '@mui/material/Select';
+import FormControlMui from '@mui/material/FormControl';
+import InputLabelMui from '@mui/material/InputLabel';
+import { colorWhite, colorGrayDark } from '/imports/ui/stylesheets/styled-components/palette';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SelectGroupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const FormControl = styled(FormControlMui)`
+  color: ${colorGrayDark} !important;
+`;
+
+const InputLabel = styled(InputLabelMui)`
+  background-color: ${colorWhite};
+  color: ${colorGrayDark} !important;
+  border-radius: 0.5rem;
+  padding: 0 0.2rem !important;
+`;
+
+const Select = styled(SelectMui)`
+  background-color: ${colorWhite};
+  flex: 1;
+  border-radius: 0.5rem !important;
+  overflow: hidden;
+`;
+
+export default {
+  Container,
+  SelectGroupContainer,
+  FormControl,
+  InputLabel,
+  Select,
+};

--- a/bigbluebutton-html5/imports/ui/components/common/selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/selector/styles.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
-import SelectMui from '@mui/material/Select';
+import { Select as SelectMui, SelectProps } from '@mui/material';
 import FormControlMui from '@mui/material/FormControl';
-import InputLabelMui from '@mui/material/InputLabel';
 import { colorWhite, colorGrayDark } from '/imports/ui/stylesheets/styled-components/palette';
+
+interface StyledSelectProps {
+  hasTitle?: boolean;
+}
 
 const Container = styled.div`
   display: flex;
@@ -16,27 +19,32 @@ const SelectGroupContainer = styled.div`
 `;
 
 const FormControl = styled(FormControlMui)`
+  height: 100%;
   color: ${colorGrayDark} !important;
 `;
 
-const InputLabel = styled(InputLabelMui)`
-  background-color: ${colorWhite};
-  color: ${colorGrayDark} !important;
-  border-radius: 0.5rem;
-  padding: 0 0.2rem !important;
-`;
-
-const Select = styled(SelectMui)`
+const Select = styled(SelectMui)<StyledSelectProps & SelectProps>`
   background-color: ${colorWhite};
   flex: 1;
   border-radius: 0.5rem !important;
   overflow: hidden;
+
+  ${({ hasTitle }) => hasTitle && `
+    & .MuiSelect-select {
+      padding: 0.25rem 0.5rem;
+    }
+  `}
+`;
+
+const Title = styled.label`
+  color: ${colorWhite};
+  font-size: 0.8rem;
 `;
 
 export default {
   Container,
   SelectGroupContainer,
   FormControl,
-  InputLabel,
   Select,
+  Title,
 };

--- a/bigbluebutton-html5/imports/ui/components/common/selector/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/selector/types.ts
@@ -1,0 +1,15 @@
+import { SelectChangeEvent } from '@mui/material';
+
+export interface Option {
+  label: string;
+  value: string | number;
+}
+
+export interface SelectorProps {
+  title?: string;
+  icon?: string;
+  options: Option[];
+  defaultOption?: Option;
+  onChange: (value: string | number, event: SelectChangeEvent<unknown>) => void;
+  width?: number;
+}

--- a/bigbluebutton-html5/imports/ui/components/common/separator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/separator/component.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { SeparatorProps } from './types';
 import Styled from './styles';
 
-const Separator = () => (
-  <Styled.Separator />
-);
+const Separator = ({ icon = '', actionsBar = false }: SeparatorProps) => {
+  if (!icon) return (<Styled.Separator actionsBar={actionsBar} />);
+  return (<Styled.IconContainer><Styled.Icon iconName={icon} /></Styled.IconContainer>);
+};
 
 export default Separator;

--- a/bigbluebutton-html5/imports/ui/components/common/separator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/separator/styles.ts
@@ -1,9 +1,42 @@
 import styled from 'styled-components';
+import OriginalIcon from '/imports/ui/components/common/icon/icon-ts/component';
+import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 
-const Separator = styled.div`
+const Separator = styled.div<{ actionsBar?: boolean }>`
   width: 10px; 
-  height: 100%;`;
+  height: 100%;
+  ${({ actionsBar }) => actionsBar && `
+    height: 2.5rem;
+    width: 0;
+    border: 1px solid ${colorWhite};
+    align-self: center;
+    opacity: .75;
+  `}
+`;
+
+const IconContainer = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+  width: 3rem;
+`;
+
+const Icon = styled(OriginalIcon)`
+  width: 1em;
+  height: 1em;
+  text-align: center;
+  font-size: 125%;
+  color: ${colorWhite};
+
+  &:before {
+    width: 1em;
+    height: 1em;
+  }
+`;
 
 export default {
   Separator,
+  IconContainer,
+  Icon,
 };

--- a/bigbluebutton-html5/imports/ui/components/common/separator/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/separator/types.ts
@@ -1,0 +1,4 @@
+export interface SeparatorProps {
+  actionsBar?: boolean;
+  icon?: string;
+}

--- a/bigbluebutton-html5/imports/ui/components/common/toggle-group/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toggle-group/component.tsx
@@ -1,0 +1,70 @@
+import React, { useState, MouseEvent } from 'react';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import { ToggleGroupProps, Option } from './types';
+import Styled from './styles';
+
+export default function ToggleGroup({
+  title = '',
+  options = [],
+  defaultOption = options[0],
+  onChange,
+  exclusive = true,
+}: ToggleGroupProps) {
+  const [selectedValues, setSelectedValues] = useState([defaultOption.value]);
+
+  const isSelected = (option: Option) => (
+    selectedValues.some((selectedItem) => option.value === selectedItem)
+  );
+
+  const handleChange = (
+    event: MouseEvent<HTMLElement>,
+    value: string | number | string[] | number[],
+  ) => {
+    // toggle button group returns an array of values when it is not exclusive
+    // Here the value is always transformed into an array.
+    const transformedValue = Array.isArray(value) ? value : [value];
+    const isEqual = (Array.isArray(value)
+      && selectedValues.length === value.length
+      && selectedValues.every((selectedValue, index) => selectedValue === selectedValues[index]))
+      || (selectedValues.length === 1 && value === selectedValues[0]);
+    if (isEqual) return;
+    setSelectedValues(transformedValue);
+    if (!onChange) return;
+    onChange(value, event);
+  };
+
+  const children = options.map((option: Option) => {
+    const {
+      label,
+      value,
+    } = option;
+    return (
+      <Styled.ToggleButton
+        selected={isSelected(option)}
+        value={value}
+        key={value}
+      >
+        {label}
+      </Styled.ToggleButton>
+    );
+  });
+
+  return (
+    <Styled.Container>
+      <Styled.ToggleGroupContainer>
+        {title && <Styled.Title>{title}</Styled.Title>}
+        <Styled.FormControl sx={{}} size="small">
+          <ToggleButtonGroup
+            size="small"
+            color="primary"
+            value={selectedValues}
+            onChange={handleChange}
+            exclusive={exclusive}
+          >
+            {children}
+          </ToggleButtonGroup>
+        </Styled.FormControl>
+      </Styled.ToggleGroupContainer>
+    </Styled.Container>
+  );
+}

--- a/bigbluebutton-html5/imports/ui/components/common/toggle-group/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toggle-group/component.tsx
@@ -43,6 +43,7 @@ export default function ToggleGroup({
         selected={isSelected(option)}
         value={value}
         key={value}
+        hasTitle={!!title}
       >
         {label}
       </Styled.ToggleButton>
@@ -55,7 +56,7 @@ export default function ToggleGroup({
         {title && <Styled.Title>{title}</Styled.Title>}
         <Styled.FormControl sx={{}} size="small">
           <ToggleButtonGroup
-            size="small"
+            size={title ? 'small' : 'medium'}
             color="primary"
             value={selectedValues}
             onChange={handleChange}

--- a/bigbluebutton-html5/imports/ui/components/common/toggle-group/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/toggle-group/styles.ts
@@ -1,11 +1,15 @@
 import styled from 'styled-components';
-import MuiToggleButton from '@mui/material/ToggleButton';
+import { ToggleButton as MuiToggleButton, ToggleButtonProps } from '@mui/material';
 import FormControlMui from '@mui/material/FormControl';
 import { colorPrimary, colorWhite, colorGrayLight } from '/imports/ui/stylesheets/styled-components/palette';
 
-const ToggleButton = styled(MuiToggleButton)`
+interface ToggleButton {
+  hasTitle?: boolean;
+}
+
+const ToggleButton = styled(MuiToggleButton)<ToggleButtonProps & ToggleButton>`
   border-radius: .5rem !important;
-  padding: 0.2rem 0.5rem !important;
+  ${({ hasTitle }) => hasTitle && 'padding: 0.2rem 0.5rem !important'};
 
   ${({ selected }) => selected && `
     background-color: ${colorPrimary} !important;

--- a/bigbluebutton-html5/imports/ui/components/common/toggle-group/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/toggle-group/styles.ts
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+import MuiToggleButton from '@mui/material/ToggleButton';
+import FormControlMui from '@mui/material/FormControl';
+import { colorPrimary, colorWhite, colorGrayLight } from '/imports/ui/stylesheets/styled-components/palette';
+
+const ToggleButton = styled(MuiToggleButton)`
+  border-radius: .5rem !important;
+  padding: 0.2rem 0.5rem !important;
+
+  ${({ selected }) => selected && `
+    background-color: ${colorPrimary} !important;
+    color: ${colorWhite} !important;
+  `};
+
+  ${({ selected }) => !selected && `
+    background-color: ${colorWhite} !important;
+    color: ${colorGrayLight} !important;
+  `};
+
+  .MuiToggleButtonGroup-lastButton {
+    margin-left: 0;
+  }
+`;
+
+const ToggleGroupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  .MuiToggleButtonGroup-root {
+    background-color: ${colorWhite};
+    border-radius: 2rem;
+  }
+`;
+
+const Title = styled.label`
+  color: ${colorWhite};
+  font-size: 0.8rem;
+`;
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const FormControl = styled(FormControlMui)`
+  outline: transparent;
+`;
+
+export default {
+  ToggleButton,
+  ToggleGroupContainer,
+  Title,
+  Container,
+  FormControl,
+};

--- a/bigbluebutton-html5/imports/ui/components/common/toggle-group/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/common/toggle-group/types.ts
@@ -1,0 +1,14 @@
+import { MouseEvent } from 'react';
+
+export interface Option {
+  label: string;
+  value: string | number;
+}
+
+export interface ToggleGroupProps {
+  title?: string;
+  options: Option[];
+  defaultOption: Option;
+  exclusive?: boolean;
+  onChange: (selectedValues: string | number | string[] | number[], event: MouseEvent<HTMLElement>) => void
+}

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -30,7 +30,7 @@
         "autoprefixer": "^10.4.4",
         "axios": "^1.7.8",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.69",
+        "bigbluebutton-html-plugin-sdk": "0.0.70",
         "bowser": "^2.11.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6142,9 +6142,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.69.tgz",
-      "integrity": "sha512-zmTHWZdzRhkGydx7taAHyumMx3RT8BwPY1ue2RlTIrAVQWMMtrurLMHdiicUMKgN1y9MqWVRm8sDpsYnpM5jJQ==",
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.70.tgz",
+      "integrity": "sha512-TxNaRin5wQPVETB0l2vwidogWqlfYxRsdBvOsuldu8i/wREA+K+jIGfdRwRZaO2BhpIy+HlpPKwlIPYg7fOaDw==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -59,7 +59,7 @@
     "autoprefixer": "^10.4.4",
     "axios": "^1.7.8",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.69",
+    "bigbluebutton-html-plugin-sdk": "0.0.70",
     "bowser": "^2.11.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
### What does this PR do?

This PR is a backport of #22001.

> This PR is the core part of the following PR in plugins-sdk repo: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/141
> 
> - Adds proper handling and components for rendering the two new actions bar items that can be injected through plugins sdk: selector and toggle group.
> - Extend the Separator component to allow rendering icons as separators in the actions bar as requested by plugins sdk.

### How to test
![Screenshot from 2025-01-30 17-20-02](https://github.com/user-attachments/assets/a02301c0-99e3-4a00-b811-309814d3bb15)
Just setup and run the sample actions bar example plugin from the plugins-sdk samples
