### PR TITLE
fix(chat): User is not able to select text from messages by using only the mouse

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -136,6 +136,7 @@ export const ChatAvatar = styled(UserAvatar)`
 export const Container = styled.div<{ $sequence: number }>`
   display: flex;
   flex-direction: column;
+  user-select: text;
 
   &:not(:first-of-type) {
     margin-top: calc((${fontSizeSmaller} + ${lgPadding} * 2) / 2);


### PR DESCRIPTION
### What does this PR do?
Adds a commit that went missing from [previous merge](https://github.com/bigbluebutton/bigbluebutton/pull/22004).