### PR TITLE
fix: Shortcuts list was crashing the client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -47,7 +47,7 @@ const intlMessages = defineMessages({
     id: 'app.shortcut-help.toggleUserList',
     description: 'describes the toggle userlist shortcut',
   },
-  openLeaveMenu: {
+  openleavemenu: {
     id: 'app.shortcut-help.openLeaveMenu',
     description: 'describes the open leave menu shortcut',
   },


### PR DESCRIPTION
    The key is used as an id when it is lowercased.
    However, here it was camelCased thus causing a discrepancy and
    the internationalization was crashing the client

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Corrects an issue with https://github.com/bigbluebutton/bigbluebutton/pull/22117 where the internationalization key was expected to be all lowercase but was camelCase instead

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
reported by @paulseto 

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Load the client and try to open the Shortcuts table from the "kebob" button (where Settings are located).

