### PR TITLE
fix(html5): data-channel dispatching multiple replace/delete messages to akka

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDeleteEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDeleteEntryMsgHdlr.scala
@@ -4,9 +4,9 @@ import org.bigbluebutton.common2.msgs.PluginDataChannelDeleteEntryMsg
 import org.bigbluebutton.core.apps.plugin.PluginHdlrHelpers.{ checkPermission, dataChannelCheckingLogic, defaultCreatorCheck }
 import org.bigbluebutton.core.db.PluginDataChannelEntryDAO
 import org.bigbluebutton.core.domain.MeetingState2x
-import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, LogHelper }
 
-trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers {
+trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers with LogHelper {
 
   def handle(msg: PluginDataChannelDeleteEntryMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
     dataChannelCheckingLogic(liveMeeting, msg.header.userId, msg.body.pluginName, msg.body.channelName, (user, dc, meetingId) => {
@@ -14,7 +14,7 @@ trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers {
         meetingId, msg.body, msg.header.userId
       ))
       if (!hasPermission.contains(true)) {
-        println(s"No permission to delete in plugin: '${msg.body.pluginName}', data channel: '${msg.body.channelName}'.")
+        log.warning("No permission to delete data-channel entry for plugin [{}] in data-channel [{}].", msg.body.pluginName, msg.body.channelName)
       } else {
         PluginDataChannelEntryDAO.delete(
           meetingId,
@@ -22,6 +22,10 @@ trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers {
           msg.body.channelName,
           msg.body.subChannelName,
           msg.body.entryId
+        )
+        log.info(
+          "Successfully deleted entry with ID [{}] for plugin [{}] and data-channel [{}].",
+          msg.body.entryId, msg.body.pluginName, msg.body.channelName
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDeleteEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDeleteEntryMsgHdlr.scala
@@ -14,7 +14,10 @@ trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers with LogHelper 
         meetingId, msg.body, msg.header.userId
       ))
       if (!hasPermission.contains(true)) {
-        log.warning("No permission to delete data-channel entry for plugin [{}] in data-channel [{}].", msg.body.pluginName, msg.body.channelName)
+        log.warning(
+          "User [{}] in meeting [{}] lacks permission to delete entry for data-channel [{}] from plugin [{}].",
+          msg.header.userId, msg.header.meetingId, msg.body.channelName, msg.body.pluginName
+        )
       } else {
         PluginDataChannelEntryDAO.delete(
           meetingId,
@@ -23,9 +26,9 @@ trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers with LogHelper 
           msg.body.subChannelName,
           msg.body.entryId
         )
-        log.info(
-          "Successfully deleted entry with ID [{}] for plugin [{}] and data-channel [{}].",
-          msg.body.entryId, msg.body.pluginName, msg.body.channelName
+        log.debug(
+          "Successfully deleted entry [{}] for plugin [{}] in data-channel [{}] (meetingId: [{}]).",
+          msg.body.entryId, msg.body.pluginName, msg.body.channelName, msg.header.meetingId
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelPushEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelPushEntryMsgHdlr.scala
@@ -12,11 +12,14 @@ trait PluginDataChannelPushEntryMsgHdlr extends HandlerHelpers with LogHelper {
     dataChannelCheckingLogic(liveMeeting, msg.header.userId, msg.body.pluginName, msg.body.channelName, (user, dc, meetingId) => {
       val hasPermission = checkPermission(user, dc.pushPermission)
       if (!hasPermission.contains(true)) {
-        log.warning("No permission to write in data-channel [{}] for plugin [{}].", msg.body.channelName, msg.body.pluginName)
+        log.warning(
+          "User [{}] in meeting [{}] lacks permission to write in data-channel [{}] from plugin [{}].",
+          msg.header.userId, msg.header.meetingId, msg.body.channelName, msg.body.pluginName
+        )
       } else if (msg.body.payloadJson == null) {
         log.error(
-          "Received payload null for plugin [{}] and data channel [{}]. Not persisting entry.",
-          msg.body.pluginName, msg.body.channelName
+          "Received payload null for plugin [{}] and data-channel [{}]. Not persisting entry. (meetingId: [{}])",
+          msg.body.pluginName, msg.body.channelName, msg.header.meetingId
         )
       } else {
         PluginDataChannelEntryDAO.insert(
@@ -29,9 +32,9 @@ trait PluginDataChannelPushEntryMsgHdlr extends HandlerHelpers with LogHelper {
           msg.body.toRoles,
           msg.body.toUserIds
         )
-        log.info(
-          "Successfully inserted entry for plugin: [{}] and data channel: [{}].",
-          msg.body.pluginName, msg.body.channelName
+        log.debug(
+          "Successfully inserted entry for plugin [{}] and data-channel [{}]. (meetingId: [{}])",
+          msg.body.pluginName, msg.body.channelName, msg.header.meetingId
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelReplaceEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelReplaceEntryMsgHdlr.scala
@@ -4,9 +4,9 @@ import org.bigbluebutton.common2.msgs.PluginDataChannelReplaceEntryMsg
 import org.bigbluebutton.core.apps.plugin.PluginHdlrHelpers.{checkPermission, dataChannelCheckingLogic, defaultCreatorCheck}
 import org.bigbluebutton.core.db.{JsonUtils, PluginDataChannelEntryDAO}
 import org.bigbluebutton.core.domain.MeetingState2x
-import org.bigbluebutton.core.running.{HandlerHelpers, LiveMeeting}
+import org.bigbluebutton.core.running.{HandlerHelpers, LiveMeeting, LogHelper}
 
-trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers {
+trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers with LogHelper {
 
   def handle(msg: PluginDataChannelReplaceEntryMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
 
@@ -15,7 +15,12 @@ trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers {
         meetingId, msg.body, msg.header.userId))
 
       if (!hasPermission.contains(true)) {
-        println(s"No permission to write in plugin: '${msg.body.pluginName}', data channel: '${msg.body.channelName}'.")
+        log.warning(
+          "No permission to update data-channel entry with ID [{}] for plugin [{}] and data-channel [{}].",
+          msg.body.entryId,
+          msg.body.pluginName,
+          msg.body.channelName
+        )
       } else {
         PluginDataChannelEntryDAO.replace(
           msg.header.meetingId,
@@ -24,6 +29,10 @@ trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers {
           msg.body.subChannelName,
           msg.body.entryId,
           JsonUtils.mapToJson(msg.body.payloadJson),
+        )
+        log.info(
+          "Successfully updated entry with ID [{}] for plugin [{}] and data-channel [{}].",
+          msg.body.entryId, msg.body.pluginName, msg.body.channelName
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelReplaceEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelReplaceEntryMsgHdlr.scala
@@ -16,11 +16,13 @@ trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers with LogHelper
 
       if (!hasPermission.contains(true)) {
         log.warning(
-          "No permission to update data-channel entry with ID [{}] for plugin [{}] and data-channel [{}].",
+          s"User [${msg.header.userId}] in meeting [{}] lacks permission to update entry [{}] for plugin [{}] in data channel [{}].",
+          msg.header.meetingId,
           msg.body.entryId,
           msg.body.pluginName,
           msg.body.channelName
         )
+
       } else {
         PluginDataChannelEntryDAO.replace(
           msg.header.meetingId,
@@ -30,9 +32,9 @@ trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers with LogHelper
           msg.body.entryId,
           JsonUtils.mapToJson(msg.body.payloadJson),
         )
-        log.info(
-          "Successfully updated entry with ID [{}] for plugin [{}] and data-channel [{}].",
-          msg.body.entryId, msg.body.pluginName, msg.body.channelName
+        log.debug(
+          "Successfully updated entry [{}] for plugin [{}] and data-channel [{}]. (meetingId: [{}])",
+          msg.body.entryId, msg.body.pluginName, msg.body.channelName, msg.header.meetingId
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelResetMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelResetMsgHdlr.scala
@@ -14,9 +14,8 @@ trait PluginDataChannelResetMsgHdlr extends HandlerHelpers with LogHelper {
 
       if (!hasPermission.contains(true)) {
         log.warning(
-          "No permission to reset data-channel [{}] for plugin [{}].",
-          msg.body.channelName,
-          msg.body.pluginName,
+          "User [{}] in meeting [{}] lacks permission to reset data-channel [{}] from plugin [{}].",
+          msg.header.userId, msg.header.meetingId, msg.body.channelName, msg.body.pluginName
         )
       } else {
         PluginDataChannelEntryDAO.reset(
@@ -25,9 +24,9 @@ trait PluginDataChannelResetMsgHdlr extends HandlerHelpers with LogHelper {
           msg.body.channelName,
           msg.body.subChannelName
         )
-        log.info(
-          "Successfully reset data-channel [{}] for plugin [{}].",
-          msg.body.channelName, msg.body.pluginName
+        log.debug(
+          "Successfully reset data-channel [{}] for plugin [{}]. (meetingId: [{}])",
+          msg.body.channelName, msg.body.pluginName, msg.header.meetingId
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelResetMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelResetMsgHdlr.scala
@@ -4,22 +4,30 @@ import org.bigbluebutton.common2.msgs.PluginDataChannelResetMsg
 import org.bigbluebutton.core.apps.plugin.PluginHdlrHelpers.{ checkPermission, dataChannelCheckingLogic }
 import org.bigbluebutton.core.db.PluginDataChannelEntryDAO
 import org.bigbluebutton.core.domain.MeetingState2x
-import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, LogHelper }
 
-trait PluginDataChannelResetMsgHdlr extends HandlerHelpers {
+trait PluginDataChannelResetMsgHdlr extends HandlerHelpers with LogHelper {
 
   def handle(msg: PluginDataChannelResetMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
     dataChannelCheckingLogic(liveMeeting, msg.header.userId, msg.body.pluginName, msg.body.channelName, (user, dc, meetingId) => {
       val hasPermission = checkPermission(user, dc.replaceOrDeletePermission)
 
       if (!hasPermission.contains(true)) {
-        println(s"No permission to delete (reset) in plugin: '${msg.body.pluginName}', data channel: '${msg.body.channelName}'.")
+        log.warning(
+          "No permission to reset data-channel [{}] for plugin [{}].",
+          msg.body.channelName,
+          msg.body.pluginName,
+        )
       } else {
         PluginDataChannelEntryDAO.reset(
           meetingId,
           msg.body.pluginName,
           msg.body.channelName,
           msg.body.subChannelName
+        )
+        log.info(
+          "Successfully reset data-channel [{}] for plugin [{}].",
+          msg.body.channelName, msg.body.pluginName
         )
       }
     })

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginHdlrs.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginHdlrs.scala
@@ -11,5 +11,4 @@ class PluginHdlrs(implicit val context: ActorContext)
   with PluginDataChannelResetMsgHdlr
   with PluginPersistEventMsgHdlr {
 
-  val log = Logging(context.system, getClass)
 }

--- a/bbb-graphql-actions/src/imports/validation.ts
+++ b/bbb-graphql-actions/src/imports/validation.ts
@@ -62,7 +62,7 @@ export const throwErrorIfInvalidInput = (input: Record<string, unknown>, expecte
                     }
                     break;
                 case 'json':
-                    if (typeof value !== 'object') {
+                    if (typeof value !== 'object' || value === null) {
                         throw new ValidationError(`Parameter '${param.name}' should be of type ${param.type}`, 400);
                     }
                     try {


### PR DESCRIPTION
### What does this PR do?

It fixes a wrong behaviour of sending multiple delete/replace data-channel entry messages in redis calling it only once;
Adds a validation to not allow null payloads in push function of data-channel;
Adds some logs to inform the dev/sysadmin where the data-channels information is passing;

### Motivation

Avoid misinterpretation of multiple data-channel messages being sent at once.

### How to test

1. Load a plugin known to send delete/replace functions of the data-channel (e.g.: pick-random-user);
2. Observe redis traffic when clearing the data-channels and make sure only one message is sent at a time (in pick-random-user this would mean to clear the already picked user list, for instance).

To check on Redis traffic, I'd recommend:
```bash
echo 'PSUBSCRIBE *' | redis-cli &> redis.log
```

This will create a process in which you can end by doing CTRL + C, and all the traffic passed through redis during the time the command was on is getting captured and saved in redis.log 


