### PR TITLE
Refactor(html5): Disable assets tool on whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -156,6 +156,9 @@ const GlobalStyle = createGlobalStyle`
       left: none !important;
     }
   }
+  button[data-testid="tools.more.asset"] {
+    display: none;
+  }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
### What does this PR do?
This PR disable the assets button on whiteboard.

I used as base this issue and PR
https://github.com/tldraw/tldraw-v1/issues/289
https://github.com/tldraw/tldraw/pull/511

### Closes Issue(s)
Closes #22745

### How to test
- Join a meeting as presenter
- Click on `more` button
- Don't see assets tool 


### More

[Screencast from 25-03-2025 09:16:39.webm](https://github.com/user-attachments/assets/22362952-3e3f-42bc-ac51-2611aab65d62)

