### PR TITLE
fix (html5) (3.0): "Open in BigBlueButton in Table App" not working in cluster setup (using wrong api domain)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/mobile-app-modal/mobile-app-modal-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/mobile-app-modal/mobile-app-modal-graphql/component.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { defineMessages, useIntl } from 'react-intl';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import getBaseUrl from '/imports/ui/core/utils/getBaseUrl';
 import Auth from '/imports/ui/services/auth';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 import Button from '/imports/ui/components/common/button/component';
@@ -69,7 +70,7 @@ const MobileAppModalGraphql: React.FC<MobileAppModalGraphqlProps> = (props) => {
   const BBB_TABLET_APP_CONFIG = window.meetingClientSettings.public.app.bbbTabletApp;
 
   useEffect(() => {
-    const url = `/bigbluebutton/api/getJoinUrl?sessionToken=${sessionToken}`;
+    const url = `${getBaseUrl()}/api/getJoinUrl?sessionToken=${sessionToken}`;
     const options = {
       method: 'GET',
       headers: {


### PR DESCRIPTION
Currently, the "Open in BigBlueButton in Table App" option requests a join URL from the `getJoinUrl` endpoint. However, it attempts to use the client's domain, which is incompatible with a Cluster setup. This PR adjusts the request to retrieve the domain from the `public.app.bbbWebBase` configuration (`getBaseUrl`).

<img src="https://github.com/user-attachments/assets/3637a631-fe4a-4867-9ea4-c1d62cd449bd" width=170 />


Fix #22205