### PR TITLE
Refactor(html5): Add error for extraInfo to improve log details

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -193,6 +193,7 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
                   errorName: error.name,
                   errorMessage: error.message,
                   errorReason: error.reason,
+                  error,
                 },
               }, 'Connection terminated (4499)');
             } else if (isDetailedError) {
@@ -202,6 +203,7 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
                   errorName: error.name,
                   errorMessage: error.message,
                   errorReason: error.reason,
+                  error,
                 },
               }, `Connection error (${error.code})`);
             } else {
@@ -211,8 +213,9 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
                   errorName: 'Error',
                   errorMessage: JSON.stringify(error),
                   errorReason: 'Unknown',
+                  error,
                 },
-              }, `Connection error: ${JSON.stringify(error)}`);
+              }, `Connection error: ${(error as WsError)?.code}`);
             }
 
             if (error && typeof error === 'object' && 'code' in error && error.code === 4403) {


### PR DESCRIPTION
### What does this PR do?
Include the error object in extraInfo for WebSocket error logs to enhance detail and provide better insight into the root cause.

### Closes Issue(s)
No issue Opened.


### How to test
- Create a meeting and join it
- on server console run `sudo systemctl restart nginx`
- Take a look on browser's console logs


### More
Before:
![image](https://github.com/user-attachments/assets/97e1709b-cf4a-4860-8da9-f60b8430c28d)

After:
![image](https://github.com/user-attachments/assets/b90b3968-2bc4-41b7-b02a-c691501f9bc7)

