### PR TITLE
chore: Bump docusaurus to 3.7.0

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,10 @@
       "name": "bigbluebutton-docs",
       "version": "0.0.1",
       "dependencies": {
-        "@docusaurus/core": "^3.3.2",
-        "@docusaurus/plugin-client-redirects": "^3.3.2",
-        "@docusaurus/preset-classic": "^3.5.0",
+        "@docusaurus/core": "^3.7.0",
+        "@docusaurus/plugin-client-redirects": "^3.7.0",
+        "@docusaurus/plugin-content-blog": "^3.7.0",
+        "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
         "@easyops-cn/docusaurus-search-local": "^0.40.1",
         "@mdx-js/react": "^3.0.0",
@@ -3169,63 +3170,6 @@
         "node": ">=18.0"
       }
     },
-    "node_modules/@docusaurus/babel/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/babel/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/babel/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/@docusaurus/bundler": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.7.0.tgz",
@@ -3279,63 +3223,6 @@
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.4.38",
         "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/bundler/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3424,77 +3311,53 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
+      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "@docusaurus/babel": "3.7.0",
+        "@docusaurus/bundler": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/mdx-loader": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
         "cli-table3": "^0.6.3",
         "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
         "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
         "del": "^6.1.1",
         "detect-port": "^1.5.1",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
         "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
+        "html-webpack-plugin": "^5.6.0",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
         "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.3.4",
         "react-router-config": "^5.1.1",
         "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
         "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
+        "serve-handler": "^6.1.6",
         "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
         "tslib": "^2.6.0",
         "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
+        "webpack": "^5.95.0",
+        "webpack-bundle-analyzer": "^4.10.2",
+        "webpack-dev-server": "^4.15.2",
+        "webpack-merge": "^6.0.1"
       },
       "bin": {
         "docusaurus": "bin/docusaurus.mjs"
@@ -3503,25 +3366,29 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@mdx-js/react": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.3.2",
+    "node_modules/@docusaurus/core/node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
       "license": "MIT",
       "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
+      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3532,12 +3399,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
+      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3564,8 +3433,8 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
@@ -3588,14 +3457,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.7.0.tgz",
+      "integrity": "sha512-6B4XAtE5ZVKOyhPgpgMkb7LwCkN+Hgd4vOnlbwR8nCdTQhLjz8MHbGlwwvZ/cay2SPNRX5KssqKAlcHVZP2m8g==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.7.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/utils-validation": "3.7.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3605,8 +3476,8 @@
         "node": ">=18.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
@@ -3643,196 +3514,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
@@ -3865,196 +3546,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.7.0.tgz",
@@ -4078,196 +3569,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-debug": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.7.0.tgz",
@@ -4289,196 +3590,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.7.0.tgz",
@@ -4496,196 +3607,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
@@ -4708,196 +3629,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.7.0.tgz",
@@ -4915,196 +3646,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
@@ -5131,196 +3672,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-svgr": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.7.0.tgz",
@@ -5342,196 +3693,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/preset-classic": {
@@ -5561,196 +3722,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic": {
@@ -5794,196 +3765,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.7.0.tgz",
@@ -6012,121 +3793,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/@docusaurus/theme-mermaid": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.7.0.tgz",
@@ -6147,196 +3813,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-mermaid/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
@@ -6368,196 +3844,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^4.15.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/webpack-merge": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
-      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@docusaurus/theme-translations": {
@@ -6595,12 +3881,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
+      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@svgr/webpack": "^8.1.0",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/types": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
@@ -6616,47 +3904,39 @@
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
+      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
       "license": "MIT",
       "dependencies": {
+        "@docusaurus/types": "3.7.0",
         "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.3.2",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
+      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.7.0",
+        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/utils-common": "3.7.0",
+        "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -9100,10 +6380,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/consola": {
-      "version": "2.15.3",
-      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.2",
@@ -18036,10 +15312,6 @@
         "points-on-path": "^0.2.1"
       }
     },
-    "node_modules/rtl-detect": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/rtlcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -19798,22 +17070,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpackbar": {
-      "version": "5.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "consola": "^2.15.3",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
       }
     },
     "node_modules/websocket-driver": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,10 @@
     "serve": "npx docusaurus serve"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.3.2",
-    "@docusaurus/plugin-client-redirects": "^3.3.2",
-    "@docusaurus/preset-classic": "^3.5.0",
+    "@docusaurus/core": "^3.7.0",
+    "@docusaurus/plugin-client-redirects": "^3.7.0",
+    "@docusaurus/plugin-content-blog": "^3.7.0",
+    "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",
     "@easyops-cn/docusaurus-search-local": "^0.40.1",
     "@mdx-js/react": "^3.0.0",


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Updates Docusaurus to 3.7.0

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Seems we bumped some portion of the docusaurus libs to newer versions and the discrepancy caused some docs building issues. Here we set them all to 3.7.0.
