### PR TITLE
refactor (gql-server): tweak deploy script to make it work in any server

### DIFF
--- a/bbb-graphql-server/deploy.sh
+++ b/bbb-graphql-server/deploy.sh
@@ -18,37 +18,38 @@ if [ "$hasura_status" = "active" ]; then
 fi
 
 echo "Restarting database bbb_graphql"
-sudo runuser -u postgres -- psql -q -c "drop database if exists bbb_graphql with (force)"
-sudo runuser -u postgres -- psql -q -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
-sudo runuser -u postgres -- psql -q -c "alter database bbb_graphql set timezone to 'UTC'"
+sudo -i -u postgres -- psql -q -c "drop database if exists bbb_graphql with (force)"
+sudo -i -u postgres -- psql -q -c "create database bbb_graphql WITH TEMPLATE template0 LC_COLLATE 'C.UTF-8'"
+sudo -i -u postgres -- psql -q -c "alter database bbb_graphql set timezone to 'UTC'"
 
 echo "Creating tables in bbb_graphql"
-sudo runuser -u postgres -- psql -U postgres -d bbb_graphql -q -f bbb_schema.sql --set ON_ERROR_STOP=on
+sudo cp bbb_schema.sql /tmp/
+sudo -i -u postgres -- psql -U postgres -d bbb_graphql -q -f "/tmp/bbb_schema.sql" --set ON_ERROR_STOP=on
 
 echo "Creating users"
   # Create user hasura_app@hasura_app (for hasura metadata)
-  sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='hasura_app'" | grep -q 1 || \
-    sudo runuser -u postgres -- psql -c "CREATE USER hasura_app WITH PASSWORD 'hasura_app'"
+  sudo -i -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='hasura_app'" | grep -q 1 || \
+    sudo -i -u postgres -- psql -c "CREATE USER hasura_app WITH PASSWORD 'hasura_app'"
 
   HASURA_DATABASE_NAME="hasura_app"
-  sudo runuser -u postgres -- psql -q -c "DROP DATABASE IF EXISTS $HASURA_DATABASE_NAME WITH (FORCE);"
-  sudo runuser -u postgres -- psql -q -c "CREATE DATABASE $HASURA_DATABASE_NAME OWNER hasura_app;"
+  sudo -i -u postgres -- psql -q -c "DROP DATABASE IF EXISTS $HASURA_DATABASE_NAME WITH (FORCE);"
+  sudo -i -u postgres -- psql -q -c "CREATE DATABASE $HASURA_DATABASE_NAME OWNER hasura_app;"
 
   # Create user bbb_core@bbb_graphql (for akka-apps)
-  sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
-    sudo runuser -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"
-  sudo runuser -u postgres -- psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_core"
-  sudo runuser -u postgres -- psql -q -d bbb_graphql -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bbb_core"
-  sudo runuser -u postgres -- psql -q -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO bbb_core"
-  sudo runuser -u postgres -- psql -q -d bbb_graphql -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bbb_core"
-  sudo runuser -u postgres -- psql -q -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bbb_core"
+  sudo -i -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_core'" | grep -q 1 || \
+    sudo -i -u postgres -- psql -c "CREATE USER bbb_core WITH PASSWORD 'bbb_core'"
+  sudo -i -u postgres -- psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_core"
+  sudo -i -u postgres -- psql -q -d bbb_graphql -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO bbb_core"
+  sudo -i -u postgres -- psql -q -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO bbb_core"
+  sudo -i -u postgres -- psql -q -d bbb_graphql -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO bbb_core"
+  sudo -i -u postgres -- psql -q -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bbb_core"
 
   # Create user bbb_hasura@bbb_graphql (for Hasura ReadOnly)
-  sudo runuser -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_hasura'" | grep -q 1 || \
-    sudo runuser -u postgres -- psql -c "CREATE USER bbb_hasura WITH PASSWORD 'bbb_hasura'"
-  sudo runuser -u postgres -- psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_hasura"
-  sudo runuser -u postgres -- psql -q -d bbb_graphql -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO bbb_hasura"
-  sudo runuser -u postgres -- psql -q -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO bbb_hasura"
+  sudo -i -u postgres -- psql -tc "SELECT 1 FROM pg_roles WHERE rolname='bbb_hasura'" | grep -q 1 || \
+    sudo -i -u postgres -- psql -c "CREATE USER bbb_hasura WITH PASSWORD 'bbb_hasura'"
+  sudo -i -u postgres -- psql -q -c "GRANT CONNECT ON DATABASE bbb_graphql TO bbb_hasura"
+  sudo -i -u postgres -- psql -q -d bbb_graphql -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO bbb_hasura"
+  sudo -i -u postgres -- psql -q -d bbb_graphql -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO bbb_hasura"
 
 
 echo "Starting Hasura"
@@ -67,4 +68,5 @@ if [ "$akka_apps_status" = "active" ]; then
 fi
 
 echo "Applying new metadata to Hasura"
-timeout 15s sudo hasura metadata apply --skip-update-check
+source <(sudo cat /etc/default/bbb-graphql-server-admin-pass)
+timeout 15s sudo hasura metadata apply --skip-update-check --admin-secret "$HASURA_GRAPHQL_ADMIN_SECRET"


### PR DESCRIPTION
It will handle problems when running the script in a server different from docker dev:

Example of errors:

```
FATA[0000] {
  "error": "invalid \"x-hasura-admin-secret\"/\"x-hasura-access-key\"",
  "path": "$",
  "code": "access-denied"
} 
```

or

```
could not change directory to "/root/bigbluebutton/bbb-graphql-server": Permission denied
```