### PR TITLE
fix(screenshare): audio from shared tabs is muted

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -252,7 +252,7 @@ export default class KurentoScreenshareBridge {
     return error;
   }
 
-  async view(options = {
+  async view(streamId, options = {
     hasAudio: false,
     outputDeviceId: null,
   }) {
@@ -263,6 +263,7 @@ export default class KurentoScreenshareBridge {
     const SIGNAL_CANDIDATES = SFU_CONFIG.signalCandidates;
     const TRACE_LOGS = SFU_CONFIG.traceLogs;
     const GATHERING_TIMEOUT = SFU_CONFIG.gatheringTimeout;
+    this.streamId = streamId;
     this.hasAudio = options.hasAudio;
     this.outputDeviceId = options.outputDeviceId;
     this.role = RECV_ROLE;


### PR DESCRIPTION
### What does this PR do?

- [fix(screenshare): audio from shared tabs is muted](https://github.com/bigbluebutton/bigbluebutton/commit/d818291392cf169685e6918736fa651867a750b0) 
  * When using the default bridge (bbb-webrtc-sfu/mediasoup), audio from
a shared tab is muted on the receiver's end. This is caused by a change
in the `view` bridge argument signature that was not applied to the
webrtc-sfu bridge - causing the hasAudio property to be undefined the
media element to be muted.
  * Adjust bbb-webrtc-sfu's screen sharing bridge so that the options object
and hasAudio property are properly picked up.


### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/22240
Closes https://github.com/bigbluebutton/bigbluebutton/issues/22106