### PR TITLE
fix: audio/screenshare isn't stopped when joining breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@apollo/client';
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
 import ModalFullscreen from '/imports/ui/components/common/modal/fullscreen/component';
@@ -14,13 +14,9 @@ import {
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { BREAKOUT_ROOM_REQUEST_JOIN_URL } from '../../breakout-room/mutations';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
-import AudioManager from '/imports/ui/services/audio-manager';
-import AudioService from '/imports/ui/components/audio/service';
-import VideoService from '/imports/ui/components/video-provider/service';
-import { useExitVideo, useStreams } from '/imports/ui/components/video-provider/hooks';
-import logger from '/imports/startup/client/logger';
 import { rejoinAudio } from '../../breakout-room/breakout-room/service';
 import { useBreakoutExitObserver } from './hooks';
+import { useStopMediaOnMainRoom } from '/imports/ui/components/breakout-room/hooks';
 
 const intlMessages = defineMessages({
   title: {
@@ -65,26 +61,20 @@ interface BreakoutJoinConfirmationProps {
   freeJoin: boolean;
   breakouts: BreakoutRoom[];
   currentUserJoined: boolean,
+  presenter: boolean;
   firstBreakoutId: string;
-  isUsingAudio: () => boolean;
-  exitVideo: () => Promise<boolean>;
-  exitAudio: () => Promise<unknown>;
-  storeVideoDevices: () => void;
 }
 
 const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   freeJoin,
   breakouts,
   currentUserJoined,
+  presenter,
   firstBreakoutId,
-  isUsingAudio,
-  exitAudio,
-  exitVideo,
-  storeVideoDevices,
 }) => {
   const [breakoutRoomRequestJoinURL] = useMutation(BREAKOUT_ROOM_REQUEST_JOIN_URL);
   const [callHandleInviteDismissedAt] = useMutation(handleInviteDismissedAt);
-
+  const stopMediaOnMainRoom = useStopMediaOnMainRoom();
   const intl = useIntl();
   const [waiting, setWaiting] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -116,16 +106,9 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
     }
   };
 
-  const handleJoinBreakoutConfirmation = () => {
-    if (isUsingAudio()) {
-      exitAudio();
-      logger.info(
-        { logCode: 'breakout_join_confirmation' },
-        'Joining breakout room closed audio in the main room',
-      );
-    }
-    storeVideoDevices();
-    exitVideo();
+  const handleJoinBreakoutConfirmation = useCallback(() => {
+    stopMediaOnMainRoom(presenter);
+
     if (breakouts.length === 1) {
       const breakout = breakouts[0];
 
@@ -139,7 +122,7 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
         window.open(selectedBreakout.joinURL, '_blank');
       }
     }
-  };
+  }, [breakouts, selectValue, presenter, stopMediaOnMainRoom]);
 
   const select = useMemo(() => {
     return (
@@ -223,18 +206,12 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
     return {
       isModerator: u.isModerator,
       breakoutRooms: u.breakoutRooms,
+      presenter: u.presenter,
     };
   });
   const {
     data: breakoutData,
   } = useDeduplicatedSubscription<GetBreakoutDataResponse>(getBreakoutData);
-  const exitVideo = useExitVideo(true);
-  const videoStreams = useStreams();
-  const storeVideoDevices = () => {
-    VideoService.storeDeviceIds(videoStreams);
-  };
-  const { exitAudio } = AudioService;
-  const { isUsingAudio } = AudioManager;
   const breakoutExitObserver = useBreakoutExitObserver();
   useEffect(() => {
     breakoutExitObserver.setCallback('rejoinAudio', rejoinAudio);
@@ -259,11 +236,8 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
       freeJoin={freeJoin}
       breakouts={breakoutData.breakoutRoom}
       currentUserJoined={currentUser?.breakoutRooms?.isUserCurrentlyInRoom ?? false}
+      presenter={currentUser?.presenter ?? false}
       firstBreakoutId={breakoutRoomId}
-      isUsingAudio={isUsingAudio}
-      exitVideo={exitVideo}
-      exitAudio={exitAudio}
-      storeVideoDevices={storeVideoDevices}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
@@ -18,12 +18,7 @@ import { BREAKOUT_ROOM_END_ALL, BREAKOUT_ROOM_REQUEST_JOIN_URL, USER_TRANSFER_VO
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import TimeRemaingPanel from './components/timeRemaining';
 import BreakoutMessageForm from './components/messageForm';
-import {
-  finishScreenShare,
-  forceExitAudio,
-  stopVideo,
-} from './service';
-import { useExitVideo, useStreams } from '/imports/ui/components/video-provider/hooks';
+import { useStopMediaOnMainRoom } from '/imports/ui/components/breakout-room/hooks';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 
 interface BreakoutRoomProps {
@@ -115,6 +110,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
   const [breakoutRoomEndAll] = useMutation(BREAKOUT_ROOM_END_ALL);
   const [breakoutRoomTransfer] = useMutation(USER_TRANSFER_VOICE_TO_MEETING);
   const [breakoutRoomRequestJoinURL] = useMutation(BREAKOUT_ROOM_REQUEST_JOIN_URL);
+  const stopMediaOnMainRoom = useStopMediaOnMainRoom();
 
   const layoutContextDispatch = layoutDispatch();
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
@@ -156,12 +152,10 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
       if (breakout && breakout.joinURL) {
         window.open(breakout.joinURL, '_blank');
         setRequestedBreakoutRoomId('');
+        stopMediaOnMainRoom(presenter);
       }
     }
-  }, [breakouts]);
-
-  const exitVideo = useExitVideo();
-  const streams = useStreams();
+  }, [breakouts, stopMediaOnMainRoom, presenter]);
 
   return (
     <Styled.Panel
@@ -245,15 +239,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
                                   requestJoinURL(breakout.breakoutRoomId);
                                 } else {
                                   window.open(breakout.joinURL, '_blank');
-                                  // leave main room's audio,
-                                  // and stops video and screenshare when joining a breakout room
-                                  forceExitAudio();
-                                  stopVideo(exitVideo, streams);
-                                  logger.info({
-                                    logCode: 'breakoutroom_join',
-                                    extraInfo: { logType: 'user_action' },
-                                  }, 'joining breakout room closed audio in the main room');
-                                  if (presenter) finishScreenShare();
+                                  stopMediaOnMainRoom(presenter);
                                 }
                               }}
                               disabled={requestedBreakoutRoomId}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+import logger from '/imports/startup/client/logger';
