### PR TITLE
Fix captions getting stuck and showing with wrong timing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
@@ -16,13 +16,11 @@ interface AudioCaptionsLiveProps {
 const AudioCaptionsLive: React.FC<AudioCaptionsLiveProps> = ({
   captions,
 }) => {
-  const CAPTIONS_CONFIG = window.meetingClientSettings.public.captions;
-  const LINES_PER_MESSAGE = CAPTIONS_CONFIG.lines;
   return (
     <Styled.Wrapper>
       <>
         {
-          captions.length > 0 && captions.length <= LINES_PER_MESSAGE ? captions.map((caption) => {
+          captions.length > 0 ? captions.map((caption) => {
             const {
               user,
               captionText,

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -50,7 +50,7 @@ export const splitTranscript = (obj: Caption) => {
       captionText: t,
       // if messages where split the captions will have a 'part' id
       captionId: `${obj.captionId}-${i}`,
-      };
+    };
   });
 };
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -9,7 +9,9 @@ export const splitTranscript = (obj: Caption) => {
   const CAPTIONS_CONFIG = window.meetingClientSettings.public.captions;
   const CHARACTERS_PER_LINE = CAPTIONS_CONFIG.lineLimit;
   const LINES_PER_MESSAGE = CAPTIONS_CONFIG.lines;
-  const transcripts = [];
+  const CAPTION_LIMIT = CAPTIONS_CONFIG.captionLimit;
+
+  let transcripts = [];
   const words = obj.captionText.split(' ');
 
   let currentLine = '';
@@ -35,7 +37,19 @@ export const splitTranscript = (obj: Caption) => {
   }
   transcripts.push(currentLine.trim());
 
-  return transcripts.map((t) => { return { ...obj, captionText: t }; });
+  // If there are more caption objects than CAPTION_LIMIT
+  // just get the last N captions
+  transcripts = transcripts.slice(-CAPTION_LIMIT);
+
+  let i = 0;
+  return transcripts.map((t) => {
+    i+=1;
+    return {  ...obj,
+      captionText: t,
+      // if messages where split the captions will have a 'part' id
+      captionId: `${obj.captionId}-${i}`
+    };
+  });
 };
 
 export const useIsAudioTranscriptionEnabled = () => useIsLiveTranscriptionEnabled();

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -43,12 +43,14 @@ export const splitTranscript = (obj: Caption) => {
 
   let i = 0;
   return transcripts.map((t) => {
-    i+=1;
-    return {  ...obj,
+    i += 1;
+
+    return {
+      ...obj,
       captionText: t,
       // if messages where split the captions will have a 'part' id
-      captionId: `${obj.captionId}-${i}`
-    };
+      captionId: `${obj.captionId}-${i}`,
+      };
   });
 };
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -160,12 +160,19 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
   };
 
   const onEnd = useCallback(() => {
+    logger.debug({
+      logCode: 'captions_speech_recognition_ended',
+    }, 'Captions speech recognition ended by browser');
+
     stop();
+    if (!mutedRef.current) {
+      logger.debug("Speech recogniction ended by browser, but we're not muted. Restart it");
+      start(localeRef.current);
+    }
   }, []);
   const onError = useCallback((event: SpeechRecognitionErrorEvent) => {
-    stop();
     logger.error({
-      logCode: 'captions_speech_recognition',
+      logCode: 'captions_speech_recognition_error',
       extraInfo: {
         error: event.error,
         message: event.message,
@@ -212,6 +219,7 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
       if (!isFinal) {
         const { id } = resultRef.current;
         updateFinalTranscript(id, transcript, localeRef.current);
+        resultRef.current.isFinal = true;
         speechRecognitionRef.current.abort();
       } else {
         speechRecognitionRef.current.stop();


### PR DESCRIPTION
This fixes several problems with the captions UI elements:

- We need to respect the captionLimit value from settings.yml properly, it should show the last 'N' captions when we split it in too many elements
- Sometimes the browser will throw speech recognition errors and/or end the transcription because of inactivity. We detect those cases and restart the transcription