### PR TITLE
fix (html5): Improve check RTT flow to avoid wrong bad connection alert (and add more logs for errors)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -9,9 +9,11 @@ import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import getBaseUrl from '/imports/ui/core/utils/getBaseUrl';
 import useCurrentUser from '../../core/hooks/useCurrentUser';
 import getStatus from '../../core/utils/getStatus';
+import logger from '/imports/startup/client/logger';
 
 const ConnectionStatus = () => {
   const STATS_INTERVAL = window.meetingClientSettings.public.stats.interval;
+  const STATS_TIMEOUT = window.meetingClientSettings.public.stats.timeout;
   const networkRttInMs = useRef(0); // Ref to store the last rtt
   const timeoutRef = useRef(null);
 
@@ -31,7 +33,7 @@ const ConnectionStatus = () => {
     const startTime = performance.now();
     fetch(
       `${getBaseUrl()}/rtt-check`,
-      { signal: AbortSignal.timeout(STATS_INTERVAL) },
+      { signal: AbortSignal.timeout(STATS_TIMEOUT) },
     )
       .then((res) => {
         if (res.ok && res.status === 200) {
@@ -57,7 +59,13 @@ const ConnectionStatus = () => {
           }
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        logger.error({
+          logCode: 'rtt_fetch_error',
+          extraInfo: {
+            error,
+          },
+        }, 'Error fetching rtt');
         connectionStatus.setLastRttRequestSuccess(false);
         // gets the worst status
         connectionStatus.setConnectionStatus(2000, 'critical');

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -957,7 +957,7 @@ public:
   stats:
     enabled: true
     interval: 10000
-    timeout: 30000
+    timeout: 10000
     log: true
     notification:
       warning: false


### PR DESCRIPTION
### What does this PR do?
Change rtt timeout to use `stats.timout` and decrease settings value to 10s, also add a log for failed requests to improve debug.


### Closes Issue(s)
No issue opened.

### More

Server didn'r repond:
![image](https://github.com/user-attachments/assets/b956c5d7-4133-4fe5-95d3-f5269363fbc8)

Request timed out:
![image](https://github.com/user-attachments/assets/e7b4fe71-f416-4a2c-823e-fd9b2f11ce9f)

Failed to register user history:
![image](https://github.com/user-attachments/assets/a1e8ae04-a8a6-4f9a-b350-dca9e37f5669)
