### PR TITLE
fix(session-details): generalize modal title for better localization

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/session-details/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/session-details/component.tsx
@@ -54,7 +54,6 @@ interface SessionDetailsContainerProps {
 }
 
 interface SessionDetailsProps extends SessionDetailsContainerProps {
-  meetingName: string;
   welcomeMessage: string;
   welcomeMsgForModerators: string;
   loginUrl: string,
@@ -67,7 +66,6 @@ const COPY_MESSAGE_TIMEOUT = 3000;
 
 const SessionDetails: React.FC<SessionDetailsProps> = (props) => {
   const {
-    meetingName,
     welcomeMessage,
     welcomeMsgForModerators,
     isOpen,
@@ -100,7 +98,7 @@ const SessionDetails: React.FC<SessionDetailsProps> = (props) => {
 
   return (
     <ModalSimple
-      title={intl.formatMessage(intlMessages.title, { 0: meetingName })}
+      title={intl.formatMessage(intlMessages.title)}
       dismiss={{
         label: intl.formatMessage(intlMessages.dismissLabel),
         description: intl.formatMessage(intlMessages.dismissDesc),
@@ -232,7 +230,6 @@ const SessionDetailsContainer: React.FC<SessionDetailsContainerProps> = ({
       isOpen={isOpen}
       onRequestClose={onRequestClose}
       priority={priority}
-      meetingName={currentMeeting.name ?? ''}
       loginUrl={loginUrl}
       welcomeMessage={welcomeData.user_welcomeMsgs[0]?.welcomeMsg ?? ''}
       welcomeMsgForModerators={welcomeData.user_welcomeMsgs[0]?.welcomeMsgForModerators ?? ''}

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1542,7 +1542,7 @@
     "app.learningDashboard.statusTimelineTable.setAt": "Set at",
     "app.learningDashboard.errors.invalidToken": "Invalid session token",
     "app.learningDashboard.errors.dataUnavailable": "Data is no longer available",
-    "app.sessionDetails.title": "{0} Details",
+    "app.sessionDetails.title": "Session Details",
     "app.sessionDetails.dismissLabel": "Close",
     "app.sessionDetails.dismissDesc": "Close modal",
     "app.sessionDetails.joinByUrl": "Join by URL",


### PR DESCRIPTION
### What does this PR do?
The modal title was too specific in English and didn't translate well into other languages(e.g., portuguese). This commit changes the title to something more generic, improving its fit accross multiple languages.

![Screenshot from 2025-02-13 15-31-27](https://github.com/user-attachments/assets/22ea1b05-1229-4016-9e30-a952f1a153ba)
