### PR TITLE
fix(private-chat): viewers can't chat with each other

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -144,10 +144,9 @@ export const generateActionsPermissions = (
   // A breakout room user that has a moderator role in it's parent room
   const parentRoomModerator = getFromUserSettings('bbb_parent_room_moderator', false);
   const hasAuthority = currentUser.isModerator || amISubjectUser;
-  const userChatIsLocked = currentUser.locked || lockSettings?.disablePrivateChat;
   const allowedToChatPrivately = isChatEnabled && (
     currentUser.isModerator || (
-      !userChatIsLocked
+      !lockSettings?.disablePrivateChat
         // TODO: Add check for hasPrivateChat between users
         || subjectUser.isModerator
     )) && !amISubjectUser

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -144,9 +144,10 @@ export const generateActionsPermissions = (
   // A breakout room user that has a moderator role in it's parent room
   const parentRoomModerator = getFromUserSettings('bbb_parent_room_moderator', false);
   const hasAuthority = currentUser.isModerator || amISubjectUser;
+  const userChatIsLocked = currentUser.locked && lockSettings?.disablePrivateChat;
   const allowedToChatPrivately = isChatEnabled && (
     currentUser.isModerator || (
-      !lockSettings?.disablePrivateChat
+      !userChatIsLocked
         // TODO: Add check for hasPrivateChat between users
         || subjectUser.isModerator
     )) && !amISubjectUser


### PR DESCRIPTION
### What does this PR do?
Viewers couldn't open private chat with other viewers because there was a wrong permission check. This PR fixes this check.
