### PR TITLE
fix: Raise hand notification not well aligned on 75% font-size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
@@ -181,8 +181,8 @@ const Toast = styled.div`
 const ToastifyContainer = styled(Toastify)`
   z-index: 998;
   position: fixed;
-  min-width: 20rem !important;
-  max-width: 23rem !important;
+  min-width: 240px !important;
+  max-width: 320px !important;
   box-sizing: border-box;
   right: ${jumboPaddingY};
   left: auto;

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
@@ -4,7 +4,6 @@ import {
   borderSize,
   avatarInset,
   smPaddingX,
-  toastIconSide,
   toastMargin,
   toastMarginMobile,
 } from '/imports/ui/stylesheets/styled-components/general';
@@ -36,7 +35,7 @@ const Avatar = styled.div`
   border: solid ${borderSize} ${colorWhite};
   margin-left: ${avatarInset};
   text-align: center;
-  padding: 5px 0;
+  padding: 0.75rem 0;
 
   &:hover,
   &:focus {
@@ -72,8 +71,8 @@ const ToastContent = styled.div`
 
 const IconWrapper = styled.div`
   background-color: ${colorPrimary};
-  width: ${toastIconSide};
-  height: ${toastIconSide};
+  width: ${avatarSide};
+  height: ${avatarSide};
   border-radius: 50%;
   
   & > i {

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -79,7 +79,7 @@ const pollBottomOffset = '4.5rem';
 const pollColAmount = '2';
 
 const toastMargin = '.5rem';
-const avatarSide = '34px';
+const avatarSide = '3rem';
 const avatarWrapperOffset = '14px';
 const avatarInset = '-7px';
 

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -92,9 +92,7 @@ const GlobalStyle = createGlobalStyle`
     animation-duration: 0.75s;
     -webkit-animation-fill-mode: both;
     animation-fill-mode: both;
-    max-width: 20rem !important;
-    min-width: 20rem !important;
-    width: 20rem !important;
+    width: 320px !important;
     cursor: pointer;
     background-color: ${colorWhite};
 


### PR DESCRIPTION
### What does this PR do?

Adjusts toast size to be the same in all font-size %.
(also applies to other toasts, not just raise hand, making all the same size)

### Closes Issue(s)
Closes #22676

### How to test
1. Join a meeting
2. Go to the meeting settings and decrease the font-size to 75%
3. Raise hand
4. See the notification