### PR TITLE
Refactor(html5, akka): Make fit to width be persisted between presenters changes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodHdlrs.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodHdlrs.scala
@@ -32,6 +32,7 @@ class PresentationPodHdlrs(implicit val context: ActorContext)
   with PresentationUploadedFileVirusErrorPubMsgHdlr
   with PresentationUploadedFileScanFailedPubMsgHdlr
   with PresentationConversionFailedErrorSysPubMsgHdlr
+  with SetPresentationFitToWidthCmdMsgHdlr
   with PresentationHasInvalidMimeTypeErrorPubMsgHdlr {
 
   val log = Logging(context.system, getClass)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresentationFitToWidthCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresentationFitToWidthCmdMsgHdlr.scala
@@ -1,0 +1,31 @@
+package org.bigbluebutton.core.apps.presentationpod
+import org.bigbluebutton.common2.msgs.{ SetPresentationFitToWidthCmdMsg }
+import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.PresPageDAO
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.running.LiveMeeting
+
+trait SetPresentationFitToWidthCmdMsgHdlr extends RightsManagementTrait {
+  this: PresentationPodHdlrs =>
+  def handle(
+      msg: SetPresentationFitToWidthCmdMsg, state: MeetingState2x,
+      liveMeeting: LiveMeeting, bus: MessageBus
+  ): MeetingState2x = {
+    if (liveMeeting.props.meetingProp.disabledFeatures.contains("infiniteWhiteboard")) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "Infinite whiteboard is disabled for this meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    } else if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "No permission to set infinite whiteboard."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    } else {
+      val pageId = msg.body.pageId
+      val fitToWidth = msg.body.fitToWidth;
+
+      PresPageDAO.updateFitToWidth(pageId, fitToWidth)
+    }
+    state
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPageDAO.scala
@@ -27,6 +27,8 @@ case class PresPageDbModel(
     maxImageHeight:  Int,
     uploadCompleted: Boolean,
     infiniteWhiteboard:  Boolean,
+    fitToWidth:  Boolean,
+
 )
 
 class PresPageDbTableDef(tag: Tag) extends Table[PresPageDbModel](tag, None, "pres_page") {
@@ -49,9 +51,10 @@ class PresPageDbTableDef(tag: Tag) extends Table[PresPageDbModel](tag, None, "pr
   val maxImageHeight = column[Int]("maxImageHeight")
   val uploadCompleted = column[Boolean]("uploadCompleted")
   val infiniteWhiteboard = column[Boolean]("infiniteWhiteboard")
+  val fitToWidth = column[Boolean]("fitToWidth")
 
   def * = (
-    pageId, presentationId, num, urlsJson, content, slideRevealed, current, xOffset, yOffset, widthRatio, heightRatio, width, height, viewBoxWidth, viewBoxHeight, maxImageWidth, maxImageHeight, uploadCompleted, infiniteWhiteboard
+    pageId, presentationId, num, urlsJson, content, slideRevealed, current, xOffset, yOffset, widthRatio, heightRatio, width, height, viewBoxWidth, viewBoxHeight, maxImageWidth, maxImageHeight, uploadCompleted, infiniteWhiteboard, fitToWidth
   ) <> (PresPageDbModel.tupled, PresPageDbModel.unapply)
 }
 
@@ -87,6 +90,7 @@ object PresPageDAO {
           maxImageHeight = 1080,
           uploadCompleted = page.converted,
           infiniteWhiteboard = page.infiniteWhiteboard,
+          fitToWidth = page.fitToWidth,
         )
       )
     )
@@ -129,6 +133,18 @@ object PresPageDAO {
     ).onComplete {
       case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated infiniteWhiteboard on PresPage table")
       case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating infiniteWhiteboard on PresPage: $e")
+    }
+  }
+
+  def updateFitToWidth(pageId: String, fitToWidth: Boolean): Unit = {
+    DatabaseConnection.db.run(
+      TableQuery[PresPageDbTableDef]
+        .filter(_.pageId === pageId)
+        .map(p => p.fitToWidth)
+        .update(fitToWidth)
+    ).onComplete {
+      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated fitToWidth on PresPage table")
+      case Failure(e)            => DatabaseConnection.logger.debug(s"Error updating fitToWidth on PresPage: $e")
     }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PresPresentationDAO.scala
@@ -180,6 +180,7 @@ object PresPresentationDAO {
               maxImageHeight = 1080,
               uploadCompleted = page._2.converted,
               infiniteWhiteboard = page._2.infiniteWhiteboard,
+              fitToWidth = page._2.fitToWidth,
             )
           )
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.models
 
 import org.bigbluebutton.core.util.RandomStringGenerator
