### PR TITLE
docs: typo in LiveKit restart command

### DIFF
--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -207,7 +207,7 @@ rtc:
       - <network_interface_name_1>
       - <any_other_network_interface_name>
 ```
-3. Restart bbb-livekit: `$ sudo systemctl restart bbb-livekit`
+3. Restart livekit-server: `$ sudo systemctl restart livekit-server`
 
 Once enabled, LiveKit still won't be used by default. There are two ways to make
 use of it in meetings:


### PR DESCRIPTION
### What does this PR do?

- [docs: typo in LiveKit restart command](https://github.com/bigbluebutton/bigbluebutton/commit/af4dd02b3d28f818e20440e891adadc28d49a88b) 
  - Service name is livekit-server - bbb-livekit is the package

### Closes Issue(s)

None