### PR TITLE
Fix(html5): External video player not restoring presenter's volume

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -263,10 +263,25 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     return 1;
   }, []);
 
+  const getVolume = useCallback((player: ReactPlayer) => {
+    if (player) {
+      const internalPlayer = player.getInternalPlayer();
+      if (internalPlayer instanceof HTMLVideoElement) {
+        return internalPlayer.volume;
+      }
+
+      if (internalPlayer?.getVolume) {
+        return internalPlayer.getVolume();
+      }
+    }
+    return 1;
+  }, []);
+
   useEffect(() => {
     const storedVolume = storage.getItem('externalVideoVolume');
     if (storedVolume) {
-      setVolume(storedVolume as number);
+      const volumeValue = parseFloat(storedVolume as string);
+      setVolume(volumeValue > 1 ? volumeValue / 100 : volumeValue);
     }
   }, []);
 
@@ -335,7 +350,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         && typeof internalPlayer?.getVolume === 'function'
         && internalPlayer?.getVolume() !== currentVolume.current) {
         const playerVolume = internalPlayer?.getVolume();
-        // the scale fiven by the player is 0 to 100, but the accepted scale is 0 to 1
+        // the scale given by the player is 0 to 100, but the accepted scale is 0 to 1
         // So we need to divide by 100
         setVolume(playerVolume > 1 ? playerVolume / 100 : playerVolume);
       }
@@ -427,6 +442,14 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         time: currentTime,
         state: playing ? 'playing' : '',
       });
+    }
+
+    const storedVolume = storage.getItem('externalVideoVolume');
+    const playerVolume = getVolume(playerRef.current as ReactPlayer);
+    // The value used to restore the volume is get from the browser storage
+    // So update the state isn't necessary as it's not saved on component unmount
+    if (storedVolume !== playerVolume) {
+      storage.setItem('externalVideoVolume', playerVolume);
     }
   };
 


### PR DESCRIPTION
### What does this PR do?

This PR enables saving the presenter's volume to persist it across video sessions in the external video player. Since the player does not provide a callback for volume changes, I used the onProgress callback to capture and store the volume.

### Closes Issue(s)
N/A


### How to test
- Join a Meeting
- Share a video 
- change volume 
- stop sharing 
- share a video again 
- See volume at same position


### More
[Screencast from 15-05-2025 16:46:02.webm](https://github.com/user-attachments/assets/cbd60744-bdaf-4299-ae4e-2a1cedf00967)

