### PR TITLE
fix: add sidebar navigation and presentation toolbar scroll

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -734,7 +734,7 @@ class Presentation extends PureComponent {
 
     const { presentationToolbarMinWidth } = DEFAULT_VALUES;
 
-    const isLargePresentation = (svgWidth > presentationToolbarMinWidth || isMobile)
+    const isLargePresentation = (svgWidth > presentationToolbarMinWidth)
       && !(
         layoutType === LAYOUT_TYPE.VIDEO_FOCUS
         && numCameras > 0
@@ -744,6 +744,10 @@ class Presentation extends PureComponent {
     const containerWidth = isLargePresentation
       ? svgWidth
       : presentationToolbarMinWidth;
+
+    const mobileAwareContainerWidth = isMobile
+      ? presentationBounds.width
+      : containerWidth;
 
     const slideContent = currentSlide?.content
       ? `${intl.formatMessage(intlMessages.slideContentStart)}
@@ -879,7 +883,7 @@ class Presentation extends PureComponent {
                     this.refPresentationToolbar = ref;
                   }}
                   style={{
-                    width: containerWidth,
+                    width: mobileAwareContainerWidth,
                   }}
                 >
                   {this.renderPresentationToolbar(svgWidth)}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -383,6 +383,7 @@ class PresentationToolbar extends PureComponent {
     return (
       <Styled.PresentationToolbarWrapper
         id="presentationToolbarWrapper"
+        isMobile={isMobile}
       >
         {this.renderAriaDescs()}
         <Styled.QuickPollButtonWrapper>

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -28,12 +28,15 @@ const PresentationToolbarWrapper = styled.div`
   background-color: ${colorOffWhite};
   border-top: 1px solid ${colorBlueLightest};
   border-radius: 0 0 ${lgBorderRadius} ${lgBorderRadius};
-  min-width: fit-content;
   width: 100%;
   bottom: 0px;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   padding: 2px;
+  ${({ isMobile }) => (isMobile
+    ? 'overflow: auto;'
+    : 'min-width: fit-content;'
+  )};
 
   select {
     &:-moz-focusring {

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/component.jsx
@@ -224,7 +224,8 @@ class ApplicationMenu extends BaseMenu {
 
     const obj = this.state;
     obj.settings.microphoneConstraints = _newConstraints;
-    this.handleUpdateSettings(this.state.settings, obj.settings);
+    this.handleUpdateSettings(this.state.settingsName, obj.settings);
+    this.setState({ audioFilterEnabled: _audioFilterEnabled });
   }
 
   handleUpdateFontSize(size) {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
@@ -20,6 +20,9 @@ import {
   colorGrayIcons,
   colorBackground,
 } from '/imports/ui/stylesheets/styled-components/palette';
+import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
+
+const smallHeight = '(max-height: 40em)';
 
 const NavigationSidebarBackdrop = styled.div<{isMobile: boolean}>`
   position: absolute;
@@ -37,12 +40,18 @@ const NavigationSidebar = styled.div<{isMobile: boolean}>`
   ${({ isMobile }) => isMobile && 'box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2)'};
 `;
 
-const NavigationSidebarListItemsContainer = styled.div`
+const NavigationSidebarListItemsContainer = styled(ScrollboxVertical)`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   flex-grow: 1;
+  overflow-y: auto;
+  border-radius: ${navigationSidebarBorderRadius};
   gap: ${navigationSidebarListItemsContainerGap};
+
+  @media ${smallHeight} {
+    gap: 1.25rem;
+  }
 `;
 
 const PositionedDiv = styled.div`
@@ -50,6 +59,10 @@ const PositionedDiv = styled.div`
   flex-direction: column;
   width: 100%;
   gap: ${navigationSidebarListItemsGap};
+
+  @media ${smallHeight} {
+    gap: 0.4rem;
+  }
 `;
 
 const Top = styled(PositionedDiv)`
@@ -81,8 +94,12 @@ const ListItem = styled.div<ListItemProps>`
   > i {
     font-size: 175%;
     color: ${colorGrayLight};
+
+    @media ${smallHeight} {
+      font-size: 125%;
+    }
   }
-  
+
   &:hover {
     outline: transparent;
     outline-style: dotted;


### PR DESCRIPTION
### What does this PR do?
- Fixes the icons being out of screen when screen is too small in the navigation sidebard
![image](https://github.com/user-attachments/assets/1a395ea6-eab6-4747-9f6a-3eabe2a8eee0)

- (mobile): Adjusts presentation toolbar in mobile, also adds scroll if needed (by @Arthurk12)
![320015341-abd0eedd-6730-460f-b77b-7a994a960ae5](https://github.com/user-attachments/assets/11edee27-020c-49fc-9452-a209c29fc67f)

- Fix Audio Filters toggle state not updating
