### PR TITLE
fix: External Video is played in CAMERAS_ONLY Layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -581,7 +581,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const { element } = fullscreen;
   const fullscreenContext = (element === fullscreenElementId);
   const [key, setKey] = React.useState(uniqueId('react-player'));
-  if (!currentUser || !currentMeeting?.externalVideo) return null;
+  if (!currentUser || !currentMeeting?.externalVideo || !externalVideo?.display) return null;
   if (!hasExternalVideoOnLayout) return null;
   const playerPlaybackRate = currentMeeting.externalVideo?.playerPlaybackRate ?? 1;
   const isPresenter = currentUser.presenter ?? false;

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -1216,13 +1216,15 @@ const reducer = (state, action) => {
         top,
         left,
         right,
+        display,
       } = action.value;
       const { externalVideo } = state.output;
       if (externalVideo.width === width
         && externalVideo.height === height
         && externalVideo.top === top
         && externalVideo.left === left
-        && externalVideo.right === right) {
+        && externalVideo.right === right
+        && externalVideo.display === display) {
         return state;
       }
       return {
@@ -1236,6 +1238,7 @@ const reducer = (state, action) => {
             top,
             left,
             right,
+            display,
           },
         },
       };

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -753,6 +753,7 @@ const CustomLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
+        display: externalVideoInput.hasExternalVideo,
         width: mediaBounds.width,
         height: mediaBounds.height,
         top: mediaBounds.top,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -414,6 +414,7 @@ const MediaOnlyLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
+        display: externalVideoInput.hasExternalVideo,
         width: mediaBounds.width,
         height: mediaBounds.height,
         top: mediaBounds.top,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -463,6 +463,7 @@ const PresentationFocusLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
+        display: externalVideoInput.hasExternalVideo,
         width: isOpen ? mediaBounds.width : 0,
         height: isOpen ? mediaBounds.height : 0,
         top: mediaBounds.top,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -33,6 +33,7 @@ const PresentationOnlyLayout = (props) => {
   const currentPanelType = layoutSelect((i) => i.currentPanelType);
 
   const presentationInput = layoutSelectInput((i) => i.presentation);
+  const externalVideoInput = layoutSelectInput((i) => i.externalVideo);
   const actionbarInput = layoutSelectInput((i) => i.actionBar);
   const navbarInput = layoutSelectInput((i) => i.navBar);
   const layoutContextDispatch = layoutDispatch();
@@ -282,6 +283,7 @@ const PresentationOnlyLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
+        display: externalVideoInput.hasExternalVideo,
         width: isOpen ? mediaBounds.width : 0,
         height: isOpen ? mediaBounds.height : 0,
         top: mediaBounds.top,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -531,6 +531,7 @@ const SmartLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
+        display: externalVideoInput.hasExternalVideo,
         width: mediaBounds.width,
         height: mediaBounds.height,
         top: mediaBounds.top,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -473,6 +473,7 @@ const VideoFocusLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_EXTERNAL_VIDEO_OUTPUT,
       value: {
+        display: externalVideoInput.hasExternalVideo,
         width: mediaBounds.width,
         height: mediaBounds.height,
         top: mediaBounds.top,


### PR DESCRIPTION
### What does this PR do?

Adjusts external video component behavior so external video is not mounted on layouts that do not have it

### Closes Issue(s)
Closes #22431

### How to test
1. Go to API Mate with BBB 3.0.0-rc.4 credentials
2. Create a new meeting
3. Join as moderator (User A)
4. Add enforceLayout=CAMERAS_ONLY to Custom parameters
5. Join meeting with a new user (User B)
6. Open the dev tools, networking tab (User B)
7. Start external video (User A)
8. Mute your chrome tab (User A)
9. The audio should not be played (User B)