### PR TITLE
fix: a series of UI adjustments and adaptations in the interaction between userdata and UI commands with the new UI.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/service.js
+++ b/bigbluebutton-html5/imports/ui/components/app/service.js
@@ -29,7 +29,7 @@ export const setDarkTheme = (value) => {
 
   if (value && !DarkReader.isEnabled()) {
     DarkReader.enable(
-      { brightness: 100, contrast: 90 },
+      { brightness: 100, contrast: 90, sepia: 0 },
       {
         invert,
         ignoreInlineStyle: [Styled.DtfCss],

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -1,5 +1,11 @@
 import styled from 'styled-components';
 import { FlexColumn } from '/imports/ui/stylesheets/styled-components/placeholders';
+import {
+  colorBackgroundDarkTheme,
+  colorOverlaysDarkTheme,
+  colorTextDarkTheme,
+  colorPrimaryDarkTheme,
+} from '/imports/ui/stylesheets/styled-components/palette';
 
 const CaptionsWrapper = styled.div`
   height: auto;
@@ -13,17 +19,32 @@ const CaptionsWrapper = styled.div`
 const Layout = styled(FlexColumn)``;
 
 const DtfInvert = `
+  :root {
+    --darkreader-bg-neutral-background: ${colorBackgroundDarkTheme};
+    --darkreader-bg--color-background: ${colorBackgroundDarkTheme};
+    --darkreader-bg--color-white: ${colorOverlaysDarkTheme};
+    --darkreader-bg--btn-default-bg: ${colorOverlaysDarkTheme};
+    --darkreader-text--btn-default-color: ${colorTextDarkTheme};
+    --darkreader-text--color-gray-light: ${colorTextDarkTheme};
+    --darkreader-text--color-text: ${colorTextDarkTheme};
+    --darkreader-text--color-gray: ${colorTextDarkTheme};
+    --darkreader-text--color-white: ${colorTextDarkTheme};
+    --darkreader-text--color-gray-dark: ${colorTextDarkTheme};
+    --darkreader-bg--color-primary: ${colorPrimaryDarkTheme};
+    --darkreader-text--color-primary: ${colorPrimaryDarkTheme};
+    --darkreader-bg--item-focus-border: ${colorPrimaryDarkTheme};
+  }
   body {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg-neutral-background) !important;
   }
   header[id="Navbar"] {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg-neutral-background) !important;
   }
   section[id="ActionsBar"] {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg-neutral-background) !important;
   }
   div[id="app"] {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg-neutral-background) !important;
   }
   select {
     border: 0.1rem solid #FFFFFF !important;
@@ -32,7 +53,7 @@ const DtfInvert = `
     border: unset !important;
   }
   div[data-test="presentationContainer"] {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg-neutral-background) !important;
   }
   select {
     border-top: unset !important;
@@ -54,7 +75,7 @@ const DtfInvert = `
     background: var(--darkreader-border--color-selected) !important;
   }
   div[id="cameraDock"] {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg-neutral-background) !important;
   }
   .bnjzQC > div span div:hover {
     background-color: var(--darkreader-selection-background) !important;
@@ -67,6 +88,18 @@ const DtfInvert = `
   }
   #connectionBars > div {
     background-color: var(--darkreader-neutral-text) !important;
+  }
+  div[id^="layout"] {
+    background-color: var(--darkreader-bg-neutral-background) !important;
+  }
+  div[id^="scroll-box"],
+  div[id^="chat-list"],
+  div[id^="breakoutBox"] {
+    background-image: 
+      linear-gradient(rgb(45 47 56 / 0%) 30%, rgba(34, 36, 37, 0)),
+      linear-gradient(rgba(34, 36, 37, 0), rgb(45 47 56 / 0%) 70%),
+      radial-gradient(farthest-side at 50% 0px, rgba(13, 13, 13, 0.2), rgba(13, 13, 13, 0)),
+      radial-gradient(farthest-side at 50% 100%, rgba(13, 13, 13, 0.2), rgba(13, 13, 13, 0));
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -20,19 +20,20 @@ const Layout = styled(FlexColumn)``;
 
 const DtfInvert = `
   :root {
-    --darkreader-bg-neutral-background: ${colorBackgroundDarkTheme};
-    --darkreader-bg--color-background: ${colorBackgroundDarkTheme};
-    --darkreader-bg--color-white: ${colorOverlaysDarkTheme};
-    --darkreader-bg--btn-default-bg: ${colorOverlaysDarkTheme};
-    --darkreader-text--btn-default-color: ${colorTextDarkTheme};
-    --darkreader-text--color-gray-light: ${colorTextDarkTheme};
-    --darkreader-text--color-text: ${colorTextDarkTheme};
-    --darkreader-text--color-gray: ${colorTextDarkTheme};
-    --darkreader-text--color-white: ${colorTextDarkTheme};
-    --darkreader-text--color-gray-dark: ${colorTextDarkTheme};
-    --darkreader-bg--color-primary: ${colorPrimaryDarkTheme};
-    --darkreader-text--color-primary: ${colorPrimaryDarkTheme};
-    --darkreader-bg--item-focus-border: ${colorPrimaryDarkTheme};
+    --darkreader-bg-neutral-background: ${colorBackgroundDarkTheme} !important;
+    --darkreader-bg--color-background: ${colorBackgroundDarkTheme} !important;
+    --darkreader-bg--color-white: ${colorOverlaysDarkTheme} !important;
+    --darkreader-bg--btn-default-bg: ${colorOverlaysDarkTheme} !important;
+    --darkreader-text--btn-default-color: ${colorTextDarkTheme} !important;
+    --darkreader-text--color-gray-light: ${colorTextDarkTheme} !important;
+    --darkreader-text--color-text: ${colorTextDarkTheme} !important;
+    --darkreader-text--color-gray: ${colorTextDarkTheme} !important;
+    --darkreader-text--color-white: ${colorTextDarkTheme} !important;
+    --darkreader-text--color-gray-dark: ${colorTextDarkTheme} !important;
+    --darkreader-bg--color-primary: ${colorPrimaryDarkTheme} !important;
+    --darkreader-text--color-primary: ${colorPrimaryDarkTheme} !important;
+    --darkreader-bg--item-focus-border: ${colorPrimaryDarkTheme} !important;
+  }
   }
   body {
     background-color: var(--darkreader-bg-neutral-background) !important;
@@ -100,6 +101,12 @@ const DtfInvert = `
       linear-gradient(rgba(34, 36, 37, 0), rgb(45 47 56 / 0%) 70%),
       radial-gradient(farthest-side at 50% 0px, rgba(13, 13, 13, 0.2), rgba(13, 13, 13, 0)),
       radial-gradient(farthest-side at 50% 100%, rgba(13, 13, 13, 0.2), rgba(13, 13, 13, 0));
+  }
+  button[data-test="increaseFontSize"],
+  button[data-test="decreaseFontSize"] {
+    & > span > i {
+      color: var(--darkreader-text--btn-default-color) !important;
+    }
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -146,7 +146,9 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
         </Styled.BoldText>
         {intl.formatMessage(intlMessages.pinnedAppsContinue)}
       </Styled.DescWrapper>
-      <Styled.Wrapper>
+      <Styled.Wrapper
+        id="scroll-box"
+      >
         {renderedPinnedApps.length > 0 && (
           <Styled.PinnedAppsWrapper>
             {renderedPinnedApps}

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -7,6 +7,7 @@ import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import Styled from './styles';
 import TooManyPinnedAppsModal from './modal/component';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 
 const intlMessages = defineMessages({
   appsGalleryTitle: {
@@ -24,6 +25,14 @@ const intlMessages = defineMessages({
   pinnedAppsContinue: {
     id: 'app.appsGallery.maxpinnedAppsContinue',
     description: 'Last part of warning about pinned apps',
+  },
+  pinTooltip: {
+    id: 'app.appsGallery.pinTooltip',
+    description: 'Tooltip of the pin button',
+  },
+  unpinTooltip: {
+    id: 'app.appsGallery.unpinTooltip',
+    description: 'Tooltip of the unpin buuton',
   },
 });
 
@@ -61,7 +70,9 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
       });
     };
     return (
-      <Styled.RegisteredAppContent>
+      <Styled.RegisteredAppContent
+        key={`${appKey}${isPinned}`}
+      >
         <Styled.ClickableArea
           onClick={openAppPanel}
         >
@@ -71,22 +82,27 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
             type="button"
             onClick={openAppPanel}
             icon={icon}
-            pinned={isPinned}
+            $pinned={isPinned}
           />
           <Styled.AppTitle>
             {name}
           </Styled.AppTitle>
         </Styled.ClickableArea>
-        <Styled.PinApp
-          key={`PIN${appKey}`}
-          role="button"
-          onClick={togglePinApp}
-          onKeyDown={togglePinApp}
-          tabIndex={0}
-          pinned={isPinned}
+        <TooltipContainer
+          title={isPinned
+            ? intl.formatMessage(intlMessages.unpinTooltip)
+            : intl.formatMessage(intlMessages.pinTooltip)}
         >
-          <Icon iconName={isPinned ? 'pin-video_on' : 'pin-video_off'} />
-        </Styled.PinApp>
+          <Styled.PinApp
+            role="button"
+            onClick={togglePinApp}
+            onKeyDown={togglePinApp}
+            tabIndex={0}
+            pinned={isPinned}
+          >
+            <Icon iconName={isPinned ? 'pin-video_on' : 'pin-video_off'} />
+          </Styled.PinApp>
+        </TooltipContainer>
       </Styled.RegisteredAppContent>
     );
   };

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -66,11 +66,11 @@ const RegisteredAppContent = styled.div`
 `;
 
 // @ts-expect-error -> Untyped component.
-const OpenButton = styled(Button)<{pinned: boolean}>`
+const OpenButton = styled(Button)<{$pinned: boolean}>`
   padding: ${$2xlPadding};
   border-radius: ${appsButtonsBorderRadius} 0px 0px ${appsButtonsBorderRadius};
   
-  ${({ pinned }) => (pinned ? `
+  ${({ $pinned }) => ($pinned ? `
     background-color: ${colorPrimary};
     color: ${colorWhite};
   ` : `

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -5,6 +5,7 @@ import {
   appsGalleryOutlineColor,
   unpinnedAppIconColor,
   colorWhite,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import Button from '/imports/ui/components/common/button/component';
 import { titlesFontWeight, headingsFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
@@ -58,9 +59,9 @@ const RegisteredAppContent = styled.div`
   flex-direction: row;
   flex-grow: 1;
   border-radius: ${appsButtonsBorderRadius};
-  border-top: 1px solid ${appsGalleryOutlineColor};
-  border-right: 1px solid ${appsGalleryOutlineColor};
-  border-bottom: 1px solid ${appsGalleryOutlineColor};
+  border-top: 1px solid ${colorBorder};
+  border-right: 1px solid ${colorBorder};
+  border-bottom: 1px solid ${colorBorder};
   align-items: center;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
@@ -211,7 +211,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
         )}
       />
       <Styled.Separator />
-      <Styled.Content>
+      <Styled.Content id="scroll-box">
         <TimeRemaingPanel
           showChangeTimeForm={showChangeTimeForm}
           isModerator={isModerator}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -556,7 +556,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         customRightButton={null}
       />
       <Styled.PanelSeparator />
-      <Styled.Content>
+      <Styled.Content id="scroll-box">
         <Styled.TitleWrapper>
           {title}
           {form}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-offline-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/chat-offline-indicator/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colorText, colorGrayLighter } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorText, colorBorder } from '/imports/ui/stylesheets/styled-components/palette';
 
 export const ChatOfflineIndicator = styled.div`
   display: flex;
@@ -10,7 +10,7 @@ export const ChatOfflineIndicator = styled.div`
   margin-top: 0.2rem;
   padding: 0.5rem;
   border-radius: 2px;
-  border-top: 1px solid ${colorGrayLighter};
+  border-top: 1px solid ${colorBorder};
   & > span {
     color: ${colorText};
     font-size: 1rem;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -2,9 +2,10 @@ import styled from 'styled-components';
 import {
   colorText,
   colorGrayLighter,
+  colorGrayLight,
   colorDanger,
   colorGrayDark,
-  colorGrayLightest,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPaddingX,
@@ -42,7 +43,7 @@ const Input = styled(TextareaAutosize)`
   background: #fff;
   background-clip: padding-box;
   margin: ${xsPadding} 0 ${xsPadding} ${xsPadding};
-  color: ${colorGrayLighter};
+  color: ${colorGrayLight};
   -webkit-appearance: none;
   padding: calc(${smPaddingY} * 2.5) 0 calc(${smPaddingX} * 1.25) calc(${smPaddingY} * 2.5);
   resize: none;
@@ -53,7 +54,7 @@ const Input = styled(TextareaAutosize)`
   min-height: 2.5rem;
   max-height: 3.5rem;
   overflow-y: auto;
-  border: ${colorGrayLightest};
+  border: ${colorBorder};
   box-shadow: none;
   outline: none;
 
@@ -137,7 +138,7 @@ position: absolute;
 bottom: calc(100% + 0.5rem);
 left: 0;
 right: 0;
-border: 1px solid ${colorGrayLighter};
+border: 1px solid ${colorBorder};
 border-radius: ${borderRadius};
 box-shadow: 0 2px 10px rgba(0,0,0,0.1);
 z-index: 1000;
@@ -182,10 +183,10 @@ const InputWrapper = styled.div`
   min-width: 0;
   z-index: 0;
   border-radius: 0.75rem;
-  border: 1px solid ${colorGrayLighter};
+  border: 1px solid ${colorBorder};
 
   &:focus-within {
-    box-shadow: 0 0 0 ${xsPadding} ${colorGrayLighter};
+    box-shadow: 0 0 0 ${xsPadding} ${colorBorder};
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/styles.ts
@@ -25,6 +25,8 @@ export const UnreadButton = styled(ButtonElipsis)`
 
 export const Wrapper = styled.div`
   flex-flow: column;
+  flex-grow: 1;
+  flex-shrink: 1;
   overflow: hidden auto;
   display: flex;
   height: 100%;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -128,7 +128,9 @@ const Chat: React.FC<ChatProps> = ({
     <>
       <ChatHeader />
       <Styled.Separator />
-      <Styled.ContentWrapper>
+      <Styled.ContentWrapper
+        id="scroll-box"
+      >
         {filteredPrivateChats.length > 0 ? (
           <Styled.ButtonsWrapper>
             <Button

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-back-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-back-button/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import {
-  colorGrayLighter,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Form = styled.div`
@@ -19,7 +19,7 @@ const ArrowWrapper = styled.div`
   border-left: 1px solid transparent;
   border-top: 1px solid transparent;
   border-bottom: 1px solid transparent;
-  border-right: 1px solid ${colorGrayLighter};
+  border-right: 1px solid ${colorBorder};
   color: #1976D2;
   padding: 8px;
   cursor: pointer;
@@ -30,7 +30,7 @@ const InputWrapper = styled.div`
   align-items: center;
   border-radius: 0.75rem;
   cursor: pointer;
-  border: 1px solid ${colorGrayLighter};
+  border: 1px solid ${colorBorder};
   background-color: #fff;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import {
   colorGray,
-  colorGrayLighter,
+  colorBorder,
   colorPrimary,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
@@ -33,7 +33,7 @@ const Separator = styled.hr`
   margin: 1rem auto;
   width: 2.2rem;
   border: 0;
-  border-top: 1px solid ${colorGrayLighter};
+  border-top: 1px solid ${colorBorder};
 `;
 
 const MessagesTitle = styled.h2`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
@@ -25,8 +25,8 @@ const ContentWrapper = styled.div`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  height: inherit;
   gap: ${contentSidebarPadding};
+  overflow: hidden;
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -426,6 +426,7 @@ class ConnectionStatusComponent extends PureComponent {
 
     return (
       <Styled.NetworkDataContainer
+        id="scroll-box"
         data-test="networkDataContainer"
         tabIndex={0}
       >

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/styles.js
@@ -8,6 +8,7 @@ import {
   colorWhite,
   btnPrimaryActiveBg,
   colorDanger,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPaddingX,
@@ -179,7 +180,7 @@ const CopyContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   border: none;
-  border-top: 1px solid ${colorOffWhite};
+  border-top: 1px solid ${colorBorder};
   padding: ${mdPaddingX} 0 0 0;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
@@ -1,5 +1,14 @@
 import { LAYOUT_TYPE, CAMERADOCK_POSITION, PANELS } from './enums';
 
+export const SIDEBAR_NAVIGATION_PANEL_WIDTH = 60; // px
+export const SIDEBAR_NAVIGATION_MARGIN = 24; // px
+export const SIDEBAR_CONTENT_PANEL_MIN_HEIGHT = 300; // px
+export const SIDEBAR_CONTENT_VERTICAL_MARGIN = 72; // px
+export const SIDEBAR_CONTENT_PANEL_MIN_WIDTH = 70; // px
+export const SIDEBAR_CONTENT_PANEL_MAX_WIDTH = 800; // px
+export const SIDEBAR_CONTENT_MARGIN_TO_MEDIA = 48; // px
+export const SIDEBAR_NAVIGATION_MARGIN_TO_THE_EDGE_MOBILE = 16; // px
+
 const DEFAULT_VALUES = {
   layoutType: LAYOUT_TYPE.CUSTOM_LAYOUT,
   panelType: 'chat',
@@ -26,20 +35,20 @@ const DEFAULT_VALUES = {
   actionBarPadding: 11.2,
   actionBarTabOrder: 6,
 
-  sidebarNavWidth: 60,
-  sidebarNavWidthMobile: 48,
-  sidebarNavHeightPercentage: 0.97,
+  sidebarNavWidth: SIDEBAR_NAVIGATION_PANEL_WIDTH
+    + (2 * SIDEBAR_NAVIGATION_MARGIN),
+  sidebarNavWidthMobile: 48, // px
+  sidebarNavMarginToTheEdgeMobile: 16, // px
+  sidebarNavHeightPercentage: 1,
   sidebarNavHeightPercentageMobile: 0.80,
-  sidebarNavHorizontalMargin: 24, // px
-  sidebarNavHorizontalMarginMobile: 5, // px
   sidebarNavTop: 0,
   sidebarNavLeft: 0,
   sidebarNavTabOrder: 1,
 
-  sidebarContentMaxWidth: 800,
-  sidebarContentMinWidth: 70,
-  sidebarContentMinHeight: 200,
-  sidebarContentHeight: '100%',
+  sidebarContentMaxWidth: SIDEBAR_CONTENT_PANEL_MAX_WIDTH + SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+  sidebarContentMinWidth: SIDEBAR_CONTENT_PANEL_MIN_WIDTH + SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+  sidebarContentMinHeight: SIDEBAR_CONTENT_PANEL_MIN_HEIGHT
+    + (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
   sidebarContentTop: 0,
   sidebarContentTabOrder: 2,
   sidebarContentPanel: PANELS.NONE,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { throttle } from '/imports/utils/throttle';
 import { layoutSelect, layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA } from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import { ACTIONS, CAMERADOCK_POSITION, PANELS } from '../enums';
 import Storage from '/imports/ui/services/storage/session';
@@ -257,6 +257,9 @@ const CustomLayout = (props) => {
     const hasPresentation = isPresentationEnabled && slidesLength !== 0;
     const isGeneralMediaOff = !hasPresentation && !hasExternalVideo
       && !hasScreenShare && !isSharedNotesPinned && !genericContentId;
+    const {
+      sidebarContentMinHeight,
+    } = DEFAULT_VALUES;
 
     let sidebarContentHeight = 0;
     if (sidebarContentInput.isOpen) {
@@ -274,7 +277,11 @@ const CustomLayout = (props) => {
       }
       sidebarContentHeight -= bannerAreaHeight();
     }
-    return sidebarContentHeight;
+    return {
+      height: sidebarContentHeight,
+      minHeight: sidebarContentMinHeight,
+      maxHeight: sidebarContentHeight,
+    };
   };
 
   const calculatesCameraDockBounds = (sidebarNavWidth, sidebarContentWidth, mediaAreaBounds) => {
@@ -294,6 +301,7 @@ const CustomLayout = (props) => {
       cameraDockMinWidth,
       navBarHeight,
       presentationToolbarMinWidth,
+      sidebarContentMinHeight,
     } = DEFAULT_VALUES;
 
     const cameraDockBounds = {};
@@ -320,7 +328,9 @@ const CustomLayout = (props) => {
         cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_BOTTOM;
 
       Storage.setItem('webcamSize', {
-        width: isCameraTopOrBottom || isCameraSidebar ? lastWidth : cameraDockInput.width,
+        width: isCameraTopOrBottom || (
+          isCameraSidebar ? lastWidth : cameraDockInput.width - SIDEBAR_CONTENT_MARGIN_TO_MEDIA
+        ),
         height: isCameraTopOrBottom || isCameraSidebar ? cameraDockInput.height : lastHeight,
       });
 
@@ -420,7 +430,7 @@ const CustomLayout = (props) => {
       cameraDockBounds.maxWidth = sidebarContentWidth;
       cameraDockBounds.minHeight = cameraDockMinHeight;
       cameraDockBounds.height = cameraDockHeight;
-      cameraDockBounds.maxHeight = windowHeight() * 0.8;
+      cameraDockBounds.maxHeight = windowHeight() - sidebarContentMinHeight;
     }
     return cameraDockBounds;
   };
@@ -571,7 +581,11 @@ const CustomLayout = (props) => {
       sidebarContentWidth.width,
       cameraDockBounds,
     );
-    const sidebarContentHeight = calculatesSidebarContentHeight(cameraDockBounds.height);
+    const {
+      height: sidebarContentHeight,
+      minHeight: sidebarContentMinHeight,
+      maxHeight: sidebarContentMaxHeight,
+    } = calculatesSidebarContentHeight(cameraDockBounds.height);
     const mediaBounds = calculatesMediaBounds(
       sidebarNavWidth.horizontalSpaceOccupied,
       sidebarContentWidth.width,
@@ -649,6 +663,8 @@ const CustomLayout = (props) => {
         width: sidebarContentWidth.width,
         maxWidth: sidebarContentWidth.maxWidth,
         height: sidebarContentHeight,
+        minHeight: sidebarContentMinHeight,
+        maxHeight: sidebarContentMaxHeight,
         top: sidebarContentBounds.top,
         left: sidebarContentBounds.left,
         right: sidebarContentBounds.right,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -185,7 +185,6 @@ const LayoutEngine = () => {
     const {
       sidebarNavWidth,
       sidebarNavWidthMobile,
-      sidebarNavHorizontalMargin,
     } = DEFAULT_VALUES;
 
     const { isOpen } = sidebarNavigationInput;
@@ -201,7 +200,7 @@ const LayoutEngine = () => {
         horizontalSpaceOccupied = 0;
       } else {
         width = sidebarNavWidth;
-        horizontalSpaceOccupied = sidebarNavWidth + (2 * sidebarNavHorizontalMargin);
+        horizontalSpaceOccupied = sidebarNavWidth;
       }
     }
     return {
@@ -235,24 +234,22 @@ const LayoutEngine = () => {
 
   const calculatesSidebarNavBounds = (sidebarNavHeight) => {
     const {
-      sidebarNavLeft,
-      sidebarNavHorizontalMargin,
-      sidebarNavHorizontalMarginMobile,
+      sidebarNavMarginToTheEdgeMobile,
     } = DEFAULT_VALUES;
 
-    let offset = bannerAreaHeight();
-    let horizontalPlacement = sidebarNavLeft + sidebarNavHorizontalMargin;
-    if (isMobile) {
-      offset = 0;
-      horizontalPlacement = sidebarNavLeft + sidebarNavHorizontalMarginMobile;
+    let left = null;
+    let right = null;
+    if (isRTL) {
+      right = isMobile ? sidebarNavMarginToTheEdgeMobile : 0;
+    } else {
+      left = isMobile ? sidebarNavMarginToTheEdgeMobile : 0;
     }
-    const remainingVerticalEmptySpace = windowHeight() - offset - sidebarNavHeight;
 
     return {
-      top: offset + (remainingVerticalEmptySpace / 2),
-      left: !isRTL ? horizontalPlacement : null,
-      right: isRTL ? horizontalPlacement : null,
-      zIndex: isMobile ? 11 : 2,
+      top: isMobile ? (windowHeight() - sidebarNavHeight) / 2 : bannerAreaHeight(),
+      left,
+      right,
+      zIndex: isMobile ? 12 : 2,
     };
   };
 
@@ -294,9 +291,9 @@ const LayoutEngine = () => {
   };
 
   const calculatesSidebarContentBounds = (sidebarNavWidth) => {
-    const { navBarHeight, sidebarNavTop } = DEFAULT_VALUES;
+    const { navBarHeight } = DEFAULT_VALUES;
 
-    let top = sidebarNavTop + bannerAreaHeight();
+    let top = bannerAreaHeight();
 
     if (isMobile) top = navBarHeight + bannerAreaHeight();
 

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -222,44 +222,37 @@ const LayoutObserver: React.FC = () => {
         const Settings = getSettingsSingletonInstance();
         Settings.save(setLocalSettings);
 
-        if (getFromUserSettings('bbb_show_participants_on_login', window.meetingClientSettings.public.layout.showParticipantsOnLogin) && !deviceInfo.isPhone) {
-          if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
-            const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+          value: true,
+        });
 
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-              value: true,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-              value: true,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-              value: PANELS.CHAT,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_ID_CHAT_OPEN,
-              value: PUBLIC_CHAT_ID,
-            });
-          } else {
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-              value: true,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-              value: false,
-            });
-          }
-        } else {
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-            value: false,
-          });
+        if (getFromUserSettings('bbb_show_participants_on_login', window.meetingClientSettings.public.layout.showParticipantsOnLogin)
+          && !deviceInfo.isPhone) {
           layoutContextDispatch({
             type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-            value: false,
+            value: true,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+            value: PANELS.USERLIST,
+          });
+        }
+
+        if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
+          const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
+
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+            value: true,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+            value: PANELS.CHAT,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_ID_CHAT_OPEN,
+            value: PUBLIC_CHAT_ID,
           });
         }
 

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -101,7 +101,6 @@ const PushLayoutEngine = (props) => {
     setMeetingLayout,
     setPushLayout,
     hasMeetingLayout,
-    isChatEnabled,
   } = props;
 
   useEffect(() => {
@@ -126,10 +125,8 @@ const PushLayoutEngine = (props) => {
     Settings.save(setLocalSettings);
 
     const HIDE_PRESENTATION = window.meetingClientSettings.public.layout.hidePresentationOnJoin;
-    const HIDE_CHAT = window.meetingClientSettings.public.chat.startClosed;
 
     const shouldOpenPresentation = shouldShowScreenshare || shouldShowExternalVideo;
-    const shouldOpenChat = isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !HIDE_CHAT);
     let presentationLastState = !getFromUserSettings('bbb_hide_presentation_on_join', HIDE_PRESENTATION);
     presentationLastState = pushLayoutMeeting ? meetingPresentationIsOpen : presentationLastState;
     presentationLastState = shouldOpenPresentation || presentationLastState;
@@ -147,16 +144,7 @@ const PushLayoutEngine = (props) => {
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
           value: meetingLayoutCameraPosition || 'contentTop',
         });
-        if (shouldOpenChat) {
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-            value: true,
-          });
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-            value: PANELS.CHAT,
-          });
-        }
+
         if (!equalDouble(meetingLayoutVideoRate, 0)) {
           let w; let h;
           if (horizontalPosition) {

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.js
@@ -8,7 +8,12 @@ import {
   mdPaddingX,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { fontSizeBase, fontSizeSmall } from '/imports/ui/stylesheets/styled-components/typography';
-import { colorGray, colorGrayLabel, colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  colorGray,
+  colorGrayLabel,
+  colorPrimary,
+  colorBorder,
+} from '/imports/ui/stylesheets/styled-components/palette';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 import Button from '/imports/ui/components/common/button/component';
 
@@ -27,8 +32,8 @@ const LockViewersModal = styled(ModalSimple)`
 
 const Container = styled.div`
   padding: 1.14rem 2.25rem 1.14rem;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+  border-top: 1px solid ${colorBorder};
+  border-bottom: 1px solid ${colorBorder};
   gap: 1rem;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -223,26 +223,9 @@ class NavBar extends Component {
   handleToggleUserList() {
     const {
       sidebarNavigation,
-      sidebarContent,
       layoutContextDispatch,
     } = this.props;
 
-    if (sidebarNavigation.isOpen) {
-      if (sidebarContent.isOpen) {
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-          value: false,
-        });
-        layoutContextDispatch({
-          type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-          value: PANELS.NONE,
-        });
-        layoutContextDispatch({
-          type: ACTIONS.SET_ID_CHAT_OPEN,
-          value: '',
-        });
-      }
-    }
     layoutContextDispatch({
       type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
       value: !sidebarNavigation.isOpen,

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -97,7 +97,7 @@ const NotificationsBarContainer = () => {
     }
   }, [data.message, hasNotification]);
 
-  if (isEmpty(data.message)) {
+  if (isEmpty(data.message) || !hasNotification) {
     return null;
   }
 

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import {
   colorGray,
-  colorGrayLightest,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Wrapper = styled.div`
@@ -43,8 +43,8 @@ white-space: normal;
 const Iframe = styled.iframe`
   border-width: 0;
   width: 100%;
-  border-top: 1px solid ${colorGrayLightest};
-  border-bottom: 1px solid ${colorGrayLightest};
+  border-top: 1px solid ${colorBorder};
+  border-bottom: 1px solid ${colorBorder};
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-options-container/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-options-container/handler.tsx
@@ -2,32 +2,19 @@ import { useEffect } from 'react';
 import {
   SidekickOptionsContainerEnum,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-options-container/enums';
-import { layoutDispatch } from '../../../layout/context';
-import { PANELS, ACTIONS } from '../../../layout/enums';
+import logger from '/imports/startup/client/logger';
 
 const PluginSidekickOptionsContainerUiCommandsHandler = () => {
-  const layoutContextDispatch = layoutDispatch();
-
   const handleSidekickOptionsContainerOpen = () => {
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-      value: true,
-    });
+    logger.info({
+      logCode: 'navigation_open_called_by_plugin',
+    }, 'Plugin tried to open the navigation sidebar. Intentionally ignored.');
   };
 
   const handleSidekickOptionsContainerClose = () => {
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-      value: false,
-    });
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-      value: PANELS.NONE,
-    });
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-      value: false,
-    });
+    logger.info({
+      logCode: 'navigation_close_called_by_plugin',
+    }, 'Plugin tried to close the navigation sidebar. Intentionally ignored.');
   };
 
   useEffect(() => {
@@ -35,8 +22,8 @@ const PluginSidekickOptionsContainerUiCommandsHandler = () => {
     window.addEventListener(SidekickOptionsContainerEnum.CLOSE, handleSidekickOptionsContainerClose);
 
     return () => {
-      window.addEventListener(SidekickOptionsContainerEnum.OPEN, handleSidekickOptionsContainerOpen);
-      window.addEventListener(SidekickOptionsContainerEnum.OPEN, handleSidekickOptionsContainerClose);
+      window.removeEventListener(SidekickOptionsContainerEnum.OPEN, handleSidekickOptionsContainerOpen);
+      window.removeEventListener(SidekickOptionsContainerEnum.CLOSE, handleSidekickOptionsContainerClose);
     };
   }, []);
   return null;

--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -510,7 +510,9 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
         customRightButton={null}
       />
       <Styled.Separator />
-      <Styled.ContentWrapper>
+      <Styled.ContentWrapper
+        id="scroll-box"
+      >
         {pollOptions()}
         <span className="sr-only" id="poll-config-button">{intl.formatMessage(intlMessages.showRespDesc)}</span>
         <span className="sr-only" id="add-item-button">{intl.formatMessage(intlMessages.addRespDesc)}</span>

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -761,6 +761,7 @@ class Presentation extends PureComponent {
       userIsPresenter,
       currentSlide,
       slidePosition,
+      isRTL,
       presentationBounds,
       fullscreenContext,
       isMobile,
@@ -835,7 +836,7 @@ class Presentation extends PureComponent {
     const presentationZIndex = fullscreenContext ? presentationBounds.zIndex : undefined;
 
     const APP_CRASH_METADATA = { logCode: 'whiteboard_crash', logMessage: 'Possible whiteboard crash' };
-  if (!presentationIsOpen) return null;
+    if (!presentationIsOpen) return null;
     return (
       <>
         <Styled.PresentationContainer
@@ -844,6 +845,8 @@ class Presentation extends PureComponent {
           ref={(ref) => {
             this.refPresentationContainer = ref;
           }}
+          isRTL={isRTL}
+          isVideoFocus={isVideoFocus}
           style={{
             top: presentationBounds.top,
             left: presentationBounds.left,
@@ -974,6 +977,7 @@ Presentation.propTypes = {
   presentationIsOpen: PropTypes.bool,
   totalPages: PropTypes.number.isRequired,
   publishedPoll: PropTypes.bool.isRequired,
+  isRTL: PropTypes.bool.isRequired,
   presentationBounds: PropTypes.shape({
     top: PropTypes.number,
     left: PropTypes.number,

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -202,6 +202,7 @@ const PresentationContainer = (props) => {
   }
 
   const cameraDock = layoutSelectInput((i) => i.cameraDock);
+  const isRTL = layoutSelect((i) => i.isRTL);
   const presentation = layoutSelectOutput((i) => i.presentation);
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const deviceType = layoutSelect((i) => i.deviceType);
@@ -236,6 +237,7 @@ const PresentationContainer = (props) => {
           numCameras,
           ...props,
           userIsPresenter,
+          isRTL,
           presentationBounds: presentation,
           fullscreenContext,
           fullscreenElementId,

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.js
@@ -4,6 +4,7 @@ import {
   toastIconSide,
   smPaddingX,
   smPaddingY,
+  contentSidebarMarginToMedia,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
   colorPrimary,
@@ -127,6 +128,8 @@ const PresentationContainer = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
+  ${({ isVideoFocus, isRTL }) => isVideoFocus && isRTL && `padding: 0px 0px 0px ${contentSidebarMarginToMedia}`};
+  ${({ isVideoFocus, isRTL }) => isVideoFocus && !isRTL && `padding: 0px ${contentSidebarMarginToMedia} 0px 0px`};
 `;
 
 const Presentation = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css, keyframes } from 'styled-components';
 import {
-  colorWhite, colorText, colorPrimary, colorGrayLightest, colorGrayLighter,
-  colorGrayDark, colorLink, listItemBgHover,
+  colorWhite, colorText, colorPrimary,
+  colorGrayDark, colorLink, listItemBgHover, colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPadding,
@@ -168,7 +168,7 @@ const UserPresenceContainer = styled.div`
   align-items: center;
   gap: 1rem;
   border-radius: 1rem;
-  border: 1px solid ${colorGrayLighter};
+  border: 1px solid ${colorBorder};
 `;
 
 const UserPresenceButton = styled(SimpleButton)<{ active?: boolean }>`
@@ -198,13 +198,13 @@ const UserPresenceText = styled.div`
 const UserPresenceDivider = styled.div`
   width: 0.0625rem;
   height: 2.5rem;
-  background: ${colorGrayLightest};
+  background: ${colorBorder};
 `;
 
 const Separator = styled.hr`
   width: 100%;
   border: 0;
-  border-bottom: 1px solid ${colorGrayLightest};
+  border-bottom: 1px solid ${colorBorder};
 `;
 
 const DevicesSettingsContainer = styled.div`
@@ -352,7 +352,7 @@ const BrightnessSlider = styled(Slider)`
 const VirtualBgSelectorBorder = styled.div`
   width: 100%;
   border-radius: 0.25rem;
-  border: 1px solid ${colorGrayLightest};
+  border: 1px solid ${colorBorder};
 `;
 
 const CaptionsContainer = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/settings/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/styles.js
@@ -8,6 +8,7 @@ import {
   colorPrimary,
   colorText,
   settingsModalTabSelected,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { fontSizeLarge } from '/imports/ui/stylesheets/styled-components/typography';
 import {
@@ -41,8 +42,8 @@ const SettingsTabList = styled(TabList)`
   display: flex;
   flex-flow: column;
   margin: 0;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+  border-top: 1px solid ${colorBorder};
+  border-bottom: 1px solid ${colorBorder};
   padding: 0;
   width: calc(100% / 3);
   height: 39rem;
@@ -110,9 +111,9 @@ const SettingsTabPanel = styled(TabPanel)`
   display: none;
   flex-grow: 1;
   padding: 1.5rem 3rem;
-  border-top: 1px solid #ddd;
-  border-left: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
+  border-top: 1px solid ${colorBorder};
+  border-left: 1px solid ${colorBorder};
+  border-bottom: 1px solid ${colorBorder};
   width: calc(100% / 3 * 2);
 
   [dir="rtl"] & {
@@ -136,7 +137,7 @@ const ActionsContainer = styled.div`
   justify-content: flex-end;
   gap: 1.5rem;
   padding: 1.5rem;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid ${colorBorder};
 `;
 
 const ActionButton = styled.button`

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
@@ -3,7 +3,7 @@ import {
   colorGrayLabel,
   colorPrimary,
   colorWhite,
-  colorGrayLighter,
+  colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { borderSize, borderSizeLarge, lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
 import SpinnerStyles from '/imports/ui/components/common/loading-screen/styles';
@@ -67,7 +67,7 @@ const Bounce2 = styled(SpinnerStyles.Bounce2)``;
 
 const Separator = styled.hr`
   margin: 2.5rem 0;
-  border: 1px solid ${colorGrayLighter};
+  border: 1px solid ${colorBorder};
   opacity: 0.25;
 `;
 
@@ -93,7 +93,7 @@ const LocalesDropdownSelect = styled.div`
 
   & > select {
     background-color: ${colorWhite};
-    border: ${borderSize} solid ${colorGrayLighter};
+    border: ${borderSize} solid ${colorBorder};
     border-radius: ${lgBorderRadius};  
     color: ${colorGrayLabel};
     width: 100%;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Resizable from 're-resizable';
-import { ACTIONS, PANELS } from '../layout/enums';
+import { ACTIONS, DEVICE_TYPE, PANELS } from '../layout/enums';
 import ChatContainer from '/imports/ui/components/chat/chat-graphql/component';
 import ProfileSettings from '/imports/ui/components/profile-settings/component';
 import NotesContainer from '/imports/ui/components/notes/component';
@@ -17,19 +17,23 @@ import browserInfo from '/imports/utils/browserInfo';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import { SidebarContentProps } from './types';
+import {
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+  SIDEBAR_CONTENT_VERTICAL_MARGIN,
+} from '/imports/ui/components/layout/defaultValues';
 
 const SidebarContent = (props: SidebarContentProps) => {
   const {
     top,
     left = undefined,
     right = undefined,
+    zIndex,
     minWidth,
     width,
     maxWidth,
     minHeight,
     height,
     maxHeight,
-    zIndex,
     isResizable,
     resizableEdge,
     contextDispatch,
@@ -43,6 +47,8 @@ const SidebarContent = (props: SidebarContentProps) => {
   const [resizeStartWidth, setResizeStartWidth] = useState(0);
   const [resizeStartHeight, setResizeStartHeight] = useState(0);
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
+  const deviceType = layoutSelect((i: Layout) => i.deviceType);
+  const isMobile = deviceType === DEVICE_TYPE.MOBILE;
 
   useEffect(() => {
     if (!isResizing) {
@@ -73,87 +79,112 @@ const SidebarContent = (props: SidebarContentProps) => {
 
   if (sidebarContentPanel === PANELS.NONE) return null;
 
+  const innerPanel = !isMobile ? {
+    minWidth: minWidth - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+    maxWidth: maxWidth - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+    minHeight: minHeight - (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
+    maxHeight: maxHeight - (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
+    width: width - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+    height: height - (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
+  } : {
+    minWidth,
+    maxWidth,
+    minHeight,
+    maxHeight,
+    width,
+    height,
+  };
+
   return (
-    <Resizable
-      minWidth={minWidth}
-      maxWidth={maxWidth}
-      minHeight={minHeight}
-      maxHeight={maxHeight}
-      size={{
-        width,
-        height,
-      }}
-      enable={{
-        top: isResizable && resizableEdge?.top,
-        left: isResizable && resizableEdge?.left,
-        bottom: isResizable && resizableEdge?.bottom,
-        right: isResizable && resizableEdge?.right,
-      }}
-      handleWrapperClass="resizeSidebarContentWrapper"
-      onResizeStart={() => {
-        setIsResizing(true);
-        setResizeStartWidth(resizableWidth);
-        setResizeStartHeight(resizableHeight);
-      }}
-      onResize={(...[, , , delta]) => setSidebarContentSize(delta.width, delta.height)}
-      onResizeStop={() => {
-        setIsResizing(false);
-        setResizeStartWidth(0);
-        setResizeStartHeight(0);
-      }}
+    <Styled.SidebarContentBackdrop
+      isMobile={isMobile}
+      isRTL={isRTL}
       style={{
-        position: 'absolute',
-        display: 'flex',
-        alignItems: 'center',
         top,
         left,
         right,
         zIndex,
         width,
         height,
-      }}
-      handleStyles={{
-        left: {
-          width: '4px',
-          height: '100vh',
-          left: '-2px',
-          cursor: 'ew-resize',
-        },
-        right: {
-          width: '12px',
-          height: '100vh',
-          right: '-12px',
-          cursor: 'ew-resize',
-        },
+        maxWidth,
+        minHeight,
       }}
     >
-      <Styled.SidebarContentPanel isRTL={isRTL} isChrome={isChrome}>
-        {sidebarContentPanel === PANELS.CHAT
-          && (
-            <ErrorBoundary
-              Fallback={FallbackView}
-            >
-              <ChatContainer />
-            </ErrorBoundary>
+      <Resizable
+        minWidth={innerPanel.minWidth}
+        maxWidth={innerPanel.maxWidth}
+        minHeight={innerPanel.minHeight}
+        maxHeight={innerPanel.maxHeight}
+        size={{
+          width: innerPanel.width,
+          height: innerPanel.height,
+        }}
+        enable={{
+          top: isResizable && resizableEdge?.top,
+          left: isResizable && resizableEdge?.left,
+          bottom: isResizable && resizableEdge?.bottom,
+          right: isResizable && resizableEdge?.right,
+        }}
+        handleWrapperClass="resizeSidebarContentWrapper"
+        onResizeStart={() => {
+          setIsResizing(true);
+          setResizeStartWidth(resizableWidth);
+          setResizeStartHeight(resizableHeight);
+        }}
+        onResize={(...[, , , delta]) => setSidebarContentSize(delta.width, delta.height)}
+        onResizeStop={() => {
+          setIsResizing(false);
+          setResizeStartWidth(0);
+          setResizeStartHeight(0);
+        }}
+        style={{
+          position: 'absolute',
+          display: 'flex',
+          zIndex,
+        }}
+        handleStyles={{
+          left: {
+            width: '4px',
+            height: '100%',
+            left: '-2px',
+            cursor: 'ew-resize',
+          },
+          right: {
+            width: '12px',
+            height: '100%',
+            right: '-12px',
+            cursor: 'ew-resize',
+          },
+        }}
+      >
+        <Styled.SidebarContentPanel isRTL={isRTL} isChrome={isChrome}>
+          {sidebarContentPanel === PANELS.CHAT
+            && (
+              <ErrorBoundary
+                Fallback={FallbackView}
+              >
+                <ChatContainer />
+              </ErrorBoundary>
+            )}
+          {!isSharedNotesPinned && (
+            <NotesContainer
+              isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES}
+            />
           )}
-        {!isSharedNotesPinned && (
-          <NotesContainer
-            isToSharedNotesBeShow={sidebarContentPanel === PANELS.SHARED_NOTES}
-          />
-        )}
-        {sidebarContentPanel === PANELS.PROFILE && <ProfileSettings />}
-        {sidebarContentPanel === PANELS.USERLIST && <UserListComponent />}
-        {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}
-        {sidebarContentPanel === PANELS.TIMER && <TimerContainer />}
-        {sidebarContentPanel === PANELS.POLL && <PollContainer />}
-        {sidebarContentPanel === PANELS.APPS_GALLERY && <AppsGallery />}
-        {sidebarContentPanel.includes(PANELS.GENERIC_CONTENT_SIDEKICK) && (
-          <GenericContentSidekickContainer
-            genericSidekickContentId={sidebarContentPanel}
-          />
-        )}
-      </Styled.SidebarContentPanel>
-    </Resizable>
+          {sidebarContentPanel === PANELS.PROFILE && <ProfileSettings />}
+          {sidebarContentPanel === PANELS.USERLIST && <UserListComponent />}
+          {sidebarContentPanel === PANELS.BREAKOUT && <BreakoutRoomContainer />}
+          {sidebarContentPanel === PANELS.TIMER && <TimerContainer />}
+          {sidebarContentPanel === PANELS.POLL && <PollContainer />}
+          {sidebarContentPanel === PANELS.APPS_GALLERY && <AppsGallery />}
+          {sidebarContentPanel.includes(PANELS.GENERIC_CONTENT_SIDEKICK) && (
+            <GenericContentSidekickContainer
+              genericSidekickContentId={sidebarContentPanel}
+            />
+          )}
+        </Styled.SidebarContentPanel>
+      </Resizable>
+    </Styled.SidebarContentBackdrop>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
@@ -4,19 +4,34 @@ import {
   colorPrimary,
   colorBorder,
   appsPanelTextColor,
+  colorBackground,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   borderSize,
   navbarHeight,
   smPaddingX,
-  contentSidebarHeight,
   contentSidebarBorderRadius,
   contentSidebarPadding,
+  contentSidebarMarginToMedia,
+  contentSidebarVerticalMargin,
 } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly, mediumUp } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import { SidebarContentPanelProps } from './types';
 import Header from '../common/control-header/component';
 import { textFontWeight } from '../../stylesheets/styled-components/typography';
+
+const SidebarContentBackdrop = styled.div<{isRTL: boolean, isMobile: boolean}>`
+  position: absolute;
+  background-color: ${colorBackground};
+  ${({ isMobile, isRTL }) => !isMobile && `
+    padding: ${isRTL
+    ? `
+      ${contentSidebarVerticalMargin} 0px ${contentSidebarVerticalMargin} ${contentSidebarMarginToMedia}
+    ` : `
+      ${contentSidebarVerticalMargin} ${contentSidebarMarginToMedia} ${contentSidebarVerticalMargin} 0px
+    `};
+  `}
+`;
 
 const Poll = styled.div`
   position: absolute;
@@ -60,7 +75,6 @@ export const SidebarContentPanel = styled.div<SidebarContentPanelProps>`
   flex-direction: column;
   justify-content: space-around;
   overflow: hidden;
-  height: ${contentSidebarHeight};
   border-radius: ${contentSidebarBorderRadius};
   user-select: none;
 
@@ -121,6 +135,7 @@ export const PanelContent = styled.div`
 `;
 
 export default {
+  SidebarContentBackdrop,
   Poll,
   SidebarContentPanel,
   HeaderContainer,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import {
   colorWhite,
   colorPrimary,
-  colorGrayLightest,
+  colorBorder,
   appsPanelTextColor,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
@@ -110,7 +110,7 @@ export const HeaderContainer = styled(Header)`
 export const Separator = styled.hr`
   width: 100%;
   border: 0;
-  border-bottom: 1px solid ${colorGrayLightest};
+  border-bottom: 1px solid ${colorBorder};
 `;
 
 export const PanelContent = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -14,6 +14,7 @@ import { SidebarNavigation as SidebarNavigationInput } from '../layout/layoutTyp
 import Styled from './styles';
 
 interface SidebarNavigationProps {
+  isMobile: boolean,
   top: number,
   left?: number,
   right?: number,
@@ -25,6 +26,7 @@ interface SidebarNavigationProps {
 }
 
 const SidebarNavigation = ({
+  isMobile,
   top,
   left = undefined,
   right = undefined,
@@ -38,7 +40,8 @@ const SidebarNavigation = ({
   const isChatEnabled = useIsChatEnabled();
 
   return (
-    <Styled.NavigationSidebar
+    <Styled.NavigationSidebarBackdrop
+      isMobile={isMobile}
       style={{
         top,
         left,
@@ -48,28 +51,30 @@ const SidebarNavigation = ({
         width,
       }}
     >
-      <Styled.NavigationSidebarListItemsContainer>
-        <Styled.Top>
-          {showBrandingArea && <CustomLogo />}
-          <ProfileListItem />
-          <UsersListItem />
-          {isChatEnabled && <ChatListItemContainer />}
-          <UserNotesListItemContainer />
-        </Styled.Top>
+      <Styled.NavigationSidebar isMobile={isMobile}>
+        <Styled.NavigationSidebarListItemsContainer>
+          <Styled.Top>
+            {showBrandingArea && <CustomLogo />}
+            <ProfileListItem />
+            <UsersListItem />
+            {isChatEnabled && <ChatListItemContainer />}
+            <UserNotesListItemContainer />
+          </Styled.Top>
 
-        <Styled.Center>
-          <AppsListItem />
-          <PinnedApps
-            sidebarNavigationInput={sidebarNavigationInput}
-          />
-        </Styled.Center>
+          <Styled.Center>
+            <AppsListItem />
+            <PinnedApps
+              sidebarNavigationInput={sidebarNavigationInput}
+            />
+          </Styled.Center>
 
-        <Styled.Bottom>
-          { isModerator ? <LearningDashboardListItem /> : null }
-          <SettingsListItem />
-        </Styled.Bottom>
-      </Styled.NavigationSidebarListItemsContainer>
-    </Styled.NavigationSidebar>
+          <Styled.Bottom>
+            { isModerator ? <LearningDashboardListItem /> : null }
+            <SettingsListItem />
+          </Styled.Bottom>
+        </Styled.NavigationSidebarListItemsContainer>
+      </Styled.NavigationSidebar>
+    </Styled.NavigationSidebarBackdrop>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect, useMemo } from 'react';
 import {
   layoutDispatch,
+  layoutSelect,
   layoutSelectInput,
   layoutSelectOutput,
 } from '/imports/ui/components/layout/context';
 import { useIntl } from 'react-intl';
 import SidebarNavigation from './component';
 import { User } from '/imports/ui/Types/user';
-import { Input, Output } from '/imports/ui/components/layout/layoutTypes';
+import { Input, Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { userIsInvited } from '/imports/ui/components/breakout-room/breakout-rooms-list-item/query';
@@ -15,7 +16,7 @@ import useTimer from '/imports/ui/core/hooks/useTImer';
 import { BREAKOUTS_ICON, BREAKOUTS_LABEL, BREAKOUTS_APP_KEY } from '/imports/ui/components/breakout-room/constants';
 import { TIMER_ICON, TIMER_LABEL, TIMER_APP_KEY } from '/imports/ui/components/timer/constants';
 import { POLLS_ICON, POLLS_LABEL, POLLS_APP_KEY } from '/imports/ui/components/poll/constants';
-import { ACTIONS } from '/imports/ui/components/layout/enums';
+import { ACTIONS, DEVICE_TYPE } from '/imports/ui/components/layout/enums';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { Meeting } from '/imports/ui/Types/meeting';
 
@@ -47,6 +48,8 @@ const SidebarNavigationContainer = () => {
   const intl = useIntl();
   const sidebarNavigationInput = layoutSelectInput((i: Input) => i.sidebarNavigation);
   const sidebarNavigation = layoutSelectOutput((i: Output) => i.sidebarNavigation);
+  const deviceType = layoutSelect((i: Layout) => i.deviceType);
+  const isMobile = deviceType === DEVICE_TYPE.MOBILE;
   const layoutContextDispatch = layoutDispatch();
   const {
     top,
@@ -150,6 +153,7 @@ const SidebarNavigationContainer = () => {
 
   return (
     <SidebarNavigation
+      isMobile={isMobile}
       top={top}
       left={left}
       right={right}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/custom-logo/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/custom-logo/styles.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
-import { colorGrayLighter } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorBorder } from '/imports/ui/stylesheets/styled-components/palette';
 import { lineHeightComputed } from '/imports/ui/stylesheets/styled-components/typography';
 import { navigationSidebarLogoPadding } from '/imports/ui/stylesheets/styled-components/general';
 
 const Separator = styled.div`
   height: 1px;
-  background-color: ${colorGrayLighter};
+  background-color: ${colorBorder};
   margin-bottom: calc(${lineHeightComputed} * .5);
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
@@ -7,6 +7,7 @@ import {
   navigationSidebarListItemsGap,
   navigationSidebarListItemsWidth,
   navigationSidebarPaddingY,
+  navigationSidebarMargin,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
   colorGrayDark,
@@ -17,15 +18,23 @@ import {
   listItemBgHover,
   itemFocusBorder,
   colorGrayIcons,
+  colorBackground,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
-const NavigationSidebar = styled.div`
+const NavigationSidebarBackdrop = styled.div<{isMobile: boolean}>`
   position: absolute;
+  background-color: ${({ isMobile }) => (!isMobile ? `${colorBackground}` : 'transparent')};
+  ${({ isMobile }) => !isMobile && `padding: ${navigationSidebarMargin}`};
+`;
+
+const NavigationSidebar = styled.div<{isMobile: boolean}>`
   background-color: ${colorWhite};
   border-radius: ${navigationSidebarBorderRadius};
   padding: ${navigationSidebarPaddingY} 0;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  ${({ isMobile }) => isMobile && 'box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2)'};
 `;
 
 const NavigationSidebarListItemsContainer = styled.div`
@@ -121,6 +130,7 @@ const ListItem = styled.div<ListItemProps>`
 `;
 
 export default {
+  NavigationSidebarBackdrop,
   NavigationSidebar,
   NavigationSidebarListItemsContainer,
   Top,

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
@@ -9,7 +9,7 @@ import {
 import {
   colorGrayDark,
   colorGrayLighter,
-  colorGrayLightest,
+  colorBorder,
   colorGray,
   colorBlueLight,
   colorWhite,
@@ -79,8 +79,8 @@ const TimerContent = styled.div`
 `;
 
 const TimerCurrent = styled.span`
-  border-bottom: 1px solid ${colorGrayLightest};
-  border-top: 1px solid ${colorGrayLightest};
+  border-bottom: 1px solid ${colorBorder};
+  border-top: 1px solid ${colorBorder};
   display: flex;
   font-size: xxx-large;
   justify-content: center;

--- a/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
@@ -76,6 +76,15 @@ const UserList: React.FC<UserListComponentProps> = () => {
     );
   };
 
+  const renderScrollableSection = () => {
+    return (
+      <Styled.ScrollableSection>
+        {renderGuestManagement()}
+        <UserListParticipants count={count} />
+      </Styled.ScrollableSection>
+    );
+  };
+
   const renderCrowdActionButtons = () => {
     if (!currentUserData?.isModerator) return null;
     return (
@@ -111,14 +120,13 @@ const UserList: React.FC<UserListComponentProps> = () => {
             data-test="downloadUserNamesList"
             icon="template_download"
             aria-label={intl.formatMessage(intlMessages.saveUsersNames)}
-            tooltip={intl.formatMessage(intlMessages.saveUsersNames)}
+            label={intl.formatMessage(intlMessages.saveUsersNames)}
             onClick={getUsers}
           />
         )}
       />
       <Styled.Separator />
-      {renderGuestManagement()}
-      <UserListParticipants count={count} />
+      {renderScrollableSection()}
       {renderCrowdActionButtons()}
     </Styled.PanelContent>
   );

--- a/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
@@ -78,7 +78,7 @@ const UserList: React.FC<UserListComponentProps> = () => {
 
   const renderScrollableSection = () => {
     return (
-      <Styled.ScrollableSection>
+      <Styled.ScrollableSection id="scroll-box">
         {renderGuestManagement()}
         <UserListParticipants count={count} />
       </Styled.ScrollableSection>

--- a/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx
@@ -69,6 +69,7 @@ const CrowdActionButtons: React.FC<CrowdActionButtonsProps> = () => {
           {/* @ts-ignore - button is js component */}
           <Styled.ActionButton
             aria-label={intl.formatMessage(intlMessages.muteAllExceptPresenterDesc)}
+            tooltipLabel={intl.formatMessage(intlMessages.muteAllExceptPresenterDesc)}
             icon="mute"
             size="lg"
             data-test="muteAllUsers"
@@ -82,6 +83,7 @@ const CrowdActionButtons: React.FC<CrowdActionButtonsProps> = () => {
           {/* @ts-ignore - button is js component */}
           <Styled.ActionButton
             aria-label={intl.formatMessage(intlMessages.lockSettingsButtonDescription)}
+            tooltipLabel={intl.formatMessage(intlMessages.lockSettingsButtonDescription)}
             icon="lock"
             size="lg"
             data-test="lockViewersButton"

--- a/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/styles.ts
@@ -2,14 +2,18 @@ import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
 import {
   appsGalleryOutlineColor,
-  appsPanelTextColor,
+  colorGrayDark,
   colorGrayUserListToolbar,
 } from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  fontSizeSmall,
+  textFontWeight,
+} from '/imports/ui/stylesheets/styled-components/typography';
 import { ActionButtonProps } from './types';
 
 const ActionButtonsWrapper = styled.div`
   display: flex;
-  padding: 1rem;
+  padding: 0.8rem;
   align-items: flex-end;
   gap: 1.5rem;
 `;
@@ -19,15 +23,20 @@ const ActionButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  overflow: hidden;
+  max-height: 5rem;
+  padding: 0.2rem;
 `;
 
 const ActionButtonLabel = styled.span`
-  color: ${appsPanelTextColor}; 
+  color: ${colorGrayDark};
+  font-size: ${fontSizeSmall};
+  font-weight: ${textFontWeight};
   text-align: center;
-  font-size: 14px;
-  font-style: normal;
-  font-weight: 400;
   line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 // @ts-ignore - Button is JSX element

--- a/bigbluebutton-html5/imports/ui/components/user-list/guest-management/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/guest-management/styles.ts
@@ -7,15 +7,12 @@ import { fontSizeSmall, textFontWeight } from '../../../stylesheets/styled-compo
 import {
   contentSidebarBorderRadius, contentSidebarPadding,
 } from '/imports/ui/stylesheets/styled-components/general';
-import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
 
-const GuestManagement = styled(ScrollboxVertical)`
+const GuestManagement = styled.div`
   padding: ${contentSidebarPadding} ${contentSidebarPadding} 
            ${contentSidebarPadding} ${contentSidebarPadding};
   border-radius: ${contentSidebarBorderRadius};
   background: ${colorWhite};
-  overflow-y: auto;
-  max-height: 50%;
 `;
 
 const GuestPolicyContainer = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.ts
@@ -10,6 +10,7 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPaddingX,
+  mdPadding,
   borderSize,
   contentSidebarBottomScrollPadding,
 } from '/imports/ui/stylesheets/styled-components/general';
@@ -32,6 +33,7 @@ const Separator = styled(BaseSeparator)``;
 const ScrollableSection = styled(ScrollboxVertical)`
   flex-grow: 1;
   padding-bottom: ${contentSidebarBottomScrollPadding};
+  margin: ${mdPadding};
 `;
 
 const UserList = styled(FlexColumn)`

--- a/bigbluebutton-html5/imports/ui/components/user-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/styles.ts
@@ -8,12 +8,17 @@ import {
   listItemBgHover,
   itemFocusBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { smPaddingX, borderSize } from '/imports/ui/stylesheets/styled-components/general';
+import {
+  smPaddingX,
+  borderSize,
+  contentSidebarBottomScrollPadding,
+} from '/imports/ui/stylesheets/styled-components/general';
 import {
   HeaderContainer as BaseHeaderContainer,
   PanelContent as BasePanelContent,
   Separator as BaseSeparator,
 } from '/imports/ui/components/sidebar-content/styles';
+import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
 
 const HeaderContainer = styled(BaseHeaderContainer)``;
 
@@ -23,6 +28,11 @@ const PanelContent = styled(BasePanelContent)`
 `;
 
 const Separator = styled(BaseSeparator)``;
+
+const ScrollableSection = styled(ScrollboxVertical)`
+  flex-grow: 1;
+  padding-bottom: ${contentSidebarBottomScrollPadding};
+`;
 
 const UserList = styled(FlexColumn)`
   justify-content: flex-start;
@@ -90,6 +100,7 @@ export default {
   HeaderContainer,
   PanelContent,
   Separator,
+  ScrollableSection,
   UserList,
   SmallTitle,
   ListItem,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
@@ -5,9 +5,6 @@ import {
 import {
   colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import {
-  ScrollboxVertical,
-} from '/imports/ui/stylesheets/styled-components/scrollable';
 
 interface AvatarProps {
   color: string;
@@ -97,9 +94,7 @@ const pulse = (color: string) => keyframes`
   }
 `;
 
-const VirtualizedList = styled(ScrollboxVertical)`
-  outline: none;
-  overflow-x: hidden;
+const VirtualizedList = styled.div`
   display: flex;
   flex-flow: column;
   gap: 1rem;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/styles.ts
@@ -3,6 +3,7 @@ import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import { mediumUp } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import { actionsBarHeight, navbarHeight, mdPaddingX } from '/imports/ui/stylesheets/styled-components/general';
 import Button from '/imports/ui/components/common/button/component';
+import { CAMERADOCK_POSITION } from '../../layout/enums';
 
 // @ts-expect-error -> Untyped component.
 const NextPageButton = styled(Button)`
@@ -75,7 +76,7 @@ const VideoListItem = styled.div<{
 const VideoCanvas = styled.div<{
   $position: string;
 }>`
-  position: absolute;
+  ${({ $position }) => ($position !== CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM && 'position: absolute')};
   width: 100%;
   min-height: calc((100vh - calc(${navbarHeight} + ${actionsBarHeight})) * 0.2);
   height: 100%;

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -22,6 +22,7 @@ import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import useSettings from '../../services/settings/hooks/useSettings';
 import { SETTINGS } from '../../services/settings/enums';
 import { INITIAL_INPUT_STATE } from '../layout/initState';
+import { contentSidebarMarginToMedia } from '../../stylesheets/styled-components/general';
 
 interface WebcamComponentProps {
   cameraDock: Output['cameraDock'];
@@ -191,6 +192,9 @@ const WebcamComponent: React.FC<WebcamComponentProps> = ({
   const isDesktopWidth = isDragging ? cameraSize?.width : cameraDock.width;
   const isDesktopHeight = isDragging ? cameraSize?.height : cameraDock.height;
   const camOpacity = isDragging ? 0.5 : undefined;
+  let padding = '';
+  if (isCameraSidebar && isRTL) padding = `0px 0px 0px ${contentSidebarMarginToMedia}`;
+  if (isCameraSidebar && !isRTL) padding = `0px ${contentSidebarMarginToMedia} 0px 0px`;
 
   return (
     <>
@@ -265,6 +269,7 @@ const WebcamComponent: React.FC<WebcamComponentProps> = ({
             style={{
               position: 'absolute',
               zIndex: isCameraSidebar && !isDragging ? 0 : cameraDock?.zIndex,
+              padding,
             }}
           >
             <Styled.Draggable

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -1,3 +1,9 @@
+import {
+  SIDEBAR_CONTENT_VERTICAL_MARGIN,
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+  SIDEBAR_NAVIGATION_MARGIN,
+} from '/imports/ui/components/layout/defaultValues';
+
 const borderSizeSmall = '1px';
 const borderSize = '2px';
 const borderSizeLarge = '3px';
@@ -28,6 +34,8 @@ const contentSidebarPadding = '1rem';
 const contentSidebarBottomScrollPadding = '2rem';
 const contentSidebarHeight = '86%';
 const contentSidebarBorderRadius = '1rem';
+const contentSidebarVerticalMargin = `${SIDEBAR_CONTENT_VERTICAL_MARGIN}px`;
+const contentSidebarMarginToMedia = `${SIDEBAR_CONTENT_MARGIN_TO_MEDIA}px`;
 const minModalHeight = '20rem';
 const descriptionMargin = '3.5rem';
 const navbarHeight = '3.9375rem';
@@ -38,6 +46,7 @@ const navigationSidebarListItemsGap = '0.8rem';
 const navigationSidebarListItemsWidth = '65%';
 const navigationSidebarBorderRadius = '48px';
 const navigationSidebarPaddingY = '20px';
+const navigationSidebarMargin = `${SIDEBAR_NAVIGATION_MARGIN}px`;
 const pollHeaderOffset = '-0.875rem';
 const toastContentWidth = '98%';
 const modalMargin = '3rem';
@@ -145,6 +154,7 @@ export {
   navigationSidebarListItemsWidth,
   navigationSidebarBorderRadius,
   navigationSidebarPaddingY,
+  navigationSidebarMargin,
   pollHeaderOffset,
   toastContentWidth,
   modalMargin,
@@ -219,6 +229,8 @@ export {
   contentSidebarBottomScrollPadding,
   contentSidebarHeight,
   contentSidebarBorderRadius,
+  contentSidebarVerticalMargin,
+  contentSidebarMarginToMedia,
   appsPanelGroupItemsSpacing,
   appsPanelItemsSpacing,
   appsButtonsBorderRadius,

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -11,6 +11,8 @@ const colorGrayLightest = 'var(--color-gray-lightest, #D4D9DF)';
 const colorGrayIcons = 'var(--color-gray-icons, #909CAF)';
 const colorGrayUserListToolbar = 'var(--color-gray-user-list-toolbar, #F4F6FA)';
 
+const colorBorder = 'var(--color-border, #B8C9D8)';
+
 const colorBlueLight = 'var(--color-blue-light, #54a1f3)';
 const colorBlueLighter = 'var(--color-blue-lighter, #92BCEA)';
 const colorBlueLightest = 'var(--color-blue-lightest, #E4ECF2)';
@@ -149,6 +151,7 @@ export {
   colorGrayLightest,
   colorGrayIcons,
   colorGrayUserListToolbar,
+  colorBorder,
   colorTransparent,
   colorUserModerator,
   colorUserYou,

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -140,6 +140,12 @@ const webcamPlaceholderBorder = 'var(--webcam-placeholder-border, rgba(255, 255,
 const toastWarningColor = `var(--toast-warning-color, ${colorWhite})`;
 const toastWarningBg = `var(--toast-warning-bg, ${colorWarning})`;
 
+// DARK THEME COLORS
+const colorBackgroundDarkTheme = 'var(--color-background-dark-theme, #181A23)';
+const colorOverlaysDarkTheme = 'var(--color-overlays-dark-theme, #2D2F38)';
+const colorTextDarkTheme = `var(--color-text-dark-theme, ${colorWhite})`;
+const colorPrimaryDarkTheme = `var(--color-primary-dark-theme, ${colorPrimary})`;
+
 export {
   colorWhite,
   colorOffWhite,
@@ -247,4 +253,8 @@ export {
   toastWarningBg,
   webcamBackgroundColor,
   webcamPlaceholderBorder,
+  colorBackgroundDarkTheme,
+  colorOverlaysDarkTheme,
+  colorTextDarkTheme,
+  colorPrimaryDarkTheme,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -803,7 +803,7 @@ public:
     pinnable: true
   layout:
     hidePresentationOnJoin: false
-    showParticipantsOnLogin: true
+    showParticipantsOnLogin: false
     showPushLayoutButton: true
     showPushLayoutToggle: true
     showSessionDetailsOnJoin: true

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -159,6 +159,8 @@
     "app.appsGallery.minimize": "Minimize Apps Gallery",
     "app.appsGallery.maxpinnedApps": "{0} out of {1} pinned apps",
     "app.appsGallery.maxpinnedAppsContinue": " in the sidebar.",
+    "app.appsGallery.pinTooltip": "Pin app",
+    "app.appsGallery.unpinTooltip": "Unpin app",
     "app.appsGallery.modal.title": "Oops!",
     "app.appsGallery.modal.subtitle": "You already have {0} pinned apps in the sidebar.",
     "app.appsGallery.modal.description": "To pin a new app, you must unpin another first.",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -227,7 +227,7 @@
     "app.userList.userOptions.usersJoinMutedDisableDesc": "Joining users are not muted by default",
     "app.userList.userOptions.clearAllReactionsLabel": "Clear all reactions",
     "app.userList.userOptions.clearAllReactionsDesc": "Clears all reaction emojis from users",
-    "app.userList.userOptions.muteAllExceptPresenterLabel": "Mute all users except presenter",
+    "app.userList.userOptions.muteAllExceptPresenterLabel": "Mute all users",
     "app.userList.userOptions.muteAllExceptPresenterDesc": "Mutes all users in the session except the presenter",
     "app.userList.userOptions.lockViewersLabel": "Lock viewers",
     "app.userList.userOptions.lockViewersDesc": "Lock certain functionalities for attendees of the session",

--- a/bigbluebutton-html5/public/locales/pt_BR.json
+++ b/bigbluebutton-html5/public/locales/pt_BR.json
@@ -207,7 +207,7 @@
     "app.userList.userOptions.usersJoinMutedDisableDesc": "Novos usuários não são mutados por padrão",
     "app.userList.userOptions.clearAllReactionsLabel": "Limpar reações",
     "app.userList.userOptions.clearAllReactionsDesc": "Limpa as reações de todos os usuários",
-    "app.userList.userOptions.muteAllExceptPresenterLabel": "Colocar todos em mudo, exceto o apresentador",
+    "app.userList.userOptions.muteAllExceptPresenterLabel": "Silenciar todos",
     "app.userList.userOptions.muteAllExceptPresenterDesc": "Coloca todos em mudo exceto o apresentador",
     "app.userList.userOptions.lockViewersLabel": "Restringir espectadores",
     "app.userList.userOptions.lockViewersDesc": "Restringir algumas funcionalidades aos participantes da sessão",

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1490,7 +1490,7 @@ The use of *more will include all shapes listed above.
 | `userdata-bbb_auto_swap_layout=`           | If set to `true`, the presentation area will be minimized when a user joins a meeting. (Removed in 2.6)                                  | `false`       |
 | `userdata-bbb_hide_presentation=`          | If set to `true`, the presentation area will not be displayed. (Removed in 2.6)                                                          | `false`       |
 | `userdata-bbb_hide_presentation_on_join=`          | If set to `true`, the presentation area will start minimized, but can be restored                                                          | `false`       |
-| `userdata-bbb_show_participants_on_login=` | If set to `false`, the participants panel (and the chat panel) will not be displayed until opened.                      | `true`        |
+| `userdata-bbb_show_participants_on_login=` | If set to `true`, the participants panel will start opened.                                                             | `false`        |
 | `userdata-bbb_show_public_chat_on_login=`  | If set to `false`, the chat panel will not be visible on page load until opened. Not the same as disabling chat.        | `true`        |
 | `userdata-bbb_hide_nav_bar=`               | If set to `true`, the navigation bar (the top portion of the client) will not be displayed. Introduced in BBB 2.4-rc-3. | `false`       |
 | `userdata-bbb_hide_actions_bar=`           | If set to `true`, the actions bar (the bottom portion of the client) will not be displayed. Introduced in BBB 2.4-rc-3. | `false`       |


### PR DESCRIPTION
### What does this PR do?
This PR is a compilation of UI enhancements:
- Joins the user list and the guests management into one scroll section to improve the UX in the panel
- Adjusts the label of the crowd actions button, limit its size and add tooltip for more detailed description
  <img src="https://github.com/user-attachments/assets/f86965ae-5b36-4fa7-bba0-df5d666aedf2" width=300 />

- Changes border colors to increase contrast in the UI, allowing for better accessibility
- Changes a bunch of styles for dark theme to ensure that the color scheme has good contrast and looks good
  <img src="https://github.com/user-attachments/assets/9ce17325-3c43-451c-bdcd-a0e1781c866a" width=500 />

- Adds missing tooltip to the pin/unpin button in the apps gallery
  <img src="https://github.com/user-attachments/assets/3f10d645-a980-4767-bd90-26489511e5f7" width=300 />

Also this PR fixes some inconsistencies that might happen due to the interaction between the new UI and userdata or ui commands from plugins:
- [fix(navigation-sidebar): prevent plugins from changing its state](https://github.com/bigbluebutton/bigbluebutton/commit/5894f681ee8b44c5baf1149abd4dda2885021a79) 
  Since the navigation sidebar is not colapsable anymore, it can't be closed or opened by other sources. Otherwise it can't be reopened.
- [fix(sidebar): update 'bbb_show_participants_on_login' behavior](https://github.com/bigbluebutton/bigbluebutton/commit/8a651f3e58f037dd07c7f7728060f180ee243d65)
  The userdata 'bbb_show_participants_on_login' was used to open the navigation
sidebar in versions <=3.0, where the participants list was located. In version
3.1, the participants list was moved to a separate panel, and the navigation
sidebar is no longer collapsible. Now, 'bbb_show_participants_on_login'
controls whether the user list panel opens on login.

  Additionally, the userdata 'bbb_show_public_chat_on_login' determines
whether the chat panel opens first and now it takes precedence over
'bbb_show_participants_on_login'. If both are true, the chat panel will
be opened by default. To mimic the previous behavior when
'bbb_show_participants_on_login' was set to true(where no panel is
opened on login), set both 'bbb_show_participants_on_login' and
'bbb_show_public_chat_on_login' to false (or their analogous flags in
the settings.yml file).

  The ideal solution would be to consolidate these userdatas into one
that defines the initial open panel(where sending nothing means closed).

  Changes the default settings flag
'public.layout.showParticipantsOnLogin' to false, so the default panel
is opening the chat.


Additionally, adds a commit that went missing from previous PRs:
- [fix(layout): add backdrop to the side panels](https://github.com/bigbluebutton/bigbluebutton/commit/57938a0c161cd2cd53f0feb80f9f5183a3121b8a)