### PR TITLE
ci (3.1): Improve git merge strategy by adding `--no-rebase param`

### DIFF
--- a/.github/actions/merge-branches/action.yml
+++ b/.github/actions/merge-branches/action.yml
@@ -14,4 +14,4 @@ runs:
         git config user.name "BBB Automated Tests"
         git config user.email "tests@bigbluebutton.org"
         git config pull.rebase false
-        git pull origin pull/${{ github.event.number }}/head:${{ github.head_ref }}
+        git pull --no-rebase --no-edit origin pull/${{ github.event.number }}/head:${{ github.head_ref }}


### PR DESCRIPTION
Same as #22321