### PR TITLE
fix(layout): focused camera missing required parameter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -38,7 +38,7 @@ const useMeetingLayoutUpdater = (
         presentationIsOpen,
         isResizing,
         cameraPosition: position || 'contentTop',
-        focusedCamera: focusedId,
+        focusedCamera: focusedId || 'none',
         presentationVideoRate: calculatePresentationVideoRate(cameraDockOutput),
       },
     });


### PR DESCRIPTION

### What does this PR do?

Adds a fallback value for the focused camera ID to 'none', which can be undefined while the layout context is still calculating the output values.

(originally part of #22108)