### PR TITLE
fix(html5): Extra padding on whiteboard toolbar when cursor is outside + auto hide enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -214,7 +214,7 @@ const TldrawV2GlobalStyle = createGlobalStyle`
           top: 2px !important;
         }
 
-        .tlui-toolbar__tools.tlui-toolbar__tools__mobile.fade-in {
+        .tlui-toolbar__tools.tlui-toolbar__tools__mobile {
           height: 30px !important;
         }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

[Screencast from 21-03-2025 13:01:52.webm](https://github.com/user-attachments/assets/8f303839-c897-4f50-89f7-5408741e27f9)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22735

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Join a meeting.
2. Options > Settings > Enable Auto Hide Whiteboard Toolbars.
3. Move cursor in and out whiteboard.