### PR TITLE
test: Re-enable reconnection tests

### DIFF
--- a/bigbluebutton-tests/playwright/reconnection/reconnection.js
+++ b/bigbluebutton-tests/playwright/reconnection/reconnection.js
@@ -2,7 +2,7 @@ const { expect } = require('@playwright/test');
 const { MultiUsers } = require('../user/multiusers');
 const e = require('../core/elements');
 const { killConnection } = require('./util');
-const { ELEMENT_WAIT_TIME } = require('../core/constants');
+const { ELEMENT_WAIT_TIME, ELEMENT_WAIT_EXTRA_LONG_TIME } = require('../core/constants');
 
 class Reconnection extends MultiUsers {
   constructor(browser, context) {
@@ -25,8 +25,8 @@ class Reconnection extends MultiUsers {
     ]);
 
     // reconnected -> chat enabled
+    await this.modPage.wasRemoved(e.notificationBannerBar, 'notification bar should be removed after reconnecting successfully', ELEMENT_WAIT_EXTRA_LONG_TIME);
     await expect(chatBoxLocator, 'chat box should be enabled again after reconnecting successfully').toBeEnabled();
-    await this.modPage.wasRemoved(e.notificationBannerBar, 'notification bar should be removed after reconnecting successfully');
   }
 
   async microphone() {
@@ -43,7 +43,7 @@ class Reconnection extends MultiUsers {
     await this.modPage.hasText(e.notificationBannerBar, 'Reconnection in progress');
 
     // reconnected
-    await this.modPage.wasRemoved(e.notificationBannerBar, 'notification bar should be removed after reconnecting successfully');
+    await this.modPage.wasRemoved(e.notificationBannerBar, 'notification bar should be removed after reconnecting successfully', ELEMENT_WAIT_EXTRA_LONG_TIME);
 
     // audio connection should keep connected
     await this.modPage.hasElement(e.muteMicButton, 'user audio should keep connected after reconnection');

--- a/bigbluebutton-tests/playwright/reconnection/reconnection.spec.js
+++ b/bigbluebutton-tests/playwright/reconnection/reconnection.spec.js
@@ -2,10 +2,7 @@ const { test } = require('../fixtures');
 const { Reconnection } = require('./reconnection');
 const { checkRootPermission } = require('../core/helpers');
 
-test.describe.parallel('Reconnection', { tag: '@flaky' }, () => {
-  // @ci Note: both tests are failing due to "server closed connection" bug
-  // see issue https://github.com/bigbluebutton/bigbluebutton/issues/21147
-
+test.describe.parallel('Reconnection', () => {
   test('Chat', async ({ browser, context, page }) => {
     await checkRootPermission(); // check sudo permission before starting test
     const reconnection = new Reconnection(browser, context);


### PR DESCRIPTION
### What does this PR do?
Re-enables `Reconnection` tests as the blocking issue has been fixed