### PR TITLE
fix(html5): Add timeout to redirect on meeting end

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -105,6 +105,7 @@ export interface App {
   maxMutationPayloadSize: number
   enableApolloDevTools: boolean
   terminateAndRetryConnection: number
+  timeoutBeforeRedirectOnMeetingEnd: number | null
 }
 
 export interface BbbTabletApp {

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -284,6 +284,15 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
     }
   }, []);
 
+  useEffect(() => {
+    const { timeoutBeforeRedirectOnMeetingEnd } = window.meetingClientSettings.public.app;
+    if (typeof timeoutBeforeRedirectOnMeetingEnd === 'number' && !skipMeetingEnded) {
+      setTimeout(() => {
+        confirmRedirect(isBreakout, allowRedirect);
+      }, timeoutBeforeRedirectOnMeetingEnd);
+    }
+  }, []);
+
   if (skipMeetingEnded) {
     confirmRedirect(isBreakout, allowRedirect);
     return <></>; // even though well redirect, return empty component and prevent lint error
@@ -315,20 +324,7 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
   } = useQuery<MeetingEndDataResponse>(getMeetingEndData);
 
   if (meetingEndLoading || !meetingEndData) {
-    return (
-      <MeetingEnded
-        endedBy=""
-        joinErrorCode=""
-        meetingEndedCode=""
-        allowRedirect={false}
-        skipMeetingEnded={false}
-        learningDashboardAccessToken=""
-        isModerator={false}
-        logoutUrl=""
-        learningDashboardBase=""
-        isBreakout={false}
-      />
-    );
+    return null;
   }
 
   if (meetingEndError) {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -212,7 +212,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       fallbackOnEmptyLocaleString: true,
       disableWebsocketFallback: true,
       maxMutationPayloadSize: 10485760, // 10MB
-      timeoutBeforeRedirectOnMeetingEnd: null,
+      timeoutBeforeRedirectOnMeetingEnd: 10000,
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -212,7 +212,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       fallbackOnEmptyLocaleString: true,
       disableWebsocketFallback: true,
       maxMutationPayloadSize: 10485760, // 10MB
-      timeoutBeforeRedirectOnMeetingEnd: 10000,
+      timeoutBeforeRedirectOnMeetingEnd: 20000,
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -212,6 +212,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       fallbackOnEmptyLocaleString: true,
       disableWebsocketFallback: true,
       maxMutationPayloadSize: 10485760, // 10MB
+      timeoutBeforeRedirectOnMeetingEnd: null,
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -307,6 +307,9 @@ public:
   # plugins:
   #   - name: SamplePresentationToolbarPlugin
   #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js
+    # Timeout before automatically redirecting users to the logout URL (or closing the window if the session is
+    # a breakout room). Either a number (in miliseconds) or null.
+    timeoutBeforeRedirectOnMeetingEnd: 10000
   externalVideoPlayer:
     enabled: true
   kurento:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -306,7 +306,7 @@ public:
     maxMutationPayloadSize: 10485760
     # Timeout before automatically redirecting users to the logout URL (or closing the window if the session is
     # a breakout room). Either a number (in miliseconds) or null.
-    timeoutBeforeRedirectOnMeetingEnd: 10000
+    timeoutBeforeRedirectOnMeetingEnd: 20000
   # plugins:
   #   - name: SamplePresentationToolbarPlugin
   #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -304,12 +304,12 @@ public:
     # Maximum number of bytes allowed in each mutation message payload.
     # Defaults to 10485760 (10MB)
     maxMutationPayloadSize: 10485760
-  # plugins:
-  #   - name: SamplePresentationToolbarPlugin
-  #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js
     # Timeout before automatically redirecting users to the logout URL (or closing the window if the session is
     # a breakout room). Either a number (in miliseconds) or null.
     timeoutBeforeRedirectOnMeetingEnd: 10000
+  # plugins:
+  #   - name: SamplePresentationToolbarPlugin
+  #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js
   externalVideoPlayer:
     enabled: true
   kurento:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Add timeout to automatically redirect users to the logout URL on meeting end (or closing the window if the session is a breakout room).


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #22993