### PR TITLE
fix(API): Use errorRedirectUrl on Validation failure during Join calls

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -237,8 +237,14 @@ class ApiController {
       } catch (Exception ignored) {}
     }
 
+    String errorRedirectUrl = ""
+    if(!StringUtils.isEmpty(params.errorRedirectUrl)) {
+      errorRedirectUrl = params.errorRedirectUrl
+    }
+
+
     if(!(validationResponse == null)) {
-      invalid(validationResponse.getKey(), validationResponse.getValue(), redirectClient)
+      invalid(validationResponse.getKey(), validationResponse.getValue(), redirectClient, errorRedirectUrl)
       return
     }
 
@@ -263,11 +269,6 @@ class ApiController {
     String attPW = params.password
 
     Meeting meeting = ServiceUtils.findMeetingFromMeetingID(params.meetingID);
-
-    String errorRedirectUrl = ""
-    if(!StringUtils.isEmpty(params.errorRedirectUrl)) {
-      errorRedirectUrl = params.errorRedirectUrl
-    }
 
     // the createTime mismatch with meeting's createTime, complain
     // In the future, the createTime param will be required


### PR DESCRIPTION
### What does this PR do?

Makes use of the `errorRedirectUrl` parameter, if it is provided, when validation fails during a `join` call.


### Closes Issue(s)
Closes #20178


### How to test

Attempt to join  meeting that does not exist an pass a URL as a value for `errorRedirectURL` and you will be redirected to that URL.
