### PR TITLE
fix(html5): Whiteboard crash when trying to use the rectangle shortcut

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -16,6 +16,9 @@ import {
   setDefaultEditorAssetUrls,
   toolbarItem,
 } from '@bigbluebutton/tldraw';
+import {
+  GeoShapeGeoStyle,
+} from '@bigbluebutton/editor';
 import '@bigbluebutton/tldraw/tldraw.css';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { compressToBase64, decompressFromBase64 } from 'lz-string';
@@ -175,6 +178,7 @@ const Whiteboard = React.memo((props) => {
 
   const customUiOverrides = React.useMemo(() => ({
     tools: (editor, tools) => {
+      console.log("🚀 -> customUiOverrides -> tools:", tools)
       const updatedTools = {
         ...tools,
         deleteAll: {
@@ -220,6 +224,7 @@ const Whiteboard = React.memo((props) => {
 
   const setWheelZoomTimeout = () => {
     isWheelZoomRef.currentTimeout = setTimeout(() => {
+        console.log("🚀 -> customUiOverrides -> tools:", tools)
       setIsWheelZoom(false);
     }, 300);
   };
@@ -434,11 +439,17 @@ const Whiteboard = React.memo((props) => {
           tlEditorRef.current?.setCurrentTool('hand');
         }
       },
-      r: () => tlEditorRef.current?.setCurrentTool('geo'),
-      o: () => tlEditorRef.current?.setCurrentTool('ellipse'),
+      r: () => {
+        tlEditorRef.current?.setStyleForNextShapes(GeoShapeGeoStyle, 'rectangle');
+        tlEditorRef.current?.setCurrentTool('geo');
+      },
+      o: () => {
+        tlEditorRef.current?.setStyleForNextShapes(GeoShapeGeoStyle, 'ellipse');
+        tlEditorRef.current?.setCurrentTool('geo');
+      },
       a: () => tlEditorRef.current?.setCurrentTool('arrow'),
       l: () => tlEditorRef.current?.setCurrentTool('line'),
-      t: () => tlEditorRef.current?.setCurrentTool('text'),
+      t: () => tlEditorRef.current?.setCurrentTool('t'),
       f: () => tlEditorRef.current?.setCurrentTool('frame'),
       n: () => tlEditorRef.current?.setCurrentTool('note'),
     };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -178,7 +178,6 @@ const Whiteboard = React.memo((props) => {
 
   const customUiOverrides = React.useMemo(() => ({
     tools: (editor, tools) => {
-      console.log("🚀 -> customUiOverrides -> tools:", tools)
       const updatedTools = {
         ...tools,
         deleteAll: {
@@ -224,7 +223,6 @@ const Whiteboard = React.memo((props) => {
 
   const setWheelZoomTimeout = () => {
     isWheelZoomRef.currentTimeout = setTimeout(() => {
-        console.log("🚀 -> customUiOverrides -> tools:", tools)
       setIsWheelZoom(false);
     }, 300);
   };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -434,7 +434,7 @@ const Whiteboard = React.memo((props) => {
           tlEditorRef.current?.setCurrentTool('hand');
         }
       },
-      r: () => tlEditorRef.current?.setCurrentTool('rectangle'),
+      r: () => tlEditorRef.current?.setCurrentTool('geo'),
       o: () => tlEditorRef.current?.setCurrentTool('ellipse'),
       a: () => tlEditorRef.current?.setCurrentTool('arrow'),
       l: () => tlEditorRef.current?.setCurrentTool('line'),
@@ -491,6 +491,7 @@ const Whiteboard = React.memo((props) => {
     if (!event.altKey && !event.ctrlKey && !event.shiftKey && simpleKeyMap[key]) {
       event.preventDefault();
       event.stopPropagation();
+      console.log("🚀 -> handleKeyDown -> simpleKeyMap:", simpleKeyMap)
       simpleKeyMap[key]();
       return;
     }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -491,7 +491,6 @@ const Whiteboard = React.memo((props) => {
     if (!event.altKey && !event.ctrlKey && !event.shiftKey && simpleKeyMap[key]) {
       event.preventDefault();
       event.stopPropagation();
-      console.log("🚀 -> handleKeyDown -> simpleKeyMap:", simpleKeyMap)
       simpleKeyMap[key]();
       return;
     }

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -447,7 +447,7 @@ const Whiteboard = React.memo((props) => {
       },
       a: () => tlEditorRef.current?.setCurrentTool('arrow'),
       l: () => tlEditorRef.current?.setCurrentTool('line'),
-      t: () => tlEditorRef.current?.setCurrentTool('t'),
+      t: () => tlEditorRef.current?.setCurrentTool('text'),
       f: () => tlEditorRef.current?.setCurrentTool('frame'),
       n: () => tlEditorRef.current?.setCurrentTool('note'),
     };


### PR DESCRIPTION
### What does this PR do?
This PR fixes a crash on the whiteboard when trying to select a tool using a keybind. The issue was caused by an incorrect ID being provided.

### Closes Issue(s)
N/A

### How to test
- Join a user
- click on whiteboard
- Press "R" in teh keyboard
- See it working.


### More
[Screencast from 24-03-2025 09:06:31.webm](https://github.com/user-attachments/assets/fae15049-71a6-4e91-9294-f0a846ddb17f)

