### PR TITLE
Fix(html5): controls on fullscreen screenshare

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -700,7 +700,6 @@ class ScreenshareComponent extends React.Component {
           key="screenshareContainer"
           ref={(ref) => {
             this.screenshareContainer = ref;
-            console.log("🚀 -> ScreenshareComponent -> render -> screenshareRef:", screenshareRef)
             if (!screenshareRef && ref) {
               this.setState({
                 screenshareRef: ref,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -443,7 +443,6 @@ class ScreenshareComponent extends React.Component {
       <Styled.MobileControlsOverlay
         key="mobile-overlay-screenshare"
         ref={(ref) => { this.overlay = ref; }}
-        on
         onTouchStart={() => {
           clearTimeout(this.mobileHoverSetTimeout);
           this.setState({ showHoverToolBar: true });

--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
@@ -74,10 +74,6 @@ const MobileControlsOverlay = styled.span`
 const HoverToolbar = styled.div`
   ${({ toolbarStyle }) => toolbarStyle === 'hoverToolbar' && `
     display: none;
-
-    #screenshareContainer:hover > & {
-      display: flex;
-    }
   `}
 
   ${({ toolbarStyle }) => toolbarStyle === 'dontShowMobileHoverToolbar' && `


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the volume slider remained visible in fullscreen mode during screen sharing. The issue occurred because the event listener was set to the hover event. I updated it to use the mousemove event and added a timeout to control the slider's visibility.


### Closes Issue(s)
Closes #21375


### How to test
- Join two users
- With presenter share it's screen
- with viewer put the screenshare on fullscreen
- just let the cursor over the screenshare
- See results


### More
[Screencast from 19-03-2025 11:34:37.webm](https://github.com/user-attachments/assets/0c5ec083-1003-4ca2-8b44-f47a1274c042)
