### PR TITLE
refactor (html5): Add class for plugins floating window content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/floating-window/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/floating-window/component.tsx
@@ -31,6 +31,7 @@ const renderComponent = (
       backgroundColor,
       boxShadow,
     }}
+    className="floating-window-content"
   />
 );
 

--- a/bigbluebutton-html5/imports/ui/components/floating-window/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/floating-window/component.tsx
@@ -25,13 +25,13 @@ const renderComponent = (
   <Styled.FloatingWindowContent
     ref={elementRef}
     id={key}
+    className="floating-window-content"
     style={{
       top,
       left,
       backgroundColor,
       boxShadow,
     }}
-    className="floating-window-content"
   />
 );
 


### PR DESCRIPTION
Currently, there is no way to identify floating windows to apply specific styles or hide them. I'm adding this class to allow hiding floating windows for the `external-device-camera` plugin, which should display only the user's camera and nothing else.