### PR TITLE
Fix(html5): Connection status bars not showing colors on dark mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -65,9 +65,6 @@ const DtfInvert = `
   textarea {
     caret-color: black !important;
   }
-  #connectionBars > div {
-    background-color: var(--darkreader-neutral-text) !important;
-  }
 `;
 
 const DtfBrandingInvert = `


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the connection bars displayed a grayscale instead of a colored indicator when in a bad status. The issue was caused by a style det by dark mode, and I removed the css inline enforcing the gray scale to ensure the correct color representation based on the connection status. 


### Closes Issue(s)
Closes #21496

### How to test
- Join a user
- Open setting modal
- Enable dark mode
- Run the mutation 
```
mutation UpdateConnectionAliveAt($networkRttInMs: Float!) {
  userSetConnectionAlive(networkRttInMs: $networkRttInMs)
}
```

with the variable 
```
{"networkRttInMs":2000}
```
on apollo [devtools](https://www.apollographql.com/docs/react/development-testing/developer-tooling#apollo-client-devtools)
- Open connection status modal
- Select the session logs
- See the results




### More
Before
![image](https://github.com/user-attachments/assets/697c8a79-4dce-4908-81a8-49c506ad91e0)

After
![image](https://github.com/user-attachments/assets/f4c60f78-9ffd-44ef-91fb-9388264744f5)

