### PR TITLE
feat(default-settings): support meeting-scoped settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -156,7 +156,7 @@ class ActionsBar extends PureComponent {
     } = this.props;
 
     const Settings = getSettingsSingletonInstance();
-    const { selectedLayout } = Settings.application;
+    const { selectedLayout } = Settings.layout;
     const shouldShowPresentationButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
       && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;
     const shouldShowVideoButton = selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -108,14 +108,14 @@ const ActionsBarContainer = (props) => {
   const [darkModeIsEnabled, setDarkModeIsEnabled] = useState(isDarkThemeEnabled());
   const isPollingEnabled = useIsPollingEnabled() && isPresentationEnabled;
   const isRaiseHandEnabled = useIsRaiseHandEnabled();
-  const applicationSettings = useSettings(SETTINGS.APPLICATION);
-  const { pushLayout } = applicationSettings;
+  const layoutSettings = useSettings(SETTINGS.LAYOUT);
+  const { pushLayout } = layoutSettings;
   const setPushLayout = usePushLayoutUpdater(pushLayout);
   const setMeetingLayout = useMeetingLayoutUpdater(
     cameraDockOutput,
     cameraDockInput,
     presentationInput,
-    applicationSettings,
+    layoutSettings,
   );
   const { isOpen: sidebarNavigationIsOpen } = sidebarNavigation;
   const { isOpen: sidebarContentIsOpen } = sidebarContent;
@@ -176,7 +176,7 @@ const ActionsBarContainer = (props) => {
         hasGenericContent: isThereGenericMainContent,
         setPushLayout,
         setMeetingLayout,
-        showPushLayout: showPushLayoutButton && applicationSettings.selectedLayout === 'custom',
+        showPushLayout: showPushLayoutButton && layoutSettings.selectedLayout === 'custom',
         ariaHidden,
         isDarkThemeEnabled: darkModeIsEnabled,
         isMobile,

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
@@ -13,7 +13,7 @@ const LayoutModalContainer = (props) => {
     intl, setIsOpen, onRequestClose, isOpen,
   } = props;
   const setLocalSettings = useUserChangedLocalSettings();
-  const application = useSettings(SETTINGS.APPLICATION);
+  const layoutSettings = useSettings(SETTINGS.LAYOUT);
   const { data: currentUser } = useCurrentUser((u) => ({
     presenter: u.presenter,
     isModerator: u.isModerator,
@@ -24,7 +24,7 @@ const LayoutModalContainer = (props) => {
       setIsOpen,
       isModerator: currentUser?.isModerator ?? false,
       isPresenter: currentUser?.presenter ?? false,
-      application,
+      layoutSettings,
       updateSettings,
       onRequestClose,
       isOpen,

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -39,7 +39,7 @@ const LayoutObserver: React.FC = () => {
   const { sidebarContentPanel } = sidebarContent;
 
   const [, setEnableResize] = useState(!window.matchMedia(MOBILE_MEDIA).matches);
-  const { selectedLayout } = useSettings(SETTINGS.APPLICATION) as { selectedLayout: string };
+  const { selectedLayout } = useSettings(SETTINGS.LAYOUT) as { selectedLayout: string };
   const {
     data: currentMeeting,
   } = useMeeting((m) => ({

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -21,14 +21,14 @@ const useMeetingLayoutUpdater = (
   cameraDockOutput: Output['cameraDock'],
   cameraDockInput: Input['cameraDock'],
   presentationInput: Input['presentation'],
-  applicationSettings: { pushLayout: boolean, selectedLayout: boolean },
+  layoutSettings: { pushLayout: boolean, selectedLayout: boolean },
 ) => {
   const [setMeetingLayoutProps] = useMutation(SET_LAYOUT_PROPS);
 
   const { focusedId, position } = cameraDockOutput;
   const { isResizing } = cameraDockInput;
   const { isOpen: presentationIsOpen } = presentationInput;
-  const { pushLayout, selectedLayout } = applicationSettings;
+  const { pushLayout, selectedLayout } = layoutSettings;
 
   const setMeetingLayout = () => {
     setMeetingLayoutProps({

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -14,7 +14,7 @@ import {
   PANELS,
 } from '../enums';
 import { isLayoutSupported, isMobile, LAYOUTS_SYNC } from '../utils';
-import { updateSettings, isKeepPushingLayoutEnabled } from '/imports/ui/components/settings/service';
+import { updateSettings } from '/imports/ui/components/settings/service';
 import Session from '/imports/ui/services/storage/in-memory';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
@@ -32,8 +32,6 @@ import { calculatePresentationVideoRate } from './service';
 import { useMeetingLayoutUpdater, usePushLayoutUpdater } from './hooks';
 import { changeEnforcedLayout } from '/imports/ui/components/plugins-engine/ui-commands/layout/handler';
 import { useIsChatEnabled } from '/imports/ui/services/features';
-import Auth from '/imports/ui/services/auth';
-import Storage from '/imports/ui/services/storage/session';
 
 const equalDouble = (n1, n2) => {
   const precision = 0.01;
@@ -116,15 +114,15 @@ const PushLayoutEngine = (props) => {
     const defaultLayout = LAYOUT_TYPE[getFromUserSettings('bbb_default_layout', null)];
     const enforcedLayout = LAYOUT_TYPE[enforceLayoutResult] || null;
 
-    Settings.application.selectedLayout = enforcedLayout
+    Settings.layout.selectedLayout = enforcedLayout
       || changeLayout
       || defaultLayout
       || meetingLayout;
 
-    let { selectedLayout: actualLayout } = Settings.application;
+    let { selectedLayout: actualLayout } = Settings.layout;
     if (isMobile()) {
       actualLayout = actualLayout === 'custom' ? 'smart' : actualLayout;
-      Settings.application.selectedLayout = actualLayout;
+      Settings.layout.selectedLayout = actualLayout;
     }
     Session.setItem('isGridEnabled', actualLayout === LAYOUT_TYPE.VIDEO_FOCUS);
 
@@ -225,8 +223,8 @@ const PushLayoutEngine = (props) => {
       // Shouldn't run when enforceLayoutDidChange
       if (pushLayoutMeeting) {
         updateSettings({
-          application: {
-            ...Settings.application,
+          layout: {
+            ...Settings.layout,
             selectedLayout: contextLayout,
           },
         }, null, setLocalSettings);
@@ -298,8 +296,8 @@ const PushLayoutEngine = (props) => {
       && pushLayoutMeetingDidChange
       && pushLayoutMeeting !== pushLayout) {
       updateSettings({
-        application: {
-          ...Settings.application,
+        layout: {
+          ...Settings.layout,
           pushLayout: pushLayoutMeeting,
         },
       }, null, setLocalSettings);
@@ -367,19 +365,11 @@ const PushLayoutEngineContainer = (props) => {
   const layoutContextDispatch = layoutDispatch();
   const isChatEnabled = useIsChatEnabled();
 
-  const applicationSettings = useSettings(SETTINGS.APPLICATION);
+  const layoutSettings = useSettings(SETTINGS.LAYOUT);
   const {
     selectedLayout,
-  } = applicationSettings;
-
-  const isPushLayoutEnabled = isKeepPushingLayoutEnabled();
-
-  const getKeepPushingLayout = () => {
-    if (!isPushLayoutEnabled) return false;
-
-    const storageKey = `keepPushingLayout_${Auth.meetingID}`;
-    return Storage.getItem(storageKey) === true;
-  };
+    pushLayout,
+  } = layoutSettings;
 
   const {
     width: cameraWidth,
@@ -431,15 +421,13 @@ const PushLayoutEngineContainer = (props) => {
 
   const presentationVideoRate = calculatePresentationVideoRate(cameraDockOutput);
 
-  const pushLayout = getKeepPushingLayout();
-
   const setLocalSettings = useUserChangedLocalSettings();
   const setPushLayout = usePushLayoutUpdater(pushLayout);
   const setMeetingLayout = useMeetingLayoutUpdater(
     cameraDockOutput,
     cameraDockInput,
     presentationInput,
-    applicationSettings,
+    layoutSettings,
   );
 
   const validateEnforceLayout = (currUser) => {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -309,7 +309,7 @@ class NavBar extends Component {
     const { leftPluginItems, centerPluginItems, rightPluginItems } = this.splitPluginItems();
 
     const Settings = getSettingsSingletonInstance();
-    const { selectedLayout } = Settings.application;
+    const { selectedLayout } = Settings.layout;
     const shouldShowNavBarToggleButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
       && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
       && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/component.jsx
@@ -262,7 +262,7 @@ class OptionsDropdown extends PureComponent {
     }
 
     const Settings = getSettingsSingletonInstance();
-    const { selectedLayout } = Settings.application;
+    const { selectedLayout } = Settings.layout;
     const shouldShowManageLayoutButton = selectedLayout !== LAYOUT_TYPE.CAMERAS_ONLY
       && selectedLayout !== LAYOUT_TYPE.PRESENTATION_ONLY
       && selectedLayout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY;

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -32,7 +32,7 @@ const fetchedpresentation = {};
 const PresentationContainer = (props) => {
   const { presentationIsOpen } = props;
   const layoutContextDispatch = layoutDispatch();
-  const { selectedLayout } = useSettings(SETTINGS.APPLICATION);
+  const { selectedLayout } = useSettings(SETTINGS.LAYOUT);
 
   const { data: presentationPageData } = useDeduplicatedSubscription(
     CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -343,7 +343,7 @@ const WebcamContainer: React.FC = () => {
   const { data: currentUserData } = useCurrentUser((user) => ({
     presenter: user.presenter,
   }));
-  const { selectedLayout } = useSettings(SETTINGS.APPLICATION) as { selectedLayout: string };
+  const { selectedLayout } = useSettings(SETTINGS.LAYOUT) as { selectedLayout: string };
 
   const isGridEnabled = selectedLayout === LAYOUT_TYPE.VIDEO_FOCUS;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -591,7 +591,7 @@ const WhiteboardContainer = (props) => {
           skipToSlide,
           locale: Settings?.application?.locale,
           darkTheme: Settings?.application?.darkTheme,
-          selectedLayout: Settings?.application?.selectedLayout,
+          selectedLayout: Settings?.layout?.selectedLayout,
           isInfiniteWhiteboard,
           curPageNum,
           setEditor,

--- a/bigbluebutton-html5/imports/ui/services/settings/enums.ts
+++ b/bigbluebutton-html5/imports/ui/services/settings/enums.ts
@@ -1,4 +1,5 @@
 const SETTINGS = {
+  LAYOUT: 'layout',
   APPLICATION: 'application',
   AUDIO: 'audio',
   VIDEO: 'video',
@@ -9,17 +10,25 @@ const SETTINGS = {
   TRANSCRIPTION: 'transcription',
 } as const;
 
+// keys inside this array will be saved with the meeting id appended to it
+// so they don't persist between meetings even when using local storage.
+const MEETING_SCOPED_SETTINGS = [
+  'layout',
+];
+
 const CHANGED_SETTINGS = 'changed_settings';
 const DEFAULT_SETTINGS = 'default_settings';
 
 export {
   SETTINGS,
+  MEETING_SCOPED_SETTINGS,
   CHANGED_SETTINGS,
   DEFAULT_SETTINGS,
 };
 
 export default {
   SETTINGS,
+  MEETING_SCOPED_SETTINGS,
   CHANGED_SETTINGS,
   DEFAULT_SETTINGS,
 };

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -195,9 +195,10 @@ public:
     # 'local' -> settings are stored in browser localStorage
     userSettingsStorage: session
     defaultSettings:
-      application:
+      layout:
         selectedLayout: 'custom'
         pushLayout: false
+      application:
         animations: true
         chatAudioAlerts: false
         chatPushAlerts: false


### PR DESCRIPTION
### What does this PR do?
Allows adding default setting keys to a list of meeting-scoped settings that won't be persisted between meetings, even when `userSettingsStorage` is set to 'local'. This is achieved by appending the meeting ID to the key used for storage, using  the same strategy introduced in https://github.com/bigbluebutton/bigbluebutton/pull/22333, generalized to apply to any meeting setting.

Also introduces a new settings group for layout-related settings and add this key to the meeting-scoped list, preventing layout settings - such as push layout state and selected layout type - from being persisted across meetings.

Initial state of push layout toggle is defined by `public.defaultSettings.layout.pushLayout`.
Initial selected layout is defined by `public.defaultSettings.layout.selectedLayout`.

### Closes Issue(s)
Closes #23078 

### Motivation
Some in-meeting settings should not persist across meetings, even when the configured storage strategy is `'local'`. The most prominent example is layout preferences, which are session-specific by nature. Persisting them could lead to inconsistencies in user experience. These settings already support default values defined in `settings.yml`, which should act as the baseline each time a meeting starts.

### How to test
1. Create meeting and join.
2. Alter the push layout state and the selected layout.
3. Close meeting.
4. Create a new meeting and join.
5. Check that the layout settings have reset to their default values.

### More
New settings added to default settings group:
```yml
...
defaultSettings:
  layout:
    selectedLayout: 'custom'
    pushLayout: false
...
```
