### PR TITLE
fix: locale not updating in recording button and chat system messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -454,7 +454,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           ),
         };
     }
-  }, [message.message]);
+  }, [message.message, intl.locale]);
 
   sameSender = message.messageType === ChatMessageType.BREAKOUT_ROOM
     ? false

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -165,7 +165,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
         : intl.formatMessage(intlMessages.startTitle);
     }
     return intl.formatMessage(intlMessages.stopTitle);
-  }, [recording, isPhone, disabled]);
+  }, [recording, isPhone, disabled, intl.locale]);
 
   const recordingIndicatorIcon = useMemo(() => (
     <Styled.RecordingIndicatorIcon


### PR DESCRIPTION
### What does this PR do?

fix issue where the recording button and system messages in the chat would be displayed in the wrong language after switching locales

### How to test
1. join a meeting with recording enabled
2. change language in settings menu
3. save settings
4. see the recording button label and the message in the chat "{user}  is now the presenter" - both should be in the same language as the rest of the client
