### PR TITLE
perf: Include `bot` for the list of columns for userlist index

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -457,14 +457,17 @@ AS SELECT "user"."userId",
   FROM "user"
   WHERE "user"."currentlyInMeeting" is true;
 
+--index for currentlyInMeeting column
 CREATE INDEX "idx_v_user_meetingId" ON "user"("meetingId")
                 where "user"."loggedOut" IS FALSE
                 AND "user"."expired" IS FALSE
                 AND "user"."ejected" IS NOT TRUE
                 and "user"."joined" IS TRUE;
 
+--this index should follow the `UserListSubscription` filters + order by
 CREATE INDEX "idx_v_user_meetingId_orderByColumns" ON "user"(
                         "meetingId",
+                        "bot",
                         "presenter",
                         "role",
                         "raiseHandTime",


### PR DESCRIPTION
The `order_by` of `UserListSubscription` was adjusted here: https://github.com/bigbluebutton/bigbluebutton/commit/445e85e4b3a9512dad3fc97e5db35f17de599174

The table index should be updated accordingly.