### PR TITLE
fix: client logger does not send userInfo to external stream

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/logger/ServerStream.ts
+++ b/bigbluebutton-html5/imports/startup/client/logger/ServerStream.ts
@@ -23,21 +23,15 @@ export default class ServerLoggerStream extends ServerStream {
   }
 
   static getUserData() {
-    let userInfo: Record<string, unknown> = {
+    const userInfo: Record<string, unknown> = {
       meetingId: Auth.meetingID,
-      userId: Auth.userID,
+      requesterUserId: Auth.userID,
+      fullname: Auth.fullname,
+      confname: Auth.confname,
+      externUserID: Auth.externUserID,
       logoutUrl: Auth.logoutURL,
       sessionToken: Auth.sessionToken,
-      userName: Auth.fullname,
-      extId: Auth.externUserID,
-      meetingName: Auth.confname,
     };
-
-    if (userInfo.meetingId) {
-      userInfo = {
-        sessionToken: sessionStorage.getItem('sessionToken'),
-      };
-    }
 
     return {
       fullInfo: userInfo,


### PR DESCRIPTION
### What does this PR do?

- [fix: client logger does not send userInfo to external stream](https://github.com/bigbluebutton/bigbluebutton/commit/6f7cb2071fbcbe04f48ca7ec71a12bf7b9c3e4c4) 
  - The `userInfo` metadata that's used in the client's external logging
stream is broken. The userInfo object is incorrectly overwritten with a
sessionToken-only object and is consequently not sent due to it missing
a meetingId.
  - Adjust the ServerStream so that:
    - The `userInfo` object is sent in payloads when available (same
    trigger as 2.7, meetingId)
    - The `userInfo` object attributes have the same names as the 2.7
    variants (if they existed there). Some were renamed, and that may
    break log parsers.

### Closes Issue(s)

None