### PR TITLE
Fix(html5): Presenters height not propagating for another user when fit to width is enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -963,7 +963,7 @@ const Whiteboard = React.memo((props) => {
 
           const zoomed = prevCam.z !== nextCam.z;
 
-          if ((panned || (zoomed && fitToWidthRef.current)) && isPresenterRef.current) {
+          if ((panned || (zoomed || fitToWidthRef.current)) && isPresenterRef.current) {
             const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
               editor?.getViewportPageBounds()?.w,
               currentPresentationPageRef.current?.scaledWidth,


### PR DESCRIPTION
### What does this PR do?
this PR fixes the issue of the presentation zoom was not propagated when the fit to width was enabled.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22729

### How to test
- Join Two users
- WIth Presenter enable fit to width
- With Presenter open a webcam.

### More
[Screencast from 31-03-2025 17:21:36.webm](https://github.com/user-attachments/assets/2d42c753-0837-4266-813b-20b9147668ec)
