### PR TITLE
test: Fix correct assertion element

### DIFF
--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -153,7 +153,7 @@ class MultiUsers {
     await this.modPage.waitForSelector(e.whiteboard);
     await this.initUserPage();
     await this.userPage.waitAndClick(e.raiseHandBtn);
-    await this.userPage.hasElement(e.raiseHandBtn, 'should display the lower hand button for the attendee');
+    await this.userPage.hasElement(e.lowerHandBtn, 'should display the lower hand button for the attendee');
     await this.userPage.press('Escape');
     await this.modPage.comparingSelectorsBackgroundColor(e.avatarsWrapperAvatar, `${e.userListItem} div:first-child`);
     await this.modPage.waitAndClick(e.raiseHandRejection);


### PR DESCRIPTION
### What does this PR do?
This PR fixes an incorrect element expected in an assertion of the `User › Actions › Raise Hand Rejected` test. This incorrect element, however, didn't throw the test failure every time, only when it took a bit longer to load as it expected the previous state, not the current.