### PR TITLE
Fix(html5): Whiteboard dark mode buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -816,7 +816,7 @@ class Presentation extends PureComponent {
                       aria-label={intl?.messages["app.shortcut-help.undo"]}
                       onClick={() => tldrawAPI?.undo()}
                     >
-                      <img src={`${window.meetingClientSettings.public.app.basename}/svgs/tldraw/undo.svg`} width="20" height="20" />
+                      <Styled.IconWithMask mask={`${window.meetingClientSettings.public.app.basename}/svgs/tldraw/undo.svg`} />
                     </Styled.Button>
                   </TooltipContainer>
                   <TooltipContainer title={intl?.messages["app.shortcut-help.redo"]}>
@@ -824,7 +824,7 @@ class Presentation extends PureComponent {
                       aria-label={intl?.messages["app.shortcut-help.redo"]}
                       onClick={() => tldrawAPI?.redo()}
                     >
-                      <img src={`${window.meetingClientSettings.public.app.basename}/svgs/tldraw/redo.svg`} width="20" height="20" />
+                      <Styled.IconWithMask mask={`${window.meetingClientSettings.public.app.basename}/svgs/tldraw/redo.svg`} />
                     </Styled.Button>
                   </TooltipContainer>
                 </Styled.ExtraTools>}

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.js
@@ -208,6 +208,12 @@ const ExtraTools = styled.div`
   `}
 `;
 
+const IconWithMask = styled.div.attrs({
+  className: 'tlui-icon',
+})`
+  mask: url(${({ mask }) => mask})  center 100% / 100% no-repeat;
+`;
+
 export default {
   VisuallyHidden,
   PresentationSvg,
@@ -226,4 +232,5 @@ export default {
   ToastSeparator,
   Button,
   ExtraTools,
+  IconWithMask,
 };

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -1,5 +1,5 @@
 import styled, { createGlobalStyle } from 'styled-components';
-import { colorOffWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorOffWhite, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 
 const TldrawV2GlobalStyle = createGlobalStyle`
   ${({ isPresenter, hasWBAccess }) => (!isPresenter && hasWBAccess) && `
@@ -129,7 +129,7 @@ const TldrawV2GlobalStyle = createGlobalStyle`
   [data-testid="main.page-menu"],
   [data-testid="main.menu"],
   [data-testid="tools.more.laser"],
-  [data-testid="tools.asset"],
+  [data-testid="tools.more.asset"],
   [data-testid="page-menu.button"],
   [data-testid="menu-item.zoom-to-100"],
   .tlui-menu-zone {
@@ -226,6 +226,11 @@ const TldrawV2GlobalStyle = createGlobalStyle`
 
     return `.tlui-layout__bottom { top: ${topValue} !important; }${additionalStyles}`;
   }}
+  [data-darkreader-scheme="dark"] button[data-testid="mobile.styles"] {
+    & > div.tlui-icon {
+      color: ${colorWhite};
+    }
+  }
 `;
 
 const EditableWBWrapper = styled.div`

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -156,14 +156,6 @@ const GlobalStyle = createGlobalStyle`
       left: none !important;
     }
   }
-  [data-darkreader-scheme="dark"] button[data-testid="mobile.styles"] {
-    & > div.tlui-icon {
-      color: ${colorWhite};
-    }
-  }
-  button[data-testid="tools.more.asset"] {
-    display: none;
-  }
 `;
 
 export default GlobalStyle;

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -156,6 +156,12 @@ const GlobalStyle = createGlobalStyle`
       left: none !important;
     }
   }
+  [data-darkreader-scheme="dark"] button[data-testid="mobile.styles"] {
+    & > div.tlui-icon {
+      color: ${colorWhite};
+    }
+    
+  }
 `;
 
 export default GlobalStyle;

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -160,7 +160,7 @@ const GlobalStyle = createGlobalStyle`
     & > div.tlui-icon {
       color: ${colorWhite};
     }
-    
+  }
   button[data-testid="tools.more.asset"] {
     display: none;
   }


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the three buttons on the whiteboard were not having their colors inverted when dark mode was enabled.

To resolve this, I used two approaches:
1. For the **Undo** and **Redo** buttons, which were using `<img>` elements to load images, I replaced them with `<div>` elements using CSS `mask`, following the same approach used by Tldraw. This allows the colors to be correctly inverted by dark mode.
2. For the **Styles** button, which is managed internally by Tldraw, I applied a global CSS style to ensure proper color inversion when dark mode is active.

Also made a small change suggested here https://github.com/bigbluebutton/bigbluebutton/pull/22777#issuecomment-2752995386 moving the styles for the tldraw global styles instead of keeping them on general one.

### Closes Issue(s)
n/a


### How to test
- Join a user.
- Open settings modal and enable the dark mode.
- See the buttons with the colors inverted.


### More

Before
![image](https://github.com/user-attachments/assets/6d73e5fd-46f3-479d-869b-e6c01a931ac3)

After
![image](https://github.com/user-attachments/assets/ded3a921-e801-4547-9c45-251b20e751d8)

