### PR TITLE
chore (gql-middleware): Log the reason why middleware disconnected the browser

### DIFF
--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -478,6 +478,8 @@ func disconnectWithError(
 	jsonData, _ := json.Marshal(browserResponseData)
 
 	logger.Tracef("sending to browser: %s", string(jsonData))
+	logger.Infof("deliberately disconnecting browser with error, reason: %s (%s)", reasonMessage, reasonMessageId)
+
 	err := browserConnectionWs.Write(browserConnectionContext, websocket.MessageText, jsonData)
 	if err != nil {
 		logger.Debugf("Browser is disconnected, skipping writing of ws message: %v", err)


### PR DESCRIPTION
It will help to debug when the client log show `graphql_server_closed_connection` "Graphql Server closed the connection".


![image](https://github.com/user-attachments/assets/47cdd910-dd4b-40c6-a5ad-f1bfe21aafac)
