### PR TITLE
fix(audio): bridge callbacks might be uninitialized

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -383,7 +383,9 @@ class AudioManager {
     // Initialize device IDs in configured bridges
     this.fullAudioBridge.inputDeviceId = this.inputDeviceId;
     this.fullAudioBridge.outputDeviceId = this.outputDeviceId;
+    this.fullAudioBridge.callback = this.callStateCallback;
     this.listenOnlyBridge.outputDeviceId = this.outputDeviceId;
+    this.listenOnlyBridge.callback = this.callStateCallback;
     logger.debug({
       logCode: 'audiomanager_bridges_loaded',
       extraInfo: {


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): bridge callbacks might be uninitialized](https://github.com/bigbluebutton/bigbluebutton/commit/f4e329ce71431db84c981492d96f713c7a687ae6) 
  - Audio bridge callbacks are, for unknown reasons, specified through
joinAudio calls rather than when initializing bridges. This has the
potential to cause issues with bridge such as LiveKit which triggers
audio join automatically rather than due to user input.
  - Set the audio-manager callback in bridges during the bridge load
procedure and thus guarantee that it exists in bridges in all scenarios.

### Closes Issue(s)

n/a