### PR TITLE
fix(profile-settings): several ui bug fixes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/profile-settings/audio-selectors/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/audio-selectors/component.tsx
@@ -250,7 +250,7 @@ const AudioSelectors: React.FC<AudioSelectorsProps> = ({
         {outputDevices.length > 0
           ? (
             <Styled.DeviceSelector
-              value={outputDeviceId || ''}
+              value={outputDeviceId || outputDevices[0].deviceId}
               IconComponent={ExpandMoreIcon}
               onChange={(event: SelectChangeEvent<unknown>) => {
                 const deviceId = event.target.value as string;
@@ -271,7 +271,7 @@ const AudioSelectors: React.FC<AudioSelectorsProps> = ({
         {inputDevices.length > 0
           ? (
             <Styled.DeviceSelector
-              value={inputDeviceId || ''}
+              value={inputDeviceId || inputDevices[0].deviceId}
               IconComponent={ExpandMoreIcon}
               onChange={(event: SelectChangeEvent<unknown>) => {
                 const deviceId = event.target.value as string;

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -945,10 +945,10 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
         title={formatMessage(intlMessages.title)}
         leftButtonProps={{}}
         rightButtonProps={{
-          'aria-label': formatMessage(intlMessages.closeLabel),
+          'aria-label': formatMessage(intlMessages.minimizeLabel),
           'data-test': 'closeProfileSettings',
           icon: 'close',
-          label: formatMessage(intlMessages.closeLabel),
+          label: formatMessage(intlMessages.minimizeLabel),
           onClick: () => {
             layoutContextDispatch({
               type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
@@ -20,6 +20,7 @@ import Headphones from '@mui/icons-material/Headphones';
 import Mic from '@mui/icons-material/Mic';
 import Select from '@mui/material/Select';
 import Switch from '@mui/material/Switch';
+import Slider from '@mui/material/Slider';
 import { styled as materialStyled } from '@mui/material/styles';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import {
@@ -44,6 +45,7 @@ const ProfileSettings = styled(ScrollboxVertical)`
   border-radius: ${contentSidebarBorderRadius};
   background: ${colorWhite};
   overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 const HeaderContainer = styled(BaseHeaderContainer)``;
@@ -55,6 +57,8 @@ interface VideoPreviewProps {
 const VideoPreview = styled.video<VideoPreviewProps>`
   height: 100%;
   width: 100%;
+  border-radius: 0.5rem;
+  box-shadow: 8px 8px 24px 0px rgba(0, 0, 0, 0.10);
 
   @media ${smallOnly} {
     height: 10rem;
@@ -67,8 +71,6 @@ const VideoPreview = styled.video<VideoPreviewProps>`
 
 const VideoPreviewContent = styled.div`
   padding: 0px ${contentSidebarPadding};
-  position: sticky;
-  top: 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -215,7 +217,6 @@ const DevicesSettingsContainer = styled.div`
 const DeviceContainer = styled.div`
   display: flex;
   flex-direction: row;
-  height: 3.5rem;
   flex-shrink: 0;
   gap: 1rem;
   align-items: center;
@@ -280,7 +281,6 @@ const VirtualBackgroundContainer = styled.div`
 `;
 
 const SwitchTitle = styled(FormControlLabel)`
-  height: 1.5rem;
   flex-shrink: 0;
   .MuiFormControlLabel-label {
     color: ${colorGrayDark};
@@ -336,6 +336,17 @@ const MaterialSwitch = materialStyled(Switch)(({ theme }) => ({
     }),
   },
 }));
+
+const BrightnessSlider = styled(Slider)`
+  color: ${colorPrimary};
+  & .MuiSlider-thumb {
+    height: 1rem;
+    width: 1rem;
+  };
+  & .MuiSlider-track {
+    height: 5px;
+  }
+`;
 
 const VirtualBgSelectorBorder = styled.div`
   width: 100%;
@@ -413,6 +424,7 @@ export default {
   VirtualBackgroundContainer,
   SwitchTitle,
   MaterialSwitch,
+  BrightnessSlider,
   VirtualBgSelectorBorder,
   CaptionsContainer,
   CaptionsToggleContainer,

--- a/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/component.tsx
@@ -238,11 +238,11 @@ const GuestUsersManagementPanel: React.FC<GuestUsersManagementPanelProps> = ({
       )}
       {authedGuestUsers.length > 0 && (
         <>
-          <Styled.WaitingUsersHeader>
-            <Tooltip title={waitingAuthedUsersVisible
-              ? intl.formatMessage(intlMessages.hideWaitingGuests)
-              : intl.formatMessage(intlMessages.showWaitingGuests)}
-            >
+          <Tooltip title={waitingAuthedUsersVisible
+            ? intl.formatMessage(intlMessages.hideWaitingGuests)
+            : intl.formatMessage(intlMessages.showWaitingGuests)}
+          >
+            <Styled.WaitingUsersHeader onClick={() => setWaitingAuthedUsersVisible(!waitingAuthedUsersVisible)}>
               <IconButton
                 size="small"
                 sx={{
@@ -258,14 +258,14 @@ const GuestUsersManagementPanel: React.FC<GuestUsersManagementPanelProps> = ({
               >
                 {waitingAuthedUsersVisible ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
               </IconButton>
-            </Tooltip>
-            <Styled.MainTitle>{intl.formatMessage(intlMessages.title)}</Styled.MainTitle>
-            <Avatar sx={{ bgcolor: '#F59240', width: '1.25rem', height: '1.25rem' }}>
-              <Styled.GuestNumberIndicator>
-                {authedGuestUsers.length}
-              </Styled.GuestNumberIndicator>
-            </Avatar>
-          </Styled.WaitingUsersHeader>
+              <Styled.MainTitle>{intl.formatMessage(intlMessages.title)}</Styled.MainTitle>
+              <Avatar sx={{ bgcolor: '#F59240', width: '1.25rem', height: '1.25rem' }}>
+                <Styled.GuestNumberIndicator>
+                  {authedGuestUsers.length}
+                </Styled.GuestNumberIndicator>
+              </Avatar>
+            </Styled.WaitingUsersHeader>
+          </Tooltip>
           {waitingAuthedUsersVisible && (
             renderPendingUsers(
               authedGuestUsers,


### PR DESCRIPTION
Supersedes https://github.com/bigbluebutton/bigbluebutton/pull/22136

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
- Round Camera Preview border
- Fix empty input/output devices
- Only add scrollbar to area below video preview
- Re-apply brightness after changing camera quality profile
- Save camera and profile in storage
- Fix unable to disable VirtualBackound toggle when there was brightness applied
- Disable camera quality selector when camera is already shared, add tooltip
- Change brightness slider sizes according to design
- Fix some extra white spaces
- Correct minimize label

Bonus: add onClick to Waiting Users header so all label and button can be clicked to expand to show waiting users.
