### PR TITLE
fix(doc): fix broken link in presentationConversionCacheEnabled 

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -1,3 +1,4 @@
+import Link from '@docusaurus/Link';
 import React from 'react';
 
 const createEndpointTableData = [
@@ -470,7 +471,7 @@ const createEndpointTableData = [
     "name": "presentationConversionCacheEnabled",
     "required": false,
     "type": "Boolean",
-    "description": (<>Parameter to decide whether to use the caching system in a S3-based storage system for presentation assets per meeting. If this parameter is true, the other settings related to the caching feature must be configured properly (see section <a href="/administration/customize/#configure-s3-based-cache-for-presentation-assets">Configure S3-based cache for presentation assets</a>).</>)
+    "description": (<>Parameter to decide whether to use the caching system in a S3-based storage system for presentation assets per meeting. If this parameter is true, the other settings related to the caching feature must be configured properly (see section <Link to="/administration/customize/#configure-s3-based-cache-for-presentation-assets">Configure S3-based cache for presentation assets</Link>).</>)
   },
   {
     "name": "recordFullDurationMedia",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,6 +2,7 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "baseUrl": "."
   }
 }


### PR DESCRIPTION
### What does this PR do?

It's really just a minor tweak to make the linking of `presentationConversionCacheEnabled` work in both development environment and production environment

### How to test

Just checkout to this branch, and do `./run-dev.sh`.
