### PR TITLE
fix (gql-middleware): Handle error when request Origin is not authorized

### DIFF
--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -71,6 +71,8 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 	browserWsConn, err := websocket.Accept(w, r, &acceptOptions)
 	if err != nil {
 		connectionLogger.Errorf("error: %v", err)
+		http.Error(w, "Closing browser connection, reason: request Origin is not authorized", http.StatusForbidden)
+		return
 	}
 	browserWsConn.SetReadLimit(9999999) //10MB
 


### PR DESCRIPTION
Closes: #22626

Before:
![image](https://github.com/user-attachments/assets/e2125dcc-90a7-4bba-8cd1-46ef8a221965)

After:
![image](https://github.com/user-attachments/assets/3cf5f81f-60bc-4356-920b-2b088d811901)

And now the browser receive a return with header `403 Forbidden`:
![image](https://github.com/user-attachments/assets/428b03f3-3a5d-440f-a176-e436462e3bf6)
