### PR TITLE
fix: crash due to MediaDevices EventTarget unavailability

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -3,6 +3,7 @@
 import { useReactiveVar } from '@apollo/client';
 import React, { useCallback, useEffect } from 'react';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { hasMediaDevicesEventTarget } from '/imports/ui/services/webrtc-base/utils';
 import AudioManager from '/imports/ui/services/audio-manager';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { User } from '/imports/ui/Types/user';
@@ -186,10 +187,12 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   }, [inAudio, inputDevices, outputDevices, updateRemovedDevices]);
 
   useEffect(() => {
-    navigator.mediaDevices.addEventListener('devicechange', updateDevices);
+    if (hasMediaDevicesEventTarget()) navigator.mediaDevices.addEventListener('devicechange', updateDevices);
 
     return () => {
-      navigator.mediaDevices.removeEventListener('devicechange', updateDevices);
+      if (hasMediaDevicesEventTarget()) {
+        navigator.mediaDevices.removeEventListener('devicechange', updateDevices);
+      }
     };
   }, [updateDevices]);
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -9,6 +9,7 @@ import AudioStreamVolume from '/imports/ui/components/audio/audio-stream-volume/
 import LocalEchoContainer from '/imports/ui/components/audio/local-echo/container';
 import DeviceSelector from '/imports/ui/components/audio/device-selector/component';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
+import { hasMediaDevicesEventTarget } from '/imports/ui/services/webrtc-base/utils';
 import AudioManager from '/imports/ui/services/audio-manager';
 import Session from '/imports/ui/services/storage/in-memory';
 import AudioCaptionsSelectContainer from '../audio-graphql/audio-captions/captions/component';
@@ -166,10 +167,12 @@ class AudioSettings extends React.Component {
       .then(() => {
         if (!this._isMounted) return;
 
-        navigator.mediaDevices.addEventListener(
-          'devicechange',
-          this.updateDeviceList,
-        );
+        if (hasMediaDevicesEventTarget()) {
+          navigator.mediaDevices.addEventListener(
+            'devicechange',
+            this.updateDeviceList,
+          );
+        }
         this.setState({ findingDevices: false });
         this.setInputDevice(inputDeviceId);
         this.setOutputDevice(outputDeviceId);
@@ -203,9 +206,12 @@ class AudioSettings extends React.Component {
     }
 
     AudioManager.isEchoTest = false;
-    navigator.mediaDevices.removeEventListener(
-      'devicechange', this.updateDeviceList,
-    );
+
+    if (hasMediaDevicesEventTarget()) {
+      navigator.mediaDevices.removeEventListener(
+        'devicechange', this.updateDeviceList,
+      );
+    }
 
     this.unmuteOnExit();
   }

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -20,6 +20,7 @@ import {
 } from '/imports/api/audio/client/bridge/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import { makeVar } from '@apollo/client';
+import { hasMediaDevicesEventTarget } from '/imports/ui/services/webrtc-base/utils';
 import AudioErrors from '/imports/ui/services/audio-manager/error-codes';
 import GrahqlSubscriptionStore, { stringToHash } from '/imports/ui/core/singletons/subscriptionStore';
 import VOICE_ACTIVITY from '../../core/graphql/queries/whoIsTalking';
@@ -53,6 +54,17 @@ const FILTER_AUDIO_STATS = [
   'local-candidate',
   'transport',
 ];
+
+const checkMediaDevicesTarget = () => {
+  if (!hasMediaDevicesEventTarget()) {
+    logger.warn({
+      logCode: 'media_devices_event_target_unavailable',
+      extraInfo: {
+        hasMediaDevicesIface: typeof navigator?.mediaDevices !== 'undefined',
+      },
+    }, 'navigator.mediaDevices EventTarget unavailable');
+  }
+};
 
 class AudioManager {
   constructor() {
@@ -100,6 +112,7 @@ class AudioManager {
 
     window.addEventListener('StopAudioTracks', () => this.forceExitAudio());
     window.addEventListener('beforeunload', this.onBeforeUnload);
+    checkMediaDevicesTarget();
   }
 
   onBeforeUnload() {

--- a/bigbluebutton-html5/imports/ui/services/webrtc-base/utils.js
+++ b/bigbluebutton-html5/imports/ui/services/webrtc-base/utils.js
@@ -12,6 +12,9 @@ const stopStream = (stream) => {
   stream.getTracks().forEach(stopTrack);
 };
 
+const hasMediaDevicesEventTarget = () => typeof navigator?.mediaDevices?.addEventListener === 'function'
+    && typeof navigator?.mediaDevices?.removeEventListener === 'function';
+
 const silentConsole = {
   log: () => {},
   info: () => {},
@@ -23,6 +26,7 @@ const silentConsole = {
 };
 
 export {
+  hasMediaDevicesEventTarget,
   stopStream,
   stopTrack,
   silentConsole,


### PR DESCRIPTION
### What does this PR do?

- [fix: crash due to MediaDevices EventTarget unavailability](https://github.com/bigbluebutton/bigbluebutton/commit/d6b1a65a5bced120ae2569661f6b36ae686265cb) 
  - It seems that for some browsers (Safari 18.x), under some specific
circumstances, either the MediaDevices interface or the EventTarget
it should be inheriting from  aren't available. This causes a client
crash when trying to add devicechange event listeners.
  - Add availability checks before adding/removing devicechange listeners.
Additionally:
    - Log a warning whenever the MediaDevices interface is not fully
    available. This is a *browser bug* and the log will help us report
    this to vendors and help clear up any report that might be related
    to the missing devicechange callbacks.

### Closes Issue(s)

None