### PR TITLE
fix(livekit): blurry screen sharing due to borked presets

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -17,18 +17,14 @@ import {
   LocalTrack,
   RemoteTrack,
   type TrackPublishOptions,
+  VideoPreset,
+  ScreenSharePresets,
 } from 'livekit-client';
 import {
   liveKitRoom,
   getLKStats,
 } from '/imports/ui/services/livekit';
-
-const BRIDGE_NAME = 'livekit';
-const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
-const SEND_ROLE = 'send';
-const RECV_ROLE = 'recv';
-const DEFAULT_VOLUME = 1;
-const ROOM_CONNECTION_TIMEOUT = 15000;
+import { LiveKitPresetConfig } from 'imports/ui/Types/meetingClientSettings';
 
 interface Options {
   hasAudio?: boolean;
@@ -39,6 +35,52 @@ interface PublicationData {
   track: LocalTrack | RemoteTrack;
   publication: LocalTrackPublication | RemoteTrackPublication;
 }
+
+const BRIDGE_NAME = 'livekit';
+const SCREENSHARE_VIDEO_TAG = 'screenshareVideo';
+const SEND_ROLE = 'send';
+const RECV_ROLE = 'recv';
+const DEFAULT_VOLUME = 1;
+const ROOM_CONNECTION_TIMEOUT = 15000;
+
+const FALLBACK_PRESET_ORG_HIGH = new VideoPreset(1920, 1080, 2_000_000, 15, 'medium');
+
+const getDefaultPresets = (mediaStream: MediaStream): VideoPreset[] => {
+  const fallbackPresets = [FALLBACK_PRESET_ORG_HIGH];
+
+  try {
+    if (!mediaStream.getVideoTracks().length) return fallbackPresets;
+
+    const { width = 1920, height = 1080 } = mediaStream.getVideoTracks()[0].getSettings();
+
+    return [
+      new VideoPreset(width, height, 2_000_000, 15, 'medium'),
+    ];
+  } catch (error) {
+    logger.error({
+      logCode: 'livekit_screenshare_get_presets_error',
+      extraInfo: {
+        errorName: (error as Error).name,
+        errorMessage: (error as Error).message,
+        errorStack: (error as Error).stack,
+      },
+    }, `LiveKit: failed to get screen share presets: ${(error as Error).message}`);
+
+    return fallbackPresets;
+  }
+};
+
+const assemblePresetFromConfig = (config: LiveKitPresetConfig): VideoPreset => {
+  const {
+    width,
+    height,
+    maxBitrate,
+    maxFramerate,
+    priority,
+  } = config;
+
+  return new VideoPreset(width, height, maxBitrate, maxFramerate, priority);
+};
 
 export default class LiveKitScreenshareBridge {
   private readonly liveKitRoom: Room;
@@ -454,18 +496,30 @@ export default class LiveKitScreenshareBridge {
 
   async share(stream: MediaStream, onFailure: (error: Error) => void, contentType: string): Promise<void> {
     // @ts-ignore
-    const LIVEKIT_SCREEN_SETTINGS = window.meetingClientSettings.public.media?.livekit?.screenshare;
+    const configScreenPubOpts = window.meetingClientSettings.public.media?.livekit?.screenshare?.publishOptions
+      || {};
+    const presets = window.meetingClientSettings.public.media?.livekit?.screenshare?.presets;
+    const screenSharePresets = presets
+      ? presets.map((preset: LiveKitPresetConfig) => assemblePresetFromConfig(preset))
+      : getDefaultPresets(stream);
+    const screenShareEncoding = screenSharePresets[screenSharePresets.length - 1]?.encoding
+      || ScreenSharePresets.h1080fps15.encoding;
     // @ts-ignore
-    const LIVEKIT_AUDIO_SETTINGS = window.meetingClientSettings.public.media?.livekit?.audio;
-    const baseAudioOptions: TrackPublishOptions = LIVEKIT_AUDIO_SETTINGS?.publishOptions || {
+    const configAudioPubOpts = window.meetingClientSettings.public.media?.livekit?.audio?.publishOptions || {};
+    const baseAudioOptions: TrackPublishOptions = {
       audioPreset: AudioPresets.speech,
       dtx: true,
       red: false,
       forceStereo: false,
+      ...configAudioPubOpts,
     };
-    const baseVideoOptions: TrackPublishOptions = LIVEKIT_SCREEN_SETTINGS?.publishOptions || {
+    const baseVideoOptions: TrackPublishOptions = {
       videoCodec: 'vp8',
+      simulcast: true,
+      screenShareEncoding,
+      ...configScreenPubOpts,
     };
+
     this.role = SEND_ROLE;
     this.hasAudio = BridgeService.streamHasAudioTrack(stream);
     this.gdmStream = stream;

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -619,16 +619,27 @@ export interface Media {
   traceSip: boolean
   sdpSemantics: string
   localEchoTest: LocalEchoTest
+  networkPriorities: MediaNetworkPriorities
   muteAudioOutputWhenAway: boolean
   livekit: LiveKitSettings
 }
 
+export interface LiveKitPresetConfig {
+  width: number
+  height: number
+  maxBitrate: number
+  maxFramerate: number
+  priority?: RTCPriorityType
+}
+
 export interface LiveKitCameraSettings {
   publishOptions?: TrackPublishOptions
+  presets?: LiveKitPresetConfig[]
 }
 
 export interface LiveKitScreenShareSettings {
   publishOptions?: TrackPublishOptions
+  presets?: LiveKitPresetConfig[]
 }
 
 export interface LiveKitAudioSettings {
@@ -661,6 +672,12 @@ export interface LocalEchoTest {
   initialHearingState: boolean
   useRtcLoopbackInChromium: boolean
   delay: Delay
+}
+
+export interface MediaNetworkPriorities {
+  audio: RTCPriorityType
+  webcam: RTCPriorityType
+  screenshare: RTCPriorityType
 }
 
 export interface Delay {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -664,6 +664,11 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           maxDelayTime: 2,
         },
       },
+      networkPriorities: {
+        audio: 'high',
+        webcam: 'medium',
+        screenshare: 'medium',
+      },
       muteAudioOutputWhenAway: false,
       screenshare: {
         showButtonForNonPresenters: false,


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): blurry screen sharing due to borked presets](https://github.com/bigbluebutton/bigbluebutton/commit/5930a1b1d5b2333bfbf8ed21cbded1fdb16267d9) 
  -  LiveKit's screen sharing presets aren't configurable in BBB. The default values
are also not ideal right now, which causes the received stream to be in
a lower quality than it should in specific scenarios due to adaptive
streaming.
  - Make screen sharing's presets configurable, as well as adjust the
default encoding preset to something that makes for nicer layers
(1080p, 15fps).

### Closes Issue(s)

None