### PR TITLE
ci: Improve git merge strategy by adding `--no-rebase param`

### DIFF
--- a/.github/actions/merge-branches/action.yml
+++ b/.github/actions/merge-branches/action.yml
@@ -14,4 +14,4 @@ runs:
         git config user.name "BBB Automated Tests"
         git config user.email "tests@bigbluebutton.org"
         git config pull.rebase false
-        git pull origin pull/${{ github.event.number }}/head:${{ github.head_ref }}
+        git pull --no-rebase --no-edit origin pull/${{ github.event.number }}/head:${{ github.head_ref }}


### PR DESCRIPTION
It will avoid the error while merging branches to build packages:

```
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
hint: your next pull:
hint: 
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
```

![image](https://github.com/user-attachments/assets/368c10a6-613f-4d2c-a4ce-ff4b90ddcba0)
