### PR TITLE
docs: Adjust yq commands to yq version 4.16.2

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -518,8 +518,8 @@ For **live meetings**, the following parameters can be changed:
 
 The bitrate is specified in kbps and represents screen sharing's maximum bandwidth usage. Setting it to a higher value *may* improve quality but also increase bandwidth usage, while setting it to a lower value *may* reduce quality but will reduce average bandwidth usage.
 The constraints are specified as an YAML object with the same semantics as the [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) from the WebRTC specification. We recommend checking the aforementioned MDN link as well as the [Media Capture and Streams API spec](https://www.w3.org/TR/mediacapture-streams) for an extensive list of constraints.
-To set new screen sharing constraints, translate the JSON constraints object into an YAML format object and put it into `public.kurento.screenshare.constraints`. Restart bbb-html5 afterwards.
-As an example, suppose you want to set the maximum screen sharing resolution to 1080p, alter the maximum bitrate to 2000 kbps and set a 10 FPS target. The following would need to be added to `etc/bigbluebutton/bbb-html5.yml`:
+To set new screen sharing constraints, translate the JSON constraints object into an YAML format object and put it into `public.kurento.screenshare.constraints`. Restart BigBlueButton afterwards (`sudo bbb-conf --restart`).
+As an example, suppose you want to set the maximum screen sharing resolution to 1080p, alter the maximum bitrate to 2000 kbps and set a 10 FPS target. The following would need to be added to `/etc/bigbluebutton/bbb-html5.yml`:
 ```yaml
 public:
   kurento:

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -508,9 +508,9 @@ For **recordings**, the following parameters can be changed (presentation format
   - `/usr/local/bigbluebutton/core/scripts/presentation.yml`: `deskshare_output_framerate` (default: 5)
 
 As an example, suppose you want to increase the output resolution and framerate of the recorded screen share media to match a 1080p/15 FPS stream. The following changes would be necessary:
-  -  `$ yq w -i /usr/local/bigbluebutton/core/scripts/presentation.yml deskshare_output_width 1920`
-  -  `$ yq w -i /usr/local/bigbluebutton/core/scripts/presentation.yml deskshare_output_height 1080`
-  -  `$ yq w -i /usr/local/bigbluebutton/core/scripts/presentation.yml deskshare_output_framerate 15`
+  -  `$ yq e -i '.deskshare_output_width = 1920' /usr/local/bigbluebutton/core/scripts/presentation.yml`
+  -  `$ yq e -i '.deskshare_output_height = 1080' /usr/local/bigbluebutton/core/scripts/presentation.yml`
+  -  `$ yq e -i '.deskshare_output_framerate = 15' /usr/local/bigbluebutton/core/scripts/presentation.yml`
 
 For **live meetings**, the following parameters can be changed:
   - `/etc/bigbluebutton/bbb-html5.yml`: `public.kurento.screenshare.bitrate`


### PR DESCRIPTION
* 2ab81a2f0ef5799e60a1b1c9d67a7945d782850b
This set of changes was added to BBB 2.7 via https://github.com/bigbluebutton/bigbluebutton/pull/18884 and later ported to BBB 3.0 via https://github.com/bigbluebutton/bigbluebutton/pull/19098 However, the port was done after all the yq commands had been bulk-updated and was these three were thus missed.

* 3e9f2450ed3401913fef480e5bb03d8bf169b0eb
Missing / in the file path
On BBB 3.0 we no longer have a `bbb-html5` service, so need to restart
BigBlueButton in its entirety.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adjust the yq commands to the correct yq version's syntax.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22451

### Motivation
<!-- What inspired you to submit this pull request? -->
The old commands were only relevant to BBB <=2.7

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

```
 cat /usr/local/bigbluebutton/core/scripts/presentation.yml | grep deskshare
# Alternate output size to use when deskshare videos are present
# Set higher so that deskshare output is higher quality, but uses more space.
deskshare_output_width: 1280
deskshare_output_height: 720
deskshare_output_framerate: 5
include_deskshare: true
```

and then run the commands from the PR

```
 cat /usr/local/bigbluebutton/core/scripts/presentation.yml | grep deskshare
# Alternate output size to use when deskshare videos are present
# Set higher so that deskshare output is higher quality, but uses more space.
deskshare_output_width: 1920
deskshare_output_height: 1080
deskshare_output_framerate: 15
include_deskshare: true
```

You should notice the values changed.
