### PR TITLE
Fix: whiteboard crash on second user join

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -171,7 +171,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   </main>
   </div>
   <span id="destination"></span>
-  <audio id="remote-media" autoplay></audio>
-  <audio id="local-media" autoplay></audio>
+  <audio id="remote-media"></audio>
+  <audio id="local-media"></audio>
   <div id="modals-container"></div>
 </body>

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/component.jsx
@@ -52,6 +52,7 @@ const LocalEcho = ({
 
   const applyHearingState = (_stream) => {
     if (hearing) {
+      setAudioSink(outputDeviceId);
       playEchoStream(_stream, loopbackAgent.current);
     } else {
       deattachEchoStream();

--- a/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/local-echo/service.js
@@ -128,7 +128,7 @@ const playEchoStream = async (stream, loopbackAgent = null) => {
 
 const setAudioSink = (deviceId) => {
   const audioElement = document.querySelector(LOCAL_MEDIA_TAG);
-
+  audioElement.autoplay = true;
   if (audioElement.setSinkId) {
     audioElement.setSinkId(deviceId).catch((error) => {
       logger.warn({


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where the client was crashing the whiteboard due to an error caught by the ErrorBoundary that handles all client log errors. The issue was related to two `<audio>` tags in the main HTML, both set with `autoplay`. During the client loading phase, users who had not yet interacted with the page were not granting permission for audio playback, which triggered the error.

### Closes Issue(s)
Closes #22485

### How to test
- Join with two users on FF
- Select first user and watis it load completely
- Select second user
- Se no crash and no erro of DOM exception on console.



### More
Before:
[Screencast from 21-03-2025 09:19:49.webm](https://github.com/user-attachments/assets/5d9da7e8-c989-4504-960b-583e98dff665)


After:
[Screencast from 21-03-2025 09:24:33.webm](https://github.com/user-attachments/assets/60899433-c02a-4330-900e-e7bb5202ec80)



