### PR TITLE
Fix(html5): Rtt error when trying to register instability on network

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -145,6 +145,16 @@ const ConnectionStatusContainer = () => {
   }
 
   if (error) {
+    connectionStatus.setSubscriptionFailed(true);
+    logger.error(
+      {
+        logCode: 'subscription_Failed',
+        extraInfo: {
+          error,
+        },
+      },
+      'Subscription failed to load',
+    );
     return null;
   }
 

--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useMutation } from '@apollo/client';
 import { UPDATE_CONNECTION_ALIVE_AT } from './mutations';
 import {
@@ -11,23 +11,15 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import getStatus from '../../core/utils/getStatus';
 import logger from '/imports/startup/client/logger';
 
-const ConnectionStatus = () => {
+const ConnectionStatus = ({
+  user,
+}) => {
   const STATS_INTERVAL = window.meetingClientSettings.public.stats.interval;
   const STATS_TIMEOUT = window.meetingClientSettings.public.stats.timeout;
   const networkRttInMs = useRef(0); // Ref to store the last rtt
   const timeoutRef = useRef(null);
 
   const [updateConnectionAliveAtM] = useMutation(UPDATE_CONNECTION_ALIVE_AT);
-
-  const {
-    data,
-  } = useCurrentUser((u) => ({
-    userId: u.userId,
-    avatar: u.avatar,
-    isModerator: u.isModerator,
-    color: u.color,
-    currentlyInMeeting: u.currentlyInMeeting,
-  }));
 
   const setErrorOnRtt = (error) => {
     logger.error({
@@ -69,7 +61,7 @@ const ConnectionStatus = () => {
 
             if (Object.keys(rttLevels).includes(rttStatus)) {
               connectionStatus.addUserNetworkHistory(
-                data,
+                user,
                 rttStatus,
                 Date.now(),
               );
@@ -136,4 +128,27 @@ const ConnectionStatus = () => {
   return null;
 };
 
-export default ConnectionStatus;
+const ConnectionStatusContainer = () => {
+  const {
+    data,
+    error,
+  } = useCurrentUser((u) => ({
+    userId: u.userId,
+    avatar: u.avatar,
+    isModerator: u.isModerator,
+    color: u.color,
+    currentlyInMeeting: u.currentlyInMeeting,
+  }));
+
+  if (!data) {
+    return null;
+  }
+
+  if (error) {
+    return null;
+  }
+
+  return <ConnectionStatus user={data} />;
+};
+
+export default ConnectionStatusContainer;


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where, during client instability, an attempt to register the event in local history could fail. The issue occurred because the function used to calculate RTT did not verify whether user data was available, leading to null values in function calls. I resolved this by moving the data fetching outside the component, ensuring user data is available before starting the RTT calculation.

Although it is an error log, a failure would not cause any harm to the client's usability (like a crash). The only affected component would be the connection status modal, where the "My logs" tab would not display local logs if the client was completely offline.

### Closes Issue(s)
No issue opened.

### How to test
- Join a meeting
- Open devtools 
- Navigate to Network tab 
- On throttling dropdown Select 3G

### More
Before: 
![Screenshot from 2025-03-07 20-09-12](https://github.com/user-attachments/assets/a9dbdb1a-3747-4ce4-ac47-e24137610793)

After:
![Screenshot from 2025-03-07 20-12-29](https://github.com/user-attachments/assets/8411c555-a3cb-4858-8665-ecba53831032)


