### PR TITLE
Fix(html5): Dark mode flicker on presentation snapshot

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -294,13 +294,6 @@ const PresentationMenu = (props) => {
               toastId: toastId.current,
             });
 
-            // This is a workaround to a conflict of the
-            // dark mode's styles and the html-to-image lib.
-            // Issue:
-            //  https://github.com/bubkoo/html-to-image/issues/370
-            const darkThemeState = AppService.isDarkThemeEnabled();
-            AppService.setDarkTheme(false);
-
             try {
               // filter shapes that are inside the slide
               const backgroundShape = tldrawAPI.getCurrentPageShapes().find((s) => s.id === `shape:BG-${slideNum}`);
@@ -368,9 +361,6 @@ const PresentationMenu = (props) => {
                 logCode: 'presentation_snapshot_error',
                 extraInfo: e,
               });
-            } finally {
-              // Workaround
-              AppService.setDarkTheme(darkThemeState);
             }
           },
         },


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where dark mode would flicker when the user took a snapshot of the presentation. The flicker was caused by a workaround introduced in version 2.6, which no longer appears to be necessary. I ran several tests and was unable to reproduce the original bug, so the workaround has been removed.

PR the introduced the workaround: https://github.com/bigbluebutton/bigbluebutton/pull/17194
Related issue: https://github.com/bigbluebutton/bigbluebutton/issues/17192

### Closes Issue(s)
Closes #20989

### How to test
- Join a meeting
- Open settings
- Enable dark mode
- On presentation click on options -> Snapshot of current slide

### More
[Screencast from 27-03-2025 11:55:37.webm](https://github.com/user-attachments/assets/917d214e-b1b8-42ec-9e4a-bcda5c8c7fe6)
