### PR TITLE
Fix(html5): Make modal z-index be under notification z-index

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
@@ -386,7 +386,7 @@ const UploaderModal = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1300;
+  z-index: 900;
 `;
 
 const ModalInner = styled.div`

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -66,7 +66,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   .fullscreenModalOverlay {
-    z-index: 1000;
+    z-index: 900;
     background: #fff;
     display: flex;
     align-items: center;


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where notifications did not appear over fullscreen modals due to the modal's z-index being higher than that of notifications. I've adjusted the modal's z-index to be below notifications while keeping it relatively high.


### Closes Issue(s)
Closes #21435

### How to test
- Click to Raise Hand.
- Open a fullscreen modal (Like create breakout room).


### More
![image](https://github.com/user-attachments/assets/50b63e14-ca15-4dd6-b36f-925309f486f3)

