### PR TITLE
fix(whiteboard): Remove duplicate zoom propagation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -727,7 +727,7 @@ const Whiteboard = React.memo((props) => {
 
           const zoomed = prevCam.z !== nextCam.z;
 
-          if ((panned || (zoomed && fitToWidthRef.current)) && isPresenterRef.current) {
+          if ((panned || zoomed) && isPresenterRef.current) {
             const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
               editor?.getViewportPageBounds()?.w,
               currentPresentationPageRef.current?.scaledWidth,
@@ -1026,7 +1026,6 @@ const Whiteboard = React.memo((props) => {
 
   React.useEffect(() => {
     zoomValueRef.current = zoomValue;
-    let timeoutId = null;
     setPageZoomMap(prev => ({
       ...prev,
       [curPageIdRef.current]: zoomValue,
@@ -1104,31 +1103,9 @@ const Whiteboard = React.memo((props) => {
       if (newCamera) {
         tlEditorRef.current.setCamera(newCamera, { duration: 175 });
       }
-
-      timeoutId = setTimeout(() => {
-        const viewportBounds = tlEditorRef.current.getViewportPageBounds();
-        const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
-          viewportBounds.w,
-          currentPresentationPageRef.current.scaledWidth
-        );
-        const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
-          viewportBounds.h,
-          currentPresentationPageRef.current.scaledHeight
-        );
-        const updatedCamera = tlEditorRef.current.getCamera();
-
-        zoomSlide(
-          viewedRegionW,
-          viewedRegionH,
-          updatedCamera.x,
-          updatedCamera.y,
-          currentPresentationPageRef.current
-        );
-      }, 500);
     }
 
     prevZoomValueRef.current = zoomValue;
-    return () => clearTimeout(timeoutId);
   }, [
     zoomValue, tlEditorRef.current, curPageId, isWheelZoomRef.current, fitToWidthRef.current,
   ]);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Since we're already propagating zoom changes on camera updates dispatched by tldraw state on this line https://github.com/bigbluebutton/bigbluebutton/blob/68f3a0ec3c1e8d16ab3a4a25676d5cc9b0f9ae99/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx#L741
this PR removes duplicate logic which runs within a useEffect. This PR also slightly adjusts the condition for propagating zoom updates in order to comprise all cases.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21527

### More

The removed code is sometimes being executed before the whiteboard canvas is rendered, so the zoom mutation is being called with some odd values, which in turn is messing with the viewers zoom.

### How to test

There must not be zoom propagation regressions.