### PR TITLE
breakouts: randomly assign users to rooms in an evenly distributed manner

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
@@ -153,10 +153,18 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
   };
 
   const randomlyAssign = () => {
+    // assign users to rooms in an evenly distributed manner
     const withoutModerators = rooms[0].users.filter((user) => !user.isModerator);
-    const userIds = withoutModerators.map((user) => user.userId);
-    const randomRooms = withoutModerators.map(() => Math.floor(Math.random() * numberOfRooms) + 1);
-    moveUser(userIds, 0, randomRooms);
+    const userIds = withoutModerators.sort(() => Math.random() - 0.5).map((user) => user.userId);
+    const numberOfUsers = withoutModerators.length;
+    const assignments = new Array(numberOfUsers);
+
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < numberOfUsers; i++) {
+      assignments[i] = (i % numberOfRooms) + 1;
+    }
+
+    moveUser(userIds, 0, assignments);
   };
 
   const resetRooms = (cap: number) => {


### PR DESCRIPTION
### What does this PR do?

Adjusts random assign algorithm, so users are evenly spread in breakout rooms

#### before

![Screenshot from 2025-04-02 09-20-13](https://github.com/user-attachments/assets/241bc315-44af-49a4-95f1-d8b28838d5ee)

#### after

![Screenshot from 2025-04-02 09-17-51](https://github.com/user-attachments/assets/c12d855b-7f22-4410-92c1-62d061ea0b06)


### Motivation
current algorithm only assigns a random room to each user, leading to rooms with many users and rooms with less users (sometimes empty) - with the new approach the users will be shuffled and then assigned to the rooms


### How to test
1. join a meeting with a moderator and a a big number of viewers (> 10)
2. open create breakout panel
3. increase the number of breakouts
4. select "randomly assign" 
5. see if the users are evenly distributed
