### PR TITLE
test: Remove flaky flag from chat test

### DIFF
--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -42,8 +42,7 @@ test.describe('Chat', { tag: '@ci' }, () => {
     await chat.emptyMessage();
   });
 
-  test('Copy and paste public message', { tag: '@flaky' }, async () => {
-    linkIssue(22198);
+  test('Copy and paste public message', async () => {
     await chat.copyPastePublicMessage();
   })
 


### PR DESCRIPTION
### What does this PR do?
Re-enables `Chat › Copy and paste public message` test in CI as https://github.com/bigbluebutton/bigbluebutton/issues/22198 got fixed