### PR TITLE
doc(bbb-web): Documentation for presentationConversionCacheEnabled

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -467,6 +467,12 @@ const createEndpointTableData = [
     "description": (<>Message to be displayed in presentation uploader modal describing how to use an external application to upload presentation files. Only works if <code className="language-plaintext highlighter-rouge">presentationUploadExternalUrl</code> is also set. (added 2.6)</>)
   },
   {
+    "name": "presentationConversionCacheEnabled",
+    "required": false,
+    "type": "Boolean",
+    "description": (<>Parameter to decide whether to use the caching system in a S3-based storage system for presentation assets per meeting. If this parameter is true, the other settings related to the caching feature must be configured properly (see section <a href="/administration/customize/#configure-s3-based-cache-for-presentation-assets">Configure S3-based cache for presentation assets</a>).</>)
+  },
+  {
     "name": "recordFullDurationMedia",
     "required": false,
     "type": "Boolean",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -112,7 +112,7 @@ Updated in 2.7:
 
 Updated in 3.0:
 
-- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`, `pluginManifests`. **Removed:** `breakoutRoomsEnabled`, `learningDashboardEnabled`, `virtualBackgroundsDisabled`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`, `deleteChatMessage`, `editChatMessage`, `replyChatMessage`, `chatMessageReactions`;
+- **create** - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`, `pluginManifests`, `presentationConversionCacheEnabled`. **Removed:** `breakoutRoomsEnabled`, `learningDashboardEnabled`, `virtualBackgroundsDisabled`. Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY; **Added POST module:** `clientSettingsOverride`; **Added:** `disabledFeatures` options `infiniteWhiteboard`, `deleteChatMessage`, `editChatMessage`, `replyChatMessage`, `chatMessageReactions`;
 - **join** - **Added:** `enforceLayout`, `logoutURL`, `firstName`, `lastName`, `userdata-bbb_default_layout`, `userdata-bbb_skip_echotest_if_previous_device`, `userdata-bbb_prefer_dark_theme`. `userdata-bbb_hide_notifications`, `userdata-bbb_hide_controls`, **Removed:** `defaultLayout` (replaced by `userdata-bbb_default_layout`) and removed support for all HTTP request methods except GET.
 - **sendChatMessage** endpoint was first introduced.
 - **getJoinUrl** endpoint was first introduced.

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -151,7 +151,8 @@ For more information check the [pull request](https://github.com/bigbluebutton/b
 #### S3-based cache for presentation assets
 
 BigBlueButton now supports caching for presentation assets at Amazon S3/Minio or similar.
-For details check the [server customization](/administration/customize/#configure-s3-based-cache-for-presentation-assets) portion of the documents.
+For details check the [server customization](/administration/customize/#configure-s3-based-cache-for-presentation-assets) portion of the documents and see the new `/create` parameter to control it per meeting in the [API reference](/development/api/#get-post-create).
+
 
 #### Support for ClamAV as presentation file scanner
 

--- a/docs/run-dev.sh
+++ b/docs/run-dev.sh
@@ -16,7 +16,7 @@ do
 done
 
 if [ ! -d ./node_modules ] ; then
-	npm install
+	npm ci
 fi
 
 sudo cp bbb-docs.nginx /usr/share/bigbluebutton/nginx/bbb-docs.nginx


### PR DESCRIPTION
### What does this PR do?

Just documentation for the `presentationConversionCacheEnabled` create parameter introced.


### More
See some screenshots of the added portions:

![image](https://github.com/user-attachments/assets/d28f2582-be4e-4c1d-95ea-ad3449dc9cb7)
![image](https://github.com/user-attachments/assets/eb33a26a-cbbf-4fb9-8a34-0fdbc186fb27)
![image](https://github.com/user-attachments/assets/15b25dcf-ec36-4c7d-ab17-9803c5bb85ed)
