### PR TITLE
fix: undo and redo buttons do not fade away

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -815,6 +815,7 @@ class Presentation extends PureComponent {
                     <Styled.Button
                       aria-label={intl?.messages["app.shortcut-help.undo"]}
                       onClick={() => tldrawAPI?.undo()}
+                      className="tlui-undo"
                     >
                       <img src={`${window.meetingClientSettings.public.app.basename}/svgs/tldraw/undo.svg`} width="20" height="20" />
                     </Styled.Button>
@@ -823,6 +824,7 @@ class Presentation extends PureComponent {
                     <Styled.Button
                       aria-label={intl?.messages["app.shortcut-help.redo"]}
                       onClick={() => tldrawAPI?.redo()}
+                      className="tlui-redo"
                     >
                       <img src={`${window.meetingClientSettings.public.app.basename}/svgs/tldraw/redo.svg`} width="20" height="20" />
                     </Styled.Button>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -134,7 +134,7 @@ const toggleToolsAnimations = (activeAnim, anim, time, hasWBAccess = false) => {
   }
 
   const checkElementsAndRun = () => {
-    const tlEls = document.querySelectorAll('.tlui-menu-zone, .tlui-toolbar__tools, .tlui-toolbar__extras, .tlui-style-panel__wrapper');
+    const tlEls = document.querySelectorAll('.tlui-menu-zone, .tlui-toolbar__tools, .tlui-toolbar__extras, .tlui-style-panel__wrapper, .tlui-undo, .tlui-redo');
     if (tlEls.length) {
       tlEls?.forEach((el) => {
         el.classList.remove(activeAnim);


### PR DESCRIPTION
### What does this PR do?

Adjusts undo and redo buttons so they also fade away when "Auto Hide Whiteboard Toolbars" is enabled.

### Closes Issue(s)
Closes #22706

### How to test
1. join a meeting
2. enable "Auto Hide Whiteboard Toolbars" in settings
3. move mouse over the whiteboard
4. move mouse out of the whiteboard
5. undo and redo buttons should fade away the same way as other whiteboard buttons