### PR TITLE
Fix(html5): Version being incorrectly placed in CSS

### DIFF
--- a/build/packages-template/bbb-html5/build.sh
+++ b/build/packages-template/bbb-html5/build.sh
@@ -62,17 +62,17 @@ else
 fi
 cd ..
 
-# Compress CSS, Javascript and tensorflow WASM binaries used for virtual backgrounds. Keep the
-# uncompressed versions as well so it works with mismatched nginx location blocks
-find dist -name '*.js' -exec gzip -k -f -9 '{}' \;
-find dist -name '*.css' -exec gzip -k -f -9 '{}' \;
-find dist -name '*.wasm' -exec gzip -k -f -9 '{}' \;
-
 # replace v=VERSION with build number in head and css files
 if [ -f dist/index.html ] || [ -f dist/stylesheets/fonts.css ]; then
   sed -i "s/VERSION/$(($BUILD))/g" dist/index.html
   sed -i "s/VERSION/$(($BUILD))/g" dist/stylesheets/fonts.css
 fi
+
+# Compress CSS, Javascript and tensorflow WASM binaries used for virtual backgrounds. Keep the
+# uncompressed versions as well so it works with mismatched nginx location blocks
+find dist -name '*.js' -exec gzip -k -f -9 '{}' \;
+find dist -name '*.css' -exec gzip -k -f -9 '{}' \;
+find dist -name '*.wasm' -exec gzip -k -f -9 '{}' \;
 
 cp -r dist/* staging/usr/share/bigbluebutton/html5-client
 


### PR DESCRIPTION
### What does this PR do?
This PR resolves the issue where CSS file requests included the default version instead of the build version. The problem occurred because the CSS files were being compressed before the build script had a chance to set their correct version, resulting in modified CSS files but outdated compressed versions. By moving the version assignment step to occur before compression, all files now correctly reflect the intended build version.

### Closes Issue(s)
N/A
But probably related with the PR #22839 

### How to test
Best way to test it, is the the binary from the test summary and install it on your own server, the files will be in `/usr/share/bigbluebutton/html5-client/`


### More
Before:
![2025-04-04_11-34-normal-building](https://github.com/user-attachments/assets/d2cffa6c-0bb1-4955-94de-65743f3e42d8)

After:
![2025-04-04_11-34-preloaded](https://github.com/user-attachments/assets/95b2f90d-a736-46eb-a015-50d4a9452b25)
