### PR TITLE
Fix(html5): Whiteboard autohide not working for opened menus

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/menu/component.jsx
@@ -139,6 +139,7 @@ class BBBMenu extends React.Component {
           <Styled.BBBMenuItem
             emoji={emojiSelected ? 'yes' : 'no'}
             key={label}
+            id={dataTest}
             data-test={dataTest}
             data-key={`menuItem-${dataTest}`}
             disableRipple={true}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -244,6 +244,8 @@ const PresentationMenu = (props) => {
   }
 
   function getAvailableOptions() {
+    // if any item is changed, please verify the function handleMouseLeave in whiteboard/hooks.js
+    // to make sure the menu is closed when clicking on the options
     const menuItems = [];
 
     if (!isIphone) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -170,6 +170,8 @@ const useMouseEvents = ({
     }, 150);
   };
 
+  useEffect(() => () => clearTimeout(mouseLeaveTimeoutRef.current), []);
+
   const handleMouseWheel = throttle({ interval: 175 }, (event) => {
     event.preventDefault();
     event.stopPropagation();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -283,7 +283,6 @@ const useMouseEvents = ({
 
   React.useEffect(() => {
     if (whiteboardToolbarAutoHide) {
-      console.log("🚀 -> React.useEffect -> animations ? '3s': if", '3s');
       toggleToolsAnimations(
         'fade-in',
         'fade-out',
@@ -291,7 +290,6 @@ const useMouseEvents = ({
         hasWBAccess || isPresenterRef.current,
       );
     } else {
-      console.log("🚀 -> React.useEffect -> animations ? '3s': else", '3s');
       toggleToolsAnimations(
         'fade-out',
         'fade-in',

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { set, throttle } from 'radash';
+import { throttle } from 'radash';
 
 const hasBackgroundImageUrl = (el) => {
   const style = window.getComputedStyle(el);
@@ -28,10 +28,22 @@ const useCursor = (publishCursorUpdate, whiteboardId) => {
   return [cursorPosition, updateCursorPosition];
 };
 
-const getPrensentationMenuItem = () => document.querySelector('li#presentationFullscreen')
+const getPresentationOptionsMenuItem = () => document.querySelector('li#presentationFullscreen')
     || document.querySelector('li#presentationSnapshot')
     || document.querySelector('li#toolVisibility')
     || null;
+
+const getTldrawOpenMenu = () => {
+  const tlElement = document.querySelectorAll('[id^=radix-]');
+  const tldrawMenu = Array.from(tlElement).find((el) => {
+    const menuClasses = ['tlui-popover__content', 'tlui-menu'];
+    if (el && menuClasses.includes(el.className)) {
+      return el;
+    }
+    return false;
+  });
+  return tldrawMenu;
+};
 
 const useMouseEvents = ({
   whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoomRef, isPresenterRef,
@@ -128,12 +140,13 @@ const useMouseEvents = ({
   const handleMouseLeave = () => {
     if (whiteboardToolbarAutoHide) {
       clearTimeout(mouseLeaveTimeoutRef.current);
-      const presentationWBOptionsMenuItem = getPrensentationMenuItem();
-      if (presentationWBOptionsMenuItem) {
-        const ulElemnt = presentationWBOptionsMenuItem.parentElement;
-        const menuWrapper = ulElemnt.parentElement;
+      const presentationWBOptionsMenuItem = getPresentationOptionsMenuItem();
+      const tldrawMenu = getTldrawOpenMenu();
+      if (presentationWBOptionsMenuItem || tldrawMenu) {
+        const ulElement = presentationWBOptionsMenuItem.parentElement;
+        const menuWrapper = ulElement.parentElement;
         const isVisible = menuWrapper.style.visibility !== 'hidden';
-        if (isVisible) {
+        if (isVisible || tldrawMenu) {
           mouseLeaveTimeoutRef.current = setTimeout(() => {
             handleMouseLeave();
           }, 500);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -146,7 +146,11 @@ const useMouseEvents = ({
         const ulElement = presentationWBOptionsMenuItem.parentElement;
         const menuWrapper = ulElement.parentElement;
         const isVisible = menuWrapper.style.visibility !== 'hidden';
-        if (isVisible || tldrawMenu) {
+        if (isVisible) {
+          mouseLeaveTimeoutRef.current = setTimeout(() => {
+            handleMouseLeave();
+          }, 500);
+        } else if (tldrawMenu) {
           mouseLeaveTimeoutRef.current = setTimeout(() => {
             handleMouseLeave();
           }, 500);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -143,17 +143,26 @@ const useMouseEvents = ({
       const presentationWBOptionsMenuItem = getPresentationOptionsMenuItem();
       const tldrawMenu = getTldrawOpenMenu();
       if (presentationWBOptionsMenuItem || tldrawMenu) {
-        const ulElement = presentationWBOptionsMenuItem.parentElement;
-        const menuWrapper = ulElement.parentElement;
-        const isVisible = menuWrapper.style.visibility !== 'hidden';
-        if (isVisible) {
+        if (tldrawMenu) {
           mouseLeaveTimeoutRef.current = setTimeout(() => {
             handleMouseLeave();
           }, 500);
-        } else if (tldrawMenu) {
-          mouseLeaveTimeoutRef.current = setTimeout(() => {
-            handleMouseLeave();
-          }, 500);
+        } else if (presentationWBOptionsMenuItem) {
+          const ulElement = presentationWBOptionsMenuItem.parentElement;
+          const menuWrapper = ulElement.parentElement;
+          const isVisible = menuWrapper.style.visibility !== 'hidden';
+          if (isVisible) {
+            mouseLeaveTimeoutRef.current = setTimeout(() => {
+              handleMouseLeave();
+            }, 500);
+          } else {
+            toggleToolsAnimations(
+              'fade-in',
+              'fade-out',
+              animations ? '3s' : '0s',
+              hasWBAccess || isPresenterRef.current,
+            );
+          }
         } else {
           toggleToolsAnimations(
             'fade-in',

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -127,6 +127,7 @@ const useMouseEvents = ({
   };
 
   const handleMouseEnter = () => {
+    clearTimeout(mouseLeaveTimeoutRef.current);
     if (whiteboardToolbarAutoHide) {
       toggleToolsAnimations(
         'fade-out',
@@ -282,6 +283,7 @@ const useMouseEvents = ({
 
   React.useEffect(() => {
     if (whiteboardToolbarAutoHide) {
+      console.log("🚀 -> React.useEffect -> animations ? '3s': if", '3s');
       toggleToolsAnimations(
         'fade-in',
         'fade-out',
@@ -289,6 +291,7 @@ const useMouseEvents = ({
         hasWBAccess || isPresenterRef.current,
       );
     } else {
+      console.log("🚀 -> React.useEffect -> animations ? '3s': else", '3s');
       toggleToolsAnimations(
         'fade-out',
         'fade-in',


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue of the autohide being hiding the buttons when a dropdown is open, it happened because the options button is non-native and is rendered in anothe part of the dom and just positioned over the whinteboard, so on mouse leave, I made it veirfy if the menu is open and just hide the buttons when menu is closed and the mouse out of the screen.


### Closes Issue(s)
N/A

### How to test
- Join with one user
- on settings enable auto hide for whiteboard tools
- Open the options dropdown and hover it
- See the tools visible 


### More
[Screencast from 03-04-2025 10:50:43.webm](https://github.com/user-attachments/assets/d03bff02-f350-4ed0-afaa-d0033c778989)

