### PR TITLE
Feat(bbb-record): Support screenshare quick swap on record

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/ScreenshareAsContenthdlrHelper.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/ScreenshareAsContenthdlrHelper.scala
@@ -1,0 +1,27 @@
+package org.bigbluebutton.core.apps.layout
+
+import org.bigbluebutton.common2.msgs.{BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, MessageTypes, Routing, SetScreenshareAsContentEvtMsg, SetScreenshareAsContentEvtMsgBody}
+import org.bigbluebutton.core.models.Layouts
+import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
+
+object ScreenshareAsContenthdlrHelper {
+
+  def sendSetScreenshareAsContentEvtMsg(
+   fromUserId: String,
+   liveMeeting:       LiveMeeting,
+   outGW:             OutMsgRouter,
+  ): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, fromUserId)
+    val envelope = BbbCoreEnvelope(SetScreenshareAsContentEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(SetScreenshareAsContentEvtMsg.NAME, liveMeeting.props.meetingProp.intId, fromUserId)
+
+    val body = SetScreenshareAsContentEvtMsgBody(
+      Layouts.getScreenshareAsContent(liveMeeting.layouts),
+    )
+    val event = SetScreenshareAsContentEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+
+    outGW.send(msgEvent)
+  }
+
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/SetScreenshareAsContentReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/SetScreenshareAsContentReqMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.layout
 
 import org.bigbluebutton.ClientSettings.getConfigPropertyValueByPathAsBooleanOrElse
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.{PermissionCheck, RightsManagementTrait}
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.db.LayoutDAO
 import org.bigbluebutton.core.models.Layouts
 import org.bigbluebutton.core.running.OutMsgRouter
@@ -24,21 +24,8 @@ trait SetScreenshareAsContentReqMsgHdlr extends RightsManagementTrait {
     } else {
       Layouts.setScreenshareAsContent(liveMeeting.layouts, msg.body.screenshareAsContent)
       LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
-      sendSetScreenshareAsContentEvtMsg(msg.header.userId)
+      ScreenshareAsContenthdlrHelper.sendSetScreenshareAsContentEvtMsg(msg.header.userId, liveMeeting, outGW)
     }
   }
 
-  def sendSetScreenshareAsContentEvtMsg(fromUserId: String): Unit = {
-    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, fromUserId)
-    val envelope = BbbCoreEnvelope(SetScreenshareAsContentEvtMsg.NAME, routing)
-    val header = BbbClientMsgHeader(SetScreenshareAsContentEvtMsg.NAME, liveMeeting.props.meetingProp.intId, fromUserId)
-
-    val body = SetScreenshareAsContentEvtMsgBody(
-      Layouts.getScreenshareAsContent(liveMeeting.layouts),
-    )
-    val event = SetScreenshareAsContentEvtMsg(header, body)
-    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
-
-    outGW.send(msgEvent)
-  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
@@ -1,10 +1,12 @@
 package org.bigbluebutton.core.apps.screenshare
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.layout.ScreenshareAsContenthdlrHelper
 import org.bigbluebutton.core.apps.{ ExternalVideoModel, ScreenshareModel }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.db.{ LayoutDAO, ScreenshareDAO }
 import org.bigbluebutton.core.models.Layouts
+import org.bigbluebutton.core.models.Users2x.findPresenter
 import org.bigbluebutton.core.running.LiveMeeting
 
 trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
@@ -61,8 +63,15 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         log.info("START broadcast ALLOWED when isBroadcastingRTMP=false")
 
         ScreenshareDAO.insert(liveMeeting.props.meetingProp.intId, liveMeeting.screenshareModel)
-        Layouts.setScreenshareAsContent(liveMeeting.layouts, true)
-        LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
+        if (!Layouts.getScreenshareAsContent(liveMeeting.layouts)) {
+          Layouts.setScreenshareAsContent(liveMeeting.layouts, true)
+          LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
+          for {
+            presenter <- findPresenter(liveMeeting.users2x)
+          } yield {
+            ScreenshareAsContenthdlrHelper.sendSetScreenshareAsContentEvtMsg(presenter.intId, liveMeeting, bus.outGW)
+          }
+        }
 
         // Notify viewers in the meeting that there's an rtmp stream to view
         val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.stream,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Layouts.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Layouts.scala
