### PR TITLE
fix: typescript warning

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -158,6 +158,8 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
               'aria-label': intl.formatMessage(intlMessages.hide),
               label: intl.formatMessage(intlMessages.title),
             }}
+            data-test="notesHeader"
+            rightButtonProps={null}
             customRightButton={
               <NotesDropdown handlePinSharedNotes={handlePinSharedNotes} presentationEnabled={isPresentationEnabled} />
           }


### PR DESCRIPTION
### What does this PR do?

adds missing properties from shared notes header component

### Motivation
typescript code compilation step in ci was failing due to this