### PR TITLE
fix(livekit): ensure camera subscription on meeting join

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -99,7 +99,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   const connectionState = useConnectionState(liveKitRoom);
   const cameraTracks = useTracks([Track.Source.Camera], {
     room: liveKitRoom,
-    onlySubscribed: true,
+    onlySubscribed: false,
     updateOnlyOn: [
       RoomEvent.TrackPublished, RoomEvent.TrackUnpublished,
       RoomEvent.TrackSubscribed, RoomEvent.TrackUnsubscribed,


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): ensure camera subscription on meeting join](https://github.com/bigbluebutton/bigbluebutton/commit/24013705b7ca908a9df0530a33e85ad62fe0cbcc) 
  - Cameras could fail to subscribe on meeting join due to missing initial
publish events. The `cameraTracks` prop, intended to
handle this, incorrectly filtered for only subscribed tracks. This
prevented updates when trailing cameras needed subscription.
  - Removed the `onlySubscribed` filter from the `useTracks` hook call in
LK's camera bridge. This ensures state updates for all tracks,
guaranteeing subscription of previously missed cameras.

### Closes Issue(s)

None