### PR TITLE
Layout: mobile landscape improvs + layout settings reactive to device type + adjust margins

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Styled from './styles';
 import Session from '/imports/ui/services/storage/in-memory';
-import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { ACTIONS, PANELS, DEVICE_TYPE } from '/imports/ui/components/layout/enums';
 import {
-  layoutSelectInput,
+  layoutSelectInput, layoutSelect,
 } from '/imports/ui/components/layout/context';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 
@@ -69,6 +69,7 @@ const PresentationOptionsContainer = ({
   const isChatOpen = sidebarContent.sidebarContentPanel === PANELS.CHAT;
   const PUBLIC_GROUP_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
   const isGridLayout = useStorageKey('isGridEnabled');
+  const isTabletLandscape = layoutSelect((i) => i.deviceType) === DEVICE_TYPE.TABLET_LANDSCAPE;
   return (
     <Styled.PresentationButton
       icon={`${buttonType}${!presentationIsOpen ? '_off' : ''}`}
@@ -86,7 +87,7 @@ const PresentationOptionsContainer = ({
       size="lg"
       onClick={(e) => {
         e.currentTarget.blur();
-        if (!isChatOpen && isGridLayout && !presentationIsOpen) {
+        if (!isChatOpen && isGridLayout && !presentationIsOpen && !isTabletLandscape) {
           layoutContextDispatch({
             type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
             value: PANELS.CHAT,

--- a/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
@@ -1,12 +1,12 @@
 import { LAYOUT_TYPE, CAMERADOCK_POSITION, PANELS } from './enums';
 
 export const SIDEBAR_NAVIGATION_PANEL_WIDTH = 60; // px
-export const SIDEBAR_NAVIGATION_MARGIN = 24; // px
+export const SIDEBAR_NAVIGATION_MARGIN_PERCENTAGE_WIDTH = 0.01;
 export const SIDEBAR_CONTENT_PANEL_MIN_HEIGHT = 300; // px
-export const SIDEBAR_CONTENT_VERTICAL_MARGIN = 56; // px
+export const SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT = 0.04;
 export const SIDEBAR_CONTENT_PANEL_MIN_WIDTH = 70; // px
 export const SIDEBAR_CONTENT_PANEL_MAX_WIDTH = 800; // px
-export const SIDEBAR_CONTENT_MARGIN_TO_MEDIA = 24; // px
+export const SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH = 0.01;
 export const SIDEBAR_NAVIGATION_MARGIN_TO_THE_EDGE_MOBILE = 16; // px
 
 const DEFAULT_VALUES = {
@@ -35,8 +35,6 @@ const DEFAULT_VALUES = {
   actionBarPadding: 11.2,
   actionBarTabOrder: 6,
 
-  sidebarNavWidth: SIDEBAR_NAVIGATION_PANEL_WIDTH
-    + (2 * SIDEBAR_NAVIGATION_MARGIN),
   sidebarNavWidthMobile: 48, // px
   sidebarNavMarginToTheEdgeMobile: 16, // px
   sidebarNavHeightPercentage: 1,
@@ -45,10 +43,9 @@ const DEFAULT_VALUES = {
   sidebarNavLeft: 0,
   sidebarNavTabOrder: 1,
 
-  sidebarContentMaxWidth: SIDEBAR_CONTENT_PANEL_MAX_WIDTH + SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-  sidebarContentMinWidth: SIDEBAR_CONTENT_PANEL_MIN_WIDTH + SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-  sidebarContentMinHeight: SIDEBAR_CONTENT_PANEL_MIN_HEIGHT
-    + (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
+  sidebarContentMaxWidth: SIDEBAR_CONTENT_PANEL_MAX_WIDTH,
+  sidebarContentMinWidth: SIDEBAR_CONTENT_PANEL_MIN_WIDTH,
+  sidebarContentMinHeight: SIDEBAR_CONTENT_PANEL_MIN_HEIGHT,
   sidebarContentTop: 0,
   sidebarContentTabOrder: 2,
   sidebarContentPanel: PANELS.NONE,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { throttle } from '/imports/utils/throttle';
 import { layoutSelect, layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA, SIDEBAR_CONTENT_VERTICAL_MARGIN } from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, {
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH,
+  SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT,
+} from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import {
   ACTIONS, CAMERADOCK_POSITION, LAYOUT_TYPE, PANELS,
@@ -85,8 +88,10 @@ const CustomLayout = (props) => {
   const calculatesDropAreas = (sidebarNavWidth, sidebarContentWidth, cameraDockBounds) => {
     const { height: actionBarHeight } = calculatesActionbarHeight();
     const mediaAreaHeight = windowHeight() - (DEFAULT_VALUES.navBarHeight + actionBarHeight);
+    const sidebarContentMarginToMedia = windowWidth()
+      * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
     const mediaAreaWidth = windowWidth()
-      - (sidebarNavWidth + sidebarContentWidth) - SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+      - (sidebarNavWidth + sidebarContentWidth) - sidebarContentMarginToMedia;
     const DROP_ZONE_DEFAUL_SIZE = 100;
     const dropZones = {};
     const sidebarSize = sidebarNavWidth + sidebarContentWidth;
@@ -254,7 +259,8 @@ const CustomLayout = (props) => {
                 isPinned: sharedNotes.isPinned,
               },
             },
-            hasLayoutEngineLoadedOnce ? prevInput : INITIAL_INPUT_STATE,
+            hasLayoutEngineLoadedOnce && prevLayout !== LAYOUT_TYPE.MEDIA_ONLY
+              ? prevInput : INITIAL_INPUT_STATE,
           );
         },
       });
@@ -342,10 +348,12 @@ const CustomLayout = (props) => {
     if (stoppedResizing) {
       const isCameraTopOrBottom = cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_TOP
         || cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_BOTTOM;
+      const sidebarContentMarginToMedia = windowWidth()
+        * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
 
       Storage.setItem('webcamSize', {
         width: isCameraTopOrBottom || (
-          isCameraSidebar ? lastWidth : cameraDockInput.width - SIDEBAR_CONTENT_MARGIN_TO_MEDIA
+          isCameraSidebar ? lastWidth : cameraDockInput.width - sidebarContentMarginToMedia
         ),
         height: isCameraTopOrBottom || isCameraSidebar ? cameraDockInput.height : lastHeight,
       });
@@ -414,11 +422,11 @@ const CustomLayout = (props) => {
 
       if (isCameraRight) {
         const sizeValue = mediaAreaBounds.left + mediaAreaBounds.width - cameraDockWidth;
-        cameraDockBounds.left = !isRTL ? sizeValue - camerasMargin : 0;
-        cameraDockBounds.right = isRTL ? sizeValue + sidebarSize - camerasMargin : null;
+        cameraDockBounds.left = !isRTL ? sizeValue : 0;
+        cameraDockBounds.right = isRTL ? sizeValue + sidebarSize : null;
       } else if (isCameraLeft) {
-        cameraDockBounds.left = mediaAreaBounds.left + camerasMargin;
-        cameraDockBounds.right = isRTL ? sidebarSize + camerasMargin * 2 : null;
+        cameraDockBounds.left = mediaAreaBounds.left;
+        cameraDockBounds.right = isRTL ? sidebarSize : null;
       }
 
       return cameraDockBounds;
@@ -437,9 +445,13 @@ const CustomLayout = (props) => {
           windowHeight() - cameraDockMinHeight,
         );
       }
+      const sidebarContentVerticalMargin = windowHeight()
+        * SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT;
+      const sidebarContentMarginToMedia = windowWidth()
+        * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
 
       cameraDockBounds.top = windowHeight() - cameraDockHeight
-        - bannerAreaHeight() - SIDEBAR_CONTENT_VERTICAL_MARGIN + SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+        - bannerAreaHeight() - sidebarContentVerticalMargin + sidebarContentMarginToMedia;
       cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.minWidth = sidebarContentWidth;
@@ -463,8 +475,10 @@ const CustomLayout = (props) => {
     const navBarHeight = calculatesNavbarHeight();
     const mediaAreaHeight = windowHeight()
       - (DEFAULT_VALUES.navBarHeight + actionBarHeight + bannerAreaHeight());
+    const sidebarContentMarginToMedia = windowWidth()
+      * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
     const mediaAreaWidth = windowWidth()
-      - (sidebarNavWidth + sidebarContentWidth) - SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+      - (sidebarNavWidth + sidebarContentWidth) - sidebarContentMarginToMedia;
     const mediaBounds = {};
     const { element: fullscreenElement } = fullscreen;
     const { camerasMargin } = DEFAULT_VALUES;
@@ -706,7 +720,8 @@ const CustomLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_MEDIA_AREA_SIZE,
       value: {
-        width: windowWidth() - sidebarNavWidth.width - sidebarContentWidth.width,
+        width: windowWidth() - sidebarNavWidth.width - sidebarContentWidth.width
+          - (windowWidth() * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH),
         height: windowHeight() - DEFAULT_VALUES.navBarHeight - actionBarHeight,
       },
     });

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 import { layoutSelect, layoutSelectInput, layoutSelectOutput } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA } from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, {
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH,
+  SIDEBAR_NAVIGATION_PANEL_WIDTH,
+  SIDEBAR_NAVIGATION_MARGIN_PERCENTAGE_WIDTH,
+} from '/imports/ui/components/layout/defaultValues';
 import { LAYOUT_TYPE, DEVICE_TYPE } from '/imports/ui/components/layout/enums';
 
 import CustomLayout from '/imports/ui/components/layout/layout-manager/customLayout';
@@ -183,7 +187,6 @@ const LayoutEngine = () => {
 
   const calculatesSidebarNavWidth = () => {
     const {
-      sidebarNavWidth,
       sidebarNavWidthMobile,
     } = DEFAULT_VALUES;
 
@@ -199,8 +202,9 @@ const LayoutEngine = () => {
         // position of other layout elements.
         horizontalSpaceOccupied = 0;
       } else {
-        width = sidebarNavWidth;
-        horizontalSpaceOccupied = sidebarNavWidth;
+        const margin = windowWidth() * SIDEBAR_NAVIGATION_MARGIN_PERCENTAGE_WIDTH;
+        width = SIDEBAR_NAVIGATION_PANEL_WIDTH + (2 * margin);
+        horizontalSpaceOccupied = width;
       }
     }
     return {
@@ -319,6 +323,8 @@ const LayoutEngine = () => {
   ) => {
     const { height: actionBarHeight } = calculatesActionbarHeight();
     const navBarHeight = calculatesNavbarHeight();
+    const sidebarContentMarginToMedia = windowWidth()
+      * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
 
     let left = 0;
     let width = 0;
@@ -327,7 +333,8 @@ const LayoutEngine = () => {
     } else {
       left = !isRTL ? sidebarNavWidth + sidebarContentWidth : 0;
       width = windowWidth()
-        - sidebarNavWidth - sidebarContentWidth - SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+        - sidebarNavWidth - sidebarContentWidth
+        - (margin || selectedLayout === LAYOUT_TYPE.CAMERAS_ONLY ? 0 : sidebarContentMarginToMedia);
     }
 
     return {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { throttle } from '/imports/utils/throttle';
 import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES, { SIDEBAR_CONTENT_VERTICAL_MARGIN, SIDEBAR_CONTENT_MARGIN_TO_MEDIA } from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, {
+  SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT,
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH,
+} from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import {
   ACTIONS,
@@ -214,6 +217,10 @@ const PresentationFocusLayout = (props) => {
     const cameraDockBounds = {};
 
     let cameraDockHeight = 0;
+    const sidebarContentMediaMargin = windowWidth()
+      * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
+    const sidebarContentVerticalMargin = windowHeight()
+      * SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT;
 
     if (isMobile) {
       cameraDockBounds.top = mediaAreaBounds.top + mediaBounds.height;
@@ -253,7 +260,7 @@ const PresentationFocusLayout = (props) => {
         );
       }
       cameraDockBounds.top = windowHeight() - cameraDockHeight
-        - bannerAreaHeight() - (SIDEBAR_CONTENT_VERTICAL_MARGIN) + SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+        - bannerAreaHeight() - sidebarContentVerticalMargin + sidebarContentMediaMargin;
       cameraDockBounds.left = !isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.right = isRTL ? sidebarNavWidth : 0;
       cameraDockBounds.minWidth = sidebarContentWidth;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -8,6 +8,7 @@ import {
   PANELS,
   CAMERADOCK_POSITION,
   LAYOUT_TYPE,
+  DEVICE_TYPE,
 } from '/imports/ui/components/layout/enums';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
@@ -49,6 +50,7 @@ const PresentationFocusLayout = (props) => {
   const layoutContextDispatch = layoutDispatch();
 
   const prevDeviceType = usePrevious(deviceType);
+  const isTabletLandscape = deviceType === DEVICE_TYPE.TABLET_LANDSCAPE;
   const { isPresentationEnabled, prevLayout } = props;
 
   const throttledCalculatesLayout = throttle(() => calculatesLayout(),
@@ -169,7 +171,7 @@ const PresentationFocusLayout = (props) => {
         height = windowHeight() - navBarHeight - bannerAreaHeight();
         minHeight = height;
         maxHeight = height;
-      } else if (cameraDockInput.numCameras > 0 && isOpen && !isGeneralMediaOff) {
+      } else if (cameraDockInput.numCameras > 0 && isOpen && !isGeneralMediaOff && !isTabletLandscape) {
         if (sidebarContentInput.height === 0) {
           height = windowHeight() * 0.75 - bannerAreaHeight();
         } else {
@@ -223,6 +225,18 @@ const PresentationFocusLayout = (props) => {
       cameraDockBounds.minHeight = cameraDockMinHeight;
       cameraDockBounds.height = mediaAreaBounds.height - mediaBounds.height;
       cameraDockBounds.maxHeight = mediaAreaBounds.height - mediaBounds.height;
+    } else if (isTabletLandscape && presentationInput.isOpen) {
+      // don't show camera dock if presentation is open in tablet landscape mode
+      // the sidebar height gets too small, so only one or the other is shown
+      cameraDockBounds.top = 0;
+      cameraDockBounds.left = 0;
+      cameraDockBounds.right = 0;
+      cameraDockBounds.width = 0;
+      cameraDockBounds.height = 0;
+      cameraDockBounds.minWidth = 0;
+      cameraDockBounds.maxWidth = 0;
+      cameraDockBounds.minHeight = 0;
+      cameraDockBounds.maxHeight = 0;
     } else {
       if (cameraDockInput.height === 0) {
         cameraDockHeight = min(

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -191,7 +191,6 @@ const SmartLayout = (props) => {
       cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
       cameraDockBounds.height = mediaAreaBounds.height;
       cameraDockBounds.maxHeight = mediaAreaBounds.height;
-      cameraDockBounds.left += camerasMargin;
       cameraDockBounds.width -= camerasMargin * 2;
       cameraDockBounds.isCameraHorizontal = true;
       cameraDockBounds.position = CAMERADOCK_POSITION.CONTENT_LEFT;
@@ -302,6 +301,7 @@ const SmartLayout = (props) => {
     }
 
     const mediaContentSize = hasScreenShare ? screenShareSize : slideSize;
+    const { camerasMargin } = DEFAULT_VALUES;
 
     if (cameraDockInput.numCameras > 0 && !cameraDockInput.isDragging) {
       if (mediaContentSize.width !== 0 && mediaContentSize.height !== 0
@@ -314,7 +314,8 @@ const SmartLayout = (props) => {
           }
           mediaBounds.height = mediaAreaBounds.height;
           mediaBounds.top = mediaAreaBounds.top;
-          const sizeValue = mediaAreaBounds.left + (mediaAreaBounds.width - mediaBounds.width);
+          const sizeValue = mediaAreaBounds.left
+            + (mediaAreaBounds.width - mediaBounds.width - camerasMargin / 2);
           mediaBounds.left = !isRTL ? sizeValue : null;
           mediaBounds.right = isRTL ? sidebarSize : null;
         } else {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -530,7 +530,7 @@ const VideoFocusLayout = (props) => {
     layoutContextDispatch({
       type: ACTIONS.SET_SHARED_NOTES_OUTPUT,
       value: {
-        width: mediaBounds.width - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
+        width: mediaBounds.width,
         height: mediaBounds.height,
         top: mediaBounds.top,
         left: mediaBounds.left,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -6,7 +6,7 @@ import {
   layoutSelectInput,
   layoutSelectOutput,
 } from '/imports/ui/components/layout/context';
-import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA } from '/imports/ui/components/layout/defaultValues';
+import DEFAULT_VALUES, { SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH } from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE } from '/imports/ui/components/layout/initState';
 import {
   ACTIONS, PANELS, LAYOUT_TYPE, DEVICE_TYPE,
@@ -296,12 +296,14 @@ const VideoFocusLayout = (props) => {
         mediaBounds.right = isRTL ? sidebarSize : null;
         mediaBounds.zIndex = 1;
       } else {
+        const sidebarContentMarginToMedia = windowWidth()
+          * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
         mediaBounds.height = windowHeight()
-          - sidebarContentHeight - bannerAreaHeight() - SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+          - sidebarContentHeight - bannerAreaHeight() - sidebarContentMarginToMedia;
         mediaBounds.left = !isRTL ? sidebarNavWidth : 0;
         mediaBounds.right = isRTL ? sidebarNavWidth : 0;
-        mediaBounds.top = sidebarContentHeight + bannerAreaHeight() - SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
-        mediaBounds.width = sidebarContentWidth - SIDEBAR_CONTENT_MARGIN_TO_MEDIA;
+        mediaBounds.top = sidebarContentHeight + bannerAreaHeight() - sidebarContentMarginToMedia;
+        mediaBounds.width = sidebarContentWidth - sidebarContentMarginToMedia;
         mediaBounds.zIndex = 1;
       }
     } else if (!presentationInput.isOpen) {

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
@@ -6,7 +6,7 @@ import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { layoutSelect } from '../context';
-import { suportedLayouts } from '/imports/ui/components/layout/utils';
+import { suportedLayouts, layoutAllowedInSettings } from '/imports/ui/components/layout/utils';
 
 const LayoutModalContainer = (props) => {
   const {
@@ -30,7 +30,9 @@ const LayoutModalContainer = (props) => {
       isOpen,
       setLocalSettings,
       deviceType: layoutSelect((i) => i.deviceType),
-      availableLayouts: suportedLayouts,
+      availableLayouts: suportedLayouts.filter(
+        (layout) => layoutAllowedInSettings(layout.layoutKey),
+      ),
     }}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/container.jsx
@@ -5,6 +5,8 @@ import useUserChangedLocalSettings from '/imports/ui/services/settings/hooks/use
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import { layoutSelect } from '../context';
+import { suportedLayouts } from '/imports/ui/components/layout/utils';
 
 const LayoutModalContainer = (props) => {
   const {
@@ -27,6 +29,8 @@ const LayoutModalContainer = (props) => {
       onRequestClose,
       isOpen,
       setLocalSettings,
+      deviceType: layoutSelect((i) => i.deviceType),
+      availableLayouts: suportedLayouts,
     }}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -5,8 +5,10 @@ import {
 } from './enums';
 import {
   isMobile, isTablet, isTabletPortrait, isTabletLandscape, isDesktop,
+  isLayoutSupported,
 } from './utils';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
+import { updateSettings } from '/imports/ui/components/settings/service';
 import { Input, Layout } from './layoutTypes';
 import { throttle } from '/imports/utils/throttle';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
@@ -19,6 +21,7 @@ import { useIsChatEnabled, useIsPresentationEnabled, useIsScreenSharingEnabled }
 import useUserChangedLocalSettings from '/imports/ui/services/settings/hooks/useUserChangedLocalSettings';
 import Session from '/imports/ui/services/storage/in-memory';
 import deviceInfo from '/imports/utils/deviceInfo';
+import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 
@@ -27,6 +30,7 @@ const LayoutObserver: React.FC = () => {
   const checkedUserSettings = useRef(false);
   const layoutContextDispatch = layoutDispatch();
   const deviceType = layoutSelect((i: Layout) => i.deviceType);
+  const previousDeviceType = usePreviousValue(deviceType);
   const cameraDockInput = layoutSelectInput((i: Input) => i.cameraDock);
   const sidebarContentInput = layoutSelectInput((i: Input) => i.sidebarContent);
   const presentationInput = layoutSelectInput((i: Input) => i.presentation);
@@ -79,6 +83,22 @@ const LayoutObserver: React.FC = () => {
     () => setDeviceType(),
     50, { trailing: true, leading: true },
   );
+
+  useEffect(() => {
+    if (deviceType !== previousDeviceType) {
+      const Settings = getSettingsSingletonInstance();
+      const currentLayout = Settings.application.selectedLayout;
+      if (!isLayoutSupported(deviceType, currentLayout)) {
+        updateSettings({
+          application: {
+            ...Settings.application,
+            selectedLayout: LAYOUT_TYPE.SMART_LAYOUT,
+          },
+        }, null, setLocalSettings);
+      }
+    }
+    return () => { };
+  }, [deviceType, previousDeviceType, selectedLayout]);
 
   useEffect(() => {
     const Settings = getSettingsSingletonInstance();
@@ -192,11 +212,27 @@ const LayoutObserver: React.FC = () => {
   }, [meetingLayout, layoutContextDispatch, layoutType]);
 
   useEffect(() => {
-    layoutContextDispatch({
-      type: ACTIONS.SET_LAYOUT_TYPE,
-      value: selectedLayout,
-    });
-  }, [selectedLayout]);
+    const layoutSupported = isLayoutSupported(deviceType, selectedLayout);
+    if (layoutSupported) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_LAYOUT_TYPE,
+        value: selectedLayout,
+      });
+    } else {
+      // fallback to smart layout
+      layoutContextDispatch({
+        type: ACTIONS.SET_LAYOUT_TYPE,
+        value: LAYOUT_TYPE.SMART_LAYOUT,
+      });
+      const Settings = getSettingsSingletonInstance();
+      updateSettings({
+        application: {
+          ...Settings.application,
+          selectedLayout: LAYOUT_TYPE.SMART_LAYOUT,
+        },
+      }, null, setLocalSettings);
+    }
+  }, [deviceType, selectedLayout]);
 
   useEffect(() => {
     MediaService.buildLayoutWhenPresentationAreaIsDisabled(

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -171,7 +171,7 @@ const LayoutObserver: React.FC = () => {
     if (
       selectedLayout?.toLowerCase?.()?.includes?.('focus')
       && !sidebarContentIsOpen
-      && deviceType !== DEVICE_TYPE.MOBILE
+      && deviceType !== DEVICE_TYPE.MOBILE && deviceType !== DEVICE_TYPE.TABLET_LANDSCAPE
       && numCameras > 0
       && presentationIsOpen
     ) {

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -31,19 +31,15 @@ export {
 // Array for select component to select different layout
 const suportedLayouts = [
   {
-    layoutKey: LAYOUT_TYPE.SMART_LAYOUT,
-    layoutName: 'Smart Layout',
+    layoutKey: LAYOUT_TYPE.CUSTOM_LAYOUT,
+    layoutName: 'Custom Layout',
     suportedDevices: [
-      DEVICE_TYPE.MOBILE,
-      DEVICE_TYPE.TABLET,
-      DEVICE_TYPE.TABLET_PORTRAIT,
-      DEVICE_TYPE.TABLET_LANDSCAPE,
       DEVICE_TYPE.DESKTOP,
     ],
   },
   {
-    layoutKey: LAYOUT_TYPE.VIDEO_FOCUS,
-    layoutName: 'Video Focus',
+    layoutKey: LAYOUT_TYPE.SMART_LAYOUT,
+    layoutName: 'Smart Layout',
     suportedDevices: [
       DEVICE_TYPE.MOBILE,
       DEVICE_TYPE.TABLET,
@@ -64,9 +60,13 @@ const suportedLayouts = [
     ],
   },
   {
-    layoutKey: LAYOUT_TYPE.CUSTOM_LAYOUT,
-    layoutName: 'Custom Layout',
+    layoutKey: LAYOUT_TYPE.VIDEO_FOCUS,
+    layoutName: 'Video Focus',
     suportedDevices: [
+      DEVICE_TYPE.MOBILE,
+      DEVICE_TYPE.TABLET,
+      DEVICE_TYPE.TABLET_PORTRAIT,
+      DEVICE_TYPE.TABLET_LANDSCAPE,
       DEVICE_TYPE.DESKTOP,
     ],
   },
@@ -124,4 +124,20 @@ const LAYOUTS_SYNC = {
     ],
   },
 };
-export { suportedLayouts, LAYOUTS_SYNC };
+
+// This function checks whether the givenLayout is supported by the deviceType
+const isLayoutSupported = (deviceType, givenLayout) => {
+  if (givenLayout == null || deviceType == null) return false;
+  const layout = suportedLayouts.find((tentative) => tentative.layoutKey === givenLayout);
+  if (layout == null || layout.suportedDevices == null) return false;
+
+  return layout.suportedDevices.includes(deviceType);
+};
+
+const getSupportedLayouts = (deviceType) => suportedLayouts.filter(
+  (layout) => layout.suportedDevices.includes(deviceType),
+);
+
+export {
+  suportedLayouts, LAYOUTS_SYNC, getSupportedLayouts, isLayoutSupported,
+};

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -70,6 +70,50 @@ const suportedLayouts = [
       DEVICE_TYPE.DESKTOP,
     ],
   },
+  {
+    layoutKey: LAYOUT_TYPE.CAMERAS_ONLY,
+    layoutName: 'Cameras Only',
+    suportedDevices: [
+      DEVICE_TYPE.MOBILE,
+      DEVICE_TYPE.TABLET,
+      DEVICE_TYPE.TABLET_PORTRAIT,
+      DEVICE_TYPE.TABLET_LANDSCAPE,
+      DEVICE_TYPE.DESKTOP,
+    ],
+  },
+  {
+    layoutKey: LAYOUT_TYPE.PRESENTATION_ONLY,
+    layoutName: 'Presentation Only',
+    suportedDevices: [
+      DEVICE_TYPE.MOBILE,
+      DEVICE_TYPE.TABLET,
+      DEVICE_TYPE.TABLET_PORTRAIT,
+      DEVICE_TYPE.TABLET_LANDSCAPE,
+      DEVICE_TYPE.DESKTOP,
+    ],
+  },
+  {
+    layoutKey: LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY,
+    layoutName: 'Participants and Chat Only',
+    suportedDevices: [
+      DEVICE_TYPE.MOBILE,
+      DEVICE_TYPE.TABLET,
+      DEVICE_TYPE.TABLET_PORTRAIT,
+      DEVICE_TYPE.TABLET_LANDSCAPE,
+      DEVICE_TYPE.DESKTOP,
+    ],
+  },
+  {
+    layoutKey: LAYOUT_TYPE.MEDIA_ONLY,
+    layoutName: 'Media Only',
+    suportedDevices: [
+      DEVICE_TYPE.MOBILE,
+      DEVICE_TYPE.TABLET,
+      DEVICE_TYPE.TABLET_PORTRAIT,
+      DEVICE_TYPE.TABLET_LANDSCAPE,
+      DEVICE_TYPE.DESKTOP,
+    ],
+  },
 ];
 
 const COMMON_ELEMENTS = {
@@ -138,6 +182,11 @@ const getSupportedLayouts = (deviceType) => suportedLayouts.filter(
   (layout) => layout.suportedDevices.includes(deviceType),
 );
 
+const layoutAllowedInSettings = (layout) => layout !== LAYOUT_TYPE.CAMERAS_ONLY
+  && layout !== LAYOUT_TYPE.PRESENTATION_ONLY
+  && layout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY
+  && layout !== LAYOUT_TYPE.MEDIA_ONLY;
+
 export {
-  suportedLayouts, LAYOUTS_SYNC, getSupportedLayouts, isLayoutSupported,
+  suportedLayouts, LAYOUTS_SYNC, getSupportedLayouts, isLayoutSupported, layoutAllowedInSettings,
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -747,7 +747,7 @@ class Presentation extends PureComponent {
       ? svgWidth
       : presentationToolbarMinWidth;
 
-    const mobileAwareContainerWidth = isMobile
+    const mobileAwareContainerWidth = isMobile || layoutType === LAYOUT_TYPE.VIDEO_FOCUS
       ? presentationBounds.width
       : containerWidth;
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -684,6 +684,7 @@ class Presentation extends PureComponent {
       presentationBounds,
       fullscreenContext,
       isMobile,
+      isTabledLandscape,
       layoutType,
       numCameras,
       currentPresentationId,
@@ -739,6 +740,7 @@ class Presentation extends PureComponent {
         layoutType === LAYOUT_TYPE.VIDEO_FOCUS
         && numCameras > 0
         && !fullscreenContext
+        && !isTabledLandscape
       );
 
     const containerWidth = isLargePresentation

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -242,6 +242,7 @@ const PresentationContainer = (props) => {
           fullscreenContext,
           fullscreenElementId,
           isMobile: deviceType === DEVICE_TYPE.MOBILE,
+          isTabledLandscape: deviceType === DEVICE_TYPE.TABLET_LANDSCAPE,
           isIphone,
           currentSlide,
           slidePosition,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
-import deviceInfo from '/imports/utils/deviceInfo';
+import { LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import injectWbResizeEvent from '/imports/ui/components/presentation/resize-wrapper/component';
 import Button from '/imports/ui/components/common/button/component';
 import {
@@ -344,9 +344,9 @@ class PresentationToolbar extends PureComponent {
       tldrawAPI,
       maxNumberOfActiveUsers,
       numberOfJoinedUsers,
+      isMobile,
+      layoutType,
     } = this.props;
-
-    const { isMobile } = deviceInfo;
 
     const startOfSlides = !(currentSlideNum > 1);
     const endOfSlides = !(currentSlideNum < numberOfSlides);
@@ -383,7 +383,7 @@ class PresentationToolbar extends PureComponent {
     return (
       <Styled.PresentationToolbarWrapper
         id="presentationToolbarWrapper"
-        isMobile={isMobile}
+        isMobile={isMobile || layoutType === LAYOUT_TYPE.VIDEO_FOCUS}
       >
         {this.renderAriaDescs()}
         <Styled.QuickPollButtonWrapper>
@@ -589,6 +589,8 @@ PresentationToolbar.propTypes = {
   multiUserSize: PropTypes.number.isRequired,
   maxNumberOfActiveUsers: PropTypes.number.isRequired,
   numberOfJoinedUsers: PropTypes.number.isRequired,
+  isMobile: PropTypes.bool.isRequired,
+  layoutType: PropTypes.string.isRequired,
 };
 
 PresentationToolbar.defaultProps = {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -11,6 +11,8 @@ import Session from '/imports/ui/services/storage/in-memory';
 import { useMeetingIsBreakout } from '/imports/ui/components/app/service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { USER_AGGREGATE_COUNT_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
+import { layoutSelect } from '/imports/ui/components/layout/context';
+import { DEVICE_TYPE } from '/imports/ui/components/layout/enums';
 
 const infiniteWhiteboardIcon = (isinfiniteWhiteboard) => {
   if (isinfiniteWhiteboard) {
@@ -187,6 +189,8 @@ const PresentationToolbarContainer = (props) => {
   const allowInfiniteWhiteboard = useIsInfiniteWhiteboardEnabled();
   const { data: countData } = useDeduplicatedSubscription(USER_AGGREGATE_COUNT_SUBSCRIPTION);
   const numberOfJoinedUsers = countData?.user_aggregate?.aggregate?.count || 0;
+  const isMobile = layoutSelect((i) => i.deviceType) === DEVICE_TYPE.MOBILE;
+  const layoutType = layoutSelect((i) => i.layoutType);
 
   if (userIsPresenter && !layoutSwapped) {
     // Only show controls if user is presenter and layout isn't swapped
@@ -219,6 +223,8 @@ const PresentationToolbarContainer = (props) => {
           infiniteWhiteboardIcon,
           resetSlide,
           meetingIsBreakout,
+          isMobile,
+          layoutType,
         }}
       />
     );

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -68,6 +68,31 @@ const PresentationToolbarWrapper = styled.div`
     justify-content: center;
     align-items: center;
   }
+
+  // Fancy scroll
+  &::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
+  }
+  &::-webkit-scrollbar-button {
+    width: 0;
+    height: 0;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(0,0,0,.25);
+    border: none;
+    border-radius: 50px;
+  }
+  &::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,.5); }
+  &::-webkit-scrollbar-thumb:active { background: rgba(0,0,0,.25); }
+  &::-webkit-scrollbar-track {
+    background: rgba(0,0,0,.25);
+    border: none;
+    border-radius: 50px;
+  }
+  &::-webkit-scrollbar-track:hover { background: rgba(0,0,0,.25); }
+  &::-webkit-scrollbar-track:active { background: rgba(0,0,0,.25); }
+  &::-webkit-scrollbar-corner { background: 0 0; }
 `;
 
 const QuickPollButton = styled(QuickPollDropdownContainer)`

--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/component.tsx
@@ -18,8 +18,8 @@ import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import { SidebarContentProps } from './types';
 import {
-  SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-  SIDEBAR_CONTENT_VERTICAL_MARGIN,
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH,
+  SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT,
 } from '/imports/ui/components/layout/defaultValues';
 import AudioCaptionsPanel from '../audio-captions/panel/component';
 
@@ -80,13 +80,16 @@ const SidebarContent = (props: SidebarContentProps) => {
 
   if (sidebarContentPanel === PANELS.NONE) return null;
 
+  const sidebarContentMarginToMedia = window.innerWidth * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
+  const sidebarContentVerticalMargin = window.innerHeight * SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT;
+
   const innerPanel = !isMobile ? {
-    minWidth: minWidth - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-    maxWidth: maxWidth - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-    minHeight: minHeight - (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
-    maxHeight: maxHeight - (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
-    width: width - SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-    height: height - (2 * SIDEBAR_CONTENT_VERTICAL_MARGIN),
+    minWidth: minWidth - sidebarContentMarginToMedia,
+    maxWidth: maxWidth - sidebarContentMarginToMedia,
+    minHeight: minHeight - (2 * sidebarContentVerticalMargin),
+    maxHeight: maxHeight - (2 * sidebarContentVerticalMargin),
+    width: width - sidebarContentMarginToMedia,
+    height: height - (2 * sidebarContentVerticalMargin),
   } : {
     minWidth,
     maxWidth,

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -1,7 +1,7 @@
 import {
-  SIDEBAR_CONTENT_VERTICAL_MARGIN,
-  SIDEBAR_CONTENT_MARGIN_TO_MEDIA,
-  SIDEBAR_NAVIGATION_MARGIN,
+  SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT,
+  SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH,
+  SIDEBAR_NAVIGATION_MARGIN_PERCENTAGE_WIDTH,
 } from '/imports/ui/components/layout/defaultValues';
 
 const borderSizeSmall = '1px';
@@ -35,8 +35,8 @@ const contentSidebarUserListPadding = '0.5rem';
 const contentSidebarBottomScrollPadding = '2rem';
 const contentSidebarHeight = '92%';
 const contentSidebarBorderRadius = '1rem';
-const contentSidebarVerticalMargin = `${SIDEBAR_CONTENT_VERTICAL_MARGIN}px`;
-const contentSidebarMarginToMedia = `${SIDEBAR_CONTENT_MARGIN_TO_MEDIA}px`;
+const contentSidebarVerticalMargin = `${SIDEBAR_CONTENT_VERTICAL_MARGIN_PERCENTAGE_HEIGHT * 100}vh`;
+const contentSidebarMarginToMedia = `${SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH * 100}vw`;
 const minModalHeight = '20rem';
 const descriptionMargin = '3.5rem';
 const navbarHeight = '3.9375rem';
@@ -47,7 +47,7 @@ const navigationSidebarListItemsGap = '0.8rem';
 const navigationSidebarListItemsWidth = '65%';
 const navigationSidebarBorderRadius = '48px';
 const navigationSidebarPaddingY = '20px';
-const navigationSidebarMargin = `${SIDEBAR_NAVIGATION_MARGIN}px`;
+const navigationSidebarMargin = `${SIDEBAR_NAVIGATION_MARGIN_PERCENTAGE_WIDTH * 100}vw`;
 const pollHeaderOffset = '-0.875rem';
 const toastContentWidth = '98%';
 const modalMargin = '3rem';

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1469,6 +1469,7 @@
     "app.layout.modal.layoutBtnDesc": "Sets layout as selected option",
     "app.layout.modal.layoutToastLabelAuto": "Auto layout updates enabled, layout updates are now applied to everyone",
     "app.layout.modal.layoutToastLabelAutoOff": "Auto layout updates disabled",
+    "app.layout.modal.layoutNotAvailable": "Layout not available on your device.",
     "app.layout.style.custom": "Custom layout",
     "app.layout.style.smart": "Smart layout",
     "app.layout.style.presentationFocus": "Focus on presentation",

--- a/bigbluebutton-html5/public/locales/es.json
+++ b/bigbluebutton-html5/public/locales/es.json
@@ -1304,6 +1304,7 @@
     "app.layout.modal.layoutLabel": "Selecciona tu diseño",
     "app.layout.modal.pushLayoutLabel": "Forzar para todos/as",
     "app.layout.modal.layoutToastLabel": "Ha cambiado la configuración del diseño",
+    "app.layout.modal.layoutNotAvailable": "Diseño no disponible en tu dispositivo.",
     "app.layout.modal.layoutSingular": "Diseño",
     "app.layout.modal.layoutBtnDesc": "Establece el diseño como opción seleccionada",
     "app.layout.modal.layoutToastLabelAuto": "Actualizaciones automáticas de diseño activadas, las actualizaciones de diseño se aplican ahora a todos.",

--- a/bigbluebutton-html5/public/locales/pt_BR.json
+++ b/bigbluebutton-html5/public/locales/pt_BR.json
@@ -1469,6 +1469,7 @@
     "app.layout.modal.layoutBtnDesc": "Utilizar layout selecionado",
     "app.layout.modal.layoutToastLabelAuto": "Sincronização de layout ativada, mudanças no layout serão propagadas para todos",
     "app.layout.modal.layoutToastLabelAutoOff": "Sincronização de layout desativada",
+    "app.layout.modal.layoutNotAvailable": "Layout não disponível em seu dispositivo.",
     "app.layout.style.custom": "Personalizado",
     "app.layout.style.smart": "Layout inteligente",
     "app.layout.style.presentationFocus": "Foco na apresentação",


### PR DESCRIPTION
### What does this PR do?
A few improvements to the layout settings in different device types and mobile landscape presentation and video focus mode:

- [fix: equalize layout picker and pusher supported layouts](https://github.com/bigbluebutton/bigbluebutton/commit/9db6d0314df7694cda449400262578f232d65620): 
  - The layout picker currently uses an UA-based check to verify which are the supported layouts. The layout pusher uses a viewport-based approach, ie the ones defined in the layout services. This causes weird behavior like small-viewport desktops having the option to pick CUSTOM, but are unable to push it.
  - This commit makes the layout picker use the viewport-based deviceType to define which are the supported layouts, this way things are mostly consistent. It also keeps unsupported layouts in the modal, but disables them to avoid confusion. This could be further improved with a tooltip and a toast whenever the user tries to apply disabled layouts.
- [fix(layout): update layout when device changes](https://github.com/bigbluebutton/bigbluebutton/commit/f74d9ef6846ab363ea54c7ed5fb1dbe3f9081f27):
  - Currently the client allows to stay in custom layout when in mobile or tablet, but it isn't supported.
  - When the new device type don't support the current layout, fallback to Smart Layout and update the selected layout in settings
- [update(layout): tablet landscape improvments](https://github.com/bigbluebutton/bigbluebutton/commit/df447d993830c9efa82e87933b74926109f7485a):
  - This improves the usability in landscape mode when in mobile/tablet, because the height of the screen is too small to show both things in the new sidebar content.
  - Don't show cameras or presentation below the sidebar content when in tablet landscape (= mobile landscape)
  - Only cameras/grid or presentation is shown at a time, controlled by if the presentation is open or not
- [update(layout): change margins to % and reduce them +](https://github.com/bigbluebutton/bigbluebutton/pull/23135/commits/157b16fa3f996fa87c417cb12eb4fb47f0af1e3d):
  - Change sidebars and media area margin to % and reduce them to have more utilized space
  - Several fixes to margins in some layouts
  - Fixes bug when changing from media_only to custom

  ### Motivation
Bugs in the selected layout for the current device type and screen too small to fit cameras/presentation below the sidebard with the new design:
![image](https://github.com/user-attachments/assets/36225285-5289-44d5-9b9c-b15188921425)


Closes https://github.com/bigbluebutton/bigbluebutton/issues/23156
Closes https://github.com/bigbluebutton/bigbluebutton/issues/23104

