### PR TITLE
fix: Enable allow users to choose room blocking create button on breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -373,7 +373,6 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         id: 'freeJoinCheckbox',
         onChange: checkboxCallbackFactory((e: boolean) => {
           setFreeJoin(e);
-          setLeastOneUserIsValid(true);
         }),
         label: intl.formatMessage(intlMessages.freeJoinLabel),
       },
@@ -535,7 +534,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
             ? intl.formatMessage(intlMessages.updateConfirm)
             : intl.formatMessage(intlMessages.confirmButton),
           callback: isUpdate ? userUpdate : createRoom,
-          disabled: !leastOneUserIsValid || !numberOfRoomsIsValid || !durationIsValid,
+          disabled: (!leastOneUserIsValid && !freeJoin) || !numberOfRoomsIsValid || !durationIsValid,
         }
       }
       dismiss={{


### PR DESCRIPTION
### What does this PR do?

Fix incorrect state of create breakout button after moving user with free join enabled.

### Closes Issue(s)
Closes #22268

### How to test

1. Create a meeting with a presenter and an attendee
2. Click on Create Breakout Rooms
3. Enable the "allow users to choose room" option
4. Move the user to a room, then move back to the main box.
5. See the Create button not disabled