### PR TITLE
fix: restore unsupported browser check

### DIFF
--- a/bigbluebutton-html5/client/meetingClient.jsx
+++ b/bigbluebutton-html5/client/meetingClient.jsx
@@ -21,11 +21,13 @@ import React, { useContext, useEffect } from 'react';
 import logger from '/imports/startup/client/logger';
 import '/imports/ui/services/mobile-app';
 import Base from '/imports/startup/client/base';
+import Legacy from '/imports/ui/components/legacy/component';
 import ContextProviders from '/imports/ui/components/context-providers/component';
 import ConnectionManager from '/imports/ui/components/connection-manager/component';
 // The adapter import is "unused" as far as static code is concerned, but it
 // needs to here to override global prototypes. So: don't remove it - prlanzarin 25 Apr 2022
 import adapter from 'webrtc-adapter';
+import Bowser from 'bowser';
 
 import { LoadingContext } from '/imports/ui/components/common/loading-screen/loading-screen-HOC/component';
 import IntlAdapter from '/imports/startup/client/intlAdapter';
@@ -62,6 +64,10 @@ const Startup = () => {
     }, message);
   });
 
+  const MIN_BROWSER_CONFIG = window.meetingClientSettings.public.minBrowserVersions;
+  const userAgent = window.navigator?.userAgent;
+  const isSupportedBrowser = Bowser.getParser(userAgent).satisfies(MIN_BROWSER_CONFIG);
+
   const { data: pluginConfig } = createUseSubscription(
     PLUGIN_CONFIGURATION_QUERY,
   )((obj) => obj);
@@ -69,7 +75,7 @@ const Startup = () => {
     <ContextProviders>
       <PresenceAdapter>
         <IntlAdapter>
-          <Base pluginConfig={pluginConfig} />
+          {isSupportedBrowser ? <Base pluginConfig={pluginConfig} /> : <Legacy />}
         </IntlAdapter>
       </PresenceAdapter>
     </ContextProviders>

--- a/bigbluebutton-html5/client/meetingClient.jsx
+++ b/bigbluebutton-html5/client/meetingClient.jsx
@@ -21,13 +21,11 @@ import React, { useContext, useEffect } from 'react';
 import logger from '/imports/startup/client/logger';
 import '/imports/ui/services/mobile-app';
 import Base from '/imports/startup/client/base';
-import Legacy from '/imports/ui/components/legacy/component';
 import ContextProviders from '/imports/ui/components/context-providers/component';
 import ConnectionManager from '/imports/ui/components/connection-manager/component';
 // The adapter import is "unused" as far as static code is concerned, but it
 // needs to here to override global prototypes. So: don't remove it - prlanzarin 25 Apr 2022
 import adapter from 'webrtc-adapter';
-import Bowser from 'bowser';
 
 import { LoadingContext } from '/imports/ui/components/common/loading-screen/loading-screen-HOC/component';
 import IntlAdapter from '/imports/startup/client/intlAdapter';
@@ -64,10 +62,6 @@ const Startup = () => {
     }, message);
   });
 
-  const MIN_BROWSER_CONFIG = window.meetingClientSettings.public.minBrowserVersions;
-  const userAgent = window.navigator?.userAgent;
-  const isSupportedBrowser = Bowser.getParser(userAgent).satisfies(MIN_BROWSER_CONFIG);
-
   const { data: pluginConfig } = createUseSubscription(
     PLUGIN_CONFIGURATION_QUERY,
   )((obj) => obj);
