### PR TITLE
fix: External youtube video is not syncing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -562,6 +562,14 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   };
 
   useEffect(() => {
+    // clear lastMessageRef when video is changed
+    if (lastMessageRef?.current?.event) {
+      lastMessageRef.current.event = '';
+      lastMessageRef.current.rate = 0;
+      lastMessageRef.current.time = 0;
+      lastMessageRef.current.state = undefined;
+    }
+
     if (!currentMeeting?.externalVideo?.externalVideoUrl && hasExternalVideo.current) {
       layoutContextDispatch({
         type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,


### PR DESCRIPTION
### What does this PR do?

Resolved an issue where external video event updates were no longer propagated to viewers due to a reference to the last event not being cleared upon external video change

### Closes Issue(s)
Closes #22964

### How to test
1. join a meeting with 2 users
2. share an external video
3. pause the video
4. stop sharing the video
5. share another external video
6. pause the video
7. the video should also be stopped for the viewer