### PR TITLE
fix(whiteboard): Unstable zoom when presentation area is resized

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -765,7 +765,6 @@ const Whiteboard = React.memo((props) => {
   };
 
   const handleTldrawMount = (editor) => {
-    console.log('Tldraw:mount');
     tlEditorRef.current = editor;
     setTldrawAPI(editor);
     setEditor(editor);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1448,23 +1448,25 @@ const Whiteboard = React.memo((props) => {
     if (innerWrapperPollingFrameRef.current !== null) {
       cancelAnimationFrame(innerWrapperPollingFrameRef.current);
     }
-    pollInnerWrapperDimensionsUntilStable(() => {
-      syncCameraWithPresentationArea({
-        tlEditorRef,
-        isPresenter,
-        currentPresentationPageRef,
-        presentationAreaWidth,
-        presentationAreaHeight,
-        zoomValueRef,
-        fitToWidthRef,
-        curPageIdRef,
-        initialViewBoxWidthRef,
-        initialViewBoxHeightRef,
-      });
-    }, {
-      maxTries: 120,
-      stabilityFrames: 35,
-    }, innerWrapperPollingFrameRef);
+    innerWrapperPollingFrameRef.current = requestAnimationFrame(() => {
+      pollInnerWrapperDimensionsUntilStable(() => {
+        syncCameraWithPresentationArea({
+          tlEditorRef,
+          isPresenter,
+          currentPresentationPageRef,
+          presentationAreaWidth,
+          presentationAreaHeight,
+          zoomValueRef,
+          fitToWidthRef,
+          curPageIdRef,
+          initialViewBoxWidthRef,
+          initialViewBoxHeightRef,
+        });
+      }, {
+        maxTries: 120,
+        stabilityFrames: 35,
+      }, innerWrapperPollingFrameRef);  
+    });
   }, [presentationHeight, presentationWidth, curPageId, presentationId]);
 
   React.useEffect(() => {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Cancels previous polling for stable whiteboard container when the presentation area is resized. This way we guarantee that the polling queuing is done in the right order.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22292
Closes #21302
Closes #21191