### PR TITLE
test: Update messsage only to mods param test

### DIFF
--- a/bigbluebutton-tests/playwright/parameters/constants.js
+++ b/bigbluebutton-tests/playwright/parameters/constants.js
@@ -7,7 +7,7 @@ exports.color = color;
 exports.bannerColor = `bannerColor=${color}`;
 exports.maxParticipants = 'maxParticipants=2';
 exports.duration = 'duration=2';
-const messageModerator = 'Test';
+const messageModerator = 'This is a moderator only message';
 exports.messageModerator = messageModerator;
 exports.moderatorOnlyMessage = `moderatorOnlyMessage=${messageModerator}`;
 exports.webcamsOnlyForModerator = 'webcamsOnlyForModerator=true';

--- a/bigbluebutton-tests/playwright/parameters/createParameters.js
+++ b/bigbluebutton-tests/playwright/parameters/createParameters.js
@@ -1,6 +1,7 @@
 const { expect } = require('@playwright/test');
 const { MultiUsers } = require('../user/multiusers');
 const e = require('../core/elements');
+const { messageModerator } = require('../parameters/constants');
 
 class CreateParameters extends MultiUsers {
   constructor(browser, context) {
@@ -38,13 +39,19 @@ class CreateParameters extends MultiUsers {
     await this.modPage.hasText(e.timeRemaining, /[1-2]:[0-5][0-9]/, 'should display the time remaining of the meeting decreasing');
   }
 
-  async moderatorOnlyMessage(context) {
-    await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard for the moderator');
-    await this.modPage.checkElementCount(e.chatWelcomeMessageText, 2, 'should display two welcome messages');
-    await this.modPage.hasText(`${e.chatWelcomeMessageText}>>nth=1`, 'Test', 'should display the second welcome message with the word Test');
-
-    await this.initUserPage(true, context);
-    await this.userPage.checkElementCount(e.chatWelcomeMessageText, 1, 'should display one welcome message for the attendee');
+  async moderatorOnlyMessage() {
+    await this.modPage.waitForSelector(e.whiteboard);
+    // check for the mod only message on the mod page
+    await this.modPage.waitAndClick(e.presentationTitle);
+    await this.modPage.hasElement(e.simpleModal, 'should display meeting details modal');
+    await this.modPage.hasText(e.simpleModal, messageModerator, 'should display the moderator only message on meeting detail modal');
+    // join a user and check if the message is not displayed
+    await this.initUserPage();
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitAndClick(e.presentationTitle);
+    await this.userPage.hasElement(e.simpleModal, 'should display meeting details modal');
+    const modalLocator = this.userPage.getLocator(e.simpleModal);
+    await expect(modalLocator, 'should not display the moderator only message on meeting detail modal').not.toContainText(messageModerator);
   }
 
   async webcamsOnlyForModerator(context) {

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.js
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.js
@@ -40,11 +40,10 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     await createParam.duration();
   });
 
-  // welcome message moved on #21909
-  test.fixme('Message Only To Moderators', async ({ browser, context, page }) => {
+  test('Message Only To Moderators', async ({ browser, context, page }) => {
     const createParam = new CreateParameters(browser, context);
-    await createParam.initModPage(page, true, { createParameter: c.moderatorOnlyMessage });
-    await createParam.moderatorOnlyMessage(context);
+    await createParam.initModPage(page, true, { createParameter: encodeCustomParams(c.moderatorOnlyMessage) });
+    await createParam.moderatorOnlyMessage();
   });
 
   test('Webcams Shows Only For Moderators', async ({ browser, context, page }) => {


### PR DESCRIPTION
### What does this PR do?
This PR updates/fixes the `Create Parameters › Message Only To Moderators` test, which has been disabled since the welcome message moved to the session details modal. it will also run in CI again for now on