### PR TITLE
[3.1] Hides learning analytics dashboard for non-moderators.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -246,7 +246,7 @@ const ChatContainer: React.FC = () => {
     && chat?.totalUnread
     && chat.totalUnread > 0
   ));
-  const filteredPrivateChats = (chats || []).filter(
+  const filteredPrivateChats = (chats || [] as ChatType[]).filter(
     (chat) => !chat.public && chat.totalMessages !== 0,
   );
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
@@ -15,7 +15,7 @@ import {
 } from '/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries';
 
 interface PrivateChatListItemProps {
-  chat: Chat;
+  chat: Partial<Chat>;
   chatNodeRef: React.Ref<HTMLButtonElement>;
   index: number;
   privateChatSelectedCallback: () => void;
@@ -49,7 +49,8 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
 
   const chatQuery = CHAT_MESSAGE_PRIVATE_SUBSCRIPTION;
   const defaultVariables = {
-    offset: chat.totalMessages - 1,
+    // The || 0 is here because chat is a partial type (can have undefined fields)
+    offset: (chat.totalMessages || 0) - 1,
     limit: 1,
   }; // to get only the last message from private chat
   const variables = { ...defaultVariables, requestedChatId: chat.chatId };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Styled from './styles';
 import PrivateChatListItem from './chat-list-item/component';
-import { Chat as Chat } from '/imports/ui/Types/chat';
+import { Chat } from '/imports/ui/Types/chat';
 import Service from '/imports/ui/components/user-list/service';
 
 interface ChatListProps {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/component.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Styled from './styles';
 import PrivateChatListItem from './chat-list-item/component';
-import { Chat } from '/imports/ui/Types/chat';
+import { Chat as Chat } from '/imports/ui/Types/chat';
 import Service from '/imports/ui/components/user-list/service';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 
 interface ChatListProps {
-  chats: Chat[],
+  chats: Partial<Chat>[],
   privateChatSelectedCallback: () => void;
 }
 
 const getActiveChats = (
-  chats: Chat[],
+  chats: Partial<Chat>[],
   chatNodeRef: React.Ref<HTMLButtonElement>,
   privateChatSelectedCallback: () => void,
 ) => chats.map((chat, idx) => (
@@ -71,7 +70,7 @@ const PrivateChatList: React.FC<ChatListProps> = ({ chats, privateChatSelectedCa
 
 interface PrivateChatListContainerProps {
   privateChatSelectedCallback: () => void;
-  chats: Partial<ChatType>[];
+  chats: Partial<Chat>[];
 }
 
 const PrivateChatListContainer: React.FC<PrivateChatListContainerProps> = ({ privateChatSelectedCallback, chats }) => {

--- a/bigbluebutton-html5/imports/ui/components/common/control-header/right/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/control-header/right/component.jsx
@@ -25,6 +25,7 @@ Right.propTypes = {
   icon: PropTypes.string,
   label: PropTypes.string,
   onClick: PropTypes.func,
+  tooltip: PropTypes.string,
 };
 
 export default Right;

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/audio-selectors/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/audio-selectors/component.tsx
@@ -87,8 +87,8 @@ const AudioSelectors: React.FC<AudioSelectorsProps> = ({
   inAudio,
 }) => {
   const intl = useIntl();
-  // @ts-expect-error TS6133: Unused variable.
-  const [findingDevices, setFindingDevices] = React.useState(false);
+  // @ts-expect-error TS6133: Unused variable
+  const [findingDevices, setFindingDevices] = React.useState(false); // eslint-disable-line
   const [inputDevices, setInputDevices] = React.useState<InputDeviceInfo[]>([]);
   const [outputDevices, setOutputDevices] = React.useState<MediaDeviceInfo[]>([]);
   const { enableDynamicAudioDeviceSelection } = window.meetingClientSettings.public.app;

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -267,7 +267,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [brightness, setBrightness] = useState<number>(100);
   // @ts-expect-error TS6133: Unused variable.
-  const [wholeImageBrightness, setWholeImageBrightness] = useState<boolean>(false);
+  const [wholeImageBrightness, setWholeImageBrightness] = useState<boolean>(false); // eslint-disable-line
   const [isCameraLoading, setIsCameraLoading] = useState<boolean>(true);
   const [virtualBackgroundChecked, setVirtualBackgroundChecked] = React.useState(false);
 
@@ -479,7 +479,8 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
         const { backgrounds } = customVirtualBackgroundsContext;
         const background = backgrounds[uniqueId]
           || Object.values(backgrounds).find(
-            (bg: any) => bg.uniqueId === uniqueId, // TODO: typing
+            // @ts-ignore
+            (bg) => bg.uniqueId === uniqueId,
           );
 
         if (background && background.data) {
@@ -654,7 +655,8 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
 
   // Unused for now, but will be used in the future when UI/UX for sharing
   // through the profile settings is implemented - prlanzarin
-  // @ts-expect-error TS6133: Unused variable.
+  // @ts-expect-error TS6133: Unused variable
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleStartSharing = async () => {
     if (!currentVideoStream.current) return;
     if (

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -62,10 +62,6 @@ const intlMessages: { [key: string]: { id: string; description?: string } } = de
     id: 'app.videoPreview.webcamSettingsTitle',
     description: 'Title for the video preview modal',
   },
-  minimizeLabel: {
-    id: 'app.videoPreview.minimizeLabel',
-    description: 'Minimize button label',
-  },
   cancelLabel: {
     id: 'app.mobileAppModal.dismissLabel',
     description: 'Close button label',

--- a/bigbluebutton-html5/imports/ui/components/recording/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/container.tsx
@@ -12,7 +12,9 @@ interface RecordingContainerProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   amIModerator: boolean;
   onRequestClose: () => void;
+  // eslint-disable-next-line react/no-unused-prop-types
   priority: string;
+  // eslint-disable-next-line react/no-unused-prop-types
   isOpen: boolean;
 }
 
@@ -23,6 +25,7 @@ const RecordingContainer: React.FC<RecordingContainerProps> = (props) => {
   const [setRecordingStatus] = useMutation(SET_RECORDING_STATUS);
   // TODO: unused connected status variable, should we use it to disable the recording button?
   // @ts-expect-error TS6133: Unused variable.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const connected = useReactiveVar(ConnectionStatus.getConnectedStatusVar());
   const {
     data: recordingData,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -21,6 +21,7 @@ interface SidebarNavigationProps {
   height: number,
   width: number,
   sidebarNavigationInput: SidebarNavigationInput,
+  isModerator: boolean,
 }
 
 const SidebarNavigation = ({
@@ -31,6 +32,7 @@ const SidebarNavigation = ({
   height,
   width,
   sidebarNavigationInput,
+  isModerator,
 }: SidebarNavigationProps) => {
   const showBrandingArea = getFromUserSettings('bbb_display_branding_area', window.meetingClientSettings.public.app.branding.displayBrandingArea);
   const isChatEnabled = useIsChatEnabled();
@@ -63,7 +65,7 @@ const SidebarNavigation = ({
         </Styled.Center>
 
         <Styled.Bottom>
-          <LearningDashboardListItem />
+          { isModerator ? <LearningDashboardListItem /> : null }
           <SettingsListItem />
         </Styled.Bottom>
       </Styled.NavigationSidebarListItemsContainer>

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
@@ -157,6 +157,7 @@ const SidebarNavigationContainer = () => {
       width={width}
       height={height}
       sidebarNavigationInput={sidebarNavigationInput}
+      isModerator={isModerator}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
@@ -33,10 +33,6 @@ const intlMessages = defineMessages({
     id: 'app.actionsBar.actionsDropdown.saveUserNames',
     description: 'Label for the save user names button',
   },
-  minimizeLabel: {
-    id: 'app.userList.minimize',
-    description: 'Label for the minimize button in the user list panel',
-  },
 });
 
 const UserList: React.FC<UserListComponentProps> = () => {

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
@@ -140,7 +140,10 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
       <Styled.UserName>
         <TooltipContainer title={subjectUser.name}>
           {isMe(subjectUser.userId) ? (
-            <Styled.StrongName>{subjectUser.name} {`(${intl.formatMessage(intlMessages.you)})`}</Styled.StrongName>
+            <Styled.StrongName>
+              {subjectUser.name}
+              {`(${intl.formatMessage(intlMessages.you)})`}
+            </Styled.StrongName>
           ) : (
             <Styled.RegularName>{subjectUser.name}</Styled.RegularName>
           )}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
@@ -1,6 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
 import {
-  contentSidebarBottomScrollPadding,
   contentSidebarPadding,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-avatar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-avatar/component.tsx
@@ -47,7 +47,7 @@ const UserAvatarVideo: React.FC<UserAvatarVideoProps> = (props) => {
       avatar={avatar}
       unhealthyStream={unhealthyStream}
       talking={talking}
-      whiteboardAccess={undefined}
+      whiteboardAccess={false}
     >
       {handleUserIcon()}
     </Styled.UserAvatarStyled>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-avatar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-avatar/styles.ts
@@ -12,6 +12,7 @@ const UserAvatarStyled = styled(UserAvatar)<{
   unhealthyStream: boolean;
   dialIn: boolean;
   presenter: boolean;
+  whiteboardAccess: boolean;
 }>`
   height: 60%;
   width: 45%;

--- a/bigbluebutton-html5/imports/ui/core/utils/keyboardRove.ts
+++ b/bigbluebutton-html5/imports/ui/core/utils/keyboardRove.ts
@@ -42,6 +42,7 @@ const roveBuilder = (
           nextEl.focus();
         }
       } catch (error) {
+        // eslint-disable-next-line
         console.error('Navigation error:', error);
       }
     }


### PR DESCRIPTION
Merge after: https://github.com/bigbluebutton/bigbluebutton/pull/22214

In the new design the learning analytics dashboard button in the navigation sidebar should not be visible for non-moderators.

Before:
![image](https://github.com/user-attachments/assets/20c25833-6cdc-4530-8565-38fe7a9ac77c)

After:
![image](https://github.com/user-attachments/assets/cdb29c58-add4-466e-994a-2156d39e86dc)