-import org.bigbluebutton.core.db.{NotificationDAO, PresPageDAO, PresPresentationDAO}
+import org.bigbluebutton.core.db.{ NotificationDAO, PresPageDAO, PresPresentationDAO }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 object PresentationPodFactory {
@@ -20,19 +20,20 @@ object PresentationPodFactory {
 }
 
 case class PresentationPage(
-    id:          String,
-    num:         Int,
-    urls:        Map[String, String],
-    content:     String,
-    current:     Boolean             = false,
-    xOffset:     Double              = 0,
-    yOffset:     Double              = 0,
-    widthRatio:  Double              = 100.0,
-    heightRatio: Double              = 100.0,
-    width:       Double              = 1440D,
-    height:      Double              = 1080D,
-    converted:   Boolean             = false,
-    infiniteWhiteboard: Boolean          = false,
+    id:                 String,
+    num:                Int,
+    urls:               Map[String, String],
+    content:            String,
+    current:            Boolean             = false,
+    xOffset:            Double              = 0,
+    yOffset:            Double              = 0,
+    widthRatio:         Double              = 100.0,
+    heightRatio:        Double              = 100.0,
+    width:              Double              = 1440D,
+    height:             Double              = 1080D,
+    converted:          Boolean             = false,
+    infiniteWhiteboard: Boolean             = false,
+    fitToWidth:         Boolean             = false
 )
 
 object PresentationInPod {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -292,6 +292,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[SetCurrentPagePubMsg](envelope, jsonNode)
       case SetPageInfiniteWhiteboardPubMsg.NAME =>
         routeGenericMsg[SetPageInfiniteWhiteboardPubMsg](envelope, jsonNode)
+      case SetPresentationFitToWidthCmdMsg.NAME =>
+        routeGenericMsg[SetPresentationFitToWidthCmdMsg](envelope, jsonNode)
       case ResizeAndMovePagePubMsg.NAME =>
         routeGenericMsg[ResizeAndMovePagePubMsg](envelope, jsonNode)
       case SlideResizedPubMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -632,6 +632,7 @@ class MeetingActor(
         state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
         updateUserLastActivity(m.header.userId)
       case m: SetPageInfiniteWhiteboardPubMsg                  => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
+      case m: SetPresentationFitToWidthCmdMsg                  => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: RemovePresentationPubMsg                         => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: SetPresentationDownloadablePubMsg                => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: PresentationConversionUpdateSysPubMsg            => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
@@ -402,6 +402,10 @@ object SetCurrentPresentationEvtMsg { val NAME = "SetCurrentPresentationEvtMsg" 
 case class SetCurrentPresentationEvtMsg(header: BbbClientMsgHeader, body: SetCurrentPresentationEvtMsgBody) extends BbbCoreMsg
 case class SetCurrentPresentationEvtMsgBody(podId: String, presentationId: String)
 
+object SetPresentationFitToWidthCmdMsg { val NAME = "SetPresentationFitToWidthCmdMsg"}
+case class SetPresentationFitToWidthCmdMsg(header: BbbClientMsgHeader, body: SetPresentationFitToWidthCmdMsgBody) extends StandardMsg
+case class SetPresentationFitToWidthCmdMsgBody(userId: String, pageId: String, fitToWidth: Boolean)
+
 // ------------ akka-apps to client ------------
 
 // ------------ akka-apps to bbb-common-web ------------

--- a/bbb-graphql-actions/src/actions/presentationSetFitToWidth.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetFitToWidth.ts
@@ -1,0 +1,31 @@
+import { RedisMessage } from '../types';
+import { throwErrorIfNotPresenter, throwErrorIfInvalidInput } from "../imports/validation";
+
+export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
+  throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input, [
+    {name: 'pageId', type: 'string', required: true},
+    { name: 'fitToWidth', type: 'boolean', required: true },
+  ]);
+
+  const eventName = `SetPresentationFitToWidthCmdMsg`;
+
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as string,
+    userId: sessionVariables['x-hasura-userid'] as string,
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId,
+  };
+
+  const body = {
+    userId: routing.userId,
+    pageId: input.pageId,
+    fitToWidth: input.fitToWidth,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1362,7 +1362,8 @@ CREATE UNLOGGED TABLE "pres_page" (
     "maxImageWidth" integer,
     "maxImageHeight" integer,
     "uploadCompleted" boolean,
-    "infiniteWhiteboard" boolean
+    "infiniteWhiteboard" boolean,
+    "fitToWidth" boolean
 );
 CREATE INDEX "idx_pres_page_presentationId" ON "pres_page"("presentationId");
 CREATE INDEX "idx_pres_page_presentationId_curr" ON "pres_page"("presentationId") where "current" is true;
@@ -1422,7 +1423,8 @@ SELECT pres_presentation."meetingId",
     (pres_page."width" * pres_page."widthRatio" / 100 * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledViewBoxWidth",
     (pres_page."height" * pres_page."heightRatio" / 100 * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledViewBoxHeight",
     pres_page."uploadCompleted",
-    pres_page."infiniteWhiteboard"
+    pres_page."infiniteWhiteboard",
+    pres_page."fitToWidth"
 FROM pres_page
 JOIN pres_presentation ON pres_presentation."presentationId" = pres_page."presentationId";
 
@@ -1456,6 +1458,7 @@ SELECT pres_presentation."meetingId",
     (pres_page."width" * pres_page."widthRatio" / 100 * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledViewBoxWidth",
     (pres_page."height" * pres_page."heightRatio" / 100 * LEAST(pres_page."maxImageWidth" / pres_page."width", pres_page."maxImageHeight" / pres_page."height")) AS "scaledViewBoxHeight",
     pres_page."infiniteWhiteboard",
+    pres_page."fitToWidth",
     (
         select array_agg("nextPages"."urlsJson"->>'svg')
         from pres_page "nextPages"

--- a/bigbluebutton-html5/imports/ui/components/app/app-graphql/mutations.ts
+++ b/bigbluebutton-html5/imports/ui/components/app/app-graphql/mutations.ts
@@ -1,0 +1,17 @@
+import { gql } from '@apollo/client';
+
+export const SET_PRESENTATION_FIT_TO_WIDTH = gql`
+  mutation presentationSetFitToWidth(
+  $fitToWidth: Boolean!
+  $pageId: String!
+) {
+  presentationSetFitToWidth(
+    fitToWidth: $fitToWidth
+    pageId: $pageId
+  )
+}
+`;
+
+export default {
+  SET_PRESENTATION_FIT_TO_WIDTH,
+};

--- a/bigbluebutton-html5/imports/ui/components/app/app-graphql/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/app/app-graphql/queries.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client';
+
+export const GET_CURR_PRESS_PAGE_INFO = gql`
+  subscription MySubscription {
+    pres_page_curr {
+      fitToWidth
+      pageId
+    }
+  }
+`;
+
+export default {
+  GET_CURR_PRESS_PAGE_INFO,
+};

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -154,6 +154,7 @@ class App extends Component {
       currentUserAway,
       currentUserRaiseHand,
       intl,
+      fitToWidth,
     } = this.props;
 
     this.renderDarkMode();
@@ -173,6 +174,10 @@ class App extends Component {
         notify(intl.formatMessage(intlMessages.loweredHand), 'info', 'clear_status');
       }
     }
+
+    if (prevProps.fitToWidth !== fitToWidth) {
+      this.setState({ presentationFitToWidth: fitToWidth });
+    }
   }
 
   componentWillUnmount() {
@@ -184,6 +189,8 @@ class App extends Component {
   }
 
   setPresentationFitToWidth(presentationFitToWidth) {
+    const { handlePresentationFitToWidth } = this.props;
+    handlePresentationFitToWidth(presentationFitToWidth);
     this.setState({ presentationFitToWidth });
   }
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1406,7 +1406,7 @@ const Whiteboard = React.memo((props) => {
       zoomChanger(HUNDRED_PERCENT);
       zoomSlide(HUNDRED_PERCENT, HUNDRED_PERCENT, 0, 0);
     }
-  }, [fitToWidth, isPresenter]);
+  }, [fitToWidth]);
 
   React.useEffect(() => {
     if (
@@ -1479,7 +1479,7 @@ const Whiteboard = React.memo((props) => {
         );
       }, isMountedPollingFrameRef);
     });
-  }, [presentationHeight, presentationWidth, curPageId, presentationId]);
+  }, [presentationHeight, presentationWidth, curPageId, presentationId, isPresenter]);
 
   React.useEffect(() => {
     if (!isPresenter
@@ -1681,7 +1681,7 @@ const Whiteboard = React.memo((props) => {
 
   React.useEffect(() => {
     setTldrawIsMounting(true);
-    isPresenterRef?.current && zoomChanger(HUNDRED_PERCENT);
+
     return () => {
       isMountedRef.current = false;
       localStorage.removeItem('initialViewBoxWidth');


### PR DESCRIPTION
### What does this PR do?
This PR is a follow-up to #22490, addressing the issue with the 'Fit to Width' functionality. The bug causing 'Fit to Width' to reset occurred because the server did not store this state—it was a client-side only setting. When the client applied zoom with 'Fit to Width' enabled, switching the presenter caused the new presenter's client to be unaware of this setting, resulting in the values being reset to zero.


### Closes Issue(s)

Closes #21873

### How to test
- Join with to users (I'll name them one and two).
-  Get user One and put to fill half of the screen.
- Get User Two and maximize the window.
- Upload a vertical Presentation.
- In the one that is presenter apply fit to width.
- Change the Presenter.
- See results. 


### More
[Screencast from 10-03-2025 13:47:45.webm](https://github.com/user-attachments/assets/3de74f0d-852c-4604-ad22-7fce2da3805b)
