### PR TITLE
fix(audio): prevent retry loop when skip_check=true and error occurs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -224,6 +224,7 @@ const AudioModal = ({
   const [errorInfo, setErrorInfo] = useState(null);
   const [autoplayChecked, setAutoplayChecked] = useState(false);
   const [findingDevices, setFindingDevices] = useState(false);
+  const [initialJoinExecuted, setInitialJoinExecuted] = useState(false);
   const [setAway] = useMutation(SET_AWAY);
   const voiceToggle = useToggleVoice();
 
@@ -661,7 +662,12 @@ const AudioModal = ({
       if (forceListenOnlyAttendee || audioLocked) {
         handleJoinListenOnly();
       } else if (!listenOnlyMode) {
-        if (joinFullAudioImmediately) {
+        // Audio join should only be automatic if the prop says so, listen only
+        // mode is off, and automatic audio join hasn't been tried yet. For the
+        // latter, the reason is that we don't want to loop audio join retries
+        // if an error occurs.
+        if (joinFullAudioImmediately && !initialJoinExecuted) {
+          setInitialJoinExecuted(true);
           checkMicrophonePermission({ doGUM: true, permissionStatus })
             .then((hasPermission) => {
               // No permission - let the Help screen be shown as it's triggered
@@ -684,6 +690,7 @@ const AudioModal = ({
     forceListenOnlyAttendee,
     joinFullAudioImmediately,
     listenOnlyMode,
+    initialJoinExecuted,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): prevent retry loop when skip_check=true and error occurs](https://github.com/bigbluebutton/bigbluebutton/commit/dae725956cf800b782b6871a0d2fc4b3247c4f25) 
  - When skip_check_audio=true and audio fails with some specific errors,
the audio modal gets stuck into a join retry loop. This causes logs to
be spammed and the modal to be effectively stuck in the Help screen with
an `UnknownError` identifier.
  - Add a blocking state to the automatic audio join procedure that only
allows it to run once per audio modal mount lifecycle. If it fails once,
it won't retry automatically and instead follow the expected `Help -> Retry
-> Audio Settings -> Join` flow for error scenarios.

### Closes Issue(s)

None