### PR TITLE
Fix missing top padding for NotificationBar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/styles.js
@@ -10,7 +10,7 @@ import {
 import Button from '/imports/ui/components/common/button/component';
 
 const NotificationsBar = styled.div`
-  padding-bottom: calc(${lineHeightComputed} / 2);
+  padding: calc(${lineHeightComputed} / 2) 0;
   gap: .5rem;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
### What does this PR do?
Fix issue with NotificationBar having uneven padding and a gap below to the chat/userlist.

### Motivation
Experienced visual consistency in BBB Community Call 2025-03-04

### Before
![image](https://github.com/user-attachments/assets/4c6fa99b-9efc-448f-918b-130bef741967)

![image](https://github.com/user-attachments/assets/31dd9cb7-3ace-4437-9cbe-00059aa91a46)


### After
![image](https://github.com/user-attachments/assets/bb0293ee-7e07-48ad-ab54-9307dea1d682)

![image](https://github.com/user-attachments/assets/e61a4aa0-99a0-4c4f-9fc5-3030e68bcc92)
