### PR TITLE
fix: Activating the 'Custom Input' toggle on/off in the polling component returns it to an invalid state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -407,7 +407,6 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
                     defaultChecked={customInput}
                     onChange={() => {
                       setCustomInput(!customInput);
-                      setType(pollTypes.Custom);
                     }}
                     ariaLabel={intl.formatMessage(intlMessages.customInputToggleLabel)}
                     showToggleLabel={false}


### PR DESCRIPTION
### What does this PR do?

fix incorrect state in poll panel after turning custom input on and off

### Closes Issue(s)
Closes #22254

### How to test

1. Open Polling component
2. Click 'Custom Input' toggle on
3. Click 'Custom Input' toggle off
4. Lower part of the panel should not contain incorrect values