### PR TITLE
Fix(html5): Audio Dropping when exit confirmation is called

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -103,7 +103,10 @@ class AudioManager {
   }
 
   onBeforeUnload() {
-    this.exitAudio();
+    const CONFIRMATION_ON_LEAVE = window.meetingClientSettings.public.app.askForConfirmationOnLeave;
+    if (!CONFIRMATION_ON_LEAVE) {
+      this.forceExitAudio();
+    }
   }
 
   _trackAudioJoinTime() {


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where audio would be dropped when the user accidentally clicked to leave or reload the page and then canceled the action. The issue was caused by an event listener added to the `AudioManager` for the same event. I modified the function to respect the `app.askForConfirmationOnLeave` setting, ensuring that in such cases, the function responsible for stopping the audio is not called. However, in other use cases, the behavior remains unaffected.

### Closes Issue(s)
Closes #22110

### How to test
- Enable the settings `app.askForConfirmationOnLeave`
- Ensure the settings is applied on client.
- Try to leave.
- See user still connected on audio


### More
[Screencast from 19-02-2025 20:03:00.webm](https://github.com/user-attachments/assets/60615b97-c783-4f33-9971-f63b787e30f6)

