### PR TITLE
Fix(html5): User list dropwdown not focusing the first item

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -143,7 +143,7 @@ class BBBMenu extends React.Component {
             data-key={`menuItem-${dataTest}`}
             disableRipple={true}
             disableGutters={true}
-            disabled={disabled}
+            disabled={disabled || isTitle}
             style={customStyles}
             $roundButtons={roundButtons}
             $isToggle={isToggle}
@@ -170,6 +170,7 @@ class BBBMenu extends React.Component {
             key={a.key}
             isTitle={isTitle}
             isGenericContent={!!contentFunction}
+            disabled={disabled || isTitle}
           >
             <Styled.MenuItemWrapper
               hasSpaceBetween={isTitle && titleActions}


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the first item in the user list dropdown was not being focused when the dropdown opened. The issue was caused by the implementation of the user name title in the dropdown items, which was treated as an 'action.' This may have been done due to the use of a third-party component for rendering the list. The solution was to disable this item, as per the documentation, since disabled components are not auto-focused, allowing the next item to be selected instead.

docs: https://mui.com/material-ui/api/menu/#menu-prop-autoFocus


### Closes Issue(s)
Closes #22466


### How to test
- Join two users
- Navigate to User list using keyboard
- Select "not you" user 
- Press enter
- See Item selected and dropdown navigable 


### More
[Screencast from 17-03-2025 18:09:26.webm](https://github.com/user-attachments/assets/9e012766-9fb2-4166-947d-448423469e30)

