### PR TITLE
fix: Changing slide while a poll is open closes the poll

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -212,7 +212,7 @@ class PresentationToolbar extends PureComponent {
 
   nextSlideHandler(event) {
     const {
-      nextSlide, endCurrentPoll, currentSlide, setPresentationPageInfiniteWhiteboard,
+      nextSlide, currentSlide, setPresentationPageInfiniteWhiteboard,
     } = this.props;
     const isInfiniteWhiteboard = currentSlide?.infiniteWhiteboard;
 
@@ -220,13 +220,12 @@ class PresentationToolbar extends PureComponent {
 
     this.handleFTWSlideChange();
     if (event) event.currentTarget.blur();
-    endCurrentPoll();
     nextSlide();
   }
 
   previousSlideHandler(event) {
     const {
-      previousSlide, endCurrentPoll, currentSlide, setPresentationPageInfiniteWhiteboard,
+      previousSlide, currentSlide, setPresentationPageInfiniteWhiteboard,
     } = this.props;
 
     const isInfiniteWhiteboard = currentSlide?.infiniteWhiteboard;
@@ -235,7 +234,6 @@ class PresentationToolbar extends PureComponent {
 
     this.handleFTWSlideChange();
     if (event) event.currentTarget.blur();
-    endCurrentPoll();
     previousSlide();
   }
 


### PR DESCRIPTION
### What does this PR do?

changes poll behavior, so current poll is not ended on slide change.

### Closes Issue(s)
Closes #22396

### How to test
1. Click on the '+'
2. Click on 'Start a Poll'
3. Choose any type of poll and click 'Start Poll'
4. Change to a different slide using the > or < button