### PR TITLE
refactor(bbb-web): Add more logging to presentation conversion process

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfSlidesGenerationService.java
@@ -53,9 +53,9 @@ public class PdfSlidesGenerationService {
                 new ArrayList<>());
 
         presentationConversionCompletionService.handle(msg);
-        log.info("Progress message handled for page {}", pageToConvert.getPageNumber());
+        log.info("Progress message handled for page {} of presentation [{}] in meeting [{}]", pageToConvert.getPageNumber(), pageToConvert.getPresId(), pageToConvert.getMeetingId());
       } catch (Throwable t) {
-        log.error("Conversion task failed for page {}", pageToConvert.getPageNumber(), t);
+        log.error("Conversion task failed for page {} of presentation [{}] in meeting [{}]", pageToConvert.getPageNumber(), pageToConvert.getPresId(), pageToConvert.getMeetingId(), t);
       }
     });
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -57,7 +57,8 @@ public class PresentationConversionCompletionService {
                 log.info("Found presentation with key {}", presentationToConvertKey);
                 p.incrementPagesCompleted();
                 notifier.sendConversionUpdateMessage(p.getPagesCompleted(), p.pres, m.page);
-                log.info("{} of {} pages successfully converted", p.getPagesCompleted(), p.pres.getNumberOfPages());
+                log.info("{} of {} pages successfully converted for presentation [{}] in meeting [{}]", p.getPagesCompleted(), p.pres.getNumberOfPages(),
+                        ((PageConvertProgressMessage) msg).presId, ((PageConvertProgressMessage) msg).meetingId);
                 if (p.getPagesCompleted() == p.pres.getNumberOfPages()) {
                     log.info("Last presentation page converted");
                     handleEndProcessing(p);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -57,6 +57,7 @@ public class PresentationConversionCompletionService {
                 log.info("Found presentation with key {}", presentationToConvertKey);
                 p.incrementPagesCompleted();
                 notifier.sendConversionUpdateMessage(p.getPagesCompleted(), p.pres, m.page);
+                log.info("{} of {} pages successfully converted", p.getPagesCompleted(), p.pres.getNumberOfPages());
                 if (p.getPagesCompleted() == p.pres.getNumberOfPages()) {
                     log.info("Last presentation page converted");
                     handleEndProcessing(p);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SlidesGenerationProgressNotifier.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SlidesGenerationProgressNotifier.java
@@ -101,6 +101,7 @@ public class SlidesGenerationProgressNotifier {
   }
 
   public void sendConversionUpdateMessage(int slidesCompleted, UploadedPresentation pres, int pageGenerated) {
+    log.info("Sending conversion update message for page {} of presentation [{}] in meeting [{}]", pageGenerated, pres.getId(), pres.getMeetingId());
     DocPageGeneratedProgress progress = new DocPageGeneratedProgress(pres.getPodId(),
             pres.getMeetingId(),
             pres.getId(),
@@ -129,6 +130,7 @@ public class SlidesGenerationProgressNotifier {
   }
 
   public void sendConversionCompletedMessage(UploadedPresentation pres) {
+    log.info("Sending conversion completed message for presentation [{}] in meeting [{}]", pres.getId(), pres.getMeetingId());
     if (generatedSlidesInfoHelper == null) {
       log.error("GeneratedSlidesInfoHelper was not set. Could not notify interested listeners.");
       return;


### PR DESCRIPTION
### What does this PR do?

Adds more logging to the to presentation conversion processor particularly around the handling page and presentation completion messages. Also adds a thread factory to the conversion message handling executor thread pool to allow restarts if one of the threads fails as well as catching any exceptions that may be thrown in the threads to allow them to continue.

### Motivation

The purpose of these logs is to help track down an issue where presentation conversion status is not being properly communicated with Akka Apps. The issue may be related to the presentation not being found in the collection of presentations to convert. If this is the case the following error will be logged `No presentation found with key`. Another possible explanation of the issue is that the thread handling conversion messages is encountering an exception and being killed so no further messages can be handled.
