### PR TITLE
fix(whiteboard): Refetch shapes after toggling fit-to-width

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -59,6 +59,7 @@ const WhiteboardContainer = (props) => {
   const {
     intl,
     zoomChanger,
+    fitToWidth,
   } = props;
 
   const WHITEBOARD_CONFIG = window.meetingClientSettings.public.whiteboard;
@@ -288,7 +289,7 @@ const WhiteboardContainer = (props) => {
     if (isTabVisible && curPageId) {
       refetchInitialPageAnnotations();
     }
-  }, [isTabVisible, curPageId, presentationId]);
+  }, [isTabVisible, curPageId, presentationId, fitToWidth]);
 
   const processAnnotations = (data) => {
     let annotationsToBeRemoved = [];


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Refetchs whiteboard shapes after toggling fit-to-width.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22409

### Motivation

When toggling fit-to-width the whiteboard component is remounted (is that intentional?), so all previous shapes are lost (except the last one; it is kept as the last state of the annotation stream).