### PR TITLE
Fx(html5): External video no seeking when sliding the progress bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -303,7 +303,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
-      const currentTime = played * duration;
+      const currentTime = internalPlayer?.getCurrentTime() ?? 0;
       sendMessage('play', {
         rate,
         time: currentTime,

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -188,7 +188,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const playerParentRef = useRef<HTMLDivElement| null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const presenterRef = useRef(isPresenter);
-  const [duration, setDuration] = React.useState(0);
   const [reactPlayerPlaying, setReactPlayerPlaying] = React.useState(false);
   const clientReloadedRef = useRef(false);
 
@@ -201,10 +200,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       const internalPlayer = playerRef.current?.getInternalPlayer();
       internalPlayer?.unMute?.();
     }
-  };
-
-  const handleDuration = (duration: number) => {
-    setDuration(duration);
   };
 
   useEffect(() => {
@@ -435,7 +430,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           onStart={handleOnStart}
           onPlay={handleOnPlay}
           onSeek={handleOnSeek}
-          onDuration={handleDuration}
           onProgress={handleProgress}
           onPause={handleOnStop}
           onEnded={handleOnStop}


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where the player does not correctly sync when the presenter drags the progress bar instead of clicking to seek.


### Closes Issue(s)
Part of ##22176

### How to test
- Join with two participants
- on presenter's client drag the progress bar
- See both clients synced


### More
Before
[Screencast from 02-04-2025 09:58:34.webm](https://github.com/user-attachments/assets/6d171dd5-eb6c-47cb-8ee8-c7f73a952e6b)

After
[Screencast from 02-04-2025 09:56:19.webm](https://github.com/user-attachments/assets/41e96cb1-b864-48bd-9d9e-fa8763f66873)

