### PR TITLE
style: adjust chat message styles (blue background for moderators)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -355,7 +355,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           isSystemSender: true,
           component: (
             <ChatMessageTextContent
-              emphasizedMessage
               text={message.message}
             />
           ),
@@ -371,7 +370,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           isSystemSender: true,
           component: (
             <ChatMessageTextContent
-              emphasizedMessage
               text={message.message}
             />
           ),
@@ -434,7 +432,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             ? null
             : (
               <ChatMessageTextContent
-                emphasizedMessage={message.chatEmphasizedText}
                 text={message.message}
               />
             ),
@@ -452,7 +449,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           showToolbar: true,
           component: (
             <ChatMessageTextContent
-              emphasizedMessage={message.chatEmphasizedText}
               text={message.message}
             />
           ),
@@ -503,6 +499,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
       $keyboardFocused={keyboardFocused}
       $reactionPopoverIsOpen={isToolbarReactionPopoverOpen}
       data-test="chatMessageItem"
+      $emphasizedMessage={message.chatEmphasizedText}
     >
       <ChatMessageToolbar
         keyboardFocused={keyboardFocused}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -528,7 +528,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
       <ChatMessageReplied
         message={message.replyToMessage.message || ''}
         sequence={message.replyToMessage.messageSequence}
-        emphasizedMessage={message.replyToMessage.chatEmphasizedText}
         deletedByUser={message.replyToMessage.deletedBy?.name ?? null}
       />
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
@@ -5,18 +5,16 @@ import { textToMarkdown } from '/imports/ui/components/chat/chat-graphql/service
 
 interface ChatMessageTextContentProps {
   text: string;
-  emphasizedMessage: boolean;
   dataTest?: string | null;
 }
 const ChatMessageTextContent: React.FC<ChatMessageTextContentProps> = ({
   text,
-  emphasizedMessage,
   dataTest = 'messageContent',
 }) => {
   const { allowedElements } = window.meetingClientSettings.public.chat;
 
   return (
-    <Styled.ChatMessage emphasizedMessage={emphasizedMessage} data-test={dataTest}>
+    <Styled.ChatMessage data-test={dataTest}>
       <ReactMarkdown
         linkTarget="_blank"
         allowedElements={allowedElements}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { colorText } from '/imports/ui/stylesheets/styled-components/palette';
 
 interface ChatMessageProps {
-  emphasizedMessage: boolean;
   systemMsg?: boolean;
 }
 
@@ -13,10 +12,6 @@ export const ChatMessage = styled.div<ChatMessageProps>`
   flex-direction: column;
   color: ${colorText};
   word-break: break-word;
-
-  ${({ emphasizedMessage }) => emphasizedMessage && `
-    font-weight: bold;
-  `}
 
   & img {
     max-width: 100%;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -14,13 +14,12 @@ const intlMessages = defineMessages({
 interface MessageRepliedProps {
   message: string;
   sequence: number;
-  emphasizedMessage: boolean;
   deletedByUser: string | null;
 }
 
 const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
   const {
-    message, sequence, emphasizedMessage, deletedByUser,
+    message, sequence, deletedByUser,
   } = props;
 
   const intl = useIntl();
@@ -45,7 +44,6 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
       {!deletedByUser && (
         <Styled.Message>
           <Styled.Markdown
-            $emphasizedMessage={emphasizedMessage}
             linkTarget="_blank"
             allowedElements={window.meetingClientSettings.public.chat.allowedElements}
             unwrapDisallowed

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/styles.tsx
@@ -37,14 +37,8 @@ export const DeleteMessage = styled.span`
   white-space: nowrap;
 `;
 
-export const Markdown = styled(ReactMarkdown)<{
-  $emphasizedMessage: boolean;
-}>`
+export const Markdown = styled(ReactMarkdown)`
   color: ${colorText};
-
-  ${({ $emphasizedMessage }) => $emphasizedMessage && `
-    font-weight: bold;
-  `}
 
   & img {
     max-width: 100%;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -22,6 +22,8 @@ import {
   colorGrayLight,
   colorGrayLightest,
   colorGrayDark,
+  emphasizedMessageBackgroundColor,
+  highlightedMessageBorderColor,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 import Header from '/imports/ui/components/common/control-header/component';
@@ -42,6 +44,7 @@ interface ChatContentProps {
   $highlight: boolean;
   $reactionPopoverIsOpen: boolean;
   $keyboardFocused: boolean;
+  $emphasizedMessage: boolean;
 }
 
 interface ChatAvatarProps {
@@ -95,6 +98,7 @@ export const ChatContent = styled.div<ChatContentProps>`
   width: 100%;
   border-radius: 0.5rem;
   position: relative;
+  border: 1px solid transparent;
 
   ${({ $isSystemSender }) => !$isSystemSender && `
     background-color: #f4f6fa;
@@ -102,8 +106,8 @@ export const ChatContent = styled.div<ChatContentProps>`
 
   ${({ $highlight }) => $highlight && `
     &:hover {
-      background-color: ${colorBlueLightest} !important;
-    }
+      border: 1px solid ${highlightedMessageBorderColor};
+     }
   `}
 
   ${({
@@ -116,6 +120,15 @@ export const ChatContent = styled.div<ChatContentProps>`
   .chat-message-container:focus & {
     background-color: ${colorBlueLightest} !important;
   }
+
+  ${({ $emphasizedMessage }) => $emphasizedMessage && `
+    background-color: ${emphasizedMessageBackgroundColor} !important;
+
+    &:hover {
+      border: 1px solid ${highlightedMessageBorderColor};
+    }
+  `}
+
 `;
 
 export const ChatContentFooter = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -18,7 +18,6 @@ const CANCEL_KEY = 'Esc';
 const ChatReplyIntention = () => {
   const [username, setUsername] = useState<string>();
   const [message, setMessage] = useState<string>();
-  const [emphasizedMessage, setEmphasizedMessage] = useState<boolean>();
   const [sequence, setSequence] = useState<number>();
   const intl = useIntl();
   const { animations } = useSettings(SETTINGS.APPLICATION) as {
@@ -33,7 +32,6 @@ const ChatReplyIntention = () => {
       if (e instanceof CustomEvent) {
         setUsername(e.detail.username);
         setMessage(e.detail.message);
-        setEmphasizedMessage(e.detail.emphasizedMessage);
         setSequence(e.detail.sequence);
       }
     };
@@ -42,7 +40,6 @@ const ChatReplyIntention = () => {
       if (e instanceof CustomEvent) {
         setUsername(undefined);
         setMessage(undefined);
-        setEmphasizedMessage(undefined);
         setSequence(undefined);
       }
     };
@@ -87,9 +84,7 @@ const ChatReplyIntention = () => {
       }}
     >
       <Styled.Message>
-        <Styled.Markdown
-          $emphasizedMessage={!!emphasizedMessage}
-        >
+        <Styled.Markdown>
           {messageChunks ? messageChunks[0] : ''}
         </Styled.Markdown>
       </Styled.Message>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
@@ -61,14 +61,8 @@ const Message = styled.div`
   min-width: 0;
 `;
 
-const Markdown = styled(ReactMarkdown)<{
-  $emphasizedMessage: boolean;
-}>`
+const Markdown = styled(ReactMarkdown)`
   color: ${colorText};
-
-  ${({ $emphasizedMessage }) => $emphasizedMessage && `
-    font-weight: bold;
-  `}
 
   & img {
     max-width: 100%;

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -90,7 +90,8 @@ const systemMessageBackgroundColor = 'var(--system-message-background-color, #F9
 const systemMessageBorderColor = 'var(--system-message-border-color, #C5CDD4)';
 const systemMessageFontColor = `var(--system-message-font-color, ${colorGrayDark})`;
 const highlightedMessageBackgroundColor = 'var(--system-message-background-color, #fef9f1)';
-const highlightedMessageBorderColor = 'var(--system-message-border-color, #f5c67f)';
+const highlightedMessageBorderColor = 'var(--system-message-border-color, #B5D3F7)';
+const emphasizedMessageBackgroundColor = 'var(--emphasized-message-background-color, #E9F1F9)';
 const colorHeading = `var(--color-heading, ${colorGrayDark})`;
 const palettePlaceholderText = 'var(--palette-placeholder-text, #787675)';
 const pollAnnotationGray = 'var(--poll-annotation-gray, #333333)';
@@ -197,6 +198,7 @@ export {
   systemMessageFontColor,
   highlightedMessageBackgroundColor,
   highlightedMessageBorderColor,
+  emphasizedMessageBackgroundColor,
   colorHeading,
   palettePlaceholderText,
   pollAnnotationGray,


### PR DESCRIPTION
### What does this PR do?

- adjusts moderator messages in the chat to have a different background color instead of making the text bold
- adjusts hover styles for the messages, to have a different border color instead of a different background color

#### moderator and viewer messages (before / after)

![messages-before](https://github.com/user-attachments/assets/cabf9842-1b93-4b97-bca0-85b2c18bbbbc) ![messages](https://github.com/user-attachments/assets/cb53846c-fce2-4137-bf37-38dd9cae963c)

#### hover styles (before / after)

![hover-before](https://github.com/user-attachments/assets/56a17893-23d8-43f2-8194-2db64434531f) ![hover](https://github.com/user-attachments/assets/3ee67922-d8f6-4542-ae9f-c84ceceb134f)


### Closes Issue(s)
Closes #19852

### How to test

1. join a meeting with 2 users: one moderator and one viewer
2. send messages in the chat
3. see styles for viewer and moderator messages