### PR TITLE
Fix(html5): Non subscription error triggering 3006 error

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -72,12 +72,10 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     });
   }
 
+
   if (networkError) {
-    if (
-      networkError?.cause
-      // Mutations doesn't have extensions, only subscriptions
-      // @ts-ignore - extensions is not in the type definition
-      && networkError.cause.extensions) {
+    const isMutation = networkError.message.includes('graphql actions request failed');
+    if (!isMutation) {
       connectionStatus.setSubscriptionFailed(true);
     }
     logger.error(`[Network error]: ${networkError}`);

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -72,7 +72,6 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     });
   }
 
-
   if (networkError) {
     const isMutation = networkError.message.includes('graphql actions request failed');
     if (!isMutation) {

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -73,7 +73,13 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   }
 
   if (networkError) {
-    connectionStatus.setSubscriptionFailed(true);
+    if (
+      networkError?.cause
+      // Mutations doesn't have extensions, only subscriptions
+      // @ts-ignore - extensions is not in the type definition
+      && networkError.cause.extensions) {
+      connectionStatus.setSubscriptionFailed(true);
+    }
     logger.error(`[Network error]: ${networkError}`);
   }
 });


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where error 3006 was incorrectly displayed for network errors unrelated to subscriptions. I've updated the logic to filter errors based on subscription type.

### Closes Issue(s)
No issue opened.


### How to test
- Modify some mutation field to fail the request.
- Trigger the mutation.
- Don't see the error notification.
- Modify a subscription to failed (Add a invalid field).
- See the error.

