### PR TITLE
fix: restore bbb_record_permission and bbb_record_permission_tooltip

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -170,9 +170,10 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
     if (disabled) return intl.formatMessage(intlMessages.unavailableTitle);
 
     if (!recording) {
-      if (!isModerator && time > 0) {
+      if (!showButton && time > 0) {
         return intl.formatMessage(intlMessages.resumeViewTitle);
       }
+
       return time > 0
         ? intl.formatMessage(intlMessages.resumeTitle)
         : intl.formatMessage(intlMessages.startTitle);
@@ -183,9 +184,12 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
 
   const tooltipTitle = useMemo(() => {
     if (!recording) {
-      return recordTitle;
+      return !showButton
+        ? Service.getCustomRecordTooltip(recordTitle)
+        : recordTitle;
     }
-    return isModerator
+
+    return showButton
       ? intl.formatMessage(intlMessages.stopTitle)
       : intl.formatMessage(intlMessages.recordingTitle);
   }, [recording, isModerator, recordTitle]);


### PR DESCRIPTION
### What does this PR do?

- [fix: restore bbb_record_permission and bbb_record_permission_tooltip](https://github.com/bigbluebutton/bigbluebutton/commit/6bbe929092cc5c2d1553cc1555a31e733fcd367f) 
  - Both userdatas were partially broken after re-implementing the
recording indicator.
  - Correctly render bbb_record_permission_tooltip when appropriate (i.e.:
recording is paused and the user has no permission, following 3.0
behavior).
  - Adjust places where bbb_record_permission was partially ignored when
rendering tooltips, titles and buttons.

### Closes Issue(s)

None