### PR TITLE
Fix: Limit time size on breakout duration change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
@@ -120,6 +120,7 @@ const TimeRemaingPanel: React.FC<TimeRemainingPanelProps> = ({
               value={newTime}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 const newSetTime = Number.parseInt(e.target.value, 10) || 0;
+                if (newSetTime > 99999) return;
                 setNewTime(newSetTime);
               }}
               aria-label={intl.formatMessage(intlMessages.setTimeInMinutes)}


### PR DESCRIPTION
### What does this PR do?
This PR limits the maximum size of the time variable in the breakout time change form. It prevents sending a number larger than the server can handle. In such cases, the UI resets without applying any changes, making it unnecessary to allow excessively large values.


### How to test
- Create a Breakout.
- try to change it duration
- see results

