### PR TITLE
fix: The pencil tool should look like a pencil while using it

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -132,6 +132,7 @@ const Whiteboard = React.memo((props) => {
   clearTldrawCache();
 
   const [isMounting, setIsMounting] = React.useState(true);
+  const [cursorType, setCursorType] = React.useState('');
 
   if (isMounting) {
     setDefaultEditorAssetUrls(getCustomEditorAssetUrls());
@@ -1823,6 +1824,23 @@ const Whiteboard = React.memo((props) => {
   // so this is not run on every render
   });
 
+  React.useEffect(() => {
+    const baseName = window.meetingClientSettings.public.app.cdn + window.meetingClientSettings.public.app.basename;
+    const makeCursorUrl = (filename) => `${baseName}/resources/images/whiteboard-cursor/${filename}`;
+
+    const TOOL_CURSORS = {
+      draw: `url('${makeCursorUrl('pencil.png')}') 2 22, default`,
+      line: `url('${makeCursorUrl('line.png')}'), default`,
+      text: `url('${makeCursorUrl('text.png')}'), default`,
+      note: `url('${makeCursorUrl('square.png')}'), default`,
+      pan: `url('${makeCursorUrl('pan.png')}'), default`,
+    };
+
+    const currentTool = tlEditorRef.current?.getCurrentToolId();
+    const newCursor = hasWBAccessRef.current || currentUser?.presenter ? TOOL_CURSORS[currentTool] || '' : 'inherit';
+    setCursorType(newCursor);
+  }, [tlEditorRef.current?.getCurrentToolId()]);
+
   return (
     <div
       ref={whiteboardRef}
@@ -1847,6 +1865,7 @@ const Whiteboard = React.memo((props) => {
           isMultiUserActive,
           isToolbarVisible,
           presentationHeight,
+          cursorType,
         }}
       />
     </div>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -231,6 +231,13 @@ const TldrawV2GlobalStyle = createGlobalStyle`
       color: ${colorWhite};
     }
   }
+
+    ${({ cursorType }) => (cursorType) && `
+      .tl-canvas {
+        cursor: ${cursorType} !important;
+      }
+  `}
+
 `;
 
 const EditableWBWrapper = styled.div`


### PR DESCRIPTION
### What does this PR do?

restores custom cursor icons for whiteboard tools

![Screenshot from 2025-04-14 17-04-39](https://github.com/user-attachments/assets/41f3b664-419b-47d2-a81f-748d3f90443a)

### Closes Issue(s)
Closes #22892

### How to test
1. join a meeting
2. select "draw" tool
3. see custom icon