### PR TITLE
fix(html5): Chat scroll not sticking to bottom

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -388,6 +388,41 @@ const ChatMessageList: React.FC<ChatListProps> = ({
     }
   };
 
+  const scrollToBottom = useCallback(() => {
+    const container = messageListContainerRef.current;
+
+    if (!container) return;
+
+    let initialPosition = 0;
+    let initialTimestamp = 0;
+    let scrollPositionDiff = 0;
+
+    const animateScrollPosition = (timestamp: number) => {
+      const value = (timestamp - initialTimestamp) / 300;
+      if (value <= 1) {
+        container.scrollTop = initialPosition + (value * scrollPositionDiff);
+        requestAnimationFrame(animateScrollPosition);
+      } else {
+        container.scrollTop = container.scrollHeight - container.offsetHeight;
+      }
+    };
+
+    const startScrollAnimation = (timestamp: number) => {
+      const {
+        scrollTop,
+        scrollHeight,
+        offsetHeight,
+      } = container;
+
+      initialTimestamp = timestamp;
+      initialPosition = scrollTop;
+      scrollPositionDiff = scrollHeight - offsetHeight - scrollTop;
+      requestAnimationFrame(animateScrollPosition);
+    };
+
+    requestAnimationFrame(startScrollAnimation);
+  }, []);
+
   const renderUnreadNotification = useMemo(() => {
     if (totalUnread && !followingTail) {
       return (
@@ -397,11 +432,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
           size="sm"
           key="unread-messages"
           label={intl.formatMessage(intlMessages.moreMessages)}
-          onClick={() => {
-            if (endSentinelRef.current) {
-              endSentinelRef.current.scrollIntoView({ behavior: 'smooth' });
-            }
-          }}
+          onClick={scrollToBottom}
         />
       );
     }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Fixes chat scroll not sticking to the bottom after clicking 'More messages' button.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
n/a

### Motivation

Sometimes, when lots of activity is going on in the chat, if the user clicks 'More messages below' to see the latest messages the client will not take him to the bottom if a new message arrives. That's because when a new message arrives, the container is resized and assumes a new height. But the auto scroll engine doesn't know this new height and will take the old height into account.


### How to test

You need a way to send messages in the chat on regular interval in order to test it. Then, you can play around with the 'More messages below' button.

![Screenshot from 2025-04-16 17-55-36](https://github.com/user-attachments/assets/2ea1068f-b20b-4c20-a7f9-0a1520e1ea23)
