### PR TITLE
build(livekit): automatically set LK keys to webrtc-recorder

### DIFF
--- a/build/packages-template/bbb-livekit/after-install.sh
+++ b/build/packages-template/bbb-livekit/after-install.sh
@@ -29,20 +29,47 @@ EOT
   chown bigbluebutton:bigbluebutton /etc/bigbluebutton/livekit.yaml
   chown bigbluebutton:bigbluebutton /etc/bigbluebutton/livekit-sip.yaml
 
-  # Update bbb-webrtc-sfu's production.yml with the generated keys.
-  # We're opting not to use the /usr/local file because it may be overwritten
-  # on SFU package upgrades. It also only runs when livekit.yaml is missing (i.e.
-  # secrets are not set), so it won't overwrite any meaningful admin configs.
-  # This part is *temporary* to facilitate testing while the pkg is experimental.
-  # Ideally we should move it to the SFU package (and use the /usr/local file instead)
-  # after bbb-livekit becomes mandatory and bbb-webrtc-sfu depends on it.
-  if [ ! -f /etc/bigbluebutton/bbb-webrtc-sfu/production.yml ]; then
-    touch /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
-    chown bigbluebutton:bigbluebutton /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
-  fi
+else
+  # If livekit.yaml exists, extract the API key and secret
+  API_KEY=$(yq e '.keys | keys | .[0]' /etc/bigbluebutton/livekit.yaml)
+  API_SECRET=$(yq e ".keys.[\"$API_KEY\"]" /etc/bigbluebutton/livekit.yaml)
+fi
+
+# Update bbb-webrtc-sfu's and recorder's overrides with the generated keys.
+# We're opting not to use the /usr/local file because it may be overwritten
+# on package upgrades. It also only runs when livekit installed and secrets
+# are not set on apps, so it won't overwrite any meaningful admin configs.
+# This part is *temporary* to facilitate testing while the pkg is experimental.
+# We MUST move it to the SFU/recorder packages (and use the /usr/local file instead)
+# after bbb-livekit becomes mandatory and bbb-webrtc-sfu/recorder depends on it.
+if [ ! -f /etc/bigbluebutton/bbb-webrtc-sfu/production.yml ]; then
+  mkdir -p /etc/bigbluebutton/bbb-webrtc-sfu
+  touch /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
+  chown bigbluebutton:bigbluebutton /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
+fi
+
+# If key and secret are not the same as the ones in livekit.yaml, update them
+SFU_KEY=$(yq e '.livekit.key' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml)
+SFU_SECRET=$(yq e '.livekit.secret' /etc/bigbluebutton/bbb-webrtc-sfu/production.yml)
+
+if [ "$SFU_KEY" = "null" ] || [ -z "$SFU_KEY" ] || [ "$SFU_KEY" != "$API_KEY" ] || \
+   [ "$SFU_SECRET" = "null" ] || [ -z "$SFU_SECRET" ] || [ "$SFU_SECRET" != "$API_SECRET" ]; then
   yq e -i ".livekit.key = \"$API_KEY\"" /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
   yq e -i ".livekit.secret = \"$API_SECRET\"" /etc/bigbluebutton/bbb-webrtc-sfu/production.yml
+fi
 
+# For the recorder, add as env vars to /etc/default/bbb-webrtc-recorder
+if [ ! -f /etc/default/bbb-webrtc-recorder ]; then
+  touch /etc/default/bbb-webrtc-recorder
+  chown bigbluebutton:bigbluebutton /etc/default/bbb-webrtc-recorder
+fi
+
+if ! grep -q "BBBRECORDER_LIVEKIT_APIKEY" /etc/default/bbb-webrtc-recorder; then
+  echo "BBBRECORDER_LIVEKIT_APIKEY=$API_KEY" >> /etc/default/bbb-webrtc-recorder
+fi
+
+if ! grep -q "BBBRECORDER_LIVEKIT_APISECRET" /etc/default/bbb-webrtc-recorder; then
+  echo "BBBRECORDER_LIVEKIT_APISECRET=$API_SECRET" >> /etc/default/bbb-webrtc-recorder
 fi
 
 if [ ! -f /.dockerenv ]; then


### PR DESCRIPTION
### What does this PR do?

- [build(livekit): automatically set keys to webrtc-recorder](https://github.com/bigbluebutton/bigbluebutton/commit/ff4f2d920947955265cb9d172104f37dd34ed43a) 
  - Automatically set LK's API key and secret to bbb-webrtc-recorder when
livekit-server is installed. See inline comment in after-install for
more details.
  - Additionally:
    - Guarantee key/secret are set for both webrtc-sfu and webrtc-recorder
  regardless of whether livekit.yaml exists beforehand. Take only their
  (SFU/rec) own configs into account when determining whether they
  should be set or not.

### Closes Issue(s)

None
Ref #21059 
Ref #23015