### PR TITLE
test(chat): Add tests for new chat features (reply, edit, delete and react)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-editing-warning/component.tsx
@@ -51,7 +51,7 @@ const ChatEditingWarning = () => {
 
   return (
     <Root role="note" aria-describedby="cancel-editing-msg">
-      <Container>
+      <Container data-test="chatEditingWarningContainer">
         <Left>
           <Icon iconName="pen_tool" />
           {editingMessage}
@@ -60,11 +60,12 @@ const ChatEditingWarning = () => {
           onClick={() => {
             window.dispatchEvent(new CustomEvent(ChatEvents.CHAT_CANCEL_EDIT_REQUEST));
           }}
+          data-test="cancelEditingButton"
         >
           {cancelMessage.split(CANCEL_KEY_LABEL)[0]}
-        &nbsp;
+          &nbsp;
           <Highlighted>{CANCEL_KEY_LABEL}</Highlighted>
-        &nbsp;
+          &nbsp;
           {cancelMessage.split(CANCEL_KEY_LABEL)[1]}
         </Cancel>
         <span className="sr-only" id="cancel-editing-msg">

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -641,7 +641,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
       $editing={editing}
       $keyboardFocused={keyboardFocused}
       $reactionPopoverIsOpen={isToolbarReactionPopoverOpen}
-      data-test="chatMessageItem"
       $emphasizedMessage={message.chatEmphasizedText}
       role="listitem"
     >
@@ -664,41 +663,41 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
         onReply={onReply}
       />
       {message.replyToMessage && !deleteTime && (
-      <ChatMessageReplied
-        message={message.replyToMessage.message || ''}
-        sequence={message.replyToMessage.messageSequence}
-        deletedByUser={message.replyToMessage.deletedBy?.name ?? null}
-      />
+        <ChatMessageReplied
+          message={message.replyToMessage.message || ''}
+          sequence={message.replyToMessage.messageSequence}
+          deletedByUser={message.replyToMessage.deletedBy?.name ?? null}
+        />
       )}
       {!deleteTime && (
-      <MessageItemWrapper>
-        {messageContent.component}
-        {messageReadFeedbackEnabled && (
-        <MessageReadConfirmation
-          message={message}
-        />
-        )}
-      </MessageItemWrapper>
+        <MessageItemWrapper>
+          {messageContent.component}
+          {messageReadFeedbackEnabled && (
+            <MessageReadConfirmation
+              message={message}
+            />
+          )}
+        </MessageItemWrapper>
       )}
       {sameSender && (
-      <ChatContentFooter>
-        {!deleteTime && editTime && (
-        <Tooltip title={intl.formatTime(editTime, { hour12: false })}>
-          <EditLabel>
-            <Icon iconName="pen_tool" />
-            <span>{intl.formatMessage(intlMessages.edited)}</span>
-          </EditLabel>
-        </Tooltip>
-        )}
-        <ChatTime>
-          <FormattedTime value={dateTime} hour12={false} />
-        </ChatTime>
-      </ChatContentFooter>
+        <ChatContentFooter>
+          {!deleteTime && editTime && (
+            <Tooltip title={intl.formatTime(editTime, { hour12: false })}>
+              <EditLabel>
+                <Icon iconName="pen_tool" />
+                <span>{intl.formatMessage(intlMessages.edited)}</span>
+              </EditLabel>
+            </Tooltip>
+          )}
+          <ChatTime>
+            <FormattedTime value={dateTime} hour12={false} />
+          </ChatTime>
+        </ChatContentFooter>
       )}
       {deleteTime && (
-      <DeleteMessage>
-        {intl.formatMessage(intlMessages.deleteMessage, { 0: message.deletedBy?.name })}
-      </DeleteMessage>
+        <DeleteMessage>
+          {intl.formatMessage(intlMessages.deleteMessage, { 0: message.deletedBy?.name })}
+        </DeleteMessage>
       )}
     </ChatContent>
   );
@@ -747,6 +746,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
 
   return (
     <Container
+      data-test="chatMessageItem"
       className={classNames('chat-message-container', {
         'chat-message-container-keyboard-focused': keyboardFocused,
       })}
@@ -834,6 +834,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           description={intl.formatMessage(intlMessages.confirmationDescription)}
           confirmButtonColor="danger"
           priority="high"
+          confirmButtonDataTest="confirmDeleteChatMessageButton"
         />
       )}
     </Container>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
@@ -53,7 +53,7 @@ const ChatMessageHeader: React.FC<ChatMessageHeaderProps> = ({
         <Styled.Center />
         {!deleteTime && editTime && (
           <Tooltip title={intl.formatTime(editTime, { hour12: false })}>
-            <Styled.EditLabel>
+            <Styled.EditLabel data-test="chatMessageEditedLabel">
               <Icon iconName="pen_tool" />
               <span>{intl.formatMessage(intlMessages.edited)}</span>
             </Styled.EditLabel>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/component.tsx
@@ -66,6 +66,7 @@ const ReactionItem: React.FC<ReactionItemProps> = (props) => {
   return (
     <TooltipContainer title={label} key={reactionEmojiId}>
       <Styled.EmojiWrapper
+        data-test="messageReactionItem"
         tabIndex={-1}
         aria-describedby={id}
         highlighted={reactedByMe}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-replied/component.tsx
@@ -26,6 +26,7 @@ const ChatMessageReplied: React.FC<MessageRepliedProps> = (props) => {
 
   return (
     <Styled.Container
+      data-test="chatMessageReplied"
       onClick={(e) => {
         e.stopPropagation();
         if (e.target instanceof HTMLAnchorElement) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -82,7 +82,7 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const showDivider = (showReplyButton || showReactionsButton) && (showEditButton || showDeleteButton);
 
   const container = (
-    <Container className="chat-message-toolbar">
+    <Container className="chat-message-toolbar" data-test="chatMessageToolbar">
       {showReplyButton && (
       <>
         <Tooltip title={intl.formatMessage(intlMessages.replyTooltip)}>
@@ -91,6 +91,7 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
             icon="undo"
             color="light"
             onClick={onReply}
+            data-test="replyMessageButton"
           />
         </Tooltip>
       </>
@@ -105,7 +106,7 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
           }}
           svgIcon="reactions"
           color="light"
-          data-test="reactionsPickerButton"
+          data-test="reactMessageButton"
         />
       </Tooltip>
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/component.tsx
@@ -71,6 +71,7 @@ const ChatReplyIntention = () => {
 
   return (
     <Styled.Container
+      data-test="chatReplyIntentionContainer"
       $hidden={hidden}
       $animations={animations}
       onClick={() => {
@@ -104,6 +105,7 @@ const ChatReplyIntention = () => {
           tabIndex={hidden ? -1 : 0}
           aria-hidden={hidden}
           aria-label={intl.formatMessage(intlMessages.cancel, { 0: CANCEL_KEY })}
+          data-test="closeChatReplyIntentionButton"
         />
       </Tooltip>
     </Styled.Container>

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -1,88 +1,192 @@
 const { test } = require('../fixtures');
-const { fullyParallel } = require('../playwright.config');
-const { initializePages } = require('../core/helpers');
 const { Chat } = require('./chat');
+const { MessageActions } = require('./messageActions');
 
 test.describe('Chat', { tag: '@ci' }, () => {
-  const chat = new Chat();
-
-  test.describe.configure({ mode: fullyParallel ? 'parallel' : 'serial' });
-  test[fullyParallel ? 'beforeEach' : 'beforeAll'](async ({ browser }) => {
-    await initializePages(chat, browser, { isMultiUser: true });
-  });
-
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#public-message-automated
-  test('Send public message', async () => {
+  test('Send public message', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.sendPublicMessage();
   });
 
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#private-message-automated
-  test('Send private message', async () => {
+  test('Send private message', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.sendPrivateMessage();
   });
 
-  test('Clear chat', async () => {
+  test('Clear chat', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.clearChat();
   });
 
-  test('Copy chat', async () => {
+  test('Copy chat', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.copyChat();
   });
 
-  test('Save chat', async ({}, testInfo) => {
+  test('Save chat', async ({ browser, context, page }, testInfo) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.saveChat(testInfo);
   });
 
-  test('Verify character limit', async () => {
+  test('Verify character limit', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.characterLimit();
   });
 
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#sending-empty-chat-message-automated
-  test('Not able to send an empty message', async () => {
+  test('Not able to send an empty message', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.emptyMessage();
   });
 
-  test('Copy and paste public message', async () => {
+  test('Copy and paste public message', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.copyPastePublicMessage();
   })
 
-  test('Send emoji on public chat using emoji picker', { tag: '@setting-required:chat.emojiPicker' }, async () => {
+  test('Send emoji on public chat using emoji picker', { tag: '@setting-required:chat.emojiPicker' }, async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.sendEmoji();
   });
 
-  test('Copy chat with emoji', async () => {
+  test('Copy chat with emoji', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.emojiCopyChat();
   });
 
-  test('Close private chat', async () => {
+  test('Close private chat', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.closePrivateChat();
   });
 
-  test('Save chat with emoji', { tag: '@setting-required:chat.emojiPicker' }, async ({}, testInfo) => {
+  test('Save chat with emoji', { tag: '@setting-required:chat.emojiPicker' }, async ({ browser, context, page }, testInfo) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.emojiSaveChat(testInfo);
   });
 
-  test('Send emoji on private chat', { tag: '@setting-required:chat.emojiPicker' }, async () => {
+  test('Send emoji on private chat', { tag: '@setting-required:chat.emojiPicker' }, async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.emojiSendPrivateChat();
   });
 
-  test('Send auto converted emoji on public chat', { tag: '@setting-required:chat.autoConvertEmoji' }, async () => {
+  test('Send auto converted emoji on public chat', { tag: '@setting-required:chat.autoConvertEmoji' }, async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.autoConvertEmojiPublicChat();
   });
 
-  test('Copy chat with auto converted emoji', { tag: '@setting-required:chat.autoConvertEmoji' }, async () => {
+  test('Copy chat with auto converted emoji', { tag: '@setting-required:chat.autoConvertEmoji' }, async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.autoConvertEmojiCopyChat();
   });
 
-  test('Auto convert emoji save chat', { tag: '@setting-required:chat.autoConvertEmoji' }, async ({}, testInfo) => {
+  test('Auto convert emoji save chat', { tag: '@setting-required:chat.autoConvertEmoji' }, async ({ browser, context, page }, testInfo) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.autoConvertEmojiSaveChat(testInfo);
   });
 
-  test('Send auto converted emoji on private chat', { tag: '@setting-required:chat.autoConvertEmoji' }, async () => {
+  test('Send auto converted emoji on private chat', { tag: '@setting-required:chat.autoConvertEmoji' }, async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.autoConvertEmojiSendPrivateChat();
   });
 
-  test('Private chat disabled when user leaves meeting', async () => {
+  test('Private chat disabled when user leaves meeting', async ({ browser, context, page }) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page);
     await chat.chatDisabledUserLeaves();
+  });
+
+  test.describe('Message actions', () => {
+    test.describe('Edit', () => {
+      test('Edit a message using the toolbar button', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.editMessageFromToolbarButton();
+      });
+
+      test('Edit a message using the arrow up key', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.editMessageFromArrowUp();
+      });
+
+      test('Able to edit only their own message sent', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.ableToEditOwnMessage();
+      });
+    });
+
+    test.describe('Delete', () => {
+      test('Delete own message', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.deleteOwnMessage();
+      });
+
+      test('Delete message from a viewer', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.deleteViewerMessage();
+      });
+    });
+
+    test.describe('Reply', () => {
+      test('Reply to a message', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initModPage(page);
+        await message.replyMessage();
+      });
+
+      test('Cancel a reply to a message', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initModPage(page);
+        await message.cancelReplyMessage();
+      });
+
+      test('Scroll to replied message', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.scrollToRepliedMessage();
+      });
+    });
+
+    test.describe('Reactions', () => {
+      test('Add and remove a message reaction', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.addRemoveReaction();
+      });
+
+      test('Increment and decrement a message reaction', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.incrementDecrementReaction();
+      });
+
+      test('Order message reaction by highest amount', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.orderReactions();
+      });
+    });
   });
 });

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -142,10 +142,10 @@ test.describe('Chat', { tag: '@ci' }, () => {
         await message.deleteOwnMessage();
       });
 
-      test('Delete message from a viewer', async ({ browser, context, page }) => {
+      test('Moderator can delete a message from another user', async ({ browser, context, page }) => {
         const message = new MessageActions(browser, context);
         await message.initPages(page);
-        await message.deleteViewerMessage();
+        await message.deleteAnotherUserMessage();
       });
     });
 

--- a/bigbluebutton-tests/playwright/chat/chat.spec.js
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.js
@@ -147,6 +147,12 @@ test.describe('Chat', { tag: '@ci' }, () => {
         await message.initPages(page);
         await message.deleteAnotherUserMessage();
       });
+
+      test('User can delete only his own messages in breakout rooms', async ({ browser, context, page }) => {
+        const message = new MessageActions(browser, context);
+        await message.initPages(page);
+        await message.breakoutsModDelete();
+      });
     });
 
     test.describe('Reply', () => {

--- a/bigbluebutton-tests/playwright/chat/messageActions.js
+++ b/bigbluebutton-tests/playwright/chat/messageActions.js
@@ -126,9 +126,9 @@ class MessageActions extends Chat {
     await this.modPage.wasRemoved(e.messageToolbar, 'should not display the message toolbar when hovering a deleted message');
   }
 
-  async deleteViewerMessage() {
+  async deleteAnotherUserMessage() {
     await openPublicChat(this.userPage);
-    // send a message
+    // user send a message
     await this.userPage.type(e.chatBox, e.message);
     await this.userPage.waitAndClick(e.sendButton);
     await this.userPage.hasElement(e.chatUserMessageText, 'should display the message sent by the user on its public chat');
@@ -153,6 +153,23 @@ class MessageActions extends Chat {
     await this.modPage.wasRemoved(e.messageReactionItem, 'should remove the message reaction item from the deleted message');
     await lastMessageItem.hover();
     await this.modPage.wasRemoved(e.messageToolbar, 'should not display the message toolbar when hovering a deleted message');
+    // join mod2 and send a message
+    await this.initModPage2();
+    await this.modPage2.type(e.chatBox, e.message);
+    await this.modPage2.waitAndClick(e.sendButton);
+    // check if mod2 message is deletable by mod1
+    await this.modPage.hasElement(e.chatUserMessageText, 'should display the message sent by the mod2 on the public chat');
+    await checkLastMessageSent(this.modPage, e.message);
+    await hoverLastMessage(this.modPage);
+    await this.modPage.hasElement(e.messageToolbar, 'should display the message toolbar when hovering a message');
+    await this.modPage.waitAndClick(e.deleteMessageButton);
+    await this.modPage.hasElement(e.simpleModal, 'should display the delete message confirmation modal');
+    await this.modPage.waitAndClick(e.confirmDeleteChatMessageButton);
+    // check deleted message
+    const lastMessageItem2 = await this.modPage.getLocator(e.chatMessageItem).last();
+    await expect(lastMessageItem2, 'should display the message deleted label after deleting a message').toContainText(`This message was deleted by ${this.modPage.username}`);
+    await this.modPage.wasRemoved(e.chatUserMessageText, 'should remove the message content from the public chat');
+    await this.modPage.hasElementCount(e.chatMessageItem, initialMessageItemsCount + 1, 'should keep displaying the mod2 deleted message item on the public chat');
   }
 
   async replyMessage() {

--- a/bigbluebutton-tests/playwright/chat/util.js
+++ b/bigbluebutton-tests/playwright/chat/util.js
@@ -25,11 +25,22 @@ async function openPrivateChat(testPage) {
   await testPage.clickOnLocator(lastUserStartPrivateChat);
 }
 
+async function getLastMessageSent(testPage) {
+  return testPage.getLocator(e.chatUserMessageText).last();
+}
+
 async function checkLastMessageSent(testPage, expectedMessage) {
-  const lastMessageSent = await testPage.getLocator(e.chatUserMessageText).last();
-  await expect(lastMessageSent, 'should display the last message sent on the chat').toHaveText(expectedMessage);
+  const lastMessageSentLocator = await getLastMessageSent(testPage);
+  await expect(lastMessageSentLocator, 'should display the last message sent on the chat').toHaveText(expectedMessage);
+}
+
+async function hoverLastMessage(testPage) {
+  const lastMessageSentLocator = await getLastMessageSent(testPage);
+  await lastMessageSentLocator.hover();
 }
 
 exports.openPublicChat = openPublicChat;
 exports.openPrivateChat = openPrivateChat;
+exports.getLastMessageSent = getLastMessageSent;
 exports.checkLastMessageSent = checkLastMessageSent;
+exports.hoverLastMessage = hoverLastMessage;

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -148,9 +148,24 @@ exports.inputPrivateLobbyMessage = 'div[data-test="privateLobbyMessage"] >> text
 exports.sendPrivateLobbyMessage = 'div[data-test="privateLobbyMessage"] >> button';
 exports.rememberCheckboxId = 'input[id="rememberCheckboxId"]';
 exports.welcomeMessage = 'h1[id="welcome-message"]';
+exports.chatMessageEditedLabel = 'span[data-test="chatMessageEditedLabel"]';
+exports.chatEditingWarningContainer = 'div[data-test="chatEditingWarningContainer"]';
+exports.cancelEditingButton = 'button[data-test="cancelEditingButton"]';
+exports.confirmDeleteChatMessageButton = 'button[data-test="confirmDeleteChatMessageButton"]';
+exports.chatReplyIntentionContainerContent = 'div[data-test="chatReplyIntentionContainer"] p';
+exports.closeChatReplyIntentionButton = 'button[data-test="closeChatReplyIntentionButton"]';
+exports.chatMessageReplied = 'div[data-test="chatMessageReplied"]';
+exports.messageReactionItem = 'button[data-test="messageReactionItem"]';
+// Message toolbar
+exports.messageToolbar = 'div[data-test="chatMessageToolbar"]';
+exports.replyMessageButton = 'button[data-test="replyMessageButton"]';
+exports.reactMessageButton = 'button[data-test="reactMessageButton"]';
+exports.editMessageButton = 'button[data-test="editMessageButton"]';
+exports.deleteMessageButton = 'button[data-test="deleteMessageButton"]';
 // Emoji picker
 exports.emojiPickerButton = 'button[data-test="emojiPickerButton"]';
 exports.frequentlyUsedEmoji = '👍';
+exports.grinningFaceEmoji = '😀';
 // Auto Convert Emoji
 exports.autoConvertEmojiMessage = ':)';
 exports.convertedEmojiMessage = '😊';

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -145,8 +145,8 @@ class Page {
     await this.wasRemoved(e.webcamConnecting, VIDEO_LOADING_WAIT_TIME);
   }
 
-  getLocator(selector) {
-    return this.page.locator(selector);
+  getLocator(selector, options = {}) {
+    return this.page.locator(selector, options);
   }
 
   getVisibleLocator(selector) {
@@ -208,6 +208,11 @@ class Page {
     await handle.type(text, { timeout: ELEMENT_WAIT_TIME });
   }
 
+  async fill(selector, text) {
+    const locator = this.getLocator(selector);
+    await locator.fill(text);
+  }
+
   async waitAndClickElement(element, index = 0, timeout = ELEMENT_WAIT_TIME) {
     await this.waitForSelector(element, timeout);
     await this.page.evaluate(([elem, i]) => {
@@ -222,7 +227,7 @@ class Page {
   }
 
   async getByLabelAndClick(label, timeout = ELEMENT_WAIT_TIME) {
-    await this.page.getByLabel(label).click({ timeout });
+    await this.page.getByLabel(label).first().click({ timeout });
   }
 
   async clickOnLocator(locator, timeout = ELEMENT_WAIT_TIME) {
@@ -295,6 +300,10 @@ class Page {
 
   async dragDropSelector(selector, position) {
     await this.getLocator(selector).dragTo(this.page.locator(position), { timeout: ELEMENT_WAIT_TIME });
+  }
+
+  async hoverElement(selector) {
+    await this.getLocator(selector).hover();
   }
 
   async dragAndDropWebcams(position) {


### PR DESCRIPTION
### What does this PR do?
This PR adds automated tests for the following features and cases with the new chat functionalities:
- Edit message
  - triggered by button and arrow up
- Delete message
  - mod can delete other users' messages (mod or viewer)
  - users can delete only their messages in breakouts
- Reply message
  - cancel reply
  - scroll to the replied message
- React to a message
  - increment and decrement reactions
  - order reactions by the highest amount
- Lock viewer
  - locked users are unable to reply, react, edit, and delete on public and private chats


### Closes Issue(s)
Closes #21357

