### PR TITLE
Fix(presentation): toolbar being overlapped on video focus layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -771,7 +771,7 @@ class Presentation extends PureComponent {
             height: presentationBounds.height,
             display: !presentationIsOpen ? 'none' : 'flex',
             overflow: 'hidden',
-            zIndex: !isVideoFocus ? presentationZIndex : 0,
+            zIndex: !isVideoFocus ? presentationZIndex : 1,
             background:
               layoutType === isVideoFocus && !fullscreenContext
                 ? colorContentBackground


### PR DESCRIPTION
### What does this PR do?
Fix the presentation toolbar appearing under webcams and actions bar 


### Closes Issue(s)
No issue opened


### How to test
- Join a meeting
- Change layout to focus on video
- click to open the preesntation toolbar

### More
Before:
![Screenshot from 2025-02-21 13-53-25](https://github.com/user-attachments/assets/6c63a364-9693-47f4-8f60-6daef95ae788)

After:
![Screenshot from 2025-02-21 13-58-32](https://github.com/user-attachments/assets/f987a7d8-f0ba-4c50-9b88-afd44e4d227b)

