### PR TITLE
fix(client): log info about multiple users being returned from current user subscription and filter results

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useCurrentUser.ts
@@ -2,14 +2,31 @@ import { useMemo } from 'react';
 import { User } from '../../Types/user';
 import createUseSubscription from './createUseSubscription';
 import CURRENT_USER_SUBSCRIPTION from '../graphql/queries/currentUserSubscription';
+import logger from '/imports/startup/client/logger';
+import Auth from '/imports/ui/services/auth';
 
 const currentUserSubscription = createUseSubscription<User>(CURRENT_USER_SUBSCRIPTION, {}, true);
 const useCurrentUser = (fn: (c: Partial<User>) => Partial<User> = (u) => u) => {
   const response = currentUserSubscription(fn);
+  let responseData = response.data;
+
+  if (responseData && responseData.length > 1) {
+    // log info about the current user if the subscription returns more than one user
+    logger.error({
+      logCode: 'multiple_current_user_error',
+      extraInfo: {
+        data: JSON.stringify(responseData),
+        currentUserId: Auth.userID,
+      },
+    }, 'More than one user returned from current user subscription error');
+
+    responseData = responseData.filter((user) => user.userId === Auth.userID);
+  }
+
   const returnObject = useMemo(() => ({
     ...response,
-    data: response.data ? response.data[0] : null,
-    rawData: response.data ?? null,
+    data: responseData ? responseData[0] : null,
+    rawData: responseData ?? null,
   }), [response]);
   return returnObject;
 };


### PR DESCRIPTION
### What does this PR do?

- adds a new error (logCode `multiple_current_user_error`) to log if the current user subscription returns more than one user
- filters results to only return those with the same id as the current user
