### PR TITLE
Recording: Remove 'duration' lines from ffmpeg playlist

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -121,7 +121,6 @@ module BigBlueButton
           f.write("ffconcat version 1.0\n") 
           segment_files.each do |segment|
             f.write("file #{segment[:file]}\n") 
-            f.write("duration #{ms_to_s(segment[:duration])}\n") 
           end
         end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -371,7 +371,6 @@ module BigBlueButton
           outio.write("ffconcat version 1.0\n")
           concat.each do |segment|
             outio.write("file #{segment[:file]}\n")
-            outio.write("duration #{ms_to_s(segment[:duration])}\n")
           end
         end
 


### PR DESCRIPTION
Although adding these (in theory) improved audio/video sync slightly, they sometimes cause problems when the video is transcoded to vp9 after concatenation, if there are multiple short cuts near the start of the video which cause ffmpeg to identify the framerate of the concatenated file as a fraction which is close to (but not equal to) the desired framerate.

Remove these, reverting to the previous behaviour. I have some alternate ideas for improving audio/video sync that I'm still investigating.

The maximum expected difference in A/V sync is less than the duration of 1 video frame (no more than 66ms), although on long recordings with lots of cuts it's possible that the error may accumulate towards the end of the recording.

Fixes #23131