### PR TITLE
fix: Avoid Cannot read properties of undefined (reading 'userId')

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -78,9 +78,9 @@ export const useStreams = () => {
       logger.warn({
         logCode: 'missing_stream_id',
         extraInfo: {
-          userId: user.userId,
-          role: user.role,
-          clientType: user.clientType,
+          userId: user?.userId || '',
+          role: user?.role || '',
+          clientType: user?.clientType || '',
         },
       }, 'Stream entry has no streamId.');
     }
@@ -88,9 +88,9 @@ export const useStreams = () => {
     return {
       stream: streamId ?? '',
       deviceId: streamId?.split?.('_')?.[3] ?? '',
-      name: user.name,
-      nameSortable: user.nameSortable,
-      userId: user.userId,
+      name: user?.name || '',
+      nameSortable: user?.nameSortable || '',
+      userId: user?.userId || '',
       user,
       floor: voice?.floor ?? false,
       lastFloorTime: voice?.lastFloorTime ?? '0',


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->

I see client error logs `Cannot read properties of undefined (reading 'userId')` which point to this part of the codebase.
![image](https://github.com/user-attachments/assets/1cec71a6-cc4f-48d3-a024-4fff2a7e4a27)


Note: I had reported issues like this in BBB 3.0.6 which resulted in https://github.com/bigbluebutton/bigbluebutton/pull/23112
cc @Tainan404 
Also cc @prlanzarin in case we should be handling this differently...