### PR TITLE
fix: Show users who have not responded to the poll results

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/poll/queries.ts
@@ -61,7 +61,7 @@ subscription getCurrentPollData {
       questionText
       ended
       multipleResponses
-      users(where: {responded: {_eq: true}}) {
+      users {
         user {
           name
           userId


### PR DESCRIPTION
### What does this PR do?

change poll results query to also show users who have not responded in live results.

### Closes Issue(s)
Closes #22456

### How to test
1. join a meeting with at least 2 users
2. start a poll
3. see live results in poll panel