### PR TITLE
feat(akka): Validating plugin-settings-template from manifest.json

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -127,55 +127,11 @@ object ClientSettings extends SystemConfiguration {
         for {
           plugin <- plugins
         } yield {
-          if (plugin.contains("name") && plugin.contains("url")) {
+          if (plugin.contains("name")) {
 
             val pluginName = plugin("name").toString
-            val pluginUrl = plugin("url").toString
-            var pluginDataChannels: Map[String, DataChannel] = Map()
-            if (plugin.contains("dataChannels")) {
-              plugin("dataChannels") match {
-                case dataChannels: List[Map[String, Any]] =>
-                  for {
-                    dataChannel <- dataChannels
-                  } yield {
-                    if (dataChannel.contains("name")) {
-                      val channelName = dataChannel("name").toString
-                      val pushPermission = {
-                        if (dataChannel.contains("pushPermission")) {
-                          dataChannel("pushPermission") match {
-                            case wPerm: List[String] => wPerm
-                            case _ => {
-                              logger.warn(s"Invalid pushPermission for channel $channelName in plugin $pluginName")
-                              List()
-                            }
-                          }
-                        } else {
-                          logger.warn(s"Missing config pushPermission for channel $channelName in plugin $pluginName")
-                          List()
-                        }
-                      }
-                      val replaceOrDeletePermission = {
-                        if (dataChannel.contains("replaceOrDeletePermission")) {
-                          dataChannel("replaceOrDeletePermission") match {
-                            case dPerm: List[String] => dPerm
-                            case _ => {
-                              logger.warn(s"Invalid replaceOrDeletePermission for channel $channelName in plugin $pluginName")
-                              List()
-                            }
-                          }
-                        } else {
-                          List()
-                        }
-                      }
-
-                      pluginDataChannels += (channelName -> DataChannel(channelName, pushPermission, replaceOrDeletePermission))
-                    }
-                  }
-                case _ => logger.warn(s"Plugin $pluginName has an invalid dataChannels format")
-              }
-            }
-
-            pluginsFromConfig += (pluginName -> Plugin(pluginName, pluginUrl, pluginDataChannels))
+            val configs: Map[String, Object] = plugin("settings").asInstanceOf[Map[String, Object]]
+            pluginsFromConfig += (pluginName -> Plugin(pluginName, configs))
           }
         }
       case _ => logger.warn(s"Invalid plugins config found.")
@@ -184,7 +140,6 @@ object ClientSettings extends SystemConfiguration {
     pluginsFromConfig
   }
 
-  case class DataChannel(name: String, pushPermission: List[String], replaceOrDeletePermission: List[String])
-  case class Plugin(name: String, url: String, dataChannels: Map[String, DataChannel])
+  case class Plugin(name: String, settings: Map[String, Object])
 
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -161,7 +161,7 @@ object MeetingDAO {
     MeetingBreakoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.breakoutProps)
     LayoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.usersProp.meetingLayout)
     MeetingClientSettingsDAO.insert(meetingProps.meetingProp.intId, JsonUtils.mapToJson(clientSettings))
-    PluginModel.persistPluginsForClient(pluginProps, meetingProps.meetingProp.intId)
+    PluginModel.persistPluginsForClient(meetingProps.meetingProp.intId, pluginProps, clientSettings)
   }
 
   def updateMeetingDurationByParentMeeting(parentMeetingId: String, newDurationInSeconds: Int) = {

--- a/bbb-graphql-server/bbb-graphql-schema.md
+++ b/bbb-graphql-server/bbb-graphql-schema.md
@@ -807,10 +807,8 @@ Permission: Restricted to Moderators
 
 ## Type: meeting_clientPluginSettings
 ### Fields:
-- `dataChannels`
 - `name`
 - `settings`
-- `url`
 
 ## Type: pollUserCurrent
 Permission: Restricted to User Viewing Self-Related Data

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -251,9 +251,7 @@ CREATE VIEW "v_meeting_clientSettings" AS SELECT * FROM "meeting_clientSettings"
 create view "v_meeting_clientPluginSettings" as
 select "meetingId",
        plugin->>'name' as "name",
-       plugin->>'url' as "url",
-       (plugin->>'settings')::jsonb as "settings",
-       (plugin->>'dataChannels')::jsonb as "dataChannels"
+       (plugin->>'settings')::jsonb as "settings"
 from (
     select "meetingId", jsonb_array_elements("clientSettingsJson"->'public'->'plugins') AS plugin
     from "meeting_clientSettings"

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientPluginSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_clientPluginSettings.yaml
@@ -10,10 +10,8 @@ select_permissions:
   - role: bbb_client
     permission:
       columns:
-        - dataChannels
         - name
         - settings
-        - url
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId


### PR DESCRIPTION
### What does this PR do?

This introduces the validation of the settings sent for plugins via client-settings through the new plugin-settings-template, provided by `manifest.json`.


### Motivation

This will guarantee that the plugin will have each and every setting needed for it to work properly, otherwise it will fail and not load in client.

### How to test

Pretty simple, add a setting template configuration in your `manifest.json` just like the following:
```json
{
  "requiredSdkVersion": "~0.0.73",
  "name": "SampleActionButtonDropdownPlugin",
  ...
  "settingsTemplate": [
    {
      "name": "avatarUrl",
      "label": "Avatar Url",
      "required": true,
      "settingType": "string" // possible types: boolean, int, string and json.
    }
  ]
}
```

Next add the propper setting to your `/etc/bigbluebutton/bbb-html5.yml`:

```yaml
public:
  plugins:
    - name: SampleActionButtonDropdownPlugin
      settings:
        avatarUrl: https://www.google.com.br/
```
The plugin settings are located at `public.plugins` and need `name` and `settings` directives.

And voilà, you have a setting validation in your back-end. Now just play around with the possibilities, like passing wrong typing, and stuff like that - see errors in the log for the validation.
