### PR TITLE
fix: client crashes when paginationThresholds comes into effect

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -200,6 +200,7 @@ export const usePageSizeDictionary = () => {
     desktopPageSizes: DESKTOP_PAGE_SIZES,
     mobilePageSizes: MOBILE_PAGE_SIZES,
   } = window.meetingClientSettings.public.kurento.pagination;
+  const userCount = getCountData();
 
   const PAGINATION_THRESHOLDS_CONF = window.meetingClientSettings.public.kurento.paginationThresholds;
   const PAGINATION_THRESHOLDS_ENABLED = PAGINATION_THRESHOLDS_CONF.enabled;
@@ -235,7 +236,7 @@ export const usePageSizeDictionary = () => {
   };
 
   // Short-circuit: no threshold yet, return stock values (processThreshold has a default arg)
-  if (getCountData() < PAGINATION_THRESHOLDS[0].users) return processThreshold();
+  if (userCount < PAGINATION_THRESHOLDS[0].users) return processThreshold();
 
   // Reverse search for the threshold where our participant count is directly equal or great
   // The PAGINATION_THRESHOLDS config is sorted when imported.
@@ -245,7 +246,7 @@ export const usePageSizeDictionary = () => {
     mapIndex -= 1
   ) {
     targetThreshold = PAGINATION_THRESHOLDS[mapIndex];
-    if (targetThreshold.users <= getCountData()) {
+    if (targetThreshold.users <= userCount) {
       return processThreshold(targetThreshold);
     }
   }


### PR DESCRIPTION
### What does this PR do?

- [fix: client crashes when paginationThresholds comes into effect](https://github.com/bigbluebutton/bigbluebutton/commit/28674d58ed5525215ebc25ff33c3e14d7e9720fb) 
  - Whenever paginationThresholds kicks in, the client crashes for everyone
in the room. That's caused by a conditional hook call when calculating
new page sizes :)

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/22355