### PR TITLE
refactor (bbb-web): Allow `getJoinUrl` parameters for non-moderators

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -150,6 +150,7 @@ public class ParamsProcessorUtil {
     private Boolean allowOverrideClientSettingsOnCreateCall = false;
 
     private Integer defaultMaxNumPages;
+    private String getJoinUrlUserdataBlocklist;
 
   	private String formatConfNum(String s) {
   		if (s.length() > 5) {
@@ -963,6 +964,10 @@ public class ParamsProcessorUtil {
         return graphqlApiUrl;
     }
 
+    public String getGetJoinUrlUserdataBlocklist() {
+        return getJoinUrlUserdataBlocklist;
+    }
+
 	public Boolean getUseDefaultLogo() {
 		return useDefaultLogo;
 	}
@@ -1691,5 +1696,9 @@ public class ParamsProcessorUtil {
 	}
 
     public void setMaxNumPages(Integer maxNumPages) { this.defaultMaxNumPages = maxNumPages; }
+
+    public void setGetJoinUrlUserdataBlocklist(String getJoinUrlUserdataBlocklist) {
+        this.getJoinUrlUserdataBlocklist = getJoinUrlUserdataBlocklist;
+    }
 
 }

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -532,3 +532,9 @@ allowDuplicateExtUserid=true
 # list of plugins manifests (json array)
 # e.g: [{url: "https://plugin_manifest.json"}]
 pluginManifests=
+
+# Comma-separated list of `userdata-` parameters that should be blocked when generating a getJoinUrl
+# This restriction applies only to viewers, moderators are allowed to pass any parameter
+# To block all `userdata-` parameters, set this value to "all"
+# List the parameters without including the 'userdata-' prefix
+getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -209,6 +209,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="allowOverrideClientSettingsOnCreateCall" value="${allowOverrideClientSettingsOnCreateCall}"/>
         <property name="pluginManifests" value="${pluginManifests}"/>
         <property name="maxNumPages" value="${maxNumPages}"/>
+        <property name="getJoinUrlUserdataBlocklist" value="${getJoinUrlUserdataBlocklist}"/>
     </bean>
 
     <bean id="presentationService" class="org.bigbluebutton.web.services.PresentationService">

--- a/docs/docs/data/getJoinUrl.tsx
+++ b/docs/docs/data/getJoinUrl.tsx
@@ -38,6 +38,7 @@ const getJoinUrlTableData = [
             <>
                 Include additional user data parameters prefixed with userdata-. These parameters will merge with the original user's existing userdata
                 settings. In cases where the same parameter is defined both in the original and the new session, the new session's parameter takes precedence.
+                The list of blocked parameters for viewers can be configured using the config `getJoinUrlUserdataBlocklist` at `bbb-web.properties`.
             </>
         ),
     },

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -1255,7 +1255,7 @@ http&#58;//yourserver.com/bigbluebutton/api/sendChatMessage?meetingID=test01&mes
 
 ### `GET` getJoinUrl
 
-The `getJoinUrl` endpoint generates a new `/join` URL that can be used to create a new session for an existing user. By associating the new session token with the same user ID, all sessions will appear as the same user in the user list, ensuring accurate user counts. Moderators can also customize the new session’s layout and user data parameters, allowing flexible control over the session’s environment and functionality.
+The `getJoinUrl` endpoint generates a new `/join` URL that can be used to create a new session for an existing user. By associating the new session token with the same user ID, all sessions will appear as the same user in the user list, ensuring accurate user counts. Users can also customize the new session’s layout and user data parameters, allowing flexible control over the session’s environment and functionality.
 
 This is particularly useful for hybrid environments where multiple screens in the same room each require a distinct session with different layouts.
 


### PR DESCRIPTION
Currently, only moderators can pass parameters when calling the `getJoinUrl` endpoint. However, this limitation poses issues in certain cases:

- **Mobile App (Whiteboard in iframe):** The app requests the `joinUrl` with the `enforceLayout` parameter to display only the whiteboard.
- **Plugins (e.g., hybrid rooms, remote-camera):** These may need to define a specific layout or pass `userdata-` parameters to control layout traits or behavior.

To address these scenarios while maintaining meeting security, we’ve introduced a new config option:  
`getJoinUrlUserdataBlocklist` in `bigbluebutton.properties`.

This config defines which `userdata-` parameters should be **blocked** when the user is **not a moderator**. By default, the following `userdata-` parameters are blocked:

- `bbb_record_permission`
- `bbb_record_video`
- `bbb_fullaudio_bridge`
- `bbb_transparent_listen_only`
- `bbb_multi_user_pen_only`
- `bbb_presenter_tools`
- `bbb_multi_user_tools`

You can customize the blocklist as needed. Setting the value to `all` blocks all `userdata-` parameters.

This solution was discussed and agreed upon with @lfzawacki.