### PR TITLE
fix: Unable to resize webcams/screen sharing when there's no presentation uploaded

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -697,6 +697,8 @@ const CustomLayout = (props) => {
       },
     });
 
+    const isMediaOpen = mediaBounds?.width > 0 && mediaBounds?.height > 0;
+
     layoutContextDispatch({
       type: ACTIONS.SET_CAMERA_DOCK_OUTPUT,
       value: {
@@ -716,16 +718,19 @@ const CustomLayout = (props) => {
         isDraggable: !isMobile && !isTablet && presentationInput.isOpen,
         resizableEdge: {
           top:
-            input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_BOTTOM ||
-            (input.cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM &&
-              input.sidebarContent.isOpen),
+          isMediaOpen
+            && (input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_BOTTOM
+            || (input.cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM
+            && input.sidebarContent.isOpen)),
           right:
-            (!isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_LEFT) ||
-            (isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_RIGHT),
-          bottom: input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_TOP,
+            isMediaOpen
+            && ((!isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_LEFT)
+            || (isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_RIGHT)),
+          bottom: isMediaOpen && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_TOP,
           left:
-            (!isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_RIGHT) ||
-            (isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_LEFT),
+          isMediaOpen
+            && ((!isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_RIGHT)
+            || (isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_LEFT)),
         },
         zIndex: cameraDockBounds.zIndex,
         focusedId: input.cameraDock.focusedId,

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -261,11 +261,10 @@ const WebcamComponent: React.FC<WebcamComponentProps> = ({
               });
             }}
             enable={{
-              top: !isFullscreen && !isDragging && !swapLayout && cameraDock?.resizableEdge?.top,
-              bottom: !isFullscreen && !isDragging && !swapLayout
-              && cameraDock?.resizableEdge?.bottom,
-              left: !isFullscreen && !isDragging && !swapLayout && cameraDock?.resizableEdge?.left,
-              right: !isFullscreen && !isDragging && !swapLayout && cameraDock?.resizableEdge?.right,
+              top: !isFullscreen && !isDragging && cameraDock?.resizableEdge?.top,
+              bottom: !isFullscreen && !isDragging && cameraDock?.resizableEdge?.bottom,
+              left: !isFullscreen && !isDragging && cameraDock?.resizableEdge?.left,
+              right: !isFullscreen && !isDragging && cameraDock?.resizableEdge?.right,
               topLeft: false,
               topRight: false,
               bottomLeft: false,


### PR DESCRIPTION
### What does this PR do?

Updates the webcam component resize condition to allow resizing whenever any media type component is active, removing the dependency on the presentation component.

### Closes Issue(s)

Closes #23071

### How to test
1. join a meeting
2. set layout as "custom"
3. start sharing webcam
4. remove all presentations
5. start screenshare
6. try to resize cameras area