### PR TITLE
chore(html5): Add logs for breakout management

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -121,6 +121,7 @@ class App extends Component {
       isAudioModalOpen: false,
       isVideoPreviewModalOpen: false,
       presentationFitToWidth: false,
+      isJoinLogged: false,
     };
 
     this.timeOffsetInterval = null;
@@ -128,12 +129,13 @@ class App extends Component {
     this.setPresentationFitToWidth = this.setPresentationFitToWidth.bind(this);
     this.setAudioModalIsOpen = this.setAudioModalIsOpen.bind(this);
     this.setVideoPreviewModalIsOpen = this.setVideoPreviewModalIsOpen.bind(this);
+    this.logJoin = this.logJoin.bind(this);
   }
 
   componentDidMount() {
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
-    const { isBreakout, meetingId, meetingName } = this.props;
+    const { isJoinLogged } = this.state;
 
     Session.setItem('videoPreviewFirstOpen', true);
 
@@ -150,15 +152,9 @@ class App extends Component {
     window.ondragover = (e) => { e.preventDefault(); };
     window.ondrop = (e) => { e.preventDefault(); };
 
-    const logMessage = isBreakout ? 'User joined breakout room' : 'User joined main room';
-
-    logger.info({
-      logCode: 'app_component_componentdidmount',
-      extraInfo: {
-        meetingId,
-        meetingName,
-      },
-    }, logMessage);
+    if (!isJoinLogged) {
+      this.logJoin();
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -168,6 +164,8 @@ class App extends Component {
       intl,
       fitToWidth,
     } = this.props;
+
+    const { isJoinLogged } = this.state;
 
     this.renderDarkMode();
 
@@ -189,6 +187,10 @@ class App extends Component {
 
     if (prevProps.fitToWidth !== fitToWidth) {
       this.setState({ presentationFitToWidth: fitToWidth });
+    }
+
+    if (!isJoinLogged) {
+      this.logJoin();
     }
   }
 
@@ -212,6 +214,24 @@ class App extends Component {
 
   setVideoPreviewModalIsOpen(value) {
     this.setState({ isVideoPreviewModalOpen: value });
+  }
+
+  logJoin() {
+    const { isJoinLogged } = this.state;
+    const { meetingId, meetingName, isBreakout } = this.props;
+
+    const logMessage = isBreakout ? 'User joined breakout room' : 'User joined main room';
+
+    if (!isJoinLogged && meetingId) {
+      logger.info({
+        logCode: 'app_component_componentdidmount',
+        extraInfo: {
+          meetingId,
+          meetingName,
+        },
+      }, logMessage);
+      this.setState({ isJoinLogged: true });
+    }
   }
 
   renderDarkMode() {

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -109,6 +109,9 @@ const intlMessages = defineMessages({
 const propTypes = {
   darkTheme: PropTypes.bool.isRequired,
   hideNotificationToasts: PropTypes.bool.isRequired,
+  isBreakout: PropTypes.bool.isRequired,
+  meetingId: PropTypes.string.isRequired,
+  meetingName: PropTypes.string.isRequired,
 };
 
 class App extends Component {
@@ -130,6 +133,7 @@ class App extends Component {
   componentDidMount() {
     const { browserName } = browserInfo;
     const { osName } = deviceInfo;
+    const { isBreakout, meetingId, meetingName } = this.props;
 
     Session.setItem('videoPreviewFirstOpen', true);
 
@@ -146,7 +150,15 @@ class App extends Component {
     window.ondragover = (e) => { e.preventDefault(); };
     window.ondrop = (e) => { e.preventDefault(); };
 
-    logger.info({ logCode: 'app_component_componentdidmount' }, 'Client loaded successfully');
+    const logMessage = isBreakout ? 'User joined breakout room' : 'User joined main room';
+
+    logger.info({
+      logCode: 'app_component_componentdidmount',
+      extraInfo: {
+        meetingId,
+        meetingName,
+      },
+    }, logMessage);
   }
 
   componentDidUpdate(prevProps) {

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -42,6 +42,9 @@ const AppContainer = (props) => {
   } = useMeeting((m) => ({
     layout: m.layout,
     componentsFlags: m.componentsFlags,
+    isBreakout: m.isBreakout,
+    name: m.name,
+    meetingId: m.meetingId,
   }));
 
   const { data: currentPageInfo } = useDeduplicatedSubscription(
@@ -149,6 +152,9 @@ const AppContainer = (props) => {
           hideNotificationToasts: hideNotificationToasts
             || getFromUserSettings('bbb_hide_notifications', false),
           darkTheme,
+          isBreakout: currentMeeting?.isBreakout,
+          meetingName: currentMeeting?.name,
+          meetingId: currentMeeting?.meetingId,
         }}
         {...props}
       />

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -17,6 +17,7 @@ import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedS
 import { rejoinAudio } from '../../breakout-room/breakout-room/service';
 import { useBreakoutExitObserver } from './hooks';
 import { useStopMediaOnMainRoom } from '/imports/ui/components/breakout-room/hooks';
+import logger from '/imports/startup/client/logger';
 
 const intlMessages = defineMessages({
   title: {
@@ -119,6 +120,12 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
     } else {
       const selectedBreakout = breakouts.find(({ breakoutRoomId }) => breakoutRoomId === selectValue);
       if (selectedBreakout?.joinURL) {
+        // log which breakout room the user is joining
+        logger.info({
+          logCode: 'breakoutroom_freejoin_selected',
+          extraInfo: { selectedBreakout },
+        }, 'User selected breakout room to join');
+
         window.open(selectedBreakout.joinURL, '_blank');
       }
     }
@@ -171,6 +178,16 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
       setIsOpen(true);
     }
   }, [breakouts, currentUserJoined]);
+
+  useEffect(() => {
+    // log which breakout rooms the user has the option to join
+    if (freeJoin) {
+      logger.info({
+        logCode: 'breakoutroom_freejoin_options',
+        extraInfo: { breakouts },
+      }, 'User is given the option to join these breakout rooms');
+    }
+  }, []);
 
   return (
     <ModalFullscreen

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -328,6 +328,14 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         });
       }
     }
+
+    logger.info({
+      logCode: 'breakout_create_rooms',
+      extraInfo: {
+        rooms: roomsArray,
+      },
+    }, 'Creating breakout rooms');
+
     createBreakoutRoom(
       {
         variables: {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
@@ -25,7 +25,7 @@ export const useStopMediaOnMainRoom = () => {
     } catch (error) {
       logger.error({
         logCode: 'breakoutroom_stop_media_error',
-        extraInfo: { error, logType: 'error' },
+        extraInfo: { errorMessage: error.message, errorStack: error.stack },
       }, 'Failed to stop media while joining breakout room');
     }
   }, [exitVideo, streams]);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
@@ -13,14 +13,21 @@ export const useStopMediaOnMainRoom = () => {
   const streams = useStreams();
 
   const stop = useCallback((presenter: boolean) => {
-    forceExitAudio();
-    VideoService.storeDeviceIds(streams);
-    stopVideo(exitVideo, streams);
-    logger.info({
-      logCode: 'breakoutroom_join_stop_media',
-      extraInfo: { logType: 'user_action' },
-    }, 'Joining breakout room closed audio in the main room');
-    if (presenter) finishScreenShare();
+    try {
+      forceExitAudio();
+      VideoService.storeDeviceIds(streams);
+      stopVideo(exitVideo, streams);
+      logger.info({
+        logCode: 'breakoutroom_join_stop_media',
+        extraInfo: { logType: 'user_action' },
+      }, 'Joining breakout room closed audio in the main room');
+      if (presenter) finishScreenShare();
+    } catch (error) {
+      logger.error({
+        logCode: 'breakoutroom_stop_media_error',
+        extraInfo: { error, logType: 'error' },
+      }, 'Failed to stop media while joining breakout room');
+    }
   }, [exitVideo, streams]);
 
   return stop;

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/hooks.ts
@@ -23,9 +23,13 @@ export const useStopMediaOnMainRoom = () => {
       }, 'Joining breakout room closed audio in the main room');
       if (presenter) finishScreenShare();
     } catch (error) {
+      const err = error as Error;
+      const errorMessage = err.message || 'Error stopping media';
+      const errorStack = err.stack || 'No stack trace available';
+
       logger.error({
         logCode: 'breakoutroom_stop_media_error',
-        extraInfo: { errorMessage: error.message, errorStack: error.stack },
+        extraInfo: { errorMessage, errorStack },
       }, 'Failed to stop media while joining breakout room');
     }
   }, [exitVideo, streams]);


### PR DESCRIPTION
### What does this PR do?

- adds a log for the moderator with room info when breakout rooms are created
![Screenshot from 2025-04-01 10-17-45](https://github.com/user-attachments/assets/19a21756-87d3-4de6-b66e-5cc4b5e86ff1)


- adds a log if media stop fails when joining a breakout room
![Screenshot from 2025-04-01 10-19-37](https://github.com/user-attachments/assets/601079c7-e5f7-4f19-966e-6a2ad94bb259)


- adds a log to the breakout room invitation when free join is selected, with info about the breakout rooms available for the user to join
![Screenshot from 2025-04-01 10-20-55](https://github.com/user-attachments/assets/376fddc6-8330-4429-93f7-f9c6aa0794a6)

- adds a log to the breakout room invitation when free join is selected, with info about the room selected by the user
![Screenshot from 2025-04-01 10-21-38](https://github.com/user-attachments/assets/2c7e75ea-db6a-49b7-83e9-7b211f27510c)


- change `app_component_componentdidmount` log to include info about the room being joined
![Screenshot from 2025-04-01 10-23-21](https://github.com/user-attachments/assets/e581b3b0-1777-41f2-bf21-cb1ea71ec679)
![Screenshot from 2025-04-01 10-31-48](https://github.com/user-attachments/assets/94d70d61-48d5-414e-8222-13c48634b1a1)



### Closes Issue(s)
partially #22836 

### More
Does not implement akka-apps logs (to be addressed in a subsequent pull request, cc @gustavotrott )