### PR TITLE
Fix(html5): viewer being able to select tool via shortcuts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -497,7 +497,7 @@ const Whiteboard = React.memo((props) => {
       }
     }
 
-    if (!event.altKey && !event.ctrlKey && !event.shiftKey && simpleKeyMap[key]) {
+    if (!event.altKey && !event.ctrlKey && !event.shiftKey && simpleKeyMap[key] && (isPresenterRef.current || hasWBAccessRef.current)) {
       event.preventDefault();
       event.stopPropagation();
       simpleKeyMap[key]();


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where viewers, upon receiving whiteboard access, could incorrectly select tools via keyboard shortcuts and add/remove shapes locally. The issue occurred because the shortcut handlers were not properly checking user permissions. The fix adds appropriate permission checks to ensure viewers can only interact according to their assigned privileges.


### Closes Issue(s)
Closes #22856

### How to test
- Join two users, One moderator and one viewer
- enable and disable multiuser whiteboard
- on viewers cliend try to select tools using shortcuts.
