### PR TITLE
fix(html5): remove fragments with only one child

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
@@ -155,7 +155,7 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
       // Return keys with empty arrays
       return Object.keys(userAssignedRooms).filter((key) => {
         return userAssignedRooms[key].length === 0
-        || userAssignedRooms[key].includes(0);
+          || userAssignedRooms[key].includes(0);
       });
     }
     // Return keys whose array includes the given number
@@ -242,7 +242,7 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
       (lastBreakoutData
         && lastBreakoutData.breakoutRoom_createdLatest.length > 0)
       && (runningRooms
-      && runningRooms.length === 0)
+        && runningRooms.length === 0)
     ) {
       const assignUsers = lastBreakoutData.user.reduce((acc: { [key: string]: number[] }, user) => {
         //  means user wasn't either not assigned or not joined a breakout room
@@ -344,29 +344,27 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
   }, [rooms, setRoomsRef]);
 
   return (
-    <>
-      <RendererComponent
-        moveUser={moveUser}
-        rooms={rooms}
-        getRoomName={roomName}
-        changeRoomName={changeRoomName}
-        numberOfRooms={numberOfRooms}
-        selectedId={selectedId ?? ''}
-        setSelectedId={setSelectedId}
-        selectedRoom={selectedRoom}
-        setSelectedRoom={setSelectedRoom}
-        randomlyAssign={randomlyAssign}
-        resetRooms={resetRooms}
-        users={users}
-        currentSlidePrefix={currentSlidePrefix}
-        presentations={presentations}
-        roomPresentations={roomPresentations}
-        setRoomPresentations={setRoomPresentations}
-        getRoomPresentation={getRoomPresentation}
-        currentPresentation={currentPresentation}
-        isUpdate={isUpdate}
-      />
-    </>
+    <RendererComponent
+      moveUser={moveUser}
+      rooms={rooms}
+      getRoomName={roomName}
+      changeRoomName={changeRoomName}
+      numberOfRooms={numberOfRooms}
+      selectedId={selectedId ?? ''}
+      setSelectedId={setSelectedId}
+      selectedRoom={selectedRoom}
+      setSelectedRoom={setSelectedRoom}
+      randomlyAssign={randomlyAssign}
+      resetRooms={resetRooms}
+      users={users}
+      currentSlidePrefix={currentSlidePrefix}
+      presentations={presentations}
+      roomPresentations={roomPresentations}
+      setRoomPresentations={setRoomPresentations}
+      getRoomPresentation={getRoomPresentation}
+      currentPresentation={currentPresentation}
+      isUpdate={isUpdate}
+    />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -84,7 +84,6 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const container = (
     <Container className="chat-message-toolbar" data-test="chatMessageToolbar">
       {showReplyButton && (
-      <>
         <Tooltip title={intl.formatMessage(intlMessages.replyTooltip)}>
           <EmojiButton
             aria-label={intl.formatMessage(intlMessages.reply, { 0: messageSequence })}
@@ -94,44 +93,43 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
             data-test="replyMessageButton"
           />
         </Tooltip>
-      </>
       )}
       {showReactionsButton && (
-      <Tooltip title={intl.formatMessage(intlMessages.reactTooltip)}>
-        <EmojiButton
-          aria-label={intl.formatMessage(intlMessages.reactTooltip)}
-          onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-            e.stopPropagation();
-            onReactionPopoverOpenChange(true);
-          }}
-          svgIcon="reactions"
-          color="light"
-          data-test="reactMessageButton"
-        />
-      </Tooltip>
+        <Tooltip title={intl.formatMessage(intlMessages.reactTooltip)}>
+          <EmojiButton
+            aria-label={intl.formatMessage(intlMessages.reactTooltip)}
+            onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+              e.stopPropagation();
+              onReactionPopoverOpenChange(true);
+            }}
+            svgIcon="reactions"
+            color="light"
+            data-test="reactMessageButton"
+          />
+        </Tooltip>
       )}
       {showDivider && <Divider role="separator" />}
       {showEditButton && (
-      <Tooltip title={intl.formatMessage(intlMessages.editTooltip)}>
-        <EmojiButton
-          aria-label={intl.formatMessage(intlMessages.editTooltip)}
-          onClick={onEdit}
-          icon="pen_tool"
-          color="light"
-          data-test="editMessageButton"
-        />
-      </Tooltip>
+        <Tooltip title={intl.formatMessage(intlMessages.editTooltip)}>
+          <EmojiButton
+            aria-label={intl.formatMessage(intlMessages.editTooltip)}
+            onClick={onEdit}
+            icon="pen_tool"
+            color="light"
+            data-test="editMessageButton"
+          />
+        </Tooltip>
       )}
       {showDeleteButton && (
-      <Tooltip title={intl.formatMessage(intlMessages.deleteTooltip)}>
-        <EmojiButton
-          aria-label={intl.formatMessage(intlMessages.deleteTooltip)}
-          onClick={onDelete}
-          icon="delete"
-          color="light"
-          data-test="deleteMessageButton"
-        />
-      </Tooltip>
+        <Tooltip title={intl.formatMessage(intlMessages.deleteTooltip)}>
+          <EmojiButton
+            aria-label={intl.formatMessage(intlMessages.deleteTooltip)}
+            onClick={onDelete}
+            icon="delete"
+            color="light"
+            data-test="deleteMessageButton"
+          />
+        </Tooltip>
       )}
     </Container>
   );

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/component.tsx
@@ -82,7 +82,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   return (
     (
       <Styled.UserListColumn
-      // @ts-ignore
+        // @ts-ignore
         onKeyDown={rove}
         tabIndex={0}
         role="list"
@@ -135,11 +135,9 @@ const UserListParticipantsContainer: React.FC = () => {
   const count = countData?.user_aggregate?.aggregate?.count || 0;
 
   return (
-    <>
-      <UserListParticipants
-        count={count ?? 0}
-      />
-    </>
+    <UserListParticipants
+      count={count ?? 0}
+    />
   );
 };
 


### PR DESCRIPTION

### What does this PR do?
removes React fragments with only one child that were caught in sonar cloud alerts


### Motivation
React fragments are a feature in React that allows you to group multiple elements together without adding an extra DOM element. They are a way to return multiple elements from a component's render method without requiring a wrapping parent element.

However, a fragment is redundant if it contains only one child, or if it is the child of an HTML element.
