### PR TITLE
fix: only use AbortSignal.timeout if available

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -43,9 +43,13 @@ const ConnectionStatus = () => {
 
   const handleUpdateConnectionAliveAt = () => {
     const startTime = performance.now();
+    const fetchOptions = {
+      signal: AbortSignal.timeout ? AbortSignal.timeout(STATS_TIMEOUT) : undefined,
+    };
+
     fetch(
       `${getBaseUrl()}/rtt-check`,
-      { signal: AbortSignal.timeout(STATS_TIMEOUT) },
+      fetchOptions,
     )
       .then((res) => {
         if (res.ok && res.status === 200) {


### PR DESCRIPTION
### What does this PR do?

Attempts to fix an error that only happens in older Safari versions, due to AbortSignal.timeout not being available

### How to test
1. join a meeting on Safari 15
2. see whiteboard