### PR TITLE
fix(html5/poll): Save poll state on unmount, restore it on mount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import Header from '/imports/ui/components/common/control-header/component';
@@ -17,6 +19,7 @@ import ResponseTypes from './components/ResponseTypes';
 import PollQuestionArea from './components/PollQuestionArea';
 import LiveResultContainer from './components/LiveResult';
 import Session from '/imports/ui/services/storage/in-memory';
+import SessionStorage from '/imports/ui/services/storage/session';
 import { useStorageKey } from '../../services/storage/hooks';
 
 const intlMessages = defineMessages({
@@ -333,6 +336,65 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
 
   useEffect(() => () => {
     Session.removeItem('quickPollVariables');
+  }, []);
+
+  const getPollCurrentState = useCallback(() => {
+    return {
+      customInput,
+      question,
+      questionAndOptions,
+      optList,
+      error,
+      isMultipleResponse,
+      secretPoll,
+      warning,
+      type,
+    };
+  }, [
+    customInput, question, questionAndOptions, optList,
+    isMultipleResponse, secretPoll, warning, type, error,
+  ]);
+
+  useEffect(() => () => {
+    SessionStorage.setItem('pollSavedState', getPollCurrentState());
+  }, [getPollCurrentState]);
+
+  useEffect(() => {
+    const pollSavedState = SessionStorage.getItem('pollSavedState') as {
+      customInput: boolean;
+      question: string[] | string;
+      questionAndOptions: string[] | string;
+      optList: { val: string }[];
+      error: string;
+      isMultipleResponse: boolean;
+      secretPoll: boolean;
+      warning: string;
+      type: string;
+    };
+
+    if (pollSavedState) {
+      const {
+        customInput,
+        isMultipleResponse,
+        optList,
+        error,
+        question,
+        questionAndOptions,
+        secretPoll,
+        type,
+        warning,
+      } = pollSavedState;
+
+      setCustomInput(customInput);
+      setIsMultipleResponse(isMultipleResponse);
+      setOptList(optList);
+      setError(error);
+      setQuestion(question);
+      setQuestionAndOptions(questionAndOptions);
+      setSecretPoll(secretPoll);
+      setType(type);
+      setWarning(warning);
+    }
   }, []);
 
   const handleInputChange = (


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Save poll state in the session storage on unmount, restore it on mount.

[Screencast from 12-05-2025 09:58:29.webm](https://github.com/user-attachments/assets/a2b0ae8e-e07b-4b5f-a991-167a67afff38)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23030