### PR TITLE
Fix(html5): Late users not being able to join, free join breakouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/breakout-room/queries.ts
@@ -8,6 +8,14 @@ export const userIsInvited = gql`
   }
 `;
 
+export const isBreakoutFreeJoin = gql`
+  subscription breakoutsAreFreeJoin {
+    breakoutRoom(where: {freeJoin: {_eq: true}}) {
+      sequence
+    }
+  }
+`;
+
 export default {
   userIsInvited,
 };


### PR DESCRIPTION
### What does this PR do?
This PR resolves a problem where late users were unable to join breakout rooms configured with the **free join** policy.  
The issue occurred because the join condition did not account for the `freeJoin` flag set on the breakout room configuration.

The Modal Open will come in another PR, it's a change on backend and talking to Gustavo he thought would be better he takes a look to ensure the query performarnce.


### Closes Issue(s)
Closes #23077

### How to test
- Join a Mod and a Viewer.
- Start a breakout with free Join enabled
- Join a new Viewer
- See breakouts panel

### More
[Screencast from 05-05-2025 15:35:40.webm](https://github.com/user-attachments/assets/90b46e15-c881-43cd-926d-99e5559cd6ef)

