### PR TITLE
Refactor(html5): Add support to Vimeo player methods

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -214,8 +214,10 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       const internalPlayer = player.getInternalPlayer();
       if (internalPlayer instanceof HTMLVideoElement) {
         internalPlayer.pause();
-      } else {
-        internalPlayer?.pauseVideo?.();
+      } else if (internalPlayer.pauseVideo) {
+        internalPlayer.pauseVideo();
+      } else if (internalPlayer.pause) {
+        internalPlayer?.pause();
       }
     }
   }, []);
@@ -225,19 +227,22 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       const internalPlayer = player.getInternalPlayer();
       if (internalPlayer instanceof HTMLVideoElement) {
         internalPlayer.play();
-      } else {
-        internalPlayer?.playVideo?.();
+      } else if (internalPlayer.playVideo) {
+        internalPlayer.playVideo();
+      } else if (internalPlayer.play) {
+        internalPlayer.play();
       }
     }
   }, []);
 
-  const getPlayerCurrentTime = useCallback((player: ReactPlayer) => {
+  const getPlayerCurrentTime = useCallback(async (player: ReactPlayer) => {
     if (player) {
       const internalPlayer = player.getInternalPlayer();
       if (internalPlayer instanceof HTMLVideoElement) {
         return internalPlayer.currentTime;
       }
-      return internalPlayer?.getCurrentTime?.() ?? 0;
+      // Vimeo player returns a promise for getCurrentTime
+      return await internalPlayer?.getCurrentTime?.() ?? 0;
     }
     return 0;
   }, []);
@@ -324,13 +329,13 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   }, [isPresenter]);
 
-  const handleOnStart = () => {
+  const handleOnStart = async () => {
     if (isPresenter) {
       const rate = internalPlayer instanceof HTMLVideoElement
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
-      const currentTime = getPlayerCurrentTime(playerRef.current as ReactPlayer);
+      const currentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
       sendMessage('start', {
         rate,
         time: currentTime,
@@ -346,7 +351,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
-      const currentTime = getPlayerCurrentTime(playerRef.current as ReactPlayer);
+      const currentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
       sendMessage('play', {
         rate,
         time: currentTime,
@@ -376,7 +381,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         rate = await rate;
       }
 
-      const currentTime = getPlayerCurrentTime(playerRef.current as ReactPlayer);
+      const currentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
       sendMessage('stop', {
         rate,
         time: currentTime,
@@ -388,11 +393,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
   };
 
-  const handleProgress = (state: OnProgressProps) => {
+  const handleProgress = async (state: OnProgressProps) => {
     setPlayed(state.played);
     setLoaded(state.loaded);
     if (playing && isPresenter) {
-      currentTime = getPlayerCurrentTime(playerRef.current as ReactPlayer);
+      currentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -242,7 +242,12 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         return internalPlayer.currentTime;
       }
       // Vimeo player returns a promise for getCurrentTime
-      return await internalPlayer?.getCurrentTime?.() ?? 0;
+      try {
+        return (await internalPlayer?.getCurrentTime?.()) ?? 0;
+      } catch (e) {
+        // If the player is not ready yet, we return 0
+        return 0;
+      }
     }
     return 0;
   }, []);


### PR DESCRIPTION
### What does this PR do?
This PR adds support for the Vimeo Player. Since its method names differ from those of the YouTube player and getCurrentTime returns a Promise instead of a number, I updated our callbacks accordingly to handle these differences.

### Closes Issue(s)
Closes #23038

### How to test
- Join with a Mod and a Viewer.
- Share an external video from Vimeo.
- Pause and play a few times.
- See both synced.

### More
[Screencast from 12-05-2025 09:49:40.webm](https://github.com/user-attachments/assets/f4b17b07-838d-4cc2-abe1-ea47f2874aef)
