### PR TITLE
test: Enhance pinning webcam assertions

### DIFF
--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -436,6 +436,7 @@ exports.advancedVideoSettingsBtn = 'li[data-test="advancedVideoSettingsButton"]'
 exports.mirrorWebcamBtn = 'li[data-test="mirrorWebcamBtn"]';
 exports.focusWebcamBtn = 'li[data-test="focusWebcamBtn"]';
 exports.pinWebcamBtn = 'li[data-test="pinWebcamBtn"]';
+exports.pinVideoButton = 'button[data-test="pinVideoButton"]';
 exports.webcamsFullscreenButton = 'li[data-test="webcamsFullscreenButton"]';
 exports.webcamSettingsTitle = 'span[id="webcam-settings-title"]';
 exports.backgroundSettingsTitle = 'span[id="backgrounds-title"]';

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -140,6 +140,10 @@ class Page {
     return this.page.locator(selector);
   }
 
+  getVisibleLocator(selector) {
+    return this.getLocator(`${selector}:visible`);
+  }
+
   getLocatorByIndex(selector, index) {
     return this.page.locator(selector).nth(index);
   }

--- a/bigbluebutton-tests/playwright/playwright.config.js
+++ b/bigbluebutton-tests/playwright/playwright.config.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const { chromiumConfig, firefoxConfig, webkitConfig } = require('./core/browsersConfig');
-const { ELEMENT_WAIT_TIME, CI } = require('./core/constants');
+const { ELEMENT_WAIT_TIME, CI, ELEMENT_WAIT_LONGER_TIME } = require('./core/constants');
 
 const isParallel = !!process.env.npm_config_parallel;
 
@@ -19,6 +19,7 @@ const config = {
     trace: 'on',
     screenshot: 'on',
     video: CI ? 'retain-on-failure' : 'on',
+    actionTimeout: ELEMENT_WAIT_LONGER_TIME,
   },
   projects: [
     chromiumConfig,

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -185,29 +185,43 @@ class MultiUsers {
   }
 
   async pinningWebcams() {
+    // start webcam sharing
     await this.modPage.shareWebcam();
     await this.modPage2.shareWebcam();
     await this.userPage.shareWebcam();
-    await this.modPage.page.waitForFunction(
-      checkElementLengthEqualTo,
-      [e.webcamContainer, 2], //wait two 'videoContainer', as current user has data-test="mirroredVideoContainer"
-      { timeout: ELEMENT_WAIT_TIME },
-    );
-    // Pin first webcam (Mod2)
-    await this.modPage.waitAndClick(`:nth-match(${e.dropdownWebcamButton}, 3)`);
-    await this.modPage.waitAndClick(`:nth-match(${e.pinWebcamBtn}, 2)`);
-    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should the first webcam display the second moderator username for the first moderator');
-    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should the first webcam display the second moderator username for the second moderator');
-    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should the first webcam display the second moderator username for the attendee');
-    // Pin second webcam (user)
-    await this.modPage.waitAndClick(`:nth-match(${e.dropdownWebcamButton}, 3)`);
-    await this.modPage.waitAndClick(`:nth-match(${e.pinWebcamBtn}, 3)`);
-    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage.username, 'should the first webcam display the attendee username for the first moderator');
-    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 2)`, this.modPage2.username, 'should the second webcam display the second moderator username for the first moderator');
-    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should the first webcam display the second moderator username for the first attendee');
-    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 2)`, this.userPage.username, 'should the second webcam display the attendee username for the attendee');
-    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage.username, 'should the first webcam display the attendee username for the second moderator');
-    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 2)`, this.modPage2.username, 'should the second webcam display the second moderator username for the second moderator');
+    // check own webcam sharing
+    await this.modPage.hasElement(e.webcamMirroredVideoContainer, 'should display mirrored webcam video container (own share) for Mod1');
+    await this.modPage2.hasElement(e.webcamMirroredVideoContainer, 'should display mirrored webcam video container (own share) for Mod2');
+    await this.userPage.hasElement(e.webcamMirroredVideoContainer, 'should display mirrored webcam video container (own share) for Attendee');
+    // check other webcams sharing for each user
+    await this.modPage.hasNElements(e.webcamContainer, 2, 'should display the other two webcams for Mod1');
+    await this.modPage2.hasNElements(e.webcamContainer, 2, 'should display the other two webcams for Mod2');
+    await this.userPage.hasNElements(e.webcamContainer, 2, 'should display the other two webcams for Attendee');
+    // pin first webcam (Mod2)
+    await this.modPage.getLocator(e.dropdownWebcamButton)
+      .filter({ hasText: this.modPage2.username })
+      .click();
+    await this.modPage.getVisibleLocator(e.pinWebcamBtn).click();
+    // check pinned webcam
+    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should display the username of Mod2 on the pinned webcam for Mod1');
+    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should display the username of Mod2 on the pinned webcam for Mod2');
+    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should display the username of Mod2 on the pinned webcam for the Attendee');
+    // pin second webcam (user)
+    await this.modPage.getLocator(e.dropdownWebcamButton)
+      .filter({ hasText: this.userPage.username })
+      .click();
+    await this.modPage.getVisibleLocator(e.pinWebcamBtn).click();
+    // check pin webcam button number for mods
+    await this.modPage.hasNElements(e.pinVideoButton, 2, 'should display two buttons of pinned video for Mod1');
+    await this.modPage2.hasNElements(e.pinVideoButton, 2, 'should display two buttons of pinned video for Mod2');
+    // check first pinned webcam
+    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage.username, 'should display the username of Attendee on the first pinned webcam for Mod1');
+    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage.username, 'should display the username of Attendee on the first pinned webcam for Mod2');
+    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage2.username, 'should display the username of Mod2 on the first pinned webcam for Attendee (mods priority for viewers)');
+    // check second pinned webcam
+    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 2)`, this.modPage2.username, 'should display the username of Mod2 on the second pinned webcam for Mod1');
+    await this.modPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 2)`, this.modPage2.username, 'should display the username of Mod2 on the second pinned webcam for Mod2');
+    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 2)`, this.userPage.username, 'should display the username of Attendee on the second pinned webcam for Attendee');
   }
 
   async giveAndRemoveWhiteboardAccess() {


### PR DESCRIPTION
### What does this PR do?
This PR improves the pinning and unpinning webcam assertions. we've recently spotted a few CIs failing in related steps. The test expects this pinning behavior:
- for viewers: Mods priority -> pinned order;
- for mods: pinned order;

now, this test also:
- waits for each user's own webcam to load;
- waits for other users' webcam to load (both actions prevent failure when performing clicks before the camera video is not fully loaded);

### More
- sets a default `actionTimeout` value;
- adds `getVisibleLocator` function;
- assertion descriptions improved