### PR TITLE
Fix(html5): Add more details for error log on rtt fail

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -75,6 +75,9 @@ const ConnectionStatus = () => {
               logCode: 'rtt_failed_to_register_user_history',
               extraInfo: {
                 error,
+                errorMessage: error.message,
+                errorStack: error.stack,
+                errorCause: error.cause,
               },
             }, 'Error registering user network history');
           }


### PR DESCRIPTION
### What does this PR do?
This PR add more details for the log `rtt_failed_to_register_user_history` to spot whats causing it on server side logs.

