### PR TITLE
Fix(html5): External video playback rate unsync

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -242,6 +242,17 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     return 0;
   }, []);
 
+  const getPlaybackRate = useCallback((player: ReactPlayer) => {
+    if (player) {
+      const internalPlayer = player.getInternalPlayer();
+      if (internalPlayer instanceof HTMLVideoElement) {
+        return internalPlayer.playbackRate;
+      }
+      return internalPlayer?.getPlaybackRate?.() ?? 1;
+    }
+    return 1;
+  }, []);
+
   useEffect(() => {
     const storedVolume = storage.getItem('externalVideoVolume');
     if (storedVolume) {
@@ -393,6 +404,14 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     setLoaded(state.loaded);
     if (playing && isPresenter) {
       currentTime = getPlayerCurrentTime(playerRef.current as ReactPlayer);
+    }
+    const interPlayerPlaybackRate = getPlaybackRate(playerRef.current as ReactPlayer);
+    if (isPresenter && playing && interPlayerPlaybackRate !== playerPlaybackRate) {
+      sendMessage('seek', {
+        rate: interPlayerPlaybackRate,
+        time: currentTime,
+        state: 'playing',
+      });
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -406,11 +406,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       currentTime = getPlayerCurrentTime(playerRef.current as ReactPlayer);
     }
     const interPlayerPlaybackRate = getPlaybackRate(playerRef.current as ReactPlayer);
-    if (isPresenter && playing && interPlayerPlaybackRate !== playerPlaybackRate) {
+    if (isPresenter && interPlayerPlaybackRate !== playerPlaybackRate) {
       sendMessage('seek', {
         rate: interPlayerPlaybackRate,
         time: currentTime,
-        state: 'playing',
+        state: playing ? 'playing' : '',
       });
     }
   };
@@ -446,7 +446,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       sendMessage('playbackRateChange', {
         rate,
         time: getCurrentTime(),
-        state: playing ? 'playing' : 'paused',
+        state: playing ? 'playing' : '',
       });
     }
   };

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.ts
@@ -24,7 +24,7 @@ const getPlayingState = (state: number) => {
 
 const calculateCurrentTime = (timeSync: number, externalVideoProps?: ExternalVideo) => {
   const playerCurrentTime = externalVideoProps?.playerCurrentTime ?? 0;
-  const playerPlaybackRate = externalVideoProps?.playerPlaybackRate ?? 1;
+
   const playerUpdatedAt = externalVideoProps?.updatedAt ?? Date.now();
   const playerUpdatedAtDate = new Date(playerUpdatedAt);
   const currentDate = new Date(Date.now() + (timeSync ?? 0));
@@ -32,7 +32,7 @@ const calculateCurrentTime = (timeSync: number, externalVideoProps?: ExternalVid
   const currentTime = isPaused
     ? playerCurrentTime
     : ((currentDate.getTime() - playerUpdatedAtDate.getTime()) / 1000)
-      + (playerCurrentTime) * playerPlaybackRate;
+    + (playerCurrentTime);
 
   return currentTime;
 };


### PR DESCRIPTION
### What does this PR do?
This PR resolves the issue of desynchronized players when the playback rate differs from 1. The problem occurred because the playback rate was not being sent to the server, preventing other clients from being aware of the rate change and leading to playback inconsistencies.

### Closes Issue(s)
Closes #23109

### How to test
- Join Two users.
- Share an external video as presenter.
- Change the playback rate as presenter.
- See it synced.

### More
[Screencast from 07-05-2025 16:16:56.webm](https://github.com/user-attachments/assets/68b2c23e-3d13-4d00-be2e-0aac99cf2017)