+import { useExitVideo, useStreams } from '/imports/ui/components/video-provider/hooks';
+import {
+  finishScreenShare,
+  forceExitAudio,
+  stopVideo,
+} from '/imports/ui/components/breakout-room/breakout-room/service';
+import VideoService from '/imports/ui/components/video-provider/service';
+
+export const useStopMediaOnMainRoom = () => {
+  const exitVideo = useExitVideo(true);
+  const streams = useStreams();
+
+  const stop = useCallback((presenter: boolean) => {
+    forceExitAudio();
+    VideoService.storeDeviceIds(streams);
+    stopVideo(exitVideo, streams);
+    logger.info({
+      logCode: 'breakoutroom_join_stop_media',
+      extraInfo: { logType: 'user_action' },
+    }, 'Joining breakout room closed audio in the main room');
+    if (presenter) finishScreenShare();
+  }, [exitVideo, streams]);
+
+  return stop;
+};
+
+export default {
+  useStopMediaOnMainRoom,
+};


### PR DESCRIPTION
### What does this PR do?

- [fix: audio/screenshare isn't stopped when joining breakouts](https://github.com/bigbluebutton/bigbluebutton/commit/ed843020fed4870189d64d5a3f00d863b8ceed6b) 
  - There are two scenarios where media in the main room isn't properly
stopped when joining breakouts:
    - Audio: when manually requesting to join a breakout the user was not
      invited to
    - Screen share: when accepting an invite to a breakout room.
  - This commit rewrites and centralizes the procedure to stop the user's media
in the main room in a hook called useStopMediaOnMainRoom. Both the
join-confirmation and manual join procedure now use that hook, which
guarantees audio, screen sharing and video to be stopped when necessary.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/22070

### How to test

See https://github.com/bigbluebutton/bigbluebutton/issues/22070