### PR TITLE
fix: Client crash when exporting a presentation (not every time)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toast/presentation-uploader-toast/component.jsx
@@ -411,14 +411,14 @@ function renderToastExportItem(item, intl) {
   );
 }
 
-function renderExportToast(presToShow, intl) {
+function renderExportToast(presToShow, intl, exportToastId) {
   const isAllExported = presToShow.every(
     (p) => p.exportToChatStatus === EXPORT_STATUSES.EXPORTED,
   );
-  const shouldDismiss = isAllExported && this.exportToastId;
+  const shouldDismiss = isAllExported && exportToastId;
 
   if (shouldDismiss) {
-    handleDismissToast(this.exportToastId);
+    handleDismissToast(exportToastId);
     return null;
   }
 
@@ -502,11 +502,11 @@ export const PresentationUploaderToast = ({
     if (exportingPres && exportingPres.length > 0) {
       if (toast.isActive(exportToastIdRef.current)) {
         toast.update(exportToastIdRef.current, {
-          render: renderExportToast(exportingPres, intl),
+          render: renderExportToast(exportingPres, intl, exportToastIdRef.current),
         });
       } else {
         toast(
-          renderExportToast(exportingPres, intl), {
+          renderExportToast(exportingPres, intl, exportToastIdRef.current), {
             hideProgressBar: true,
             autoClose: false,
             newestOnTop: true,


### PR DESCRIPTION
### What does this PR do?

adjusts presentation uploader toast to prevent undefined toastId crash

### Closes Issue(s)
Closes #22463