### PR TITLE
Fix(html5): Push layout changes not notifying other users than the presenter

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -63,13 +63,12 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
     outGW.send(msgEvent)
 
     if (body.pushLayout) {
-      val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
-        fromUserId,
+      val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
         liveMeeting.props.meetingProp.intId,
         "info",
         "user",
         "app.layoutUpdate.label",
-        "Notification to when the presenter changes size of cams",
+        "Notification to when the presenter change layout",
         Vector()
       )
       outGW.send(notifyEvent)


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where users were not receiving notifications when the layout was changed while the push layout feature was active. The problem was caused by the use of the wrong function on the server — it was notifying only the user instead of the entire meeting about the layout change.


### Closes Issue(s)
Closes #21462

### How to test
- Join two user.
- in one user activate the push layout and change the layout.
- See the notification in both users.


### More
[Screencast from 25-03-2025 16:01:39.webm](https://github.com/user-attachments/assets/b7957547-57d5-4ebf-a71e-78434e66e79a)

