### PR TITLE
Fix: External video autoplaying when presenter changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -190,6 +190,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const presenterRef = useRef(isPresenter);
   const [duration, setDuration] = React.useState(0);
   const [reactPlayerPlaying, setReactPlayerPlaying] = React.useState(false);
+  const clientReloadedRef = useRef(false);
 
   let currentTime = getCurrentTime();
 
@@ -263,6 +264,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   useEffect(() => {
     if (isPresenter !== presenterRef.current) {
+      clientReloadedRef.current = true;
       setPlayerKey(uniqueId('react-player'));
       presenterRef.current = isPresenter;
     }
@@ -275,7 +277,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   const handleOnPlay = async () => {
     setReactPlayerPlaying(true);
-    if (isPresenter && !playing) {
+    if (isPresenter && !playing && !clientReloadedRef.current) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
       const rate = internalPlayer instanceof HTMLVideoElement
         ? internalPlayer.playbackRate
@@ -290,6 +292,9 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
     if (!playing && !isPresenter) {
       playerRef.current?.getInternalPlayer().pauseVideo();
+    }
+    if (clientReloadedRef.current) {
+      clientReloadedRef.current = false;
     }
   };
 
@@ -412,6 +417,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           onPause={handleOnStop}
           onEnded={handleOnStop}
           muted={mute || isEchoTest}
+          controls={isPresenter}
         />
         {
           shouldShowTools() ? (


### PR DESCRIPTION
### What does this PR do?
This PR fixes the bug that occurs when a user becomes the presenter and the player reloads. The issue arises because the react-player library does not treat the controls prop as reactive; it only reads its value during mounting and doesn't update if that value changes.
(I've opened a issue for it on react-player repository https://github.com/cookpete/react-player/issues/1920)

Additionally, there was no straightforward way to distinguish between a user-initiated onPlay event and one triggered by the system. To address this, I introduced a new variable that detects client reloads and ignores the first onPlay handler call in those cases.

### Closes Issue(s)
Closes #22090

### How to test
- Join with two users.
- Play a external video.
- Pause the external video.
- Switch the presenter between users.


### More
[Screencast from 30-01-2025 21:07:50.webm](https://github.com/user-attachments/assets/d7059686-c246-4226-9888-dba05e697ac6)

