### PR TITLE
ref(doc): refactor documentation structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,30 @@ and GitHub Actions (see [deploy-docs.yml](../.github/workflows/deploy-docs.yml))
 
 ## Local Development
 
+If you want to test the documentation as a whole, we suggest you to checkout to the development branch. There you'll have the hability to build all the versionings we currently support (3.0, 2.7, 2.6 and 2.5-legacy).
+
+### Docker environment approach
+
+If you are already on the development branch, to run the docs you'll run the following commands
+
+First outside of a docker-container:
+
+```bash
+./build.sh --remote upstream
+```
+
+Feel free to edit the command and insert whatever remote fork you want to fetch from. For some cases `upstream` is pointing to the official repo (and that's what we recommend fetching from).
+
+Now inside of the docker container (BigBlueButton dev environment):
+
+```bash
+./run-dev.sh
+```
+
+Now this command is going to create the server so you can access it.
+
+### Pure Local environment (no docker container needed)
+
 To test build the docs locally use:
 
 ```bash
@@ -56,6 +80,25 @@ This step is optional and if you don't run it, docusaurus will only build the
 currently checkout out version which is recommended for local development
 (building all the versions locally can lead to problems with the live
 updates when using `npx docusaurus start`).
+
+### Comments and tips
+
+**Use Link tags when adding to the docs**
+In order to avoid problems with referencing within the documentation, we highly recommend you to use Link tags inside react files such as `docs/data/create.tsx` instead of `a` tags.
+
+So an example would be:
+
+Instead of:
+```tsx
+<a href='/administration/install/#minimum-server-requirements'>Here are the minimum requirements</a>
+```
+
+Use:
+```tsx
+<Link to='/administration/install/#minimum-server-requirements'>Here are the minimum requirements</a>
+```
+
+For more information, refer back to the official docusaurus documentation: https://docusaurus.io/docs/docusaurus-core#link
 
 ### Build
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,9 +17,9 @@ Now this command is going to start the server so you can access it.
 
 ### Develop branch details
 
-If you want to test the documentation as a whole, we suggest you to checkout to the `develop` branch. There you'll have the hability to build all the versionings we currently support (3.0, 2.7, 2.6 and 2.5-legacy).
+If you want to test the documentation as a whole, we suggest you to check out to the `develop` branch. There you'll have the ability to build all the versioning we currently support (3.0, 2.7, 2.6 and 2.5-legacy).
 
-If you are already into the `develop` branch, to run the docs you'll run the following command first outside of a docker-container (Previous to the `run-dev.sh`):
+If you are already into the `develop` branch, to run the docs you'll run the following command first outside a docker-container (Previous to the `run-dev.sh`):
 
 ```bash
 ./build.sh --remote upstream

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,27 +5,28 @@ and GitHub Actions (see [deploy-docs.yml](../.github/workflows/deploy-docs.yml))
 
 ## Local Development
 
-If you want to test the documentation as a whole, we suggest you to checkout to the development branch. There you'll have the hability to build all the versionings we currently support (3.0, 2.7, 2.6 and 2.5-legacy).
-
 ### Docker environment approach
 
-If you are already on the development branch, to run the docs you'll run the following commands
-
-First outside of a docker-container:
-
-```bash
-./build.sh --remote upstream
-```
-
-Feel free to edit the command and insert whatever remote fork you want to fetch from. For some cases `upstream` is pointing to the official repo (and that's what we recommend fetching from).
-
-Now inside of the docker container (BigBlueButton dev environment):
+To run the docs in dev environments (likely BigBlueButton docker container) you'll run the following command:
 
 ```bash
 ./run-dev.sh
 ```
 
-Now this command is going to create the server so you can access it.
+Now this command is going to start the server so you can access it.
+
+### Develop branch details
+
+If you want to test the documentation as a whole, we suggest you to checkout to the `develop` branch. There you'll have the hability to build all the versionings we currently support (3.0, 2.7, 2.6 and 2.5-legacy).
+
+If you are already into the `develop` branch, to run the docs you'll run the following command first outside of a docker-container (Previous to the `run-dev.sh`):
+
+```bash
+./build.sh --remote upstream
+```
+
+Feel free to edit the command and insert whatever remote fork you want to fetch from. For most cases `upstream` is pointing to the official repo (and that's what we recommend fetching from).
+
 
 ### Pure Local environment (no docker container needed)
 

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -2,6 +2,26 @@
 
 set -eu
 
+# Defines the git remote used to fetch the branches and tags
+REMOTE="origin"
+
+while [ $# -gt 0 ]; do
+  if [ "$1" = "--remote" -o "$1" = "-remote" -o "$1" = "-r" ]; then
+    REMOTE_OVERRIDE="${2}"
+    if [ -z "$REMOTE_OVERRIDE" ]; then
+      echo
+      echo "    No remote was given, using '$REMOTE' to fetch branches and tags"
+      echo
+      exit 0
+    fi
+    shift; shift
+    continue
+  fi
+
+  usage
+  exit 1
+done
+
 # Build the docs for these tags (the last tag of old major releases)
 # We build the docs for historical reasons. The branch no longer exists
 # since the release is no longer supported/maintained.
@@ -15,7 +35,6 @@ BRANCHES=(
   v2.7.x-release
   v3.0.x-release
 )
-REMOTE="origin"
 
 git fetch --all
 git fetch --tags

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -14,13 +14,24 @@ while [ $# -gt 0 ]; do
       echo
       exit 0
     fi
+    REMOTE="$REMOTE_OVERRIDE"
     shift; shift
     continue
   fi
-
-  usage
   exit 1
 done
+
+# Remove directories and files related to previous build (otherwise it would crash).
+echo Removing directories and files from previous builds
+if [ -d versioned_docs ]; then
+  rm -rf versioned_docs
+fi
+if [ -d versioned_sidebars ]; then
+  rm -rf versioned_sidebars
+fi
+if [ -f versions.json ]; then
+  rm versions.json
+fi
 
 # Build the docs for these tags (the last tag of old major releases)
 # We build the docs for historical reasons. The branch no longer exists
@@ -36,7 +47,7 @@ BRANCHES=(
   v3.0.x-release
 )
 
-git fetch --all
+git fetch "$REMOTE"
 git fetch --tags
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
     title: 'BigBlueButton',
     tagline: 'Official Documentation',
     url: 'https://docs.bigbluebutton.org/',
-    baseUrl: isDev ? '/docs' : '/',
+    baseUrl: '/',
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
     title: 'BigBlueButton',
     tagline: 'Official Documentation',
     url: 'https://docs.bigbluebutton.org/',
-    baseUrl: '/',
+    baseUrl: isDev ? '/docs/' : '/',
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
     title: 'BigBlueButton',
     tagline: 'Official Documentation',
     url: 'https://docs.bigbluebutton.org/',
-    baseUrl: isDev ? '/docs/' : '/',
+    baseUrl: isDev ? '/docs' : '/',
     onBrokenLinks: 'warn',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.ico',


### PR DESCRIPTION
### What does this PR do?

It does 2 things to enhance development experience:
- Adds Readme information to ease the learning curve of how to build and run the documentation;
- Adds a new parameter `--remote` to the `build.sh` script to select the git remote that one wants to fetch the branches from;

For the 1st point, I simply added some more information on tags to use and the `build.sh` script as well as the `run-dev.sh`.

The 2nd makes it more convenient to use the `build.sh` script. In my case, for instance, my git remote origin (My fork) is not quite synced with the official repository, so I'd rather fetch everything from upstream, which in my case is pointing to the official BBB repo.


### Motivation

Make it easier to add new documentation and even enhance docs structure.
