### PR TITLE
fix(freeswitch): add basic dialplan instructions to reject anonymous UAs

### DIFF
--- a/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
+++ b/bbb-voice-conference/config/freeswitch/conf/dialplan/default/bbb_conference.xml
@@ -1,4 +1,34 @@
 <include>
+   <extension name="reject_empty_cid">
+      <!-- This condition should never be removed as far as BBB is concerned -->
+      <condition field="${caller_id_number}" expression="^$" break="on-true">
+        <action application="log" data="WARNING Rejecting call with empty Caller-ID-Number" />
+        <action application="hangup" data="CALL_REJECTED" />
+      </condition>
+   </extension>
+   <!-- The reject_anonymous extension can be removed if you don't want to reject anonymous calls -->
+   <extension name="reject_anonymous">
+      <condition field="${caller_id_name}" expression="^$" break="on-true">
+        <action application="log" data="WARNING Rejecting call with empty Caller-ID-Name" />
+        <action application="hangup" data="CALL_REJECTED" />
+      </condition>
+      <condition field="caller_id_number" expression="^(?i)(0000000000|anonymous|unknown|private|restricted|withheld)$" break="on-true">
+         <action application="log" data="WARNING Rejecting call from anonymous User-Agent (cid)" />
+         <action application="hangup" data="CALL_REJECTED" />
+      </condition>
+      <condition field="caller_id_name" expression="^(?i)(0000000000|anonymous|unknown|private|restricted|withheld)$" break="on-true">
+         <action application="log" data="WARNING Rejecting call from anonymous User-Agent (cin)" />
+         <action application="hangup" data="CALL_REJECTED" />
+      </condition>
+      <condition field="privacy_hide_name" expression="true" break="on-true">
+         <action application="log" data="WARNING Blocked call due to CLIR anonymity headers" />
+         <action application="hangup" data="CALL_REJECTED" />
+      </condition>
+      <condition field="privacy_hide_number" expression="true" break="on-true">
+         <action application="log" data="WARNING Blocked call due to CLIR anonymity headers" />
+         <action application="hangup" data="CALL_REJECTED" />
+      </condition>
+   </extension>
    <extension name="bbb_conferences_ws">
       <condition field="${bbb_authorized}" expression="true" break="on-false" />
       <condition field="${sip_via_protocol}" expression="^wss?$" />

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -839,6 +839,9 @@ $ sudo systemctl restart freeswitch
 
 Try calling the phone number. It should connect to FreeSWITCH and you should hear a voice prompting you to enter the five digit PIN number for the conference. Please note, that dialin will currently only work if at least one web participant has joined with their microphone.
 
+It's also important to note that there are basic checks in place to prevent anonymous callers from joining BigBlueButton audio conferences.
+If you want to allow anonymous SIP UAs, you need to remove the `reject_anonymous` extension in `/opt/freeswitch/conf/dialplan/default/bbb_conference.xml`, then restart FreeSWITCH again.
+
 To always show users the phone number along with the 5-digit PIN number within BigBlueButton, not only while selecting the microphone participation, edit `/etc/bigbluebutton/bbb-web.properties` and set the phone number provided by your Internet Telephone Service Provider
 
 ```properties


### PR DESCRIPTION
### What does this PR do?

- [fix(freeswitch): add basic dialplan instructions to reject anonymous UAs](https://github.com/bigbluebutton/bigbluebutton/commit/fc6f77f8522b728f1a46b604bf7bc0f3b2d3ba81) 
  - Add the following basic checks to deny anonymous callers from joining
BBB-FreeSWITCH conferences by default:
    - Caller-ID-Name/Number: common anonymity values, empty headers
    - CLIR headers: honor number/name anonymity requests.
  - Those checks reside at the conference level (bbb_conference.xml), which should
capture all calls directed to a *BigBlueButton* conference.
  - Allowing anonymous UAs can be achieved by removing the
`reject_anonymous` extension and reloading the XML Dialplan
module/restarting FS.

### Closes Issue(s)

None