### PR TITLE
fix (akka-apps): Prevents line breaks in logs

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -196,6 +196,7 @@ class BigBlueButtonActor(
 
   def handleCreateMeetingReqMsg(msg: CreateMeetingReqMsg): Unit = {
     log.debug("RECEIVED CreateMeetingReqMsg msg {}", msg)
+    //    log.debug("RECEIVED CreateMeetingReqMsg msg {}", msg.toString.replaceAll("\n", " "))
 
     RunningMeetings.findWithId(meetings, msg.body.props.meetingProp.intId) match {
       case None =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -196,7 +196,6 @@ class BigBlueButtonActor(
 
   def handleCreateMeetingReqMsg(msg: CreateMeetingReqMsg): Unit = {
     log.debug("RECEIVED CreateMeetingReqMsg msg {}", msg)
-    //    log.debug("RECEIVED CreateMeetingReqMsg msg {}", msg.toString.replaceAll("\n", " "))
 
     RunningMeetings.findWithId(meetings, msg.body.props.meetingProp.intId) match {
       case None =>

--- a/akka-bbb-apps/src/universal/conf/logback.xml
+++ b/akka-bbb-apps/src/universal/conf/logback.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"} %-5level %logger{35} - %msg%n</Pattern>
+      <Pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"} %-5level %logger{35} - %replace(%msg){'[\n\r]', ' '}%n</Pattern>
     </layout>
-</appender>
+  </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <File>logs/bbb-apps-akka.log</File>
@@ -14,17 +14,17 @@
       <MaxHistory>14</MaxHistory>
     </rollingPolicy>
     <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"} %-5level %logger{35} - %msg%n</Pattern>
+      <Pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"} %-5level %logger{35} - %replace(%msg){'[\n\r]', ' '}%n</Pattern>
     </layout>
   </appender>
-      
-    <logger name="akka" level="INFO" />
-    <logger name="org.bigbluebutton" level="DEBUG" />
-    <logger name="io.lettuce" level="INFO" />
-    <logger name="slick" level="INFO" />
 
-    <root level="DEBUG">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="FILE" />
-    </root>
+  <logger name="akka" level="INFO" />
+  <logger name="org.bigbluebutton" level="DEBUG" />
+  <logger name="io.lettuce" level="INFO" />
+  <logger name="slick" level="INFO" />
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="FILE" />
+  </root>
 </configuration>


### PR DESCRIPTION
Modify logback to replace \n with spaces in log output.

Before:
![createmeeting-before](https://github.com/user-attachments/assets/b2543597-d1da-4da0-9bb4-b2eac2aab82d)

After:
![image](https://github.com/user-attachments/assets/3fca135a-12ec-4922-9675-51cf9f9e777c)

