### PR TITLE
fix(bbb-export-annotations): `@svgdotjs/svg.js` not respecting provided image dimensions

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -279,6 +279,37 @@ function overlayAnnotations(svg, slideAnnotations) {
 }
 
 /**
+ * Resize an SVG image if it contains an embedded base64 image.
+ * 
+ * `WARNING`: This function is intended to be a hotfix for bad generated SVG's.
+ * It should be removed in the future.
+ * @param {string} file Path of the file.
+ * @param {number} width The new width of the image.
+ * @param {number} height The new height of the image.
+ * @param {number} oldWidth The old width of the image.
+ * @param {number} height The old height of the image.
+ */
+function resizeAssetIfBase64Image(file, width, height, oldWidth, oldHeight) {
+  const BASE_64_HREF_REGEX = /href="data:image\/(png|jpg|jpeg);base64,[^"]+"/;
+  const isSvg = file.endsWith('.svg');
+
+  if (!isSvg) return;
+
+  try {
+    let svg = fs.readFileSync(file, { encoding: 'utf-8' });
+    const hasBase64Image = BASE_64_HREF_REGEX.test(svg);
+    if (hasBase64Image) {
+      svg = svg.replaceAll(`width="${oldWidth}"`, `width="${width}"`);
+      svg = svg.replaceAll(`height="${oldHeight}"`, `height="${height}"`);
+      fs.writeFileSync(file, svg);
+    }
+  } catch (error) {
+    logger.error(`Resizing slide ${currentSlide.page}
+      failed for job ${jobId}: ${error.message}`);
+  }
+}
+
+/**
  * Processes presentation slides and associated annotations into
  * a single PDF file.
  * @async
@@ -356,6 +387,15 @@ async function processPresentationAnnotations() {
           'xmlns': 'http://www.w3.org/2000/svg',
           'xmlns:xlink': 'http://www.w3.org/1999/xlink',
         });
+
+    // Resize the image element
+    resizeAssetIfBase64Image(
+      `${dropbox}/slide${currentSlide.page}.${backgroundFormat}`,
+      scaledWidth,
+      scaledHeight,
+      slideWidth,
+      slideHeight,
+    );
 
     // Add the image element
     canvas

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -287,9 +287,10 @@ function overlayAnnotations(svg, slideAnnotations) {
  * @param {number} width The new width of the image.
  * @param {number} height The new height of the image.
  * @param {number} oldWidth The old width of the image.
- * @param {number} height The old height of the image.
+ * @param {number} oldHeight The old height of the image.
+ * @param {number} page Page number.
  */
-function resizeAssetIfBase64Image(file, width, height, oldWidth, oldHeight) {
+function resizeAssetIfBase64Image(file, width, height, oldWidth, oldHeight, page) {
   const BASE_64_HREF_REGEX = /href="data:image\/(png|jpg|jpeg);base64,[^"]+"/;
   const isSvg = file.endsWith('.svg');
 
@@ -304,7 +305,7 @@ function resizeAssetIfBase64Image(file, width, height, oldWidth, oldHeight) {
       fs.writeFileSync(file, svg);
     }
   } catch (error) {
-    logger.error(`Resizing slide ${currentSlide.page}
+    logger.error(`Resizing slide ${page}
       failed for job ${jobId}: ${error.message}`);
   }
 }
@@ -395,6 +396,7 @@ async function processPresentationAnnotations() {
       scaledHeight,
       slideWidth,
       slideHeight,
+      currentSlide.page,
     );
 
     // Add the image element


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

- Seems like `@svgdotjs/svg.js` is not respecting provided image dimensions when the slide image has a base64 image within the SVG. This is a fix for manually resizing both width and height of the SVG with the correct values.

Sample pdf: [3.0.2.pdf](https://github.com/user-attachments/files/19490435/3.0.2.pdf)

**Whiteboard**:

![Screenshot from 2025-03-27 13-35-49](https://github.com/user-attachments/assets/b6c08959-adc1-4826-bdc3-a8b7b9f6aa86)

Exported pdf:
- With the fix: [302.pdf](https://github.com/user-attachments/files/19490502/302.pdf).
- Without the fix: [302 (1).pdf](https://github.com/user-attachments/files/19490510/302.1.pdf)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22704