### PR TITLE
Fix(html5): Whiteboard assets tool appearing on main bar for viewers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -129,7 +129,7 @@ const TldrawV2GlobalStyle = createGlobalStyle`
   [data-testid="main.page-menu"],
   [data-testid="main.menu"],
   [data-testid="tools.more.laser"],
-  [data-testid="tools.more.asset"],
+  [data-tool="asset"],
   [data-testid="page-menu.button"],
   [data-testid="menu-item.zoom-to-100"],
   .tlui-menu-zone {


### PR DESCRIPTION
### What does this PR do?
Fix issue where the Assets tool incorrectly appears in the main toolbar for viewers when Multi Whiteboard mode is enabled.

### Closes Issue(s)
N/A

### How to test
- Join the meeting with a presenter and a viewer.
- Enable multi whiteboard.
- Look at viewer toolbar.


### More
Before
![image](https://github.com/user-attachments/assets/d5fe2273-e971-4e4b-baa5-4526ee3ec54a)


After
![image](https://github.com/user-attachments/assets/73dc9adc-bb5a-4ab8-b961-70ebbe721e88)

