### PR TITLE
Fix(html5): Make breakout respect the minimum time of 5 min

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
@@ -5,6 +5,8 @@ import BreakoutRemainingTime from '/imports/ui/components/common/remaining-time/
 import Styled from '../styles';
 import { BREAKOUT_ROOM_SET_TIME } from '../../mutations';
 
+const MIN_BREAKOUT_TIME = 5;
+
 const intlMessages = defineMessages({
   breakoutTitle: {
     id: 'app.createBreakoutRoom.title',
@@ -136,7 +138,7 @@ const TimeRemaingPanel: React.FC<TimeRemainingPanelProps> = ({
               onClick={() => {
                 setShowFormError(false);
 
-                if (durationInSeconds !== 0 && newTime > durationInSeconds) {
+                if (((durationInSeconds !== 0 && newTime > durationInSeconds)) || (newTime < MIN_BREAKOUT_TIME)) {
                   setShowFormError(true);
                 } else if (setBreakoutsTime(newTime)) {
                   toggleShowChangeTimeForm(false);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -487,7 +487,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
                   const { value } = e.target;
                   const v = Number.parseInt(value, 10);
                   setDurationTime((v && !(v <= 0)) ? v : MIN_BREAKOUT_TIME);
-                  setDurationIsValid(true);
+                  setDurationIsValid(v >= MIN_BREAKOUT_TIME);
                 }}
                 aria-label={intl.formatMessage(intlMessages.duration)}
                 data-test="durationTime"


### PR DESCRIPTION
### What does this PR do?
This PR makes the minimum of 5 minutes be respected for breakout creation and change duration.


### Closes Issue(s)
Closes #23012

### How to test
- Join a Meeting
- Open breakout creation modal
- Edit time to less than five minutes and try to create it 

- on a running breakout 
- go to breakout panel
- try to edit time to less than 5 minutes


### More
[Screencast from 30-04-2025 12:59:39.webm](https://github.com/user-attachments/assets/52745d7b-9c7b-4fc2-b2d0-d8576ebbb7a6)


