### PR TITLE
fix: adds back some conditionals that got lost on merge + presentation only additional elements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -338,7 +338,10 @@ class App extends Component {
             <SidebarContentContainer isSharedNotesPinned={isSharedNotesPinned} />
             <NavBarContainer main="new" />
             <WebcamContainer />
-            <ExternalVideoPlayerContainer />
+            {
+              !isNonMediaLayout
+                && <ExternalVideoPlayerContainer />
+            }
             <GenericContentMainAreaContainer
               genericMainContentId={genericMainContentId}
             />
@@ -354,7 +357,10 @@ class App extends Component {
                 )
                 : null
             }
-            <ScreenshareContainer shouldShowScreenshare={shouldShowScreenshare} />
+            {
+              !isNonMediaLayout
+              && <ScreenshareContainer shouldShowScreenshare={shouldShowScreenshare} />
+            }
             {isSharedNotesPinned
               ? (
                 <NotesContainer
@@ -363,7 +369,9 @@ class App extends Component {
               ) : null}
             <AudioCaptionsSpeechContainer />
             {this.renderAudioCaptions()}
-            {!hideNotificationToasts && <PresentationUploaderToastContainer intl={intl} />}
+            {(
+              !hideNotificationToasts
+              && isNotificationEnabled) && <PresentationUploaderToastContainer intl={intl} />}
             <UploaderContainer />
             <BreakoutJoinConfirmationContainerGraphQL />
             <BBBLiveKitRoomContainer />
@@ -374,9 +382,11 @@ class App extends Component {
               setVideoPreviewModalIsOpen: this.setVideoPreviewModalIsOpen,
             }}
             />
-            {!hideNotificationToasts && <ToastContainer rtl />}
+            {(
+              !hideNotificationToasts
+              && isNotificationEnabled) && <ToastContainer rtl />}
             <ChatAlertContainerGraphql />
-            <RaiseHandNotifier />
+            {isRaiseHandEnabled && <RaiseHandNotifier />}
             <ManyWebcamsNotifier />
             <PollingContainer />
             <WakeLockContainer />

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -410,68 +410,6 @@ class App extends Component {
             presentationIsOpen={presentationIsOpen}
             selectedLayout={selectedLayout}
           />
-          <BannerBarContainer />
-          <NotificationsBarContainer />
-          <SidebarNavigationContainer />
-          <SidebarContentContainer isSharedNotesPinned={isSharedNotesPinned} />
-          <NavBarContainer main="new" />
-          <WebcamContainer />
-          {
-            !isNonMediaLayout
-              && <ExternalVideoPlayerContainer />
-          }
-          <GenericContentMainAreaContainer
-            genericMainContentId={genericMainContentId}
-          />
-          {
-          shouldShowPresentation
-            ? (
-              <PresentationContainer
-                setPresentationFitToWidth={this.setPresentationFitToWidth}
-                fitToWidth={presentationFitToWidth}
-                darkTheme={darkTheme}
-                presentationIsOpen={presentationIsOpen}
-              />
-            )
-            : null
-            }
-          {
-            !isNonMediaLayout
-            && <ScreenshareContainer shouldShowScreenshare={shouldShowScreenshare} />
-          }
-
-          {isSharedNotesPinned
-            ? (
-              <NotesContainer
-                area="media"
-              />
-            ) : null}
-          <AudioCaptionsSpeechContainer />
-          {this.renderAudioCaptions()}
-          { (
-            !hideNotificationToasts
-            && isNotificationEnabled) && <PresentationUploaderToastContainer intl={intl} /> }
-          <UploaderContainer />
-          <BreakoutJoinConfirmationContainerGraphQL />
-          <BBBLiveKitRoomContainer />
-          <AudioContainer {...{
-            isAudioModalOpen,
-            setAudioModalIsOpen: this.setAudioModalIsOpen,
-            isVideoPreviewModalOpen,
-            setVideoPreviewModalIsOpen: this.setVideoPreviewModalIsOpen,
-          }}
-          />
-          { (
-            !hideNotificationToasts
-            && isNotificationEnabled) && <ToastContainer rtl /> }
-          <ChatAlertContainerGraphql />
-          {isRaiseHandEnabled && <RaiseHandNotifier />}
-          <ManyWebcamsNotifier />
-          <PollingContainer />
-          <WakeLockContainer />
-          {this.renderActionsBar()}
-          <EmojiRainContainer />
-          <VoiceActivityAdapter />
         </Styled.Layout>
       </>
     );


### PR DESCRIPTION
### What does this PR do?
- [fix(layout): presentation only](https://github.com/bigbluebutton/bigbluebutton/commit/396d408bf610116393fce8365050923ea5248d33) 
 Removes additional elements that were being rendered along with the presentation. Presentation only layout should render only the presentation and other auxiliary components(i.e. layout manager/observer, plugins, global styles and screen reader alerts).

- [fix: restore conditionals lost on merge](https://github.com/bigbluebutton/bigbluebutton/commit/481e424e1683da4d88e1d16ef585ed8f49806153) 
  Restore some conditionals that were probably lost during the recent merge. Those are: flag for disabling raise hand and external video when they are specified in `disabledFeatures=` parameter. Also to disabled media when a non media layout is selected, such as `CAMERAS_ONLY` or `PARTICIPANTS_AND_CHAT_ONLY`.

### Closes Issue(s)
Closes #23174


### How to test
- PRESENTATION ONLY:
  1. Join meeting with `enforceLayout=PRESENTATION_ONLY`
  2. Check that no other graphical elements are render other than the presentation

- disabledFeatures:
  1. Join meeting with `disabledFeatures=externalVideos,raiseHand`
  2. Check that those features are proprely disabled

- Non media layouts:
  1. Join meeting with `enforceLayout=PARTICIPANTS_AND_CHAT_ONLY`
  2. Check that no presentation/screenshare/camera as content is displayed

  repeat for `enforceLayout=CAMERAS_ONLY`


