### PR TITLE
feat(plugins): add useLocaleMessage to plugins

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PluginDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PluginDAO.scala
@@ -3,10 +3,11 @@ package org.bigbluebutton.core.db
 import PostgresProfile.api._
 
 case class PluginDbModel(
-  meetingId:          String,
-  name:         String,
-  javascriptEntrypointUrl:        String,
-  javascriptEntrypointIntegrity:       String
+    meetingId:                     String,
+    name:                          String,
+    javascriptEntrypointUrl:       String,
+    javascriptEntrypointIntegrity: String,
+    localesBaseUrl:                String
 )
 
 class PluginDbTableDef(tag: Tag) extends Table[PluginDbModel](tag, None, "plugin") {
@@ -14,11 +15,15 @@ class PluginDbTableDef(tag: Tag) extends Table[PluginDbModel](tag, None, "plugin
   val name = column[String]("name", O.PrimaryKey)
   val javascriptEntrypointUrl = column[String]("javascriptEntrypointUrl")
   val javascriptEntrypointIntegrity = column[String]("javascriptEntrypointIntegrity")
-  override def * = (meetingId, name, javascriptEntrypointUrl, javascriptEntrypointIntegrity) <> (PluginDbModel.tupled, PluginDbModel.unapply)
+  val localesBaseUrl = column[String]("localesBaseUrl")
+  override def * = (meetingId, name, javascriptEntrypointUrl,
+    javascriptEntrypointIntegrity, localesBaseUrl) <> (PluginDbModel.tupled, PluginDbModel.unapply)
 }
 
 object PluginDAO {
-  def insert(meetingId: String, name: String, javascriptEntrypointUrl: String, javascriptEntrypointIntegrity: String) = {
+  def insert(meetingId: String, name: String, javascriptEntrypointUrl: String,
+             javascriptEntrypointIntegrity: String, localesBaseUrl: Option[String]) = {
+    val localesBaseUrlValue = localesBaseUrl.getOrElse("")
     DatabaseConnection.enqueue(
       TableQuery[PluginDbTableDef].forceInsert(
         PluginDbModel(
@@ -26,6 +31,8 @@ object PluginDAO {
           name = name,
           javascriptEntrypointUrl = javascriptEntrypointUrl,
           javascriptEntrypointIntegrity = javascriptEntrypointIntegrity,
+          localesBaseUrl = localesBaseUrlValue
+
         )
       )
     )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -62,17 +62,39 @@ object PluginModel {
   def getPlugins(instance: PluginModel): Map[String, Plugin] = {
     instance.plugins
   }
-  def replaceRelativeJavascriptEntrypoint(plugin: Plugin): Plugin = {
+  private def replaceRelativeJavascriptEntrypoint(plugin: Plugin): Plugin = {
     val jsEntrypoint = plugin.manifest.content.javascriptEntrypointUrl
     if (jsEntrypoint.startsWith("http://") || jsEntrypoint.startsWith("https://")) {
       plugin
     } else {
-      val baseUrl = plugin.manifest.url.substring(0, plugin.manifest.url.lastIndexOf('/') + 1)
-      val absoluteJavascriptEntrypoint = baseUrl + jsEntrypoint
+      val absoluteJavascriptEntrypoint = makeAbsoluteUrl(plugin, jsEntrypoint)
       val newPluginManifestContent = plugin.manifest.content.copy(javascriptEntrypointUrl = absoluteJavascriptEntrypoint)
       val newPluginManifest = plugin.manifest.copy(content = newPluginManifestContent)
       plugin.copy(manifest = newPluginManifest)
     }
+  }
+  private def replaceRelativeLocalesBaseUrl(plugin: Plugin): Plugin = {
+    val localesBaseUrl = plugin.manifest.content.localesBaseUrl
+    localesBaseUrl match {
+      case Some(value: String) =>
+        if (value.startsWith("http://") || value.startsWith("https://")) {
+          plugin
+        } else {
+          val absoluteLocalesBaseUrl = makeAbsoluteUrl(plugin = plugin, relativeUrl = value)
+          val newPluginManifestContent = plugin.manifest.content.copy(localesBaseUrl = Some(absoluteLocalesBaseUrl))
+          val newPluginManifest = plugin.manifest.copy(content = newPluginManifestContent)
+          plugin.copy(manifest = newPluginManifest)
+        }
+      case None => plugin
+    }
+  }
+  private def makeAbsoluteUrl(plugin: Plugin, relativeUrl: String): String = {
+    val baseUrl = plugin.manifest.url.substring(0, plugin.manifest.url.lastIndexOf('/') + 1)
+    baseUrl + relativeUrl
+  }
+  private def replaceAllRelativeUrls(plugin: Plugin): Plugin = {
+    val pluginWithAbsoluteJsEntrypoint = replaceRelativeJavascriptEntrypoint(plugin)
+    replaceRelativeLocalesBaseUrl(pluginWithAbsoluteJsEntrypoint)
   }
   def createPluginModelFromJson(json: util.Map[String, AnyRef]): PluginModel = {
     val instance = new PluginModel()
@@ -80,8 +102,8 @@ object PluginModel {
     json.forEach { case (pluginName, plugin) =>
       try {
         val pluginObject = objectMapper.readValue(objectMapper.writeValueAsString(plugin), classOf[Plugin])
-        val pluginObjectWithAbsoluteJavascriptEntrypoint = replaceRelativeJavascriptEntrypoint(pluginObject)
-        pluginsMap = pluginsMap + (pluginName -> pluginObjectWithAbsoluteJavascriptEntrypoint)
+        val pluginObjectWithAbsoluteUrls = replaceAllRelativeUrls(pluginObject)
+        pluginsMap = pluginsMap + (pluginName -> pluginObjectWithAbsoluteUrls)
       } catch {
         case err @ (_: JsonProcessingException | _: JsonMappingException) => println("Error while processing plugin " +
           pluginName + ": ", err)
@@ -93,7 +115,7 @@ object PluginModel {
   def persistPluginsForClient(instance: PluginModel, meetingId: String): Unit = {
     instance.plugins.foreach { case (_, plugin) =>
       PluginDAO.insert(meetingId, plugin.manifest.content.name, plugin.manifest.content.javascriptEntrypointUrl,
-        plugin.manifest.content.javascriptEntrypointIntegrity.getOrElse(""))
+        plugin.manifest.content.javascriptEntrypointIntegrity.getOrElse(""), plugin.manifest.content.localesBaseUrl)
     }
   }
 }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2237,6 +2237,7 @@ create index idx_notification on notification("meetingId","userId","role","creat
 create table "plugin" (
 	"meetingId" varchar(100),
 	"name" varchar(100),
+    "localesBaseUrl" varchar(500),
 	"javascriptEntrypointUrl" varchar(500),
 	"javascriptEntrypointIntegrity" varchar(500),
     CONSTRAINT "plugin_pk" PRIMARY KEY ("meetingId","name"),

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_plugin.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_plugin.yaml
@@ -13,6 +13,7 @@ select_permissions:
         - javascriptEntrypointIntegrity
         - javascriptEntrypointUrl
         - name
+        - localesBaseUrl
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
@@ -23,6 +24,7 @@ select_permissions:
         - javascriptEntrypointIntegrity
         - javascriptEntrypointUrl
         - name
+        - localesBaseUrl
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId


### PR DESCRIPTION
### What does this PR do?

This PR adds the `localesBaseUrl` to the plugin's table in the postgres. This will be useful for the plugin to fetch this data easily.

### Motivation

Add internationalization for the plugins more easily as requested in the issue https://github.com/bigbluebutton/plugin-typed-captions/issues/6

### How to test

To test this, there ar 3 PRs that work together here: This one in the CORE, the one in the SDK, mentioned ahead and the one in the typed-captions (which will be sent later on), so the 3 of them must be tested at the same time.

- First, one will have to apply the SDK manually into the plugin-typed-captions (Considering both in the correct branches);
- Run in dev mode;
- So as we are testing it with ngrok, they put some barriers there to avoid security breaches, so to properly make the testing work, do the following:

Go into the `webpack.config.js` file in the plugin, and write:
```js
headers: {
      'Access-Control-Allow-Origin': '*',
      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
      'Access-Control-Allow-Headers': 'X-Requested-With, content-type, Authorization, ngrok-skip-browser-warning', 
    },
```
Into the `devServer` directive (If that's not there yet).

Then into the file `src/components/main/component.tsx` search for the hook used to obtain the intl-messages that is `pluginApi.useLocaleMessages` and add the following argument to the function:

```js
{
    headers: {
      'ngrok-skip-browser-warning': 'any',
    },
  }
```

With that, the ngrok will not complain about the locale files and everything should flow normally.

### More

Closely related to the PR in the SDK https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/147

See demo of this feature:


https://github.com/user-attachments/assets/2ad2d66b-4976-4ab7-9438-6a77386376b0


