### PR TITLE
fix(core): increase max authToken size to 50 chars in `user` table

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -283,7 +283,7 @@ CREATE UNLOGGED TABLE "user" (
 	"avatar" varchar(500),
     "webcamBackground" varchar(500),
 	"color" varchar(7),
-    "authToken" varchar(16),
+    "authToken" varchar(50),
     "authed" bool,
     "joined" bool,
     "firstJoinedAt" timestamp with time zone,


### PR DESCRIPTION
### What does this PR do?

- [fix(core): increase max authToken size to 50 chars in user table](https://github.com/bigbluebutton/bigbluebutton/commit/bdda04165c9858ae0ff9a08da2f6b7de46d3d865) 
  - The authToken property in the `user` table has a size limit of 16 chars.
That same property can be as large as the userId (intId) in scenarios
where non-web users (e.g.: dial-in) are involved, since authToken is
spoofed in akka-apps to be the same as that user's intId.
This may cause the insert op for that external user to fail, which
translates to them being missing in the user list.
  - Increase the max authToken size to 50 chars in the `user` table, which
matches `userId`.

### Closes Issue(s)

None