### PR TITLE
perf (gql-server): Improve breakout room query efficiency via table pre-population (`breakoutRoom_user`)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
@@ -59,7 +59,7 @@ trait ChangeUserBreakoutReqMsgHdlr extends RightsManagementTrait {
         )
 
         //Update database
-        BreakoutRoomUserDAO.updateRoomChanged(
+        BreakoutRoomUserDAO.updateUserMovedToRoom(
           meetingId,
           msg.body.userId,
           msg.body.fromBreakoutId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -178,6 +178,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
     for {
       breakoutModel <- state.breakout
       if breakoutModel.rooms.exists(r => r._2.freeJoin)
+      if regUser.role != Roles.MODERATOR_ROLE || breakoutModel.sendInviteToModerators
     } yield {
       BreakoutRoomDAO.assignUserToRandomRoom(regUser.id, breakoutModel, liveMeeting)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs.UserJoinMeetingReqMsg
 import org.bigbluebutton.core.apps.breakout.BreakoutHdlrHelpers
-import org.bigbluebutton.core.db.{NotificationDAO, UserDAO, UserStateDAO}
+import org.bigbluebutton.core.db.{BreakoutRoomDAO, NotificationDAO, UserDAO, UserStateDAO}
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models._
@@ -42,12 +42,12 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
 
       validationResult.fold(
         reason => handleFailedUserJoin(msg, reason._1, reason._2),
-        validUser => handleSuccessfulUserJoin(msg, validUser)
+        validUser => handleSuccessfulUserJoin(msg, validUser, state)
       )
     }
   }
 
-  private def handleSuccessfulUserJoin(msg: UserJoinMeetingReqMsg, regUser: RegisteredUser) = {
+  private def handleSuccessfulUserJoin(msg: UserJoinMeetingReqMsg, regUser: RegisteredUser, state: MeetingState2x) = {
     val newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, msg.body.clientIsMobile, liveMeeting, state)
     updateParentMeetingWithNewListOfUsers()
     notifyPreviousUsersWithSameExtId(regUser)
@@ -57,6 +57,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
     forceUserGraphqlReconnection(newRegUser)
     updateGraphqlDatabase(newRegUser)
     generateLivekitToken(newRegUser, liveMeeting)
+    addBreakoutRoomsForLateUser(newRegUser, liveMeeting, state)
 
     newState
   }
@@ -170,6 +171,15 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
         metadata
       )
       outGW.send(generateLiveKitTokenReqMsg)
