### PR TITLE
[3.1] build(bbb-webrtc-recorder): v0.9.1

### DIFF
--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,1 +1,1 @@
-git clone --branch v0.9.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder
+git clone --branch v0.9.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/bigbluebutton/bigbluebutton/pull/23055 into 3.1.

- [build(bbb-webrtc-recorder): v0.9.1](https://github.com/bigbluebutton/bigbluebutton/commit/6a4b3a467a55873ea2c2b48cb7339c058bf3ad05) 
  * fix(livekit): deadlock on GetStats call
  * fix: inconsistent active_tracks metric
  
### Closes Issue(s)

None