### PR TITLE
fix(shared-notes): disable icon and fix tooltips when pinned/locked

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
@@ -115,23 +115,33 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
   }
 
   const renderNotes = () => {
-    const showTitle = isPinned ? intl.formatMessage(intlMessages.sharedNotesPinned)
-      : intl.formatMessage(intlMessages.sharedNotes);
+    let tooltipMessage = '';
+    if (disableNotes) {
+      tooltipMessage = `${intl.formatMessage(intlMessages.sharedNotes)}`
+        + ` ${intl.formatMessage(intlMessages.locked)}`
+        + ` ${intl.formatMessage(intlMessages.byModerator)}`;
+    } else if (isPinned) {
+      tooltipMessage = intl.formatMessage(intlMessages.sharedNotesPinned);
+    } else {
+      tooltipMessage = intl.formatMessage(intlMessages.sharedNotes);
+    }
     return (
       <TooltipContainer
-        title={showTitle}
+        title={tooltipMessage}
         position="right"
       >
         {/* @ts-ignore */}
         <Styled.ListItem
           id="shared-notes-toggle-button"
-          aria-label={showTitle}
+          aria-label={tooltipMessage}
           aria-describedby="lockedNotes"
           role="button"
           tabIndex={0}
           active={notesOpen}
           data-test="sharedNotesSidebarButton"
-          onClick={() => toggleNotesPanel(sidebarContentPanel, layoutContextDispatch)}
+          onClick={() => (!(isPinned || disableNotes)
+            ? toggleNotesPanel(sidebarContentPanel, layoutContextDispatch)
+            : null)}
           // @ts-ignore
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
@@ -139,8 +149,6 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
             }
           }}
           hasNotification={unread && !isPinned}
-          as={isPinned ? 'button' : 'div'}
-          disabled={isPinned || disableNotes}
           $disabled={isPinned || disableNotes}
         >
           <Icon iconName="shared_notes" />

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Styled from '../styles';
-import { colorGray } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorGray, colorGrayLightest } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   fontSizeSmaller,
   fontSizeXS,
@@ -10,7 +10,17 @@ const UnreadMessages = styled.div``;
 
 const UnreadMessagesText = styled.div``;
 
-const ListItem = styled(Styled.ListItem)``;
+interface ListItemProps {
+  $disabled?: boolean;
+}
+
+const ListItem = styled(Styled.ListItem)<ListItemProps>`
+  ${({ $disabled }) => $disabled && `
+    cursor: not-allowed;
+    border: none;
+    background-color: ${colorGrayLightest};
+  `}
+`;
 
 const NotesLock = styled.div`
   font-weight: 200;


### PR DESCRIPTION
### What does this PR do?
Disable icon and fix tooltips when pinned/locked

- Change pointer/background  and disable the click when notes are pinned/locked
- Fix tooltip not showing when notes are pinned, and restore the message to show notes are locked by moderator.

I had to change the style instead of using the disable property, because with disabled the tooltip was not being shown.

![image](https://github.com/user-attachments/assets/79048e5e-38f1-4c86-8efb-52c05ebf632a)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23063