### PR TITLE
fix: Whiteboard reloads with error message when webcam is denied

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -1241,7 +1241,7 @@ class VideoPreview extends Component {
       previewError,
     } = this.state;
     const shouldDisableButtons = this.shouldSkipVideoPreview()
-      && !(deviceError || previewError);
+    || !!(deviceError || previewError);
 
     const shared = this.isAlreadyShared(webcamDeviceId);
 


### PR DESCRIPTION
### What does this PR do?

disables webcam sharing button when a preview error is being displayed

![2025-02-04_10-22](https://github.com/user-attachments/assets/2e190c00-cc98-4dc6-af4c-9ba1d9890992)

### Closes Issue(s)
Closes #22163

### How to test
1. Create a meeting
2. Join the webcam and deny the permission
3. Try to start sharing the webcam
4. "Start sharing" button should be disabled
