### PR TITLE
refactor(tests/npm scripts): Add npm scripts without `CI=true`

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -407,7 +407,7 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           BBB_URL: https://bbb-ci.test/bigbluebutton/api
           BBB_SECRET: bbbci
-        run: npm run test-chromium-ci -- --shard ${{ env.shard }}
+        run: npm run test-chromium-ci -- --shard=${{ env.shard }}
       - name: Run Firefox tests
         working-directory: ./bigbluebutton-tests/playwright
         if: |
@@ -422,7 +422,7 @@ jobs:
         run: |
           sh -c '
           find $HOME/.cache/ms-playwright -name libnssckbi.so -exec rm {} \; -exec ln -s /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so {} \;
-          npm run test-firefox-ci -- --shard ${{ env.shard }}
+          npm run test-firefox-ci -- --shard=${{ env.shard }}
           '
       - if: always()
         name: Upload blob report to GitHub Actions Artifacts

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -5,6 +5,8 @@
     "test:filter": "npx playwright test -g",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug -g",
+    "test-chromium": "npx playwright test --project=chromium --grep @ci --grep-invert '@flaky|@need-update|@only-headed|@setting-required'",
+    "test-firefox": "npx playwright test --project=firefox --grep @ci --grep-invert '@flaky|@need-update|@only-headed|@setting-required'",
     "test-chromium-ci": "export CI='true' && npx playwright test --project=chromium --grep @ci --grep-invert '@flaky|@need-update|@only-headed|@setting-required'",
     "test-firefox-ci": "export CI='true' && npx playwright test --project=firefox --grep @ci --grep-invert '@flaky|@need-update|@only-headed|@setting-required'",
     "rewrite-snapshots": "read -p 'CAUTION: You will delete ALL testing folders containing snapshots and run the tests to rewrite these files.\nProceed? (y/n) ' confirm && test $confirm = 'y' && sh core/scripts/rewrite-snapshots.sh"


### PR DESCRIPTION
### What does this PR do?
- Adds same `test-chromium-ci` and `test-firefox-ci` commands without `CI=true`

### Motivation
Ease test results reading - same default test logging, especially when running on a remote server (as we usually do during release testing)

### More
You can still use `npm run test-chromium` followed by `test(s)_suite(s)` for filtering
