### PR TITLE
feat: increase bot transparency

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -72,6 +72,7 @@ interface ExternalVideoPlayerProps {
   isEchoTest: boolean;
   isGridLayout: boolean;
   isPresenter: boolean;
+  isBot: boolean;
   videoUrl: string;
   isResizing: boolean;
   fullscreenContext: boolean;
@@ -107,6 +108,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   fullscreenContext,
   videoUrl,
   isPresenter,
+  isBot,
   playing,
   playerPlaybackRate,
   isEchoTest,
@@ -139,7 +141,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       playerOptions: {
         autoPlay: true,
         playsInline: true,
-        controls: true,
+        controls: !isBot,
       },
       file: {
         attributes: {
@@ -149,11 +151,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         },
       },
       facebook: {
-        controls: true,
+        controls: !isBot,
       },
       dailymotion: {
         params: {
-          controls: true,
+          controls: !isBot,
         },
       },
       youtube: {
@@ -163,7 +165,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           autohide: 1,
           rel: 0,
           ecver: 2,
-          controls: 1,
+          controls: isBot ? 0 : 1,
           cc_lang_pref: document.getElementsByTagName('html')[0].lang.substring(0, 2),
         },
         embedOptions: {
@@ -175,14 +177,14 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       },
       twitch: {
         options: {
-          controls: true,
+          controls: !isBot,
         },
         playerId: 'externalVideoPlayerTwitch',
       },
       preload: true,
       showHoverToolBar: false,
     };
-  }, []);
+  }, [isBot]);
 
   const [showUnsynchedMsg, setShowUnsynchedMsg] = React.useState(false);
   const [showHoverToolBar, setShowHoverToolBar] = React.useState(false);
@@ -449,6 +451,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   }
 
   const shouldShowTools = () => {
+    if (isBot) return false;
     if (isPresenter || (!isPresenter && isGridLayout && !isSidebarContentOpen) || !videoUrl) {
       return false;
     }
@@ -502,7 +505,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           onPause={handleOnStop}
           onEnded={handleOnStop}
           muted={mute || isEchoTest}
-          controls
+          controls={!isBot}
           previewTabIndex={isPresenter ? 0 : -1}
           onPlaybackRateChange={handlePlaybackRateChange}
         />
@@ -540,6 +543,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const isEchoTest = useReactiveVar(audioManager._isEchoTest.value) as boolean;
   const { data: currentUser } = useCurrentUser((user) => ({
     presenter: user.presenter,
+    bot: user.bot,
   }));
   const { data: currentMeeting } = useMeeting((m) => ({
     externalVideo: m.externalVideo,
@@ -681,6 +685,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   if (!currentUser || !currentMeeting?.externalVideo || !externalVideo?.display) return null;
   if (!hasExternalVideoOnLayout) return null;
   const isPresenter = currentUser.presenter ?? false;
+  const isBot = currentUser.bot ?? false;
   const isGridLayout = currentMeeting.layout?.currentLayoutType === 'VIDEO_FOCUS';
   const {
     updatedAt = new Date().toISOString(),
@@ -698,7 +703,8 @@ const ExternalVideoPlayerContainer: React.FC = () => {
       currentVolume={currentVolume}
       isMuted={isMuted}
       isEchoTest={isEchoTest}
-      isPresenter={isPresenter ?? false}
+      isPresenter={isPresenter}
+      isBot={isBot}
       videoUrl={videoUrl}
       playing={playing}
       playerPlaybackRate={playerPlaybackRate}

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -394,11 +394,16 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderFullscreenButton() {
-    const { intl, fullscreenElementId, fullscreenContext } = this.props;
+    const {
+      intl,
+      fullscreenElementId,
+      fullscreenContext,
+      isBot,
+    } = this.props;
 
     const ALLOW_FULLSCREEN = window.meetingClientSettings.public.app.allowFullscreen;
 
-    if (!ALLOW_FULLSCREEN) return null;
+    if (!ALLOW_FULLSCREEN || isBot) return null;
 
     return (
       <Styled.FullscreenButtonWrapperForScreenshare>
@@ -462,7 +467,10 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderVolumeSlider() {
+    const { isBot } = this.props;
     const { showHoverToolBar } = this.state;
+
+    if (isBot) return null;
 
     let toolbarStyle = 'hoverToolbar';
 
@@ -740,4 +748,5 @@ ScreenshareComponent.propTypes = {
   enableVolumeControl: PropTypes.bool.isRequired,
   outputDeviceId: PropTypes.string,
   streamId: PropTypes.string.isRequired,
+  isBot: PropTypes.bool.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -107,7 +107,7 @@ const ScreenshareContainer = (props) => {
   const { data: currentMeeting } = useMeeting((m) => ({
     screenShareBridge: m.screenShareBridge,
   }));
-  const { data: currentUserData } = useCurrentUser((u) => ({ presenter: u.presenter }));
+  const { data: currentUserData } = useCurrentUser((u) => ({ presenter: u.presenter, bot: u.bot }));
   const [bridgeIsReady, setBridgeIsReady] = useState(false);
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
   const [pinSharedNotes] = useMutation(PIN_NOTES);
@@ -133,14 +133,15 @@ const ScreenshareContainer = (props) => {
   const isSharedNotesPinned = !!pinnedPadData
     && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
 
-  const isPresenter = currentUserData?.presenter;
+  const isPresenter = currentUserData?.presenter || false;
+  const isBot = currentUserData?.bot || false;
 
   const info = {
     screenshare: {
       icon: 'desktop',
       locales: screenshareIntlMessages,
       startPreviewSizeBig: false,
-      showSwitchPreviewSizeButton: true,
+      showSwitchPreviewSizeButton: !isBot,
     },
     camera: {
       icon: 'video',
@@ -201,6 +202,7 @@ const ScreenshareContainer = (props) => {
           isPresenter,
           streamId,
           shouldShowScreenshare,
+          isBot,
         }
         }
       />

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -65,6 +65,7 @@ export const GRID_USERS_SUBSCRIPTION = gql`
             predicate: { _eq: 0 },
           },
         },
+        bot:{ _eq: false },
       },
       limit: $limit,
       order_by: {


### PR DESCRIPTION
### What does this PR do?
Hides controls on screenshare and external video for bot users, since we assume there is no user input on those cases. Also, removes bot users from grid layout view.


### Closes Issue(s)
Closes none

### Motivation
Increase bot's in-meeting transparency and client view.

### How to test
Join meeting with bot user(bot=true)
See screenshare
See external video
See grid-layout
