### PR TITLE
fix: breakout room not assigning users (with extId) properly

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -77,7 +77,7 @@ object RegisteredUsers {
     //userId + "-" + roomSequence
     val userIdParts = breakoutRoomId.split("-")
     val userExtId = userIdParts(0)
-    users.toVector.filter(ru => userExtId == ru.externId)
+    users.toVector.filter(ru => userExtId == ru.id)
   }
 
   def getRegisteredUserWithToken(token: String, userId: String, regUsers: RegisteredUsers): Option[RegisteredUser] = {

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1962,7 +1962,7 @@ BEGIN
 		   from "user" bkroom_user
 		   join meeting_breakout mb on mb."meetingId" = bkroom_user."meetingId"
 		   join "breakoutRoom" br on br."parentMeetingId" = mb."parentId" and mb."sequence" = br."sequence"
-		   join "user" u on u."meetingId" = br."parentMeetingId"  and bkroom_user."extId" = u."extId" || '-' || br."sequence"
+		   join "user" u on u."meetingId" = br."parentMeetingId"  and bkroom_user."extId" = u."userId" || '-' || br."sequence"
 		   join "breakoutRoom_user" bru on bru."userId" = u."userId" and bru."breakoutRoomId" = br."breakoutRoomId"
 		   where bkroom_user."userId" = NEW."userId"
 	   ) a


### PR DESCRIPTION
Fix a bug where users with an `externalId` set during `/join` was not being assigned to breakout rooms properly.

Closes #22302