### PR TITLE
test: Flag all failing test with new UI as flaky

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -3,7 +3,7 @@ const { test } = require('../fixtures');
 const { Create } = require('./create');
 const { Join } = require('./join');
 
-test.describe.parallel('Breakout', { tag: '@ci' }, () => {
+test.describe.parallel('Breakout', { tag: ['@ci', '@flaky-3.1'] }, () => {
   test.describe.parallel('Creating', () => {
     test('Create Breakout room', async ({ browser, context, page }) => {
       const create = new Create(browser, context);

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -17,7 +17,7 @@ test.describe('Chat', { tag: '@ci' }, () => {
   });
 
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#private-message-automated
-  test('Send private message', async () => {
+  test('Send private message', { tag: '@flaky-3.1' }, async () => {
     await chat.sendPrivateMessage();
   });
 
@@ -43,7 +43,7 @@ test.describe('Chat', { tag: '@ci' }, () => {
     await chat.emptyMessage();
   });
 
-  test('Copy and paste public message', async () => {
+  test('Copy and paste public message', { tag: '@flaky-3.1' }, async () => {
     await chat.copyPastePublicMessage();
   })
 
@@ -55,7 +55,7 @@ test.describe('Chat', { tag: '@ci' }, () => {
     await chat.emojiCopyChat();
   });
 
-  test('Close private chat', async () => {
+  test('Close private chat', { tag: '@flaky-3.1' }, async () => {
     await chat.closePrivateChat();
   });
 
@@ -85,7 +85,7 @@ test.describe('Chat', { tag: '@ci' }, () => {
 
   // failure only reproducible in CI (user leaves but keeps shown in the mod user list)
   //! flaky flag recently removed in order to see current behavior
-  test('Private chat disabled when user leaves meeting', { tag: '@ci' }, async () => {
+  test('Private chat disabled when user leaves meeting', { tag: ['@ci', '@flaky-3.1'] }, async () => {
     await chat.chatDisabledUserLeaves();
   });
 });

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.js
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.js
@@ -3,7 +3,7 @@ const { fullyParallel } = require('../playwright.config');
 const { Layouts } = require('./layouts');
 const { initializePages } = require('../core/helpers');
 
-test.describe('Layout', { tag: '@ci' }, () => {
+test.describe('Layout', { tag: ['@ci', '@flaky-3.1'] }, () => {
   const layouts = new Layouts();
 
   test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });

--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.spec.js
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.spec.js
@@ -4,7 +4,7 @@ const { LearningDashboard } = require('./learningdashboard');
 const c = require('../parameters/constants');
 const { initializePages } = require('../core/helpers');
 
-test.describe('Learning Dashboard', { tag: '@ci' } , async () => {
+test.describe('Learning Dashboard', { tag: ['@ci', '@flaky-3.1'] } , async () => {
   const learningDashboard = new LearningDashboard();
 
   test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });

--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -7,7 +7,7 @@ const { recordMeeting } = require('../parameters/constants');
 const { linkIssue } = require('../core/helpers');
 
 test.describe.parallel('Notifications', { tag: '@ci' }, () => {
-  test('Save settings notification', async ({ browser, context, page }) => {
+  test('Save settings notification', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const notifications = new Notifications(browser, context);
     await notifications.initModPage(page);
     await notifications.saveSettingsNotification();
@@ -19,7 +19,7 @@ test.describe.parallel('Notifications', { tag: '@ci' }, () => {
     await notifications.audioNotification();
   });
 
-  test('User join notification', async ({ browser, context, page }) => {
+  test('User join notification', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const notifications = new Notifications(browser, context);
     await notifications.initModPage(page);
     await notifications.getUserJoinPopupResponse();
@@ -32,7 +32,7 @@ test.describe.parallel('Notifications', { tag: '@ci' }, () => {
     await notifications.raiseAndLowerHandNotification();
   });
 
-  test.describe.parallel('Chat', () => {
+  test.describe.parallel('Chat', { tag: '@flaky-3.1' }, () => {
     test('Public Chat notification', async ({ browser, context, page }) => {
       const chatNotifications = new ChatNotifications(browser, context);
       await chatNotifications.initPages(page);
@@ -51,7 +51,7 @@ test.describe.parallel('Notifications', { tag: '@ci' }, () => {
   });
 
   test.describe.parallel('Recording', () => {
-    test('Notification appearing when user is not in audio', async ({ browser, page }) => {
+    test('Notification appearing when user is not in audio', { tag: '@flaky-3.1' }, async ({ browser, page }) => {
       const recordingNotifications = new RecordingNotifications(browser, page);
       await recordingNotifications.init(true, true, { createParameter: recordMeeting });
       await recordingNotifications.notificationNoAudio();
@@ -63,13 +63,13 @@ test.describe.parallel('Notifications', { tag: '@ci' }, () => {
       await recordingNotifications.notificationListenOnly();
     });
 
-    test('No notification appearing when user is in audio', async ({ browser, page }) => {
+    test('No notification appearing when user is in audio', { tag: '@flaky-3.1' }, async ({ browser, page }) => {
       const recordingNotifications = new RecordingNotifications(browser, page);
       await recordingNotifications.init(true, true, { createParameter: recordMeeting });
       await recordingNotifications.noNotificationInAudio();
     });
 
-    test('Modal appearing when user wants to start recording', async ({ browser, page }) => {
+    test('Modal appearing when user wants to start recording', { tag: '@flaky-3.1' }, async ({ browser, page }) => {
       const recordingNotifications = new RecordingNotifications(browser, page);
       await recordingNotifications.init(true, true, { createParameter: recordMeeting });
       await recordingNotifications.modalStartRecording();
@@ -77,7 +77,7 @@ test.describe.parallel('Notifications', { tag: '@ci' }, () => {
   });
 
   test.describe.parallel('Presenter', () => {
-    test('Poll results notification', async ({ browser, context, page }) => {
+    test('Poll results notification', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
       const presenterNotifications = new PresenterNotifications(browser, context);
       await presenterNotifications.initPages(page);
       await presenterNotifications.modPage.closeAllToastNotifications();

--- a/bigbluebutton-tests/playwright/options/options.spec.js
+++ b/bigbluebutton-tests/playwright/options/options.spec.js
@@ -3,7 +3,7 @@ const { fullyParallel } = require('../playwright.config');
 const { Options } = require('./options');
 const { initializePages } = require('../core/helpers');
 
-test.describe('Options', { tag: '@ci' }, () => {
+test.describe('Options', { tag: ['@ci', '@flaky-3.1'] }, () => {
   const options = new Options();
 
   test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.js
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.js
@@ -13,7 +13,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
   });
 
   test.describe.parallel('Banner', () => {
-    test('Banner Text', async ({ browser, context, page }) => {
+    test('Banner Text', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
       const createParam = new CreateParameters(browser, context);
       await createParam.initModPage(page, true, { createParameter: c.bannerText });
       await createParam.bannerText();
@@ -60,7 +60,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     await createParam.muteOnStart();
   });
 
-  test('Allow Mods To Unmute Users', async ({ browser, context, page }) => {
+  test('Allow Mods To Unmute Users', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
     await createParam.initModPage(page, true, { createParameter: c.allowModsToUnmuteUsers });
     await createParam.allowModsToUnmuteUsers(context);
@@ -87,7 +87,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     await createParam.lockSettingsDisablePublicChat();
   });
 
-  test('Lock Settings Hide User List', async ({ browser, context, page }) => {
+  test('Lock Settings Hide User List', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
     await createParam.initModPage(page, true, { createParameter: c.lockSettingsHideUserList });
     await createParam.initUserPage(true, context);
@@ -95,7 +95,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     await createParam.lockSettingsHideUserList();
   });
 
-  test('Allow Moderator To Eject Cameras', async ({ browser, context, page }) => {
+  test('Allow Moderator To Eject Cameras', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
     await createParam.initModPage(page, true, { createParameter: c.allowModsToEjectCameras });
     await createParam.initUserPage(true, context);
@@ -103,7 +103,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
   });
 
   test.describe.parallel('Disabled Features', () => {
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Breakout rooms', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.breakoutRoomsDisabled });
@@ -145,7 +145,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Chat', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.chatDisabled });
@@ -158,7 +158,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('External Videos', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.externalVideosDisabled });
@@ -184,7 +184,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Learning Dashboard', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.learningDashboardDisabled });
@@ -197,7 +197,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Polls', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.pollsDisabled });
@@ -223,7 +223,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Shared Notes', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.sharedNotesDisabled });
@@ -249,7 +249,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Download Presentation With Annotations', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.downloadPresentationWithAnnotationsDisabled });
@@ -262,7 +262,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Import Presentation With Annotations From Breakout Rooms', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.importPresentationWithAnnotationsFromBreakoutRoomsDisabled });
@@ -275,7 +275,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Import Shared Notes From Breakout Rooms', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.importSharedNotesFromBreakoutRoomsDisabled });
@@ -327,7 +327,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
       });
     });
 
-    test.describe.serial(() => {
+    test.describe.serial('', { tag: '@flaky-3.1' }, () => {
       test('Camera As Content', async ({ browser, context, page }) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
         await disabledFeatures.initModPage(page, true, { createParameter: c.cameraAsContent });
@@ -343,7 +343,7 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
 });
 
 test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
-  test('Show Public Chat On Login', async ({ browser, context, page }) => {
+  test('Show Public Chat On Login', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, true, { joinParameter: c.showPublicChatOnLogin });
     await customParam.showPublicChatOnLogin();
@@ -361,13 +361,13 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
     await customParam.clientTitle();
   });
 
-  test('Display Branding Area', async ({ browser, context, page }) => {
+  test('Display Branding Area', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, true, { createParameter: `${c.displayBrandingArea}&${encodeCustomParams(c.logo)}` });
     await customParam.displayBrandingArea();
   });
 
-  test('Shortcuts', async ({ browser, context, page }) => {
+  test('Shortcuts', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     const shortcutParam = getAllShortcutParams();
     await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(shortcutParam) });
@@ -375,19 +375,19 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
     await customParam.shortcuts();
   });
 
-  test('Custom Styles: CSS code', async ({ browser, context, page }) => {
+  test('Custom Styles: CSS code', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.customStyle) });
     await customParam.customStyle();
   });
 
-  test('Custom Styles: URL', async ({ browser, context, page }) => {
+  test('Custom Styles: URL', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, true, { joinParameter: encodeCustomParams(c.customStyleUrl) });
     await customParam.customStyle();
   });
 
-  test('Auto Swap Layout', async ({ browser, context, page }) => {
+  test('Auto Swap Layout', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, true, { joinParameter: c.autoSwapLayout });
     await customParam.autoSwapLayout();
@@ -399,7 +399,7 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
     await customParam.hideActionsBarTest();
   });
 
-  test('Override Default Locale', async ({ browser, context, page }) => {
+  test('Override Default Locale', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, true, { joinParameter: c.overrideDefaultLocale });
     await customParam.overrideDefaultLocaleTest();
@@ -456,7 +456,7 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
   });
 
   test.describe.parallel('Presentation', () => {
-    test('Hide Presentation on join', async ({ browser, context, page }) => {
+    test('Hide Presentation on join', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
       const customParam = new CustomParameters(browser, context);
       await customParam.initModPage(page, true, { joinParameter: c.hidePresentationOnJoin });
       await customParam.initUserPage(true, context, { useModMeetingId: true, joinParameter: c.hidePresentationOnJoin });

--- a/bigbluebutton-tests/playwright/polling/polling.spec.js
+++ b/bigbluebutton-tests/playwright/polling/polling.spec.js
@@ -7,7 +7,7 @@ const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
 
 const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
 
-test.describe('Polling', { tag: '@ci' }, async () => {
+test.describe('Polling', { tag: ['@ci', '@flaky-3.1'] }, async () => {
   const polling = new Polling();
 
   test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -14,7 +14,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.skipSlide();
   });
 
-  test('Share Camera As Content', async ({ browser, context, page }) => {
+  test('Share Camera As Content', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.shareCameraAsContent();
@@ -37,7 +37,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
   });
 
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#fit-to-width-option
-  test('Presentation fit to width', async ({ browser, context, page }) => {
+  test('Presentation fit to width', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initModPage(page, true, { joinParameter: hidePresentationToast });
     await presentation.initUserPage(true, context);
@@ -72,7 +72,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.zoom();
   });
 
-  test('Select Slide', async ({ browser, context, page }) => {
+  test('Select Slide', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.selectSlide();
@@ -106,19 +106,19 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#enabling-and-disabling-presentation-download-automated
-    test('Enable and disable original presentation download', async ({ browser, context, page }, testInfo) => {
+    test('Enable and disable original presentation download', { tag: '@flaky-3.1' }, async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.enableAndDisablePresentationDownload(testInfo);
     });
     
-    test('Send presentation in the current state (with annotations) to chat for downloading', async ({ browser, context, page }, testInfo) => {
+    test('Send presentation in the current state (with annotations) to chat for downloading', { tag: '@flaky-3.1' }, async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.sendPresentationToDownload(testInfo);
     });
 
-    test('Remove all presentations', async ({ browser, context, page }) => {
+    test('Remove all presentations', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page);
       await presentation.removeAllPresentation();

--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.spec.js
@@ -3,7 +3,7 @@ const { SharedNotes } = require('./sharednotes');
 const { initializePages } = require('../core/helpers');
 const { fullyParallel } = require('../playwright.config');
 
-test.describe('Shared Notes', { tag: '@ci' }, () => {
+test.describe('Shared Notes', { tag: ['@ci', '@flaky-3.1'] }, () => {
   const sharedNotes = new SharedNotes();
 
   test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -12,7 +12,7 @@ const iPhone11 = devices['iPhone 11'];
 
 const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
 
-test.describe.parallel('User', { tag: '@ci' }, () => {
+test.describe.parallel('User', { tag: ['@ci', '@flaky-3.1'] }, () => {
   test.describe.parallel('Actions', () => {
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#set-status--raise-hand-automated
     test('Raise and lower Hand', async ({ browser, context, page }) => {

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -43,7 +43,7 @@ test.describe.parallel('Webcam', { tag: '@ci' }, () => {
     await webcam.webcamFullscreen();
   });
 
-  test('Disable Self-view', async ({ browser, page }) => {
+  test('Disable Self-view', { tag: '@flaky-3.1' }, async ({ browser, page }) => {
     const webcam = new Webcam(browser, page);
     await webcam.init(true, true);
     await webcam.disableSelfView();
@@ -58,13 +58,13 @@ test.describe.parallel('Webcam', { tag: '@ci' }, () => {
 
     // following test is throwing failures due to mis-comparison screenshot
     // as the emulated video is not static, we may add a mask in the middle part - where it moves the most
-    test('Managing new background', async ({ browser, page }) => {
+    test('Managing new background', { tag: '@flaky-3.1' }, async ({ browser, page }) => {
       const webcam = new Webcam(browser, page);
       await webcam.init(true, true);
       await webcam.managingNewBackground();
     });
 
-    test('Keep background when rejoin', async ({ browser, context, page }) => {
+    test('Keep background when rejoin', { tag: '@flaky-3.1' }, async ({ browser, context, page }) => {
       const webcam = new Webcam(browser, page);
       await webcam.init(true, true);
       await webcam.keepBackgroundWhenRejoin(context);


### PR DESCRIPTION
### What does this PR do?
Following the new UI changes + latest v3.1 CI outputs, this PR flags `145` tests as flaky (specifically `flaky-3.1` for easier filtering and further fixing) to avoid running on CI. All of these tests must be updated to follow the current steps with the new UI

![image](https://github.com/user-attachments/assets/36e4f5bc-1b13-4a78-b2f9-ac550b055d4d)