### PR TITLE
fix: Presentation overlapping Webcams with userdata-bbb_hide_nav_bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -287,9 +287,10 @@ const CustomLayout = (props) => {
       camerasMargin,
       cameraDockMinHeight,
       cameraDockMinWidth,
-      navBarHeight,
       presentationToolbarMinWidth,
     } = DEFAULT_VALUES;
+
+    const navBarHeight = calculatesNavbarHeight();
 
     const cameraDockBounds = {};
 


### PR DESCRIPTION
### What does this PR do?

adjusts cameras position when hide_nav_bar parameter is used with custom layout

### Closes Issue(s)
Closes #22430

### How to test
1. Go to API Mate with BBB 3.0.0-rc.4 credentials
2. Create a new meeting
3. Join as moderator, share webcam
4. Add `userdata-bbb_hide_nav_bar=true` to Custom parameters
5. Join meeting again