### PR TITLE
Accessibility: improve screenreader navigation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -134,6 +134,7 @@ class ActionsBar extends PureComponent {
           }
         }
       >
+        <h2 class="sr-only">{intl.formatMessage(intlMessages.actionsBarLabel)}</h2>
         <Styled.ActionsBar
           ref={this.actionsBarRef}
           style={

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -50,6 +50,14 @@ const intlMessages = defineMessages({
     id: 'app.navBar.openDetailsTooltip',
     description: 'Open details tooltip',
   },
+  sessionControlLabel: {
+    id: 'app.navBar.sessionControlLabel',
+    description: 'label for screen reader to jump to leave button and options menu',
+  },
+  speakersListLabel: {
+    id: 'app.navBar.speakersListLabel',
+    description: 'label for screen reader to jump to speakers list',
+  },
 });
 
 const propTypes = {
@@ -389,6 +397,7 @@ class NavBar extends Component {
               {renderPluginItems(centerPluginItems)}
             </Styled.Center>
             <Styled.Right>
+              <h2 class="sr-only">{intl.formatMessage(intlMessages.sessionControlLabel)}</h2>
               {renderPluginItems(rightPluginItems)}
               {ConnectionStatusService.isEnabled() ? <ConnectionStatusButton /> : null}
               {ConnectionStatusService.isEnabled() ? <ConnectionStatus /> : null}
@@ -402,6 +411,7 @@ class NavBar extends Component {
           </Styled.Top>
         )}
         <Styled.Bottom>
+          <h2 class="sr-only">{intl.formatMessage(intlMessages.speakersListLabel)}</h2>
           {enableTalkingIndicator ? <TalkingIndicator amIModerator={amIModerator} /> : null}
           <TimerIndicatorContainer />
         </Styled.Bottom>

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -52,6 +52,10 @@ const intlMessages = defineMessages({
     id: 'app.presentation.emptySlideContent',
     description: 'No content available for slide',
   },
+  presentationHeader: {
+    id: 'playback.player.presentation.wrapper.aria',
+    description: 'Aria label for header navigation',
+  },
 });
 
 const { isSafari } = browserInfo;
@@ -850,6 +854,7 @@ class Presentation extends PureComponent {
                 : null,
           }}
         >
+          <h2 class="sr-only">{intl.formatMessage(intlMessages.presentationHeader)}</h2>
           <Styled.Presentation
             ref={(ref) => {
               this.refPresentation = ref;

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import Resizable from 're-resizable';
 import Draggable, { DraggableEvent } from 'react-draggable';
 import { useVideoStreams } from '/imports/ui/components/video-provider/hooks';
@@ -22,6 +23,13 @@ import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import useSettings from '../../services/settings/hooks/useSettings';
 import { SETTINGS } from '../../services/settings/enums';
 import { INITIAL_INPUT_STATE } from '../layout/initState';
+
+const intlMessages = defineMessages({
+  camerasAriaLabel: {
+    id: 'app.video.cameraAriaLabel',
+    description: 'Aria Label for cameras component',
+  },
+});
 
 interface WebcamComponentProps {
   cameraDock: Output['cameraDock'];
@@ -52,6 +60,7 @@ const WebcamComponent: React.FC<WebcamComponentProps> = ({
   const [resizeStart, setResizeStart] = useState({ width: 0, height: 0 });
   const [cameraMaxWidth, setCameraMaxWidth] = useState(0);
   const [draggedAtLeastOneTime, setDraggedAtLeastOneTime] = useState(false);
+  const intl = useIntl();
 
   const lastSize = Storage.getItem('webcamSize') || { width: 0, height: 0 };
   const { height: lastHeight } = lastSize as { width: number, height: number };
@@ -280,7 +289,7 @@ const WebcamComponent: React.FC<WebcamComponentProps> = ({
                 background: 'none',
               }}
             >
-              <h2 class="sr-only">Cameras</h2>
+              <h2 class="sr-only">{intl.formatMessage(intlMessages.camerasAriaLabel)}</h2>
               <VideoProviderContainer
                 {...{
                   swapLayout,

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -280,6 +280,7 @@ const WebcamComponent: React.FC<WebcamComponentProps> = ({
                 background: 'none',
               }}
             >
+              <h2 class="sr-only">Cameras</h2>
               <VideoProviderContainer
                 {...{
                   swapLayout,

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -510,6 +510,8 @@
     "app.navBar.recording.unavailable": "Recording unavailable",
     "app.navBar.emptyAudioBrdige": "No active microphone. Share your microphone to add audio to this recording.",
     "app.navBar.openDetailsTooltip": "Open session details",
+    "app.navBar.sessionControlLabel": "Session control",
+    "app.navBar.speakersListLabel": "Talking people",
     "app.leaveConfirmation.confirmLabel": "Leave",
     "app.leaveConfirmation.confirmDesc": "Logs you out of the session",
     "app.endMeeting.title": "End {0}",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1241,6 +1241,7 @@
     "app.video.camCapReached": "You cannot share more cameras",
     "app.video.meetingCamCapReached": "Session reached it's simultaneous cameras limit",
     "app.video.dropZoneLabel": "Drop here",
+    "app.video.cameraAriaLabel": "Cameras",
     "app.fullscreenButton.label": "Make {0} fullscreen",
     "app.fullscreenUndoButton.label": "Undo {0} fullscreen",
     "app.switchButton.expandLabel": "Expand screenshare video",


### PR DESCRIPTION
### What does this PR do?

It improves user experience for screen reader users.

Add h2 elements to several elements of the user interface so users can consistently jump between them. This makes navigation consistent with other parts of the BBB UI such as the user panel.

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test

In NVDA press `h` to open the headings navigation. There are new targets for talking indicator area, camera area (not translated yet), actions bar and icons on the top right corner of the screen.

### More

I could not yet figure out how to make the `Cameras` string translatable. Hints would be apreciated.