### PR TITLE
Fix(html5): Error 3006 when granting WB access with no presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -211,7 +211,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   usersPolicies,
   isBreakout,
   children,
-  pageId,
+  pageId = '',
   userListDropdownItems,
   open,
   setOpenUserAction,
@@ -232,6 +232,8 @@ const UserActions: React.FC<UserActionsProps> = ({
   const isChatEnabled = useIsChatEnabled();
 
   const handleWhiteboardAccessChange = async () => {
+    // There is no presentation available, so access cannot be granted.
+    if (!pageId) return;
     try {
       // Fetch the writers data
       const { data } = await getWriters();
@@ -471,7 +473,8 @@ const UserActions: React.FC<UserActionsProps> = ({
     {
       allowed: allowedToChangeWhiteboardAccess
         && !user.presenter
-        && !isVoiceOnlyUser(user.userId),
+        && !isVoiceOnlyUser(user.userId)
+        && pageId,
       key: 'changeWhiteboardAccess',
       label: hasWhiteboardAccess
         ? intl.formatMessage(messages.removeWhiteboardAccess)


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where a failed subscription message appeared when either:
- granting access to the whiteboard without an active presentation, or
- removing a presentation while multi-whiteboard mode was enabled.

The root cause was that the `getWriters` query was being executed with a `null` `pageId` in both scenarios.

### Fixes applied:
- Hide the action button when there is no valid `pageId`.
- Prevent execution of the function when `pageId` is falsy.
- Hide the button when no current presentation exists.



### Closes Issue(s)
N/A

### How to test
- Join a Mod and a Viewer.
- Enable multi whiteboard.
- Remove all presentations.

### More
[Screencast from 05-05-2025 13:15:28.webm](https://github.com/user-attachments/assets/0fea81ab-7067-43c3-8b18-fc462982eef4)
