### PR TITLE
Fix(html5): Whiteboard crash when clipboard permission is denied

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -92,7 +92,7 @@ const ErrorBoundaryWithReload = ({ children }) => {
         return;
       }
       // Ignore errors caused by missing permissions on browser
-      if (event.reason.name === 'NotAllowedError') {
+      if (event.reason?.name === 'NotAllowedError') {
         return;
       }
 

--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -91,6 +91,10 @@ const ErrorBoundaryWithReload = ({ children }) => {
       if (event.reason?.message?.toString().indexOf('Permission Denied') !== -1) {
         return;
       }
+      // Ignore errors caused by missing permissions on browser
+      if (event.reason.name === 'NotAllowedError') {
+        return;
+      }
 
       triggerError();
     };


### PR DESCRIPTION
### What does this PR do?
Fix issue of whiteboard being crashed if the clipboard permission is denied, I've added a new condition for the reason "NotAllowedError" triggered when a browser permission is denied.


### Closes Issue(s)
Closes #22955

### How to test
- Open `Site settings`
- Change permission `Clipebaord` to `block`
![image](https://github.com/user-attachments/assets/d8ca9ddc-7275-4ef9-bfd8-c7b762ad62b2)
- Draw a line on whiteboard
- R-click to copy and past

