### PR TITLE
Refactor(html5): Make autofocus search input on emoji picker

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
@@ -15,7 +15,6 @@ const EmojiPicker = (props) => {
   const {
     intl,
     onEmojiSelect,
-    onClickOutside,
   } = props;
 
   const i18n = {
@@ -71,7 +70,6 @@ const EmojiPicker = (props) => {
       dynamicWidth
       exceptEmojis={emojisToExclude}
       autoFocus
-      onClickOutside={onClickOutside}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
@@ -15,6 +15,7 @@ const EmojiPicker = (props) => {
   const {
     intl,
     onEmojiSelect,
+    onClickOutside,
   } = props;
 
   const i18n = {
@@ -69,6 +70,8 @@ const EmojiPicker = (props) => {
       theme="light"
       dynamicWidth
       exceptEmojis={emojisToExclude}
+      autoFocus
+      onClickOutside={onClickOutside}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?
This PR adds autofocus to the search input in the emoji picker when it is opened


### Closes Issue(s)
N/A

### How to test
- Enable the emoji picker on settings `public.chat.emojiPicker.enable`
- Join a meeting with a mod
- Open the emoji picker
- type on search bar


### More
[Screencast from 08-05-2025 16:32:48.webm](https://github.com/user-attachments/assets/bb128705-9fd0-41d2-8a17-f7dd14073ee8)

