### PR TITLE
feat(plugin): Add PluginDataChannelPushEntryEvtMsg propagation

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelPushEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelPushEntryMsgHdlr.scala
@@ -1,14 +1,28 @@
 package org.bigbluebutton.core.apps.plugin
 
-import org.bigbluebutton.common2.msgs.PluginDataChannelPushEntryMsg
-import org.bigbluebutton.core.apps.plugin.PluginHdlrHelpers.{ checkPermission, dataChannelCheckingLogic }
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.common2.msgs.{ PluginDataChannelPushEntryMsg, PluginDataChannelPushEntryEvtMsg, PluginDataChannelPushEntryEvtMsgBody, BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, MessageTypes, Routing }
+import org.bigbluebutton.core.apps.plugin.PluginHdlrHelpers.{ checkPermission, dataChannelCheckingLogic, defaultCreatorCheck }
 import org.bigbluebutton.core.db.PluginDataChannelEntryDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, LogHelper }
 
 trait PluginDataChannelPushEntryMsgHdlr extends HandlerHelpers with LogHelper {
+trait PluginDataChannelPushEntryMsgHdlr extends HandlerHelpers {
+  this: PluginHdlrs =>
 
-  def handle(msg: PluginDataChannelPushEntryMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
+  def broadcastEvent(msg: PluginDataChannelPushEntryMsg, entryId: String, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
+    val envelope = BbbCoreEnvelope(PluginDataChannelPushEntryEvtMsg.NAME, routing)
+    val header = BbbClientMsgHeader(PluginDataChannelPushEntryEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
+
+    val body = PluginDataChannelPushEntryEvtMsgBody(msg.body.pluginName, msg.body.channelName, msg.body.subChannelName, msg.body.payloadJson, entryId, msg.body.toRoles, msg.body.toUserIds)
+    val event = PluginDataChannelPushEntryEvtMsg(header, body)
+    val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
+    bus.outGW.send(msgEvent)
+  }
+
+  def handle(msg: PluginDataChannelPushEntryMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
     dataChannelCheckingLogic(liveMeeting, msg.header.userId, msg.body.pluginName, msg.body.channelName, (user, dc, meetingId) => {
       val hasPermission = checkPermission(user, dc.pushPermission)
       if (!hasPermission.contains(true)) {
@@ -22,7 +36,7 @@ trait PluginDataChannelPushEntryMsgHdlr extends HandlerHelpers with LogHelper {
           msg.body.pluginName, msg.body.channelName, msg.header.meetingId
         )
       } else {
-        PluginDataChannelEntryDAO.insert(
+        val entryId = PluginDataChannelEntryDAO.insert(
           meetingId,
           msg.body.pluginName,
           msg.body.channelName,
@@ -36,6 +50,7 @@ trait PluginDataChannelPushEntryMsgHdlr extends HandlerHelpers with LogHelper {
           "Successfully inserted entry for plugin [{}] and data-channel [{}]. (meetingId: [{}])",
           msg.body.pluginName, msg.body.channelName, msg.header.meetingId
         )
+        broadcastEvent(msg, entryId, liveMeeting, bus)
       }
     })
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PluginDataChannelEntryDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PluginDataChannelEntryDAO.scala
@@ -42,11 +42,12 @@ class PluginDataChannelEntryDbTableDef(tag: Tag) extends Table[PluginDataChannel
 
 object PluginDataChannelEntryDAO {
   def insert(meetingId: String, pluginName: String, channelName: String, subChannelName: String, createdBy: String,
-             payloadJson: Map[String, Any], toRoles: List[String], toUserIds: List[String]) = {
+             payloadJson: Map[String, Any], toRoles: List[String], toUserIds: List[String]) : String = {
+    val entryId = RandomStringGenerator.randomAlphanumericString(50)
     DatabaseConnection.enqueue(
       TableQuery[PluginDataChannelEntryDbTableDef].forceInsert(
         PluginDataChannelEntryDbModel(
-          entryId = Some(RandomStringGenerator.randomAlphanumericString(50)),
+          entryId = Some(entryId),
           meetingId = meetingId,
           pluginName = pluginName,
           channelName = channelName,
@@ -63,6 +64,7 @@ object PluginDataChannelEntryDAO {
         )
       )
     )
+    entryId
   }
 
   def reset(meetingId: String, pluginName: String,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -748,7 +748,7 @@ class MeetingActor(
         updateUserLastActivity(m.header.userId)
 
       // Plugin
-      case m: PluginDataChannelPushEntryMsg    => pluginHdlrs.handle(m, state, liveMeeting)
+      case m: PluginDataChannelPushEntryMsg    => pluginHdlrs.handle(m, state, liveMeeting, msgBus)
       case m: PluginDataChannelReplaceEntryMsg => pluginHdlrs.handle(m, state, liveMeeting)
       case m: PluginDataChannelDeleteEntryMsg  => pluginHdlrs.handle(m, state, liveMeeting)
       case m: PluginDataChannelResetMsg        => pluginHdlrs.handle(m, state, liveMeeting)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PluginMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PluginMsgs.scala
@@ -26,6 +26,17 @@ case class PluginDataChannelPushEntryMsgBody(
                                               toUserIds: List[String],
                                             )
 
+object PluginDataChannelPushEntryEvtMsg { val NAME = "PluginDataChannelPushEntryEvtMsg" }
+case class PluginDataChannelPushEntryEvtMsg(header: BbbClientMsgHeader, body: PluginDataChannelPushEntryEvtMsgBody) extends StandardMsg
+case class PluginDataChannelPushEntryEvtMsgBody(
+                                              pluginName: String,
+                                              channelName: String,
+                                              subChannelName: String,
+                                              payloadJson: Map[String, Any],
+                                              entryId: String,
+                                              toRoles: List[String],
+                                              toUserIds: List[String],
+                                            )
 object PluginDataChannelReplaceEntryMsg { val NAME = "PluginDataChannelReplaceEntryMsg" }
 case class PluginDataChannelReplaceEntryMsg(header: BbbClientMsgHeader, body: PluginDataChannelReplaceEntryMsgBody) extends StandardMsg
 case class PluginDataChannelReplaceEntryMsgBody (


### PR DESCRIPTION
This adds a subsequent message to **PluginDataChannelPushEntryMsg** which happens after a successfull insert of the data in Postgres. This message is called PluginDataChannelPushEntry**Evt**Msg and has the same data and the additional `entryId` that is generated after the insert.

This is necessary for any type of server side work that processes data created by plugins in a data channel, because every usage of this data - besides the first one - will always reference `entryId`. So this adds a way for us to confirm the successfull creation of an object in a specific data channel and reference the original `entryId`  