### PR TITLE
Fix(html5): duplicated session joining full audio

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -193,7 +193,10 @@ const AudioContainer = (props) => {
   const { hasBreakoutRooms: hadBreakoutRooms } = prevProps || {};
   const userIsReturningFromBreakoutRoom = hadBreakoutRooms && !hasBreakoutRooms;
 
-  const { data: currentUser } = useCurrentUser((u) => ({ userId: u.userId }));
+  const { data: currentUser } = useCurrentUser((u) => ({
+    userId: u.userId,
+    voice: u.voice,
+  }));
   const { data: unmutedUsers } = useWhoIsUnmuted();
   const currentUserMuted = currentUser?.userId && !unmutedUsers[currentUser.userId];
 
@@ -213,13 +216,15 @@ const AudioContainer = (props) => {
     // We don't know whether the meeting is a breakout or not.
     // So, postpone the decision.
     if (meetingIsBreakout === undefined) return;
-
-    init().then(() => {
-      if (meetingIsBreakout && !Service.isUsingAudio()) {
-        joinAudio();
-      }
-    });
-  }, [meetingIsBreakout]);
+    // If the user has duplicated the session and has already joined the audio.
+    if (!currentUser?.voice) {
+      init().then(() => {
+        if (meetingIsBreakout && !Service.isUsingAudio()) {
+          joinAudio();
+        }
+      });
+    }
+  }, [meetingIsBreakout, currentUser?.voice]);
 
   useEffect(() => {
     if (userIsReturningFromBreakoutRoom) {


### PR DESCRIPTION
### What does this PR do?
Fix a issue of the duplicated tab, also joining full audio instead of just respect first joined, causing a issue of when closing the tab kicking both sessions from audio.


### Closes Issue(s)
N/A

### How to test
- Join a user
- Right-click the tab
- Select the option of duplicate tab
- See no connection for audio


### More

[Screencast from 26-03-2025 15:41:21.webm](https://github.com/user-attachments/assets/d68b9f8e-dd61-43e1-925c-675328fe273e)
