### PR TITLE
feat(layout): add userdata `bbb_hide_sidebar_navigation`

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -9,6 +9,7 @@ import {
 import Storage from '/imports/ui/services/storage/session';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -149,17 +150,20 @@ const CustomLayout = (props) => {
             externalVideo, genericMainContent, screenShare, sharedNotes,
           } = prevInput;
           const { sidebarContentPanel } = sidebarContent;
+          const overrideOpenSidebarPanel = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+            && sidebarContentPanel !== PANELS.NONE;
+          const overrideOpenSidebarNavigation = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+            && (sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false);
           const { registeredApps, pinnedApps } = sidebarNavigation;
           return defaultsDeep(
             {
               sidebarNavigation: {
-                isOpen:
-                  sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false,
+                isOpen: overrideOpenSidebarNavigation,
                 registeredApps,
                 pinnedApps,
               },
               sidebarContent: {
-                isOpen: sidebarContentPanel !== PANELS.NONE,
+                isOpen: overrideOpenSidebarPanel,
                 sidebarContentPanel: sidebarContent.sidebarContentPanel,
               },
               sidebarContentHorizontalResizer: {
@@ -204,12 +208,14 @@ const CustomLayout = (props) => {
           } = prevInput;
           const { sidebarContentPanel } = sidebarContent;
           let sidebarContentPanelOverride = sidebarContentPanel;
-          let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
-          let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
-            || sidebarContentPanel !== PANELS.NONE || false;
-          if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+          let overrideOpenSidebarPanel = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+            && sidebarContentPanel !== PANELS.NONE;
+          let overrideOpenSidebarNavigation = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+            && (sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false);
+          if ((prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
             || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
-            || prevLayout === LAYOUT_TYPE.MEDIA_ONLY) {
+            || prevLayout === LAYOUT_TYPE.MEDIA_ONLY)
+            && !getFromUserSettings('bbb_hide_sidebar_navigation', false)) {
             overrideOpenSidebarNavigation = true;
             overrideOpenSidebarPanel = true;
             sidebarContentPanelOverride = PANELS.CHAT;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -11,6 +11,7 @@ import {
 } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -89,13 +90,15 @@ const PresentationFocusLayout = (props) => {
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
         let sidebarContentPanelOverride = sidebarContentPanel;
-        let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
-        let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
-          || sidebarContentPanel !== PANELS.NONE || false;
-        if (
+        let overrideOpenSidebarPanel = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+          && sidebarContentPanel !== PANELS.NONE;
+        let overrideOpenSidebarNavigation = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+          && (sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false);
+        if ((
           prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
           || prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
-          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY
+          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY)
+          && !getFromUserSettings('bbb_hide_sidebar_navigation', false)
         ) {
           overrideOpenSidebarNavigation = true;
           overrideOpenSidebarPanel = true;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -8,6 +8,7 @@ import {
 } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -88,12 +89,15 @@ const SmartLayout = (props) => {
         const { registeredApps, pinnedApps } = sidebarNavigation;
         const { sidebarContentPanel } = sidebarContent;
         let sidebarContentPanelOverride = sidebarContentPanel;
-        let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
-        let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
-          || sidebarContentPanel !== PANELS.NONE || false;
-        if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+        let overrideOpenSidebarPanel = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+          && sidebarContentPanel !== PANELS.NONE;
+        let overrideOpenSidebarNavigation = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+          && (sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false);
+        if ((prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
           || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
-          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY) {
+          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY)
+          && !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+        ) {
           overrideOpenSidebarNavigation = true;
           overrideOpenSidebarPanel = true;
           sidebarContentPanelOverride = PANELS.CHAT;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -11,6 +11,7 @@ import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import { ACTIONS, PANELS, LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -93,12 +94,14 @@ const VideoFocusLayout = (props) => {
         } = prevInput;
         const { sidebarContentPanel } = sidebarContent;
         let sidebarContentPanelOverride = sidebarContentPanel;
-        let overrideOpenSidebarPanel = sidebarContentPanel !== PANELS.NONE;
-        let overrideOpenSidebarNavigation = sidebarNavigation.isOpen
-          || sidebarContentPanel !== PANELS.NONE || false;
-        if (prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
+        let overrideOpenSidebarPanel = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+          && sidebarContentPanel !== PANELS.NONE;
+        let overrideOpenSidebarNavigation = !getFromUserSettings('bbb_hide_sidebar_navigation', false)
+          && (sidebarNavigation.isOpen || sidebarContentPanel !== PANELS.NONE || false);
+        if ((prevLayout === LAYOUT_TYPE.CAMERAS_ONLY
           || prevLayout === LAYOUT_TYPE.PRESENTATION_ONLY
-          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY
+          || prevLayout === LAYOUT_TYPE.MEDIA_ONLY)
+          && !getFromUserSettings('bbb_hide_sidebar_navigation', false)
         ) {
           overrideOpenSidebarNavigation = true;
           overrideOpenSidebarPanel = true;

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -154,6 +154,7 @@ const LayoutObserver: React.FC = () => {
       && deviceType !== DEVICE_TYPE.MOBILE
       && numCameras > 0
       && presentationIsOpen
+      && !getFromUserSettings('bbb_hide_sidebar_navigation', false)
     ) {
       setTimeout(() => {
         layoutContextDispatch({
@@ -221,6 +222,18 @@ const LayoutObserver: React.FC = () => {
       if (!checkedUserSettings.current) {
         const Settings = getSettingsSingletonInstance();
         Settings.save(setLocalSettings);
+
+        if (getFromUserSettings('bbb_hide_sidebar_navigation', false)) {
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+            value: false,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+            value: false,
+          });
+          return;
+        }
 
         layoutContextDispatch({
           type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -21,6 +21,7 @@ import Tooltip from '/imports/ui/components/common/tooltip/component';
 import SessionDetailsModal from '/imports/ui/components/session-details/component';
 import Icon from '/imports/ui/components/common/icon/icon-ts/component';
 import getStorageSingletonInstance from '../../services/storage';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const intlMessages = defineMessages({
   toggleUserListLabel: {
@@ -313,7 +314,8 @@ class NavBar extends Component {
       && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
       && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY
       && selectedLayout !== LAYOUT_TYPE.MEDIA_ONLY
-      && isPhone === true;
+      && isPhone === true
+      && !getFromUserSettings('bbb_hide_sidebar_navigation', false);
 
     const APP_CONFIG = window.meetingClientSettings?.public?.app;
     const enableTalkingIndicator = APP_CONFIG?.enableTalkingIndicator;


### PR DESCRIPTION
### What does this PR do?
Introduces the userdata join parameter `bbb_hide_sidebar_navigation`, which hides the sidebar navigation.

### Motivation
To allow adapting the UI for scenarios where there is no user input - kiosk mode or streaming, for instance.

### How to test
Create meeting and join passing the userdata: `userdata-bbb_hide_sidebar_navigation=true`.
![image](https://github.com/user-attachments/assets/8793f4c6-93e9-42fc-adec-ba25e590704f)


