### PR TITLE
fix: client crash in breakout room mgmt panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
@@ -105,7 +105,7 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
           name: intl.formatMessage(intlMessages.breakoutRoom, {
             0: toRoom,
           }),
-          users: [users.find((user) => user.userId === id)],
+          users: [users.find((user) => user.userId === id)].filter((user) => user),
         } as Room;
       } else {
         updatedRooms[toRoom] = {
@@ -113,7 +113,7 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
           users: [
             ...(room?.users ?? []),
             roomFrom?.users?.find((user) => user.userId === id),
-          ],
+          ].filter((user) => user),
         } as Room;
         updatedRooms[fromRoom] = {
           ...roomFrom,
@@ -170,7 +170,7 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
             users: [
               ...prevRooms[0].users,
               ...rooms[Number(room)].users,
-            ],
+            ].filter((user) => user),
           },
           [Number(room)]: {
             ...prevRooms[Number(room)],


### PR DESCRIPTION
The client may crash in breakout room's management panel due to undefined user entries being set in the rooms' users arrays. Repro:
  - Join with u1, u2; create BRs
  - u2: join a BR, then leave *the main room*
  - u1: try opening the mgmt panel

Properly filter user arrays in the RoomManagementState component so that no undefined entries are present there. This should prevent the crash described here as well as further issues.
