### PR TITLE
html5: Add stream ids to webcam video tags

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -428,6 +428,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
               gridTemplateColumns: `repeat(${optimalGrid.columns}, 1fr)`,
               gridTemplateRows: `repeat(${optimalGrid.rows}, 1fr)`,
             }}
+            className="video-provider_list"
           >
             {this.renderVideoList()}
           </Styled.VideoList>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -160,9 +160,11 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
   }));
 
   let user;
+  let streamId = '';
   switch (stream.type) {
     case VIDEO_TYPES.STREAM: {
       user = stream.user;
+      streamId = stream.stream;
       break;
     }
     case VIDEO_TYPES.GRID: {
@@ -172,6 +174,7 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
     case VIDEO_TYPES.CONNECTING:
     default: {
       user = currentUser ?? {};
+      streamId = stream.stream;
       break;
     }
   }
@@ -419,6 +422,8 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
     >
       {renderScreenshareButtons()}
       <Styled.VideoContainer
+        className="videoContainer"
+        data-stream={streamId}
         $selfViewDisabled={(isSelfViewDisabled && stream.userId === Auth.userID)
           || disabledCams.includes(cameraId)}
       >


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Add camera stream ids to video tags.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
None

### Motivation
<!-- What inspired you to submit this pull request? -->

For selection purposes. That way, we can select a video tag by stream id.