### PR TITLE
fix: Avoid reading properties of null

### DIFF
--- a/bigbluebutton-html5/client/meetingClient.jsx
+++ b/bigbluebutton-html5/client/meetingClient.jsx
@@ -48,7 +48,8 @@ const Startup = () => {
     // will strip that so the errors can hopefully be grouped better.
     if (message) message = message.replace(/^Uncaught/, '').trim();
 
-    let { stack } = e.error;
+    let stack = {};
+    stack = e.error?.stack;
 
     // Checks if stack includes the message, if not add the two together.
     if (!stack.includes(message)) {

--- a/bigbluebutton-html5/client/meetingClient.jsx
+++ b/bigbluebutton-html5/client/meetingClient.jsx
@@ -48,8 +48,7 @@ const Startup = () => {
     // will strip that so the errors can hopefully be grouped better.
     if (message) message = message.replace(/^Uncaught/, '').trim();
 
-    let stack = {};
-    stack = e.error?.stack;
+    let stack = e.error?.stack || '';
 
     // Checks if stack includes the message, if not add the two together.
     if (!stack.includes(message)) {


### PR DESCRIPTION
We see examples of trying to log when there is no stack property in e.error. Adding a bit of protection. It's possible that with this change we could avoid a whiteboard area crash , one of the instances of "Something went wrong. Trying to recover"

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
[fix: Avoid reading properties of null](https://github.com/bigbluebutton/bigbluebutton/commit/b3e6aee76314f118887c035898cdec5d15694d1b) 

We see examples of trying to log when there is no stack property in
e.error. Adding a bit of protection. It's possible that with this change
we could avoid a whiteboard area crash , one of the instances of
"Something went wrong. Trying to recover"

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->

Seeing the following error + console logs
![image](https://github.com/user-attachments/assets/ee3bcb49-ed07-44c0-a833-6cad0d25acfa)

reported by @gabriellpr 

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Joining the client with Chrome 93-95. Possibly other cases too but not sure how to consistently trigger.
