### PR TITLE
Fix(html5): Add support for Tab on keyboard navigation over user list

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/utils/keyboardRove.ts
+++ b/bigbluebutton-html5/imports/ui/core/utils/keyboardRove.ts
@@ -8,7 +8,7 @@ const roveBuilder = (
   const isActionKey = ev.code === 'Enter' || ev.code === 'Space';
   const isInitialArrowDown = ev.code === 'ArrowDown' && selectedRef.current !== document.activeElement;
   const firstSelect = selectedRef.current !== document.activeElement;
-  if (isActionKey || isInitialArrowDown || (ev.code === 'Tab' && firstSelect)) {
+  if (isActionKey || isInitialArrowDown || ((ev.code === 'Tab' && firstSelect) && !ev.shiftKey)) {
     ev.preventDefault();
     ev.stopPropagation();
     if (selectedRef.current && (selectedRef.current === document.activeElement)) {

--- a/bigbluebutton-html5/imports/ui/core/utils/keyboardRove.ts
+++ b/bigbluebutton-html5/imports/ui/core/utils/keyboardRove.ts
@@ -7,7 +7,8 @@ const roveBuilder = (
 ) => (ev: React.KeyboardEvent<HTMLDivElement>) => {
   const isActionKey = ev.code === 'Enter' || ev.code === 'Space';
   const isInitialArrowDown = ev.code === 'ArrowDown' && selectedRef.current !== document.activeElement;
-  if (isActionKey || isInitialArrowDown) {
+  const firstSelect = selectedRef.current !== document.activeElement;
+  if (isActionKey || isInitialArrowDown || (ev.code === 'Tab' && firstSelect)) {
     ev.preventDefault();
     ev.stopPropagation();
     if (selectedRef.current && (selectedRef.current === document.activeElement)) {


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the 'Tab' key was not selecting the user list during keyboard navigation. The issue occurred because 'Tab' was not mapped in the rove navigation function, which has now been corrected.


### Closes Issue(s)
Closes #22466

### How to test
- Join a meeting
- Navigate using keyboard til select the user list 
- Press tab to Select it


### More
[Screencast from 06-03-2025 10:52:10.webm](https://github.com/user-attachments/assets/8bc4a058-eb4f-4503-acfc-7b9d6b5b86c5)

