### PR TITLE
fix (html5): Syncing problems when receiving annotations too frequently

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -111,8 +111,10 @@ export const PROCESSED_PRESENTATIONS_SUBSCRIPTION = gql`subscription ProcessedPr
   }
 }`;
 
-export const CURRENT_PAGE_ANNOTATIONS_QUERY = gql`query CurrentPageAnnotationsQuery {
-  pres_annotation_curr(order_by: { lastUpdatedAt: desc }) {
+export const CURRENT_PAGE_ANNOTATIONS_QUERY = gql`query CurrentPageAnnotationsQuery($pageId: String!) {
+  pres_annotation_curr(
+    where: {pageId: {_eq: $pageId}},
+    order_by: { lastUpdatedAt: desc }) {
     annotationId
     annotationInfo
     lastUpdatedAt
@@ -134,9 +136,10 @@ export const CURRENT_PAGE_ANNOTATIONS_STREAM = gql`subscription annotationsStrea
 }`;
 
 export const ANNOTATION_HISTORY_STREAM = gql`
-  subscription annotationHistoryStream($updatedAt: timestamptz) {
+  subscription annotationHistoryStream($updatedAt: timestamptz, $pageId: String!) {
     pres_annotation_history_curr_stream(
       batch_size: 1000,
+      where: {pageId: {_eq: $pageId}},
       cursor: {initial_value: {updatedAt: $updatedAt}, ordering: ASC}
     ) {
       annotationId


### PR DESCRIPTION
This PR addresses two main issues:

1. **Ensure `annotationHistoryStream` waits for `CurrentPageAnnotationsQuery`** (ec5be7cdd2d497775aaf78a529b3d14be56a62f5)
   Previously, when navigating to a new page, the `annotationHistoryStream` subscription would start receiving annotations from the new page while still using the `updatedAt` timestamp from the previous one. This commit ensures that:
   - Annotations from different pages are ignored during this transition.
   - `annotationHistoryStream` only starts after `CurrentPageAnnotationsQuery` completes, avoiding premature updates.

2. **Fix race condition when receiving annotations too frequently** (bf84157e0ab1f6b0825032b48ee446109c5e931e)  
   When many annotation messages were received in a short period (e.g., after reconnecting before the GraphQL WebSocket had closed), the `shapes` state was updated too often. This caused `<Whiteboard>` to miss some updates due to React's `useEffect` not firing in time.  
   To fix this, a queueing system was implemented:
   - The first component pushes updates into a queue instead of immediately updating the state.
   - The second component processes all queued updates in batch, ensuring none are lost.  
   This issue was observed in [[#22868](https://github.com/.../issues/22868)](https://github.com/.../issues/22868).