### PR TITLE
fix(html5): fix actions-bar extensible area breaking when plugin used old SDK 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -52,9 +52,9 @@ class ActionsBar extends PureComponent {
                   circle: true,
                   label: plugin.tooltip,
                 };
-                if (plugin?.icon && 'iconName' in plugin.icon) {
+                if (plugin?.icon && typeof plugin.icon === 'object' && 'iconName' in plugin.icon) {
                   buttonProps.icon = plugin.icon.iconName;
-                } else if (plugin?.icon && 'svgContent' in plugin.icon) {
+                } else if (plugin?.icon && typeof plugin.icon === 'object' && 'svgContent' in plugin.icon) {
                   buttonProps.customIcon = (
                     <i>
                       {plugin.icon.svgContent}


### PR DESCRIPTION
### What does this PR do?

The PR https://github.com/bigbluebutton/bigbluebutton/pull/22923 changed the structure of the plugin extensible-area in the actions-bar button. This PR is a hot-fix to avoid that plugins with old SDKs break the entire client.

### More

Closely related to https://github.com/bigbluebutton/bigbluebutton/pull/22923