### PR TITLE
fix: Youtube video not synced when chaging video speed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -415,6 +415,23 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   };
 
+  const handlePlaybackRateChange = async () => {
+    if (isPresenter) {
+      const internalPlayer = playerRef.current?.getInternalPlayer();
+      let rate = internalPlayer instanceof HTMLVideoElement
+        ? internalPlayer.playbackRate
+        : internalPlayer?.getPlaybackRate?.() ?? 1;
+      if (rate instanceof Promise) {
+        rate = await rate;
+      }
+      sendMessage('playbackRateChange', {
+        rate,
+        time: getCurrentTime(),
+        state: playing ? 'playing' : 'paused',
+      });
+    }
+  };
+
   const isMinimized = width === 0 && height === 0;
 
   // @ts-ignore accessing lib private property
@@ -487,6 +504,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           muted={mute || isEchoTest}
           controls
           previewTabIndex={isPresenter ? 0 : -1}
+          onPlaybackRateChange={handlePlaybackRateChange}
         />
         {
           shouldShowTools() ? (
@@ -545,6 +563,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
     // don't re-send repeated update messages
     if (
       lastMessageRef.current.event === event
+      && event !== 'playbackRateChange' // playback rate change is always sent
       && Math.abs(lastMessageRef.current.time - data.time) < UPDATE_INTERVAL_THRESHOLD_MS
     ) {
       return;


### PR DESCRIPTION
### What does this PR do?

Fix issue where playback rate changes were not reflected for non-presenter users.

### Closes Issue(s)
Closes #23047

### How to test
1. Join with two users(A, B)
2. Share an external YouTube video with user A
3. Change the video speed
4. It should be applied for both users