### PR TITLE
docs(livekit): add note on LiveKit iface filtering and egress cleanup

### DIFF
--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -191,6 +191,24 @@ To enable support for LiveKit:
     1. Set the appropriate LiveKit endpoint URL in bbb-html5.yml's `public.media.livekit.url`. See
       the aforementioned [docs section](/administration/cluster-proxy.md#bigbluebutton-servers) for details.
 
+We also *strongly recommend* setting up network interface filtering in LiveKit.
+While optional, this speeds up negotation times and works around an issue with the latest
+LiveKit versions that might cause CPU spikes if there's no filtering in place.
+To set up network interface filtering:
+1. Gather relevant network interfaces names to be used for media communication.
+For most setups, the default network interface is enough. See the `route` command
+to find it (`Destination: default`). If any other network interfaces are needed,
+make note of them.
+2. Set the following in `/etc/bigbluebutton/livekit.yaml`:
+```yaml
+rtc:
+  interfaces:
+    includes:
+      - <network_interface_name_1>
+      - <any_other_network_interface_name>
+```
+3. Restart bbb-livekit: `$ sudo systemctl restart bbb-livekit`
+
 Once enabled, LiveKit still won't be used by default. There are two ways to make
 use of it in meetings:
 - Per meeting: set any of the following meeting `/create` parameters
@@ -208,7 +226,8 @@ and screen sharing by setting just `audioBridge=livekit`.
 
 As of BigBlueButton v3.0.7, recording is enabled by default for LiveKit sessions
 via the bbb-webrtc-recorder application. If `livekit/egress` was previously
-[installed](https://github.com/bigbluebutton/bigbluebutton/blob/6eab874ffa8d0e82453dad3b06621dea16e15e6d/docs/docs/new-features.md?plain=1#L209-L237), the docker image and any leftover egress containers can be removed safely.
+installed in a server, any steps done to enable it should be reverted. Refer to
+the [previous installations steps](https://github.com/bigbluebutton/bigbluebutton/blob/6eab874ffa8d0e82453dad3b06621dea16e15e6d/docs/docs/new-features.md?plain=1#L209-L237).
 
 Keep in mind that the LiveKit integration is still experimental and not feature
 complete. Configuration, API parameters, and other details are subject to change.


### PR DESCRIPTION
### What does this PR do?

- [ocs(livekit): add note on LiveKit iface filtering and egress cleanup](https://github.com/bigbluebutton/bigbluebutton/commit/cc223ed935df360fcb62856079c5707bd05867ae) 
  - Extend LiveKit install docs with a note suggesting network interface
filtering to be set up. While optional, this has two benefits:
    - It speeds up negotation times significantly
    - It works around an issue affecting LK >= 1.8.3 where the lack of
    iface filtering might cause significant CPU spikes during
    negotiation. I'm opting not to rollback yet and rather suggest this
    workaround while the issue is reported and fixed upstream.
  - Additionally, make the docs regarding livekit/egress cleanup more
clearer - everything can/should be cleaned up, not just the Docker part
of it.

### Closes Issue(s)

None

Ref #21059 