### PR TITLE
fix: prevent undefined functions in external video component

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -268,13 +268,22 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
   useEffect(() => {
     if (isPresenter !== presenterRef.current) {
-      const internalPlayer = playerRef.current?.getInternalPlayer();
-      const playerVolume = internalPlayer?.getVolume();
-      const isMuted = internalPlayer?.isMuted();
-      // the scale fiven by the player is 0 to 100, but the accepted scale is 0 to 1
-      // So we need to divide by 100
-      setVolume(playerVolume / 100);
-      setMute(isMuted);
+      const internalPlayer = playerRef.current?.getInternalPlayer ? playerRef.current?.getInternalPlayer() : null;
+      if (internalPlayer && internalPlayer?.isMuted
+        && typeof internalPlayer?.isMuted === 'function') {
+        const isMuted = internalPlayer?.isMuted();
+        setMute(isMuted);
+      }
+
+      if (internalPlayer && internalPlayer?.getVolume
+        && typeof internalPlayer?.getVolume === 'function'
+        && internalPlayer?.getVolume() !== currentVolume.current) {
+        const playerVolume = internalPlayer?.getVolume();
+        // the scale fiven by the player is 0 to 100, but the accepted scale is 0 to 1
+        // So we need to divide by 100
+        setVolume(playerVolume / 100);
+      }
+
       clientReloadedRef.current = true;
       setPlayerKey(uniqueId('react-player'));
       presenterRef.current = isPresenter;


### PR DESCRIPTION
### What does this PR do?

Adds checks for external video player functions `isMuted` and `getVolume` to avoid calling them when they are not yet available.

### Motivation
Client logs pointing to a case where these functions can be unavailable
