### PR TITLE
test(fix): Update user talking indicator check to use regex for exact match

### DIFF
--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -229,8 +229,8 @@ class Page {
   }
 
   async checkUserTalkingIndicator() {
-    const isTalkingLocator = await this.page.locator(e.isTalking).filter({ hasText: this.username });
-    await expect(isTalkingLocator, `should display the "${this.username}" user's conversation indicator to himself`).toBeVisible();
+    const isTalkingLocator = await this.page.locator(e.isTalking).locator(`:text-is("${this.username}")`);
+    await expect(isTalkingLocator, `should display the "${this.username}" user's talking indicator to himself`).toBeVisible();
   }
 
   async checkElement(selector, index = 0) {


### PR DESCRIPTION
### What does this PR do?
Avoids `User › Manage > Mute all users except presenter` test assertion matching two elements:

```sh
Error: should display the "Moderator" user's conversation indicator to himself

should display the "Moderator" user's conversation indicator to himself: Error: strict mode violation: locator('button[data-test="isTalking"]').filter({ hasText: 'Moderator' }) resolved to 2 elements:
    1) <button id="tippy-80" color="primary" position="bottom" aria-disabled="false" data-test="isTalking" aria-describedby="description" aria-label="Moderator is talking" class="sc-lcIPJg gatcbm sc-cAkrUM iwQwIV">…</button> aka getByLabel('Moderator is talking')
    2) <button id="tippy-81" color="primary" position="bottom" aria-disabled="false" data-test="isTalking" aria-describedby="description" aria-label="Moderator2 is talking" class="sc-lcIPJg gatcbm sc-cAkrUM iwQwIV">…</button> aka getByLabel('Moderator2 is talking')
```