### PR TITLE
fix (html5): Client always showing "Current presentation" notification

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
@@ -2,10 +2,11 @@ package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.db.PresPresentationDAO
+import org.bigbluebutton.core.db.{NotificationDAO, PresPresentationDAO}
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.PresentationInPod
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait PresentationConversionCompletedSysPubMsgHdlr {
   this: PresentationPodHdlrs =>
@@ -55,6 +56,18 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
       pods = pods.addPresentationToPod(pod.id, presWithConvertedName)
 
       PresPresentationDAO.updatePages(presWithConvertedName)
+      if(pres.current) {
+        val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+          meetingId,
+          "info",
+          "presentation",
+          "app.presentation.newPresentationActiveNotification",
+          "Notification when a new presentation is set as current",
+          Vector(s"${pres.name}")
+        )
+        NotificationDAO.insert(notifyEvent)
+      }
+
       state.update(pods)
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
@@ -61,7 +61,7 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
           meetingId,
           "info",
           "presentation",
-          "app.presentation.newPresentationActiveNotification",
+          "app.presentation.newCurrentPresentationNotification",
           "Notification when a new presentation is set as current",
           Vector(s"${pres.name}")
         )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPageConversionStartedSysMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPageConversionStartedSysMsgHdlr.scala
@@ -55,7 +55,7 @@ trait PresentationPageConversionStartedSysMsgHdlr {
       var pods = state.presentationPodManager.addPod(pod)
       pods = pods.addPresentationToPod(pod.id, pres)
       if (msg.body.current) {
-        pods = pods.setCurrentPresentation(pod.id, pres.id)
+        pods = pods.setCurrentPresentation(liveMeeting.props.meetingProp.intId, pod.id, pres)
       }
 
       state.update(pods)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPageConversionStartedSysMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPageConversionStartedSysMsgHdlr.scala
@@ -55,7 +55,7 @@ trait PresentationPageConversionStartedSysMsgHdlr {
       var pods = state.presentationPodManager.addPod(pod)
       pods = pods.addPresentationToPod(pod.id, pres)
       if (msg.body.current) {
-        pods = pods.setCurrentPresentation(liveMeeting.props.meetingProp.intId, pod.id, pres)
+        pods = pods.setCurrentPresentation(pod.id, pres)
       }
 
       state.update(pods)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodsApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodsApp.scala
@@ -96,15 +96,6 @@ object PresentationPodsApp {
       pres.removable, defaultPresentation, filenameConverted)
   }
 
-  def setCurrentPresentationInPod(state: MeetingState2x, podId: String, nextCurrentPresId: String): Option[PresentationPod] = {
-    for {
-      pod <- getPresentationPod(state, podId)
-      updatedPod <- pod.setCurrentPresentation(nextCurrentPresId)
-    } yield {
-      updatedPod
-    }
-  }
-
   def generateToken(podId: String, userId: String): String = {
     "PresUploadToken-" + RandomStringGenerator.randomAlphanumericString(8) + podId + "-" + userId
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
@@ -38,8 +38,8 @@ trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
 
       val newState = for {
         pod <- PresentationPodsApp.getPresentationPodIfPresenter(state, podId, userId)
-        _ <- pod.getPresentation(presId)
-        updatedPod <- pod.setCurrentPresentation(presId)
+        pres <- pod.getPresentation(presId)
+        updatedPod <- pod.setCurrentPresentation(liveMeeting.props.meetingProp.intId, pres)
       } yield {
         broadcastSetCurrentPresentationEvent(podId, userId, presId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
@@ -49,7 +49,7 @@ trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
           liveMeeting.props.meetingProp.intId,
           "info",
           "presentation",
-          "app.presentation.newPresentationActiveNotification",
+          "app.presentation.newCurrentPresentationNotification",
           "Notification when a new presentation is set as current",
           Vector(s"${pres.name}")
         )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
@@ -3,8 +3,10 @@ package org.bigbluebutton.core.apps.presentationpod
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.NotificationDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
@@ -39,9 +41,19 @@ trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
       val newState = for {
         pod <- PresentationPodsApp.getPresentationPodIfPresenter(state, podId, userId)
         pres <- pod.getPresentation(presId)
-        updatedPod <- pod.setCurrentPresentation(liveMeeting.props.meetingProp.intId, pres)
+        updatedPod <- pod.setCurrentPresentation(pres)
       } yield {
         broadcastSetCurrentPresentationEvent(podId, userId, presId)
+
+        val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+          liveMeeting.props.meetingProp.intId,
+          "info",
+          "presentation",
+          "app.presentation.newPresentationActiveNotification",
+          "Notification when a new presentation is set as current",
+          Vector(s"${pres.name}")
+        )
+        NotificationDAO.insert(notifyEvent)
 
         val pods = state.presentationPodManager.addPod(updatedPod)
         state.update(pods)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresentationDownloadablePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresentationDownloadablePubMsgHdlr.scala
@@ -3,9 +3,10 @@ package org.bigbluebutton.core.apps.presentationpod
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.db.PresPresentationDAO
+import org.bigbluebutton.core.db.{ NotificationDAO, PresPresentationDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.LiveMeeting
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait SetPresentationDownloadablePubMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
@@ -54,6 +55,19 @@ trait SetPresentationDownloadablePubMsgHdlr extends RightsManagementTrait {
         val pods = state.presentationPodManager.setPresentationDownloadableInPod(pod.id, presentationId, downloadable, downloadableExtension)
 
         PresPresentationDAO.updateDownloadable(presentationId, downloadable, downloadableExtension)
+
+        if (downloadable && pres.current) {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "info",
+            "presentation",
+            "app.presentation.downloadEnabledNotification",
+            "Notification when the download of the presentation has been enabled",
+            Vector(s"${pres.name}")
+          )
+          NotificationDAO.insert(notifyEvent)
+        }
+
         state.update(pods)
       }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -1,7 +1,8 @@
 package org.bigbluebutton.core.models
 
 import org.bigbluebutton.core.util.RandomStringGenerator
-import org.bigbluebutton.core.db.{ PresPageDAO, PresPresentationDAO }
+import org.bigbluebutton.core.db.{NotificationDAO, PresPageDAO, PresPresentationDAO}
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 object PresentationPodFactory {
   private def genId(): String = System.currentTimeMillis() + "-" + RandomStringGenerator.randomAlphanumericString(8)
@@ -98,23 +99,33 @@ case class PresentationPod(id: String, currentPresenter: String,
   def getPresentationsByFilename(filename: String): Iterable[PresentationInPod] =
     presentations.values filter (p => p.name.startsWith(filename))
 
-  def setCurrentPresentation(presId: String): Option[PresentationPod] = {
+  def setCurrentPresentation(meetingId: String, newPresentation: PresentationInPod): Option[PresentationPod] = {
     var updatedPod: PresentationPod = this
-    presentations.get(presId) match {
+    presentations.get(newPresentation.id) match {
       case Some(newCurrentPresentation) =>
         // set new current presentation
         updatedPod = updatedPod.addPresentation(newCurrentPresentation.copy(current = true))
 
         // unset previous current presentation
         presentations.values foreach (curPres => {
-          if (curPres.current && curPres.id != presId) {
+          if (curPres.current && curPres.id != newPresentation.id) {
             val newPres = curPres.copy(current = false)
             updatedPod = updatedPod.addPresentation(newPres)
           }
         })
 
         // update graphql
-        PresPresentationDAO.setCurrentPres(presId)
+        PresPresentationDAO.setCurrentPres(newPresentation.id)
+
+        val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+          meetingId,
+          "info",
+          "presentation",
+          "app.presentation.newPresentationActiveNotification",
+          "Notification when a new presentation is set as current",
+          Vector(s"${newPresentation.name}")
+        )
+        NotificationDAO.insert(notifyEvent)
 
         Some(updatedPod)
       case None =>
@@ -260,10 +271,10 @@ case class PresentationPodManager(presentationPods: collection.immutable.Map[Str
     a
   }
 
-  def setCurrentPresentation(podId: String, presId: String): PresentationPodManager = {
+  def setCurrentPresentation(meetingId: String, podId: String, pres: PresentationInPod): PresentationPodManager = {
     val updatedManager = for {
       pod <- getPod(podId)
-      podWithAdjustedCurrentPresentation <- pod.setCurrentPresentation(presId)
+      podWithAdjustedCurrentPresentation <- pod.setCurrentPresentation(meetingId, pres)
 
     } yield {
       updatePresentationPod(podWithAdjustedCurrentPresentation)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -99,7 +99,7 @@ case class PresentationPod(id: String, currentPresenter: String,
   def getPresentationsByFilename(filename: String): Iterable[PresentationInPod] =
     presentations.values filter (p => p.name.startsWith(filename))
 
-  def setCurrentPresentation(meetingId: String, newPresentation: PresentationInPod): Option[PresentationPod] = {
+  def setCurrentPresentation(newPresentation: PresentationInPod): Option[PresentationPod] = {
     var updatedPod: PresentationPod = this
     presentations.get(newPresentation.id) match {
       case Some(newCurrentPresentation) =>
@@ -116,16 +116,6 @@ case class PresentationPod(id: String, currentPresenter: String,
 
         // update graphql
         PresPresentationDAO.setCurrentPres(newPresentation.id)
-
-        val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
-          meetingId,
-          "info",
-          "presentation",
-          "app.presentation.newPresentationActiveNotification",
-          "Notification when a new presentation is set as current",
-          Vector(s"${newPresentation.name}")
-        )
-        NotificationDAO.insert(notifyEvent)
 
         Some(updatedPod)
       case None =>
@@ -271,10 +261,10 @@ case class PresentationPodManager(presentationPods: collection.immutable.Map[Str
     a
   }
 
-  def setCurrentPresentation(meetingId: String, podId: String, pres: PresentationInPod): PresentationPodManager = {
+  def setCurrentPresentation(podId: String, pres: PresentationInPod): PresentationPodManager = {
     val updatedManager = for {
       pod <- getPod(podId)
-      podWithAdjustedCurrentPresentation <- pod.setCurrentPresentation(meetingId, pres)
+      podWithAdjustedCurrentPresentation <- pod.setCurrentPresentation(pres)
 
     } yield {
       updatePresentationPod(podWithAdjustedCurrentPresentation)

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -88,8 +88,6 @@ class Presentation extends PureComponent {
 
     const PAN_ZOOM_INTERV = window.meetingClientSettings.public.presentation.panZoomInterval || 200;
 
-    this.currentPresentationToastId = 'currentPresentationToastId';
-
     this.getSvgRef = this.getSvgRef.bind(this);
     this.zoomChanger = debounce(this.zoomChanger.bind(this), 200);
     this.updateLocalPosition = this.updateLocalPosition.bind(this);
@@ -489,7 +487,7 @@ class Presentation extends PureComponent {
       },
       () => {
         setPresentationFitToWidth(!fitToWidth);
-      }
+      },
     );
   }
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -4,14 +4,12 @@ import WhiteboardContainer from '/imports/ui/components/whiteboard/container';
 import { HUNDRED_PERCENT, MAX_PERCENT, MIN_PERCENT } from '/imports/utils/slideCalcUtils';
 import { SPACE } from '/imports/utils/keyCodes';
 import { defineMessages, injectIntl } from 'react-intl';
-import { toast } from 'react-toastify';
 import Session from '/imports/ui/services/storage/in-memory';
 import PresentationToolbarContainer from './presentation-toolbar/container';
 import PresentationMenu from './presentation-menu/container';
 import DownloadPresentationButton from './download-presentation-button/component';
 import Styled from './styles';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
-import Icon from '/imports/ui/components/common/icon/component';
 import PollingContainer from '/imports/ui/components/polling/container';
 import { ACTIONS, LAYOUT_TYPE } from '../layout/enums';
 import DEFAULT_VALUES from '../layout/defaultValues';
@@ -27,10 +25,6 @@ const intlMessages = defineMessages({
   presentationLabel: {
     id: 'app.presentationUploder.title',
     description: 'presentation area element label',
-  },
-  changeNotification: {
-    id: 'app.presentation.notificationLabel',
-    description: 'label displayed in toast when presentation switches',
   },
   downloadLabel: {
     id: 'app.presentation.downloadLabel',
@@ -92,14 +86,14 @@ class Presentation extends PureComponent {
       ignorePresentationRestoring: true,
     };
 
-    const PAN_ZOOM_INTERVAL = window.meetingClientSettings.public.presentation.panZoomInterval || 200;
+    const PAN_ZOOM_INTERV = window.meetingClientSettings.public.presentation.panZoomInterval || 200;
 
     this.currentPresentationToastId = 'currentPresentationToastId';
 
     this.getSvgRef = this.getSvgRef.bind(this);
     this.zoomChanger = debounce(this.zoomChanger.bind(this), 200);
     this.updateLocalPosition = this.updateLocalPosition.bind(this);
-    this.panAndZoomChanger = throttle(this.panAndZoomChanger.bind(this), PAN_ZOOM_INTERVAL);
+    this.panAndZoomChanger = throttle(this.panAndZoomChanger.bind(this), PAN_ZOOM_INTERV);
     this.fitToWidthHandler = this.fitToWidthHandler.bind(this);
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
     this.getPresentationSizesAvailable = this.getPresentationSizesAvailable.bind(this);
@@ -111,7 +105,6 @@ class Presentation extends PureComponent {
     this.renderPresentationMenu = this.renderPresentationMenu.bind(this);
 
     this.onResize = () => setTimeout(this.handleResize.bind(this), 0);
-    this.renderCurrentPresentationToast = this.renderCurrentPresentationToast.bind(this);
     this.setPresentationRef = this.setPresentationRef.bind(this);
     this.setTldrawIsMounting = this.setTldrawIsMounting.bind(this);
     Session.setItem('componentPresentationWillUnmount', false);
@@ -225,7 +218,6 @@ class Presentation extends PureComponent {
       currentPresentationId,
       fitToWidth,
       isDefaultPresentation,
-      presentationIsDownloadable,
       setPresentationFitToWidth,
     } = this.props;
     const {
@@ -263,46 +255,6 @@ class Presentation extends PureComponent {
           0: currentSlide.num,
         }),
       );
-    }
-
-    if (currentPresentationId) {
-      const downloadableOn = !prevProps?.presentationIsDownloadable && presentationIsDownloadable;
-
-      const shouldCloseToast = !(
-        presentationIsDownloadable && !userIsPresenter
-      );
-
-      if (
-        prevProps?.currentPresentationId !== currentPresentationId
-        || (downloadableOn && !userIsPresenter)
-      ) {
-        if (toast.isActive(this.currentPresentationToastId)) {
-          toast.update(this.currentPresentationToastId, {
-            autoClose: shouldCloseToast,
-            render: this.renderCurrentPresentationToast(),
-          });
-        } else {
-          toast(
-            this.renderCurrentPresentationToast(),
-            {
-              autoClose: shouldCloseToast,
-              className: 'toastClass actionToast currentPresentationToast',
-              bodyClassName: 'toastBodyClass',
-              progressClassName: 'toastProgressClass',
-              toastId: this.currentPresentationToastId,
-            },
-          );
-        }
-      }
-
-      const downloadableOff = prevProps?.presentationIsDownloadable && !presentationIsDownloadable;
-
-      if (toast.isActive(this.currentPresentationToastId) && downloadableOff) {
-        toast.update(this.currentPresentationToastId, {
-          autoClose: true,
-          render: this.renderCurrentPresentationToast(),
-        });
-      }
     }
 
     if (prevProps?.slidePosition && slidePosition) {
@@ -519,7 +471,7 @@ class Presentation extends PureComponent {
 
   zoomChanger(zoom) {
     const { currentSlide } = this.props;
-    let boundZoom = parseInt(zoom);
+    let boundZoom = parseInt(zoom, 10);
     const min = currentSlide?.infiniteWhiteboard ? MIN_PERCENT : HUNDRED_PERCENT;
     if (boundZoom < min) {
       boundZoom = min;
@@ -673,48 +625,6 @@ class Presentation extends PureComponent {
     );
   }
 
-  renderCurrentPresentationToast() {
-    const {
-      intl,
-      userIsPresenter,
-      downloadPresentationUri,
-      presentationIsDownloadable,
-      presentationName,
-    } = this.props;
-
-    return (
-      <Styled.InnerToastWrapper data-test="toastContainer">
-        <Styled.ToastIcon>
-          <Styled.IconWrapper>
-            <Icon iconName="presentation" />
-          </Styled.IconWrapper>
-        </Styled.ToastIcon>
-
-        <Styled.ToastTextContent data-test="currentPresentationToast">
-          <div>{`${intl.formatMessage(intlMessages.changeNotification)}`}</div>
-          <Styled.PresentationName>{`${presentationName}`}</Styled.PresentationName>
-        </Styled.ToastTextContent>
-
-        {presentationIsDownloadable && !userIsPresenter ? (
-          <Styled.ToastDownload>
-            <Styled.ToastSeparator />
-            <a
-              data-test="toastDownload"
-              aria-label={`${intl.formatMessage(intlMessages.downloadLabel)} ${
-                presentationName
-              }`}
-              href={downloadPresentationUri}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {intl.formatMessage(intlMessages.downloadLabel)}
-            </a>
-          </Styled.ToastDownload>
-        ) : null}
-      </Styled.InnerToastWrapper>
-    );
-  }
-
   renderPresentationDownload() {
     const { presentationIsDownloadable, downloadPresentationUri } = this.props;
 
@@ -838,8 +748,11 @@ class Presentation extends PureComponent {
     const isVideoFocus = layoutType === LAYOUT_TYPE.VIDEO_FOCUS;
     const presentationZIndex = fullscreenContext ? presentationBounds.zIndex : undefined;
 
-    const APP_CRASH_METADATA = { logCode: 'whiteboard_crash', logMessage: 'Possible whiteboard crash' };
-  if (!presentationIsOpen) return null;
+    const APP_CRASH_METADATA = {
+      logCode: 'whiteboard_crash',
+      logMessage: 'Possible whiteboard crash',
+    };
+    if (!presentationIsOpen) return null;
     return (
       <>
         <Styled.PresentationContainer
@@ -863,7 +776,7 @@ class Presentation extends PureComponent {
                 : null,
           }}
         >
-          <h2 class="sr-only">{intl.formatMessage(intlMessages.presentationHeader)}</h2>
+          <h2 className="sr-only">{intl.formatMessage(intlMessages.presentationHeader)}</h2>
           <Styled.Presentation
             ref={(ref) => {
               this.refPresentation = ref;
@@ -974,7 +887,6 @@ Presentation.propTypes = {
   setPresentationIsOpen: PropTypes.func.isRequired,
   layoutContextDispatch: PropTypes.func.isRequired,
   presentationIsDownloadable: PropTypes.bool,
-  presentationName: PropTypes.string,
   currentPresentationId: PropTypes.string,
   presentationIsOpen: PropTypes.bool,
   totalPages: PropTypes.number.isRequired,
@@ -1017,6 +929,5 @@ Presentation.defaultProps = {
   userIsPresenter: false,
   presentationIsDownloadable: false,
   currentPresentationId: '',
-  presentationName: '',
   presentationIsOpen: true,
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -262,7 +262,6 @@ const PresentationContainer = (props) => {
           isViewersAnnotationsLocked,
           setPresentationIsOpen: MediaService.setPresentationIsOpen,
           isDefaultPresentation: currentPresentationPage?.isDefaultPresentation,
-          presentationName: currentPresentationPage?.presentationName,
           presentationAreaSize,
           currentUser,
           hasPoll,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
@@ -254,6 +254,8 @@ function renderToastItem(item, intl) {
   let icon = isProcessing ? 'blank' : 'check';
   if (hasError) icon = 'circle_close';
 
+  const isDone = !isProcessing && !hasError;
+
   return (
     <Styled.UploadRow
       key={item.presentationId || item.temporaryPresentationId}
@@ -270,7 +272,8 @@ function renderToastItem(item, intl) {
         </Styled.ToastFileName>
         <Styled.StatusIcon>
           <Styled.ToastItemIcon
-            done={!isProcessing && !hasError}
+            data-test={isDone && 'uploadDoneIcon'}
+            done={isDone}
             error={hasError}
             loading={isProcessing}
             iconName={icon}
@@ -278,7 +281,7 @@ function renderToastItem(item, intl) {
         </Styled.StatusIcon>
       </Styled.FileLine>
       <Styled.StatusInfo>
-        <Styled.StatusInfoSpan data-test="presentationStatusInfo" styles={hasError ? 'error' : 'info'}>
+        <Styled.StatusInfoSpan data-test={isProcessing && 'processingPresentationItem'} styles={hasError ? 'error' : 'info'}>
           {renderPresentationItemStatus(item, intl)}
         </Styled.StatusInfoSpan>
       </Styled.StatusInfo>

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -280,7 +280,7 @@
     "app.meeting.alertBreakoutEndsUnderMinutesPlural": "Breakout is closing in {0} minutes.",
     "app.meeting.alertBreakoutEndsUnderMinutesSingular": "Breakout is closing in one minute.",
     "app.presentation.hide": "Hide presentation",
-    "app.presentation.newPresentationActiveNotification": "A new presentation is now active: {0}",
+    "app.presentation.newCurrentPresentationNotification": "The current presentation is now: {0}",
     "app.presentation.downloadEnabledNotification": "You can now download the presentation",
     "app.presentation.downloadLabel": "Download",
     "app.presentation.actionsLabel": "Actions",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -280,7 +280,7 @@
     "app.meeting.alertBreakoutEndsUnderMinutesPlural": "Breakout is closing in {0} minutes.",
     "app.meeting.alertBreakoutEndsUnderMinutesSingular": "Breakout is closing in one minute.",
     "app.presentation.hide": "Hide presentation",
-    "app.presentation.notificationLabel": "Current presentation",
+    "app.presentation.newPresentationActiveNotification": "A new presentation is now active: {0}",
     "app.presentation.downloadLabel": "Download",
     "app.presentation.actionsLabel": "Actions",
     "app.presentation.slideContent": "Slide Content",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -281,6 +281,7 @@
     "app.meeting.alertBreakoutEndsUnderMinutesSingular": "Breakout is closing in one minute.",
     "app.presentation.hide": "Hide presentation",
     "app.presentation.newPresentationActiveNotification": "A new presentation is now active: {0}",
+    "app.presentation.downloadEnabledNotification": "You can now download the presentation",
     "app.presentation.downloadLabel": "Download",
     "app.presentation.actionsLabel": "Actions",
     "app.presentation.slideContent": "Slide Content",

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -6,7 +6,7 @@ const { getSettings } = require('../core/settings');
 const { expect } = require('@playwright/test');
 const { sleep } = require('../core/helpers');
 const { getNotesLocator } = require('../sharednotes/util');
-const { uploadSinglePresentation } = require('../presentation/util.js');
+const { uploadSinglePresentation, hasCurrentPresentationToastElement } = require('../presentation/util.js');
 
 class Join extends Create {
   constructor(browser, context) {
@@ -104,17 +104,17 @@ class Join extends Create {
     await this.modPage.waitAndClick(e.breakoutOptionsMenu);
     await this.modPage.waitAndClick(e.openUpdateBreakoutUsersModal);
     await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
-    await this.modPage.hasText(e.breakoutBox1, /Attendee/,  'should have the attende name on the second breakout room box.');
+    await this.modPage.hasText(e.breakoutBox1, /Attendee/,  'should have the attendee name on the second breakout room box.');
     await this.modPage.waitAndClick(e.modalConfirmButton);
 
-    await this.userPage.hasElement(e.modalConfirmButton, 'should display the modal confirm button for the attende to join the meeting');
+    await this.userPage.hasElement(e.modalConfirmButton, 'should display the modal confirm button for the attendee to join the meeting');
     await this.userPage.waitAndClick(e.modalDismissButton);
   }
 
   async usernameShowsBelowRoomsName() {
     const breakoutUserPage = await this.joinRoom();
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
-    await this.modPage.hasText(e.userNameBreakoutRoom, /Attendee/, 'should have the attende name on the breakout room below a room on the main breakout panel');
+    await this.modPage.hasText(e.userNameBreakoutRoom, /Attendee/, 'should have the attendee name on the breakout room below a room on the main breakout panel');
   }
 
   async showBreakoutRoomTimeRemaining() {
@@ -129,7 +129,7 @@ class Join extends Create {
     await this.modPage.waitAndClick(e.sendButtonDurationTime);
     await this.modPage.hasText(e.breakoutRemainingTime, /[11-12]:[0-5][0-9]/, 'should have the breakout room time remaining counting down on the breakout main panel.');
 
-    await breakoutUserPage.hasText(e.timeRemaining, /[11-12]:[0-5][0-9]/, 'should display the remaining time inside the breakout rooom');
+    await breakoutUserPage.hasText(e.timeRemaining, /[11-12]:[0-5][0-9]/, 'should display the remaining time inside the breakout room');
   }
 
   async endAllBreakoutRooms() {
@@ -195,7 +195,7 @@ class Join extends Create {
     ];
     await this.modPage.checkElementCount(e.actionsItem, expectedActionItems.length);
     await shareNotesPDF.click();
-    await this.modPage.hasElement(e.currentPresentationToast, 'should display the current presentation toast when changing to the whiteboard exported file');
+    await hasCurrentPresentationToastElement(this.modPage, 'should display the current presentation toast when changing to the whiteboard exported file');
     //! avoiding the following screenshot comparison due to https://github.com/microsoft/playwright/issues/18827
     // TODO should be updated and use entire view page screenshot after https://github.com/bigbluebutton/bigbluebutton/issues/22160 is fixed
     // visual assertion
@@ -254,7 +254,7 @@ class Join extends Create {
     await this.modPage.wasRemoved(e.presentationUploadProgressToast, 'should have removed the presentation upload progress toast after clicking on it');
     await this.modPage.waitAndClick(e.actions);
     await whiteboardPDF.click();
-    await this.modPage.hasElement(e.currentPresentationToast, 'should display the current presentation toast when changing to the whiteboard exported file');
+    await hasCurrentPresentationToastElement(this.modPage, 'should display the current presentation toast when changing to the whiteboard exported file');
     //! avoiding the following screenshot comparison due to https://github.com/microsoft/playwright/issues/18827
     // TODO should be updated and use entire view page screenshot after https://github.com/bigbluebutton/bigbluebutton/issues/22160 is fixed
     // visual assertion

--- a/bigbluebutton-tests/playwright/core/constants.js
+++ b/bigbluebutton-tests/playwright/core/constants.js
@@ -21,7 +21,4 @@ exports.MAX_PARTICIPANTS_TO_JOIN = 4;
 // MEDIA CONNECTION TIMEOUTS
 exports.VIDEO_LOADING_WAIT_TIME = 15000;
 exports.UPLOAD_PDF_WAIT_TIME = 25000 * MULTIPLIER;
-
 exports.CUSTOM_MEETING_ID = 'custom-meeting';
-// it only works for snapshot comparisons. playwright assertions will complain about the element (still in the DOM)
-exports.PARAMETER_HIDE_PRESENTATION_TOAST = 'userdata-bbb_custom_style=.presentationUploaderToast{display: none;}.currentPresentationToast{display:none;}';

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -214,14 +214,13 @@ exports.exporthtml = 'span[id="exporthtml"]';
 // Notifications
 exports.smallToastMsg = 'div[data-test="toastSmallMsg"]';
 exports.closeToastBtn = 'i[data-test="closeToastBtn"]';
-const currentPresentationToast = 'div[data-test="currentPresentationToast"]';
-exports.currentPresentationToast = currentPresentationToast
 exports.notificationsTab = 'span[id="notificationTab"]';
 exports.chatPopupAlertsBtn = 'input[data-test="chatPopupAlertsBtn"]';
 exports.hasUnreadMessages = 'div[data-test="unreadMessages"]';
 exports.userJoinPushAlerts = 'input[data-test="userJoinPopupAlerts"]';
 exports.toastContainer = 'div[data-test="toastContainer"]';
-exports.presentationStatusInfo = 'span[data-test="presentationStatusInfo"]';
+exports.processingPresentationItem = 'span[data-test="processingPresentationItem"]';
+exports.uploadDoneIcon = 'i[data-test="uploadDoneIcon"]';
 exports.noButton = 'button[aria-label="No"]';
 exports.yesButton = 'button[aria-label="Yes"]';
 // Toasts
@@ -296,8 +295,6 @@ exports.currentSlideImg = '[id="whiteboard-element"] [class="tl-image"]';
 exports.uploadPresentationFileName = 'uploadTest.png';
 exports.presentationPPTX = 'BBB.pptx';
 exports.presentationTXT = 'helloWorld.txt';
-exports.presentationPlaceholderLabel = 'There is no currently active presentation';
-exports.noPresentationLabel = 'There is no currently active presentation';
 exports.startScreenSharing = 'button[data-test="startScreenShare"]';
 exports.stopScreenSharing = 'button[data-test="stopScreenShare"]';
 exports.managePresentations = 'li[data-test="managePresentations"]';
@@ -308,7 +305,6 @@ exports.prevSlide = 'button[data-test="prevSlide"]';
 exports.skipSlide = 'select[data-test="skipSlide"]';
 exports.presentationOptionsDownloadBtn = 'button[data-test="presentationOptionsDownload"]';
 exports.confirmManagePresentation = 'button[data-test="confirmManagePresentation"]';
-exports.toastDownload = 'a[data-test="toastDownload"]';
 exports.presentationDownloadBtn = 'button[data-test="presentationDownload"]';
 exports.presentationItem = 'tr[data-test="presentationItem"]';
 exports.removePresentation = 'button[data-test="removePresentation"]';
@@ -340,7 +336,10 @@ exports.ytFrameTitle = 'a[class^="ytp-title-link"]';
 // Toasts
 exports.statingUploadPresentationToast = 'To be uploaded ...';
 exports.convertingPresentationFileToast = 'Converting file';
-exports.presentationUploadedToast = 'Current presentation';
+exports.defaultCurrentPresentationLabel = 'A new presentation is now active';
+exports.presentationPlaceholderLabel = 'There is no currently active presentation';
+exports.noPresentationLabel = 'There is no currently active presentation';
+exports.presentationDownloadEnabledLabel = 'You can now download the presentation';
 
 // Settings
 exports.languageSelector = 'select[id="langSelector"]';

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -336,7 +336,7 @@ exports.ytFrameTitle = 'a[class^="ytp-title-link"]';
 // Toasts
 exports.statingUploadPresentationToast = 'To be uploaded ...';
 exports.convertingPresentationFileToast = 'Converting file';
-exports.defaultCurrentPresentationLabel = 'A new presentation is now active';
+exports.defaultCurrentPresentationLabel = 'The current presentation is now';
 exports.presentationPlaceholderLabel = 'There is no currently active presentation';
 exports.noPresentationLabel = 'There is no currently active presentation';
 exports.presentationDownloadEnabledLabel = 'You can now download the presentation';

--- a/bigbluebutton-tests/playwright/notifications/chatNotifications.js
+++ b/bigbluebutton-tests/playwright/notifications/chatNotifications.js
@@ -13,7 +13,7 @@ class ChatNotifications extends MultiUsers {
     await openSettings(this.modPage);
     await util.enableChatPopup(this.modPage);
     await util.saveSettings(this.modPage);
-    await util.waitAndClearNotification(this.modPage);
+    await this.modPage.closeAllToastNotifications();
     await sleep(1000);
     await util.publicChatMessageToast(this.modPage, this.userPage);
     await this.modPage.waitAndClick(e.chatTitle);
@@ -26,11 +26,11 @@ class ChatNotifications extends MultiUsers {
     await openSettings(this.modPage);
     await util.enableChatPopup(this.modPage);
     await util.saveSettings(this.modPage);
-    await util.waitAndClearNotification(this.modPage);
+    await this.modPage.closeAllToastNotifications();
     await sleep(2000);
     await util.privateChatMessageToast(this.userPage);
     await this.modPage.hasElement(e.smallToastMsg, 'should the small toast message with the new text sent on the private chat');
-    await this.modPage.hasElement(e.hasUnreadMessages, 'should the notifcation on the public chat button appear with a number of messages sent and not read');
+    await this.modPage.hasElement(e.hasUnreadMessages, 'should the notification on the public chat button appear with a number of messages sent and not read');
     await util.checkNotificationText(this.modPage, e.privateChatToast);
   }
 }

--- a/bigbluebutton-tests/playwright/notifications/notifications.spec.js
+++ b/bigbluebutton-tests/playwright/notifications/notifications.spec.js
@@ -4,7 +4,6 @@ const { ChatNotifications } = require('./chatNotifications');
 const { PresenterNotifications } = require('./presenterNotifications');
 const { RecordingNotifications } = require('./recordingNotifications');
 const { recordMeeting } = require('../parameters/constants');
-const { linkIssue } = require('../core/helpers');
 
 test.describe.parallel('Notifications', { tag: '@ci' }, () => {
   test('Save settings notification', async ({ browser, context, page }) => {

--- a/bigbluebutton-tests/playwright/notifications/presenterNotifications.js
+++ b/bigbluebutton-tests/playwright/notifications/presenterNotifications.js
@@ -1,7 +1,7 @@
-const { MultiUsers } = require("../user/multiusers");
 const util = require('./util');
 const e = require('../core/elements');
 const utilPolling = require('../polling/util');
+const { MultiUsers } = require("../user/multiusers");
 const utilScreenShare = require('../screenshare/util');
 const utilPresentation = require('../presentation/util');
 const { ELEMENT_WAIT_LONGER_TIME } = require('../core/constants');
@@ -22,12 +22,10 @@ class PresenterNotifications extends MultiUsers {
 
   async fileUploaderNotification() {
     await utilPresentation.uploadSinglePresentation(this.modPage, e.uploadPresentationFileName, ELEMENT_WAIT_LONGER_TIME);
-    await this.modPage.hasElement(e.currentPresentationToast, 'should display the current presentation toast when the upload finishes');
-    await this.modPage.hasText(e.currentPresentationToast, e.uploadPresentationFileName, 'should display the uploaded presentation name in the toast');
+    await utilPresentation.hasTextOnCurrentPresentationToast(this.modPage, e.uploadPresentationFileName, 'should display the uploaded presentation name in the toast');
   }
 
   async screenshareToast() {
-    await util.waitAndClearDefaultPresentationNotification(this.modPage);
     await utilScreenShare.startScreenshare(this.modPage);
     await util.checkNotificationText(this.modPage, e.startScreenshareToast);
     await this.modPage.closeAllToastNotifications();

--- a/bigbluebutton-tests/playwright/notifications/recordingNotifications.js
+++ b/bigbluebutton-tests/playwright/notifications/recordingNotifications.js
@@ -1,7 +1,5 @@
-const { expect } = require('@playwright/test');
 const Page = require('../core/page');
 const util = require('./util');
-const { waitAndClearNotification, waitAndClearDefaultPresentationNotification } = require('../notifications/util');
 const e = require('../core/elements');
 const { connectMicrophone } = require('../audio/util');
 const { ELEMENT_WAIT_EXTRA_LONG_TIME } = require('../core/constants');
@@ -13,7 +11,7 @@ class RecordingNotifications extends Page {
 
   async notificationNoAudio() {
     // when you don't join audio at all, there's notification about no active mic
-    await waitAndClearDefaultPresentationNotification(this);
+    await this.closeAllToastNotifications();
     await this.waitAndClick(e.recordingIndicator, ELEMENT_WAIT_EXTRA_LONG_TIME);
     await this.hasElement(e.smallToastMsg, 'should appear a toast small message with the new message sent on the chat');
     await util.checkNotificationText(this, e.noActiveMicrophoneToast);
@@ -21,7 +19,7 @@ class RecordingNotifications extends Page {
 
   async notificationListenOnly() {
     // when you join listen only, there's notification about no active mic
-    await waitAndClearDefaultPresentationNotification(this);
+    await this.closeAllToastNotifications();
     await this.waitAndClick(e.joinAudio, ELEMENT_WAIT_EXTRA_LONG_TIME);
     await this.waitAndClick(e.listenOnlyButton, ELEMENT_WAIT_EXTRA_LONG_TIME);
     await util.checkNotificationText(this, e.joinAudioToast);
@@ -29,11 +27,11 @@ class RecordingNotifications extends Page {
 
   async noNotificationInAudio() {
     // when you join audio with mic, there's no notification about no active mic
-    await waitAndClearDefaultPresentationNotification(this);
+    await this.closeAllToastNotifications();
     await this.waitAndClick(e.joinAudio, ELEMENT_WAIT_EXTRA_LONG_TIME);
     await this.hasElement(e.audioModal, 'should the audio modal be displayed', ELEMENT_WAIT_EXTRA_LONG_TIME);
     await connectMicrophone(this);
-    await waitAndClearNotification(this);
+    await this.closeAllToastNotifications();
     await this.waitAndClick(e.recordingIndicator);
     await this.wasRemoved(e.smallToastMsg, 'should the small toast message disappear', ELEMENT_WAIT_EXTRA_LONG_TIME);
   }

--- a/bigbluebutton-tests/playwright/notifications/util.js
+++ b/bigbluebutton-tests/playwright/notifications/util.js
@@ -1,5 +1,4 @@
 const { expect } = require('@playwright/test');
-const { ELEMENT_WAIT_LONGER_TIME } = require('../core/constants');
 const e = require('../core/elements');
 const { sleep } = require('../core/helpers');
 
@@ -48,20 +47,6 @@ async function privateChatMessageToast(page2) {
   await page2.waitAndClick(e.sendButton);
 }
 
-async function waitAndClearNotification(testPage) {
-  await testPage.waitAndClick(e.smallToastMsg, ELEMENT_WAIT_LONGER_TIME);
-  await testPage.wasRemoved(e.smallToastMsg, 'should the new small toast message disappear');
-}
-
-async function waitAndClearDefaultPresentationNotification(testPage) {
-  await testPage.hasElement(e.whiteboard, 'should the whiteboard appear on the meeting', ELEMENT_WAIT_LONGER_TIME);
-  const hasCurrentPresentationToast = await testPage.checkElement(e.currentPresentationToast);
-  if (hasCurrentPresentationToast) {
-    await testPage.waitAndClick(e.currentPresentationToast, ELEMENT_WAIT_LONGER_TIME);
-    await testPage.wasRemoved(e.currentPresentationToast, 'should disappear the current presentation toast');
-  }
-}
-
 exports.privateChatMessageToast = privateChatMessageToast;
 exports.publicChatMessageToast = publicChatMessageToast;
 exports.enableUserJoinPopup = enableUserJoinPopup;
@@ -69,5 +54,3 @@ exports.checkNotificationText = checkNotificationText;
 exports.checkNotificationIcon = checkNotificationIcon;
 exports.enableChatPopup = enableChatPopup;
 exports.saveSettings = saveSettings;
-exports.waitAndClearNotification = waitAndClearNotification;
-exports.waitAndClearDefaultPresentationNotification = waitAndClearDefaultPresentationNotification;

--- a/bigbluebutton-tests/playwright/polling/polling.spec.js
+++ b/bigbluebutton-tests/playwright/polling/polling.spec.js
@@ -2,17 +2,13 @@ const { test } = require('../fixtures');
 const { fullyParallel } = require('../playwright.config');
 const { Polling } = require('./poll');
 const { initializePages } = require('../core/helpers');
-const { encodeCustomParams } = require('../parameters/util');
-const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
-
-const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
 
 test.describe('Polling', { tag: '@ci' }, async () => {
   const polling = new Polling();
 
   test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });
   test[fullyParallel ? 'beforeEach' : 'beforeAll'](async ({ browser }) => {
-    await initializePages(polling, browser, { isMultiUser: true, joinParameter: hidePresentationToast });
+    await initializePages(polling, browser, { isMultiUser: true });
   });
 
   // Manage

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -2,9 +2,6 @@ const { test } = require('../fixtures');
 const { encodeCustomParams } = require('../parameters/util');
 const { Presentation } = require('./presentation');
 const { linkIssue } = require('../core/helpers');
-const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
-
-const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
 
 test.describe.parallel('Presentation', { tag: '@ci' }, () => {
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#navigation-automated
@@ -39,7 +36,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#fit-to-width-option
   test('Presentation fit to width', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
-    await presentation.initModPage(page, true, { joinParameter: hidePresentationToast });
+    await presentation.initModPage(page, true);
     await presentation.initUserPage(true, context);
     await presentation.fitToWidthTest();
   });
@@ -58,8 +55,8 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
 
   test('Hide Presentation Toolbar', async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
-    await presentation.initModPage(page, true, { joinParameter: hidePresentationToast });
-    await presentation.initUserPage(page, context, { joinParameter: hidePresentationToast });
+    await presentation.initModPage(page, true);
+    await presentation.initUserPage(page, context);
     await presentation.hidePresentationToolbar();
   });
 
@@ -82,20 +79,20 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#uploading-a-presentation-automated
     test('Upload single presentation', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
-      await presentation.initPages(page, true);
+      await presentation.initPages(page);
       await presentation.uploadSinglePresentationTest();
     });
 
     test('Upload Other Presentations Format', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
-      await presentation.initPages(page, true);
+      await presentation.initPages(page);
       await presentation.uploadOtherPresentationsFormat();
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#uploading-multiple-presentations-automated
     test('Upload multiple presentations', async ({ browser, context, page }) => {
       const presentation = new Presentation(browser, context);
-      await presentation.initPages(page, true);
+      await presentation.initPages(page);
       await presentation.uploadMultiplePresentationsTest();
     });
 

--- a/bigbluebutton-tests/playwright/presentation/util.js
+++ b/bigbluebutton-tests/playwright/presentation/util.js
@@ -1,7 +1,11 @@
 const { expect } = require('@playwright/test');
 const path = require('path');
 const e = require('../core/elements');
-const { UPLOAD_PDF_WAIT_TIME, ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_TIME } = require('../core/constants');
+const {
+  ELEMENT_WAIT_TIME,
+  UPLOAD_PDF_WAIT_TIME,
+  ELEMENT_WAIT_EXTRA_LONG_TIME,
+} = require('../core/constants');
 
 async function checkSvgIndex(test, element) {
   const check = await test.page.evaluate(([el, slideImg]) => {
@@ -23,45 +27,44 @@ async function getCurrentPresentationHeight(locator) {
   });
 }
 
-async function uploadSinglePresentation(test, fileName, uploadTimeout = UPLOAD_PDF_WAIT_TIME) {
-  const firstSlideSrc = await test.page.evaluate(selector => document.querySelector(selector)
+async function uploadSinglePresentation(testPage, fileName, uploadTimeout = UPLOAD_PDF_WAIT_TIME) {
+  const firstSlideSrc = await testPage.page.evaluate(selector => document.querySelector(selector)
     ?.style.backgroundImage.split('"')[1],
     [e.currentSlideImg],
   );
-  await test.waitAndClick(e.actions);
-  await test.waitAndClick(e.managePresentations);
-  await test.hasElement(e.presentationFileUpload, 'should display the presentation space for uploading a new file, when the manage presentations is opened');
+  await testPage.waitAndClick(e.actions);
+  await testPage.waitAndClick(e.managePresentations);
+  await testPage.hasElement(e.presentationFileUpload, 'should display the presentation space for uploading a new file, when the manage presentations is opened');
 
-  await test.page.setInputFiles(e.presentationFileUpload, path.join(__dirname, `../core/media/${fileName}`));
-  await test.hasText('body', e.statingUploadPresentationToast, 'should display the toast message uploading the presentation');
+  await testPage.page.setInputFiles(e.presentationFileUpload, path.join(__dirname, `../core/media/${fileName}`));
+  await testPage.hasText('body', e.statingUploadPresentationToast, 'should display the toast message uploading the presentation');
 
-  await test.waitAndClick(e.confirmManagePresentation);
-  await test.hasElement(e.presentationUploadProgressToast, 'should display the toast presentation upload progress after confirming the presentation to be uploaded');
-  await test.page.waitForFunction(([selector, firstSlideSrc]) => {
+  await testPage.waitAndClick(e.confirmManagePresentation);
+  await testPage.hasElement(e.presentationUploadProgressToast, 'should display the toast presentation upload progress after confirming the presentation to be uploaded');
+  // ensures the current slide (uploaded file) is different from the previous slide - successful upload
+  await testPage.page.waitForFunction(([selector, firstSlideSrc]) => {
     const currentSrc = document.querySelector(selector)
     ?.style?.backgroundImage?.split('"')[1];
     return currentSrc != firstSlideSrc;
   }, [e.currentSlideImg, firstSlideSrc], {
     timeout: uploadTimeout,
   });
+  await hasCurrentPresentationToastElement(testPage, { timeout: uploadTimeout });
 }
 
-async function uploadMultiplePresentations(test, fileNames, uploadTimeout = ELEMENT_WAIT_EXTRA_LONG_TIME) {
-  await test.waitAndClick(e.actions);
-  await test.waitAndClick(e.managePresentations);
-  await test.hasElement(e.presentationFileUpload, 'should display the modal for uploading a new presentation after opening the manage presentations');
+async function uploadMultiplePresentations(testPage, fileNames, uploadTimeout = ELEMENT_WAIT_EXTRA_LONG_TIME) {
+  await testPage.waitAndClick(e.actions);
+  await testPage.waitAndClick(e.managePresentations);
+  await testPage.hasElement(e.presentationFileUpload, 'should display the modal for uploading a new presentation after opening the manage presentations');
 
-  await test.page.setInputFiles(e.presentationFileUpload, fileNames.map((fileName) => path.join(__dirname, `../core/media/${fileName}`)));
-  await test.hasText('body', e.statingUploadPresentationToast, 'should display the toast of a presentation to be uploaded after selecting the files to upload');
+  await testPage.page.setInputFiles(e.presentationFileUpload, fileNames.map((fileName) => path.join(__dirname, `../core/media/${fileName}`)));
+  await testPage.hasText('body', e.statingUploadPresentationToast, 'should display the toast of a presentation to be uploaded after selecting the files to upload');
 
-  await test.waitAndClick(e.confirmManagePresentation);
-  await expect(async () => {
-    await test.hasText(e.presentationStatusInfo, e.convertingPresentationFileToast, 'should display the presentation status info after confirmation to upload the new file', 200);
-  }).toPass({
-    intervals: [200],
-    timeout: ELEMENT_WAIT_TIME,
-  });
-  await test.hasText(e.currentPresentationToast, e.presentationUploadedToast, 'should display the toast notification saying that the presentation is uploaded', uploadTimeout);
+  await testPage.waitAndClick(e.confirmManagePresentation);
+  await testPage.hasElement(e.presentationUploadProgressToast, 'should display a toast presentation upload progress after confirming the presentation to be uploaded');
+  await testPage.hasNElements(e.processingPresentationItem, fileNames.length, 'should display the presentation status info element with converting label after confirmation to upload the new file');
+  await testPage.hasNElements(e.uploadDoneIcon, fileNames.length, 'should display the upload done icon after all presentations are successfully uploaded');
+  await hasCurrentPresentationToastElement(testPage, { timeout: uploadTimeout });
 }
 
 async function skipSlide(page) {
@@ -71,9 +74,26 @@ async function skipSlide(page) {
   await expect(selectSlideLocator).not.toHaveValue(currentSlideNumber);
 }
 
+async function getCurrentPresentationToastLocator(page) {
+  return page.getLocator(e.smallToastMsg).filter({ hasText: e.defaultCurrentPresentationLabel });
+}
+
+async function hasCurrentPresentationToastElement(page, { description, timeout = ELEMENT_WAIT_TIME } = {}) {
+  const toastLocator = await getCurrentPresentationToastLocator(page);
+  await expect(toastLocator, description ?? 'should display the current presentation element after uploading the presentation').toBeVisible({ timeout });
+}
+
+async function hasTextOnCurrentPresentationToast(page, text, description, timeout = ELEMENT_WAIT_TIME) {
+  const toastLocator = await getCurrentPresentationToastLocator(page);
+  await expect(toastLocator, description).toContainText(text, { timeout });
+}
+
 exports.checkSvgIndex = checkSvgIndex;
 exports.getSlideOuterHtml = getSlideOuterHtml;
 exports.uploadSinglePresentation = uploadSinglePresentation;
 exports.uploadMultiplePresentations = uploadMultiplePresentations;
 exports.getCurrentPresentationHeight = getCurrentPresentationHeight;
 exports.skipSlide = skipSlide;
+exports.getCurrentPresentationToastLocator = getCurrentPresentationToastLocator;
+exports.hasCurrentPresentationToastElement = hasCurrentPresentationToastElement;
+exports.hasTextOnCurrentPresentationToast = hasTextOnCurrentPresentationToast;

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -2,11 +2,9 @@ const { expect } = require('@playwright/test');
 const playwright = require("playwright");
 const Page = require('../core/page');
 const e = require('../core/elements');
-const { waitAndClearDefaultPresentationNotification } = require('../notifications/util');
 const { sleep } = require('../core/helpers');
 const { checkTextContent, checkElementLengthEqualTo } = require('../core/util');
 const { checkAvatarIcon, checkIsPresenter, checkMutedUsers } = require('./util');
-const { getNotesLocator } = require('../sharednotes/util');
 const { getSettings } = require('../core/settings');
 const { ELEMENT_WAIT_TIME } = require('../core/constants');
 
@@ -16,11 +14,8 @@ class MultiUsers {
     this.context = context;
   }
 
-  async initPages(page1, waitAndClearDefaultPresentationNotificationModPage = false) {
+  async initPages(page1) {
     await this.initModPage(page1);
-    if (waitAndClearDefaultPresentationNotificationModPage) {
-      await waitAndClearDefaultPresentationNotification(this.modPage);
-    }
     await this.initUserPage();
   }
 

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -5,12 +5,7 @@ const { GuestPolicy } = require('./guestPolicy');
 const { LockViewers } = require('./lockViewers');
 const { MobileDevices } = require('./mobileDevices');
 const { Timer } = require('./timer');
-const { encodeCustomParams } = require('../parameters/util');
-const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
-const motoG4 = devices['Moto G4'];
 const iPhone11 = devices['iPhone 11'];
-
-const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
 
 test.describe.parallel('User', { tag: '@ci' }, () => {
   test.describe.parallel('Actions', () => {
@@ -229,8 +224,7 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
 
       test('Lock see other viewers annotations', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
-        await lockViewers.initModPage(page, true, { joinParameter: hidePresentationToast });
-        await lockViewers.initUserPage(true, context, { joinParameter: hidePresentationToast });
+        await lockViewers.initPages(page);
         await lockViewers.lockSeeOtherViewersAnnotations();
       });
 

--- a/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js
+++ b/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.js
@@ -9,8 +9,6 @@ const { DrawStickyNote } = require('./drawStickyNote');
 const { Pan } = require('./pan');
 const { Eraser } = require('./eraser');
 const { DrawArrow } = require('./drawArrow');
-const { encodeCustomParams } = require('../parameters/util');
-const { PARAMETER_HIDE_PRESENTATION_TOAST } = require('../core/constants');
 const { DeleteDrawing } = require('./deleteDrawing');
 const { UndoDrawing } = require('./undoDraw');
 const { RedoDrawing } = require('./redoDraw');
@@ -18,8 +16,6 @@ const { ChangeStyles } = require('./changeStyles');
 const { RealTimeText } = require('./realTimeText');
 const { ShapeOptions } = require('./shapeOptions');
 const { linkIssue } = require('../core/helpers');
-
-const hidePresentationToast = encodeCustomParams(PARAMETER_HIDE_PRESENTATION_TOAST);
 
 //! @flaky note:
 // all whiteboard tests are flagged as flaky due to unexpected zooming slides
@@ -35,42 +31,42 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
   test('Draw rectangle', async ({ browser, context, page }) => {
     const drawRectangle = new DrawRectangle(browser, context);
     await drawRectangle.initModPage(page, true, { customMeetingId: 'draw_rectangle_meeting', joinParameter: hidePresentationToast });
-    await drawRectangle.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawRectangle.initUserPage(true, context);
     await drawRectangle.test();
   });
 
   test('Draw ellipse', async ({ browser, context, page }) => {
     const drawEllipse = new DrawEllipse(browser, context);
     await drawEllipse.initModPage(page, true, { customMeetingId: 'draw_ellipse_meeting', joinParameter: hidePresentationToast });
-    await drawEllipse.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawEllipse.initUserPage(true, context);
     await drawEllipse.test();
   });
 
   test('Draw triangle', async ({ browser, context, page }) => {
     const drawTriangle = new DrawTriangle(browser, context);
     await drawTriangle.initModPage(page, true, { customMeetingId: 'draw_triangle_meeting', joinParameter: hidePresentationToast });
-    await drawTriangle.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawTriangle.initUserPage(true, context);
     await drawTriangle.test();
   });
 
   test('Draw line', async ({ browser, context, page }) => {
     const drawLine = new DrawLine(browser, context);
     await drawLine.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await drawLine.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawLine.initUserPage(true, context);
     await drawLine.test();
   });
 
   test('Draw with pencil', async ({ browser, context, page }) => {
     const drawPencil = new DrawPencil(browser, context);
     await drawPencil.initModPage(page, true, { customMeetingId: 'draw_pencil_meeting', joinParameter: hidePresentationToast });
-    await drawPencil.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawPencil.initUserPage(true, context);
     await drawPencil.test();
   });
 
   test('Type text', async ({ browser, context, page }) => {
     const drawText = new DrawText(browser, context);
     await drawText.initModPage(page, true, { customMeetingId: 'draw_text_meeting', joinParameter: hidePresentationToast });
-    await drawText.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawText.initUserPage(true, context);
     await drawText.test();
   });
 
@@ -79,7 +75,7 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
     linkIssue(21302);
     const drawStickyNote = new DrawStickyNote(browser, context);
     await drawStickyNote.initModPage(page, true, { customMeetingId: 'draw_sticky_meeting', joinParameter: hidePresentationToast });
-    await drawStickyNote.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawStickyNote.initUserPage(true, context);
     await drawStickyNote.test();
   });
 
@@ -88,21 +84,21 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
     linkIssue(21266);
     const pan = new Pan(browser, context);
     await pan.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await pan.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await pan.initUserPage(true, context);
     await pan.test();
   });
 
   test('Eraser', async ({ browser, context, page }) => {
     const eraser = new Eraser(browser, context);
     await eraser.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await eraser.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await eraser.initUserPage(true, context);
     await eraser.test();
   });
 
   test('Draw arrow', async ({ browser, context, page }) => {
     const drawArrow = new DrawArrow(browser, context);
     await drawArrow.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await drawArrow.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await drawArrow.initUserPage(true, context);
     await drawArrow.test();
   });
 
@@ -110,28 +106,28 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
     test('Change color', async ({ browser, context, page }) => {
       const changeColor = new ChangeStyles(browser, context);
       await changeColor.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-      await changeColor.initUserPage(true, context, { joinParameter: hidePresentationToast });
+      await changeColor.initUserPage(true, context);
       await changeColor.changingColor();
     });
 
     test('Fill drawing', async ({ browser, context, page }) => {
       const fillDrawing = new ChangeStyles(browser, context);
       await fillDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-      await fillDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
+      await fillDrawing.initUserPage(true, context);
       await fillDrawing.fillDrawing();
     });
 
     test('Dash drawing', async ({ browser, context, page }) => {
       const dashDrawing = new ChangeStyles(browser, context);
       await dashDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-      await dashDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
+      await dashDrawing.initUserPage(true, context);
       await dashDrawing.dashDrawing();
     });
 
     test('Size drawing', async ({ browser, context, page }) => {
       const sizeDrawing = new ChangeStyles(browser, context);
       await sizeDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-      await sizeDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
+      await sizeDrawing.initUserPage(true, context);
       await sizeDrawing.sizeDrawing();
     });
   });
@@ -139,7 +135,7 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
   test('Delete drawing', async ({ browser, context, page }) => {
     const deleteDrawing = new DeleteDrawing(browser, context);
     await deleteDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await deleteDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await deleteDrawing.initUserPage(true, context);
     await deleteDrawing.test();
   });
 
@@ -148,7 +144,7 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
     // alternative: use keyboard shortcut
     const undoDrawing = new UndoDrawing(browser, context);
     await undoDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await undoDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await undoDrawing.initUserPage(true, context);
     await undoDrawing.test();
   });
 
@@ -157,14 +153,14 @@ test.describe.parallel('Whiteboard tools', { tag: ['@ci', '@flaky'] }, () => {
     // alternative: use keyboard shortcut
     const redoDrawing = new RedoDrawing(browser, context);
     await redoDrawing.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await redoDrawing.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await redoDrawing.initUserPage(true, context);
     await redoDrawing.test();
   });
 
   test('Real time text typing', async ({ browser, context, page }) => {
     const realTimeText = new RealTimeText(browser, context);
     await realTimeText.initModPage(page, true, { customMeetingId: 'draw_line_meeting', joinParameter: hidePresentationToast });
-    await realTimeText.initUserPage(true, context, { joinParameter: hidePresentationToast });
+    await realTimeText.initUserPage(true, context);
     await realTimeText.realTimeTextTyping();
   });
 


### PR DESCRIPTION
The client was repeatedly displaying the notification about the Current Presentation.  
To resolve this and align with the new notification pattern, this PR moves the notification-sending action to `akka-apps`, simplifying the client by removing its complex logic.

Before:
<img src="https://github.com/user-attachments/assets/a53602cd-b704-46fd-9f7c-25a62202a3ef" width=200 />

After:
<img src="https://github.com/user-attachments/assets/38879bad-b185-4f63-9806-e46022715ad2" width=200 />

Fix: #22185