### PR TITLE
Fix(html5): User leave notification burst

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/service.ts
@@ -80,7 +80,7 @@ const playLeaveAudioAlert = throttle(() => {
   new Audio(`${window.meetingClientSettings.public.app.cdn
     + window.meetingClientSettings.public.app.basename}`
     + '/resources/sounds/userJoin.mp3').play();
-}, 5000, { leading: true, trailing: false });
+}, 500, { leading: true, trailing: false });
 
 export const userLeavePushAlert = (
   notification: Notification,

--- a/bigbluebutton-html5/imports/ui/components/notifications/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/service.ts
@@ -76,6 +76,12 @@ export const userJoinPushAlert = (
   }
 };
 
+const playLeaveAudioAlert = throttle(() => {
+  new Audio(`${window.meetingClientSettings.public.app.cdn
+    + window.meetingClientSettings.public.app.basename}`
+    + '/resources/sounds/userJoin.mp3').play();
+}, 5000, { leading: true, trailing: false });
+
 export const userLeavePushAlert = (
   notification: Notification,
   notifier: (notification: Notification) => void,
@@ -90,9 +96,7 @@ export const userLeavePushAlert = (
   if (!userLeaveAudioAlerts && !userLeavePushAlerts) return;
 
   if (userLeaveAudioAlerts) {
-    new Audio(`${window.meetingClientSettings.public.app.cdn
-      + window.meetingClientSettings.public.app.basename}`
-      + '/resources/sounds/userJoin.mp3').play();
+    playLeaveAudioAlert();
   }
 
   if (userLeavePushAlerts) {


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the leave notification audio was played multiple times when several users left the meeting simultaneously, given that the 'notify user leave' setting was enabled. I've added a throttle to ensure the audio plays at most once every 5 seconds when multiple users leave.

### Closes Issue(s)
Closes #22440

### How to test
- Join a meeting.
- In setting under notification tab, enable `user leave` audio notification.
- Join with several users (10-15).
- Leave with this users.

