### PR TITLE
Fix(html5): Client error log related to missing name of user

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -312,7 +312,7 @@ class ConnectionStatusComponent extends PureComponent {
                 moderator={conn.user.isModerator}
                 color={conn.user.color}
               >
-                {conn.user.name.toLowerCase().slice(0, 2)}
+                {(conn.user.name?.toLowerCase()?.slice(0, 2)) || ''}
               </UserAvatar>
             </Styled.Avatar>
 


### PR DESCRIPTION
### What does this PR do?
Add a Check for `name` and `toLowerCase` on connection status.


### Motivation
Client logs pointing to a case where this field can be unavailable