### PR TITLE
fix (akka-apps): Breakout rooms not inheriting `disabledFeatures` from the parent meeting

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -9,6 +9,8 @@ import org.bigbluebutton.core.models.PluginModel.getPlugins
 import org.bigbluebutton.core.models.{Plugin, PresentationInPod}
 import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
 import org.bigbluebutton.core.running.MeetingActor
+
+import java.util
 import scala.jdk.CollectionConverters._
 
 trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
@@ -84,6 +86,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     }
 
     for (breakout <- rooms.values.toVector) {
+
       val roomSlides = if (breakout.allPages) -1 else presSlide;
       val roomDetail = new BreakoutRoomDetail(
         breakout.id, breakout.name,
@@ -106,6 +109,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         breakout.captureNotesFilename,
         breakout.captureSlidesFilename,
         pluginProp = filteredPluginProp,
+        disabledFeatures = new util.ArrayList[String](liveMeeting.props.meetingProp.disabledFeatures.asJava),
         liveMeeting.props.meetingProp.audioBridge,
         liveMeeting.props.meetingProp.cameraBridge,
         liveMeeting.props.meetingProp.screenShareBridge,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -59,6 +59,7 @@ case class BreakoutRoomDetail(
     captureNotesFilename:    String,
     captureSlidesFilename:   String,
     pluginProp:              util.Map[String, AnyRef],
+    disabledFeatures:        util.ArrayList[String],
     audioBridge:             String,
     cameraBridge:            String,
     screenShareBridge:       String,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -828,6 +828,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.CAMERA_BRIDGE, message.cameraBridge);
       params.put(ApiParams.SCREEN_SHARE_BRIDGE, message.screenShareBridge);
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
+      params.put(ApiParams.DISABLED_FEATURES,String.join(",", message.disabledFeatures));
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -1,5 +1,6 @@
 package org.bigbluebutton.api.messaging.messages;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 public class CreateBreakoutRoom implements IMessage {
@@ -26,6 +27,7 @@ public class CreateBreakoutRoom implements IMessage {
     public final String captureNotesFilename;
     public final String captureSlidesFilename;
     public final Map<String, Object> pluginProp;
+    public final ArrayList<String> disabledFeatures;
     public final String audioBridge;
     public final String cameraBridge;
     public final String screenShareBridge;
@@ -51,6 +53,7 @@ public class CreateBreakoutRoom implements IMessage {
                                                             String captureNotesFilename,
                                                             String captureSlidesFilename,
                                                             Map<String, Object> pluginProp,
+                                                            ArrayList<String> disabledFeatures,
                                                             String audioBridge,
                                                             String cameraBridge,
                                                             String screenShareBridge) {
@@ -75,6 +78,7 @@ public class CreateBreakoutRoom implements IMessage {
         this.captureNotesFilename = captureNotesFilename;
         this.captureSlidesFilename = captureSlidesFilename;
         this.pluginProp = pluginProp;
+        this.disabledFeatures = disabledFeatures;
         this.audioBridge = audioBridge;
         this.cameraBridge = cameraBridge;
         this.screenShareBridge = screenShareBridge;

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -128,6 +128,7 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.captureNotesFilename,
       msg.body.room.captureSlidesFilename,
       msg.body.room.pluginProp,
+      msg.body.room.disabledFeatures,
       msg.body.room.audioBridge,
       msg.body.room.cameraBridge,
       msg.body.room.screenShareBridge,


### PR DESCRIPTION
Now breakout rooms will inherit the list of `disabledFeatures` from the parent meeting.

https://github.com/user-attachments/assets/222986cf-68ec-48ec-b0ba-80fc8750792e

Closes #21953