### PR TITLE
Fix: Current presentation toast appearing too frequently

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -90,6 +90,7 @@ class Presentation extends PureComponent {
       isToolbarVisible: true,
       hadPresentation: false,
       ignorePresentationRestoring: true,
+      lastNotifiedPresentation: localStorage.getItem('lastNotifiedPresentation') ?? '',
     };
 
     const PAN_ZOOM_INTERVAL = window.meetingClientSettings.public.presentation.panZoomInterval || 200;
@@ -114,6 +115,7 @@ class Presentation extends PureComponent {
     this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
     this.setPresentationRef = this.setPresentationRef.bind(this);
     this.setTldrawIsMounting = this.setTldrawIsMounting.bind(this);
+    this.setNotifiedPresentation = this.setNotifiedPresentation.bind(this)
     Session.setItem('componentPresentationWillUnmount', false);
   }
 
@@ -236,6 +238,7 @@ class Presentation extends PureComponent {
       presentationId,
       hadPresentation,
       ignorePresentationRestoring,
+      lastNotifiedPresentation,
     } = this.state;
     const {
       numCameras: prevNumCameras,
@@ -281,7 +284,7 @@ class Presentation extends PureComponent {
             autoClose: shouldCloseToast,
             render: this.renderCurrentPresentationToast(),
           });
-        } else {
+        } else if (lastNotifiedPresentation !== currentPresentationId) {
           toast(
             this.renderCurrentPresentationToast(),
             {
@@ -292,6 +295,7 @@ class Presentation extends PureComponent {
               toastId: this.currentPresentationToastId,
             },
           );
+          this.setNotifiedPresentation(currentPresentationId);
         }
       }
 
@@ -411,6 +415,7 @@ class Presentation extends PureComponent {
     }
   }
 
+
   handlePanShortcut(e) {
     const { userIsPresenter } = this.props;
     const { isPanning } = this.state;
@@ -447,6 +452,11 @@ class Presentation extends PureComponent {
     if (isFullscreen !== newIsFullscreen) {
       this.setState({ isFullscreen: newIsFullscreen });
     }
+  }
+
+  setNotifiedPresentation(id) {
+    this.setState({ lastNotifiedPresentation: id });
+    localStorage.setItem('lastNotifiedPresentation', id);
   }
 
   setTldrawAPI(api) {
@@ -839,7 +849,7 @@ class Presentation extends PureComponent {
     const presentationZIndex = fullscreenContext ? presentationBounds.zIndex : undefined;
 
     const APP_CRASH_METADATA = { logCode: 'whiteboard_crash', logMessage: 'Possible whiteboard crash' };
-  if (!presentationIsOpen) return null;
+    if (!presentationIsOpen) return null;
     return (
       <>
         <Styled.PresentationContainer


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue with the presentation toast notification being triggered too frequently. I’ve introduced a new register that is stored in local storage, ensuring it persists across page reloads.


### Closes Issue(s)
Closes #22185

### How to test
- Join a client
- See notification
- Reload the client
- Dont see the notification
- Change the presentation
- See notification again.


### More
[Screencast from 05-02-2025 16:16:35.webm](https://github.com/user-attachments/assets/74e422f0-0805-4aef-a6f8-420dd380b973)

