### PR TITLE
Fix(html5): Cleaning connections errors

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -247,7 +247,10 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
             closed: (e) => {
               // Check if it's a CloseEvent (which includes HTTP errors during WebSocket handshake)
               if (e instanceof CloseEvent) {
-                logger.error(`WebSocket closed with code ${e.code}: ${e.reason}`);
+                // if the code is 1000, it means the connection was closed normally
+                if (e.code !== 1000) {
+                  logger.error(`WebSocket closed with code ${e.code}: ${e.reason}`);
+                }
                 connectionStatus.setConnectedStatus(false);
               }
             },

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -284,7 +284,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
         // if not new connection is made
         apolloClient.setLink(ApolloLink.empty());
         // closes the connection
-        ws.terminate();
+        ws.dispose();
       }, 5000);
     }
   }, []);

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1295,7 +1295,7 @@ class AudioManager {
     const audioAlert = new Audio(url);
 
     audioAlert.addEventListener('ended', () => {
-      audioAlert.src = null;
+      audioAlert.src = '';
     });
 
     const { outputDeviceId } = this.bridge;


### PR DESCRIPTION
### What does this PR do?
This PR addresses two errors that appeared on the meeting end screen.

1. **WebSocket termination log**:  
   The first error was a log entry stating `terminated connection 4499`, which occurred because we were using the `terminate` method to stop the WebSocket connection, moved to `dispose` that has a friendly message.

2. **Unexpected fetch to `/html5client/null`**:  
   The second issue was a fetch request to `/html5client/null`, caused by an audio alert cleanup process that assigned `null` as the source. This `null` value was likely being stringified and incorrectly used as the new audio source, triggering the request.


### Closes Issue(s)
I kept aware about this error because of the issue #22982

### How to test
- Join a meeting.
- Open the devtools.
- leave the meeting using the button leave.
- Look ate the console and network tab for the errors.

### More
Before
![image](https://github.com/user-attachments/assets/0757b693-c940-45ba-a753-8ebd84ccd6c9)

After 
![image](https://github.com/user-attachments/assets/44566d4e-a298-4995-a20e-42629b4fdb95)

