### PR TITLE
fix: Webcams are played in PRESENTATION_ONLY Layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -356,7 +356,7 @@ const WebcamContainer: React.FC = () => {
 
   const audioModalIsOpen = useStorageKey('audioModalIsOpen');
 
-  return !audioModalIsOpen && (usersVideo.length > 0 || isGridEnabled)
+  return cameraDock?.display && !audioModalIsOpen && (usersVideo.length > 0 || isGridEnabled)
     ? (
       <WebcamComponent
         {...{


### PR DESCRIPTION
### What does this PR do?

Adjusts cameras component behavior so it is not mounted on layouts that do not have it

### Closes Issue(s)
Closes #22432

### How to test
1. Go to API Mate with BBB 3.0.0-rc.4 credentials
2. Create a new meeting
3. Join as moderator (User A)
4. Share Webcam
5. Add enforceLayout=PRESENTATION_ONLY to Custom parameters
6. Join meeting with a new user (User B)
7. cameras component should not be mounted
