### PR TITLE
test: Additional steps to ensure correct cursors on assertions

### DIFF
--- a/bigbluebutton-tests/playwright/user/lockViewers.js
+++ b/bigbluebutton-tests/playwright/user/lockViewers.js
@@ -235,25 +235,27 @@ class LockViewers extends MultiUsers {
   async lockSeeOtherViewersCursor() {
     await this.modPage.waitForSelector(e.whiteboard);
     await this.modPage.waitAndClick(e.multiUsersWhiteboardOn);
-
+    // user draw an arrow
     await this.userPage.waitForSelector(e.whiteboard);
     await drawArrow(this.userPage);
-
+    // lock the viewers cursor
     await openLockViewers(this.modPage);
     await this.modPage.waitAndClickElement(e.hideViewersCursor);
     await this.modPage.waitAndClick(e.applyLockSettings);
-
+    // check if the cursor is not displayed for the viewer
     await this.modPage.checkElementCount(e.whiteboardCursorIndicator, 1, 'should contain one whiteboard cursor indicator for the moderator');
-
-    await this.initUserPage2(true);
+    // join the second user and check if joined locked
+    await this.initUserPage2();
     await this.userPage2.checkElementCount(e.whiteboardCursorIndicator, 0,
       'should contain no whiteboard cursor indicator for the second attendee when joining a meeting with the setting locked'
     );
-
     // Unlock user2
     await this.modPage.waitAndClick(`${e.userListItem}>>nth=1`);
     await this.modPage.waitAndClick(`${e.unlockUserButton}>>nth=1`);
-    await this.userPage.getLocator(e.whiteboard).hover(); // ensure userPage cursor will be visible on the screenshot
+    await sleep(1000);  // ensure the unlock settings are applied
+    await this.modPage.getLocator(e.whiteboard).hover(); // hover modPage cursor on the whiteboard to ensure a new location
+    await this.modPage.getLocator(e.chatButton).hover(); // ensure modPage cursor WILL NOT be visible on the screenshot
+    await this.userPage.getLocator(e.whiteboard).hover(); // ensure userPage cursor WILL be visible on the screenshot
     await this.userPage.waitAndClick(e.whiteboard);
     await this.userPage2.checkElementCount(e.whiteboardCursorIndicator, 1, 'should be displayed the other viewer whiteboard cursor indicator when unlocking user is unlocked');
   }

--- a/bigbluebutton-tests/playwright/user/lockViewers.js
+++ b/bigbluebutton-tests/playwright/user/lockViewers.js
@@ -206,6 +206,7 @@ class LockViewers extends MultiUsers {
     await this.userPage2.wasRemoved(e.wbDrawnArrow, 'should not display the other viewer annotation for the viewer who just joined');
     await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
+    await sleep(1000);  // expected timeout for cursor indicator to disappear
     await expect(user2WbLocator, 'should not display the other viewer annotation for the viewer who just joined').toHaveScreenshot('viewer2-just-joined.png', screenshotOptions);
     // draw a rectangle and check if it is displayed
     await this.userPage.waitAndClick(e.wbShapesButton);
@@ -214,6 +215,7 @@ class LockViewers extends MultiUsers {
     await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await this.userPage2.wasRemoved(e.wbDrawnShape, 'should not display the new annotation for the other viewer');
+    await sleep(1000);  // expected timeout for cursor indicator to disappear
     await expect(user2WbLocator, 'should not display the new annotation for the other viewer').toHaveScreenshot('viewer2-no-rectangle.png', screenshotOptions);
     // unlock user2
     await this.modPage.waitAndClick(`${e.userListItem}>>nth=1`);
@@ -223,12 +225,14 @@ class LockViewers extends MultiUsers {
     await this.userPage2.hasElement(e.wbDrawnShape, 'should display the rectangle drawn before unlocking user');
     await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage2.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
+    await sleep(1000);  // expected timeout for cursor indicator to disappear
     await expect(user2WbLocator, 'should display the other viewer annotations when unlocking specific user').toHaveScreenshot('viewer2-previous-shapes.png', screenshotOptions);
     // check if new annotations is displayed after unlocking user
     await drawArrow(this.userPage);
     await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor will be visible on the screenshot
     await this.userPage2.checkElementCount(e.wbDrawnArrow, 2, 'should display all arrows drawn for unlocked user');
+    await sleep(1000);  // expected timeout for cursor indicator to disappear
     await expect(user2WbLocator, 'should display all arrows drawn for unlocked user').toHaveScreenshot('viewer2-new-arrow.png', screenshotOptions);
   }
 


### PR DESCRIPTION
### What does this PR do?
Adds steps to `User › Manage › Lock viewers › Lock see other viewers cursor` test to ensure expected cursors are correctly placed on the whiteboard on assertions

### Motivation
Recent CI failures:
![image](https://github.com/user-attachments/assets/f2199780-09c4-4153-89e7-592a9ff7a642)