@@ -85,7 +85,7 @@ class Layouts {
   private var cameraPosition: String = "contentTop";
   private var focusedCamera: String = "none";
   private var presentationVideoRate: Double = 0;
-  private var screenshareAsContent: Boolean = true;
+  private var screenshareAsContent: Boolean = false;
 }
 
 object LayoutsType {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/SetScreenshareAsContentEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/SetScreenshareAsContentEvent.scala
@@ -1,7 +1,15 @@
 package org.bigbluebutton.core.record.events
 
-class AbstractSetScreenshareAsContentEvent extends AbstractParticipantRecordEvent {
-
+class SetScreenshareAsContentEvent extends AbstractParticipantRecordEvent {
+  import SetScreenshareAsContentEvent._
   setEvent("SetScreenshareAsContentEvent")
 
+  def setScreenshareAsContent(screenshareAsContent: Boolean): Unit = {
+    eventMap.put(SCREENSHARE_AS_CONTENT, screenshareAsContent.toString())
+  }
+
+}
+
+object SetScreenshareAsContentEvent {
+  val SCREENSHARE_AS_CONTENT = "screenshareAsContent"
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -121,6 +121,7 @@ class RedisRecorderActor(
       case m: WebcamsOnlyForModeratorChangedEvtMsg  => handleWebcamsOnlyForModeratorChangedEvtMsg(m)
       case m: MeetingEndingEvtMsg                   => handleMeetingEndingEvtMsg(m)
       case m: MeetingCreatedEvtMsg                  => handleStarterConfigurations(m)
+      case m: SetScreenshareAsContentEvtMsg         => handleSetScreenshareAsContent(m)
 
       // Recording
       case m: RecordingChapterBreakSysMsg           => handleRecordingChapterBreakSysMsg(m)
@@ -769,6 +770,12 @@ class RedisRecorderActor(
     val ev = new MeetingConfigurationEvent()
     ev.setWebcamsOnlyForModerator(msg.body.props.usersProp.webcamsOnlyForModerator)
     record(msg.body.props.meetingProp.intId, ev.toMap().asJava)
+  }
+
+  private def handleSetScreenshareAsContent(msg: SetScreenshareAsContentEvtMsg): Unit = {
+    val ev = new SetScreenshareAsContentEvent()
+    ev.setScreenshareAsContent(msg.body.screenshareAsContent)
+    record(msg.header.meetingId, ev.toMap().asJava)
   }
 
 }

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1167,5 +1167,21 @@ module BigBlueButton
       return false
     end
 
+    def self.get_screenshare_as_content_events(events)
+      BigBlueButton.logger.info("Extracting SetScreenshareAsContentEvent")
+
+      screenshare_content_events = []
+
+      events.xpath("/recording/event[@eventname='SetScreenshareAsContentEvent']").each do |event|
+        screenshare_content_events << {
+          timestamp: event['timestamp'].to_i,
+          timestampUTC: event.at_xpath('timestampUTC')&.text.to_i,
+          date: event.at_xpath('date')&.text,
+          screenshareAsContent: event.at_xpath('screenshareAsContent')&.text == "true"
+        }
+      end
+
+      screenshare_content_events
+    end
   end
 end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1296,11 +1296,30 @@ def copy_media_files_helper(media, media_files, package_dir)
   end
 end
 
+def process_swap_events(events)
+  BigBlueButton.logger.info("Processing screenshare as content events")
+  swap_events = BigBlueButton::Events.get_screenshare_as_content_events(events)
+  @layout_swap_xml = Builder::XmlMarkup.new(indent: 2)
+  @layout_swap_xml.instruct!
+
+  @layout_swap_xml.recording('id' => 'layout_swap_events') do
+    swap_events.each do |event|
+      @layout_swap_xml.event(
+        timestamp: (translate_timestamp(event[:timestamp].to_f) / 1000).round(1),
+        show_screenshare: event[:screenshareAsContent],
+      )
+    end
+  end
+
+
+end
+
 @shapes_svg_filename = 'shapes.svg'
 @panzooms_xml_filename = 'panzooms.xml'
 @cursor_xml_filename = 'cursor.xml'
 @deskshare_xml_filename = 'deskshare.xml'
 @tldraw_shapes_filename = 'tldraw.json'
+@layout_xml_filename = 'layout_swap.xml'
 @svg_shape_id = 1
 @svg_shape_unique_id = 1
 
@@ -1460,12 +1479,16 @@ begin
 
         process_deskshare_events(@doc)
 
+        process_swap_events(@doc)
+
         process_poll_events(@doc, package_dir)
 
         process_external_video_events(@doc, package_dir)
 
         # Write deskshare.xml to file
         File.open("#{package_dir}/#{@deskshare_xml_filename}", 'w') { |f| f.puts @deskshare_xml.target! }
+        # Write layout_swap.xml to file
+        File.open("#{package_dir}/#{@layout_xml_filename}", 'w') { |f| f.puts @layout_swap_xml.target! }
 
         BigBlueButton.logger.info('Copying files to package dir')
         FileUtils.cp_r("#{@process_dir}/presentation", package_dir)


### PR DESCRIPTION
### What does this PR do?
Follow up for #22202, adding recording events and handlers, playck 

### How to test

- Checkout to this PR;
- Into the development environment (BBB server or container): go to the record-and-playback directory and run `./deploy; sudo systemctl restart bbb-rap-starter; sudo systemctl restart bbb-rap-resque-worker.service`
- Then clone https://github.com/bigbluebutton/bbb-playback and checkout to my PR there;
- Run `./deploy` of the playback;
- Record a session
- Share screen
- Swap to presentation
- end Meeting
- wait until the recording is generated (this may take a while);
- See results.

### More

Closely related to https://github.com/bigbluebutton/bbb-playback/pull/288 

Demo: 

[Screencast from 17-02-2025 14:37:49.webm](https://github.com/user-attachments/assets/ffe0361a-13ec-475c-a728-f9703a130068)

