### PR TITLE
Fix(html5): External video mute not being persisted

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -197,6 +197,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const changeVolume = (newVolume: number) => {
     setVolume(newVolume);
     storage.setItem('externalVideoVolume', newVolume);
+    if (newVolume > 0) {
+      setMute(false);
+      const internalPlayer = playerRef.current?.getInternalPlayer();
+      internalPlayer?.unMute?.();
+    }
   };
 
   const handleDuration = (duration: number) => {
@@ -266,9 +271,14 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (isPresenter !== presenterRef.current) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
       const playerVolume = internalPlayer?.getVolume();
+      const isMuted = internalPlayer?.isMuted();
       // the scale fiven by the player is 0 to 100, but the accepted scale is 0 to 1
       // So we need to divide by 100
       setVolume(playerVolume / 100);
+      if (isMuted) {
+        setMute(isMuted);
+        setVolume(0);
+      }
       clientReloadedRef.current = true;
       setPlayerKey(uniqueId('react-player'));
       presenterRef.current = isPresenter;
@@ -300,6 +310,9 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
     if (clientReloadedRef.current) {
       clientReloadedRef.current = false;
+      if ((!mute || volume > 0) && isPresenter) {
+        playerRef.current?.getInternalPlayer().unMute();
+      }
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -436,8 +436,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         {
           shouldShowTools() ? (
             <ExternalVideoPlayerToolbar
-              handleOnMuted={(m: boolean) => {
-                setMute(m); }}
+              handleOnMuted={(m: boolean) => setMute(m)}
               handleReload={() => setPlayerKey(uniqueId('react-player'))}
               setShowHoverToolBar={setShowHoverToolBar}
               toolbarStyle={toolbarStyle}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -198,7 +198,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     setVolume(newVolume);
     storage.setItem('externalVideoVolume', newVolume);
     if (newVolume > 0) {
-      setMute(false);
       const internalPlayer = playerRef.current?.getInternalPlayer();
       internalPlayer?.unMute?.();
     }
@@ -275,10 +274,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       // the scale fiven by the player is 0 to 100, but the accepted scale is 0 to 1
       // So we need to divide by 100
       setVolume(playerVolume / 100);
-      if (isMuted) {
-        setMute(isMuted);
-        setVolume(0);
-      }
+      setMute(isMuted);
       clientReloadedRef.current = true;
       setPlayerKey(uniqueId('react-player'));
       presenterRef.current = isPresenter;
@@ -310,7 +306,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
     if (clientReloadedRef.current) {
       clientReloadedRef.current = false;
-      if ((!mute || volume > 0) && isPresenter) {
+      if (!mute && isPresenter) {
         playerRef.current?.getInternalPlayer().unMute();
       }
     }
@@ -440,7 +436,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         {
           shouldShowTools() ? (
             <ExternalVideoPlayerToolbar
-              handleOnMuted={(m: boolean) => { setMute(m); }}
+              handleOnMuted={(m: boolean) => {
+                setMute(m); }}
               handleReload={() => setPlayerKey(uniqueId('react-player'))}
               setShowHoverToolBar={setShowHoverToolBar}
               toolbarStyle={toolbarStyle}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/volume-slide/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/volume-slide/component.tsx
@@ -22,34 +22,39 @@ const VolumeSlide: React.FC<VolumeSlideProps> = ({
   const volumeBeforeMute = React.useRef<number>(0);
 
   const getVolumeIcon = useCallback(() => {
-    if (mutedState || volumeState <= 0) return 'volume_off';
+    if ((mutedState || muted) || volumeState <= 0) return 'volume_off';
 
     if (volumeState <= 0.25) return 'volume_mute';
 
     if (volumeState <= 0.75) return 'volume_down';
 
     return 'volume_up';
-  }, [mutedState, volumeState]);
+  }, [mutedState, volumeState, muted]);
 
-  const handleOnChange = useCallback((volume: number) => {
+  const handleOnChange = useCallback((volume: number, mute: boolean) => {
     onVolumeChanged(volume);
-
     setVolume(volume);
+    defineMuteState(mute, volume);
   }, []);
 
-  useEffect(() => {
-    if (mutedState && volumeState > 0) { // unmute if volume was raised during mute
+  const defineMuteState = useCallback((mute: boolean, volume: number) => {
+    if (mute && volume > 0) { // unmute if volume was raised during mute
       setMuted(false);
       onMuted(false);
-    } else if (volumeState <= 0) { // mute if volume is turned to 0
+    } else if (volume <= 0) { // mute if volume is turned to 0
       setMuted(true);
       onMuted(true);
     }
-  }, [volumeState, mutedState, onMuted]);
+  }, []);
+
+  useEffect(() => {
+    setMuted(muted);
+    volumeBeforeMute.current = volume;
+  }, []);
 
   useEffect(() => {
     if (volumeState !== volume) {
-      handleOnChange(volume);
+      handleOnChange(volume, muted);
     }
 
     if (mutedState !== muted) {
@@ -66,7 +71,7 @@ const VolumeSlide: React.FC<VolumeSlideProps> = ({
           volumeBeforeMute.current = volumeState;
         }
         onVolumeChanged(muted ? volumeBeforeMute.current : 0);
-        setVolume(!muted ? 0 : volumeBeforeMute.current);
+        setVolume(!muted ? 0 : volumeBeforeMute.current || volume);
         setMuted(!muted);
         onMuted(!muted);
       }}
@@ -82,7 +87,7 @@ const VolumeSlide: React.FC<VolumeSlideProps> = ({
         max={1}
         step={0.02}
         value={mutedState ? 0 : volumeState}
-        onChange={(e) => handleOnChange(e.target.valueAsNumber)}
+        onChange={(e) => handleOnChange(e.target.valueAsNumber, muted)}
       />
     </Styled.Slider>
   );

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/volume-slide/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/volume-slide/styles.ts
@@ -17,7 +17,7 @@ const Slider = styled.div`
     font-size: 200%;
     cursor: pointer;
   }
-  z-index: 0;
+  z-index: 5;
 `;
 
 const Volume = styled.span`


### PR DESCRIPTION
### What does this PR do?
This PR fixes the mute status not being persisted on player remount


### Closes Issue(s)
Follow up of #22457

### How to test
- Join with two users 
- On presenter's client mute the user
- Make another user presenter.
- See mute status unchange.


### More
[Screencast from 10-03-2025 15:56:47.webm](https://github.com/user-attachments/assets/d5fa2d6c-0568-4871-8c22-70474bfb833c)

