### PR TITLE
fix: Avoid  Cannot read properties of undefined (reading 'length')

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -144,7 +144,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, lockSettings, index }
       </span>,
     );
   }
-  if (user.cameras.length > 0 && LABEL.sharingWebcam) {
+  if (user?.cameras?.length > 0 && LABEL.sharingWebcam) {
     subs.push(
       <span key={uniqueId('breakout-')}>
         {user.pinned === true

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -367,7 +367,7 @@ const UserActions: React.FC<UserActionsProps> = ({
           === PluginSdk.UserListDropdownSeparatorPosition.BEFORE)),
     )),
     {
-      allowed: user.cameras.length > 0
+      allowed: user?.cameras?.length > 0
         && isVideoPinEnabledForCurrentUser(currentUser, isBreakout),
       key: 'pinVideo',
       label: user.pinned
@@ -565,7 +565,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     },
     {
       allowed: allowedToEjectCameras
-        && user.cameras.length > 0
+        && user?.cameras?.length > 0
         && !isBreakout,
       key: 'ejectUserCameras',
       label: intl.formatMessage(messages.ejectUserCamerasLabel),


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adds checks to ensure we have user and cameras before we check the length.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
I am seeing client errors `Cannot read properties of undefined (reading 'length')` which I correlate to this part of the code base. Also seeing `undefined is not an object (evaluating 'user.cameras.length')`

![image](https://github.com/user-attachments/assets/9cd57338-a265-4fc6-9a58-a86c1a8b6162)
