### PR TITLE
fix (html5): Limit html5 to generate one single bundle (no more chunks) to make it work in Safari 15

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -127,8 +127,8 @@ if (env === prodEnv) {
   };
   config.performance = {
     hints: 'warning',
-    maxAssetSize: 6000000,
-    maxEntrypointSize: 6000000,
+    maxAssetSize: 8000000,
+    maxEntrypointSize: 8000000,
   };
 } else {
   config.mode = devEnv;

--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -30,6 +30,9 @@ const config = {
   },
   devtool: 'source-map',
   plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
     new HtmlWebpackPlugin({
       template: './client/main.html',
       filename: 'index.html',

--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -127,8 +127,8 @@ if (env === prodEnv) {
   };
   config.performance = {
     hints: 'warning',
-    maxAssetSize: 8000000,
-    maxEntrypointSize: 8000000,
+    maxAssetSize: isSafariTarget ? 16000000 : 8000000,
+    maxEntrypointSize: isSafariTarget ? 16000000 : 8000000,
   };
 } else {
   config.mode = devEnv;


### PR DESCRIPTION
Since #22764, the client has been generating two separate bundles. To ensure the Safari bundle uses the same hash as the standard bundle, we renamed it—but the script still tries to load chunks using the old bundle name, causing an error.

This PR updates the webpack config to generate a single bundle (no extra chunks). This resolves the naming mismatch and avoids runtime errors.

The standard bundle size increases from `5.6MB` to `6.8MB`, but this tradeoff may be beneficial, as it avoids downloading additional chunks during a meeting—potentially improving performance.

### Issue:

```
Loading chunk 446 failed.
(error: https://bbb/ 3.0.4 server/html5client/446.bundle.safari.js)
```

```
extraInfo.errorInfo_esobj.componentStack

Lazy
Player@https://BBB 3.0.4 server/html5client/bundle.3c83c873d2818f9162fa.safari.js:85906:10
Suspense
div
ReactPlayer@https://BBB 3.0.4 server/html5client/bundle.3c83c873d2818f9162fa.safari.js:86209:12
```

![image](https://github.com/user-attachments/assets/e84a0c53-f1c9-44d0-aa64-d00437d979bf)
