### PR TITLE
fix (html5): Auto show Session Details modal only once

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -21,6 +21,7 @@ import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Tooltip from '/imports/ui/components/common/tooltip/component';
 import SessionDetailsModal from '/imports/ui/components/session-details/component';
 import Icon from '/imports/ui/components/common/icon/icon-ts/component';
+import getStorageSingletonInstance from '../../services/storage';
 
 const intlMessages = defineMessages({
   toggleUserListLabel: {
@@ -159,13 +160,14 @@ class NavBar extends Component {
 
     this.handleToggleUserList = this.handleToggleUserList.bind(this);
     this.splitPluginItems = this.splitPluginItems.bind(this);
+    this.setModalIsOpen = this.setModalIsOpen.bind(this);
+
+    const ShownId = getStorageSingletonInstance().getItem('alreadyShowSessionDetailsOnJoin');
 
     this.state = {
-      isModalOpen: props.showSessionDetailsOnJoin,
+      isModalOpen: props.showSessionDetailsOnJoin && !(ShownId === props.meetingId),
     };
   }
-
-  setModalIsOpen = (isOpen) => this.setState({ isModalOpen: isOpen })
 
   renderModal(isOpen, setIsOpen, priority, Component, otherOptions) {
     return isOpen ? <Component
@@ -220,6 +222,14 @@ class NavBar extends Component {
 
   componentWillUnmount() {
     clearInterval(this.interval);
+  }
+
+  setModalIsOpen(isOpen) {
+    if (!isOpen) {
+      const { meetingId } = this.props;
+      getStorageSingletonInstance().setItem('alreadyShowSessionDetailsOnJoin', meetingId);
+    }
+    this.setState({ isModalOpen: isOpen });
   }
 
   handleToggleUserList() {


### PR DESCRIPTION
### What does this PR do?
This PR fix the details modal appearing automatically every refresh.


### Closes Issue(s)
Closes #21985

### How to test
- Join a meeting
- Close modal
- Refresh
- See result

### More
[Screencast from 21-02-2025 13:45:02.webm](https://github.com/user-attachments/assets/e8b961fc-61c3-41ac-af57-500d6891c9dd)
