### PR TITLE
Fix(chat): Emoji picker appearing out of bounds on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -527,7 +527,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
         message={message.message}
         messageSequence={message.messageSequence}
         emphasizedMessage={message.chatEmphasizedText}
-        onEmojiSelected={onEmojiSelected}
         onReactionPopoverOpenChange={setIsToolbarReactionPopoverOpen}
         reactionPopoverIsOpen={isToolbarReactionPopoverOpen}
         chatDeleteEnabled={chatDeleteEnabled}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -120,7 +120,6 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
     });
   }, [chatDeleteMessage, chatId, messageId]);
 
-  const isRTL = layoutSelect((i: Layout) => i.isRTL);
 
   if ([
     chatReplyEnabled,
@@ -134,12 +133,6 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const showEditButton = chatEditEnabled && own;
   const showDeleteButton = chatDeleteEnabled && (own || (amIModerator && !isBreakoutRoom));
   const showDivider = (showReplyButton || showReactionsButton) && (showEditButton || showDeleteButton);
-
-  const deactivateFocusTrap = () => {
-    if (keyboardFocused) {
-      setKeyboardFocused(false);
-    }
-  };
 
   const container = (
     <Container className="chat-message-toolbar">
@@ -230,32 +223,6 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
         />
       </Tooltip>
       )}
-      <Popover
-        open={reactionPopoverIsOpen}
-        anchorEl={reactionsAnchor}
-        onClose={() => {
-          onReactionPopoverOpenChange(false);
-        }}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: isRTL ? 'left' : 'right',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: isRTL ? 'right' : 'left',
-        }}
-      >
-        <EmojiPickerWrapper>
-          <EmojiPicker
-            onEmojiSelect={(emojiObject: { id: string; native: string }) => {
-              deactivateFocusTrap();
-              onEmojiSelected(emojiObject);
-            }}
-            showPreview={false}
-            showSkinTones={false}
-          />
-        </EmojiPickerWrapper>
-      </Popover>
       {isTryingToDelete && (
       <ConfirmationModal
         isOpen={isTryingToDelete}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -1,17 +1,12 @@
 import React, { useCallback } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useMutation } from '@apollo/client';
-import Popover from '@mui/material/Popover';
-import { layoutSelect } from '/imports/ui/components/layout/context';
-import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import ConfirmationModal from '/imports/ui/components/common/modal/confirmation/component';
 import {
   Container,
   Divider,
   EmojiButton,
-  EmojiPicker,
-  EmojiPickerWrapper,
   Root,
 } from './styles';
 import { CHAT_DELETE_MESSAGE_MUTATION } from '../mutations';

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -70,7 +70,6 @@ interface ChatMessageToolbarProps {
   message: string;
   messageSequence: number;
   emphasizedMessage: boolean;
-  onEmojiSelected(emoji: { id: string; native: string }): void;
   onReactionPopoverOpenChange(open: boolean): void;
   reactionPopoverIsOpen: boolean;
   hasToolbar: boolean;
@@ -86,14 +85,11 @@ interface ChatMessageToolbarProps {
 
 const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const {
-    messageId, chatId, message, username, onEmojiSelected, deleted,
+    messageId, chatId, message, username, deleted,
     messageSequence, emphasizedMessage, own, amIModerator, isBreakoutRoom, locked,
     onReactionPopoverOpenChange, reactionPopoverIsOpen, hasToolbar, keyboardFocused,
     chatDeleteEnabled, chatEditEnabled, chatReactionsEnabled, chatReplyEnabled, setKeyboardFocused,
   } = props;
-  const [reactionsAnchor, setReactionsAnchor] = React.useState<Element | null>(
-    null,
-  );
   const [isTryingToDelete, setIsTryingToDelete] = React.useState(false);
   const intl = useIntl();
   const [chatDeleteMessage] = useMutation(CHAT_DELETE_MESSAGE_MUTATION);
@@ -115,6 +111,11 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
     });
   }, [chatDeleteMessage, chatId, messageId]);
 
+  const deactivateFocusTrap = () => {
+    if (keyboardFocused) {
+      setKeyboardFocused(false);
+    }
+  };
 
   if ([
     chatReplyEnabled,
@@ -174,7 +175,6 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
           svgIcon="reactions"
           color="light"
           data-test="reactionsPickerButton"
-          ref={setReactionsAnchor}
         />
       </Tooltip>
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/styles.ts
@@ -56,6 +56,7 @@ const Container = styled.div`
 `;
 
 const EmojiPickerWrapper = styled.div`
+  width: 100%;
   bottom: calc(100% + 0.5rem);
   left: 0;
   right: 0;

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -27,6 +27,9 @@ const GlobalStyle = createGlobalStyle`
       right: 0 !important;
       max-width: none !important;
     }
+    .MuiPaper-root {
+      width: 100%;
+    }
   }
   .MuiList-padding {
     padding: 0 !important;


### PR DESCRIPTION
### What does this PR do?
Fixed the issue where the emoji picker was appearing off-screen on mobile. This was caused by the anchor being set to the toolbar and an incorrect configuration positioning the element too far to the right. I moved the emoji picker to the message component and added a condition for mobile devices to resolve this.

### Closes Issue(s)
Closes #22113

### How to test
- Send a message on mobile
- click to react on it


### More
![image](https://github.com/user-attachments/assets/6451b279-c4dc-477a-a3dd-2e00ea339dfb)

