### PR TITLE
fix (tests): Improve 'Pinning and unpinning webcams'

### DIFF
--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -190,7 +190,7 @@ class MultiUsers {
     await this.userPage.shareWebcam();
     await this.modPage.page.waitForFunction(
       checkElementLengthEqualTo,
-      [e.webcamVideoItem, 3],
+      [e.webcamContainer, 2], //wait two 'videoContainer', as current user has data-test="mirroredVideoContainer"
       { timeout: ELEMENT_WAIT_TIME },
     );
     // Pin first webcam (Mod2)


### PR DESCRIPTION
Attempt to fix the following error:

![image](https://github.com/user-attachments/assets/546d2c22-fcfb-475c-b399-cb32f43a93d2)

Watching the video the aut test is able to open the dropdown:
![image](https://github.com/user-attachments/assets/4595114e-5661-4666-8e9a-0724c0d78288)

But a few milliseconds later it loads the video and closes automatically:
![image](https://github.com/user-attachments/assets/f0ad3d51-ff8e-4310-8afe-ec9d3bd8a91a)

This PR tweak the test to wait for the `<video>` element instead of the parent container.