### PR TITLE
fix(html5): Fix ephemeral webcam settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -30,12 +30,18 @@ import { CustomVirtualBackgroundsContext } from '/imports/ui/components/video-pr
 import VBGSelectorService from '/imports/ui/components/video-preview/virtual-background/service';
 import Session from '/imports/ui/services/storage/in-memory';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import { isEqual } from 'radash';
 
 const VIEW_STATES = {
   finding: 'finding',
   found: 'found',
   error: 'error',
 };
+
+const DEFAULT_BRIGHTNESS_STATE = {
+  brightness: 100,
+  wholeImageBrightness: false,
+}
 
 const propTypes = {
   intl: PropTypes.object.isRequired,
@@ -415,7 +421,7 @@ class VideoPreview extends Component {
     Session.setItem('videoPreviewFirstOpen', false);
   }
 
-  async startCameraBrightness(initialState = { brightness: 100, wholeImageBrightness: false }) {
+  async startCameraBrightness(initialState = DEFAULT_BRIGHTNESS_STATE) {
     const ENABLE_CAMERA_BRIGHTNESS = window.meetingClientSettings.public.app.enableCameraBrightness;
     const CAMERA_BRIGHTNESS_AVAILABLE = ENABLE_CAMERA_BRIGHTNESS && isVirtualBackgroundSupported();
 
@@ -825,7 +831,7 @@ class VideoPreview extends Component {
     const webcamDeviceId = deviceId || this.state.webcamDeviceId;
     const cameraBrightness = getCameraBrightnessInfo(webcamDeviceId);
 
-    if (cameraBrightness) {
+    if (cameraBrightness && !isEqual(cameraBrightness, DEFAULT_BRIGHTNESS_STATE)) {
       return this.startCameraBrightness(cameraBrightness);
     }
   }

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/service.js
@@ -89,7 +89,13 @@ const setSessionVirtualBackgroundInfo = (deviceId, type, name, uniqueId = null) 
   getStorageSingletonInstance().setItem(`VirtualBackgroundInfo_${deviceId}`, { type, name, uniqueId });
 };
 
+const setCameraBrightnessInfo = (deviceId, brightness, wholeImageBrightness) => {
+  getStorageSingletonInstance().setItem(`CameraBrightnessInfo_${deviceId}`, { brightness, wholeImageBrightness });
+};
+
 const getSessionVirtualBackgroundInfo = (deviceId) => getStorageSingletonInstance().getItem(`VirtualBackgroundInfo_${deviceId}`);
+
+const getCameraBrightnessInfo = (deviceId) => getStorageSingletonInstance().getItem(`CameraBrightnessInfo_${deviceId}`);
 
 const getSessionVirtualBackgroundInfoWithDefault = (deviceId) => getStorageSingletonInstance()
   .getItem(`VirtualBackgroundInfo_${deviceId}`) || {
@@ -117,8 +123,10 @@ export {
   BLUR_FILENAME,
   EFFECT_TYPES,
   setSessionVirtualBackgroundInfo,
+  setCameraBrightnessInfo,
   getSessionVirtualBackgroundInfo,
   getSessionVirtualBackgroundInfoWithDefault,
+  getCameraBrightnessInfo,
   removeSessionVirtualBackgroundInfo,
   isVirtualBackgroundSupported,
   createVirtualBackgroundStream,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Store webcam brightness settings on local/session storage.
- Restore that state on video preview opening.

[Screencast from 21-03-2025 09:40:18.webm](https://github.com/user-attachments/assets/f33533c1-8983-472d-a51b-4e1927885bcc)



### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22730