### PR TITLE
fix (bbb-web): Allow `getJoinUrl` viewer's parameters in Breakout Rooms

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1226,24 +1226,22 @@ class ApiController {
         boolean isModerator = us.role?.equals(ROLE_MODERATOR);
         boolean blockAllUserdataForViewers = userdataBlocklistForViewers.any { it.equalsIgnoreCase("all") };
 
-        if (!meeting.isBreakout()) {
-          request.getParameterMap()
-                  .findAll { key, value ->
-                    // always allow `enforceLayout`
-                    if (key == "enforceLayout") return true
+        request.getParameterMap()
+                .findAll { key, value ->
+                  // always allow `enforceLayout`
+                  if (key == "enforceLayout") return true
 
-                    // For prefix userdata-
-                    if (key.startsWith("userdata-")) {
-                      if (isModerator) return true
-                      if (blockAllUserdataForViewers) return false
-                      return !userdataBlocklistForViewers.contains(key - "userdata-")
-                    }
-
-                    return false
+                  // For prefix userdata-
+                  if (key.startsWith("userdata-")) {
+                    if (isModerator && !meeting.isBreakout()) return true
+                    if (blockAllUserdataForViewers) return false
+                    return !userdataBlocklistForViewers.contains(key - "userdata-")
                   }
-                  .findAll { key, value -> !StringUtils.isEmpty(value[-1]) }
-                  .each { key, value -> queryParameters.put(key, value[-1]) }
-        }
+
+                  return false
+                }
+                .findAll { key, value -> !StringUtils.isEmpty(value[-1]) }
+                .each { key, value -> queryParameters.put(key, value[-1]) }
 
         String httpQueryString = "";
         for(String parameterName : queryParameters.keySet()) {


### PR DESCRIPTION
Breakout rooms currently block parameters like `enforceLayout` and `userdata-` because all users in breakout rooms are moderators. This restriction was originally put in place to prevent viewers from the main room from gaining moderator getJoinUrl-parameters in breakout rooms.

However, since PR #22943, even viewers are allowed to pass certain parameters when calling `getJoinUrl`. This PR updates the breakout room behavior to follow the same permission rules, allowing viewers to pass parameters accordingly (when they are in breakout rooms).