### PR TITLE
fix(layout): push layout not syncing between presenter and moderators

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -143,7 +143,6 @@ class ActionsBar extends PureComponent {
       layoutContextDispatch,
       actionsBarStyle,
       setMeetingLayout,
-      showPushLayout,
       setPushLayout,
       setPresentationFitToWidth,
       isPresentationEnabled,
@@ -248,7 +247,6 @@ class ActionsBar extends PureComponent {
                 setMeetingLayout,
                 setPushLayout,
                 presentationIsOpen,
-                showPushLayout,
                 hasCameraAsContent,
                 setPresentationFitToWidth,
               }}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/container.jsx
@@ -31,9 +31,6 @@ import { EXTERNAL_VIDEO_STOP } from '../external-video-player/mutations';
 import { PINNED_PAD_SUBSCRIPTION } from '../notes/queries';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
-import { useMeetingLayoutUpdater, usePushLayoutUpdater } from '../layout/push-layout/hooks';
-import useSettings from '/imports/ui/services/settings/hooks/useSettings';
-import { SETTINGS } from '/imports/ui/services/settings/enums';
 import deviceInfo from '/imports/utils/deviceInfo';
 
 const isLayeredView = window.matchMedia(`(max-width: ${SMALL_VIEWPORT_BREAKPOINT}px)`);
