### PR TITLE
fix: minimum breakouts duration validation & settings tabs 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -474,13 +474,13 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const { value } = e.target;
                   const v = Number.parseInt(value, 10);
-                  setDurationTime(v);
+                  setDurationTime((v && !(v <= 0) && v >= MIN_BREAKOUT_TIME) ? v : MIN_BREAKOUT_TIME);
                   setDurationIsValid(v >= MIN_BREAKOUT_TIME);
                 }}
                 onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
                   const { value } = e.target;
                   const v = Number.parseInt(value, 10);
-                  setDurationTime((v && !(v <= 0)) ? v : MIN_BREAKOUT_TIME);
+                  setDurationTime((v && !(v <= 0) && v >= MIN_BREAKOUT_TIME) ? v : MIN_BREAKOUT_TIME);
                   setDurationIsValid(true);
                 }}
                 aria-label={intl.formatMessage(intlMessages.duration)}

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
@@ -20,7 +20,7 @@ const intlMessages = defineMessages({
   },
 });
 
-const DATA_SAVINGS_TAB_NUMBER = 3;
+const DATA_SAVINGS_TAB_NUMBER = 2;
 
 class ConnectionStatusButton extends PureComponent {
   constructor(props) {

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -239,12 +239,6 @@ class Settings extends Component {
       >
         <Styled.SettingsTabList>
           <Styled.SettingsTabSelector
-            aria-labelledby="aboutTab"
-            selectedClassName="is-selected"
-          >
-            <span id="aboutTab">{intl.formatMessage(intlMessages.aboutTabLabel)}</span>
-          </Styled.SettingsTabSelector>
-          <Styled.SettingsTabSelector
             aria-labelledby="appTab"
             selectedClassName="is-selected"
           >
@@ -275,14 +269,13 @@ class Settings extends Component {
               </Styled.SettingsTabSelector>
             )
             : null}
+          <Styled.SettingsTabSelector
+            aria-labelledby="aboutTab"
+            selectedClassName="is-selected"
+          >
+            <span id="aboutTab">{intl.formatMessage(intlMessages.aboutTabLabel)}</span>
+          </Styled.SettingsTabSelector>
         </Styled.SettingsTabList>
-        <Styled.SettingsTabPanel selectedClassName="is-selected">
-          <About
-            settings={current.application}
-            setIsShortcutModalOpen={setIsShortcutModalOpen}
-            setIsOpen={setIsOpen}
-          />
-        </Styled.SettingsTabPanel>
         <Styled.SettingsTabPanel selectedClassName="is-selected">
           <Application
             allLocales={allLocales}
@@ -330,6 +323,13 @@ class Settings extends Component {
             </Styled.SettingsTabPanel>
           )
           : null}
+        <Styled.SettingsTabPanel selectedClassName="is-selected">
+          <About
+            settings={current.application}
+            setIsShortcutModalOpen={setIsShortcutModalOpen}
+            setIsOpen={setIsOpen}
+          />
+        </Styled.SettingsTabPanel>
       </Styled.SettingsTabs>
     );
   }


### PR DESCRIPTION
### What does this PR do?
- [fix(breakouts): validation of minimum breakouts duration](https://github.com/bigbluebutton/bigbluebutton/commit/2020512c62cac137b3033bcbebefbdb973682a93)
  Prevents the duration input in the breakouts creation panel from
assuming values lower than the minimum, while still showing the error
message to inform users about the minimum duration.
- [fix(settings): move about to last tab](https://github.com/bigbluebutton/bigbluebutton/commit/d1392d56c71ba5eed751fd1dfdcd22003ab75810)
  Moves 'about' to the last tab and leaves the 'application' as the first
tab.