### PR TITLE
Limit options for interaction with bots in the userlist and correct some styles 

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -719,6 +719,7 @@ export interface Label {
   mobile: boolean
   guest: boolean
   sharingWebcam: boolean
+  bot: boolean
 }
 
 export interface Whiteboard {

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -653,6 +653,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
 
   // Unused for now, but will be used in the future when UI/UX for sharing
   // through the profile settings is implemented - prlanzarin
+  // @ts-expect-error TS6133: Unused variable.
   const handleStartSharing = async () => {
     if (!currentVideoStream.current) return;
     if (

--- a/bigbluebutton-html5/imports/ui/components/recording/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/container.tsx
@@ -18,9 +18,11 @@ interface RecordingContainerProps {
 
 const RecordingContainer: React.FC<RecordingContainerProps> = (props) => {
   const {
-    amIModerator, isOpen, onRequestClose, priority, setIsOpen,
+    amIModerator, onRequestClose, setIsOpen,
   } = props;
   const [setRecordingStatus] = useMutation(SET_RECORDING_STATUS);
+  // TODO: unused connected status variable, should we use it to disable the recording button?
+  // @ts-expect-error TS6133: Unused variable.
   const connected = useReactiveVar(ConnectionStatus.getConnectedStatusVar());
   const {
     data: recordingData,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -143,6 +143,7 @@ export const generateActionsPermissions = (
   const amISubjectUser = isMe(subjectUser.userId);
   const isSubjectUserModerator = subjectUser.isModerator;
   const isSubjectUserGuest = subjectUser.guest;
+  const isSubjectUserBot = subjectUser.bot;
   // Breakout rooms mess up with role permissions
   // A breakout room user that has a moderator role in it's parent room
   const parentRoomModerator = getFromUserSettings('bbb_parent_room_moderator', false);
@@ -156,6 +157,7 @@ export const generateActionsPermissions = (
     )) && !amISubjectUser
     && !isDialInUser
     && isPrivateChatEnabled
+    && !isSubjectUserBot
     && !isBreakout;
 
   const allowedToMuteAudio = hasAuthority

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -160,6 +160,7 @@ export const generateActionsPermissions = (
     && subjectUserVoice?.joined
     && !isMuted
     && !subjectUserVoice?.listenOnly
+    && !isSubjectUserBot
     && !isBreakout;
 
   const allowedToUnmuteAudio = hasAuthority
@@ -172,10 +173,12 @@ export const generateActionsPermissions = (
 
   const allowedToChangeWhiteboardAccess = currentUser.presenter
       && !amISubjectUser && !subjectUser.presenter
+      && !isSubjectUserBot
       && !isDialInUser;
 
   const allowedToSetPresenter = amIModerator
       && !subjectUser.presenter
+      && !isSubjectUserBot
       && !isDialInUser;
 
   // if currentUser is a moderator, allow removing other users
@@ -188,6 +191,7 @@ export const generateActionsPermissions = (
     && !isSubjectUserModerator
     && !isDialInUser
     && !isBreakout
+    && !isSubjectUserBot
     && !(isSubjectUserGuest && usersPolicies?.authenticatedGuest && !usersPolicies?.allowPromoteGuestToModerator);
 
   const allowedToDemote = amIModerator
@@ -195,10 +199,12 @@ export const generateActionsPermissions = (
     && isSubjectUserModerator
     && !isDialInUser
     && !isBreakout
+    && !isSubjectUserBot
     && !(isSubjectUserGuest && usersPolicies?.authenticatedGuest && !usersPolicies?.allowPromoteGuestToModerator);
 
   const allowedToChangeUserLockStatus = amIModerator
     && !isSubjectUserModerator
+    && !isSubjectUserBot
     && lockSettings?.hasActiveLockSetting;
 
   const allowedToEjectCameras = amIModerator

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -49,10 +49,6 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.room',
     description: 'breakout room',
   },
-  you: {
-    id: 'app.userList.you',
-    description: 'Text for identifying your user',
-  },
   startPrivateChat: {
     id: 'app.userList.menu.chat.label',
     description: 'label for option to start a new private chat',

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
@@ -10,6 +10,10 @@ import { UserNameWithSubsProps } from './types';
 import { uniqueId } from '/imports/utils/string-utils';
 
 const intlMessages = defineMessages({
+  bot: {
+    id: 'app.userList.bot',
+    description: 'Text for identifying bot user',
+  },
   presenter: {
     id: 'app.userList.presenter',
     description: 'Text for identifying presenter user',
@@ -65,6 +69,9 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
   }
   if (subjectUser.mobile && LABEL.mobile) {
     subs.push(intl.formatMessage(intlMessages.mobile));
+  }
+  if (subjectUser.bot && LABEL.bot) {
+    subs.push(intl.formatMessage(intlMessages.bot));
   }
   if ((subjectUser.locked || subjectUser.userLockSettings?.disablePublicChat)
       && (subjectUser.userLockSettings?.disablePublicChat || lockSettings?.hasActiveLockSetting)

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
@@ -38,6 +38,10 @@ const intlMessages = defineMessages({
     id: 'app.userList.sharingWebcam',
     description: 'Text for identifying who is sharing webcam',
   },
+  you: {
+    id: 'app.userList.you',
+    description: 'Text for identifying your user',
+  },
 });
 
 const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
@@ -129,7 +133,7 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
       <Styled.UserName>
         <TooltipContainer title={subjectUser.name}>
           {isMe(subjectUser.userId) ? (
-            <Styled.StrongName>{subjectUser.name}</Styled.StrongName>
+            <Styled.StrongName>{subjectUser.name} {`(${intl.formatMessage(intlMessages.you)})`}</Styled.StrongName>
           ) : (
             <Styled.RegularName>{subjectUser.name}</Styled.RegularName>
           )}

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -822,6 +822,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         mobile: true,
         guest: true,
         sharingWebcam: true,
+        bot: false,
       },
     },
     whiteboard: {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1033,6 +1033,7 @@ public:
       mobile: true
       guest: true
       sharingWebcam: true
+      bot: true
   whiteboard:
     annotationsQueueProcessInterval: 60
     cursorInterval: 150

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -188,6 +188,7 @@
     "app.userList.byModerator": "(by moderator)",
     "app.userList.label": "User list",
     "app.userList.toggleCompactView.label": "Toggle compact view mode",
+    "app.userList.bot": "Automated",
     "app.userList.moderator": "Moderator",
     "app.userList.mobile": "Mobile",
     "app.userList.guest": "Guest",

--- a/bigbluebutton-html5/public/locales/pt_BR.json
+++ b/bigbluebutton-html5/public/locales/pt_BR.json
@@ -169,6 +169,7 @@
     "app.userList.byModerator": "(por moderador)",
     "app.userList.label": "Lista de participantes",
     "app.userList.toggleCompactView.label": "Alternar para o modo de exibição compacta",
+    "app.userList.bot": "Automação",
     "app.userList.moderator": "Moderador",
     "app.userList.mobile": "Móvel",
     "app.userList.guest": "Convidado",


### PR DESCRIPTION
This PR does several small things:

* Bots (automated users) can't be interacted with by moderators in the user list (no private chat, no control of whiteboard, etc...). The only button preserved is 'Remove User'
* Bots will now be labeled in the user list
* Fix the label for current user. In 3.0 it is marked by the '(you)' next to your name and on 3.1 it was only marked by bold text. We restored the behavior from 3.0