### PR TITLE
fix(bbb-export-annotations): fix image export being blank

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -312,14 +312,14 @@ async function processPresentationAnnotations() {
         `slide${currentSlide.page}.svg`);
 
     let backgroundFormat = '';
-    if (fs.existsSync(svgBackgroundSlide)) {
-      backgroundFormat = 'svg';
-    } else if (fs.existsSync(`${bgImagePath}.png`)) {
+    if (fs.existsSync(`${bgImagePath}.png`)) {
       backgroundFormat = 'png';
     } else if (fs.existsSync(`${bgImagePath}.jpg`)) {
       backgroundFormat = 'jpg';
     } else if (fs.existsSync(`${bgImagePath}.jpeg`)) {
       backgroundFormat = 'jpeg';
+    } else if (fs.existsSync(svgBackgroundSlide)) {
+      backgroundFormat = 'svg';
     } else {
       logger.error(`Skipping slide ${currentSlide.page} (${jobId}): unknown extension`);
       continue;


### PR DESCRIPTION
### What does this PR do?

This fix the problem when exporting a presentation of type image, it goes completely blank.

### Closes Issue(s)

Closes #22219

### How to test

Pretty simple:

- Checkout to this branch;
- Run `bbb-export-annotations` (you can `cd bbb-export-annotations`, then `./deploy.sh`);
- Create a meeting;
- Upload an image as a presentation;
- (optional) Make some annotations onto the whiteboard;
- Open the modal to upload a presentation;
- Click the 3 dots dropdown and click "Send out a download link for the presentation including annotations";
- Download the presentation from the chat message;
- See results. 


### More
**Technical view:**
In 2.7, we processed image typed presentations and transformed them into PDFs (The final structure of their assets was the same - it even had a pdf instead of image), so the flow for exporting an image was the same as a PDF, and worked;

In 3.0 we decided to maintain the image in the assets folder of the presentation (the structure is not of PDF anymore, even though it still has the `svg` folder) and we took out the PDF asset from there. So basically, what happened in 3.0 was that:
- First, the bbb-export-annotations check for an image (which is now present due to our recent changes), so it saves the image in a temporary folder (in our case, let's take for instance a JPG);
- Then later on the code, it will check first in the assets folder of the presentation if there is an SVG there (which there is, because in the process of the presentation we create them), so the bbb-export-annotation will take this presentation as a PDF and search in the temporary folder, previously created, for the SVGs (which are not there, because we copied over an image, in our case, a JPG). The result is quite obvious: The script we use throw an error (which is silent because is just a script - the `/usr/bin/cairosvg`) and the PDF created by the bbb-export-annotations is blank since there is no data to save over it;
- So basically, the fix moves the check for the SVG (the last portion of the flow) to be later on relative to the check for the image types (in our case `JPG`), when it finds the JPG, which exists in the assets folder of the presentation, it will consider that extension to be the type of the file in the temporary folder previously created. So now everything falls into place, and the script can find the file.  
 

Quick demo video:

https://github.com/user-attachments/assets/33cca504-a7bd-400a-9f0f-67e04ab0dd0e




