### PR TITLE
feat: Add persistent captions view to postgres

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2186,6 +2186,11 @@ SELECT *
 FROM "caption"
 WHERE "createdAt" > current_timestamp - INTERVAL '5 seconds';
 
+--------See all captions from a meeting
+CREATE OR REPLACE VIEW "v_caption_persistent" AS
+SELECT *
+FROM "caption";
+
 CREATE OR REPLACE VIEW "v_caption_activeLocales" AS
 select distinct "meetingId", "locale", "createdBy", "captionType"
 from "caption_locale";

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2187,7 +2187,7 @@ FROM "caption"
 WHERE "createdAt" > current_timestamp - INTERVAL '5 seconds';
 
 --------See all captions from a meeting
-CREATE OR REPLACE VIEW "v_caption_persistent" AS
+CREATE OR REPLACE VIEW "v_caption_history" AS
 SELECT *
 FROM "caption";
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_history.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_history.yaml
@@ -1,10 +1,10 @@
 table:
-  name: v_caption_persistent
+  name: v_caption_history
   schema: public
 configuration:
   column_config: {}
   custom_column_names: {}
-  custom_name: caption_persistent
+  custom_name: caption_history
   custom_root_fields: {}
 object_relationships:
   - name: user

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_persistent.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_caption_persistent.yaml
@@ -1,0 +1,33 @@
+table:
+  name: v_caption_persistent
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: caption_persistent
+  custom_root_fields: {}
+object_relationships:
+  - name: user
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_ref
+          schema: public
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - createdAt
+        - captionText
+        - captionId
+        - userId
+        - captionType
+        - locale
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+      allow_aggregations: true

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -6,7 +6,7 @@
 - "!include public_v_breakoutRoom_user.yaml"
 - "!include public_v_caption.yaml"
 - "!include public_v_caption_activeLocales.yaml"
-- "!include public_v_caption_persistent.yaml"
+- "!include public_v_caption_history.yaml"
 - "!include public_v_chat.yaml"
 - "!include public_v_chat_message_private.yaml"
 - "!include public_v_chat_message_public.yaml"

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -6,6 +6,7 @@
 - "!include public_v_breakoutRoom_user.yaml"
 - "!include public_v_caption.yaml"
 - "!include public_v_caption_activeLocales.yaml"
+- "!include public_v_caption_persistent.yaml"
 - "!include public_v_chat.yaml"
 - "!include public_v_chat_message_private.yaml"
 - "!include public_v_chat_message_public.yaml"

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -30,7 +30,7 @@
         "autoprefixer": "^10.4.4",
         "axios": "^1.8.3",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.78",
+        "bigbluebutton-html-plugin-sdk": "0.0.79",
         "bowser": "^2.11.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6151,9 +6151,10 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.78",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.78.tgz",
-      "integrity": "sha512-uO2apvQwMDStSfWAYx07o36dYztBKKrE5rNEbUDIizoalckWKD0rTrg6Y8Qw4k4XsF0+AbIiJ8xt5Lvjkg89Og==",
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.79.tgz",
+      "integrity": "sha512-D/YLelzhjWDs8FmUa24TbpZfN+iHuU6T29GYNPFMQ0IGpg0XaRcfQTr9jorWEBwAx1LLwx1SvvF1uXUD+Q3QKQ==",
+      "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",
         "@browser-bunyan/console-formatted-stream": "^1.8.0",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -56,7 +56,7 @@
     "autoprefixer": "^10.4.4",
     "axios": "^1.8.3",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.78",
+    "bigbluebutton-html-plugin-sdk": "0.0.79",
     "bowser": "^2.11.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
### What does this PR do?

Adds a persistent captions view to postgres just so if needed, we can fetch all captions instead of an ephemeral view as we have now.

### Motivation

This will allow us to make a live-transcription plugin which will put all the captions (including past ones) into the a sidekick panel and even download it.

### How to test

Just run it with the plugin https://github.com/bigbluebutton/live-transcription-plugin

### More

There will be a PR in the live-transcription-plugin to add the feature. 
