### PR TITLE
fix(whiteboard): Include height for polling stable container dimensions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1404,9 +1404,24 @@ const Whiteboard = React.memo((props) => {
       });
     };
 
-    const timeoutId = setTimeout(handleResize, 300);
-    return () => clearTimeout(timeoutId);
-  }, [presentationAreaHeight, presentationAreaWidth, curPageId, presentationId]);
+    pollInnerWrapperWidthUntilStable(() => {
+      syncCameraWithPresentationArea({
+        tlEditorRef,
+        isPresenter,
+        currentPresentationPageRef,
+        presentationAreaWidth,
+        presentationAreaHeight,
+        zoomValueRef,
+        fitToWidthRef,
+        curPageIdRef,
+        initialViewBoxWidthRef,
+        initialViewBoxHeightRef,
+      });
+    },{
+        maxTries: 120,
+        stabilityFrames: 25,
+    });
+  }, [presentationHeight, presentationWidth, curPageId, presentationId]);
 
   React.useEffect(() => {
     if (!isPresenter

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -679,7 +679,7 @@ const Whiteboard = React.memo((props) => {
     }
   }
 
-  const pollInnerWrapperWidthUntilStable = (
+  const pollInnerWrapperDimensionsUntilStable = (
     onReady,
     options = {
       maxTries: 120,
@@ -687,44 +687,53 @@ const Whiteboard = React.memo((props) => {
     },
     currentTry = 0,
     stableCount = 0,
-    lastWidth = 0
+    lastDimensions = { width: 0, height: 0 }
   ) => {
     const container = document.querySelector('[data-test="presentationContainer"]');
     const innerWrapper = document.getElementById('presentationInnerWrapper');
-    const containerWidth = container ? container.offsetWidth : 0;
-    const innerWrapperWidth = innerWrapper ? innerWrapper.offsetWidth : 0;
 
-    if (innerWrapperWidth <= 0) {
+    const containerWidth = container ? container.offsetWidth : 0;
+    const containerHeight = container ? container.offsetHeight : 0;
+    const innerWrapperWidth = innerWrapper ? innerWrapper.offsetWidth : 0;
+    const innerWrapperHeight = innerWrapper ? innerWrapper.offsetHeight : 0;
+
+    if (innerWrapperWidth <= 0 || innerWrapperHeight <= 0) {
       stableCount = 0;
     } else {
-      if (innerWrapperWidth === lastWidth) {
+      if (
+        innerWrapperWidth === lastDimensions.width &&
+        innerWrapperHeight === lastDimensions.height
+      ) {
         stableCount++;
       } else {
         stableCount = 0;
-        lastWidth = innerWrapperWidth;
+        lastDimensions = { width: innerWrapperWidth, height: innerWrapperHeight };
       }
     }
 
     if (stableCount >= options.stabilityFrames) {
-      onReady({ containerWidth, innerWrapperWidth });
+      onReady({ containerWidth, containerHeight, innerWrapperWidth, innerWrapperHeight });
       return;
     }
 
     if (currentTry < options.maxTries) {
       requestAnimationFrame(() => {
-        pollInnerWrapperWidthUntilStable(
+        pollInnerWrapperDimensionsUntilStable(
           onReady,
           options,
           currentTry + 1,
           stableCount,
-          lastWidth
+          lastDimensions
         );
       });
     } else {
-      logger.warn({ logCode: 'pollInnerWrapperWidthUntilStable' }, `Failed to store viewbox dimensions`);
-      onReady({ containerWidth, innerWrapperWidth });
+      logger.warn(
+        { logCode: 'pollInnerWrapperDimensionsUntilStable' },
+        `Failed to store viewbox dimensions`
+      );
+      onReady({ containerWidth, containerHeight, innerWrapperWidth, innerWrapperHeight });
     }
-  }
+  };
 
   const handleTldrawMount = (editor) => {
     tlEditorRef.current = editor;
@@ -1061,7 +1070,7 @@ const Whiteboard = React.memo((props) => {
       }
     }
 
-    pollInnerWrapperWidthUntilStable(() => {
+    pollInnerWrapperDimensionsUntilStable(() => {
       adjustCameraOnMount(!isPresenterRef.current);
     });
   };
@@ -1404,7 +1413,7 @@ const Whiteboard = React.memo((props) => {
       });
     };
 
-    pollInnerWrapperWidthUntilStable(() => {
+    pollInnerWrapperDimensionsUntilStable(() => {
       syncCameraWithPresentationArea({
         tlEditorRef,
         isPresenter,
@@ -1419,7 +1428,7 @@ const Whiteboard = React.memo((props) => {
       });
     },{
         maxTries: 120,
-        stabilityFrames: 25,
+        stabilityFrames: 35,
     });
   }, [presentationHeight, presentationWidth, curPageId, presentationId]);
 

--- a/bigbluebutton-tests/playwright/user/lockViewers.js
+++ b/bigbluebutton-tests/playwright/user/lockViewers.js
@@ -201,6 +201,7 @@ class LockViewers extends MultiUsers {
     await this.userPage2.hasElement(e.whiteboard);
     await sleep(1000);   // timeout to ensure the user2 presentation is zoomed correctly
     await this.userPage2.wasRemoved(e.wbDrawnArrow, 'should not display the other viewer annotation for the viewer who just joined');
+    await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await expect(user2WbLocator, 'should not display the other viewer annotation for the viewer who just joined').toHaveScreenshot('viewer2-just-joined.png', screenshotOptions);
 
@@ -208,6 +209,7 @@ class LockViewers extends MultiUsers {
     await this.userPage.waitAndClick(e.wbShapesButton);
     await this.userPage.waitAndClick(e.wbRectangleShape);
     await this.userPage.waitAndClick(e.whiteboard);
+    await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await this.userPage2.wasRemoved(e.wbDrawnShape, 'should not display the new annotation for the other viewer');
     await expect(user2WbLocator, 'should not display the new annotation for the other viewer').toHaveScreenshot('viewer2-no-rectangle.png', screenshotOptions);
@@ -219,10 +221,13 @@ class LockViewers extends MultiUsers {
     // check if previous annotations is displayed after unlocking user
     await this.userPage2.hasElement(e.wbDrawnArrow, 'should display the arrow drawn before user join');
     await this.userPage2.hasElement(e.wbDrawnShape, 'should display the rectangle drawn before unlocking user');
+    await this.modPage.getLocator(e.chatButton).hover();
+    await this.userPage2.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await expect(user2WbLocator, 'should display the other viewer annotations when unlocking specific user').toHaveScreenshot('viewer2-previous-shapes.png', screenshotOptions);
 
     // check if new annotations is displayed after unlocking user
     await drawArrow(this.userPage);
+    await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor will be visible on the screenshot
     await this.userPage2.checkElementCount(e.wbDrawnArrow, 2, 'should display all arrows drawn for unlocked user');
     await expect(user2WbLocator, 'should display all arrows drawn for unlocked user').toHaveScreenshot('viewer2-new-arrow.png', screenshotOptions);


### PR DESCRIPTION
### What does this PR do?
Adds height tracking to the stable dimensions polling logic and uses it to handle resize changes instead of a timeout.

### Closes Issue(s)
Closes #22293 
