### PR TITLE
fix(html5): Prevent users from changing external video volume using arrow keys

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -441,6 +441,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           onEnded={handleOnStop}
           muted={mute || isEchoTest}
           controls={isPresenter}
+          previewTabIndex={isPresenter ? 0 : -1}
         />
         {
           shouldShowTools() ? (
@@ -461,6 +462,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
               loaded={loaded}
               subtitlesOn={subtitlesOn}
               hideVolume={hideVolume[playerName as keyof typeof hideVolume]}
+              showUnsynchedMsg={showUnsynchedMsg}
             />
           ) : null
         }

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/styles.ts
@@ -57,6 +57,7 @@ export const AutoPlayWarning = styled.p`
 export const VideoPlayer = styled(ReactPlayer)`
   width: 100%;
   height: 100%;
+  z-index: 0;
   & > iframe {
     display: flex;
     flex-flow: column;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/component.tsx
@@ -10,6 +10,7 @@ import { uniqueId } from '/imports/utils/string-utils';
 import { layoutSelect } from '../../../layout/context';
 import { Layout } from '../../../layout/layoutTypes';
 import ExternalVideoPlayerProgressBar from './progress-bar/component';
+import ExternalVideoOverlay from './overlay/component';
 
 const intlMessages = defineMessages({
   refreshLabel: {
@@ -43,6 +44,7 @@ interface ExternalVideoPlayerToolbarProps {
   playerParent: HTMLDivElement | null;
   played: number;
   loaded: number;
+  showUnsynchedMsg: boolean;
 }
 
 const ExternalVideoPlayerToolbar: React.FC<ExternalVideoPlayerToolbarProps> = ({
@@ -62,9 +64,11 @@ const ExternalVideoPlayerToolbar: React.FC<ExternalVideoPlayerToolbarProps> = ({
   playerParent,
   played,
   loaded,
+  showUnsynchedMsg,
 }) => {
   const intl = useIntl();
   const mobileTimout = React.useRef<ReturnType<typeof setTimeout>>();
+  const volumeSliderRef = React.useRef<HTMLInputElement>(null);
 
   const fullscreen = layoutSelect((i: Layout) => i.fullscreen);
   const { element } = fullscreen;
@@ -82,6 +86,7 @@ const ExternalVideoPlayerToolbar: React.FC<ExternalVideoPlayerToolbarProps> = ({
                 muted={muted || mutedByEchoTest}
                 onMuted={handleOnMuted}
                 onVolumeChanged={handleVolumeChanged}
+                ref={volumeSliderRef}
               />
               <Styled.ButtonsWrapper>
                 <ReloadButton
@@ -127,6 +132,13 @@ const ExternalVideoPlayerToolbar: React.FC<ExternalVideoPlayerToolbarProps> = ({
                 }}
               />
           ),
+          (!showUnsynchedMsg && (
+            <ExternalVideoOverlay
+              onVerticalArrow={() => {
+                volumeSliderRef.current?.focus();
+              }}
+            />
+          )),
         ]
       }
     </>

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/overlay/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/overlay/component.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import KEY_CODES from '/imports/utils/keyCodes';
+import Styles from './styles';
+
+interface ExternalVideoOverlayProps {
+  onVerticalArrow?: () => void;
+}
+
+const ExternalVideoOverlay: React.FC<ExternalVideoOverlayProps> = (props) => {
+  const { onVerticalArrow } = props;
+
+  return (
+    <Styles.ExternalVideoOverlay
+      id="external-video-overlay"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return;
+
+        if ([KEY_CODES.ARROW_DOWN, KEY_CODES.ARROW_UP].includes(e.keyCode)) {
+          onVerticalArrow?.();
+        }
+      }}
+    />
+  );
+};
+
+export default ExternalVideoOverlay;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/overlay/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/overlay/styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const ExternalVideoOverlay = styled.div`
+  z-index: 1;
+  position: absolute;
+  inset: 0;
+  outline: none;
+`;
+
+export default {
+  ExternalVideoOverlay,
+};

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/progress-bar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/progress-bar/styles.ts
@@ -5,6 +5,7 @@ const ProgressBar = styled.div`
   bottom: 0;
   height: 5px;
   width: 100%;
+  z-index: 3;
 
   background-color: transparent;   
 `;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/styles.ts
@@ -30,6 +30,7 @@ const ButtonsWrapper = Styled.div`
   bottom: 0;
   top: 0;
   display: flex;
+  z-index: 3;
 
   [dir="rtl"] & {
     right: 0;
@@ -44,6 +45,7 @@ const MobileControlsOverlay = Styled.span`
   width: 100%;
   height: 100%;
   background-color: transparent;
+  z-index: 3;
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/volume-slide/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/volume-slide/component.tsx
@@ -9,13 +9,13 @@ interface VolumeSlideProps {
   hideVolume: boolean;
 }
 
-const VolumeSlide: React.FC<VolumeSlideProps> = ({
+const VolumeSlide = React.forwardRef<HTMLInputElement, VolumeSlideProps>(({
   onVolumeChanged,
   onMuted,
   volume,
   muted,
   hideVolume,
-}) => {
+}, ref) => {
   const [volumeState, setVolume] = React.useState(volume);
   const [mutedState, setMuted] = React.useState(muted);
 
@@ -82,6 +82,7 @@ const VolumeSlide: React.FC<VolumeSlideProps> = ({
         />
       </Styled.Volume>
       <Styled.VolumeSlider
+        ref={ref}
         type="range"
         min={0}
         max={1}
@@ -91,6 +92,6 @@ const VolumeSlide: React.FC<VolumeSlideProps> = ({
       />
     </Styled.Slider>
   );
-};
+});
 
 export default VolumeSlide;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

`react-player` doesn't provide a way to listen to volume changes. So, we can't have a controlled component for the volume slider when it comes to using arrow keys to change the external video volume. This PR adds an overlay component on top of the player component to prevent it from receiving keyboard events.

**Downsides**:

- Users will not be able to click any native player elements, like the video title, recommended videos, etc. An alternative to that would be sending a custom message containing the video link to the chat whenever an external video is shared.

![Screenshot from 2025-03-31 10-19-26](https://github.com/user-attachments/assets/1c6bff2f-a29c-4957-a5be-1fda9b4e6731)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22810