### PR TITLE
Accessibility improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/component.tsx
@@ -135,13 +135,13 @@ const ChatHeaderContainer: React.FC = () => {
     : intl.formatMessage(intlMessages.titlePrivate, { 0: chatData?.chat[0]?.participant?.name });
   return (
     <>
-    <h2 class="sr-only">{title}</h2>
-    <ChatHeader
-      chatId={idChatOpen}
-      isPublicChat={isPublicChat}
-      title={title}
-      isRTL={isRTL}
-    />
+      <h2 className="sr-only">{title}</h2>
+      <ChatHeader
+        chatId={idChatOpen}
+        isPublicChat={isPublicChat}
+        title={title}
+        isRTL={isRTL}
+      />
     </>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/component.tsx
@@ -134,12 +134,15 @@ const ChatHeaderContainer: React.FC = () => {
   const title = isPublicChat ? intl.formatMessage(intlMessages.titlePublic)
     : intl.formatMessage(intlMessages.titlePrivate, { 0: chatData?.chat[0]?.participant?.name });
   return (
+    <>
+    <h2 class="sr-only">{title}</h2>
     <ChatHeader
       chatId={idChatOpen}
       isPublicChat={isPublicChat}
       title={title}
       isRTL={isRTL}
     />
+    </>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -256,7 +256,6 @@ class BBBMenu extends React.Component {
           }}
           accessKey={accessKey}
           ref={(ref) => this.anchorElRef = ref}
-          role="button"
           tabIndex={-1}
         >
           {trigger}

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -141,27 +141,27 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
       {!isOnMediaArea ? (
         // @ts-ignore Until everything in Typescript
         <>
-        <h2 class="sr-only">{intl.formatMessage(intlMessages.title)}</h2>
-        <Header
-          leftButtonProps={{
-            onClick: () => {
-              layoutContextDispatch({
-                type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-                value: false,
-              });
-              layoutContextDispatch({
-                type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-                value: PANELS.NONE,
-              });
-            },
-            'data-test': 'hideNotesLabel',
-            'aria-label': intl.formatMessage(intlMessages.hide),
-            label: intl.formatMessage(intlMessages.title),
-          }}
-          customRightButton={
-            <NotesDropdown handlePinSharedNotes={handlePinSharedNotes} presentationEnabled={isPresentationEnabled} />
+          <h2 className="sr-only">{intl.formatMessage(intlMessages.title)}</h2>
+          <Header
+            leftButtonProps={{
+              onClick: () => {
+                layoutContextDispatch({
+                  type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+                  value: false,
+                });
+                layoutContextDispatch({
+                  type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+                  value: PANELS.NONE,
+                });
+              },
+              'data-test': 'hideNotesLabel',
+              'aria-label': intl.formatMessage(intlMessages.hide),
+              label: intl.formatMessage(intlMessages.title),
+            }}
+            customRightButton={
+              <NotesDropdown handlePinSharedNotes={handlePinSharedNotes} presentationEnabled={isPresentationEnabled} />
           }
-        />
+          />
         </>
       ) : renderHeaderOnMedia()}
       <PadContainer

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -140,6 +140,8 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     >
       {!isOnMediaArea ? (
         // @ts-ignore Until everything in Typescript
+        <>
+        <h2 class="sr-only">{intl.formatMessage(intlMessages.title)}</h2>
         <Header
           leftButtonProps={{
             onClick: () => {
@@ -160,6 +162,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
             <NotesDropdown handlePinSharedNotes={handlePinSharedNotes} presentationEnabled={isPresentationEnabled} />
           }
         />
+        </>
       ) : renderHeaderOnMedia()}
       <PadContainer
         externalId={NOTES_CONFIG.id}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -254,7 +254,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings, index }
       </Styled.Avatar>
       <Styled.UserNameContainer>
         <Styled.UserName>
-          <TooltipContainer title={user.name}>
+          <TooltipContainer title={user.name} role="button">
             <span>{user.name}</span>
           </TooltipContainer>
           &nbsp;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
@@ -136,6 +136,7 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
         role="button"
         tabIndex={0}
         active={notesOpen}
+        aria-expanded={notesOpen}
         data-test="sharedNotesButton"
         onClick={() => toggleNotesPanel(sidebarContentPanel, layoutContextDispatch)}
         // @ts-ignore

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
@@ -310,6 +310,7 @@ const UserActions: React.FC<UserActionProps> = (props) => {
                 tabIndex={0}
                 data-test="dropdownWebcamButton"
                 $isRTL={isRTL}
+                role="button"
               >
                 {name}
               </Styled.DropdownTrigger>


### PR DESCRIPTION
### What does this PR do?
Improves accessibility of BBB for screen reader users:

- add headings to chat and shared notes panels so screen reader users can navigate to them
- remove double button roles for menu buttons

### Motivation

BBB should be the number 1 virtual class room and videoconferencing software for everyone.

### How to test

- open either chat or shared notes panel
- in screen reader open the navigate by headings tool
- see the added navigation entry

### More

I hope I caught all cases where children of `BBBMenu` are not a `<button>` element.