### PR TITLE
Refactor(html5): Make screenshare audio be muted when quick swap is enabled and when non media layout is selected

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -91,6 +91,15 @@ export default class KurentoScreenshareBridge {
     }
   }
 
+  setStreamEnabled(enabled) {
+    if (this.gdmStream) {
+      this.gdmStream.getTracks().forEach((track) => {
+        // eslint-disable-next-line no-param-reassign
+        track.enabled = enabled;
+      });
+    }
+  }
+
   inboundStreamReconnect() {
     const currentRestartIntervalMs = this.restartIntervalMs;
 

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -90,6 +90,15 @@ export default class LiveKitScreenshareBridge {
     return source === Track.Source.ScreenShare || source === Track.Source.ScreenShareAudio;
   }
 
+  setStreamEnabled(enabled: boolean): void {
+    if (this.gdmStream) {
+      this.gdmStream.getTracks().forEach((track) => {
+        // eslint-disable-next-line no-param-reassign
+        track.enabled = enabled;
+      });
+    }
+  }
+
   getPublications(source: Track.Source): Map<string, LocalTrackPublication | RemoteTrackPublication> | null {
     if (source === Track.Source.ScreenShare) {
       return this.screenPublications;

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -255,6 +255,7 @@ class App extends Component {
       genericMainContentId,
       hideNotificationToasts,
       isNotificationEnabled,
+      isNonMediaLayout,
     } = this.props;
 
     const {
@@ -291,7 +292,10 @@ class App extends Component {
           <SidebarContentContainer isSharedNotesPinned={isSharedNotesPinned} />
           <NavBarContainer main="new" />
           <WebcamContainer />
-          <ExternalVideoPlayerContainer />
+          {
+            !isNonMediaLayout
+              && <ExternalVideoPlayerContainer />
+          }
           <GenericContentMainAreaContainer
             genericMainContentId={genericMainContentId}
           />
@@ -307,7 +311,11 @@ class App extends Component {
             )
             : null
             }
-          <ScreenshareContainer shouldShowScreenshare={shouldShowScreenshare} />
+          {
+            !isNonMediaLayout
+            && <ScreenshareContainer shouldShowScreenshare={shouldShowScreenshare} />
+          }
+
           {isSharedNotesPinned
             ? (
               <NotesContainer

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -87,8 +87,7 @@ const AppContainer = (props) => {
 
   const shouldShowScreenshare = (viewScreenshare || isPresenter)
   && (currentMeeting?.componentsFlags?.hasScreenshare
-    || currentMeeting?.componentsFlags?.hasCameraAsContent)
-    && showScreenshare && presentationIsOpen;
+    || currentMeeting?.componentsFlags?.hasCameraAsContent) && showScreenshare;
   const shouldShowPresentation = (!shouldShowScreenshare && !isSharedNotesPinned
       && !shouldShowExternalVideo && !shouldShowGenericMainContent
       && (presentationIsOpen || presentationRestoreOnUpdate)) && isPresentationEnabled;

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -23,7 +23,7 @@ const AppContainer = (props) => {
     viewScreenshare,
   } = useSettings(SETTINGS.DATA_SAVING);
   const { isNotificationEnabled } = useReactiveVar(handleIsNotificationEnabled);
-
+  const { showScreenshareQuickSwapButton } = window.meetingClientSettings.public.layout;
   const {
     data: currentUser,
   } = useCurrentUser((u) => ({
@@ -52,7 +52,6 @@ const AppContainer = (props) => {
   } = useSettings(SETTINGS.APPLICATION);
 
   const { partialUtterances, minUtteranceLength } = useSettings(SETTINGS.TRANSCRIPTION);
-
   const genericMainContent = layoutSelectInput((i) => i.genericMainContent);
   const captionsStyle = layoutSelectOutput((i) => i.captions);
   const presentation = layoutSelectInput((i) => i.presentation);
@@ -79,14 +78,19 @@ const AppContainer = (props) => {
 
   const shouldShowGenericMainContent = !!genericMainContent.genericContentId;
 
-  const shouldShowScreenshare = (viewScreenshare || isPresenter)
+  const screenshareValidators = (viewScreenshare || isPresenter)
   && (currentMeeting?.componentsFlags?.hasScreenshare
-    || currentMeeting?.componentsFlags?.hasCameraAsContent)
-    && showScreenshare && presentationIsOpen;
+    || currentMeeting?.componentsFlags?.hasCameraAsContent);
+
+  const shouldShowScreenshare = showScreenshareQuickSwapButton
+    ? (
+      screenshareValidators
+      && (showScreenshare && presentationIsOpen)
+    ) : screenshareValidators;
+
   const shouldShowPresentation = (!shouldShowScreenshare && !isSharedNotesPinned
       && !shouldShowExternalVideo && !shouldShowGenericMainContent
       && (presentationIsOpen || presentationRestoreOnUpdate)) && isPresentationEnabled;
-
   // Update after editing app savings
   useEffect(() => {
     setSpeechOptions(

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -81,7 +81,8 @@ const AppContainer = (props) => {
 
   const shouldShowScreenshare = (viewScreenshare || isPresenter)
   && (currentMeeting?.componentsFlags?.hasScreenshare
-    || currentMeeting?.componentsFlags?.hasCameraAsContent) && showScreenshare;
+    || currentMeeting?.componentsFlags?.hasCameraAsContent)
+    && showScreenshare && presentationIsOpen;
   const shouldShowPresentation = (!shouldShowScreenshare && !isSharedNotesPinned
       && !shouldShowExternalVideo && !shouldShowGenericMainContent
       && (presentationIsOpen || presentationRestoreOnUpdate)) && isPresentationEnabled;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/volume-slider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/volume-slider/component.jsx
@@ -61,7 +61,7 @@ class VolumeSlider extends Component {
 
   render() {
     const { muted, volume } = this.state;
-    const { hideVolume } = this.props;
+    const { hideVolume, onVolumeChanged } = this.props;
 
     if (hideVolume) {
       return null;
@@ -69,7 +69,11 @@ class VolumeSlider extends Component {
 
     return (
       <Styled.Slider>
-        <Styled.Volume onClick={() => this.setMuted(!muted)}>
+        <Styled.Volume onClick={() => {
+          if (!muted) onVolumeChanged(0);
+          this.setMuted(!muted);
+        }}
+        >
           <i
             tabIndex="-1"
             className={`icon-bbb-${this.getVolumeIcon()}`}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/volume-slider/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/volume-slider/component.jsx
@@ -61,7 +61,7 @@ class VolumeSlider extends Component {
 
   render() {
     const { muted, volume } = this.state;
-    const { hideVolume, onVolumeChanged } = this.props;
+    const { hideVolume } = this.props;
 
     if (hideVolume) {
       return null;
@@ -69,11 +69,7 @@ class VolumeSlider extends Component {
 
     return (
       <Styled.Slider>
-        <Styled.Volume onClick={() => {
-          if (!muted) onVolumeChanged(0);
-          this.setMuted(!muted);
-        }}
-        >
+        <Styled.Volume onClick={() => this.setMuted(!muted)}>
           <i
             tabIndex="-1"
             className={`icon-bbb-${this.getVolumeIcon()}`}

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -167,8 +167,9 @@ class ScreenshareComponent extends React.Component {
     if (prevProps.shouldShowScreenshare && !shouldShowScreenshare) {
       setVolume(0);
     } else if (!prevProps.shouldShowScreenshare && shouldShowScreenshare) {
+      this.volume = this.volume || 1;
       // if this.volume is 0, means user didn't change the volume, so we set it to 1
-      setVolume(this.volume || 1);
+      setVolume(this.volume);
     }
   }
 
@@ -336,7 +337,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   handleOnMuted(muted) {
-    if (muted) {
+    if (muted && this.volume === 0) {
       setVolume(0);
     } else {
       setVolume(this.volume);
@@ -432,6 +433,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderVolumeSlider() {
+    const { shouldShowScreenshare } = this.props;
     const { showHoverToolBar } = this.state;
 
     let toolbarStyle = 'hoverToolbar';
@@ -453,7 +455,7 @@ class ScreenshareComponent extends React.Component {
           volume={getVolume()}
           muted={getVolume() === 0}
           onVolumeChanged={this.handleOnVolumeChanged}
-          onMuted={this.handleOnMuted}
+          onMuted={shouldShowScreenshare ? this.handleOnMuted : () => {}}
         />
       </Styled.HoverToolbar>
     ),

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -24,6 +24,7 @@ import {
   setVolume,
   getVolume,
   getStats,
+  setStreamEnabled,
 } from '/imports/ui/components/screenshare/service';
 import {
   isStreamStateHealthy,
@@ -163,6 +164,8 @@ class ScreenshareComponent extends React.Component {
     if (prevProps.outputDeviceId !== outputDeviceId && !isPresenter) {
       setOutputDeviceId(outputDeviceId);
     }
+
+    if (isPresenter) setStreamEnabled(shouldShowScreenshare);
 
     if (prevProps.shouldShowScreenshare && !shouldShowScreenshare) {
       setVolume(0);
@@ -337,7 +340,7 @@ class ScreenshareComponent extends React.Component {
   }
 
   handleOnMuted(muted) {
-    if (muted && this.volume === 0) {
+    if (muted) {
       setVolume(0);
     } else {
       setVolume(this.volume);
@@ -433,7 +436,6 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderVolumeSlider() {
-    const { shouldShowScreenshare } = this.props;
     const { showHoverToolBar } = this.state;
 
     let toolbarStyle = 'hoverToolbar';
@@ -455,7 +457,7 @@ class ScreenshareComponent extends React.Component {
           volume={getVolume()}
           muted={getVolume() === 0}
           onVolumeChanged={this.handleOnVolumeChanged}
-          onMuted={shouldShowScreenshare ? this.handleOnMuted : () => {}}
+          onMuted={this.handleOnMuted}
         />
       </Styled.HoverToolbar>
     ),

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -117,7 +117,6 @@ class ScreenshareComponent extends React.Component {
 
   componentDidMount() {
     const {
-      isLayoutSwapped,
       layoutContextDispatch,
       intl,
       isPresenter,
@@ -168,7 +167,8 @@ class ScreenshareComponent extends React.Component {
     if (prevProps.shouldShowScreenshare && !shouldShowScreenshare) {
       setVolume(0);
     } else if (!prevProps.shouldShowScreenshare && shouldShowScreenshare) {
-      setVolume(this.volume);
+      // if this.volume is 0, means user didn't change the volume, so we set it to 1
+      setVolume(this.volume || 1);
     }
   }
 

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -218,6 +218,10 @@ export const getMediaElementDimensions = () => {
   };
 };
 
+export const setStreamEnabled = (enabled) => {
+  screenShareBridge.setStreamEnabled(enabled);
+};
+
 export const setVolume = (volume) => {
   screenShareBridge.setVolume(volume);
 };


### PR DESCRIPTION
### What does this PR do?
This Pull Request fixes several issues related to screenshare audio. The first issue addressed is that audio was being muted when quick swap was enabled in a meeting and the presenter switched to presentation mode. Now, the audio sent by the presenter remains muted as expected. Additionally, this PR fixes an issue where screenshare and external video continued playing even when a non-media layout was selected (such as `CAMERAS_ONLY` or `PARTICIPANTS_AND_CHAT_ONLY`).

### Closes Issue(s)
No Issue opened

### How to test
First issue:
- Change the Setting  `public.layout.showScreenshareQuickSwapButton`.
- Create a meeting with this setting enabled.
- Join with two users.
- Share a screen with live audio.
- Swap to presentation.
- audio on viewer should not be playing.

Second issue:
- Join with a normal user 
- Join a second user with the paramter `enforceLayout=CAMERAS_ONLY`
- screenshare with live audio
- User with non media layout shouldn't be playing audio
