### PR TITLE
Fix(html5): Zoom not being persisted on presenter change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1406,7 +1406,7 @@ const Whiteboard = React.memo((props) => {
       zoomChanger(HUNDRED_PERCENT);
       zoomSlide(HUNDRED_PERCENT, HUNDRED_PERCENT, 0, 0);
     }
-  }, [fitToWidth, isPresenter]);
+  }, [fitToWidth]);
 
   React.useEffect(() => {
     if (
@@ -1681,7 +1681,6 @@ const Whiteboard = React.memo((props) => {
 
   React.useEffect(() => {
     setTldrawIsMounting(true);
-    isPresenterRef?.current && zoomChanger(HUNDRED_PERCENT);
     return () => {
       isMountedRef.current = false;
       localStorage.removeItem('initialViewBoxWidth');


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the zoom level was not persisted through presenter changes. The problem occurred because a logic intended for 'fitToWidth' was incorrectly applied during presenter transitions.

### Closes Issue(s)
Part of #21873,  fitToWidth fix will be a follow up PR, because fit to width currently is a local state on client, not a meeting wide information, so more internal changed are needed.

### How to test
- Join a meeting with two users.
- Zoom in with presenter user.
- Make another user Presenter.


### More
[Screencast from 07-03-2025 11:45:29.webm](https://github.com/user-attachments/assets/53bf9c52-ee19-408d-9b39-7cad7b83c073)

