### PR TITLE
fix(API): Use meeting to get ID for insertDocument

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1070,7 +1070,7 @@ class ApiController {
                     , contentType: "text/xml")
           }
         }
-      } else if (meetingService.isMeetingWithDisabledPresentation(meetingId)) {
+      } else if (meetingService.isMeetingWithDisabledPresentation(meeting.getInternalId())) {
         withFormat {
           xml {
             render(text: responseBuilder.buildInsertDocumentResponse("Presentation feature is disabled, ignoring.",


### PR DESCRIPTION
### What does this PR do?

Fixes an error that would sometimes occur during `insertDocument` calls that was being caused by a reference to an undefined `meetingId` variable.


### Closes Issue(s)
Closes #22876


### How to test

1. Create a meeting with API and add "presentation" to "disabledFeatures".
2. Send an `insertDocument` request for that meeting.
3. A `FAILED` response should be received.
