### PR TITLE
[3.1] feat(plugins): add apps gallery extensible area & fix(plugins): unregistering generic sidekick content 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -4,7 +4,7 @@ import { AppsGalleryProps } from './types';
 import Icon from '/imports/ui/components/common/icon/component';
 import { layoutDispatch, layoutSelect } from '/imports/ui/components/layout/context';
 import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
-import { Layout } from '/imports/ui/components/layout/layoutTypes';
+import { InjectedAppGalleryItem, Layout } from '/imports/ui/components/layout/layoutTypes';
 import Styled from './styles';
 import TooManyPinnedAppsModal from './modal/component';
 
@@ -35,7 +35,13 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
   const title = intl.formatMessage(intlMessages.appsGalleryTitle);
   const [error, setError] = useState(false);
 
-  const renderApp = (appKey: string, name: string, icon: string, isPinned: boolean) => {
+  const renderApp = (
+    appKey: string,
+    name: string,
+    icon: string,
+    isPinned: boolean,
+    onClick?: undefined | (() => void),
+  ) => {
     const togglePinApp = (event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
       event.stopPropagation();
       if (!isPinned && pinnedApps.length >= MAX_PINNED_APPS_GALLERY) {
@@ -45,7 +51,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
       layoutContextDispatch({
         type: ACTIONS.SET_SIDEBAR_NAVIGATION_PIN_APP,
         value: {
-          panel: appKey,
+          id: appKey,
           pin: !isPinned,
         },
       });
@@ -60,16 +66,17 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
         value: appKey,
       });
     };
+    const functionToBeCalled = typeof onClick === 'function' ? onClick : openAppPanel;
     return (
       <Styled.RegisteredAppContent>
         <Styled.ClickableArea
-          onClick={openAppPanel}
+          onClick={functionToBeCalled}
         >
           <Styled.OpenButton
             key={`OPEN${appKey}`}
             color="primary"
             type="button"
-            onClick={openAppPanel}
+            onClick={functionToBeCalled}
             icon={icon}
             pinned={isPinned}
           />
@@ -94,7 +101,9 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
   const renderedPinnedApps = useMemo(() => (
     pinnedApps.map((pinnedAppKey) => {
       const { name, icon } = registeredApps[pinnedAppKey];
-      return renderApp(pinnedAppKey, name, icon, true);
+      // type guard
+      const { onClick } = registeredApps[pinnedAppKey] as InjectedAppGalleryItem;
+      return renderApp(pinnedAppKey, name, icon, true, onClick);
     })
   ), [registeredApps, pinnedApps]);
 
@@ -103,7 +112,9 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
       .filter((registeredObjectKey) => !pinnedApps.includes(registeredObjectKey))
       .map((unpinnedAppKey) => {
         const { name, icon } = registeredApps[unpinnedAppKey];
-        return renderApp(unpinnedAppKey, name, icon, false);
+        // type guard
+        const { onClick } = registeredApps[unpinnedAppKey] as InjectedAppGalleryItem;
+        return renderApp(unpinnedAppKey, name, icon, false, onClick);
       })
   ), [registeredApps, pinnedApps]);
 

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -409,10 +409,11 @@ const reducer = (state, action) => {
     }
     case ACTIONS.REGISTER_SIDEBAR_APP: {
       const {
-        panel,
+        id,
         name,
         icon,
         contentFunction = undefined,
+        onClick = undefined,
       } = action.value;
       const { sidebarNavigation } = state.input;
       const { registeredApps } = sidebarNavigation;
@@ -424,10 +425,11 @@ const reducer = (state, action) => {
             ...sidebarNavigation,
             registeredApps: {
               ...registeredApps,
-              [panel]: {
+              [id]: {
                 name,
                 icon,
                 ...(contentFunction && { contentFunction }),
+                ...(onClick && { onClick }),
               },
             },
           },
@@ -436,23 +438,23 @@ const reducer = (state, action) => {
     }
     case ACTIONS.UNREGISTER_SIDEBAR_APP: {
       const {
-        value,
+        id,
       } = action;
       const { sidebarNavigation } = state.input;
       const { registeredApps, pinnedApps } = sidebarNavigation;
-      if (!(value in registeredApps)) {
+      if (!(id in registeredApps)) {
         logger.warn({
           logCode: 'unregister_not_found_app',
           extraInfo: {
-            panel: value,
+            id,
           },
-        }, `Layout Context: Attempting to unregister an app "${value}" that is not registered.`);
+        }, `Layout Context: Attempting to unregister an app "${id}" that is not registered.`);
         return state;
       }
       const updatedRegisteredApps = { ...registeredApps };
-      delete updatedRegisteredApps[value];
+      delete updatedRegisteredApps[id];
       // Also remove it from pinned apps
-      const updatedPinnedApps = pinnedApps.filter((pinnedApp) => pinnedApp !== value);
+      const updatedPinnedApps = pinnedApps.filter((pinnedApp) => pinnedApp !== id);
       return {
         ...state,
         input: {
@@ -470,12 +472,12 @@ const reducer = (state, action) => {
     case ACTIONS.SET_SIDEBAR_NAVIGATION_PIN_APP: {
       const APP_CONFIG = window.meetingClientSettings.public.app;
       const MAX_PINNED_APPS_GALLERY = APP_CONFIG.appsGallery.maxPinnedApps;
-      const { panel: appKey, pin } = action.value;
+      const { id: appId, pin } = action.value;
       const { sidebarNavigation } = state.input;
       const { pinnedApps, registeredApps } = sidebarNavigation;
 
-      const isAppRegistered = appKey in registeredApps;
-      const isAppPinned = pinnedApps.includes(appKey);
+      const isAppRegistered = appId in registeredApps;
+      const isAppPinned = pinnedApps.includes(appId);
 
       if (!isAppRegistered) return state;
       if ((pin && isAppPinned) || (!pin && !isAppPinned)) {
@@ -486,8 +488,8 @@ const reducer = (state, action) => {
       }
 
       const updatedPinnedApps = pin
-        ? [...pinnedApps, appKey]
-        : pinnedApps.filter((pinnedApp) => pinnedApp !== appKey);
+        ? [...pinnedApps, appId]
+        : pinnedApps.filter((pinnedApp) => pinnedApp !== appId);
 
       return {
         ...state,

--- a/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
@@ -204,8 +204,12 @@ export interface InjectedWidget extends Widget {
     contentFunction: (element: HTMLElement) => ReactDOM.Root;
 }
 
+export interface InjectedAppGalleryItem extends Widget {
+    onClick: () => void;
+}
+
 export interface registeredApps {
-    [key: string]: NativeWidget | InjectedWidget;
+    [key: string]: NativeWidget | InjectedWidget | InjectedAppGalleryItem;
 }
 
 export interface SidebarNavigation {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/apps-gallery/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/apps-gallery/manager.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState, useCallback } from 'react';
+import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
+
+import { ExtensibleAreaComponentManagerProps, ExtensibleAreaComponentManager } from '../../types';
+import { layoutDispatch } from '/imports/ui/components/layout/context';
+import { ACTIONS } from '/imports/ui/components/layout/enums';
+
+const AppsGalleryPluginStateContainer = ((
+  props: ExtensibleAreaComponentManagerProps,
+) => {
+  const layoutContextDispatch = layoutDispatch();
+  const {
+    uuid,
+    generateItemWithId,
+    extensibleAreaMap,
+    pluginApi,
+  } = props;
+  const [
+    appsGalleryItems,
+    setAppsGalleryItems,
+  ] = useState<PluginSdk.AppsGalleryInterface[]>([]);
+
+  const excludeById = useCallback(
+    (arr1: PluginSdk.GenericContentInterface[], arr2: PluginSdk.GenericContentInterface[]) => {
+      const idsSet = new Set(arr2.map((item) => item.id));
+      return arr1.filter((item) => !idsSet.has(item.id));
+    },
+    [],
+  );
+
+  const unregisterExcludedAppsGalleryItems = useCallback(
+    (
+      currentAppsGalleryItems: PluginSdk.AppsGalleryInterface[],
+      newAppsGalleryItems: PluginSdk.AppsGalleryInterface[],
+    ) => {
+      if (currentAppsGalleryItems.length === 0) return;
+      const excluded = excludeById(
+        currentAppsGalleryItems,
+        newAppsGalleryItems,
+      );
+      excluded.forEach((agi) => {
+        layoutContextDispatch({
+          type: ACTIONS.UNREGISTER_SIDEBAR_APP,
+          value: agi.id,
+        });
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    // Change this plugin provided apps gallery items
+    extensibleAreaMap[uuid].appsGalleryItems = appsGalleryItems;
+
+    (appsGalleryItems as PluginSdk.AppsGalleryEntry[]).forEach((agi) => {
+      return layoutContextDispatch({
+        type: ACTIONS.REGISTER_SIDEBAR_APP,
+        value: {
+          id: agi.id,
+          name: agi.name,
+          icon: agi.icon,
+          onClick: agi.onClick,
+        },
+      });
+    });
+  }, [appsGalleryItems]);
+
+  pluginApi.setAppsGalleryItems = (items: PluginSdk.AppsGalleryInterface[]) => {
+    const itemsWithId = items.map(generateItemWithId) as PluginSdk.AppsGalleryInterface[];
+    setAppsGalleryItems((currentAppsGalleryItems) => {
+      unregisterExcludedAppsGalleryItems(currentAppsGalleryItems, items);
+      return itemsWithId;
+    });
+    return itemsWithId.map((i) => i.id);
+  };
+  return null;
+}) as ExtensibleAreaComponentManager;
+
+export default AppsGalleryPluginStateContainer;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useState, useContext } from 'react';
+import {
+  useEffect,
+  useState,
+  useContext,
+  useCallback,
+} from 'react';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import { GenericContentType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/generic-content-item/enums';
 
@@ -29,6 +34,50 @@ const GenericContentPluginStateContainer = ((
     setPluginsExtensibleAreasAggregatedState,
   } = useContext(PluginsContext);
 
+  const excludeById = useCallback(
+    (arr1: PluginSdk.GenericContentInterface[], arr2: PluginSdk.GenericContentInterface[]) => {
+      const idsSet = new Set(arr2.map((item) => item.id));
+      return arr1.filter((item) => !idsSet.has(item.id));
+    },
+    [],
+  );
+
+  const genericContentSidekickId = useCallback(
+    (id: string) => (
+      PANELS.GENERIC_CONTENT_SIDEKICK + id
+    ),
+    [],
+  );
+
+  const filterSidekick = useCallback(
+    (genericContentItems: PluginSdk.GenericContentInterface[]) => (
+      genericContentItems.filter((gci) => gci.type === GenericContentType.SIDEKICK_AREA)
+    ),
+    [],
+  );
+
+  const unregisterExcludedSidekickContentsFromApps = useCallback(
+    (
+      currentGenericContentItems: PluginSdk.GenericContentInterface[],
+      newGenericContentItems: PluginSdk.GenericContentInterface[],
+    ) => {
+      const currentGenericSidekickContentItems = filterSidekick(currentGenericContentItems);
+      const newGenericSidekickContentItems = filterSidekick(newGenericContentItems);
+      if (currentGenericSidekickContentItems.length === 0) return;
+      const excluded = excludeById(
+        currentGenericSidekickContentItems,
+        newGenericSidekickContentItems,
+      );
+      excluded.forEach((gs) => {
+        layoutContextDispatch({
+          type: ACTIONS.UNREGISTER_SIDEBAR_APP,
+          id: genericContentSidekickId(gs.id),
+        });
+      });
+    },
+    [],
+  );
+
   useEffect(() => {
     // Change this plugin provided toolbar items
     extensibleAreaMap[uuid].genericContentItems = genericContentItems;
@@ -44,14 +93,13 @@ const GenericContentPluginStateContainer = ((
         ...previousState,
         genericContentItems: aggregatedGenericContentItems,
       }));
-    const genericContentSidekickId = (id: string) => PANELS.GENERIC_CONTENT_SIDEKICK + id;
-    const genericContentSidekickArea = genericContentItems
-      .filter((g) => g.type === GenericContentType.SIDEKICK_AREA) as PluginSdk.GenericContentSidekickArea[];
-    genericContentSidekickArea.map((genericContentItem) => {
+    const genericContentSidekickArea = filterSidekick(genericContentItems) as PluginSdk.GenericContentSidekickArea[];
+
+    genericContentSidekickArea.forEach((genericContentItem) => {
       return layoutContextDispatch({
         type: ACTIONS.REGISTER_SIDEBAR_APP,
         value: {
-          panel: genericContentSidekickId(genericContentItem.id),
+          id: genericContentSidekickId(genericContentItem.id),
           name: genericContentItem.name,
           icon: genericContentItem.buttonIcon,
           contentFunction: genericContentItem.contentFunction,
@@ -62,7 +110,10 @@ const GenericContentPluginStateContainer = ((
 
   pluginApi.setGenericContentItems = (items: PluginSdk.GenericContentInterface[]) => {
     const itemsWithId = items.map(generateItemWithId) as PluginSdk.GenericContentInterface[];
-    setGenericContentItems(itemsWithId);
+    setGenericContentItems((currentGenericContentItems) => {
+      unregisterExcludedSidekickContentsFromApps(currentGenericContentItems, items);
+      return itemsWithId;
+    });
     return itemsWithId.map((i) => i.id);
   };
   return null;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/manager.tsx
@@ -7,6 +7,7 @@ import UserListDropdownPluginStateContainer from './components/user-list-dropdow
 import ActionButtonDropdownPluginStateContainer from './components/action-button-dropdown/manager';
 import AudioSettingsDropdownPluginStateContainer from './components/audio-settings-dropdown/manager';
 import ActionBarPluginStateContainer from './components/action-bar/manager';
+import AppsGalleryPluginStateContainer from './components/apps-gallery/manager';
 import PresentationDropdownPluginStateContainer from './components/presentation-dropdown/manager';
 import NavBarPluginStateContainer from './components/nav-bar/manager';
 import OptionsDropdownPluginStateContainer from './components/options-dropdown/manager';
@@ -30,6 +31,7 @@ const extensibleAreaComponentManagers: ExtensibleAreaComponentManager[] = [
   ActionButtonDropdownPluginStateContainer,
   AudioSettingsDropdownPluginStateContainer,
   ActionBarPluginStateContainer,
+  AppsGalleryPluginStateContainer,
   UserCameraHelperPluginStateContainer,
   PresentationDropdownPluginStateContainer,
   NavBarPluginStateContainer,

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/types.ts
@@ -13,6 +13,7 @@ export interface ExtensibleArea {
   actionButtonDropdownItems: PluginSdk.ActionButtonDropdownInterface[];
   audioSettingsDropdownItems: PluginSdk.AudioSettingsDropdownInterface[];
   actionsBarItems: PluginSdk.ActionsBarInterface[];
+  appsGalleryItems: PluginSdk.AppsGalleryInterface[];
   presentationDropdownItems: PluginSdk.PresentationDropdownInterface[];
   navBarItems: PluginSdk.NavBarInterface[];
   screenshareHelperItems: PluginSdk.ScreenshareHelperInterface[];

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
@@ -66,31 +66,31 @@ const SidebarNavigationContainer = () => {
   const timerIsRegistered = useMemo(() => (
     Object.keys(registeredApps).includes(TIMER_APP_KEY)), [registeredApps]);
 
-  const registerApp = (panel: string, name: string, icon: string) => {
+  const registerApp = (id: string, name: string, icon: string) => {
     layoutContextDispatch({
       type: ACTIONS.REGISTER_SIDEBAR_APP,
       value: {
-        panel,
+        id,
         name,
         icon,
       },
     });
   };
 
-  const pinApp = (panel: string) => {
+  const pinApp = (id: string) => {
     layoutContextDispatch({
       type: ACTIONS.SET_SIDEBAR_NAVIGATION_PIN_APP,
       value: {
-        panel,
+        id,
         pin: true,
       },
     });
   };
 
-  const unregisterApp = (panel: string) => {
+  const unregisterApp = (id: string) => {
     layoutContextDispatch({
       type: ACTIONS.UNREGISTER_SIDEBAR_APP,
-      value: panel,
+      id,
     });
   };
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/pinned-apps/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/pinned-apps/component.tsx
@@ -1,5 +1,6 @@
 import React, { memo } from 'react';
 import {
+  InjectedAppGalleryItem,
   Input,
   SidebarNavigation,
 } from '/imports/ui/components/layout/layoutTypes';
@@ -17,10 +18,24 @@ const PinnedApps = ({ sidebarNavigationInput }: PinnedAppsProps) => {
   const { registeredApps = {}, pinnedApps = [] } = sidebarNavigationInput;
   const layoutContextDispatch = layoutDispatch();
   const { sidebarContentPanel } = layoutSelectInput((i: Input) => i.sidebarContent);
+  const openPanel = (pinnedAppKey: string) => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: sidebarContentPanel !== pinnedAppKey,
+    });
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: sidebarContentPanel === pinnedAppKey
+        ? PANELS.NONE
+        : pinnedAppKey,
+    });
+  };
 
   return pinnedApps.map((pinnedAppKey: string) => {
     const pinnedAppInfo = registeredApps[pinnedAppKey];
     const { name, icon } = pinnedAppInfo;
+    // type guard
+    const { onClick } = (pinnedAppInfo as InjectedAppGalleryItem);
     return (
       <TooltipContainer
         title={name}
@@ -32,18 +47,7 @@ const PinnedApps = ({ sidebarNavigationInput }: PinnedAppsProps) => {
           tabIndex={0}
           active={sidebarContentPanel === pinnedAppKey}
           data-test={`${pinnedAppKey}SidebarButton`}
-          onClick={() => {
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-              value: sidebarContentPanel !== pinnedAppKey,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-              value: sidebarContentPanel === pinnedAppKey
-                ? PANELS.NONE
-                : pinnedAppKey,
-            });
-          }}
+          onClick={onClick || (() => openPanel(pinnedAppKey))}
         >
           <Icon iconName={icon} />
         </Styled.ListItem>

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -31,7 +31,7 @@
         "autoprefixer": "^10.4.4",
         "axios": "^1.7.8",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.70",
+        "bigbluebutton-html-plugin-sdk": "0.1.2",
         "bowser": "^2.11.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6666,10 +6666,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.70",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.70.tgz",
-      "integrity": "sha512-TxNaRin5wQPVETB0l2vwidogWqlfYxRsdBvOsuldu8i/wREA+K+jIGfdRwRZaO2BhpIy+HlpPKwlIPYg7fOaDw==",
-
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.1.2.tgz",
+      "integrity": "sha512-Ty+l2wPJXxy0is5BUPxd+9arcdC49XqmFUm3DtsHuUG8eTddnl+7rJnCskuAI+Gu17wFHmyGVo2U2FzUJjHnsg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -60,7 +60,7 @@
     "autoprefixer": "^10.4.4",
     "axios": "^1.7.8",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.70",
+    "bigbluebutton-html-plugin-sdk": "0.1.2",
     "bowser": "^2.11.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
### What does this PR do?
- [feat(plugins): add apps gallery extensible area](https://github.com/bigbluebutton/bigbluebutton/commit/35e013ccf7847e96706daafce9e56c5ef6796c45) 
  Adds new extensible area for the apps gallery. Previously, to add an entry in the apps gallery, a plugin should inject a generic sidekick content, which means that something would be shown in the sidebar content. But, as the concept of an app is growing beyond the sidebar content, this new extensible area allows for injecting an entry in the apps gallery and can execute any action using the 'onClick' callback.

- [fix(plugins): unregistering generic sidekick content](https://github.com/bigbluebutton/bigbluebutton/commit/028d797aebd54ea77df97a9235286c173d0e0cda) 
  The generic sidekick contents were not being unregistered from the apps gallery. That means that when an app was registered, it was never unregistered, even when the user lost the permission to control that feature. So this commit fixes that by properly unregistering the excluded generic sidekick contents.


### How to test
Just set the sample plugin included in the plugin sdk PR


### More
Plugin SDK pr:
- https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/149
