### PR TITLE
fix(audio): extend retryable gUM error list

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -114,11 +114,15 @@ const doGUM = async (constraints, retryOnFailure = false) => {
   } catch (error) {
     // This is probably a deviceId mismatch. Retry with base constraints
     // without an exact deviceId.
-    if (error.name === 'OverconstrainedError' && retryOnFailure) {
+    const retryableErrors = ['NotFoundError', 'OverconstrainedError', 'NotReadableError'];
+
+    if (retryOnFailure && retryableErrors.includes(error.name)) {
       logger.warn({
         logCode: 'audio_overconstrainederror_rollback',
         extraInfo: {
           constraints,
+          errorName: error.name,
+          errorMessage: error.message,
         },
       }, 'Audio getUserMedia returned OverconstrainedError, rollback');
 


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): extend retryable gUM error list](https://github.com/bigbluebutton/bigbluebutton/commit/f791a422833326be62c665b689f428e2594f78e6) 
  - A portion of audio init errors are NotFoundError-coded gUM failures.
General cause for that is having no input devices, but sometimes they
_are_ present and this error is thrown anyways. The hypothesis here is
that tainted constraints (which carry deviceId and other attributes from
previous sessions) might be causing this. Same goes for NotReadableError.
  - Add NotFoundError and NotReadableError to the list of retryable gUM
errors for audio. I'll keep an eye on telemetry data to see if this has
any effect.

### Closes Issue(s)

None