### PR TITLE
Fix: audio modal endless setState on audio modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
@@ -151,7 +151,7 @@ const AudioCaptionsSelectContainer: React.FC<AudioCaptionsContainerProps> = ({
   const voices = getSpeechVoices();
 
   useEffect(() => {
-    if (voices && voicesList.length === 0) {
+    if ((voices && voices.length > 0) && voicesList.length === 0) {
       setVoicesList(voices);
     }
   }, [voices]);


### PR DESCRIPTION
### What does this PR do?
The issue occurs when audio captions are enabled but the browser does not grant the necessary permissions, causing the client to enter a loop while attempting to fetch the data.

### Closes Issue(s)
Closes #22078

### How to test
- Set `app.audioCaptions.enabled` to `true` in the setting.yml
- Join a browser with no permission granted for audio transcription (I used chromium)
- Open audio modal and start echo test
- See the results.


### More

Before:
![image](https://github.com/user-attachments/assets/a8159a5b-fff5-423a-a905-7df5e4eeb1e0)


After: 
![image](https://github.com/user-attachments/assets/63819bdc-1d6e-45ff-a514-b1427f8aa5f8)

