### PR TITLE
fix (html5): Fix multiple markdown-related chat bugs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import Styled from './styles';
-import { textToMarkdown } from '/imports/ui/components/chat/chat-graphql/service';
+import { messageToMarkdown } from '/imports/ui/components/chat/chat-graphql/service';
 
 interface ChatMessageTextContentProps {
   text: string;
@@ -20,7 +20,7 @@ const ChatMessageTextContent: React.FC<ChatMessageTextContentProps> = ({
         allowedElements={allowedElements}
         unwrapDisallowed
       >
-        {textToMarkdown(text)}
+        {messageToMarkdown(text)}
       </ReactMarkdown>
     </Styled.ChatMessage>
   );

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -1,5 +1,10 @@
 import styled from 'styled-components';
-import { colorText } from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  colorGrayDark,
+  colorGrayLighter,
+  colorGrayLightest, colorOffWhite,
+  colorText
+} from '/imports/ui/stylesheets/styled-components/palette';
 
 interface ChatMessageProps {
   systemMsg?: boolean;
@@ -25,6 +30,11 @@ export const ChatMessage = styled.div<ChatMessageProps>`
 
   & code {
     white-space: pre-wrap;
+    background-color: ${colorOffWhite};
+    border: solid 1px ${colorGrayLightest};
+    border-radius: 4px;
+    padding: 2px;
+    font-size: 12px;
   }
   & h1 {
     font-size: 1.5em;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -1,9 +1,8 @@
 import styled from 'styled-components';
 import {
-  colorGrayDark,
-  colorGrayLighter,
-  colorGrayLightest, colorOffWhite,
-  colorText
+  colorGrayLightest,
+  colorOffWhite,
+  colorText,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 interface ChatMessageProps {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled, { DeleteMessage } from './styles';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
-import { textToMarkdown } from '/imports/ui/components/chat/chat-graphql/service';
+import { messageToQuoteMarkdown } from '/imports/ui/components/chat/chat-graphql/service';
 
 const intlMessages = defineMessages({
   deleteMessage: {
@@ -23,12 +23,6 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
   } = props;
 
   const intl = useIntl();
-  const codeBlockRegExp = new RegExp('^```.*', 'gm');
-  const messageChunks = textToMarkdown(message).split('\n');
-  let repliedMessage = messageChunks[0];
-  if (repliedMessage.match(codeBlockRegExp) && messageChunks.length > 1) {
-    repliedMessage = `\`${messageChunks[1]}\``;
-  }
 
   return (
     <Styled.Container
@@ -53,7 +47,7 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
             allowedElements={window.meetingClientSettings.public.chat.allowedElements}
             unwrapDisallowed
           >
-            {repliedMessage}
+            {messageToQuoteMarkdown(message)}
           </Styled.Markdown>
         </Styled.Message>
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -23,7 +23,12 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
   } = props;
 
   const intl = useIntl();
+  const codeBlockRegExp = new RegExp('^```.*', 'gm');
   const messageChunks = textToMarkdown(message).split('\n');
+  let repliedMessage = messageChunks[0];
+  if (repliedMessage.match(codeBlockRegExp) && messageChunks.length > 1) {
+    repliedMessage = `\`${messageChunks[1]}\``;
+  }
 
   return (
     <Styled.Container
@@ -48,7 +53,7 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
             allowedElements={window.meetingClientSettings.public.chat.allowedElements}
             unwrapDisallowed
           >
-            {messageChunks[0]}
+            {repliedMessage}
           </Styled.Markdown>
         </Styled.Message>
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/styles.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import {
   colorGrayLight,
-  colorGrayLightest, colorPrimary, colorText, colorWhite,
+  colorGrayLightest, colorOffWhite, colorPrimary, colorText, colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { $3xlPadding, smPadding } from '/imports/ui/stylesheets/styled-components/general';
 import ReactMarkdown from 'react-markdown';
@@ -54,6 +54,11 @@ export const Markdown = styled(ReactMarkdown)`
 
   & code {
     white-space: nowrap;
+    background-color: ${colorOffWhite};
+    border: solid 1px ${colorGrayLightest};
+    border-radius: 4px;
+    padding: 2px;
+    font-size: 12px;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -5,7 +5,7 @@ import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import Tooltip from '/imports/ui/components/common/tooltip/container';
-import {messageToQuoteMarkdown} from "/imports/ui/components/chat/chat-graphql/service";
+import { messageToQuoteMarkdown } from '/imports/ui/components/chat/chat-graphql/service';
 
 const intlMessages = defineMessages({
   cancel: {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -5,6 +5,7 @@ import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { ChatEvents } from '/imports/ui/core/enums/chat';
 import Tooltip from '/imports/ui/components/common/tooltip/container';
+import {messageToQuoteMarkdown} from "/imports/ui/components/chat/chat-graphql/service";
 
 const intlMessages = defineMessages({
   cancel: {
@@ -25,7 +26,6 @@ const ChatReplyIntention = () => {
   };
 
   const hidden = !username || !message;
-  const messageChunks = message ? message.split('\n') : null;
 
   useEffect(() => {
     const handleReplyIntention = (e: Event) => {
@@ -85,7 +85,7 @@ const ChatReplyIntention = () => {
     >
       <Styled.Message>
         <Styled.Markdown>
-          {messageChunks ? messageChunks[0] : ''}
+          {messageToQuoteMarkdown(message)}
         </Styled.Markdown>
       </Styled.Message>
       <Tooltip title={intl.formatMessage(intlMessages.cancel, { 0: CANCEL_KEY })}>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -84,7 +84,11 @@ const ChatReplyIntention = () => {
       }}
     >
       <Styled.Message>
-        <Styled.Markdown>
+        <Styled.Markdown
+          linkTarget="_blank"
+          allowedElements={window.meetingClientSettings.public.chat.allowedElements}
+          unwrapDisallowed
+        >
           {messageToQuoteMarkdown(message)}
         </Styled.Markdown>
       </Styled.Message>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 import ReactMarkdown from 'react-markdown';
 import {
-  colorGrayLightest,
+  colorGrayLightest, colorOffWhite,
   colorPrimary,
   colorText,
   colorWhite,
@@ -80,6 +80,11 @@ const Markdown = styled(ReactMarkdown)`
   & code {
     line-height: 1rlh;
     white-space: nowrap;
+    background-color: ${colorOffWhite};
+    border: solid 1px ${colorGrayLightest};
+    border-radius: 4px;
+    padding: 2px;
+    font-size: 12px;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -142,7 +142,7 @@ export const messageToMarkdown = (message: string) => {
 };
 
 export const messageToQuoteMarkdown = (message: string | undefined): string => {
-  // this function will try to find the next line that doesn't begin with ``` or image
+  // this function will try to find the next line that doesn't begin with ``` or image, and is not empty
   if (!message) return '';
 
   const codeBlockRegExp = /^```/;
@@ -150,15 +150,15 @@ export const messageToQuoteMarkdown = (message: string | undefined): string => {
   const messageChunks = messageToMarkdown(message).split('\n');
 
   for (let i = 0; i < messageChunks.length; i += 1) {
-    let candidate = messageChunks[i];
+    let candidate = messageChunks[i].trim();
 
     if (codeBlockRegExp.test(candidate)) {
-      if (i + 1 < messageChunks.length && !codeBlockRegExp.test(messageChunks[i + 1])) {
+      if (i + 1 < messageChunks.length && !codeBlockRegExp.test(messageChunks[i + 1].trim())) {
         candidate = `\`${messageChunks[i + 1]}\``;
       }
     }
 
-    if (!codeBlockRegExp.test(candidate) && !imageRegExp.test(candidate)) {
+    if (!codeBlockRegExp.test(candidate) && !imageRegExp.test(candidate) && candidate !== '') {
       return candidate;
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -1,4 +1,4 @@
-export const textToMarkdown = (message: string) => {
+export const messageToMarkdown = (message: string) => {
   const parsedMessage = message || '';
   const newLineRegex = /\r?\n/g;
 
@@ -141,6 +141,27 @@ export const textToMarkdown = (message: string) => {
   return finalResult.trim().replace(newLineRegex, '  \n');
 };
 
-export default {
-  textToMarkdown,
+export const messageToQuoteMarkdown = (message: string | undefined): string => {
+  // this function will try to find the next line that doesn't begin with ``` or image
+  if (!message) return '';
+
+  const codeBlockRegExp = /^```/;
+  const imageRegExp = /^!\[.*\]\(.*\)/;
+  const messageChunks = messageToMarkdown(message).split('\n');
+
+  for (let i = 0; i < messageChunks.length; i += 1) {
+    let candidate = messageChunks[i];
+
+    if (codeBlockRegExp.test(candidate)) {
+      if (i + 1 < messageChunks.length && !codeBlockRegExp.test(messageChunks[i + 1])) {
+        candidate = `\`${messageChunks[i + 1]}\``;
+      }
+    }
+
+    if (!codeBlockRegExp.test(candidate) && !imageRegExp.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  return '';
 };


### PR DESCRIPTION
<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>

![image](https://github.com/user-attachments/assets/469b9f33-f754-45ea-b3dc-de75a6220f78)

</td>
<td>

![image](https://github.com/user-attachments/assets/a2c2336d-25b3-4456-938b-b67dbb4ace0b)

</td>
</tr>
</table>


### Fix multiple markdown-related chat bugs

This PR addresses several issues related to markdown rendering in chat messages:

- Sending a link with an empty description (`[](https://bigbluebutton.org/)`) resulted in an empty message.
- Simple inline code incorrectly converted links within its content into markdown.  
  <img src="https://github.com/user-attachments/assets/e142602d-991d-4dff-8530-fc454d6d9034" width=200 />
- Code blocks were not displayed correctly in reply quotes, as only the first line (a backtick `\``) was shown.
- Messages where the first line was blank resulted in an empty reply quote.
- Messages with an image as the first line caused the reply quote to be empty, and in chat input the image was displayed above the input (which is not allowed).
- Code blocks are now visually distinct with a different background and border, making them easier to recognize.

### Future Work

- Prevent users from sending messages containing only an image, as they appear empty.  
- Prevent users from sending messages with empty links (`[]()`), which also result in empty messages.