### PR TITLE
ci: Upload HTML test result from each shard separately

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -430,6 +430,17 @@ jobs:
         with:
           name: blob-report-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/blob-report
+      - if: always()
+        name: Generate the shard HTML report from blob report
+        shell: bash
+        working-directory: ./bigbluebutton-tests/playwright
+        run: npx playwright merge-reports --reporter html ./blob-report
+      - if: always()
+        name: Upload shard HTML report to GitHub Actions Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report_shard-${{ matrix.shard }}
+          path: bigbluebutton-tests/playwright/playwright-report
       - if: failure()
         name: Prepare artifacts (configs and logs)
         run: |


### PR DESCRIPTION
### What does this PR do?
This PR enables the test result download for each shard separately

![image](https://github.com/user-attachments/assets/cefb79dc-a1d9-4f67-8b9a-abbe9e8da165)

### Motivation
The current average test result download size is around 1.3GB. Sometimes there are only a few failed tests to check locally but to see them, all the data should be downloaded. With this change, the developers can download only the one(s) they want to