### PR TITLE
fix (html5): Modify the `messageToMarkdown` function to support uppercase links

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -2,7 +2,7 @@ export const messageToMarkdown = (message: string) => {
   const parsedMessage = message || '';
 
   // this function is mostly used to convert links to markdown, so it can skip if it doesn't contain http
-  if (parsedMessage.indexOf('http') === -1) {
+  if (parsedMessage.toLowerCase().indexOf('http') === -1) {
     return parsedMessage;
   }
 
@@ -11,9 +11,9 @@ export const messageToMarkdown = (message: string) => {
   // Regex definitions
   const MULTI_LINE_CODE_BLOCK_REGEX = /```([\s\S]*?)```/g;
   const INLINE_CODE_REGEX = /`([^`]+)`/g;
-  const EMPTY_LINK_REGEX = /\[\]\((https?:\/\/[^)]+)\)/g;
+  const EMPTY_LINK_REGEX = /\[\]\((https?:\/\/[^)]+)\)/gi;
   const IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]*)\)/g;
-  const URL_REGEX = /(http(s)?:\/\/)[-a-zA-Z0-9@:%._+~#=,ß]{2,256}\.[a-z0-9]{2,6}\b([-a-zA-Z0-9@:%_+.~#!?&//=,ß]*)?/g;
+  const URL_REGEX = /(http(s)?:\/\/)[-a-zA-Z0-9@:%._+~#=,ß]{2,256}\.[a-z0-9]{2,6}\b([-a-zA-Z0-9@:%_+.~#!?&//=,ß]*)?/gi;
   const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\(([^)]+)\)/g;
 
   // First pass: extract multi-line code blocks.


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/5fb2a314-c502-4af4-8ece-a0875559e7f8)

After:
![image](https://github.com/user-attachments/assets/b8efa1e1-332d-4259-be78-538be47ea200)
