### PR TITLE
fix(livekit): no mic output after joining audio in "listen only" mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -659,14 +659,11 @@ class AudioManager {
 
   onVoiceUserChanges(fields = {}) {
     if (fields.muted !== undefined && fields.muted !== this.isMuted) {
-      let muteState;
       this.isMuted = fields.muted;
 
       if (this.isMuted) {
-        muteState = 'selfMuted';
         this.mute();
       } else {
-        muteState = 'selfUnmuted';
         this.unmute();
       }
     }
@@ -1158,10 +1155,6 @@ class AudioManager {
   }
 
   setSenderTrackEnabled(shouldEnable) {
-    // If the bridge is set to listen only mode, nothing to do here. This method
-    // is solely for muting outbound tracks.
-    if (this.isListenOnly) return;
-
     this.bridge.setSenderTrackEnabled(shouldEnable);
   }
 


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): no mic output after joining audio in "listen only" mode](https://github.com/bigbluebutton/bigbluebutton/commit/ac154fb0829775cb453210454e867bc45c396aeb) 
  - Whenever an user joins as "listen only" (no input device, lock settings
is enforced) and later tries to activate a microphone mid-call, the mic
in question will output no audio. This only affects the LiveKit bridge.
This is due to an uneeded "isListenOnly" flag check in audio-manager's
setSenderTrackEnabled interface.
  - Removed some unused vars in audio-manager

### Closes Issue(s)

Partially https://github.com/bigbluebutton/bigbluebutton/issues/22099

