### PR TITLE
fix: learning analytics button text message not showing after session end 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -215,23 +215,24 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
             && setLearningDashboardCookie(learningDashboardAccessToken, meetingId, learningDashboardBase) === true
               ? (
                 <>
-                <Styled.Text>
-                  {intl.formatMessage(intlMessage.open_activity_report_btn)}
-                </Styled.Text>
-                <Styled.MeetingEndedButton
-                  color="default"
-                  onClick={() => openLearningDashboardUrl(learningDashboardAccessToken,
-                    meetingId,
-                    authToken,
-                    learningDashboardBase,
-                    locale)}
-                  aria-details={intl.formatMessage(intlMessage.open_activity_report_btn)}
-                >
+                  <Styled.Text>
+                    {intl.formatMessage(intlMessage.open_activity_report_btn)}
+                  </Styled.Text>
+
+                  <Styled.MeetingEndedButton
+                    color="default"
+                    onClick={() => openLearningDashboardUrl(learningDashboardAccessToken,
+                      meetingId,
+                      authToken,
+                      learningDashboardBase,
+                      locale)}
+                    aria-details={intl.formatMessage(intlMessage.open_activity_report_btn)}
+                  >
                     <Icon
-                      iconName="multi_whiteboard" />
+                      iconName="multi_whiteboard"
+                    />
                   </Styled.MeetingEndedButton>
-                  </>
-                  
+                </>
               ) : null
           }
           <Styled.Text>

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -214,21 +214,24 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
             // Always set cookie in case Dashboard is already opened
             && setLearningDashboardCookie(learningDashboardAccessToken, meetingId, learningDashboardBase) === true
               ? (
+                <>
                 <Styled.Text>
-                  <Styled.MeetingEndedButton
-                    color="default"
-                    onClick={() => openLearningDashboardUrl(learningDashboardAccessToken,
-                      meetingId,
-                      authToken,
-                      learningDashboardBase,
-                      locale)}
-                    aria-details={intl.formatMessage(intlMessage.open_activity_report_btn)}
-                  >
-                    <Icon
-                      iconName="multi_whiteboard"
-                    />
-                  </Styled.MeetingEndedButton>
+                  {intl.formatMessage(intlMessage.open_activity_report_btn)}
                 </Styled.Text>
+                <Styled.MeetingEndedButton
+                  color="default"
+                  onClick={() => openLearningDashboardUrl(learningDashboardAccessToken,
+                    meetingId,
+                    authToken,
+                    learningDashboardBase,
+                    locale)}
+                  aria-details={intl.formatMessage(intlMessage.open_activity_report_btn)}
+                >
+                    <Icon
+                      iconName="multi_whiteboard" />
+                  </Styled.MeetingEndedButton>
+                  </>
+                  
               ) : null
           }
           <Styled.Text>


### PR DESCRIPTION
### What does this PR do?
Fixes issue where after session end there was no message for the Learning Analytics Dashboard button


### Closes Issue(s)
Closes #22825


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
1. Create a meeting
2. Join as moderator
3. end meeting
4. certifies the message is appearing near the Learning Analytics Dashboard button

