### PR TITLE
Fix(HTML5): Volume not being persisted on players remount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -264,6 +264,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   useEffect(() => {
     if (isPresenter !== presenterRef.current) {
+      const internalPlayer = playerRef.current?.getInternalPlayer();
+      const playerVolume = internalPlayer?.getVolume();
+      // the scale fiven by the player is 0 to 100, but the accepted scale is 0 to 1
+      // So we need to divide by 100
+      setVolume(playerVolume / 100);
       clientReloadedRef.current = true;
       setPlayerKey(uniqueId('react-player'));
       presenterRef.current = isPresenter;


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue of volume not being persisted through players when they're remounted, the react-player doesn't have any listener to volume changes, so I made it be get the volume before the remount of the player and set this as volume.


### Closes Issue(s)
Closes #21991

### How to test
- Join with two users.
- The One with presenter rights, share a video.
- Pass the presenter for the another user,
- Volume level of the video should not change.
- 
### More
[Screencast from 04-03-2025 09:31:24.webm](https://github.com/user-attachments/assets/64ddb9ea-89b1-4133-924b-c38081e7a54e)

