### PR TITLE
fix (html5) (2.7): "Open in BigBlueButton in Table App" not working in cluster setup (using wrong api domain)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/mobile-app-modal/component.jsx
@@ -8,6 +8,7 @@ import Styled from './styles';
 import Meetings from '/imports/api/meetings';
 
 const BBB_TABLET_APP_CONFIG = Meteor.settings.public.app.bbbTabletApp;
+const BBB_WEB_BASE = Meteor.settings.public.app.bbbWebBase;
 
 const intlMessages = defineMessages({
   title: {
@@ -73,7 +74,7 @@ class MobileAppModal extends Component {
       this.setState({ meetingName: meetingObject.meetingProp.name });
     }
 
-    const url = `/bigbluebutton/api/getJoinUrl?sessionToken=${sessionToken}`;
+    const url = `${BBB_WEB_BASE}/api/getJoinUrl?sessionToken=${sessionToken}`;
     const options = {
       method: 'GET',
       headers: {
@@ -97,7 +98,9 @@ class MobileAppModal extends Component {
   }
 
   render() {
-    const { intl, isOpen, onRequestClose, priority, } = this.props;
+    const {
+      intl, isOpen, onRequestClose, priority,
+    } = this.props;
     const { url, urlMessage, meetingName } = this.state;
 
     return (


### PR DESCRIPTION
Currently, the "Open in BigBlueButton in Table App" option requests a join URL from the `getJoinUrl` endpoint. However, it attempts to use the client's domain, which is incompatible with a Cluster setup. This PR adjusts the request to retrieve the domain from the `public.app.bbbWebBase` configuration.

<img src="https://github.com/user-attachments/assets/3637a631-fe4a-4867-9ea4-c1d62cd449bd" width=170 />


Fix #22205