### PR TITLE
fix(html5): remove unnecessary unused imports

### DIFF
--- a/bigbluebutton-html5/client/meetingClient.jsx
+++ b/bigbluebutton-html5/client/meetingClient.jsx
@@ -22,7 +22,6 @@ import logger from '/imports/startup/client/logger';
 import '/imports/ui/services/mobile-app';
 import Base from '/imports/startup/client/base';
 import ContextProviders from '/imports/ui/components/context-providers/component';
-import ConnectionManager from '/imports/ui/components/connection-manager/component';
 // The adapter import is "unused" as far as static code is concerned, but it
 // needs to here to override global prototypes. So: don't remove it - prlanzarin 25 Apr 2022
 import adapter from 'webrtc-adapter';

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages } from 'react-intl';
-import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import ExternalVideoModal from '/imports/ui/components/external-video-player/external-video-player-graphql/modal/component';
 import LayoutModalContainer from '/imports/ui/components/layout/modal/container';
 import BBBMenu from '/imports/ui/components/common/menu/component';

--- a/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { toast } from 'react-toastify';
 import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
 

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
@@ -5,8 +5,6 @@ import ConnectionStatusModalComponent from '/imports/ui/components/connection-st
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 import Icon from '/imports/ui/components/connection-status/icon/component';
 import Styled from './styles';
