### PR TITLE
fix (gql-server): Showing invitation forever when user joined in a different room instead of the assigned one

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/ChangeUserBreakoutReqMsgHdlr.scala
@@ -38,14 +38,11 @@ trait ChangeUserBreakoutReqMsgHdlr extends RightsManagementTrait {
           })
         }
 
-        val isSameRoom = msg.body.fromBreakoutId == msg.body.toBreakoutId
-        val removePreviousRoomFromDb = !breakoutModel.rooms.exists(r => r._2.freeJoin) && !isSameRoom
-
         //Get join URL for room To
         val redirectToHtml5JoinURL = (
             for {
               roomTo <- breakoutModel.rooms.get(msg.body.toBreakoutId)
-              (redirectToHtml5JoinURL, redirectJoinURL) <- getRedirectUrls(liveMeeting, msg.body.userId, roomTo.externalId, roomTo.sequence.toString())
+              (redirectToHtml5JoinURL, redirectJoinURL) <- getRedirectUrls(liveMeeting, msg.body.userId, roomTo.externalId, roomTo.sequence.toString)
             } yield redirectToHtml5JoinURL
           ).getOrElse("")
 
@@ -62,10 +59,8 @@ trait ChangeUserBreakoutReqMsgHdlr extends RightsManagementTrait {
         BreakoutRoomUserDAO.updateUserMovedToRoom(
           meetingId,
           msg.body.userId,
-          msg.body.fromBreakoutId,
           msg.body.toBreakoutId,
-          redirectToHtml5JoinURL,
-          removePreviousRoomFromDb)
+          redirectToHtml5JoinURL)
 
         //Send notification to moved User
         for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -177,10 +177,8 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
   private def addBreakoutRoomsForLateUser(regUser: RegisteredUser, liveMeeting: LiveMeeting, state: MeetingState2x): Unit = {
     for {
       breakoutModel <- state.breakout
-      if breakoutModel.rooms.exists(r => r._2.freeJoin)
-      if regUser.role != Roles.MODERATOR_ROLE || breakoutModel.sendInviteToModerators
     } yield {
-      BreakoutRoomDAO.assignUserToRandomRoom(regUser.id, breakoutModel, liveMeeting)
+      BreakoutRoomDAO.assignUserToRandomRoom(regUser, breakoutModel, liveMeeting)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -61,8 +61,7 @@ object BreakoutRoomUserDAO {
                 "joinedAt" = current_timestamp
                 WHERE "meetingId" = ${meetingId}
                 AND "userId" = ${userInRoom}
-                AND "breakoutRoomId" = ${breakoutRoom.id}
-                AND "joinedAt" is null"""
+                AND "breakoutRoomId" = ${breakoutRoom.id}"""
       )
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -41,8 +41,7 @@ object BreakoutRoomUserDAO {
     )
   }
 
-  def updateUserMovedToRoom(meetingId: String, userId: String, fromBreakoutRoomId: String,
-                        toBreakoutRoomId: String, joinUrl: String, removePreviousRoom: Boolean) = {
+  def updateUserMovedToRoom(meetingId: String, userId: String, toBreakoutRoomId: String, joinUrl: String) = {
     DatabaseConnection.enqueue(
       DBIO.seq(
         BreakoutRoomUserDAO.prepareInsert(toBreakoutRoomId, meetingId, userId, joinUrl, wasAssignedByMod = true)

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1968,7 +1968,7 @@ BEGIN
        update "breakoutRoom_user" set "userJoinedSomeRoomAt" = "latestJoinedAt"
           where "breakoutRoom_user"."meetingId" = meetingId
           and "breakoutRoom_user"."userId" = userId
-          and "breakoutRoom_user"."userJoinedSomeRoomAt" != "latestJoinedAt";
+          and "breakoutRoom_user"."userJoinedSomeRoomAt" is distinct from "latestJoinedAt";
 END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
Improvements on top of #23116.

Also fixes #23072 — the issue occurred because the `userJoinedSomeRoomAt` column was not being populated correctly.


https://github.com/user-attachments/assets/38eb125a-d9a8-4803-82b7-a8add2658cb6

