### PR TITLE
fix: Emojis can't be reverted

### DIFF
--- a/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
+++ b/bbb-graphql-actions/src/actions/userSetReactionEmoji.ts
@@ -10,7 +10,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
       ]
   )
 
-  if(typeof input.reactionEmoji !== 'string' || !EMOJI_REGEX.test(input.reactionEmoji)) {
+  if (input.reactionEmoji !== "none" && (typeof input.reactionEmoji !== 'string' || !EMOJI_REGEX.test(input.reactionEmoji))) {
     throw new ValidationError(`Parameter 'reactionEmoji' contains an invalid Emoji`, 400);
   }
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -33,6 +33,11 @@ const ReactionsButton = (props) => {
       description: 'reactions Label',
       defaultMessage: 'Share a reaction',
     },
+    removeReactionsLabel: {
+      id: 'app.actionsBar.reactions.removeReactionButtonLabel',
+      description: 'remove reaction Label',
+      defaultMessage: 'Remove reaction',
+    },
   });
 
   const handleClose = () => {
@@ -71,8 +76,31 @@ const ReactionsButton = (props) => {
       key: id,
       onClick: () => handleReactionSelect(native),
       customStyles: actionCustomStyles,
-      dataTest: 'reaction'
+      dataTest: 'reaction',
     });
+  });
+
+  actions.push({
+    label: (
+      <Styled.ButtonWrapper>
+        <Styled.ReactionsButton
+          data-test="removeReactionButton"
+          icon="close"
+          label={intl.formatMessage(intlMessages.removeReactionsLabel)}
+          description={intl.formatMessage(intlMessages.removeReactionsLabel)}
+          onKeyPress={() => { }}
+          hideLabel
+          circle
+          disabled={currentUserReaction === 'none'}
+          color="primary"
+          ghost
+        />
+      </Styled.ButtonWrapper>
+    ),
+    key: 'none',
+    onClick: () => (currentUserReaction !== 'none' ? handleReactionSelect('none') : null),
+    customStyles: actionCustomStyles,
+    dataTest: 'remove-reaction',
   });
 
   const svgIcon = currentUserReaction === 'none' ? 'reactions' : null;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/styles.js
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import Button from '/imports/ui/components/common/button/component';
 
 import {
+  colorWhite,
   colorGrayDark,
   colorGrayLightest,
   btnPrimaryColor,
@@ -43,6 +43,12 @@ const ButtonWrapper = styled.div`
 
   & > * > span {
     padding: 4px;
+    color: ${colorGrayDark} !important;
+    border-color: transparent !important;
+  }
+
+  & i {
+    width: 1.3rem;
   }
 
   ${({ active }) => active && `

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -711,6 +711,7 @@
     "app.actionsBar.actionsDropdown.takePresenter": "Take presenter",
     "app.actionsBar.actionsDropdown.takePresenterDesc": "Assign yourself as the new presenter",
     "app.actionsBar.reactions.reactionsButtonLabel": "Share a reaction",
+    "app.actionsBar.reactions.removeReactionLabel": "Remove reaction",
     "app.actionsBar.reactions.raiseHand": "Raise your hand",
     "app.actionsBar.reactions.lowHand": "Lower your hand",
     "app.actionsBar.reactions.autoCloseReactionsBarLabel": "Auto close the reactions bar",


### PR DESCRIPTION
### What does this PR do?

Includes a button to remove reaction in reactions bar

[Screencast from 2025-04-15 10-41-47.webm](https://github.com/user-attachments/assets/db06d592-ac44-4550-8d40-84d7103a919b)

### Closes Issue(s)
Closes #21311

### How to test
1. join a meeting
2. open reactions bar and select a reaction
3. open reactions bar again and select the X button
4. previously selected reaction should be removed