### PR TITLE
Fix(html5): Users being moved to room zero on running meetings causes a crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -352,7 +352,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
           variables: {
             userId,
             fromBreakoutRoomId: fromRoomId || '',
-            toBreakoutRoomId: toRoomId,
+            toBreakoutRoomId: toRoomId || '',
           },
         });
       }


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where moving a user from any breakout room to Room 0 (i.e., removing them from a breakout) was causing a crash. The bug occurred because the code attempted to retrieve a `breakoutId` during the move, but Room 0 does not have a `breakoutId`. As a result, `undefined` was being passed as a parameter to the mutation, which failed to affect the target user as expected.


### Closes Issue(s)
Closes #22784


### How to test
- Join with 1 mod and 2 viewers
- Create a breakout with the two viewers
- Go to "Manager users" on breakout panel
- Move a user from a breakout to room 0
- See it working


### More
[Screencast from 27-03-2025 10:21:18.webm](https://github.com/user-attachments/assets/e3415eb3-553e-4a3e-b19e-6e428d8345de)

