### PR TITLE
fix(whiteboard): Default to Draw tool on tldraw mount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1113,7 +1113,9 @@ const Whiteboard = React.memo((props) => {
       };
 
       if (!isPresenterRef.current && !hasWBAccessRef.current) {
-        editor.setCurrentTool('noop');
+        editor?.setCurrentTool('noop');
+      } else {
+        editor?.setCurrentTool('draw');
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR sets the default active tool to the Draw tool when mounting tldraw.

### Motivation
It was requested that the Draw tool be selected by default upon mount, eliminating the extra step of manually activating it and improving usability.

