### PR TITLE
docs: Include allowOverrideClientSettingsOnCreateCall mention in clientSettingsOverride

### DIFF
--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -417,7 +417,11 @@ For more information about the pre-upload slides check the following [link](http
 
 #### clientSettingsOverride
 
-You can modify the `settings.yml` configuration for the HTML5 client as part of the create call (in addition to modifying `/etc/bigbluebutton/bbb-html5.yml`).
+We support overriding the client settings (the entire set of options can be found in `/usr/share/bigbluebutton/html5-client/private/config/settings.yml`) as part of the CREATE call.
+Note that these values would have higher precedence over customizations made in `/etc/bigbluebutton/bbb-html5.yml`.
+
+By default this overriding approach on CREATE is disabled. To enable it, please set `allowOverrideClientSettingsOnCreateCall=true` in `/etc/bigbluebutton/bbb-web.properties` or as part of the CREATE call.
+
 You can construct the HTTPS POST request as follows:
 
 ```


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Improves the documentation of `clientSettingsOverride` so that it includes enabling the call by overriding `allowOverrideClientSettingsOnCreateCall`

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22654 

### Motivation
<!-- What inspired you to submit this pull request? -->
`allowOverrideClientSettingsOnCreateCall` was not mentioned before.


