### PR TITLE
refactor (tests): Add explicit flags to identify local and current user streams

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -426,6 +426,8 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
           mirrored={isMirrored}
           unhealthyStream={videoDataLoaded && !isStreamHealthy}
           data-test={isMirrored ? 'mirroredVideoContainer' : 'videoContainer'}
+          data-current-user-stream={stream.userId === Auth.userID ? 'true' : 'false'}
+          data-local-stream={VideoService.isLocalStream(cameraId) ? 'true' : 'false'}
           ref={videoTag}
           muted
           autoPlay

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -174,6 +174,7 @@ exports.reconnectingBar = '//div[@data-test="notificationBannerBar" and contains
 exports.zoomInBtn = 'button[data-test="zoomInBtn"]';
 exports.recordingIndicator = 'div[data-test="recordingIndicator"]';
 exports.webcamMirroredVideoContainer = 'video[data-test="mirroredVideoContainer"]';
+exports.currentUserLocalStreamVideo = 'video[data-local-stream="true"]';
 exports.usersList = 'div[data-test="userList"]';
 exports.selectCameraQualityId = 'select[id="setQuality"]';
 exports.virtualBackgrounds = 'div[data-test="virtualBackground"]';

--- a/bigbluebutton-tests/playwright/webcam/webcam.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.js
@@ -31,7 +31,7 @@ class Webcam extends Page {
 
   async talkingIndicator() {
     await this.webcamLayoutStart();
-    await this.waitForSelector(e.webcamMirroredVideoContainer, VIDEO_LOADING_WAIT_TIME);
+    await this.waitForSelector(e.currentUserLocalStreamVideo, VIDEO_LOADING_WAIT_TIME);
     await this.waitForSelector(e.leaveVideo, VIDEO_LOADING_WAIT_TIME);
     await this.waitForSelector(e.isTalking);
     await this.hasElement(e.webcamItemTalkingUser, 'should display the webcam item talking user');
@@ -45,7 +45,7 @@ class Webcam extends Page {
       await this.waitForSelector(e.videoQualitySelector);
       const langDropdown = await this.page.$(e.videoQualitySelector);
       await langDropdown.selectOption({ value });
-      await this.waitForSelector(e.webcamMirroredVideoPreview, videoPreviewTimeout);
+      await this.waitForSelector(e.currentUserLocalStreamVideo, videoPreviewTimeout);
       await this.waitAndClick(e.startSharingWebcam);
       await this.waitForSelector(e.webcamConnecting);
       await this.waitForSelector(e.leaveVideo, VIDEO_LOADING_WAIT_TIME);
@@ -68,8 +68,8 @@ class Webcam extends Page {
     await this.waitAndClick(`${e.selectDefaultBackground}[aria-label="Home"]`);
     await sleep(1000);
     await this.waitAndClick(e.startSharingWebcam);
-    await this.waitForSelector(e.webcamMirroredVideoContainer);
-    const webcamVideoLocator = await this.getLocator(e.webcamMirroredVideoContainer);
+    await this.waitForSelector(e.currentUserLocalStreamVideo);
+    const webcamVideoLocator = await this.getLocator(e.currentUserLocalStreamVideo);
     await expect(webcamVideoLocator).toHaveScreenshot('webcam-with-home-background.png');
   }
 
@@ -100,7 +100,7 @@ class Webcam extends Page {
     await this.waitAndClick(e.selectCustomBackground);
     await sleep(1000);
     await this.waitAndClick(e.startSharingWebcam);
-    await this.waitForSelector(e.webcamMirroredVideoContainer);
+    await this.waitForSelector(e.currentUserLocalStreamVideo);
 
     await this.waitAndClick(e.dropdownWebcamButton);
     await this.waitAndClick(e.selfViewDisableBtn);
@@ -121,8 +121,8 @@ class Webcam extends Page {
     await this.waitAndClick(e.selectCustomBackground);
     await sleep(1000);
     await this.waitAndClick(e.startSharingWebcam);
-    await this.waitForSelector(e.webcamMirroredVideoContainer);
-    const webcamVideoLocator = await this.getLocator(e.webcamMirroredVideoContainer);
+    await this.waitForSelector(e.currentUserLocalStreamVideo);
+    const webcamVideoLocator = await this.getLocator(e.currentUserLocalStreamVideo);
     await expect(webcamVideoLocator).toHaveScreenshot('webcam-with-new-background.png');
 
     // Remove


### PR DESCRIPTION
The current tests rely on the `mirrored` prop to determine if a video belongs to the current user. However, this isn't reliable, as other users' cameras might also be mirrored.

This PR adds two new props to user video elements for more accurate identification:

- `data-local-stream`: Indicates that the video stream originates from the current browser tab.  
- `data-current-user-stream`: Indicates that the video stream belongs to the current user, even if it's being shared from a different tab.