### PR TITLE
fix (akka-apps): Increase default akka-apps LimitNOFILE to 4096

### DIFF
--- a/akka-bbb-apps/src/templates/systemloader/systemd/start-template
+++ b/akka-bbb-apps/src/templates/systemloader/systemd/start-template
@@ -20,7 +20,7 @@ ExecStartPre=/bin/mkdir -p /run/bbb-apps-akka
 ExecStartPre=/bin/chown bigbluebutton:bigbluebutton /run/bbb-apps-akka
 ExecStartPre=/bin/chmod 755 /run/bbb-apps-akka
 PermissionsStartOnly=true
-LimitNOFILE=1024
+LimitNOFILE=4096
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target


### PR DESCRIPTION
Setting `LimitNOFILE=4096` will be fine for servers meeting BigBlueButton’s minimum requirements, safely handling the necessary file descriptors without issue.

`4096` is also the value used for `bbb-graphql-middleware` and `bbb-graphql-server`.

Closes: #22338