### PR TITLE
fix(html5): Prevent the whole audio modal from re-rendering

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import getFromUserSettings from '/imports/ui/services/users-settings';
@@ -92,7 +92,6 @@ const ActionsBarContainer = (props) => {
   };
   const amIPresenter = currentUserData?.presenter;
   const amIModerator = currentUserData?.isModerator;
-  const [pinnedPadDataState, setPinnedPadDataState] = useState(null);
   const { data: pinnedPadData } = useDeduplicatedSubscription(
     PINNED_PAD_SUBSCRIPTION,
   );

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -75,11 +75,11 @@ const AudioControls: React.FC<AudioControlsProps> = ({
     }
   }, []);
 
-  const openAudioSettings = (props: { unmuteOnExit?: boolean } = {}) => {
+  const openAudioSettings = useCallback((props: { unmuteOnExit?: boolean } = {}) => {
     setAudioModalContent('settings');
     setAudioModalProps(props);
     setIsAudioModalOpen(true);
-  };
+  }, []);
 
   const joinButton = useMemo(() => {
     const joinAudioLabel = away ? intlMessages.joinAudioAndSetActive : intlMessages.joinAudio;
@@ -113,17 +113,19 @@ const AudioControls: React.FC<AudioControlsProps> = ({
     }
   }, [isEchoTest]);
 
+  const setIsOpen = useCallback(() => {
+    setIsAudioModalOpen(false);
+    setAudioModalContent(null);
+    setAudioModalProps(null);
+  }, []);
+
   return (
     <Styled.Container>
       {!inAudio ? joinButton : <InputStreamLiveSelectorContainer openAudioSettings={openAudioSettings} />}
       {isAudioModalOpen && (
         <AudioModalContainer
           priority="low"
-          setIsOpen={() => {
-            setIsAudioModalOpen(false);
-            setAudioModalContent(null);
-            setAudioModalProps(null);
-          }}
+          setIsOpen={setIsOpen}
           isOpen={isAudioModalOpen}
           content={audioModalContent}
           unmuteOnExit={audioModalProps?.unmuteOnExit}
@@ -145,7 +147,11 @@ export const AudioControlsContainer: React.FC = () => {
   const { data: currentMeeting } = useMeeting((m: Partial<Meeting>) => ({
     lockSettings: m.lockSettings,
   }));
-  const [updateEchoTestRunning] = useMutation(UPDATE_ECHO_TEST_RUNNING);
+  const [updateEchoTestRunningMutation] = useMutation(UPDATE_ECHO_TEST_RUNNING);
+
+  const updateEchoTestRunning = useCallback(() => {
+    updateEchoTestRunningMutation();
+  }, []);
 
   // I access the internal variable to get the makevar reference,
   // so we doesn't broke the client that uses the value directly
@@ -166,12 +172,12 @@ export const AudioControlsContainer: React.FC = () => {
 
   return (
     <AudioControls
-      inAudio={!!currentUser.voice ?? false}
+      inAudio={!!currentUser.voice}
       isConnected={isConnected}
       disabled={(isConnecting || isHangingUp || !isClientConnected)}
       isEchoTest={isEchoTest}
       updateEchoTestRunning={updateEchoTestRunning}
-      away={currentUser.away || false}
+      away={currentUser.away ?? false}
       isConnecting={isConnecting}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -1,5 +1,6 @@
-import React, { useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 import { useReactiveVar } from '@apollo/client';
+import { isEqual } from 'radash';
 import browserInfo from '/imports/utils/browserInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import AudioModal from './component';
@@ -166,4 +167,4 @@ const AudioModalContainer = (props) => {
   );
 };
 
-export default AudioModalContainer;
+export default memo(AudioModalContainer, isEqual);


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Prevent the whole audio modal from re-rendering after calling the `UpdateUserClientEchoTestRunningAt` mutation.

**Before**

[Screencast from 05-03-2025 16:18:56.webm](https://github.com/user-attachments/assets/5a96ebef-1432-4fbc-8488-a1678ac3e29b)

**Now**

[Screencast from 05-03-2025 16:17:53.webm](https://github.com/user-attachments/assets/e9cefcac-868f-4ec3-9eed-d1501ecc4098)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #21672
