### PR TITLE
fix: Switching slides causes the next slide to slightly zoom in

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1460,7 +1460,7 @@ const Whiteboard = React.memo((props) => {
       && isPresenter
       && !isWheelZoomRef.current
     ) {
-      if (!isMounting) {
+      if (!isMounting && prevZoomValueRef.current !== zoomValue) {
         syncCameraOnPresenterZoom();
       }
     }


### PR DESCRIPTION
### What does this PR do?

add condition to only sync zoom on whiteboard mount if zoom value has been changed

### Closes Issue(s)
Closes #23035
closes #22684

### How to test

Detailed instructions on how to reproduce can be found in the issue
