### PR TITLE
accessibility: make muted audio warning accessible for screen readers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -211,12 +211,14 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   return (
     <>
       {inAudio && inputStream && muteAlertEnabled && !listenOnly && muted && showMute ? (
+        <div data-debug="live-watcher" aria-live="polite">
         <MutedAlert
           {...{
             muted, inputStream, isPresenter,
           }}
           isViewer={!isModerator}
         />
+        </div>
       ) : null}
       {
 

--- a/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/muted-alert/component.jsx
@@ -27,6 +27,10 @@ const intlMessages = defineMessages({
     id: 'app.muteWarning.label',
     description: 'Warning when someone speaks while muted',
   },
+  unmuteAudio: {
+    id: 'app.actionsBar.unmuteLabel',
+    description: 'Unmute audio button label',
+  },
 });
 
 class MutedAlert extends Component {
@@ -143,7 +147,7 @@ class MutedAlert extends Component {
           onClick={() => this.closeAlert()}
         >
           <span>
-            {intl.formatMessage(intlMessages.warningLabel, { 0: <Icon iconName="mute" /> })}
+            {intl.formatMessage(intlMessages.warningLabel, { 0: <><span class="sr-only">{intl.formatMessage(intlMessages.unmuteAudio)}</span><Icon iconName="mute" aria-hidden="true" /></> })}
           </span>
         </Styled.MuteWarning>
       </TooltipContainer>


### PR DESCRIPTION
### What does this PR do?
Improves accessibility.

When a user is muted and speaks, BBB will present a warning. This was not accessible to screen reader users. Now this is wrapped in an `aria-live` element which instructs the screen reader to read this message as soon as the warning appears.
