### PR TITLE
fix: Fix locale problem when having multiple plugins

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/manager.tsx
@@ -37,6 +37,7 @@ const PluginsEngineManager = (props: PluginsEngineManagerProps) => {
         ...p,
         name: p.name,
         url: p.javascriptEntrypointUrl,
+        localesBaseUrl: p.localesBaseUrl,
         uuid: uuidLib.v4(),
       } as EffectivePluginConfig)),
     );
@@ -65,8 +66,8 @@ const PluginsEngineManager = (props: PluginsEngineManagerProps) => {
       <PluginDomElementManipulationManager />
       {
         effectivePluginsConfig?.map((effectivePluginConfig: EffectivePluginConfig) => {
-          const { uuid, name: pluginName } = effectivePluginConfig;
-          const pluginApi: PluginSdk.PluginApi = BbbPluginSdk.getPluginApi(uuid, pluginName);
+          const { uuid, name: pluginName, localesBaseUrl } = effectivePluginConfig;
+          const pluginApi: PluginSdk.PluginApi = BbbPluginSdk.getPluginApi(uuid, pluginName, localesBaseUrl);
           return (
             <div key={uuid}>
               <PluginLoaderManager

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/query.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/query.ts
@@ -5,6 +5,7 @@ const PLUGIN_CONFIGURATION_QUERY = gql`query PluginConfigurationQuery {
     name,
     javascriptEntrypointUrl,
     javascriptEntrypointIntegrity,
+    localesBaseUrl,
   }  
 }`;
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/types.ts
@@ -6,6 +6,7 @@ export interface PluginsEngineComponentProps {
 
 export interface PluginConfigFromGraphql {
     javascriptEntrypointUrl: string;
+    localesBaseUrl: string;
     name: string;
 }
 
@@ -17,9 +18,9 @@ export interface PluginConfig {
     name: string;
     url: string;
     javascriptEntrypointIntegrity?: string;
+    localesBaseUrl: string
 }
 
 export interface EffectivePluginConfig extends PluginConfig {
-    name: string;
     uuid: string;
 }

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -30,7 +30,7 @@
         "autoprefixer": "^10.4.4",
         "axios": "^1.8.3",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.74",
+        "bigbluebutton-html-plugin-sdk": "0.0.78",
         "bowser": "^2.11.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6151,10 +6151,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.74",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.74.tgz",
-      "integrity": "sha512-SFMBd22e8Rwwcfsx8jivrkImejjUe3D89tyMp6jkn/wtfdEvGu4qx+Iw1EsaFrPHk53wYyykvoZhwqljsTBlVg==",
-      "license": "LGPL-3.0",
+      "version": "0.0.78",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.78.tgz",
+      "integrity": "sha512-uO2apvQwMDStSfWAYx07o36dYztBKKrE5rNEbUDIizoalckWKD0rTrg6Y8Qw4k4XsF0+AbIiJ8xt5Lvjkg89Og==",
       "dependencies": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -56,7 +56,7 @@
     "autoprefixer": "^10.4.4",
     "axios": "^1.8.3",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.74",
+    "bigbluebutton-html-plugin-sdk": "0.0.78",
     "bowser": "^2.11.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
### What does this PR do?

Problem: When multiple plugins were loaded in the same meeting, one `localesBaseUrl` could interfere in the others'. That's mainly because the query we had to search for this particular base URL was not filtering for the `pluginName`, so basically the locales would work quite well when having only one plugin.

Solution: As `localesBaseUrl` does not change during the entire meeting and we have that information the second we build the `pluginApi` for a particular plugin, instead of getting it via subscription, or even query, the client (bigbluebutton-html5)  will send it inside the pluginApi, which besides fixing the issue, will spare another subscription/query from running.

### More

Closely related to: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/178

See the before and after of the fix (the three red arrows are plugins, so we can see that multiple plugins are running on this meeting - both before and after the fix).

Before:

![image](https://github.com/user-attachments/assets/ca010c86-2734-4748-8972-bd6d3e023ad6)

After:

![image](https://github.com/user-attachments/assets/df078969-66da-472a-a568-fe585605939e)

