### PR TITLE
Fix(html5): External video reset when presenter Refresh client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -346,16 +346,21 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   }, [isPresenter]);
 
   const handleOnStart = async () => {
-    if (isPresenter) {
+    const currentTime = getCurrentTime();
+    const playerCurrentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
+    if (isPresenter && !playing) {
       const rate = internalPlayer instanceof HTMLVideoElement
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
-      const currentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
       sendMessage('start', {
         rate,
         time: currentTime,
       });
+    }
+
+    if (currentTime > playerCurrentTime) {
+      playerRef?.current?.seekTo(currentTime);
     }
   };
 


### PR DESCRIPTION
### What does this PR do?
The player was being reset whenever the presenter refreshed the client. This occurred because the reference time was based on the player's time, which is 0 or close to it at the start. I updated the logic to use the server-provided time instead and ensured that the start command is only sent if the video is not already playing.

### Closes Issue(s)
N/A

### How to test
- Join two users
- Share a external video 
- Refresh the presenter's client
- The player should keep at same position on viewer page 


### More

[Screencast from 14-05-2025 10:06:30.webm](https://github.com/user-attachments/assets/907b4a97-facc-407a-982d-ed19a7782914)
