### PR TITLE
Fixes for video/presentation focus layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { throttle } from '/imports/utils/throttle';
 import { layoutSelect, layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA } from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA, SIDEBAR_CONTENT_VERTICAL_MARGIN } from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import {
   ACTIONS, CAMERADOCK_POSITION, LAYOUT_TYPE, PANELS,
@@ -438,7 +438,8 @@ const CustomLayout = (props) => {
         );
       }
 
-      cameraDockBounds.top = windowHeight() - cameraDockHeight - bannerAreaHeight();
+      cameraDockBounds.top = windowHeight() - cameraDockHeight
+        - bannerAreaHeight() - SIDEBAR_CONTENT_VERTICAL_MARGIN + SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
       cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.minWidth = sidebarContentWidth;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { throttle } from '/imports/utils/throttle';
 import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, { SIDEBAR_CONTENT_VERTICAL_MARGIN, SIDEBAR_CONTENT_MARGIN_TO_MEDIA } from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import {
   ACTIONS,
@@ -85,7 +85,7 @@ const PresentationFocusLayout = (props) => {
       value: (prevInput) => {
         const {
           sidebarNavigation, sidebarContent, presentation, cameraDock,
-          externalVideo, genericMainContent, screenShare,
+          externalVideo, genericMainContent, screenShare, sharedNotes,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
         let sidebarContentPanelOverride = sidebarContentPanel;
@@ -137,8 +137,11 @@ const PresentationFocusLayout = (props) => {
               width: screenShare.width,
               height: screenShare.height,
             },
+            sharedNotes: {
+              isPinned: sharedNotes.isPinned,
+            },
           },
-          hasLayoutEngineLoadedOnce && prevLayout === LAYOUT_TYPE.PRESENTATION_FOCUS ? prevInput : INITIAL_INPUT_STATE,
+          hasLayoutEngineLoadedOnce ? prevInput : INITIAL_INPUT_STATE,
         );
       },
     });
@@ -235,7 +238,8 @@ const PresentationFocusLayout = (props) => {
           windowHeight() - cameraDockMinHeight,
         );
       }
-      cameraDockBounds.top = windowHeight() - cameraDockHeight - bannerAreaHeight();
+      cameraDockBounds.top = windowHeight() - cameraDockHeight
+        - bannerAreaHeight() - (SIDEBAR_CONTENT_VERTICAL_MARGIN) + SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
       cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.minWidth = sidebarContentWidth;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -89,7 +89,7 @@ const VideoFocusLayout = (props) => {
       value: (prevInput) => {
         const {
           sidebarNavigation, sidebarContent, presentation, cameraDock,
-          externalVideo, genericMainContent, screenShare,
+          externalVideo, genericMainContent, screenShare, sharedNotes,
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
         let sidebarContentPanelOverride = sidebarContentPanel;
@@ -139,6 +139,9 @@ const VideoFocusLayout = (props) => {
               hasScreenShare: screenShare.hasScreenShare,
               width: screenShare.width,
               height: screenShare.height,
+            },
+            sharedNotes: {
+              isPinned: sharedNotes.isPinned,
             },
           },
           hasLayoutEngineLoadedOnce ? prevInput : INITIAL_INPUT_STATE,
@@ -443,7 +446,7 @@ const VideoFocusLayout = (props) => {
       type: ACTIONS.SET_PRESENTATION_OUTPUT,
       value: {
         display: presentationInput.isOpen,
-        width: mediaBounds.width,
+        width: mediaBounds.width - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
         height: mediaBounds.height,
         top: mediaBounds.top,
         left: mediaBounds.left,

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.js
@@ -131,8 +131,6 @@ const PresentationContainer = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  ${({ isVideoFocus, isRTL }) => isVideoFocus && isRTL && `padding: 0px 0px 0px ${contentSidebarMarginToMedia}`};
-  ${({ isVideoFocus, isRTL }) => isVideoFocus && !isRTL && `padding: 0px ${contentSidebarMarginToMedia} 0px 0px`};
 `;
 
 const Presentation = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.tsx
@@ -104,7 +104,6 @@ const SidebarContent = (props: SidebarContentProps) => {
         top,
         left,
         right,
-        zIndex,
         width,
         height,
         maxWidth,


### PR DESCRIPTION
### What does this PR do?
- Fixes missing top part of presentation/shared notes when in grid layout.
- Fixed presentation not fully showing when in sidebar (missing the sides):
![image](https://github.com/user-attachments/assets/c0ce2b00-39e4-45d3-8b60-fb76afd3b12c)


- Fixed bug where the presentation is shown instead of pinned shared notes when changing between layouts
(grid, but also when notes are minimized and you change to presentationFocus)

https://github.com/user-attachments/assets/0e810083-df08-4020-ad18-29aad4c537db
This alson happens in 3.0

- Fixed CameraDock position when in sidebar (was stick to bottom)
![image](https://github.com/user-attachments/assets/2e73f7be-9b4e-4ea8-9f2c-60d07dfce3e2)