@@ -47,13 +44,8 @@ const isReactionsButtonEnabled = () => {
 
 const ActionsBarContainer = (props) => {
   const NOTES_CONFIG = window.meetingClientSettings.public.notes;
-  const LAYOUT_CONFIG = window.meetingClientSettings.public.layout;
-  const { showPushLayoutButton } = LAYOUT_CONFIG;
   const actionsBarStyle = layoutSelectOutput((i) => i.actionBar);
   const layoutContextDispatch = layoutDispatch();
-  const cameraDockOutput = layoutSelectOutput((i) => i.cameraDock);
-  const cameraDockInput = layoutSelectInput((i) => i.cameraDock);
-  const presentationInput = layoutSelectInput((i) => i.presentation);
   const sidebarNavigation = layoutSelectInput((i) => i.sidebarNavigation);
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
 
@@ -108,15 +100,6 @@ const ActionsBarContainer = (props) => {
   const [darkModeIsEnabled, setDarkModeIsEnabled] = useState(isDarkThemeEnabled());
   const isPollingEnabled = useIsPollingEnabled() && isPresentationEnabled;
   const isRaiseHandEnabled = useIsRaiseHandEnabled();
-  const applicationSettings = useSettings(SETTINGS.APPLICATION);
-  const { pushLayout } = applicationSettings;
-  const setPushLayout = usePushLayoutUpdater(pushLayout);
-  const setMeetingLayout = useMeetingLayoutUpdater(
-    cameraDockOutput,
-    cameraDockInput,
-    presentationInput,
-    applicationSettings,
-  );
   const { isOpen: sidebarNavigationIsOpen } = sidebarNavigation;
   const { isOpen: sidebarContentIsOpen } = sidebarContent;
   const ariaHidden = sidebarNavigationIsOpen
@@ -174,9 +157,6 @@ const ActionsBarContainer = (props) => {
         isTimerActive: currentMeeting.componentsFlags.hasTimer,
         isTimerEnabled: isTimerFeatureEnabled,
         hasGenericContent: isThereGenericMainContent,
-        setPushLayout,
-        setMeetingLayout,
-        showPushLayout: showPushLayoutButton && applicationSettings.selectedLayout === 'custom',
         ariaHidden,
         isDarkThemeEnabled: darkModeIsEnabled,
         isMobile,

--- a/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/modal/component.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
-import { LAYOUT_TYPE, CAMERADOCK_POSITION, HIDDEN_LAYOUTS } from '/imports/ui/components/layout/enums';
+import { LAYOUT_TYPE, CAMERADOCK_POSITION } from '/imports/ui/components/layout/enums';
 import SettingsService from '/imports/ui/components/settings/service';
 import deviceInfo from '/imports/utils/deviceInfo';
 import Button from '/imports/ui/components/common/button/component';
@@ -27,22 +27,33 @@ const LayoutModalComponent = ({
 }) => {
   const [selectedLayout, setSelectedLayout] = useState(application.selectedLayout);
   const [layoutOptions, setLayoutOptions] = useState([]);
-
+  const storageKey = `keepPushingLayout_${Auth.meetingID}`;
   const isKeepPushingLayoutEnabled = SettingsService.isKeepPushingLayoutEnabled();
 
   const getKeepPushingLayout = () => {
     if (!isKeepPushingLayoutEnabled) return false;
-
-    const storageKey = `keepPushingLayout_${Auth.meetingID}`;
     return Storage.getItem(storageKey) === true;
   };
 
   const setKeepPushingLayout = (value) => {
-    const storageKey = `keepPushingLayout_${Auth.meetingID}`;
     Storage.setItem(storageKey, value);
   };
 
-  const BASE_NAME = window.meetingClientSettings.public.app.cdn + window.meetingClientSettings.public.app.basename;
+  const [pushLayout, setPushLayout] = useState(getKeepPushingLayout());
+
+  useEffect(() => {
+    const syncValue = (event) => {
+      setPushLayout(event);
+    };
+
+    Storage.registerObserver(storageKey, syncValue);
+    return () => {
+      Storage.revokeObserver(storageKey, syncValue);
+    };
+  }, [Auth.meetingID]);
+
+  const BASE_NAME = window.meetingClientSettings.public.app.cdn
+    + window.meetingClientSettings.public.app.basename;
 
   const LAYOUTS_PATH = `${BASE_NAME}/resources/images/layouts/`;
 
@@ -141,15 +152,13 @@ const LayoutModalComponent = ({
   };
 
   const handleUpdateLayout = () => {
-    const keepPushingLayout = getKeepPushingLayout();
-
     const obj = {
       application:
-        { ...application, selectedLayout, pushLayout: keepPushingLayout },
+        { ...application, selectedLayout },
     };
-    if ((isModerator || isPresenter) && keepPushingLayout) {
+    if ((isModerator || isPresenter) && pushLayout) {
       updateSettings(obj, intlMessages.layoutToastLabelAuto);
-    } else if ((isModerator || isPresenter) && !keepPushingLayout) {
+    } else if ((isModerator || isPresenter) && !pushLayout) {
       updateSettings(obj, intlMessages.layoutToastLabelAutoOff);
     } else {
       updateSettings(obj, intlMessages.layoutToastLabel);
@@ -159,8 +168,7 @@ const LayoutModalComponent = ({
   };
 
   const toggleKeepPushingLayout = () => {
-    const current = getKeepPushingLayout();
-    setKeepPushingLayout(!current);
+    setKeepPushingLayout(!pushLayout);
   };
 
   const displayToggleStatus = (toggleValue) => (
@@ -170,24 +178,20 @@ const LayoutModalComponent = ({
     </Styled.ToggleLabel>
   );
 
-  const renderToggle = () => {
-    const keepPushingLayout = getKeepPushingLayout();
-
-    return (
-      <Styled.ToggleStatusWrapper>
-        {displayToggleStatus(keepPushingLayout)}
-        <Toggle
-          id="TogglePush"
-          icons={false}
-          defaultChecked={keepPushingLayout}
-          onChange={toggleKeepPushingLayout}
-          ariaLabel="push"
-          data-test="updateEveryoneLayoutToggle"
-          showToggleLabel={false}
-        />
-      </Styled.ToggleStatusWrapper>
-    );
-  };
+  const renderToggle = () => (
+    <Styled.ToggleStatusWrapper>
+      {displayToggleStatus(pushLayout)}
+      <Toggle
+        id="TogglePush"
+        icons={false}
+        checked={pushLayout}
+        onChange={toggleKeepPushingLayout}
+        ariaLabel="push"
+        data-test="updateEveryoneLayoutToggle"
+        showToggleLabel={false}
+      />
+    </Styled.ToggleStatusWrapper>
+  );
 
   const renderPushLayoutsOptions = () => {
     if (!isModerator && !isPresenter) {
@@ -228,7 +232,8 @@ const LayoutModalComponent = ({
               onClick={() => {
                 if (!supported) return;
                 handleSwitchLayout(layoutKey);
-                if (layoutKey === LAYOUT_TYPE.CUSTOM_LAYOUT && application.selectedLayout !== layoutKey) {
+                if (layoutKey === LAYOUT_TYPE.CUSTOM_LAYOUT
+                  && application.selectedLayout !== layoutKey) {
                   document.getElementById('layout')?.setAttribute('data-cam-position', CAMERADOCK_POSITION.CONTENT_TOP);
                 }
               }}

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -21,14 +21,14 @@ const useMeetingLayoutUpdater = (
   cameraDockOutput: Output['cameraDock'],
   cameraDockInput: Input['cameraDock'],
   presentationInput: Input['presentation'],
-  applicationSettings: { pushLayout: boolean, selectedLayout: boolean },
+  selectedLayout: string,
+  pushLayout: boolean,
 ) => {
   const [setMeetingLayoutProps] = useMutation(SET_LAYOUT_PROPS);
 
   const { focusedId, position } = cameraDockOutput;
   const { isResizing } = cameraDockInput;
   const { isOpen: presentationIsOpen } = presentationInput;
-  const { pushLayout, selectedLayout } = applicationSettings;
 
   const setMeetingLayout = () => {
     setMeetingLayoutProps({

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -435,7 +435,8 @@ const PushLayoutEngineContainer = (props) => {
     cameraDockOutput,
     cameraDockInput,
     presentationInput,
-    applicationSettings,
+    selectedLayout,
+    pushLayout,
   );
 
   const validateEnforceLayout = (currUser) => {

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -297,12 +297,8 @@ const PushLayoutEngine = (props) => {
     if ((isModerator || isPresenter)
       && pushLayoutMeetingDidChange
       && pushLayoutMeeting !== pushLayout) {
-      updateSettings({
-        application: {
-          ...Settings.application,
-          pushLayout: pushLayoutMeeting,
-        },
-      }, null, setLocalSettings);
+      const storageKey = `keepPushingLayout_${Auth.meetingID}`;
+      Storage.setItem(storageKey, pushLayoutMeeting);
     }
 
     // REPLICATE LAYOUT


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the state of the push layout didn't sync between presenter and moderators, it would always show the toggle as disabled in moderators view. This was caused by the value being updated as it was still part of the settings object, which it is not anymore, as: https://github.com/bigbluebutton/bigbluebutton/pull/22333.


- [fix(layout): unsynced push layout toggle for presenter and moderators](https://github.com/bigbluebutton/bigbluebutton/commit/f96261e4d719a5eb9f3cb1165cab4350fc8e071d) 
  Fixes an issue where the local push layout state was being updated as if it were still part of the settings object, which it no longer is.
- [fix(layout): sync push layout state on modal and update mutation](https://github.com/bigbluebutton/bigbluebutton/commit/98a46123f6abdfc22a03caccdeafb87ddae877d3) 
  Adds local state in the layout modal to reflect the changes made to the push layout to enhance UI/UX. Also updates the hook to update the meeting layout as it expected the push layout state to be member of Settings
object.
- [refactor(actions-bar): removes unused layout variables](https://github.com/bigbluebutton/bigbluebutton/commit/d84cc6b7583fdc1ddc07e79b70b2682ac132cf2a)


### Closes Issue(s)
Closes #none

### How to test
1. Join meeting in 2 sessions: presenter(p1) and moderator(m1)
2. In P1 session: open layout modal and change the push layout toggle, apply.
3. In M1 session: open layout modal, check push layout toggle state is synced.