+    }
+  }
+
+  private def addBreakoutRoomsForLateUser(regUser: RegisteredUser, liveMeeting: LiveMeeting, state: MeetingState2x): Unit = {
+    for {
+      breakoutModel <- state.breakout
+      if breakoutModel.rooms.exists(r => r._2.freeJoin)
+    } yield {
+      BreakoutRoomDAO.assignUserToRandomRoom(regUser.id, breakoutModel, liveMeeting)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -84,7 +84,8 @@ object BreakoutRoomDAO {
 
       val nonAssignedUsers = Users2x.findAll(liveMeeting.users2x)
         .filterNot(user => assignedUsers.contains(user.intId))
-        .filterNot(user => user.role == Roles.MODERATOR_ROLE)
+        .filterNot(user => user.presenter)
+        .filter(user => user.role != Roles.MODERATOR_ROLE || breakout.sendInviteToModerators)
         .map(_.intId)
 
       val roomsSeq = breakout.rooms.values.toSeq

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -103,14 +103,26 @@ object BreakoutRoomDAO {
 
     //Insert all rooms that is visible for users
     BreakoutRoomUserDAO.refreshBreakoutRoomsVisibleForUsers(liveMeeting.props.meetingProp.intId)
-
   }
 
-  //  def update(room: BreakoutRoom2x) = {
-  //    DatabaseConnection.enqueue(
-  //      prepareInsertOrUpdate(room)
-  //    )
-  //  }
+  def assignUserToRandomRoom(userId: String, breakout: BreakoutModel, liveMeeting: LiveMeeting): Unit = {
+    if(breakout.rooms.values.nonEmpty) {
+      val roomsSeq = breakout.rooms.values.toSeq
+      val randomIndex = Random.nextInt(roomsSeq.length)
+
+      for {
+        room <- Some(roomsSeq(randomIndex))
+        (redirectToHtml5JoinURL, redirectJoinURL) <- BreakoutHdlrHelpers.getRedirectUrls(liveMeeting, userId, room.externalId, room.sequence.toString())
+      } yield {
+        DatabaseConnection.enqueue(
+          BreakoutRoomUserDAO.prepareInsert(room.id, liveMeeting.props.meetingProp.intId, userId, redirectToHtml5JoinURL, wasAssignedByMod = true)
+        )
+
+        //Insert all rooms that is visible for users
+        BreakoutRoomUserDAO.refreshBreakoutRoomsVisibleForUsers(liveMeeting.props.meetingProp.intId, userId)
+      }
+    }
+  }
 
   def prepareInsertOrUpdate(room: BreakoutRoom2x, durationInSeconds: Int, sendInvitationToModerators: Boolean, createdAt: java.sql.Timestamp) = {
     TableQuery[BreakoutRoomDbTableDef].insertOrUpdate(
@@ -133,36 +145,6 @@ object BreakoutRoomDAO {
       )
     )
   }
-
-  //  def update(breakout: BreakoutModel): Unit = {
-  //    for (room <- breakout.rooms) {
-  //      insert(room._2)
-  //    }
-  //  }
-  //
-  //  def insert(room : BreakoutRoom2x) = {
-  //    DatabaseConnection.db.run(
-  //      TableQuery[BreakoutRoomDbTableDef].insertOrUpdate(
-  //        BreakoutRoomDbModel(
-  //          breakoutRoomId = room.id,
-  //          parentMeetingId = room.parentId,
-  //          externalId = room.externalId,
-  //          sequence = room.sequence,
-  //          name = room.name,
-  //          shortName = room.shortName,
-  //          isDefaultName = room.isDefaultName,
-  //          freeJoin = room.freeJoin,
-  //          startedOn = room.startedOn.getOrElse(0),
-  //          durationInSeconds = 0,
-  //          captureNotes = room.captureNotes,
-  //          captureSlides = room.captureSlides,
-  //        )
-  //      )
-  //    ).onComplete {
-  //        case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) inserted on BreakoutRoom table!")
-  //        case Failure(e)            => DatabaseConnection.logger.debug(s"Error inserting BreakoutRoom: $e")
-  //      }
-  //  }
 
   def deletePermanently(meetingId: String) = {
     DatabaseConnection.enqueue(
@@ -201,17 +183,4 @@ object BreakoutRoomDAO {
         .update(newDurationInSeconds)
     )
   }
-
-  //  def update(meetingId: String, breakoutRoomModel: BreakoutRoomModel) = {
-  //    DatabaseConnection.db.run(
-  //      TableQuery[BreakoutRoomDbTableDef]
-  //        .filter(_.meetingId === meetingId)
-  //        .map(t => (t.stopwatch, t.running, t.active, t.time, t.accumulated, t.startedAt, t.endedAt, t.songTrack))
-  //        .update((isStopwatch(breakoutRoomModel), getRunning(breakoutRoomModel), getIsACtive(breakoutRoomModel), getTime(breakoutRoomModel), getAccumulated(breakoutRoomModel), getStartedAt(breakoutRoomModel), getEndedAt(breakoutRoomModel), getTrack(breakoutRoomModel))
-  //        )
-  //    ).onComplete {
-  //      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated on BreakoutRoom table!")
-  //      case Failure(e) => DatabaseConnection.logger.debug(s"Error updating BreakoutRoom: $e")
-  //    }
-  //  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -100,6 +100,10 @@ object BreakoutRoomDAO {
         }
       ).transactionally)
     }
