### PR TITLE
Fix(html5): Update Selected room if user is moved by moderator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -83,7 +83,8 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   const defaultSelectedBreakoutId = breakouts.find(({ isLastAssignedRoom }) => isLastAssignedRoom)?.breakoutRoomId
     || firstBreakoutId;
 
-  const [selectValue, setSelectValue] = React.useState(defaultSelectedBreakoutId);
+
+  const [selectValue, setSelectValue] = React.useState('');
 
   const requestJoinURL = (breakoutRoomId: string) => {
     breakoutRoomRequestJoinURL({ variables: { breakoutRoomId } });
@@ -106,6 +107,13 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
       setWaiting(true);
     }
   };
+
+  useEffect(() => {
+    // If User is Moved to a new room, the select value is updated
+    if (defaultSelectedBreakoutId) {
+      setSelectValue(defaultSelectedBreakoutId);
+    }
+  }, [defaultSelectedBreakoutId]);
 
   const handleJoinBreakoutConfirmation = useCallback(() => {
     stopMediaOnMainRoom(presenter);

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -83,7 +83,6 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   const defaultSelectedBreakoutId = breakouts.find(({ isLastAssignedRoom }) => isLastAssignedRoom)?.breakoutRoomId
     || firstBreakoutId;
 
-
   const [selectValue, setSelectValue] = React.useState('');
 
   const requestJoinURL = (breakoutRoomId: string) => {


### PR DESCRIPTION
### What does this PR do?
Fix an issue where the viewer's assigned room appeared incorrectly in the breakout invitation modal. This was caused by a race condition: the component did not update the user's currently assigned room on mount.

### Closes Issue(s)
N/A


### How to test
- Join a meeting with a Mod and a viewer.
- Create a Breakout room and assign the user for one of them.
- Keep moving user between breakouts.
