### PR TITLE
docs: Add docs for the new event SetScreenshareAsContentEvent

### DIFF
--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -338,6 +338,7 @@ Retired events
 Modified/added events
 - `ParticipantJoinEvent` - will contain element `userdata` see https://github.com/bigbluebutton/bigbluebutton/pull/20566#pullrequestreview-2142238810
 - the old user status emojis were retired. `emojiStatus` will not be filled anymore. For more information see https://github.com/bigbluebutton/bigbluebutton/pull/20717
+- `SetScreenshareAsContentEvent` - Contains the `screenshareAsContent` field, a boolean that indicates whether the screenshare is in focus. For more information see https://github.com/bigbluebutton/bigbluebutton/pull/22312
 
 #### bbb-web properties changes
 


### PR DESCRIPTION
### What does this PR do?
Adds a mention of SetScreenshareAsContentEvent as a newly added event for recording.


### Closes Issue(s)
n/a