-import Auth from '/imports/ui/services/auth';
-import deviceInfo, { isMobile } from '/imports/utils/deviceInfo';
 
 const intlMessages = defineMessages({
   label: {
@@ -28,7 +26,7 @@ class ConnectionStatusButton extends PureComponent {
   }
 
   renderIcon(level = 'normal') {
-    return(
+    return (
       <Styled.IconWrapper>
         <Icon
           level={level}
@@ -38,17 +36,17 @@ class ConnectionStatusButton extends PureComponent {
     );
   }
 
-  setModalIsOpen = (isOpen) => this.setState({ isModalOpen: isOpen }); 
+  setModalIsOpen = (isOpen) => this.setState({ isModalOpen: isOpen });
 
   renderModal(isModalOpen) {
     return (
       isModalOpen ?
-      <ConnectionStatusModalComponent
-        {...{
-          isModalOpen,
-          setModalIsOpen: this.setModalIsOpen,
-        }}
-      /> : null
+        <ConnectionStatusModalComponent
+          {...{
+            isModalOpen,
+            setModalIsOpen: this.setModalIsOpen,
+          }}
+        /> : null
     )
   }
 
@@ -72,7 +70,7 @@ class ConnectionStatusButton extends PureComponent {
             disabled
             ghost
             circle
-            onClick={() => {}}
+            onClick={() => { }}
             data-test="connectionStatusButton"
             isMobile={isMobile}
           />
@@ -112,7 +110,7 @@ class ConnectionStatusButton extends PureComponent {
           size="sm"
           color={color}
           circle
-          onClick={() => this.setState({isModalOpen: true})}
+          onClick={() => this.setState({ isModalOpen: true })}
           data-test="connectionStatusButton"
         />
         {this.renderModal(isModalOpen)}

--- a/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/button/component.jsx
@@ -5,6 +5,7 @@ import ConnectionStatusModalComponent from '/imports/ui/components/connection-st
 import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 import Icon from '/imports/ui/components/connection-status/icon/component';
 import Styled from './styles';
+import { isMobile } from '/imports/utils/deviceInfo';
 
 const intlMessages = defineMessages({
   label: {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/component.jsx
@@ -2,7 +2,6 @@ import React, { PureComponent } from 'react';
 import { FormattedTime, defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import UserAvatar from '/imports/ui/components/user-avatar/component';
-import CommonIcon from '/imports/ui/components/common/icon/component';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import Icon from '/imports/ui/components/connection-status/icon/component';
 import { getHelp } from '../service';

--- a/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/status-helper/component.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { useReactiveVar } from '@apollo/client';
 import Styled from './styles';
@@ -86,7 +86,7 @@ class ConnectionStatusIcon extends PureComponent {
           ? (
             <div>
               <Styled.Settings
-              // eslint-disable-next-line
+                // eslint-disable-next-line
                 onClick={this.openAdjustSettings.bind(this)}
                 role="button"
               >

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, Component } from 'react';
+import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 import Toggle from '/imports/ui/components/common/switch/component';
@@ -136,9 +136,9 @@ class LockViewersComponent extends Component {
     const { intl } = this.props;
     return (
       status && (
-      <Styled.ToggleLabel>
-        {intl.formatMessage(intlMessages.lockedLabel)}
-      </Styled.ToggleLabel>
+        <Styled.ToggleLabel>
+          {intl.formatMessage(intlMessages.lockedLabel)}
+        </Styled.ToggleLabel>
       )
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { defineMessages, injectIntl } from 'react-intl';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import { NavBarItemType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/nav-bar-item/enums';
@@ -170,15 +169,17 @@ class NavBar extends Component {
   }
 
   renderModal(isOpen, setIsOpen, priority, Component, otherOptions) {
-    return isOpen ? <Component
-      {...{
-        ...otherOptions,
-        onRequestClose: () => setIsOpen(false),
-        priority,
-        setIsOpen,
-        isOpen
-      }}
-    /> : null
+    return isOpen ? (
+      <Component
+        {...{
+          ...otherOptions,
+          onRequestClose: () => setIsOpen(false),
+          priority,
+          setIsOpen,
+          isOpen,
+        }}
+      />
+    ) : null;
   }
 
   componentDidMount() {
@@ -371,7 +372,7 @@ class NavBar extends Component {
                   tooltipplacement="right"
                   onClick={this.handleToggleUserList}
                   color={isPhone && isExpanded ? 'primary' : 'dark'}
-                  size='md'
+                  size="md"
                   circle
                   hideLabel
                   data-test={hasNotification ? 'hasUnreadMessages' : 'toggleUserList'}
@@ -403,7 +404,7 @@ class NavBar extends Component {
                   </span>
                 </Tooltip>
               </Styled.PresentationTitle>
-              {this.renderModal(isModalOpen, this.setModalIsOpen, "low", SessionDetailsModal)}
+              {this.renderModal(isModalOpen, this.setModalIsOpen, 'low', SessionDetailsModal)}
               <RecordingIndicator
                 amIModerator={amIModerator}
                 currentUserId={currentUserId}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/container.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import LeaveMeetingButton from './component';
-import { layoutSelectInput, layoutSelect } from '../../layout/context';
-import { SMALL_VIEWPORT_BREAKPOINT } from '../../layout/enums';
+import { layoutSelect } from '../../layout/context';
 import { USER_LEAVE_MEETING } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
@@ -40,7 +40,6 @@ import {
   colorSuccess,
   colorGrayLightest,
   colorText,
-  colorBlueLight,
   colorOffWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import {
   defineMessages, injectIntl, FormattedMessage,
 } from 'react-intl';
-import Button from '/imports/ui/components/common/button/component';
 import VirtualBgSelector from '/imports/ui/components/video-preview/virtual-background/component'
 import logger from '/imports/startup/client/logger';
 import browserInfo from '/imports/utils/browserInfo';

--- a/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/waiting-users/guest-policy/styles.js
@@ -1,13 +1,10 @@
 import styled from 'styled-components';
-import { colorGrayDark, colorGray } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorGray } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   jumboPaddingY,
   lgPaddingX,
-  lgPaddingY,
-  titlePositionLeft,
   modalMargin,
 } from '/imports/ui/stylesheets/styled-components/general';
-import { fontSizeLarge } from '/imports/ui/stylesheets/styled-components/typography';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 import Button from '/imports/ui/components/common/button/component';
 


### PR DESCRIPTION

### What does this PR do?
remove unnecessary unused imports from different files in the project 


### Motivation
Unnecessary imports refer to importing modules, libraries, or dependencies that are not used or referenced anywhere in the code. These imports do not contribute to the functionality of the application and only add extra weight to the JavaScript bundle, leading to potential performance and maintainability issues.