### PR TITLE
fix: bbb-html5 locales lack cache busting query parameter

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -18,9 +18,11 @@ interface IntlLoaderProps extends IntlLoaderContainerProps {
 }
 
 const buildFetchLocale = (locale: string) => {
+  const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
   const localesPath = 'locales';
+
   return new Promise((resolve) => {
-    fetch(`${localesPath}/${locale !== 'index' ? `${locale}.json` : ''}`)
+    fetch(`${localesPath}/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`)
       .then((response) => {
         if (!response.ok) {
           return resolve(false);


### PR DESCRIPTION
### What does this PR do?

- [fix: bbb-html5 locales lack cache busting query parameter](https://github.com/bigbluebutton/bigbluebutton/commit/4e7c599591c0fb3c61ee38b817f9aa4d24e00897) 
  - The `v=VERSION` query parameter was lost in the rewrite of the locale
fetching component. This may cause locales to be incorrectly cached even
after server updates that alter them.
  - Restore the `v=VERSION` query parameter to the locale URL (similarly to
how it was done in 2.7).

### Closes Issue(s)

None
