### PR TITLE
fix(plugin-sdk): useCurrentUser not updating correctly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/from-core/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/from-core/hook-manager.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
-import { SubscribedEventDetails, UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
+import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import {
   HookEvents,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
@@ -11,17 +11,17 @@ import formatMeetingResponseFromGraphql from './utils';
 import { GeneralHookManagerProps } from '../../../types';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { Meeting } from '/imports/ui/Types/meeting';
+import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 
 const MeetingHookContainer: React.FunctionComponent<
   GeneralHookManagerProps<GraphqlDataHookSubscriptionResponse<Partial<Meeting>>>
 > = (
   props: GeneralHookManagerProps<GraphqlDataHookSubscriptionResponse<Partial<Meeting>>>,
 ) => {
-  const [sendSignal, setSendSignal] = useState(false);
   const previousMeeting = useRef<GraphqlDataHookSubscriptionResponse<Partial<Meeting>> | null>(null);
 
-  const { data: meeting } = props;
-
+  const { data: meeting, numberOfUses } = props;
+  const previousNumberOfUses = usePreviousValue(numberOfUses);
   const updateMeetingForPlugin = () => {
     const meetingProjection: PluginSdk.GraphqlResponseWrapper<
     PluginSdk.Meeting> = formatMeetingResponseFromGraphql(
@@ -46,21 +46,11 @@ const MeetingHookContainer: React.FunctionComponent<
     }
   }, [meeting]);
   useEffect(() => {
-    updateMeetingForPlugin();
-  }, [sendSignal]);
-  useEffect(() => {
-    const updateHookUseCurrentMeeting = ((event: CustomEvent<SubscribedEventDetails>) => {
-      if (event.detail.hook === DataConsumptionHooks.MEETING) setSendSignal((signal) => !signal);
-    }) as EventListener;
-    window.addEventListener(
-      HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseCurrentMeeting,
-    );
-    return () => {
-      window.removeEventListener(
-        HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseCurrentMeeting,
-      );
-    };
-  }, []);
+    const previousNumberOfUsesValue = previousNumberOfUses || 0;
+    if (numberOfUses > previousNumberOfUsesValue) {
+      updateMeetingForPlugin();
+    }
+  }, [previousNumberOfUses]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/presentations/current-presentation/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/presentations/current-presentation/hook-manager.tsx
@@ -1,21 +1,23 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import useCurrentPresentation from '/imports/ui/core/hooks/useCurrentPresentation';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import {
   HookEvents,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
-import { SubscribedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import { DataConsumptionHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/enums';
 
 import { CurrentPresentation } from '/imports/ui/Types/presentation';
 import formatCurrentPresentation from './utils';
+import { GeneralHookManagerProps } from '../../../types';
+import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 
-const CurrentPresentationHookContainer = () => {
-  const [sendSignal, setSendSignal] = useState(false);
-
+const CurrentPresentationHookContainer = (props: GeneralHookManagerProps) => {
   const currentPresentation = useCurrentPresentation(
     (currentPresentationData: Partial<CurrentPresentation>) => currentPresentationData,
   );
+
+  const { numberOfUses } = props;
+  const previousNumberOfUses = usePreviousValue(numberOfUses);
 
   const updatePresentationForPlugin = () => {
     const formattedCurrentPresentation:
@@ -37,22 +39,15 @@ const CurrentPresentationHookContainer = () => {
   };
 
   useEffect(() => {
-    updatePresentationForPlugin();
-  }, [currentPresentation, sendSignal]);
+    const previousNumberOfUsesValue = previousNumberOfUses || 0;
+    if (numberOfUses > previousNumberOfUsesValue) {
+      updatePresentationForPlugin();
+    }
+  }, [numberOfUses]);
 
   useEffect(() => {
-    const updateHookUseCurrentPresentation = ((event: CustomEvent<SubscribedEventDetails>) => {
-      if (event.detail.hook === DataConsumptionHooks.CURRENT_PRESENTATION) setSendSignal((signal) => !signal);
-    }) as EventListener;
-    window.addEventListener(
-      HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseCurrentPresentation,
-    );
-    return () => {
-      window.removeEventListener(
-        HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseCurrentPresentation,
-      );
-    };
-  }, []);
+    updatePresentationForPlugin();
+  }, [currentPresentation]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/types.ts
@@ -6,6 +6,7 @@ import React from 'react';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface HookWithArgumentsContainerProps {
   key: string;
+  numberOfUses: number;
   hookArguments: CustomSubscriptionArguments;
 }
 
@@ -17,4 +18,5 @@ export interface ObjectToCustomHookContainerMap {
 export interface HookWithArgumentContainerToRender{
   componentToRender: React.FunctionComponent<HookWithArgumentsContainerProps>;
   hookArguments: CustomSubscriptionArguments;
+  numberOfUses: number;
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/hook-manager.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/hook-manager.ts
@@ -1,16 +1,17 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import {
   HookEvents,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
 import { DataConsumptionHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/enums';
-import { SubscribedEventDetails, UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
+import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import formatTalkingIndicatorDataFromGraphql from './utils';
 import { UserVoice } from '/imports/ui/Types/userVoice';
 import { useTalkingIndicatorList } from '/imports/ui/core/hooks/useTalkingIndicator';
+import { GeneralHookManagerProps } from '../../../types';
+import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 
-const TalkingIndicatorHookContainer = () => {
-  const [sendSignal, setSendSignal] = useState(false);
+const TalkingIndicatorHookContainer = (props: GeneralHookManagerProps) => {
   const [userVoice] = useTalkingIndicatorList(
     (uv: Partial<UserVoice>) => ({
       talking: uv.talking,
@@ -19,6 +20,9 @@ const TalkingIndicatorHookContainer = () => {
       userId: uv.userId,
     }) as Partial<UserVoice>,
   );
+
+  const { numberOfUses } = props;
+  const previousNumberOfUses = usePreviousValue(numberOfUses);
 
   const updateTalkingIndicatorForPlugin = () => {
     window.dispatchEvent(new CustomEvent<
@@ -32,22 +36,14 @@ const TalkingIndicatorHookContainer = () => {
   };
 
   useEffect(() => {
-    updateTalkingIndicatorForPlugin();
-  }, [userVoice, sendSignal]);
-
+    const previousNumberOfUsesValue = previousNumberOfUses || 0;
+    if (numberOfUses > previousNumberOfUsesValue) {
+      updateTalkingIndicatorForPlugin();
+    }
+  }, [numberOfUses]);
   useEffect(() => {
-    const updateHookUseTalkingIndicator = ((event: CustomEvent<SubscribedEventDetails>) => {
-      if (event.detail.hook === DataConsumptionHooks.TALKING_INDICATOR) setSendSignal((signal) => !signal);
-    }) as EventListener;
-    window.addEventListener(
-      HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseTalkingIndicator,
-    );
-    return () => {
-      window.removeEventListener(
-        HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseTalkingIndicator,
-      );
-    };
-  }, []);
+    updateTalkingIndicatorForPlugin();
+  }, [userVoice]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/current-user/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/current-user/hook-manager.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
-import { SubscribedEventDetails, UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
+import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import {
   HookEvents,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
@@ -11,17 +11,17 @@ import formatCurrentUserResponseFromGraphql from './utils';
 import { User } from '/imports/ui/Types/user';
 import { GeneralHookManagerProps } from '../../../types';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
+import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 
 const CurrentUserHookContainer: React.FunctionComponent<
   GeneralHookManagerProps<GraphqlDataHookSubscriptionResponse<Partial<User>>>
 > = (
   props: GeneralHookManagerProps<GraphqlDataHookSubscriptionResponse<Partial<User>>>,
 ) => {
-  const [sendSignal, setSendSignal] = useState(false);
   const previousCurrentUser = useRef<GraphqlDataHookSubscriptionResponse<Partial<User>> | null>(null);
 
-  const { data: currentUser } = props;
-
+  const { data: currentUser, numberOfUses } = props;
+  const previousNumberOfUses = usePreviousValue(numberOfUses);
   const updateUserForPlugin = () => {
     const currentUserProjection: PluginSdk.GraphqlResponseWrapper<
     PluginSdk.CurrentUserData> = formatCurrentUserResponseFromGraphql(
@@ -46,21 +46,11 @@ const CurrentUserHookContainer: React.FunctionComponent<
     }
   }, [currentUser]);
   useEffect(() => {
-    updateUserForPlugin();
-  }, [sendSignal]);
-  useEffect(() => {
-    const updateHookUseCurrentUser = ((event: CustomEvent<SubscribedEventDetails>) => {
-      if (event.detail.hook === DataConsumptionHooks.CURRENT_USER) setSendSignal((signal) => !signal);
-    }) as EventListener;
-    window.addEventListener(
-      HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseCurrentUser,
-    );
-    return () => {
-      window.removeEventListener(
-        HookEvents.PLUGIN_SUBSCRIBED_TO_BBB_CORE, updateHookUseCurrentUser,
-      );
-    };
-  }, []);
+    const previousNumberOfUsesValue = previousNumberOfUses || 0;
+    if (numberOfUses > previousNumberOfUsesValue) {
+      updateUserForPlugin();
+    }
+  }, [numberOfUses]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
@@ -118,6 +118,7 @@ const PluginDataConsumptionManager: React.FC = () => {
           HooksWithArgumentContainerToRun.push({
             componentToRender: HooksMapWithArguments[hookName],
             hookArguments: object.hookArguments,
+            numberOfUses: object.count,
           });
         }
       });
@@ -149,8 +150,10 @@ const PluginDataConsumptionManager: React.FC = () => {
             const HookComponent = hooksMap[hookName];
             if (hookName === DataConsumptionHooks.CURRENT_USER) data = currentUser;
             if (hookName === DataConsumptionHooks.MEETING) data = meetingInformation;
+            const countOfUses = hookUtilizationCount.get(hookName) || 0;
             return (
               <HookComponent
+                numberOfUses={countOfUses}
                 key={hookName}
                 data={data}
               />
@@ -162,6 +165,7 @@ const PluginDataConsumptionManager: React.FC = () => {
           const HookComponent = hookWithArguments.componentToRender;
           return (
             <HookComponent
+              numberOfUses={hookWithArguments.numberOfUses}
               key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
               hookArguments={hookWithArguments.hookArguments}
             />

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/types.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface GeneralHookManagerProps<T = any> {
     data: T;
+    numberOfUses: number;
 }


### PR DESCRIPTION
### What does this PR do?

It fixes a strange behaviour that kept happening to some of our data-consumption hooks for the plugin-sdk, which is: data was not updated correctly in the first moments of the meeting.

The solution was to just change the way that the client core updates the data for the plugin whenever a new plugin subscribes to that data-consumption hook (now it updates based on the counter).  

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/119#issuecomment-2612663687

### How to test

I advise you to test all data-consumption hooks, see if everything goes as expected, since the changes in this PR were more structural.

And to properly test if the issue has been resolved, follow the steps to first reproduce it, then apply the PR to see if it  doesn't happen:
- On a v3.0.x-release branch, add the following plugins:
```
pluginManifests=[{"url":"https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/nav-bar-sample/manifest.json"},{"url":"https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/latest/plugin-generic-link-share/dist/manifest.json"},{"url":"https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/latest/plugin-h5p/dist/manifest.json"},{"url":"https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/latest/plugin-pick-random-user/dist/manifest.json"},{"url": "https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/mock-plugin/manifest.json"}]
```
- If you have a remote-server, just skip this step, but if you are testing this locally, use `html5` production build with the `./deploy` script, and use network throttling (usually fast 4G already do the trick);
- Keep an eye in the logs for this specific log "SIPLG: setting current user in store"
- Keep reloading the page until you see the log "SIPLG: setting current user in store undefined" and no more update on this log;

This is how you can reproduce the error, now, once you checkout to this branch and try reproducing this error, the log mentioned previously will appear at least twice and with the object updated (no undefined after the first time it appears).


### More

The main problem of the issue (two components mounted in different moments using the same consumption hooks) has not been reproduced, only the problems mentioned in the discussion later on the issue. That's the problem I gave the steps to reproduce.

