### PR TITLE
fix(whiteboard): Improve zoom stability

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -823,8 +823,8 @@ class Presentation extends PureComponent {
                     intl={intl}
                     presentationWidth={svgWidth}
                     presentationHeight={svgHeight}
-                    presentationAreaHeight={presentationBounds?.height}
-                    presentationAreaWidth={presentationBounds?.width}
+                    presentationAreaHeight={presentationBounds.height - toolbarHeight}
+                    presentationAreaWidth={presentationBounds.width}
                     isPanning={isPanning}
                     zoomChanger={this.zoomChanger}
                     fitToWidth={fitToWidth}

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -754,7 +754,10 @@ class Presentation extends PureComponent {
       logCode: 'whiteboard_crash',
       logMessage: 'Possible whiteboard crash',
     };
-    if (!presentationIsOpen) return null;
+    const presentationIsHidden = !presentationBounds
+      || presentationBounds.width === 0
+      || presentationBounds.height === 0;
+    if (!presentationIsOpen || presentationIsHidden) return null;
     return (
       <>
         <Styled.PresentationContainer

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1111,7 +1111,7 @@ const Whiteboard = React.memo((props) => {
     localHeight,
     widthAdjustment = 0,
   ) => {
-    const presentationWidthLocal = presentationAreaWidth - widthAdjustment;
+    const presentationWidthLocal = Math.max(presentationAreaWidth - widthAdjustment, 0);
     const calcedZoom = (fitToWidth
       ? presentationWidthLocal / localWidth
       : Math.min(

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -158,6 +158,7 @@ const Whiteboard = React.memo((props) => {
   const mountedTimeoutIdRef = useRef(null);
   const presentationIdRef = React.useRef(presentationId);
   const innerWrapperPollingFrameRef = React.useRef(null);
+  const isMountedPollingFrameRef = React.useRef(null);
 
   const [pageZoomMap, setPageZoomMap] = useState(() => {
     try {
@@ -761,6 +762,21 @@ const Whiteboard = React.memo((props) => {
         `Failed to store viewbox dimensions`
       );
       onReady({ containerWidth, containerHeight, innerWrapperWidth, innerWrapperHeight });
+    }
+  };
+
+  const pollUntilMounted = (onReady, onFail, ref = null, options = { maxTries: 240 }, currentTry = 0) => {
+    if (isMountedRef.current) {
+      onReady();
+    } else if (currentTry <= options.maxTries) {
+      const frameId = requestAnimationFrame(() => {
+        pollUntilMounted(onReady, onFail, ref, options, currentTry + 1);
+      });
+      if (ref) {
+        ref.current = frameId;
+      }
+    } else {
+      onFail();
     }
   };
 
@@ -1429,42 +1445,39 @@ const Whiteboard = React.memo((props) => {
   }, [presentationAreaWidth, presentationAreaHeight, presentationWidth, presentationHeight, isPresenter, presentationId, fitToWidth]);
 
   React.useEffect(() => {
-    const handleResize = () => {
-      syncCameraWithPresentationArea({
-        tlEditorRef,
-        isPresenter,
-        currentPresentationPageRef,
-        presentationAreaWidth,
-        presentationAreaHeight,
-        zoomValueRef,
-        fitToWidthRef,
-        curPageIdRef,
-        initialViewBoxWidthRef,
-        initialViewBoxHeightRef,
-      });
-    };
-
-    if (innerWrapperPollingFrameRef.current !== null) {
-      cancelAnimationFrame(innerWrapperPollingFrameRef.current);
+    if (isMountedPollingFrameRef.current !== null) {
+      cancelAnimationFrame(isMountedPollingFrameRef.current)
     }
-    innerWrapperPollingFrameRef.current = requestAnimationFrame(() => {
-      pollInnerWrapperDimensionsUntilStable(() => {
-        syncCameraWithPresentationArea({
-          tlEditorRef,
-          isPresenter,
-          currentPresentationPageRef,
-          presentationAreaWidth,
-          presentationAreaHeight,
-          zoomValueRef,
-          fitToWidthRef,
-          curPageIdRef,
-          initialViewBoxWidthRef,
-          initialViewBoxHeightRef,
+    isMountedPollingFrameRef.current = requestAnimationFrame(() => {
+      pollUntilMounted(() => {
+        if (innerWrapperPollingFrameRef.current !== null) {
+          cancelAnimationFrame(innerWrapperPollingFrameRef.current);
+        }
+        innerWrapperPollingFrameRef.current = requestAnimationFrame(() => {
+          pollInnerWrapperDimensionsUntilStable(() => {
+            syncCameraWithPresentationArea({
+              tlEditorRef,
+              isPresenter,
+              currentPresentationPageRef,
+              presentationAreaWidth,
+              presentationAreaHeight,
+              zoomValueRef,
+              fitToWidthRef,
+              curPageIdRef,
+              initialViewBoxWidthRef,
+              initialViewBoxHeightRef,
+            });
+          }, {
+            maxTries: 120,
+            stabilityFrames: 35,
+          }, innerWrapperPollingFrameRef);  
         });
-      }, {
-        maxTries: 120,
-        stabilityFrames: 35,
-      }, innerWrapperPollingFrameRef);  
+      }, () => {
+        logger.warn(
+          { logCode: 'pollUntilMounted' },
+          `Failed to wait for component to be mounted`,
+        );
+      }, isMountedPollingFrameRef);
     });
   }, [presentationHeight, presentationWidth, curPageId, presentationId]);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1119,7 +1119,7 @@ const Whiteboard = React.memo((props) => {
         presentationAreaHeight / localHeight,
       ));
     return calcedZoom === 0 || calcedZoom === Infinity
-      ? HUNDRED_PERCENT
+      ? calculateZoomValue(localWidth, localHeight) // Fallback to no gap base zoom
       : calcedZoom;
   };
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

This PR is a follow-up for https://github.com/bigbluebutton/bigbluebutton/pull/22368. In this PR we continue to improve zoom stability when the presentation area is resized and on client startup.

[fix(whiteboard): Clamp presentation width to a minimum value of 0](https://github.com/bigbluebutton/bigbluebutton/commit/07ff24462bc3483875bd36a53b99d98db1f3df11):
- When calculating zoom with gap, clamp the resulting presentation width to a minimum value of 0 when subtracting the gap value.

[fix(whiteboard): Fallback to no gap base zoom](https://github.com/bigbluebutton/bigbluebutton/commit/ecb56c29d2c3dcef2c0512bfb2763f4274109cec):
- When calculating base zoom with gap, if the calculated zoom is 0 or Infinity, force recalculation with no gap. That's because we don't know the base zoom to fit the slide beforehand. Assuming it as a hundred percent can cause mistakes.

[fix(whiteboard): Do not render the presentation before layout calculation](https://github.com/bigbluebutton/bigbluebutton/commit/ed31e98cb5a3efb460814684204cc74647e89192):
- This avoids initializing the whiteboard too early, triggering effects with bad values.

[fix(whiteboard): Subtract toolbar height from presentation are height](https://github.com/bigbluebutton/bigbluebutton/commit/5d07cce2549eb05d5c6b5ee736535191d88085d9):
- This can lead to wrong zoom values if the slide is in portrait mode.

[fix(whiteboard): Wait for whiteboard component to be mounted before syncing zoom with presentation area](https://github.com/bigbluebutton/bigbluebutton/commit/85db4ad5ccb6c5d13776e391a685aa3eee3d7066):
- Wait for whiteboard component to be mounted before syncing zoom with presentation area.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22292
Closes #21302
Closes #21191