### PR TITLE
Refactor (gql-server): Improve user list performance by relaxing `userLockSettings` view permissions

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_lockSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_lockSettings.yaml
@@ -12,12 +12,6 @@ select_permissions:
       columns:
         - disablePublicChat
       filter:
-        _and:
-          - meetingId:
-              _eq: X-Hasura-MeetingId
-          - _or:
-              - userId:
-                  _eq: X-Hasura-UserId
-              - meetingId:
-                  _eq: X-Hasura-ModeratorInMeeting
+        meetingId:
+          _eq: X-Hasura-MeetingId
     comment: ""


### PR DESCRIPTION
The user list query is one of the most expensive queries in the client. To optimize performance, we aim to leverage Hasura Subscription multiplexing [docs](https://hasura.io/docs/2.0/subscriptions/postgres/livequery/execution/) which groups subscriptions from multiple users and sends a single query to Postgres.  

For this to work, the query must not include `userId` as a variable. However, since #21133, the query is no longer benefiting from multiplexing due to a join with `userLockSettings`, which filters results based on `userId` to ensure that only moderators or the user themselves can access the data.  

To restore multiplexing and improve performance, this PR changes the permission model, allowing any user to fetch `userLockSettings` of others. I see no downside to this change. With this adjustment, `userLockSettings` can be included in the user list query without breaking multiplexing.  

Related: #21117