### PR TITLE
build(bbb-webrtc-recorder): v0.8.0

### DIFF
--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v0.7.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder
+git clone --branch v0.8.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder


### PR DESCRIPTION
v0.8.0
---
* fix: multiple adjusments to VP8 sample building in the WebM recorder
* fix: multiple adjustments to packet loss handling
* fix: better pts generation for video samples
* fix: edge case adjusments to RTP jitter buffer and receive log
* chore: change default JB size
* feat: add option to write IVF copies of recorded streams
* feat: add option to use alternative video sample builder
* feat: make jb packet timeout configurable
* feat: make EBML max write queue sizes configurable
* build: use Galene's samplebuilder instead of Pion's
* build: sync ebml-go with upstream (4b8f657f0)