### PR TITLE
fix(API): Add error handling to document conversion threads

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
@@ -42,9 +42,9 @@ public class PdfSlidesGenerationService {
   public void process(PageToConvert pageToConvert) {
     executor.submit(() -> {
       try {
-        log.info("Starting convert, page={}", pageToConvert.getPageNumber());
+        log.info("Starting conversion for page {}", pageToConvert.getPageNumber());
         pageToConvert.convert();
-        log.info("Convert finished, sending progress message");
+        log.info("Conversion finished for page {}, sending progress message", pageToConvert.getPageNumber());
 
         PageConvertProgressMessage msg = new PageConvertProgressMessage(
                 pageToConvert.getPageNumber(),
@@ -53,7 +53,7 @@ public class PdfSlidesGenerationService {
                 new ArrayList<>());
 
         presentationConversionCompletionService.handle(msg);
-        log.info("Progress message handled");
+        log.info("Progress message handled for page {}", pageToConvert.getPageNumber());
       } catch (Throwable t) {
         log.error("Conversion task failed", t);
       }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
@@ -55,7 +55,7 @@ public class PdfSlidesGenerationService {
         presentationConversionCompletionService.handle(msg);
         log.info("Progress message handled for page {}", pageToConvert.getPageNumber());
       } catch (Throwable t) {
-        log.error("Conversion task failed", t);
+        log.error("Conversion task failed for page {}", pageToConvert.getPageNumber(), t);
       }
     });
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
@@ -40,21 +40,24 @@ public class PdfSlidesGenerationService {
   }
 
   public void process(PageToConvert pageToConvert) {
-    Runnable task = new Runnable() {
-      public void run() {
+    executor.submit(() -> {
+      try {
+        log.info("Starting convert, page={}", pageToConvert.getPageNumber());
         pageToConvert.convert();
+        log.info("Convert finished, sending progress message");
+
         PageConvertProgressMessage msg = new PageConvertProgressMessage(
                 pageToConvert.getPageNumber(),
                 pageToConvert.getPresId(),
                 pageToConvert.getMeetingId(),
                 new ArrayList<>());
-        log.info("Sending PageConvertProgressMessage for page {}", pageToConvert.getPageNumber());
-        presentationConversionCompletionService.handle(msg);
-        // The pdf of the page will be removed after cache storing
-      }
-    };
 
-    executor.execute(task);
+        presentationConversionCompletionService.handle(msg);
+        log.info("Progress message handled");
+      } catch (Throwable t) {
+        log.error("Conversion task failed", t);
+      }
+    });
   }
 
   public void setPresentationConversionCompletionService(PresentationConversionCompletionService s) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -46,15 +46,11 @@ public class PresentationConversionCompletionService {
             presentationsToConvert.put(presentationToConvertKey, p);
         } else if (msg instanceof PageConvertProgressMessage) {
             PageConvertProgressMessage m = (PageConvertProgressMessage) msg;
-
-            log.info("Handling PageConvertProgressMessage for page {}", m.page);
-
             String presentationToConvertKey = m.presId + "_" + m.meetingId;
 
             PresentationToConvert p = presentationsToConvert.get(presentationToConvertKey);
             if (p != null) {
                 p.incrementPagesCompleted();
-                log.info("Finished converting {} out of {}", p.getPagesCompleted(), p.pres.getNumberOfPages());
                 notifier.sendConversionUpdateMessage(p.getPagesCompleted(), p.pres, m.page);
                 if (p.getPagesCompleted() == p.pres.getNumberOfPages()) {
                     handleEndProcessing(p);


### PR DESCRIPTION
### What does this PR do?

Adds error handling and logging for document conversion threads. Currently whenever an unchecked exception occurs in one of the worker threads responsible for document conversion the exception simply causes the thread to die and be replaced with no stacktrace which will lead to odd scenarios where document conversion fails to fully complete but no error is seen in the logs. Executing these threads in a try-catch block should allow the parent thread to catch and then log any exceptions that occur in the worker threads which will allow for a better understanding of any issues that occur during the document conversion process. Also removes some unnecessary logs that were added in #22900. 

Seeing a `Conversion task failed for page` error in the BBB Web log indicates that a problem occurred for one of the pages  in the uploaded document. Seeing multiples logs like this especially across multiple presentation uploads is a strong indicator that presentation upload is effectively disabled on the server due chronic errors in the conversion process.

### Motivation

This change should allow for a better understanding of any issues that may occur in the document conversion process. This has been motivated by the need to better understand an issue where BBB servers would suddenly lose the ability to upload presentations (seen as an endlessly spinning document upload modal in the client).
