### PR TITLE
fix(html5/external-video): Show viewer controls only on hover

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/toolbar/styles.ts
@@ -6,9 +6,9 @@ interface HoverToolbarProps {
 
 const HoverToolbar = Styled.div<HoverToolbarProps>`
   ${({ toolbarStyle }) => toolbarStyle === 'hoverToolbar' && `
-    display: flex;
+    display: none;
     z-index: 3;
-    :hover > & {
+    [data-test="videoPlayer"]:hover & {
       display: flex;
     }
   `}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

Show viewer controls only on hover instead of always displaying it.

[Screencast from 12-05-2025 11:32:34.webm](https://github.com/user-attachments/assets/74892fec-7255-4f59-be10-fbe39a3b0435)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
n/a

### Motivation
<!-- What inspired you to submit this pull request? -->

Always displaying controls can harm the visibility of the video.