### PR TITLE
fix(private-chat): back button inconsistent state

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -82,7 +82,15 @@ const Chat: React.FC<ChatProps> = ({
   };
 
   const handleClickReturnPrivateList = () => {
-    setPrivateList(true);
+    if (filteredPrivateChats.length > 0) {
+      setPrivateList(true);
+    } else {
+      // no private chat was started, go back to public chat
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: PUBLIC_GROUP_CHAT_ID,
+      });
+    }
   };
 
   React.useEffect(() => {


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
When the user started a private chat but don't send any message and then pressed the back button, the chat became empty.
 - Fixed by going back to the public chat


### How to test
1. Join with two users.
2. Click start private chat button in user list
3. Don't send any message, just press the back arrow button

