### PR TITLE
fix: Chat message audio notification not working correctly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -20,6 +20,7 @@ import Service from './service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
+import Auth from '/imports/ui/services/auth';
 
 const intlMessages = defineMessages({
   appToastChatPublic: {
@@ -97,7 +98,7 @@ const ChatAlertGraphql: React.FC<ChatAlertGraphqlProps> = (props) => {
     && !!privateUnreadMessages
     && privateUnreadMessages.length > 0;
   const shouldPlayAudioAlert = useCallback(
-    (m: Message) => !history.current.has(m.messageId),
+    (m: Message) => m.senderId !== Auth.userID && !history.current.has(m.messageId),
     [history.current],
   );
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -97,8 +97,8 @@ const ChatAlertGraphql: React.FC<ChatAlertGraphqlProps> = (props) => {
     && !!privateUnreadMessages
     && privateUnreadMessages.length > 0;
   const shouldPlayAudioAlert = useCallback(
-    (m: Message) => (m.chatId !== idChatOpen || document.hidden) && !history.current.has(m.messageId),
-    [idChatOpen, history.current],
+    (m: Message) => !history.current.has(m.messageId),
+    [history.current],
   );
 
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/queries.ts
@@ -9,6 +9,7 @@ export interface Message {
   messageMetadata: string | null;
   senderName: string | null;
   senderRole: string | null;
+  senderId: string | null;
 }
 
 export interface PublicMessageStreamResponse {
@@ -33,6 +34,7 @@ export const CHAT_MESSAGE_PUBLIC_STREAM = gql`
       messageType
       senderName
       senderRole
+      senderId
     }
   }
 `;
@@ -51,6 +53,7 @@ export const CHAT_MESSAGE_PRIVATE_STREAM = gql`
       messageType
       senderName
       senderRole
+      senderId
     }
   }
 `;


### PR DESCRIPTION
### What does this PR do?

changes audio alerts behavior, so alerts are played even when chat is open.

### Closes Issue(s)
Closes #22159

### How to test
1. join 2 users into a meeting
2. in the session settings enable audio notification for chat messages
3. ensure public chat panel is open
4. write a chat message
5. hear audio notification