@@ -75,7 +69,7 @@ const Startup = () => {
     <ContextProviders>
       <PresenceAdapter>
         <IntlAdapter>
-          {isSupportedBrowser ? <Base pluginConfig={pluginConfig} /> : <Legacy />}
+          <Base pluginConfig={pluginConfig} />
         </IntlAdapter>
       </PresenceAdapter>
     </ContextProviders>

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -28,6 +28,7 @@ export interface Public {
   whiteboard: Whiteboard
   clientLog: ClientLog
   virtualBackgrounds: VirtualBackgrounds
+  minBrowserVersions: MinBrowserVersions
 }
 export interface Locales {
   locale: string
@@ -823,7 +824,6 @@ export interface VirtualBackgrounds {
 export interface Private {
   analytics: Analytics
   app: App2
-  minBrowserVersions: MinBrowserVersion[]
   prometheus: Prometheus
 }
 
@@ -850,9 +850,17 @@ export interface Channels {
   toThirdParty: string
 }
 
-export interface MinBrowserVersion {
-  browser: string
-  version: number | number[] | string
+export interface mobileBrowsers {
+  safari: string
+  chrome: string
+}
+
+export interface MinBrowserVersions {
+  safari: string
+  chrome: string
+  firefox: string
+  edge: string
+  mobile: mobileBrowsers
 }
 
 export interface Prometheus {

--- a/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
@@ -69,7 +69,7 @@ import PropTypes from 'prop-types';
 const FETCHING = 'fetching';
 const FALLBACK = 'fallback';
 const READY = 'ready';
-const supportedBrowsers = ['Chrome', 'Firefox', 'Safari', 'Opera', 'Microsoft Edge', 'Yandex Browser'];
+const supportedBrowsers = ['Chrome', 'Firefox', 'Safari', 'Microsoft Edge'];
 
 export default class Legacy extends Component {
   constructor(props) {
@@ -161,11 +161,17 @@ export default class Legacy extends Component {
     if (!this.state) return null;
 
     const { messages, normalizedLocale, viewState } = this.state;
-    const isSupportedBrowser = supportedBrowsers.includes(browserName);
+    const isSupportedBrowser = !supportedBrowsers.includes(browserName);
     const isUnsupportedIos = isIos && !isSafari;
+    const inUnsupportedSafari = isSafari && !isSupportedBrowser;
 
     let messageId = isSupportedBrowser ? 'app.legacy.upgradeBrowser' : 'app.legacy.unsupportedBrowser';
     if (isUnsupportedIos) messageId = 'app.legacy.criosBrowser';
+    if (inUnsupportedSafari) messageId = 'app.legacy.unsupportedSafari';
+
+    const fallbackMessageSafari = inUnsupportedSafari
+      ? 'Please upgrade your browser to Safari 16 or newer for full support.'
+      : 'Please use Safari 16 or newer on iOS for full support.';
 
     switch (viewState) {
       case READY:
@@ -186,8 +192,8 @@ export default class Legacy extends Component {
       case FALLBACK:
         return (
           <p className="browserWarning">
-            {isUnsupportedIos ? (
-              <span>Please use Safari on iOS for full support.</span>
+            {isUnsupportedIos || inUnsupportedSafari ? (
+              <span>{fallbackMessageSafari}</span>
             ) : (
               <span>
                 <span>

--- a/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/legacy/component.jsx
@@ -3,7 +3,7 @@ import { IntlProvider, FormattedMessage } from 'react-intl';
 import browserInfo from '/imports/utils/browserInfo';
 import deviceInfo from '/imports/utils/deviceInfo';
 import './styles.css';
-
+import PropTypes from 'prop-types';
 
 // currently supported locales.
 // import ar from 'react-intl/locale-data/ar';
@@ -82,10 +82,13 @@ export default class Legacy extends Component {
     const localesPath = 'locales';
 
     const that = this;
-    this.state = { viewState: FETCHING };
 
     const DEFAULT_LANGUAGE = window.meetingClientSettings.public.app.defaultSettings.application.fallbackLocale;
     const CLIENT_VERSION = window.meetingClientSettings.public.app.html5ClientBuild;
+
+    const { setLoading } = this.props;
+
+    setLoading(false);
 
     fetch(url)
       .then((response) => {
@@ -155,6 +158,8 @@ export default class Legacy extends Component {
     const { browserName, isSafari } = browserInfo;
     const { isIos } = deviceInfo;
 
+    if (!this.state) return null;
+
     const { messages, normalizedLocale, viewState } = this.state;
     const isSupportedBrowser = supportedBrowsers.includes(browserName);
     const isUnsupportedIos = isIos && !isSafari;
@@ -205,3 +210,7 @@ export default class Legacy extends Component {
     }
   }
 }
+
+Legacy.propTypes = {
+  setLoading: PropTypes.func.isRequired,
+};

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -911,6 +911,16 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         'board.jpg',
       ],
     },
+    minBrowserVersions: {
+      safari: '>=16',
+      chrome: '>=100',
+      firefox: '>=100',
+      edge: '>=100',
+      mobile: {
+        safari: '>=16',
+        chrome: '>=100',
+      },
+    },
   },
   private: {
     analytics: {
@@ -922,65 +932,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       pencilChunkLength: 100,
       loadSlidesFromHttpAlways: false,
     },
-    minBrowserVersions: [
-      {
-        browser: 'chrome',
-        version: 72,
-      },
-      {
-        browser: 'chromeMobileIOS',
-        version: 94,
-      },
-      {
-        browser: 'firefox',
-        version: 68,
-      },
-      {
-        browser: 'firefoxMobile',
-        version: 68,
-      },
-      {
-        browser: 'edge',
-        version: 79,
-      },
-      {
-        browser: 'ie',
-        version: 'Infinity',
-      },
-      {
-        browser: 'safari',
-        version: [
-          12,
-          1,
-        ],
-      },
-      {
-        browser: 'mobileSafari',
-        version: [
-          12,
-          1,
-        ],
-      },
-      {
-        browser: 'opera',
-        version: 50,
-      },
-      {
-        browser: 'electron',
-        version: [
-          0,
-          36,
-        ],
-      },
-      {
-        browser: 'SamsungInternet',
-        version: 10,
-      },
-      {
-        browser: 'YandexBrowser',
-        version: 19,
-      },
-    ],
     prometheus: {
       enabled: false,
       path: '/metrics',

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -913,12 +913,12 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     },
     minBrowserVersions: {
       safari: '>=16',
-      chrome: '>=100',
-      firefox: '>=100',
-      edge: '>=100',
+      chrome: '>=114',
+      firefox: '>=80',
+      edge: '>=85',
       mobile: {
         safari: '>=16',
-        chrome: '>=100',
+        chrome: '>=114',
       },
     },
   },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1116,6 +1116,14 @@ public:
       - home.jpg
       - coffeeshop.jpg
       - board.jpg
+  minBrowserVersions:
+    safari: ">=16"
+    chrome: ">=100"
+    firefox: ">=100"
+    edge: ">=100"
+    mobile:
+      safari: ">=16"
+      chrome: ">=100"
 private:
   analytics:
     includeChat: true
@@ -1124,31 +1132,6 @@ private:
     localesUrl: /locale-list
     pencilChunkLength: 100
     loadSlidesFromHttpAlways: false
-  minBrowserVersions:
-    - browser: chrome
-      version: 72
-    - browser: chromeMobileIOS
-      version: 94
-    - browser: firefox
-      version: 68
-    - browser: firefoxMobile
-      version: 68
-    - browser: edge
-      version: 79
-    - browser: ie
-      version: Infinity
-    - browser: safari
-      version: [12, 1]
-    - browser: mobileSafari
-      version: [12, 1]
-    - browser: opera
-      version: 50
-    - browser: electron
-      version: [0, 36]
-    - browser: SamsungInternet
-      version: 10
-    - browser: YandexBrowser
-      version: 19
   # Direct Prometheus instrumentation.
   # EXPERIMENTAL, so disabled by default.
   prometheus:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1118,12 +1118,12 @@ public:
       - board.jpg
   minBrowserVersions:
     safari: ">=16"
-    chrome: ">=100"
-    firefox: ">=100"
-    edge: ">=100"
+    chrome: ">=114"
+    firefox: ">=80"
+    edge: ">=85"
     mobile:
       safari: ">=16"
-      chrome: ">=100"
+      chrome: ">=114"
 private:
   analytics:
     includeChat: true

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1408,6 +1408,7 @@
     "app.legacy.unsupportedBrowser": "It looks like you're using a browser that is not supported. Please use either {0} or {1} for full support.",
     "app.legacy.upgradeBrowser": "It looks like you're using an older version of a supported browser. Please upgrade your browser for full support.",
     "app.legacy.criosBrowser": "On iOS please use Safari for full support.",
+    "app.legacy.unsupportedSafari": "Please upgrade your browser to Safari 16 or newer for full support.",
     "app.debugWindow.windowTitle": "Debug",
     "app.debugWindow.form.userAgentLabel": "User Agent",
     "app.debugWindow.form.button.copy": "Copy",


### PR DESCRIPTION
### What does this PR do?

Restores browser version check, that should display a message if the user's browser does not have the mininum requisites to run BigBlueButton

### Motivation

BBB had a similar feature provided by MeteorJS, and it was lost in the migration to GraphQL. This PR restores it.

#### message displayed when using an unsupported Safari version
![Screenshot from 2025-03-21 15-33-39](https://github.com/user-attachments/assets/4f33445b-52dc-4e61-b0fb-3b28f811e336)

#### message displayed when using other unsupported browsers / OS
![Screenshot from 2025-03-13 16-46-25](https://github.com/user-attachments/assets/094b69f5-63e6-44b7-84b5-bf58cf7852d9)

### How to test
1. Join a meeting with a browser version older than the ones defined in settings.yml file.
2. See the legacy client page

### More
- [x] Check with testing team about better defaults for minBrowserVersions
