### PR TITLE
fix (bbb-web): Check if meeting exists before download/upload presentation cache

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationConversionCompletionService.java
@@ -105,7 +105,7 @@ public class PresentationConversionCompletionService {
             try {
                 String remoteFileName = p.pres.getUploadedFileHash() + ".tar.gz";
                 Meeting meeting = ServiceUtils.findMeetingFromMeetingID(meetingId);
-                if(meeting.isPresentationConversionCacheEnabled() && !s3FileManager.exists(remoteFileName)) {
+                if(meeting != null && meeting.isPresentationConversionCacheEnabled() && !s3FileManager.exists(remoteFileName)) {
                     File parentDir = new File(p.pres.getUploadedFile().getParent());
                     File compressedFile = TarGzManager.compress(
                             parentDir.getAbsolutePath(),

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
@@ -65,7 +65,7 @@ public class PresentationFileProcessor {
             pres.setUploadedFileHash(s3FileManager.generateHash(pres.getUploadedFile()));
             String remoteFileName = pres.getUploadedFileHash() + ".tar.gz";
             Meeting meeting = ServiceUtils.findMeetingFromMeetingID(meetingId);
-            if(meeting.isPresentationConversionCacheEnabled() && s3FileManager.exists(remoteFileName)) {
+            if(meeting != null && meeting.isPresentationConversionCacheEnabled() && s3FileManager.exists(remoteFileName)) {
                 S3Object s3Object = s3FileManager.download(remoteFileName);
                 File parentDir = new File(pres.getUploadedFile().getParent());
                 TarGzManager.decompress(s3Object, parentDir.getAbsolutePath());


### PR DESCRIPTION
Avoid error:
```
ERROR o.b.p.imp.PresentationFileProcessor - Error while downloading presentations outputs from cache: Cannot invoke "org.bigbluebutton.api.domain.Meeting.isPresentationConversionCacheEnabled()" because "<local4>" is null
``` 

It could happen when the meeting is ended before the upload was processed.