### PR TITLE
docs: Document formatting updates and corrections for 3.0

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -5,7 +5,12 @@ const createEndpointTableData = [
     "name": "name",
     "required": true,
     "type": "String",
-    "description": (<>A name for the meeting.  This is now required as of BigBlueButton 2.4.</>)
+    "description": (
+      <>
+        <p>A name for the meeting.</p>
+        <p><i>Added in 2.4:</i> This parameter is now required.</p>
+      </>
+    )
   },
   {
     "name": "meetingID",
@@ -16,14 +21,23 @@ const createEndpointTableData = [
   {
     "name": "attendeePW",
     "type": "String",
-    "description": (<>
-      <b>[DEPRECATED]</b> The password that the <a href="#join">join</a> URL can later provide as its <code className="language-plaintext highlighter-rouge">password</code> parameter to indicate the user will join as a viewer.  If no <code className="language-plaintext highlighter-rouge">attendeePW</code> is provided, the <code className="language-plaintext highlighter-rouge">create</code> call will return a randomly generated <code className="language-plaintext highlighter-rouge">attendeePW</code> password for the meeting.
+    deprecated: true,
+    "description": (
+      <>
+        <p>The password that the <a href="#join">join</a> URL can later provide as its <code className="language-plaintext highlighter-rouge">password</code> parameter to indicate the user will join as a viewer.  If no <code className="language-plaintext highlighter-rouge">attendeePW</code> is provided, the <code className="language-plaintext highlighter-rouge">create</code> call will return a randomly generated <code className="language-plaintext highlighter-rouge">attendeePW</code> password for the meeting.</p>
+        <p><i>Deprecated:</i> If the <code>role</code> parameter is used on the join URL, the <code>attendeePW</code> is unused.</p>
       </>)
   },
   {
     "name": "moderatorPW",
     "type": "String",
-    "description": (<><b>[DEPRECATED]</b> The password that will <a href="#join">join</a> URL can later provide as its <code className="language-plaintext highlighter-rouge">password</code> parameter to indicate the user will as a moderator.  if no <code className="language-plaintext highlighter-rouge">moderatorPW</code> is provided, <code className="language-plaintext highlighter-rouge">create</code> will return a randomly generated <code className="language-plaintext highlighter-rouge">moderatorPW</code> password for the meeting.</>)
+    deprecated: true,
+    "description": (
+      <>
+        <p>The password that will <a href="#join">join</a> URL can later provide as its <code className="language-plaintext highlighter-rouge">password</code> parameter to indicate the user will as a moderator.  if no <code className="language-plaintext highlighter-rouge">moderatorPW</code> is provided, <code className="language-plaintext highlighter-rouge">create</code> will return a randomly generated <code className="language-plaintext highlighter-rouge">moderatorPW</code> password for the meeting.</p>
+        <p><i>Deprecated:</i> If the <code>role</code> parameter is used on the join URL, the <code>moderatorPW</code> is unused.</p>
+      </>
+    )
   },
   {
     "name": "welcome",
@@ -475,14 +489,24 @@ const createEndpointTableData = [
     "name": "allowOverrideClientSettingsOnCreateCall",
     "required": false,
     "default": "false",
-    "type": "String",
-    "description": (<> (added in BBB 3.0.0-alpha.1)</>)
+    "type": "Boolean",
+    "description": (
+      <>
+        <p>Whether to allow <a href="#clientsettingsoverride">clientSettingsOverride</a> to be included in the body of a POST request. Because the body of the post request is not signed by the <a href="#api-security-model">checksum</a>, this parameter is set to <code>false</code> by default. If you set this to <code>true</code>, you must make sure that the signed parameters of the create API request are not visible to users.</p>
+        <p><i>Added:</i> 3.0.0-alpha.1</p>
+      </>
+    )
   },
   {
     "name": "clientSettingsOverride",
     "required": false,
-    "type": "String",
-    "description": (<> The included structure will override settings.yml needed for the HTML5 client. For an example for the HTTPS POST request check <a href='/development/api#clientsettingsoverride'>clientSettingsOverride section in API</a>(added in BBB 3.0.0-alpha.5)</>)
+    "type": "JSON",
+    "description": (
+      <>
+        <p>A data structure containing settings which override values from the HTML5 client's <code>settings.yml</code> file. This data can also be provided in the body of a POST request, see <a href='#clientsettingsoverride'>clientSettingsOverride</a> for details.</p>
+        <p><i>Added:</i> 3.0.0-alpha.5</p>
+      </>
+    )
   },
   {
     "name": "allowPromoteGuestToModerator",

--- a/docs/docs/data/end.tsx
+++ b/docs/docs/data/end.tsx
@@ -9,9 +9,13 @@ const endEndpointTableData = [
   },
   {
     "name": "password",
-    "required": true,
     "type": "String",
-    "description": (<><b>[DEPRECATED]</b> The moderator password for this meeting. You can not end a meeting using the attendee password.</>)
+    deprecated: true,
+    "description": (
+      <>
+        <i>Deprecated:</i> In older BigBlueButton versions, this parameter had to be set to the moderator password for the meeting. It is no longer required.
+      </>
+    )
   }
 ];
 

--- a/docs/docs/data/getRecordings.tsx
+++ b/docs/docs/data/getRecordings.tsx
@@ -29,13 +29,16 @@ const getRecordingsEndpointTableData = [
     "name": "offset",
     "required": false,
     "type": "Integer",
-    "description": (<>The starting index for returned recordings. Number must greater than or equal to 0.</>)
+    "minimum": 0,
+    "description": (<>The starting index for returned recordings.</>)
   },
   {
     "name": "limit",
     "required": false,
     "type": "Integer",
-    "description": (<>The maximum number of recordings to be returned. Number must be between 1 and 100.</>)
+    "minimum": 1,
+    "maximum": 100,
+    "description": (<>The maximum number of recordings to be returned per request.</>)
   }
 ];
 

--- a/docs/docs/data/join.tsx
+++ b/docs/docs/data/join.tsx
@@ -17,7 +17,13 @@ const joinEndpointTableData = [
     "name": "password",
     "required": true,
     "type": "String",
-    "description": (<><b>[DEPRECATED]</b> This password value is used to determine the role of the user based on whether it matches the moderator or attendee password.  Note: This parameter is <b>not</b> required when the role parameter is passed.</>)
+    deprecated: true,
+    "description": (
+      <>
+        <p>This password value is used to determine the role of the user. It must match either the moderator or attendee password.</p>
+        <p><i>Deprecated:</i> Use the <code>role</code> parameter instead to directly set the user's role. If the <code>role</code> parameter is passed, then the <code>password</code> parameter is not required.</p>
+      </>
+    )
   },
   {
     "name": "role",
@@ -65,7 +71,13 @@ const joinEndpointTableData = [
     "name": "webcamBackgroundURL",
     "required": false,
     "type": "String",
-    "description": (<>The link for the user's webcam background to be displayed (default can be enabled/disabled and set with “useDefaultWebcamBackground“ and “defaultWebcamBackgroundURL“ in bigbluebutton.properties). Added in BigBlueButton 2.7.10.</>)
+    "description": (
+      <>
+        <p>The URL of an image to use as the user's webcam background.</p>
+        <p>Server-wide defaults can be enabled/disabled and set with <code>useDefaultWebcamBackground</code> and <code>defaultWebcamBackgroundURL</code> in <code>bigbluebutton.properties</code>.</p>
+        <p><i>Added:</i> 2.7.10</p>
+      </>
+    )
   },
   {
     "name": "redirect",

--- a/docs/docs/data/publishRecordings.tsx
+++ b/docs/docs/data/publishRecordings.tsx
@@ -10,8 +10,8 @@ const publishRecordingsEndpointTableData = [
   {
     "name": "publish",
     "required": true,
-    "type": "String",
-    "description": (<>The value for publish or unpublish the recording(s). Available values: true or false.</>)
+    "type": "Boolean",
+    "description": (<>Either <code>true</code> to publish the recording(s), or <code>false</code> to unpublish the recording(s).</>)
   }
 ];
 

--- a/docs/docs/data/sendChatMessage.tsx
+++ b/docs/docs/data/sendChatMessage.tsx
@@ -5,20 +5,32 @@ const sendChatMessageEndpointTableData = [
     "name": "meetingID",
     "required": true,
     "type": "String",
-    "description": (<>The meeting ID that identifies the meeting you are attempting to send a message.</>)
+    "description": (
+      <p>The ID of the meeting to send the chat message to.</p>
+    )
   },
   {
     "name": "message",
     "required": true,
     "type": "String",
-    "description": (<>The message you want to send to the public chat of the meeting.</>)
+    "minLength": 1,
+    "maxLength": 500,
+    "description": (
+      <>
+        <p>The contents of the chat message to send.</p>
+        <p>Any special characters included in the message will be escaped before the message is displayed. You cannot include HTML or Markdown code to format the message.</p>
+      </>
+    )
   },
   {
     "name": "userName",
     "required": false,
     "type": "String",
+    "maxLength": 255,
     "default": "System",
-    "description": (<>Optional param to set the name that will be showed as the author of the message.</>)
+    "description": (
+      <p>The name that will be shown as the sender of the chat message.</p>
+    )
   }
 ];
 

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -1223,6 +1223,8 @@ Missing parameter error
 
 This call enables you to send a message to the public chat of a running meeting.
 
+<i>Added:</i> 3.0
+
 **Resource URL:**
 
 http&#58;//yourserver.com/bigbluebutton/api/sendChatMessage?[parameters]&checksum=[checksum]

--- a/docs/src/components/APITableComponent/index.tsx
+++ b/docs/src/components/APITableComponent/index.tsx
@@ -2,35 +2,82 @@ import React from 'react';
 import styles from './styles.module.css';
 
 function TableBody({ data }): JSX.Element {
-  const rows = data.map((entry: {deprecated: Boolean; name: String; 
-    required: Boolean; description: JSX.Element; type: String; default: String;
+  const rows = data.map((entry: {
+      deprecated: Boolean;
+      name: String;
+      required: Boolean;
+      description: JSX.Element;
+      type: String;
+      default: String;
+      minLength: Number;
+      maxLength: Number;
+      minimum: Number;
+      maximum: Number;
     }) => {
-    return (<>
-      <tr>
+      let row = [];
+      /* Param Name */
+      row.push(
         <td>
-          { 
-            entry.deprecated !== undefined ?
-            <code className={styles.apiDeprecated}>{ entry.name }</code>
-            : <code>{ entry.name }</code>
-          }
-          { entry.required !== undefined ?
-            <>
-            { entry?.required === true ?
-              <p className={styles.apiRequired}>{"(required)"}</p> : null
-            }
-            </>
-          : null}
+          <code>
+            { entry.name }
+          </code>
+	  { entry.deprecated ?
+            <p className={styles.apiDeprecated}>(deprecated)</p> : null }
+          { entry.required ?
+            <p className={styles.apiRequired}>(required)</p> : null }
         </td>
-        <td>{ entry.type }</td>
+      );
+
+      /* Type */
+      let constraints = [];
+      if (entry.minLength !== undefined || entry.maxLength !== undefined) {
+        constraints.push(
+          <span>
+            { (entry.minLength !== undefined && entry.maxLength !== undefined) ?
+              <>[ {entry.minLength} .. {entry.maxLength} ] chars</>
+            : (entry.minLength !== undefined) ?
+              <>≥ {entry.minLength} chars</>
+            : (entry.maxLength !== undefined) ?
+              <>≤ {entry.maxLength} chars</>
+            : null }
+          </span>
+        );
+      }
+      if (entry.minimum !== undefined || entry.maximum !== undefined) {
+        if (constraints.length > 0) { constraints.push(<br/>) };
+        constraints.push(
+          <span>
+            { (entry.minimum !== undefined && entry.maximum !== undefined) ?
+              <>[ {entry.minimum} .. {entry.maximum} ]</>
+            : (entry.minimum !== undefined) ?
+              <>≥ {entry.minimum}</>
+            : (entry.maximum !== undefined) ?
+              <>≤ {entry.maximum}</>
+            : null }
+          </span>
+        )
+      }
+      row.push(
+        <td>
+          { entry.type }
+          { constraints.length > 0 ?
+            <p className={styles.apiConstraints}>{ constraints }</p>
+          : null }
+        </td>
+      );
+
+      /* Description */
+      row.push(
         <td>
           {entry.description}
           { entry.default !== undefined ?
             <p className={styles.apiDefault}>Default: <code>{entry.default.toString()}</code></p> : null
           }
         </td>
-      </tr>
-    </>)
-  }) 
+      );
+
+      return (<tr>{row}</tr>);
+    })
   return rows
 }
 
@@ -39,7 +86,7 @@ export default function APITableComponent({ data }): JSX.Element {
   return (
           <>
            {data ? 
-            <table className="api-params">
+            <table className={styles.apiParams}>
               <thead>
                 <tr className="header">
                   <th>Param Name</th>

--- a/docs/src/components/APITableComponent/styles.module.css
+++ b/docs/src/components/APITableComponent/styles.module.css
@@ -6,19 +6,33 @@
 	padding: 1em 5px;
 	vertical-align: top;
 }
-
-.apiDeprecated {
-	text-decoration: line-through;
+.apiParams td > :last-child {
+	margin-bottom: 0;
 }
 
 .apiRequired {
-	font-size: 0.7em;
+	font-weight: bold;
+	font-size: 0.85rem;
 	font-style: italic;
-	margin: 0;
+	margin-bottom: 0;
+}
+.apiDeprecated {
+	font-size: 0.85rem;
+	font-style: italic;
+	margin-bottom: 0;
+}
+
+.apiConstraints {
+	font-style: italic;
+	margin-bottom: 0;
 }
 
 .apiDefault {
 	font-style: italic;
-	margin-top: 20px;
+	margin-top: var(--ifm-leading);
 	margin-bottom: 0;
+}
+
+.apiConstraints span {
+	text-wrap-mode: nowrap;
 }


### PR DESCRIPTION
Improve the formatting of the API parameters table to allow specifying minimum and maximum values, as well as minimum and maximum lengths for string values. These get displayed in the "Type" column below the data type name.

Alter the appearance of required and deprecated parameters to make required parameters stand out more, and more clearly indicate deprecated parameters.

I've reformatted some of the existing parameter entries to take advantage of the new features, and added or corrected descriptions to several parameters.

Here's how the `sendChatMessage` table looks following this change:

<img src="https://github.com/user-attachments/assets/c2030c5a-9c75-4b9f-8ccd-e6b4bc5c81bc" width="958">
