### PR TITLE
perf (gql-server): Convert all graphql tables to `UNLOGGED` to improve writing performance

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -18,7 +18,7 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- ========== Meeting tables
 
-create table "meeting" (
+create unlogged table "meeting" (
 	"meetingId"	varchar(100) primary key,
 	"extId" 	text,
 	"name" text,
@@ -52,7 +52,7 @@ ALTER TABLE "meeting" ADD COLUMN "ended" boolean GENERATED ALWAYS AS ("endedAt" 
 
 create index "idx_meeting_extId" on "meeting"("extId");
 
-create table "meeting_breakout" (
+create unlogged table "meeting_breakout" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
     "parentId"           varchar(100),
     "sequence"           integer,
@@ -68,7 +68,7 @@ create table "meeting_breakout" (
 create index "idx_meeting_breakout_meetingId" on "meeting_breakout"("meetingId");
 create view "v_meeting_breakoutPolicies" as select * from meeting_breakout;
 
-create table "meeting_recordingPolicies" (
+create unlogged table "meeting_recordingPolicies" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
 	"record" boolean,
 	"autoStartRecording" boolean,
@@ -77,7 +77,7 @@ create table "meeting_recordingPolicies" (
 );
 create view "v_meeting_recordingPolicies" as select * from "meeting_recordingPolicies";
 
-create table "meeting_recording" (
+create unlogged table "meeting_recording" (
 	"meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "startedAt" timestamp with time zone,
     "startedBy" varchar(50),
@@ -131,14 +131,14 @@ FROM (
 ) r
 where r.rn = 1;
 
-create table "meeting_welcome" (
+create unlogged table "meeting_welcome" (
 	"meetingId" varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
 	"welcomeMsg" text,
 	"welcomeMsgForModerators" text
 );
 create index "idx_meeting_welcome_meetingId" on "meeting_welcome"("meetingId");
 
-create table "meeting_voice" (
+create unlogged table "meeting_voice" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
 	"telVoice" varchar(100),
 	"voiceConf" varchar(100),
@@ -148,7 +148,7 @@ create table "meeting_voice" (
 create index "idx_meeting_voice_meetingId" on "meeting_voice"("meetingId");
 create view "v_meeting_voiceSettings" as select * from meeting_voice;
 
-create table "meeting_usersPolicies" (
+create unlogged table "meeting_usersPolicies" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
     "maxUsers"                     integer,
     "maxUserConcurrentAccesses"    integer,
@@ -182,7 +182,7 @@ SELECT "meeting_usersPolicies"."meetingId",
    FROM "meeting_usersPolicies"
    JOIN "meeting" using("meetingId");
 
-create table "meeting_metadata" (
+create unlogged table "meeting_metadata" (
 	"meetingId" 		varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "name"              varchar(255),
     "value"             varchar(1000),
@@ -196,7 +196,7 @@ SELECT "meeting_metadata"."meetingId",
     "meeting_metadata"."value"
    FROM "meeting_metadata";
 
-create table "meeting_lockSettings" (
+create unlogged table "meeting_lockSettings" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
     "disableCam"             boolean,
     "disableMic"             boolean,
@@ -241,7 +241,7 @@ FROM meeting m
 JOIN "meeting_lockSettings" mls ON mls."meetingId" = m."meetingId"
 JOIN "meeting_usersPolicies" mup ON mup."meetingId" = m."meetingId";
 
-create table "meeting_clientSettings" (
+create unlogged table "meeting_clientSettings" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
     "clientSettingsJson"    jsonb
 );
@@ -259,7 +259,7 @@ from (
     from "meeting_clientSettings"
 ) settings;
 
-create table "meeting_group" (
+create unlogged table "meeting_group" (
 	"meetingId"  varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "groupId"    varchar(100),
     "groupIndex" integer,
@@ -272,7 +272,7 @@ create view "v_meeting_group" as select * from meeting_group;
 
 -- ========== User tables
 
-CREATE TABLE "user" (
+CREATE UNLOGGED TABLE "user" (
     "meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
 	"userId" varchar(50) NOT NULL,
 	"extId" varchar(50),
@@ -457,7 +457,7 @@ AS SELECT "user"."userId",
   FROM "user"
   WHERE "user"."currentlyInMeeting" is true;
 
-CREATE INDEX "idx_v_user_meetingId" ON "user"("meetingId") 
+CREATE INDEX "idx_v_user_meetingId" ON "user"("meetingId")
                 where "user"."loggedOut" IS FALSE
                 AND "user"."expired" IS FALSE
                 AND "user"."ejected" IS NOT TRUE
@@ -598,7 +598,7 @@ AS SELECT
 FROM "user"
 where "firstJoinedAt" is not null;
 
-CREATE TABLE "user_sessionToken" (
+CREATE UNLOGGED TABLE "user_sessionToken" (
 	"meetingId" varchar(100),
 	"userId" varchar(50),
 	"sessionToken" varchar(16),
@@ -623,7 +623,7 @@ CREATE INDEX "idx_user_sessionToken_pk_reverse" ON "user_sessionToken" ("session
 create view "v_user_sessionToken" as select * from "user_sessionToken";
 create view "v_user_session_current" as select * from "user_sessionToken";
 
-CREATE TABLE "user_graphqlConnection" (
+CREATE UNLOGGED TABLE "user_graphqlConnection" (
 	"graphqlConnectionId" serial PRIMARY KEY,
 	"sessionToken" varchar(16),
 	"clientSessionUUID" varchar(36),
@@ -649,7 +649,7 @@ left join "user_graphqlConnection" ugc on ugc."sessionToken" = ust."sessionToken
 where ust."removedAt" is null
 group by ust."meetingId", ust."userId", ust."sessionToken", ust."sessionName", ust."enforceLayout";
 
-create table "user_metadata"(
+create unlogged table "user_metadata"(
     "meetingId" varchar(100),
     "userId" varchar(50),
     "sessionToken" varchar(16),
@@ -685,7 +685,7 @@ CASE WHEN u."role" = 'MODERATOR' THEN w."welcomeMsgForModerators" ELSE NULL END 
 FROM "user" u
 join meeting_welcome w USING("meetingId");
 
-create table "user_lockSettings" (
+create unlogged table "user_lockSettings" (
     "meetingId"             varchar(100),
     "userId"                varchar(50),
     "disablePublicChat"     boolean,
@@ -702,7 +702,7 @@ case when "user"."isModerator" then false else l."disablePublicChat" end "disabl
 FROM "user_lockSettings" l
 join "user" on "user"."meetingId" = l."meetingId" and "user"."userId" = l."userId";
 
-CREATE TABLE "user_voice" (
+CREATE UNLOGGED TABLE "user_voice" (
     "meetingId" varchar(100),
 	"userId" varchar(50),
 	"voiceUserId" varchar(100),
@@ -789,7 +789,7 @@ AND --filter recent activities to avoid receiving all history every time it star
 
 ----
 
-CREATE TABLE "user_camera" (
+CREATE UNLOGGED TABLE "user_camera" (
 	"streamId" varchar(150) PRIMARY KEY,
 	"meetingId" varchar(100),
     "userId" varchar(50),
@@ -805,7 +805,7 @@ CREATE INDEX "idx_user_camera_meeting_contentType" ON "user_camera"("meetingId",
 CREATE OR REPLACE VIEW "v_user_camera" AS
 SELECT * FROM "user_camera";
 
-CREATE TABLE "user_breakoutRoom" (
+CREATE UNLOGGED TABLE "user_breakoutRoom" (
 	"meetingId" varchar(100),
     "userId" varchar(50),
 	"breakoutRoomId" varchar(100),
@@ -821,7 +821,7 @@ CREATE INDEX "idx_user_breakoutRoom_pk_reverse" ON "user_breakoutRoom"("userId",
 CREATE OR REPLACE VIEW "v_user_breakoutRoom" AS
 SELECT * FROM "user_breakoutRoom";
 
-CREATE TABLE "user_connectionStatus" (
+CREATE UNLOGGED TABLE "user_connectionStatus" (
 	"meetingId" varchar(100),
     "userId" varchar(50),
 	"connectionAliveAtMaxIntervalMs" numeric,
@@ -859,12 +859,12 @@ FOR EACH ROW
 EXECUTE FUNCTION "update_connectionAliveAtMaxIntervalMs"();
 
 
---CREATE TABLE "user_connectionStatusHistory" (
+--CREATE UNLOGGED TABLE "user_connectionStatusHistory" (
 --	"userId" varchar(50) REFERENCES "user"("userId") ON DELETE CASCADE,
 --	"status" varchar(25),
 --	"statusUpdatedAt" timestamp with time zone
 --);
---CREATE TABLE "user_connectionStatusHistory" (
+--CREATE UNLOGGED TABLE "user_connectionStatusHistory" (
 --	"userId" varchar(50) REFERENCES "user"("userId") ON DELETE CASCADE,
 --	"status" varchar(25),
 --	"totalOfOccurrences" integer,
@@ -874,7 +874,7 @@ EXECUTE FUNCTION "update_connectionAliveAtMaxIntervalMs"();
 --	CONSTRAINT "user_connectionStatusHistory_pkey" PRIMARY KEY ("userId","status")
 --);
 
-CREATE TABLE "user_connectionStatusMetrics" (
+CREATE UNLOGGED TABLE "user_connectionStatusMetrics" (
 	"meetingId" varchar(100),
     "userId" varchar(50),
 	"status" varchar(25),
@@ -955,7 +955,7 @@ CREATE INDEX "idx_user_connectionStatusMetrics_UnstableReport" ON "user_connecti
 --FROM "user" u
 --LEFT JOIN "user_connectionStatus" uc ON uc."userId" = u."userId";
 
-CREATE TABLE "user_clientSettings"(
+CREATE UNLOGGED TABLE "user_clientSettings"(
 	"meetingId" varchar(100),
     "userId" varchar(50),
 	"userClientSettingsJson" jsonb,
@@ -968,7 +968,7 @@ CREATE INDEX "idx_user_clientSettings_meetingId" ON "user_clientSettings"("meeti
 create view "v_user_clientSettings" as select * from "user_clientSettings";
 
 
-CREATE TABLE "user_reaction" (
+CREATE UNLOGGED TABLE "user_reaction" (
 	"meetingId" varchar(100),
     "userId" varchar(50),
 	"reactionEmoji" varchar(25),
@@ -1008,7 +1008,7 @@ SELECT ur."meetingId", ur."userId", ur."reactionEmoji", ur."createdAt", ur."expi
 FROM "user_reaction" ur
 WHERE "expiresAt" >= current_timestamp;
 
-CREATE TABLE "user_transcriptionError"(
+CREATE UNLOGGED TABLE "user_transcriptionError"(
 	"meetingId" varchar(100),
     "userId" varchar(50),
 	"errorCode" varchar(255),
@@ -1037,7 +1037,7 @@ from "v_meeting";
 -- ===================== CHAT TABLES
 
 
-CREATE TABLE "chat" (
+CREATE UNLOGGED TABLE "chat" (
 	"meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 	"chatId"  varchar(100),
 	"access" varchar(20),
@@ -1047,7 +1047,7 @@ CREATE TABLE "chat" (
 CREATE INDEX "idx_chat_pk_reverse" ON "chat"("chatId","meetingId");
 CREATE INDEX "idx_chat_meetingId" ON "chat"("meetingId");
 
-CREATE TABLE "chat_user" (
+CREATE UNLOGGED TABLE "chat_user" (
 	"chatId" varchar(100),
 	"meetingId" varchar(100),
 	"userId" varchar(50),
@@ -1113,7 +1113,7 @@ LEFT JOIN "chat_user" chat_with ON chat_with."meetingId" = chat_user."meetingId"
 WHERE chat_user."chatId" != 'MAIN-PUBLIC-GROUP-CHAT'
 AND chat_user."visible" is true;
 
-CREATE TABLE "chat_message" (
+CREATE UNLOGGED TABLE "chat_message" (
 	"messageId" varchar(100) PRIMARY KEY,
 	"chatId" varchar(100),
 	"meetingId" varchar(100),
@@ -1168,7 +1168,7 @@ EXECUTE FUNCTION "update_chatUser_clear_lastTypingAt_trigger_func"();
 
 
 
-CREATE TABLE "chat_message_history" (
+CREATE UNLOGGED TABLE "chat_message_history" (
 	"messageId" varchar(100) REFERENCES "chat_message"("messageId") ON DELETE CASCADE,
 	"meetingId" varchar(100),
 	"messageVersionSequence" integer, --populated via trigger
@@ -1265,7 +1265,7 @@ LEFT JOIN "chat_user" chat_with ON chat_with."meetingId" = cm."meetingId"
                                 AND chat_with."userId" != cu."userId"
 WHERE cm."chatId" != 'MAIN-PUBLIC-GROUP-CHAT';
 
-CREATE TABLE "chat_message_reaction" (
+CREATE UNLOGGED TABLE "chat_message_reaction" (
 	"meetingId" varchar(100),
 	"messageId" varchar(100) REFERENCES "chat_message"("messageId") ON DELETE CASCADE,
 	"userId" varchar(100) not null,
@@ -1284,7 +1284,7 @@ CREATE OR REPLACE VIEW "v_chat_message_reaction" AS SELECT * FROM "chat_message_
 --============ Presentation / Annotation
 
 
-CREATE TABLE "pres_presentation" (
+CREATE UNLOGGED TABLE "pres_presentation" (
 	"presentationId" varchar(100) PRIMARY KEY,
 	"meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 	"uploadUserId" varchar(100),
@@ -1328,7 +1328,7 @@ CREATE TRIGGER "trigger_update_preloadNextPages" BEFORE INSERT ON "pres_presenta
 FOR EACH ROW EXECUTE FUNCTION "update_preloadNextPages"();
 
 
-CREATE TABLE "pres_page" (
+CREATE UNLOGGED TABLE "pres_page" (
 	"pageId" varchar(100) PRIMARY KEY,
 	"presentationId" varchar(100) REFERENCES "pres_presentation"("presentationId") ON DELETE CASCADE,
 	"num" integer,
@@ -1452,7 +1452,7 @@ FROM pres_presentation
 JOIN pres_page ON pres_presentation."presentationId" = pres_page."presentationId" AND pres_page."current" IS TRUE
 and pres_presentation."current" IS TRUE;
 
-CREATE TABLE "pres_annotation" (
+CREATE UNLOGGED TABLE "pres_annotation" (
 	"annotationId" varchar(100) PRIMARY KEY,
 	"pageId" varchar(100) REFERENCES "pres_page"("pageId") ON DELETE CASCADE,
 	"meetingId" varchar(100),
@@ -1464,7 +1464,7 @@ CREATE INDEX "idx_pres_annotation_pageId" ON "pres_annotation"("pageId");
 CREATE INDEX "idx_pres_annotation_updatedAt" ON "pres_annotation"("pageId","lastUpdatedAt");
 create index "idx_pres_annotation_user_meeting" on "pres_annotation" ("userId", "meetingId");
 
-CREATE TABLE "pres_annotation_history" (
+CREATE UNLOGGED TABLE "pres_annotation_history" (
 	"sequence" serial PRIMARY KEY,
 	"annotationId" varchar(100),
 	"pageId" varchar(100) REFERENCES "pres_page"("pageId") ON DELETE CASCADE,
@@ -1497,7 +1497,7 @@ JOIN "user" on "user"."meetingId" = pah."meetingId" and "user"."userId" = pah."u
 WHERE p."current" IS true
 AND pp."current" IS true;
 
-CREATE TABLE "pres_page_writers" (
+CREATE UNLOGGED TABLE "pres_page_writers" (
 	"pageId" varchar(100)  REFERENCES "pres_page"("pageId") ON DELETE CASCADE,
     "meetingId" varchar(100),
     "userId" varchar(50),
@@ -1619,7 +1619,7 @@ FOR EACH ROW EXECUTE FUNCTION ins_upd_del_pres_page_writers_trigger_func();
 
 
 
-CREATE TABLE "pres_page_cursor" (
+CREATE UNLOGGED TABLE "pres_page_cursor" (
 	"pageId" varchar(100)  REFERENCES "pres_page"("pageId") ON DELETE CASCADE,
     "meetingId" varchar(100),
     "userId" varchar(50),
@@ -1645,7 +1645,7 @@ JOIN pres_presentation ON pres_presentation."presentationId" = pres_page."presen
 -------------------------------------------------------------------
 ---- Polls
 
-CREATE TABLE "poll" (
+CREATE UNLOGGED TABLE "poll" (
 "pollId" varchar(100) PRIMARY KEY,
 "meetingId" varchar(100),
 "ownerId" varchar(100),
@@ -1664,7 +1664,7 @@ CREATE INDEX "idx_poll_ownerId" ON "poll"("meetingId","ownerId");
 CREATE INDEX "idx_poll_meetingId_active" ON "poll"("meetingId") where ended is false;
 CREATE INDEX "idx_poll_meetingId_published" ON "poll"("meetingId") where published is true;
 
-CREATE TABLE "poll_option" (
+CREATE UNLOGGED TABLE "poll_option" (
 	"pollId" varchar(100) REFERENCES "poll"("pollId") ON DELETE CASCADE,
 	"optionId" integer,
 	"optionDesc" TEXT,
@@ -1672,7 +1672,7 @@ CREATE TABLE "poll_option" (
 );
 CREATE INDEX "idx_poll_option_pollId" ON "poll_option"("pollId");
 
-CREATE TABLE "poll_response" (
+CREATE UNLOGGED TABLE "poll_response" (
 	"pollId" varchar(100),
 	"optionId" integer,
 	"meetingId" varchar(100),
@@ -1743,7 +1743,7 @@ group by "user"."meetingId", "user"."userId", "poll"."pollId";
 --------------------------------
 ----External video
 
-create table "externalVideo"(
+create unlogged table "externalVideo"(
 "externalVideoId" varchar(100) primary key,
 "meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 "externalVideoUrl" varchar(500),
@@ -1764,7 +1764,7 @@ WHERE "stoppedSharingAt" IS NULL;
 ----Screenshare
 
 
-create table "screenshare"(
+create unlogged table "screenshare"(
 "screenshareId" varchar(50) primary key,
 "meetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 "voiceConf" varchar(50),
@@ -1788,7 +1788,7 @@ WHERE "stoppedAt" IS NULL;
 --------------------------------
 ----Timer
 
-CREATE TABLE "timer" (
+CREATE UNLOGGED TABLE "timer" (
 	"meetingId" varchar(100) PRIMARY KEY REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 	"stopwatch" boolean,
 	"running" boolean,
@@ -1828,7 +1828,7 @@ SELECT
 ----breakoutRoom
 
 
-CREATE TABLE "breakoutRoom" (
+CREATE UNLOGGED TABLE "breakoutRoom" (
 	"breakoutRoomId" varchar(100) NOT NULL PRIMARY KEY,
 	"parentMeetingId" varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 	"externalId" varchar(100),
@@ -1848,7 +1848,7 @@ CREATE TABLE "breakoutRoom" (
 
 CREATE INDEX "idx_breakoutRoom_parentMeetingId" ON "breakoutRoom"("parentMeetingId", "externalId");
 
-CREATE TABLE "breakoutRoom_user" (
+CREATE UNLOGGED TABLE "breakoutRoom_user" (
 	"breakoutRoomId" varchar(100) NOT NULL REFERENCES "breakoutRoom"("breakoutRoomId") ON DELETE CASCADE,
 	"meetingId" varchar(100),
     "userId" varchar(50),
@@ -2050,7 +2050,7 @@ where bu."breakoutRoomId" in (
 ------------------------------------
 ----sharedNotes
 
-create table "sharedNotes" (
+create unlogged table "sharedNotes" (
     "meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "sharedNotesExtId" varchar(25),
     "padId" varchar(25),
@@ -2061,7 +2061,7 @@ create table "sharedNotes" (
 );
 create index "idx_sharedNotes_pk_reverse" on "sharedNotes"("sharedNotesExtId", "meetingId");
 
-create table "sharedNotes_rev" (
+create unlogged table "sharedNotes_rev" (
 	"meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
 	"sharedNotesExtId" varchar(25),
 	"rev" integer,
@@ -2083,7 +2083,7 @@ select "meetingId", "sharedNotesExtId", "userId", "start", "end", "diff", "rev"
 from "sharedNotes_rev"
 where "diff" is not null;
 
-create table "sharedNotes_session" (
+create unlogged table "sharedNotes_session" (
     "meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
     "sharedNotesExtId" varchar(25),
     "userId" varchar(50),
@@ -2115,7 +2115,7 @@ SELECT
 ------------------------------------
 ----caption
 
-CREATE TABLE "caption_locale" (
+CREATE UNLOGGED TABLE "caption_locale" (
     "meetingId" varchar(100) NOT NULL REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
     "locale" varchar(15) NOT NULL,
     "captionType" varchar(100) NOT NULL, --Audio Transcription or Typed Caption
@@ -2128,7 +2128,7 @@ CREATE TABLE "caption_locale" (
 create index "idx_caption_locale_pk_reverse" on "caption_locale"("locale","meetingId","captionType");
 create index "idx_caption_locale_pk_reverse_b" on "caption_locale"("captionType","meetingId","locale");
 
-CREATE TABLE "caption" (
+CREATE UNLOGGED TABLE "caption" (
     "captionId" varchar(100) NOT NULL PRIMARY KEY,
     "meetingId" varchar(100) NOT NULL REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
     "captionType" varchar(100) NOT NULL, --Audio Transcription or Typed Caption
@@ -2176,7 +2176,7 @@ create index "idx_caption_typed_activeLocales" on "caption"("meetingId","locale"
 ------------------------------------
 ----
 
-CREATE TABLE "layout" (
+CREATE UNLOGGED TABLE "layout" (
 	"meetingId" 			varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
 	"currentLayoutType"     varchar(100),
 	"presentationMinimized" boolean,
@@ -2195,7 +2195,7 @@ SELECT * FROM "layout";
 ------------------------------------
 ----
 
-CREATE TABLE "notification" (
+CREATE UNLOGGED TABLE "notification" (
 	"notificationId"        serial primary key,
 	"meetingId" 			varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
 	"notificationType"      varchar(100),
@@ -2238,7 +2238,7 @@ create index idx_notification on notification("meetingId","userId","role","creat
 
 -- ========== Plugin tables
 
-create table "plugin" (
+create unlogged table "plugin" (
 	"meetingId" varchar(100),
 	"name" varchar(100),
     "localesBaseUrl" varchar(500),
@@ -2254,7 +2254,7 @@ create view "v_plugin" as select * from "plugin";
 ---Plugins Data Channel
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE "pluginDataChannelEntry" (
+CREATE UNLOGGED TABLE "pluginDataChannelEntry" (
 	"meetingId" varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
 	"pluginName" varchar(255),
 	"channelName" varchar(255),
@@ -2360,7 +2360,7 @@ from "meeting";
 
 ------------------------
 ----LiveKit
-CREATE TABLE "user_livekit"(
+CREATE UNLOGGED TABLE "user_livekit"(
 	"meetingId" varchar(100),
 	"userId" varchar(50),
 	"livekitToken" TEXT,


### PR DESCRIPTION
This change converts to `UNLOGGED` all PostgreSQL tables used for Graphql-Server.

This improves write performance by eliminating Write-Ahead Logging (WAL), reducing I/O overhead for real-time operations. 
While data loss on a database crash is a risk, it’s acceptable for our use case where meeting data is temporary and only useful during each session, with no sensitive information.

Thanks to @defnull for the great suggestion!

https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-UNLOGGED
![image](https://github.com/user-attachments/assets/aee6095d-bd0d-4c05-bfec-d378e9b2f793)

https://www.crunchydata.com/blog/postgresl-unlogged-tables
![image](https://github.com/user-attachments/assets/5b7bc54c-5ac1-48d6-bac6-6c7014ec5fee)
