### PR TITLE
(html5) perf: Skip `messageToMarkdown` if the message doesn't contain `http`

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -1,5 +1,11 @@
 export const messageToMarkdown = (message: string) => {
   const parsedMessage = message || '';
+
+  // this function is mostly used to convert links to markdown, so it can skip if it doesn't contain http
+  if (parsedMessage.indexOf('http') === -1) {
+    return parsedMessage;
+  }
+
   const newLineRegex = /\r?\n/g;
 
   // Regex definitions


### PR DESCRIPTION
The `messageToMarkdown` conversion function is somewhat complex since it must account for multiple scenarios. Therefore, it's beneficial to bypass all validations if the message doesn't contain the string `http`.