### PR TITLE
fix (html5): Tweak textToMarkdown to handle images properly

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -6,7 +6,6 @@ export const textToMarkdown = (message: string) => {
   // Process the message by separating code blocks from regular text
   const segments = [];
   const CODE_BLOCK_REGEX = /```([\s\S]*?)```/g;
-  const IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]*)\)/g;
 
   let lastIndex = 0;
   let match = CODE_BLOCK_REGEX.exec(parsedMessage);
@@ -52,18 +51,126 @@ export const textToMarkdown = (message: string) => {
     if (segment.type === 'code') {
       return segment.content;
     }
-    const { content } = segment;
 
-    // Check if there are any image markdown
-    const hasImageMarkdown = IMAGE_REGEX.test(content);
-    // Reset the regex lastIndex
+    let { content } = segment;
+
+    // First, handle image markdown similar to how we handle links
+    const IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]*)\)/g;
+    const containsImages = IMAGE_REGEX.test(content);
     IMAGE_REGEX.lastIndex = 0;
 
-    if (hasImageMarkdown) {
-      return content;
+    if (containsImages) {
+      // Create a placeholder for each part of the text
+      const imageParts = [];
+      let lastIdx = 0;
+      let imageMatch;
+
+      // Extract image markdown
+      // eslint-disable-next-line no-cond-assign
+      while ((imageMatch = IMAGE_REGEX.exec(content)) !== null) {
+        // Add text before this image (if any)
+        if (imageMatch.index > lastIdx) {
+          const textBefore = content.substring(lastIdx, imageMatch.index);
+          imageParts.push({
+            type: 'text',
+            content: textBefore,
+          });
+        }
+
+        // Add the image markdown
+        imageParts.push({
+          type: 'image',
+          content: imageMatch[0],
+        });
+
+        lastIdx = imageMatch.index + imageMatch[0].length;
+      }
+
+      // Add remaining text after last image (if any)
+      if (lastIdx < content.length) {
+        imageParts.push({
+          type: 'text',
+          content: content.substring(lastIdx),
+        });
+      }
+
+      // Now process each part for links
+      const processedImageParts = imageParts.map((part) => {
+        if (part.type === 'image') {
+          return part.content; // Keep image markdown as-is
+        }
+
+        // Process text parts for links
+        const textContent = part.content;
+
+        // URL regex without lookbehind
+        const urlRegex = /(http(s)?:\/\/)[-a-zA-Z0-9@:%._+~#=,ß]{2,256}\.[a-z0-9]{2,6}\b([-a-zA-Z0-9@:%_+.~#!?&//=,ß]*)?/g;
+
+        // Handle URLs without using lookbehind
+        const markdownLinkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+        // Check if content already contains markdown links
+        const hasMarkdownLinks = markdownLinkRegex.test(textContent);
+        markdownLinkRegex.lastIndex = 0;
+
+        if (hasMarkdownLinks) {
+          // Handle links in a way similar to how we handled images
+          const linkParts = [];
+          let linkLastIdx = 0;
+          let linkMatch;
+
+          // Extract existing markdown links
+          // eslint-disable-next-line no-cond-assign
+          while ((linkMatch = markdownLinkRegex.exec(textContent)) !== null) {
+            // Add text before this link (if any)
+            if (linkMatch.index > linkLastIdx) {
+              const textBefore = textContent.substring(linkLastIdx, linkMatch.index);
+              linkParts.push({
+                type: 'text',
+                content: textBefore,
+              });
+            }
+
+            // Add the existing markdown link
+            linkParts.push({
+              type: 'link',
+              content: linkMatch[0],
+            });
+
+            linkLastIdx = linkMatch.index + linkMatch[0].length;
+          }
+
+          // Add remaining text after last link (if any)
+          if (linkLastIdx < textContent.length) {
+            linkParts.push({
+              type: 'text',
+              content: textContent.substring(linkLastIdx),
+            });
+          }
+
+          // Process each part appropriately
+          const processedLinkParts = linkParts.map((linkPart) => {
+            if (linkPart.type === 'link') {
+              return linkPart.content; // Keep existing markdown links as-is
+            }
+            // Convert URLs to markdown links in text parts only
+            return linkPart.content.replace(urlRegex, '[$&]($&)');
+          });
+
+          // Join all parts back together
+          return processedLinkParts.join('');
+        }
+
+        // If no existing markdown links, simply convert all URLs
+        return textContent.replace(urlRegex, '[$&]($&)');
+      });
+
+      // Join all image parts back together
+      return processedImageParts.join('');
     }
 
-    // URL regex without lookbehind (as it doesn't work on Safari older than 16.4
+    // If no images, proceed with link processing as before
+    // URL regex without lookbehind
     const urlRegex = /(http(s)?:\/\/)[-a-zA-Z0-9@:%._+~#=,ß]{2,256}\.[a-z0-9]{2,6}\b([-a-zA-Z0-9@:%_+.~#!?&//=,ß]*)?/g;
 
     // Handle URLs without using lookbehind
@@ -71,6 +178,7 @@ export const textToMarkdown = (message: string) => {
 
     // Check if content already contains markdown links
     const hasMarkdownLinks = markdownLinkRegex.test(content);
+    markdownLinkRegex.lastIndex = 0;
 
     // If content already has markdown links, use a different approach
     if (hasMarkdownLinks) {
@@ -78,9 +186,6 @@ export const textToMarkdown = (message: string) => {
       const parts = [];
       let lastIdx = 0;
       let linkMatch;
-
-      // Reset regex lastIndex
-      markdownLinkRegex.lastIndex = 0;
 
       // Extract existing markdown links
       // eslint-disable-next-line no-cond-assign

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -52,7 +52,7 @@ export const textToMarkdown = (message: string) => {
       return segment.content;
     }
 
-    let { content } = segment;
+    const { content } = segment;
 
     // First, handle image markdown similar to how we handle links
     const IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]*)\)/g;
@@ -104,6 +104,7 @@ export const textToMarkdown = (message: string) => {
         const textContent = part.content;
 
         // URL regex without lookbehind
+        // eslint-disable-next-line max-len
         const urlRegex = /(http(s)?:\/\/)[-a-zA-Z0-9@:%._+~#=,ß]{2,256}\.[a-z0-9]{2,6}\b([-a-zA-Z0-9@:%_+.~#!?&//=,ß]*)?/g;
 
         // Handle URLs without using lookbehind


### PR DESCRIPTION
The links are not being converted to markdown if the message contains any image!

How to test: try to send this message:
```
![test](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/1200px-Google_2015_logo.svg.png)
https://www.google.com
```

Before:
![image](https://github.com/user-attachments/assets/ccb18610-74aa-4001-9ffd-c44595a1a91a)


After:
![image](https://github.com/user-attachments/assets/2c915a57-cb04-474c-a4b4-16ffc7e78957)
