### PR TITLE
fix(html5): Skip font embeding when taking snapshot of current slide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -358,7 +358,12 @@ const PresentationMenu = (props) => {
                 const width = svgElem?.width?.baseVal?.value ?? window.screen.width;
                 const height = svgElem?.height?.baseVal?.value ?? window.screen.height;
 
-                const data = await toPng(svgElem, { width, height, backgroundColor: '#FFF' });
+                const data = await toPng(svgElem, {
+                  width,
+                  height,
+                  backgroundColor: '#FFF',
+                  skipFonts: true,
+                });
 
                 const anchor = document.createElement('a');
                 anchor.href = data;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Skip font embeding when taking snapshot of current slide.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23163

### Motivation
<!-- What inspired you to submit this pull request? -->

Since we already pull SVG's from Tldraw, there is not need to embed any fonts.