### PR TITLE
fix: blocks MiBrowser & feat: adds WebRTC API browser support check

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -175,7 +175,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
       ? 'The browser is not supported or is using an outdated version.'
       : 'WebRTC is not supported in this browser.';
     logger.warn({
-      log_code: 'unsupported_browser',
+      logCode: 'unsupported_browser',
       extraInfo: {
         reason,
       },

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from '@apollo/client';
 import React, { useContext, useEffect, useState } from 'react';
 import Bowser from 'bowser';
 import Session from '/imports/ui/services/storage/in-memory';
+import { isBrowserSupported } from 'livekit-client';
 import {
   getUserCurrent,
   GetUserCurrentResponse,
@@ -50,6 +51,7 @@ interface PresenceManagerProps extends PresenceManagerContainerProps {
     guestLobbyMessage: string | null;
     positionInWaitingQueue: number | null;
     isSupportedBrowser: boolean | undefined;
+    hasWebrtcSupport: boolean;
 }
 
 const PresenceManager: React.FC<PresenceManagerProps> = ({
@@ -77,6 +79,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
   guestStatus,
   positionInWaitingQueue,
   isSupportedBrowser,
+  hasWebrtcSupport,
 }) => {
   const [allowToRender, setAllowToRender] = React.useState(false);
   const [dispatchUserJoin] = useMutation(userJoinMutation);
@@ -166,13 +169,18 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
 
   const errorCode = loggedOut ? 'user_logged_out_reason' : joinErrorCode || ejectReasonCode;
 
-  if (isSupportedBrowser === false) {
-    logger.info({
+  if (isSupportedBrowser === false || hasWebrtcSupport === false) {
+    const reason = isSupportedBrowser === false ? 'WEBRTC' : 'USER_AGENT';
+    const message = isSupportedBrowser === false
+      ? 'The browser is not supported or is using an outdated version.'
+      : 'WebRTC is not supported in this browser.';
+    logger.warn({
       log_code: 'blocked_client',
       extraInfo: {
-        reason: 'USER_AGENT',
+        reason,
       },
-    }, 'Client blocked.');
+    }, message);
+
     return <Legacy setLoading={loadingContextInfo.setLoading} />;
   }
 
@@ -258,6 +266,7 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
   const MIN_BROWSER_CONFIG = window.meetingClientSettings.public.minBrowserVersions;
   const userAgent = window.navigator?.userAgent;
   const isSupportedBrowser = Bowser.getParser(userAgent).satisfies(MIN_BROWSER_CONFIG);
+  const hasWebrtcSupport = isBrowserSupported();
 
   return (
     <PresenceManager
@@ -284,6 +293,7 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
       positionInWaitingQueue={guestStatusDetails?.positionInWaitingQueue ?? null}
       guestStatus={guestStatus}
       isSupportedBrowser={isSupportedBrowser}
+      hasWebrtcSupport={hasWebrtcSupport}
     >
       {children}
     </PresenceManager>

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -167,6 +167,12 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
   const errorCode = loggedOut ? 'user_logged_out_reason' : joinErrorCode || ejectReasonCode;
 
   if (isSupportedBrowser === false) {
+    logger.info({
+      log_code: 'blocked_client',
+      extraInfo: {
+        reason: 'USER_AGENT',
+      },
+    }, 'Client blocked.');
     return <Legacy setLoading={loadingContextInfo.setLoading} />;
   }
 

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -175,7 +175,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
       ? 'The browser is not supported or is using an outdated version.'
       : 'WebRTC is not supported in this browser.';
     logger.warn({
-      log_code: 'blocked_client',
+      log_code: 'unsupported_browser',
       extraInfo: {
         reason,
       },

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -170,7 +170,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
   const errorCode = loggedOut ? 'user_logged_out_reason' : joinErrorCode || ejectReasonCode;
 
   if (isSupportedBrowser === false || hasWebrtcSupport === false) {
-    const reason = isSupportedBrowser === false ? 'WEBRTC' : 'USER_AGENT';
+    const reason = isSupportedBrowser === false ? 'USER_AGENT' : 'WEBRTC';
     const message = isSupportedBrowser === false
       ? 'The browser is not supported or is using an outdated version.'
       : 'WebRTC is not supported in this browser.';

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1143,6 +1143,7 @@ public:
     chrome: ">=87"
     firefox: ">=80"
     edge: ">=85"
+    miui: "<0"
     mobile:
       safari: ">=14"
       chrome: ">=87"


### PR DESCRIPTION
### What does this PR do?
- [fix: block MiBrowser regardless of its version](https://github.com/bigbluebutton/bigbluebutton/commit/9d14bdbc82bd99950e8f520b0def5994d11dd5b5) 
  Adds a rule in the `minBrowserVersions` in settings.yml file to block all devices using MiBrowser, since it doesn't support WebRTC and will not work in the meeting. Additionally, adds a log whenever an unsupported browser is identified.

- [feat: add WebRTC API browser support check](https://github.com/bigbluebutton/bigbluebutton/commit/3f8542c1457bd7026bf27c643f8e08bd13dfaf1e) 
  Adds a runtime check for WebRTC API support in the browser. This is necessary because some user agents lacking proper WebRTC support were bypassing the user-agent-based block. This additional check allows us to proactively catch those cases without needing to enumerate every unsupported user agent manually.

  The user agent check takes precedence over the new WebRTC support check. In other words, browsers explicitly blocked by user agent will always be denied, regardless of their WebRTC capabilities. Browsers not blocked by user agent must pass the WebRTC support check to be allowed.

  A specific warning log was added with a clear reason: 'USER_AGENT' or 'WEBRTC'.

### Closes Issue(s)
Closes none

### Motivation
Proactively block browsers with lack of support for WebRTC api.

### How to test
Try joining with MiBrowser.
Try joining a meeting with a browsers that is not blocked by user agent but is known for not having WebRTC support.
