### PR TITLE
fix(plugin/html5): fix ui-command changeEnforcedLayout for plugins 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -195,15 +195,18 @@ const CustomLayout = (props) => {
             externalVideo, genericMainContent, screenShare, sharedNotes,
           } = prevInput;
           const { sidebarContentPanel } = sidebarContent;
+          const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
+          const sidebarContentPanelOverride = isSidebarPanelNone
+            ? PANELS.CHAT : sidebarContentPanel;
+          const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
           return defaultsDeep(
             {
               sidebarNavigation: {
-                isOpen:
-                  sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+                isOpen: openSidebar,
               },
               sidebarContent: {
-                isOpen: sidebarContentPanel !== PANELS.NONE,
-                sidebarContentPanel,
+                isOpen: openSidebar,
+                sidebarContentPanel: sidebarContentPanelOverride,
               },
               sidebarContentHorizontalResizer: {
                 isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -3,7 +3,7 @@ import { throttle } from '/imports/utils/throttle';
 import { layoutSelect, layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
-import { ACTIONS, CAMERADOCK_POSITION, PANELS } from '../enums';
+import { ACTIONS, CAMERADOCK_POSITION, LAYOUT_TYPE, PANELS } from '../enums';
 import Storage from '/imports/ui/services/storage/session';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
@@ -14,7 +14,10 @@ const min = (value1, value2) => (value1 <= value2 ? value1 : value2);
 const max = (value1, value2) => (value1 >= value2 ? value1 : value2);
 
 const CustomLayout = (props) => {
-  const { bannerAreaHeight, calculatesActionbarHeight, calculatesNavbarHeight, isMobile } = props;
+  const {
+    bannerAreaHeight, calculatesActionbarHeight, calculatesNavbarHeight, isMobile,
+    prevLayout,
+  } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -195,17 +198,24 @@ const CustomLayout = (props) => {
             externalVideo, genericMainContent, screenShare, sharedNotes,
           } = prevInput;
           const { sidebarContentPanel } = sidebarContent;
-          const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
-          const sidebarContentPanelOverride = isSidebarPanelNone
-            ? PANELS.CHAT : sidebarContentPanel;
-          const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
+          let sidebarContentPanelOverride = sidebarContentPanel;
+          let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
+          let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
+            || sidebarContentPanel !== PANELS.NONE || false;
+          if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+            || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
+            || prevLayout === LAYOUT_TYPE.MEDIA_ONLY) {
+            overrideOpenSidebarNavigation = true;
+            overrideOpenSidebarPanel = true;
+            sidebarContentPanelOverride = PANELS.CHAT;
+          }
           return defaultsDeep(
             {
               sidebarNavigation: {
-                isOpen: openSidebar,
+                isOpen: overrideOpenSidebarNavigation,
               },
               sidebarContent: {
-                isOpen: openSidebar,
+                isOpen: overrideOpenSidebarPanel,
                 sidebarContentPanel: sidebarContentPanelOverride,
               },
               sidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -3,7 +3,9 @@ import { throttle } from '/imports/utils/throttle';
 import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
-import { ACTIONS, CAMERADOCK_POSITION, MEDIA_ONLY_LAYOUT_MARGIN } from '/imports/ui/components/layout/enums';
+import {
+  ACTIONS, CAMERADOCK_POSITION, MEDIA_ONLY_LAYOUT_MARGIN, PANELS,
+} from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
 
@@ -457,10 +459,9 @@ const MediaOnlyLayout = (props) => {
       type: ACTIONS.SET_LAYOUT_INPUT,
       value: (prevInput) => {
         const {
-          sidebarContent, presentation, cameraDock,
+          presentation, cameraDock,
           externalVideo, genericMainContent, screenShare, sharedNotes,
         } = prevInput;
-        const { sidebarContentPanel } = sidebarContent;
         return defaultsDeep(
           {
             sidebarNavigation: {
@@ -468,7 +469,7 @@ const MediaOnlyLayout = (props) => {
             },
             sidebarContent: {
               isOpen: false,
-              sidebarContentPanel,
+              sidebarContentPanel: PANELS.NONE,
             },
             SidebarContentHorizontalResizer: {
               isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
@@ -381,17 +381,18 @@ const ParticipantsAndChatOnlyLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_LAYOUT_INPUT,
       value: (prevInput) => {
-        const { sidebarNavigation, sidebarContent, presentation } = prevInput;
+        const { sidebarContent, presentation } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
+        const sidebarContentPanelOverride = sidebarContentPanel === PANELS.NONE
+          ? PANELS.CHAT : sidebarContentPanel;
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen:
-                sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+              isOpen: true,
             },
             sidebarContent: {
-              isOpen: sidebarContentPanel !== PANELS.NONE,
-              sidebarContentPanel,
+              isOpen: true,
+              sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {
               isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -88,15 +88,18 @@ const PresentationFocusLayout = (props) => {
           externalVideo, genericMainContent, screenShare,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
+        const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
+        const sidebarContentPanelOverride = isSidebarPanelNone
+          ? PANELS.CHAT : sidebarContentPanel;
+        const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen:
-                sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+              isOpen: openSidebar,
             },
             sidebarContent: {
-              isOpen: sidebarContentPanel !== PANELS.NONE,
-              sidebarContentPanel,
+              isOpen: openSidebar,
+              sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {
               isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -94,6 +94,8 @@ const PresentationFocusLayout = (props) => {
           || sidebarContentPanel !== PANELS.NONE || false;
         if (
           prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
+          || prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY
         ) {
           overrideOpenSidebarNavigation = true;
           overrideOpenSidebarPanel = true;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -88,17 +88,24 @@ const PresentationFocusLayout = (props) => {
           externalVideo, genericMainContent, screenShare,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
-        const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
-        const sidebarContentPanelOverride = isSidebarPanelNone
-          ? PANELS.CHAT : sidebarContentPanel;
-        const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
+        let sidebarContentPanelOverride = sidebarContentPanel;
+        let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
+        let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
+          || sidebarContentPanel !== PANELS.NONE || false;
+        if (
+          prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
+        ) {
+          overrideOpenSidebarNavigation = true;
+          overrideOpenSidebarPanel = true;
+          sidebarContentPanelOverride = PANELS.CHAT;
+        }
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen: openSidebar,
+              isOpen: overrideOpenSidebarNavigation,
             },
             sidebarContent: {
-              isOpen: openSidebar,
+              isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -3,7 +3,7 @@ import { throttle } from '/imports/utils/throttle';
 import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
-import { ACTIONS, PANELS, CAMERADOCK_POSITION } from '/imports/ui/components/layout/enums';
+import { ACTIONS, PANELS, LAYOUT_TYPE, CAMERADOCK_POSITION } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
 
@@ -11,7 +11,7 @@ const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
 
 const SmartLayout = (props) => {
-  const { bannerAreaHeight, isMobile, calculatesNavbarHeight } = props;
+  const { prevLayout, bannerAreaHeight, isMobile, calculatesNavbarHeight } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -82,17 +82,24 @@ const SmartLayout = (props) => {
           externalVideo, genericMainContent, screenShare, sharedNotes,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
-        const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
-        const sidebarContentPanelOverride = isSidebarPanelNone
-          ? PANELS.CHAT : sidebarContentPanel;
-        const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
+        let sidebarContentPanelOverride = sidebarContentPanel;
+        let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
+        let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
+          || sidebarContentPanel !== PANELS.NONE || false;
+        if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+          || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
+          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY) {
+          overrideOpenSidebarNavigation = true;
+          overrideOpenSidebarPanel = true;
+          sidebarContentPanelOverride = PANELS.CHAT;
+        }
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen: openSidebar,
+              isOpen: overrideOpenSidebarNavigation,
             },
             sidebarContent: {
-              isOpen: openSidebar,
+              isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -82,15 +82,18 @@ const SmartLayout = (props) => {
           externalVideo, genericMainContent, screenShare, sharedNotes,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
+        const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
+        const sidebarContentPanelOverride = isSidebarPanelNone
+          ? PANELS.CHAT : sidebarContentPanel;
+        const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen:
-                sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+              isOpen: openSidebar,
             },
             sidebarContent: {
-              isOpen: sidebarContentPanel !== PANELS.NONE,
-              sidebarContentPanel,
+              isOpen: openSidebar,
+              sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {
               isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -98,6 +98,7 @@ const VideoFocusLayout = (props) => {
           || sidebarContentPanel !== PANELS.NONE || false;
         if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
           || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
+          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY
         ) {
           overrideOpenSidebarNavigation = true;
           overrideOpenSidebarPanel = true;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -8,7 +8,7 @@ import {
 } from '/imports/ui/components/layout/context';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
-import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { ACTIONS, PANELS, LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
 
@@ -16,7 +16,9 @@ const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
 
 const VideoFocusLayout = (props) => {
-  const { bannerAreaHeight, isMobile, calculatesNavbarHeight } = props;
+  const {
+    prevLayout, bannerAreaHeight, isMobile, calculatesNavbarHeight
+  } = props;
 
   function usePrevious(value) {
     const ref = useRef();
@@ -90,17 +92,24 @@ const VideoFocusLayout = (props) => {
           externalVideo, genericMainContent, screenShare,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
-        const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
-        const sidebarContentPanelOverride = isSidebarPanelNone
-          ? PANELS.CHAT : sidebarContentPanel;
-        const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
+        let sidebarContentPanelOverride = sidebarContentPanel;
+        let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
+        let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
+          || sidebarContentPanel !== PANELS.NONE || false;
+        if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+          || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
+        ) {
+          overrideOpenSidebarNavigation = true;
+          overrideOpenSidebarPanel = true;
+          sidebarContentPanelOverride = PANELS.CHAT;
+        }
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen: openSidebar,
+              isOpen: overrideOpenSidebarNavigation,
             },
             sidebarContent: {
-              isOpen: openSidebar,
+              isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -90,15 +90,18 @@ const VideoFocusLayout = (props) => {
           externalVideo, genericMainContent, screenShare,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
+        const isSidebarPanelNone = sidebarContentPanel === PANELS.NONE;
+        const sidebarContentPanelOverride = isSidebarPanelNone
+          ? PANELS.CHAT : sidebarContentPanel;
+        const openSidebar = isSidebarPanelNone ? true : sidebarNavigation.isOpen;
         return defaultsDeep(
           {
             sidebarNavigation: {
-              isOpen:
-                sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+              isOpen: openSidebar,
             },
             sidebarContent: {
-              isOpen: sidebarContentPanel !== PANELS.NONE,
-              sidebarContentPanel,
+              isOpen: openSidebar,
+              sidebarContentPanel: sidebarContentPanelOverride,
             },
             SidebarContentHorizontalResizer: {
               isOpen: false,

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -108,6 +108,7 @@ const PushLayoutEngine = (props) => {
 
   useEffect(() => {
     const Settings = getSettingsSingletonInstance();
+    const hasLayoutEngineLoadedOnce = Session.getItem('hasLayoutEngineLoadedOnce');
 
     const changeLayout = LAYOUT_TYPE[getFromUserSettings('bbb_change_layout', null)];
     const defaultLayout = LAYOUT_TYPE[getFromUserSettings('bbb_default_layout', null)];
@@ -149,7 +150,7 @@ const PushLayoutEngine = (props) => {
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
           value: meetingLayoutCameraPosition || 'contentTop',
         });
-        if (shouldOpenChat) {
+        if (shouldOpenChat && !hasLayoutEngineLoadedOnce) {
           layoutContextDispatch({
             type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
             value: true,

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -101,27 +101,26 @@ const LAYOUTS_SYNC = {
     [SYNC.PROPAGATE_ELEMENTS]: COMMON_ELEMENTS.DEFAULT,
     [SYNC.REPLICATE_ELEMENTS]: COMMON_ELEMENTS.DEFAULT,
   },
-  // Hidden layouts neither propagate nor replicate the layout type pushed.
-  // These layouts are not available for selection in the UI and are set only via join parameters.
-  // Propagating or replicating the layout type would be inappropriate, as
-  // they are intended to maintain a specific view unaffected by layout type changes.
+  // Hidden layouts are now able to replicate their layout type, as it's currently possible
+  // to change them via plugin ui-commands and those need to be followed correctly.
   [LAYOUT_TYPE.CAMERAS_ONLY]: {
     [SYNC.PROPAGATE_ELEMENTS]: [],
-    [SYNC.REPLICATE_ELEMENTS]: [LAYOUT_ELEMENTS.FOCUSED_CAMERA],
+    [SYNC.REPLICATE_ELEMENTS]: [LAYOUT_ELEMENTS.FOCUSED_CAMERA, LAYOUT_ELEMENTS.LAYOUT_TYPE],
   },
   [LAYOUT_TYPE.PRESENTATION_ONLY]: {
     [SYNC.PROPAGATE_ELEMENTS]: [],
-    [SYNC.REPLICATE_ELEMENTS]: [],
+    [SYNC.REPLICATE_ELEMENTS]: [LAYOUT_ELEMENTS.LAYOUT_TYPE],
   },
   [LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY]: {
     [SYNC.PROPAGATE_ELEMENTS]: [],
-    [SYNC.REPLICATE_ELEMENTS]: [],
+    [SYNC.REPLICATE_ELEMENTS]: [LAYOUT_ELEMENTS.LAYOUT_TYPE],
   },
   [LAYOUT_TYPE.MEDIA_ONLY]: {
     [SYNC.PROPAGATE_ELEMENTS]: [],
     [SYNC.REPLICATE_ELEMENTS]: [
       LAYOUT_ELEMENTS.FOCUSED_CAMERA,
       LAYOUT_ELEMENTS.PRESENTATION_STATE,
+      LAYOUT_ELEMENTS.LAYOUT_TYPE,
     ],
   },
 };


### PR DESCRIPTION
### What does this PR do?

It basically fixes the ui-command `changeEnforcedLayout` in the pluginApi. The problem was that for some layout transitions, some components were being misplaced on the UI.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/158

### Motivation

With this fix, the `changeEnforcedLayout` can be better utilised in cases like hybrid classrooms, so that one can choose what to show in each device across the same session (and each device can change from oj).

### How to test

#### Compatibility tests
Well, first I would advise to test thoroughly the layout transitions that can be accessible via UI and compare the results with the same set of actions done in the `v3.0.x-release`, all the behaviours should be the same. The possible layout types, in this case, would be:

- CUSTOM_LAYOUT
- SMART_LAYOUT
- PRESENTATION_FOCUS
- VIDEO_FOCUS

And within those layouts, there are also plenty of possibilities such as sharing webcam or not, sharing screen or not, etc.

#### Test the fix proposed by this PR:

As for the other layout types, I'd consider using the plugin `sample-action-button-dropdown` and just change the last `useEffect` to add a button to each layout, just like:

```ts
new ActionButtonDropdownOption({
          label: 'Smart layout',
          icon: 'copy',
          tooltip: 'this is a button injected by plugin',
          allowed: true,
          onClick: () => {
            pluginApi.uiCommands.layout.changeEnforcedLayout(
              ChangeEnforcedLayoutTypeEnum.SMART_LAYOUT,
            );
          },
        }),
```

That would be added alongside with the current code:
```ts
pluginApi.setActionButtonDropdownItems([
        new ActionButtonDropdownSeparator(),
        ...
```

The result should look somewhat like this:

![image](https://github.com/user-attachments/assets/dae72045-5b09-4704-a9bc-ff56536ac4cc)

With that in hands, just play around with the different layout types.

### More

No needs for PR from SDK repo (BBB-Core fix only).
