### PR TITLE
fix: enable support to older chrome version

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -65,6 +65,11 @@ const ErrorBoundaryWithReload = ({ children }) => {
         },
       }, 'Global error caught by ErrorBoundaryWithReload');
 
+      // Ignore errors caused by ResizeObserver in chrome <100
+      if (event.reason?.message?.toString().indexOf('ResizeObserver loop limit exceeded') !== -1) {
+        return;
+      }
+
       triggerError();
     };
 

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -914,7 +914,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     },
     minBrowserVersions: {
       safari: '>=14',
-      chrome: '>=114',
+      chrome: '>=99',
       firefox: '>=80',
       edge: '>=85',
       mobile: {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -914,12 +914,12 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     },
     minBrowserVersions: {
       safari: '>=14',
-      chrome: '>=99',
+      chrome: '>=87',
       firefox: '>=80',
       edge: '>=85',
       mobile: {
         safari: '>=14',
-        chrome: '>=114',
+        chrome: '>=87',
       },
     },
   },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1118,7 +1118,7 @@ public:
       - board.jpg
   minBrowserVersions:
     safari: ">=14"
-    chrome: ">=114"
+    chrome: ">=99"
     firefox: ">=80"
     edge: ">=85"
     mobile:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1118,12 +1118,12 @@ public:
       - board.jpg
   minBrowserVersions:
     safari: ">=14"
-    chrome: ">=99"
+    chrome: ">=87"
     firefox: ">=80"
     edge: ">=85"
     mobile:
       safari: ">=14"
-      chrome: ">=114"
+      chrome: ">=87"
 private:
   analytics:
     includeChat: true


### PR DESCRIPTION
### What does this PR do?

- change minimum supported chrome version to 87
- adjusts error boundary to log but not reload whiteboard on resize error

(ResizeObserver loop limit exceeded warning in older versions of chrome will still be logged, but will not make the whiteboard reload)

### Closes Issue(s)
Closes #22819

### How to test
1. join a meeting on chrome >=87