### PR TITLE
fix (html5): Chat messages sent from API are not showing `userName` nor highlighting

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -24,7 +24,7 @@ import {
   ChatContentFooter,
   ChatTime,
 } from './styles';
-import { ChatMessageType } from '/imports/ui/core/enums/chat';
+import {ChatMessageType, SYSTEM_SENDERS} from '/imports/ui/core/enums/chat';
 import MessageReadConfirmation from './message-read-confirmation/component';
 import ChatMessageToolbar from './message-toolbar/component';
 import ChatMessageReactions from './message-reactions/component';
@@ -269,7 +269,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     || !JSON.parse(previousMessage?.messageMetadata).custom);
   let sameSender = ((previousMessage?.user?.userId
     || lastSenderPreviousPage) === message?.user?.userId) && pluginMessageNotCustom;
-  const isSystemSender = message.messageType === ChatMessageType.BREAKOUT_ROOM;
+  const isSystemSender = SYSTEM_SENDERS.has(message.messageType as ChatMessageType);
   const currentPluginMessageMetadata = message.messageType === ChatMessageType.PLUGIN
     && JSON.parse(message.messageMetadata);
   const isCustomPluginMessage = currentPluginMessageMetadata.custom;
@@ -368,12 +368,13 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           isModerator: true,
           isSystemSender: true,
           component: (
-            <ChatMessageNotificationContent
+            <ChatMessageTextContent
+              emphasizedMessage
               text={message.message}
             />
           ),
-          showAvatar: false,
-          showHeading: false,
+          showAvatar: true,
+          showHeading: true,
           showToolbar: false,
         };
       case ChatMessageType.USER_AWAY_STATUS_MSG: {

--- a/bigbluebutton-html5/imports/ui/core/enums/chat.ts
+++ b/bigbluebutton-html5/imports/ui/core/enums/chat.ts
@@ -25,3 +25,8 @@ export const enum ChatMessageType {
   USER_IS_PRESENTER_MSG = 'userIsPresenterMsg',
   PLUGIN = 'plugin'
 }
+
+export const SYSTEM_SENDERS = new Set<ChatMessageType>([
+  ChatMessageType.BREAKOUT_ROOM,
+  ChatMessageType.API,
+]);


### PR DESCRIPTION
- Displaying the `userName` in messages sent via the `sendChatMessage` endpoint.  
- Applying the same highlighted style used for messages sent by moderators to breakout rooms.

Before:
<img src="https://github.com/user-attachments/assets/0c11d48f-4c7e-4e1c-a31c-afb8abb1eb79" width=300 />


After:
<img src="https://github.com/user-attachments/assets/6e9c2d59-fed4-4ab4-ac8a-0d2c24e2bc67" width=300 />


Fix #22183