### PR TITLE
style: adjust raise hand toast with many users

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/styles.js
@@ -55,7 +55,7 @@ const AvatarsExtra = styled.div`
   border: solid ${borderSize} ${colorWhite};
   margin-left: ${avatarInset};
   text-align: center;
-  padding: 5px 0;
+  padding: 0.75rem 0;
 `;
 
 const ToastContent = styled.div`


### PR DESCRIPTION
### What does this PR do?

Adjusts icons position in raise hand toast when more than 3 users have raised hands

#### before

![Screenshot from 2025-03-26 09-05-39](https://github.com/user-attachments/assets/ee3c1ab4-dea2-4217-95d3-4c0baa4561cf)

#### after

![Screenshot from 2025-03-26 09-04-16](https://github.com/user-attachments/assets/694b989f-acc2-4070-af01-17ef9f2e067c)

### How to test
1. join a meeting
2. have at least 4 users with raised hands
3. as a moderator, check raise hand notification