### PR TITLE
Add visual indicator on session name

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -20,6 +20,7 @@ import LeaveMeetingButtonContainer from './leave-meeting-button/container';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Tooltip from '/imports/ui/components/common/tooltip/component';
 import SessionDetailsModal from '/imports/ui/components/session-details/component';
+import Icon from '/imports/ui/components/common/icon/icon-ts/component';
 
 const intlMessages = defineMessages({
   toggleUserListLabel: {
@@ -386,7 +387,10 @@ class NavBar extends Component {
                 onClick={() => this.setModalIsOpen(true)}
               >
                 <Tooltip title={intl.formatMessage(intlMessages.openDetailsTooltip)}>
-                  <span>{presentationTitle}</span>
+                  <span>
+                    {presentationTitle}
+                    <Icon iconName="device_list_selector" />
+                  </span>
                 </Tooltip>
               </Styled.PresentationTitle>
               {this.renderModal(isModalOpen, this.setModalIsOpen, "low", SessionDetailsModal)}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/styles.js
@@ -79,6 +79,12 @@ const PresentationTitle = styled.h1`
   > [class^="icon-bbb-"] {
     font-size: 75%;
   }
+
+  & span i {
+    margin-left: .5rem;
+    margin-right: .5rem;
+    font-size: .75rem;
+  }
 `;
 
 const PluginInfoComponent = styled.h1`


### PR DESCRIPTION
### What does this PR do?

Adds a chevron icon in the session title, as a visual indicator that the area is clickable

![chev](https://github.com/user-attachments/assets/ef9f23e6-f178-4bef-8962-808f30157686)


### How to test
1. join a meeting
2. see the new icon in session title