+
+    //Insert all rooms that is visible for users
+    BreakoutRoomUserDAO.refreshBreakoutRoomsVisibleForUsers(liveMeeting.props.meetingProp.intId)
+
   }
 
   //  def update(room: BreakoutRoom2x) = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -25,7 +25,6 @@ class BreakoutRoomUserDbTableDef(tag: Tag) extends Table[BreakoutRoomUserDbModel
 }
 
 object BreakoutRoomUserDAO {
-
   def prepareInsert(breakoutRoomId: String, meetingId: String, userId: String, joinURL: String, wasAssignedByMod: Boolean) = {
     TableQuery[BreakoutRoomUserDbTableDef].insertOrUpdate(
       BreakoutRoomUserDbModel(
@@ -42,37 +41,16 @@ object BreakoutRoomUserDAO {
     )
   }
 
-  def prepareDelete(breakoutRoomId: String, meetingId: String, userId: String, exceptBreakoutRooomId: String) = {
-    var query = TableQuery[BreakoutRoomUserDbTableDef]
-                .filter(_.meetingId === meetingId)
-                .filter(_.userId === userId)
-
-    //Sometimes the user is moved before he joined in any room, in this case remove all assignments
-    if (breakoutRoomId.nonEmpty) {
-      query = query.filter(_.breakoutRoomId === breakoutRoomId)
-    }
-
-    if (exceptBreakoutRooomId.nonEmpty) {
-      query = query.filter(_.breakoutRoomId =!= exceptBreakoutRooomId)
-    }
-
-    query.delete
-  }
-
-  def updateRoomChanged(meetingId: String, userId: String, fromBreakoutRoomId: String,
+  def updateUserMovedToRoom(meetingId: String, userId: String, fromBreakoutRoomId: String,
                         toBreakoutRoomId: String, joinUrl: String, removePreviousRoom: Boolean) = {
     DatabaseConnection.enqueue(
-      if (removePreviousRoom) {
-        DBIO.seq(
-          BreakoutRoomUserDAO.prepareDelete(fromBreakoutRoomId, meetingId, userId, exceptBreakoutRooomId = toBreakoutRoomId),
-          BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)
-        )
-      } else {
-        DBIO.seq(
-          BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)
-        )
-      }
+      DBIO.seq(
+        BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)
+      )
     )
+
+    //it will remove previous rooms if necessary
+    this.refreshBreakoutRoomsVisibleForUsers(meetingId, userId)
   }
 
   def updateUserJoined(meetingId: String, usersInRoom: Vector[String], breakoutRoom: BreakoutRoom2x) = {
@@ -98,7 +76,6 @@ object BreakoutRoomUserDAO {
       }
   }
 
-
   def updateInviteDismissedAt(meetingId: String, userId: String) = {
     DatabaseConnection.enqueue(
       TableQuery[BreakoutRoomUserDbTableDef]
@@ -109,18 +86,42 @@ object BreakoutRoomUserDAO {
     )
   }
 
-//  def updateUserJoined(meetingId: String, userId: String, breakoutRoomId: String) = {
-//    DatabaseConnection.db.run(
-//      TableQuery[BreakoutRoomUserDbTableDef]
-//        .filter(_.breakoutRoomId === breakoutRoomId)
-//        .filter(_.meetingId === meetingId)
-//        .filter(_.userId === userId)
-//        .map(u => u.joinedAt)
-//        .update(Some(new java.sql.Timestamp(System.currentTimeMillis())))
-//    ).onComplete {
-//      case Success(rowsAffected) => DatabaseConnection.logger.debug(s"$rowsAffected row(s) updated joinedAt on breakoutRoom_user table!")
-//      case Failure(e) => DatabaseConnection.logger.error(s"Error updating joinedAt breakoutRoom_user: $e")
-//    }
-//  }
+  def refreshBreakoutRoomsVisibleForUsers(meetingId: String, userId: String = "") = {
+    val userCriteria: String = {
+      if (userId.nonEmpty) {
+        s"""AND u."userId" = '${userId}'"""
+      } else {
+        ""
+      }
+    }
 
+    //Insert all rooms visible to the user into "breakoutRoom_user", as it will improve performance
+    //Also remove all rooms that is visible to the user but should no longer be visible
+    DatabaseConnection.enqueue(
+      sqlu"""
+        INSERT INTO "breakoutRoom_user" ("breakoutRoomId", "meetingId", "userId")
+        SELECT b."breakoutRoomId", u."meetingId", u."userId"
+        FROM "user" u
+        JOIN "breakoutRoom" b ON b."parentMeetingId" = u."meetingId"
+        WHERE u."meetingId" = ${meetingId} #${userCriteria}
+        AND ( b."freeJoin" IS TRUE OR u."role" = 'MODERATOR')
+        AND b."endedAt" IS NULL
+        ON CONFLICT ("breakoutRoomId", "meetingId", "userId") DO NOTHING;
+
+        DELETE FROM "breakoutRoom_user"
+            WHERE ("breakoutRoomId", "meetingId", "userId")
+            IN (
+                select bu."breakoutRoomId", bu."meetingId", bu."userId"
+                from "breakoutRoom_user" bu
+                join "breakoutRoom" b using("breakoutRoomId")
+                join "user" u using("userId")
+                where u."meetingId" = ${meetingId} #${userCriteria}
+                and bu."isLastAssignedRoom" is false
+                and b."freeJoin" is not true
+                and u."isModerator" is not true
+            )
+        """
+    )
+
+    }
 }

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2006,7 +2006,7 @@ CREATE OR REPLACE VIEW "v_breakoutRoom" AS
 SELECT bu."meetingId" as "userMeetingId", bu."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin",
             b."sequence", b."name", b."isDefaultName",
             b."shortName", b."startedAt", b."endedAt", b."durationInSeconds", b."sendInvitationToModerators",
-            bu."assignedAt", bu."joinURL", bu."inviteDismissedAt", true as "isModerator",
+            bu."assignedAt", bu."joinURL", bu."inviteDismissedAt",
             bu."isLastAssignedRoom", bu."isLastJoinedRoom", bu."isUserCurrentlyInRoom", bu."showInvitation",
             bu."joinedAt" is not null as "hasJoined"
     FROM "breakoutRoom_user" bu

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1866,6 +1866,8 @@ CREATE UNLOGGED TABLE "breakoutRoom" (
 );
 
 CREATE INDEX "idx_breakoutRoom_parentMeetingId" ON "breakoutRoom"("parentMeetingId", "externalId");
+CREATE INDEX "idx_breakoutRoom_pk_ended" ON "breakoutRoom"("breakoutRoomId") where "endedAt" is null;
+
 
 CREATE UNLOGGED TABLE "breakoutRoom_user" (
 	"breakoutRoomId" varchar(100) NOT NULL REFERENCES "breakoutRoom"("breakoutRoomId") ON DELETE CASCADE,
@@ -1878,12 +1880,14 @@ CREATE UNLOGGED TABLE "breakoutRoom_user" (
 	"userJoinedSomeRoomAt" timestamp with time zone,
 	"isLastAssignedRoom" boolean,
 	"isLastJoinedRoom" boolean,
-	"isUserCurrentlyInRoom" boolean,
+	"isUserCurrentlyInRoom" boolean not null default false,
 	CONSTRAINT "breakoutRoom_user_pkey" PRIMARY KEY ("breakoutRoomId", "meetingId", "userId"),
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 create index "idx_breakoutRoom_user_meeting_user" on "breakoutRoom_user" ("meetingId", "userId");
 create index "idx_breakoutRoom_user_user_meeting" on "breakoutRoom_user" ("userId", "meetingId");
+create index "idx_breakoutRoom_user_meeting_user_assigned" on "breakoutRoom_user" ("meetingId", "userId") where "assignedAt" is not null;
+create index "idx_breakoutRoom_user_meeting_user_currentlyInRoom" on "breakoutRoom_user" ("meetingId", "userId") where "isUserCurrentlyInRoom" is true;
 
 ALTER TABLE "breakoutRoom_user" ADD COLUMN "showInvitation" boolean GENERATED ALWAYS AS (
     CASE WHEN
@@ -1896,6 +1900,8 @@ ALTER TABLE "breakoutRoom_user" ADD COLUMN "showInvitation" boolean GENERATED AL
         ELSE false
         END) STORED;
        --AND ("isModerator" is false OR "sendInvitationToModerators")
+
+create index "idx_breakoutRoom_user_meeting_user_invitation" on "breakoutRoom_user" ("meetingId", "userId") where "showInvitation" is true;
 
 --Trigger to populate `isLastAssignedRoom` and `isLastJoinedRoom`
 CREATE OR REPLACE FUNCTION "ins_upd_del_breakoutRoom_user_trigger_func"() RETURNS TRIGGER AS $$
@@ -1997,19 +2003,16 @@ CREATE TRIGGER "update_bkroom_isUserCurrentlyInRoom_trigger" AFTER UPDATE OF "cu
     FOR EACH ROW EXECUTE FUNCTION "update_bkroom_isUserCurrentlyInRoom_trigger_func"();
 
 CREATE OR REPLACE VIEW "v_breakoutRoom" AS
-SELECT u."meetingId" as "userMeetingId", u."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin",
+SELECT bu."meetingId" as "userMeetingId", bu."userId", b."parentMeetingId", b."breakoutRoomId", b."freeJoin",
             b."sequence", b."name", b."isDefaultName",
             b."shortName", b."startedAt", b."endedAt", b."durationInSeconds", b."sendInvitationToModerators",
-            bu."assignedAt", bu."joinURL", bu."inviteDismissedAt", u."role" = 'MODERATOR' as "isModerator",
+            bu."assignedAt", bu."joinURL", bu."inviteDismissedAt", true as "isModerator",
             bu."isLastAssignedRoom", bu."isLastJoinedRoom", bu."isUserCurrentlyInRoom", bu."showInvitation",
             bu."joinedAt" is not null as "hasJoined"
-    FROM "user" u
-    JOIN "breakoutRoom" b ON b."parentMeetingId" = u."meetingId"
-    LEFT JOIN "breakoutRoom_user" bu ON bu."meetingId" = u."meetingId" AND bu."userId" = u."userId" AND bu."breakoutRoomId" = b."breakoutRoomId"
-    WHERE (bu."assignedAt" IS NOT NULL
-            OR b."freeJoin" IS TRUE
-            OR u."role" = 'MODERATOR')
-    AND b."endedAt" IS NULL;
+    FROM "breakoutRoom_user" bu
+    JOIN "breakoutRoom" b ON b."breakoutRoomId" = bu."breakoutRoomId" and b."endedAt" IS NULL
+    --JOIN  bu ON bu."meetingId" = u."meetingId" AND bu."userId" = u."userId" AND bu."breakoutRoomId" = b."breakoutRoomId"
+    ;
 
 --view used to restore last breakout rooms
 CREATE OR REPLACE VIEW "v_breakoutRoom_createdLatest" AS
@@ -2027,7 +2030,7 @@ SELECT "parentMeetingId", "breakoutRoomId", "userMeetingId", "userId"
 FROM "v_breakoutRoom"
 WHERE "assignedAt" IS NOT NULL;
 
---TODO improve performance (and handle two users with same extId)
+
 CREATE OR REPLACE VIEW "v_breakoutRoom_participant" as
 SELECT DISTINCT
         "parentMeetingId",
@@ -2043,10 +2046,14 @@ select parent_user."meetingId" as "parentMeetingId",
         parent_user."meetingId" as "userMeetingId",
         parent_user."userId",
         true as "isAudioOnly"
-from "user" bk_user
-join "user" parent_user on parent_user."userId" = bk_user."userId" and parent_user."transferredFromParentMeeting" is false
-where bk_user."transferredFromParentMeeting" is true
-and bk_user."loggedOut" is false;
+from "user" parent_user
+join "user" bk_user on parent_user."userId" = bk_user."userId"
+                    and bk_user."transferredFromParentMeeting" is true
+                    and bk_user."currentlyInMeeting" is true
+where parent_user."transferredFromParentMeeting" is false;
+
+create index on "user"("userId") where "transferredFromParentMeeting" is true and "currentlyInMeeting" is true;
+create index on "user"("meetingId") where "transferredFromParentMeeting" is false;
 
 --SELECT DISTINCT br."parentMeetingId", br."breakoutRoomId", "user"."meetingId", "user"."userId"
 --FROM v_user "user"
@@ -2055,6 +2062,7 @@ and bk_user."loggedOut" is false;
 --JOIN "breakoutRoom" br ON br."parentMeetingId" = vmbp."parentId" AND br."externalId" = m."extId";
 
 --User to update "inviteDismissedAt" via Mutation
+--TODO check if it is being used
 CREATE OR REPLACE VIEW "v_breakoutRoom_user" AS
 SELECT bu.*
 FROM "breakoutRoom_user" bu

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
@@ -96,7 +96,7 @@ export const getBreakoutCount = gql`
 `;
 
 export const getLastBreakouts = gql`
-  query {
+  query getLastBreakouts {
     user {
       lastBreakoutRoom {
         breakoutRoomId


### PR DESCRIPTION
This PR simplifies the `v_breakoutRoom` view by changing how data is populated in the `breakoutRoom_user` table.

**Before:**
Only the breakout rooms explicitly assigned to a user were inserted into the `breakoutRoom_user` table. All other visible rooms were resolved dynamically via the `v_breakoutRoom` view. Since all users subscribed to a subscription that queried this view, the cost became too high.

**Now:**
All rooms visible to a user are inserted into the `breakoutRoom_user` table ahead of time. This allows the database to serve user-specific room data more efficiently, reducing reliance on dynamic view logic.

**Fixes:**
- Late joiners (users who enter after breakout rooms are created) will now also have the appropriate room entries inserted. This resolves issue #23077.
- Moderators will now receive invitation when it's checked "free join" and "send invitation to mods". Fix #23081