### PR TITLE
Fix(html5): Breakouts could exceed main room time

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
@@ -30,6 +30,7 @@ interface BreakoutRoomProps {
   userJoinedAudio: boolean;
   userId: string;
   meetingId: string;
+  createdTime: number;
 }
 
 const intlMessages = defineMessages({
@@ -107,6 +108,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
   userJoinedAudio,
   userId,
   meetingId,
+  createdTime,
 }) => {
   const [breakoutRoomEndAll] = useMutation(BREAKOUT_ROOM_END_ALL);
   const [breakoutRoomTransfer] = useMutation(USER_TRANSFER_VOICE_TO_MEETING);
@@ -190,6 +192,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
         showChangeTimeForm={showChangeTimeForm}
         isModerator={isModerator}
         durationInSeconds={durationInSeconds}
+        createdTime={createdTime}
         toggleShowChangeTimeForm={setShowChangeTimeForm}
       />
       {isModerator ? <BreakoutMessageForm /> : null}
@@ -295,6 +298,7 @@ const BreakoutRoomContainer: React.FC = () => {
     data: meetingData,
   } = useMeeting((m) => ({
     durationInSeconds: m.durationInSeconds,
+    createdTime: m.createdTime,
     meetingId: m.meetingId,
   }));
 
@@ -313,7 +317,6 @@ const BreakoutRoomContainer: React.FC = () => {
     loading: breakoutLoading,
     error: breakoutError,
   } = useDeduplicatedSubscription<GetBreakoutDataResponse>(getBreakoutData);
-
   if (
     breakoutLoading
     || currentUserLoading
@@ -333,6 +336,7 @@ const BreakoutRoomContainer: React.FC = () => {
     return null;
   }
   if (!currentUserData || !breakoutData || !meetingData) return null; // or loading spinner or error
+
   return (
     <BreakoutRoom
       breakouts={breakoutData.breakoutRoom || []}
@@ -342,6 +346,7 @@ const BreakoutRoomContainer: React.FC = () => {
       userJoinedAudio={(currentUserData?.voice?.joined && !currentUserData?.voice?.deafened) ?? false}
       userId={currentUserData.userId ?? ''}
       meetingId={meetingData.meetingId ?? ''}
+      createdTime={meetingData.createdTime ?? 0}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { defineMessages, useIntl } from 'react-intl';
 import BreakoutRemainingTime from '/imports/ui/components/common/remaining-time/breakout-duration/component';
+import { getRemainingMeetingTime, isNewTimeValid } from '/imports/ui/core/utils/calculateRemaingTime';
 import Styled from '../styles';
 import { BREAKOUT_ROOM_SET_TIME } from '../../mutations';
+import useTimeSync from '/imports/ui/core/local-states/useTimeSync';
 
 const intlMessages = defineMessages({
   breakoutTitle: {
@@ -77,6 +79,7 @@ interface TimeRemainingPanelProps {
   isModerator: boolean;
   durationInSeconds: number;
   toggleShowChangeTimeForm: (value: boolean) => void;
+  createdTime: number;
 }
 
 const TimeRemaingPanel: React.FC<TimeRemainingPanelProps> = ({
@@ -84,11 +87,13 @@ const TimeRemaingPanel: React.FC<TimeRemainingPanelProps> = ({
   isModerator,
   durationInSeconds,
   toggleShowChangeTimeForm,
+  createdTime,
 }) => {
   const intl = useIntl();
   const durationContainerRef = React.useRef(null);
   const [showFormError, setShowFormError] = useState(false);
   const [newTime, setNewTime] = useState(0);
+  const [timeSync] = useTimeSync();
 
   const [breakoutRoomSetTime] = useMutation(BREAKOUT_ROOM_SET_TIME);
 
@@ -135,8 +140,12 @@ const TimeRemaingPanel: React.FC<TimeRemainingPanelProps> = ({
               label={intl.formatMessage(intlMessages.setTimeLabel)}
               onClick={() => {
                 setShowFormError(false);
-
-                if (durationInSeconds !== 0 && newTime > durationInSeconds) {
+                const remainingTime = getRemainingMeetingTime(
+                  durationInSeconds,
+                  createdTime,
+                  timeSync,
+                );
+                if (!isNewTimeValid(remainingTime, newTime)) {
                   setShowFormError(true);
                 } else if (setBreakoutsTime(newTime)) {
                   toggleShowChangeTimeForm(false);

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -32,6 +32,8 @@ import {
 import { BREAKOUT_ROOM_CREATE, BREAKOUT_ROOM_MOVE_USER } from '../mutations';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { notify } from '/imports/ui/services/notification';
+import useTimeSync from '/imports/ui/core/local-states/useTimeSync';
+import { getRemainingMeetingTime, isNewTimeValid } from '/imports/ui/core/utils/calculateRemaingTime';
 
 const MIN_BREAKOUT_ROOMS = 2;
 const MIN_BREAKOUT_TIME = 5;
@@ -52,6 +54,9 @@ interface CreateBreakoutRoomProps extends CreateBreakoutRoomContainerProps {
   presentations: Array<Presentation>,
   currentPresentation: string,
   groups: getMeetingGroupResponse['meeting_group'],
+  durationInSeconds: number,
+  createdTime: number,
+  timeSync: number,
 }
 
 const intlMessages = defineMessages({
@@ -219,6 +224,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.sendInvitationToMods',
     description: 'label for checkbox send invitation to moderators',
   },
+  timeCannotExceedMainRoom: {
+    id: 'app.createBreakoutRoom.timeCannotExceedMainRoom',
+    description: 'label for checkbox send invitation to moderators',
+  },
 });
 
 const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
@@ -232,6 +241,9 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   presentations,
   currentPresentation,
   groups,
+  durationInSeconds,
+  createdTime,
+  timeSync,
 }) => {
   const { isMobile } = deviceInfo;
   const intl = useIntl();
@@ -288,6 +300,15 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   };
 
   const createRoom = () => {
+    const remainingTime = getRemainingMeetingTime(
+      durationInSeconds,
+      createdTime,
+      timeSync,
+    );
+    if (!isNewTimeValid(remainingTime, durationTime)) {
+      setDurationIsValid(false);
+      return;
+    }
     const rooms = roomsRef.current;
     const roomsArray: RoomToWithSettings[] = [];
     /* eslint no-restricted-syntax: "off" */
@@ -480,27 +501,51 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   const { value } = e.target;
                   const v = Number.parseInt(value, 10);
+                  const remainingTime = getRemainingMeetingTime(
+                    durationInSeconds,
+                    createdTime,
+                    timeSync,
+                  );
+                  const isValid = isNewTimeValid(remainingTime, v);
                   setDurationTime(v);
-                  setDurationIsValid(v >= MIN_BREAKOUT_TIME);
+                  setDurationIsValid(isValid);
                 }}
                 onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
                   const { value } = e.target;
                   const v = Number.parseInt(value, 10);
+                  const remainingTime = getRemainingMeetingTime(
+                    durationInSeconds,
+                    createdTime,
+                    timeSync,
+                  );
+                  const isValid = isNewTimeValid(remainingTime, v);
                   setDurationTime((v && !(v <= 0)) ? v : MIN_BREAKOUT_TIME);
-                  setDurationIsValid(true);
+                  setDurationIsValid(isValid);
                 }}
                 aria-label={intl.formatMessage(intlMessages.duration)}
                 data-test="durationTime"
               />
             </Styled.DurationArea>
-            <Styled.SpanWarn data-test="minimumDurationWarnBreakout" valid={durationIsValid}>
-              {
-                intl.formatMessage(
-                  intlMessages.minimumDurationWarnBreakout,
-                  { 0: MIN_BREAKOUT_TIME },
-                )
-              }
-            </Styled.SpanWarn>
+            {
+              durationTime <= MIN_BREAKOUT_TIME ? (
+                <Styled.SpanWarn data-test="minimumDurationWarnBreakout" valid={durationIsValid}>
+                  {
+                    intl.formatMessage(
+                      intlMessages.minimumDurationWarnBreakout,
+                      { 0: MIN_BREAKOUT_TIME },
+                    )
+                  }
+                </Styled.SpanWarn>
+              ) : (
+                <Styled.SpanWarn data-test="timeExceed" valid={durationIsValid}>
+                  {
+                    intl.formatMessage(
+                      intlMessages.timeCannotExceedMainRoom,
+                    )
+                  }
+                </Styled.SpanWarn>
+              )
+            }
           </Styled.DurationLabel>
           <Styled.CheckBoxesContainer key="breakout-checkboxes">
             {checkboxesInfo
@@ -594,11 +639,14 @@ const CreateBreakoutRoomContainer: React.FC<CreateBreakoutRoomContainerProps> = 
 }) => {
   const intl = useIntl();
   const [fetchedBreakouts, setFetchedBreakouts] = React.useState(false);
+  const [timeSync] = useTimeSync();
   // isBreakoutRecordable - get from meeting breakout policies breakoutPolicies/record
   const {
     data: currentMeeting,
   } = useMeeting((m) => ({
     breakoutPolicies: m.breakoutPolicies,
+    durationInSeconds: m.durationInSeconds,
+    createdTime: m.createdTime,
   }));
 
   const {
@@ -668,6 +716,9 @@ const CreateBreakoutRoomContainer: React.FC<CreateBreakoutRoomContainerProps> = 
       presentations={presentations}
       currentPresentation={currentPresentation}
       groups={meetingGroupData?.meeting_group ?? []}
+      durationInSeconds={currentMeeting?.durationInSeconds ?? 0}
+      createdTime={currentMeeting?.createdTime ?? 0}
+      timeSync={timeSync}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/core/utils/calculateRemaingTime.ts
+++ b/bigbluebutton-html5/imports/ui/core/utils/calculateRemaingTime.ts
@@ -1,0 +1,32 @@
+export function getRemainingMeetingTime(durationInSeconds:number, createdTime:number, timeSync: number) {
+  const clientCurrentTime = Date.now();
+  const adjustedCurrentTime = clientCurrentTime + timeSync;
+
+  const elapsedMilliseconds = adjustedCurrentTime - createdTime;
+  const elapsedSeconds = Math.floor(elapsedMilliseconds / 1000);
+
+  const remainingSeconds = Math.max(0, durationInSeconds - elapsedSeconds);
+
+  return remainingSeconds;
+}
+
+export function isNewTimeValid(remainingTime: number, newTime: number) {
+  const FIVE_MINUTES = 300; // 5 minutes in seconds
+  const newTimeInSeconds = newTime * 60; // Convert newTime from minutes to seconds
+  if (remainingTime === 0) return newTimeInSeconds >= FIVE_MINUTES;
+  if (newTimeInSeconds > remainingTime) {
+    return false; // New time cannot exceed remaining time
+  }
+
+  if (remainingTime > FIVE_MINUTES) {
+    return newTimeInSeconds >= FIVE_MINUTES; // If > 5 min left, newTime must be at least 5 min
+  }
+
+  // If remainingTime is already under 5 min, any smaller/equal newTime is acceptable
+  return true;
+}
+
+export default {
+  getRemainingMeetingTime,
+  isNewTimeValid,
+};

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1379,6 +1379,7 @@
     "app.createBreakoutRoom.sendInvitationToMods": "Send invitation to assigned moderators",
     "app.createBreakoutRoom.leastOneWarnBreakout": "You must place at least one user in a breakout room.",
     "app.createBreakoutRoom.minimumDurationWarnBreakout": "Minimum duration for a breakout room is {0} minutes.",
+    "app.createBreakoutRoom.timeCannotExceedMainRoom": "The breakout room duration cannot exceed the session remaining time.",
     "app.createBreakoutRoom.modalDesc": "Complete the steps below to create breakout rooms in your session. To add participants to a room, simply drag their name to the desired room.",
     "app.createBreakoutRoom.roomTime": "{0} minutes",
     "app.createBreakoutRoom.numberOfRoomsError": "The number of rooms is invalid.",

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -92,11 +92,11 @@ class Join extends Create {
     await this.modPage.waitAndClick(e.breakoutOptionsMenu);
     await this.modPage.waitAndClick(e.openBreakoutTimeManager);
     await this.modPage.getLocator(e.inputSetTimeSelector).press('Backspace');
-    await this.modPage.type(e.inputSetTimeSelector, '2');
+    await this.modPage.type(e.inputSetTimeSelector, '5');
     await this.modPage.waitAndClick(e.sendButtonDurationTime);
-    await this.modPage.hasText(e.breakoutRemainingTime, /[11-12]:[0-5][0-9]/, 'should have the breakout room time remaining counting down on the main meeting');
+    await this.modPage.hasText(e.breakoutRemainingTime, /[4-5]:[0-5][0-9]/, 'should have the breakout room time remaining counting down on the main meeting');
 
-    await breakoutUserPage.hasText(e.timeRemaining, /[11-12]:[0-5][0-9]/, 'should have the time remaining counting down on the breakout room');
+    await breakoutUserPage.hasText(e.timeRemaining, /[4-5]:[0-5][0-9]/, 'should have the time remaining counting down on the breakout room');
   }
 
   async inviteUserAfterCreatingRooms() {
@@ -125,11 +125,11 @@ class Join extends Create {
     await this.modPage.waitAndClick(e.breakoutOptionsMenu);
     await this.modPage.waitAndClick(e.openBreakoutTimeManager);
     await this.modPage.getLocator(e.inputSetTimeSelector).press('Backspace');
-    await this.modPage.type(e.inputSetTimeSelector, '2');
+    await this.modPage.type(e.inputSetTimeSelector, '5');
     await this.modPage.waitAndClick(e.sendButtonDurationTime);
-    await this.modPage.hasText(e.breakoutRemainingTime, /[11-12]:[0-5][0-9]/, 'should have the breakout room time remaining counting down on the breakout main panel.');
+    await this.modPage.hasText(e.breakoutRemainingTime, /[4-5]:[0-5][0-9]/, 'should have the breakout room time remaining counting down on the breakout main panel.');
 
-    await breakoutUserPage.hasText(e.timeRemaining, /[11-12]:[0-5][0-9]/, 'should display the remaining time inside the breakout room');
+    await breakoutUserPage.hasText(e.timeRemaining, /[4-5]:[0-5][0-9]/, 'should display the remaining time inside the breakout room');
   }
 
   async endAllBreakoutRooms() {


### PR DESCRIPTION
### What does this PR do?
Fixes the issue of the Breakout Room duration exceed the main room duration, the issue was caused because the check was being made on the static value of durationInSeconds instead of calculate it on the changes;


### Closes Issue(s)
Closes #23016




### How to test
- Create a meeting with the parameter duration
- Try to create a meeting with duration greater than main room. 


### More
[Screencast from 01-05-2025 11:20:07.webm](https://github.com/user-attachments/assets/7d0e219a-6884-44ad-839a-98841428dd45)

