### PR TITLE
fix: adjust allowDefaultLogoutUrl param behavior

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -13,6 +13,7 @@ import {
   MeetingEndedTable,
   openLearningDashboardUrl,
   setLearningDashboardCookie,
+  allowRedirectToLogoutURL,
 } from './service';
 import { MeetingEndDataResponse, getMeetingEndData } from './queries';
 import useAuthData from '/imports/ui/core/local-states/useAuthData';
@@ -152,26 +153,26 @@ interface MeetingEndedContainerProps {
 }
 
 interface MeetingEndedProps extends MeetingEndedContainerProps {
-  allowDefaultLogoutUrl: boolean;
   skipMeetingEnded: boolean;
   learningDashboardAccessToken: string;
   isModerator: boolean;
   logoutUrl: string;
   learningDashboardBase: string;
   isBreakout: boolean;
+  allowRedirect: boolean;
 }
 
 const MeetingEnded: React.FC<MeetingEndedProps> = ({
   endedBy,
   joinErrorCode,
   meetingEndedCode,
-  allowDefaultLogoutUrl,
   skipMeetingEnded,
   learningDashboardAccessToken,
   isModerator,
   logoutUrl,
   learningDashboardBase,
   isBreakout,
+  allowRedirect,
 }) => {
   const loadingContextInfo = useContext(LoadingContext);
   const intl = useIntl();
@@ -236,7 +237,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
 
           <Styled.MeetingEndedButton
             color="primary"
-            onClick={() => confirmRedirect(isBreakout, allowDefaultLogoutUrl)}
+            onClick={() => confirmRedirect(isBreakout, allowRedirect)}
             /* @eslint-disable-next-line */
             aria-details={intl.formatMessage(intlMessage.confirmDesc)}
           >
@@ -284,7 +285,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
   }, []);
 
   if (skipMeetingEnded) {
-    confirmRedirect(isBreakout, allowDefaultLogoutUrl);
+    confirmRedirect(isBreakout, allowRedirect);
     return <></>; // even though well redirect, return empty component and prevent lint error
   }
 
@@ -295,7 +296,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
           <Styled.Title>
             {generateEndMessage(joinErrorCode, meetingEndedCode, endedBy)}
           </Styled.Title>
-          {allowDefaultLogoutUrl ? logoutButton : null}
+          {allowRedirect ? logoutButton : null}
         </Styled.Content>
       </Styled.Modal>
     </Styled.Parent>
@@ -319,7 +320,7 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
         endedBy=""
         joinErrorCode=""
         meetingEndedCode=""
-        allowDefaultLogoutUrl={false}
+        allowRedirect={false}
         skipMeetingEnded={false}
         learningDashboardAccessToken=""
         isModerator={false}
@@ -337,7 +338,7 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
         endedBy=""
         joinErrorCode=""
         meetingEndedCode=""
-        allowDefaultLogoutUrl={false}
+        allowRedirect={false}
         skipMeetingEnded={false}
         learningDashboardAccessToken=""
         isModerator={false}
@@ -364,17 +365,18 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
   } = meeting;
 
   const {
-    allowDefaultLogoutUrl,
     skipMeetingEnded,
     learningDashboardBase,
   } = clientSettings;
+
+  const allowRedirect = allowRedirectToLogoutURL(logoutUrl);
 
   return (
     <MeetingEnded
       endedBy={endedBy}
       joinErrorCode={joinErrorCode}
       meetingEndedCode={meetingEndedCode}
-      allowDefaultLogoutUrl={allowDefaultLogoutUrl}
+      allowRedirect={allowRedirect}
       skipMeetingEnded={skipMeetingEnded}
       learningDashboardAccessToken={learningDashboard?.learningDashboardAccessToken}
       isModerator={isModerator}

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
@@ -95,9 +95,29 @@ export const setLearningDashboardCookie = (accessToken: string, mId: string, lea
   return false;
 };
 
+export const allowRedirectToLogoutURL = (logoutURL: string) => {
+  const ALLOW_DEFAULT_LOGOUT_URL = window.meetingClientSettings.public.app.allowDefaultLogoutUrl;
+  const protocolPattern = /^((http|https):\/\/)/;
+
+  if (logoutURL) {
+    // default logoutURL
+    // compare only the host to ignore protocols
+    const urlWithoutProtocolForAuthLogout = logoutURL.replace(protocolPattern, '');
+    const urlWithoutProtocolForLocationOrigin = window.location.origin.replace(protocolPattern, '');
+    if (urlWithoutProtocolForAuthLogout === urlWithoutProtocolForLocationOrigin) {
+      return ALLOW_DEFAULT_LOGOUT_URL;
+    }
+    // custom logoutURL
+    return true;
+  }
+  // no logout url
+  return false;
+};
+
 export default {
   JoinErrorCodeTable,
   MeetingEndedTable,
   setLearningDashboardCookie,
   openLearningDashboardUrl,
+  allowRedirectToLogoutURL,
 };


### PR DESCRIPTION
### What does this PR do?

Adjusts meeting ended component to display the redirect button when `allowDefaultLogoutUrl: false` and `logoutURL` is set

### How to test
1. set `public.app.allowDefaultLogoutUrl: false` in settings.yml
2. join a meeting passing `logoutURL` parameter on join api call
3. leave the meeting
4. a button to return to the home screen should be displayed

### More
`allowDefaultLogoutUrl` true/false should have no effect if a custom logoutURL is provided