### PR TITLE
fix: Avoid Cannot read properties of null (reading 'avatar')

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
@@ -154,7 +154,7 @@ const ChatListItem = (props: ChatListItemProps) => {
                 avatar={chat.participant?.avatar}
                 color={chat.participant?.color}
               >
-                {chat.participant?.avatar.length === 0 ? chat.participant?.name.toLowerCase().slice(0, 2) : ''}
+                {chat.participant?.avatar?.length === 0 ? chat.participant?.name?.toLowerCase().slice(0, 2) : ''}
               </Styled.UserAvatar>
             )}
         </Styled.ChatIcon>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
@@ -151,8 +151,8 @@ const ChatListItem = (props: ChatListItemProps) => {
             ) : (
               <Styled.UserAvatar
                 moderator={chat.participant?.role === ROLE_MODERATOR}
-                avatar={chat.participant?.avatar}
-                color={chat.participant?.color}
+                avatar={chat.participant?.avatar || ''}
+                color={chat.participant?.color || ''}
               >
                 {chat.participant?.avatar?.length === 0 ? chat.participant?.name?.toLowerCase().slice(0, 2) : ''}
               </Styled.UserAvatar>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
@@ -151,8 +151,8 @@ const ChatListItem = (props: ChatListItemProps) => {
             ) : (
               <Styled.UserAvatar
                 moderator={chat.participant?.role === ROLE_MODERATOR}
-                avatar={chat.participant!.avatar}
-                color={chat.participant!.color}
+                avatar={chat.participant?.avatar}
+                color={chat.participant?.color}
               >
                 {chat.participant?.avatar.length === 0 ? chat.participant?.name.toLowerCase().slice(0, 2) : ''}
               </Styled.UserAvatar>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adds checks to prevent referencing null object.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
In client error logs on BBB 3.0.7 I am seeing instances of `Cannot read properties of null (reading 'avatar')` possibly causing client crashes.

In the codebase I am tracing this down to
![image](https://github.com/user-attachments/assets/56762e17-2cfe-4995-a62c-9cd6ec21a7ea)
