### PR TITLE
Fix(html5): Zoom reset not working on preseter's change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/zoom-tool/component.jsx
@@ -138,8 +138,8 @@ class ZoomTool extends PureComponent {
   }
 
   resetZoom() {
-    const { stateZoomValue, initialstateZoomValue } = this.state;
-    if (stateZoomValue !== initialstateZoomValue) this.onChanger(HUNDRED_PERCENT);
+    const { stateZoomValue } = this.state;
+    if (stateZoomValue !== HUNDRED_PERCENT) this.onChanger(HUNDRED_PERCENT);
   }
 
   render() {


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where changing the presenter with zoom applied caused the reset button to be disabled. The issue occurred because the button logic required the initial zoom value to be different from the current value. This was valid in the past when changing the presenter reset the zoom, but now the best approach is to check if the current zoom differs from the default 100% value.


### Closes Issue(s)
Closes #22661

### How to test
- Join with two users
- In Presenter user, zoom the presentation
- Pass the presenter right for another user
- in new Presenter click to reset the zoom


### More
[Screencast from 19-03-2025 14:38:46.webm](https://github.com/user-attachments/assets/e6fd72ce-aeb5-4278-9aae-4e804842f4ad)
