### PR TITLE
fix(audio): use storage to check if input device was previously set

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -22,6 +22,7 @@ import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockCon
 import deviceInfo from '/imports/utils/deviceInfo';
 import { useIsAudioTranscriptionEnabled } from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
 import useIsAudioConnected from '/imports/ui/components/audio/audio-graphql/hooks/useIsAudioConnected';
+import { getStoredAudioInputDeviceId } from '/imports/api/audio/client/bridge/service';
 
 const invalidDialNumbers = ['0', '613-555-1212', '613-555-1234', '0000'];
 
@@ -95,7 +96,7 @@ const AudioModalContainer = (props) => {
   const { userLocks } = useLockContext();
   const isListenOnlyInputDevice = Service.inputDeviceId() === 'listen-only';
   const devicesAlreadyConfigured = skipEchoTestIfPreviousDevice
-    && Service.inputDeviceId();
+    && !!getStoredAudioInputDeviceId();
   const joinFullAudioImmediately = !isListenOnlyInputDevice
     && (skipCheck || (skipCheckOnJoin && !getEchoTest) || devicesAlreadyConfigured);
   const joinMic = useCallback(


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): use storage to check if input device was previously set](https://github.com/bigbluebutton/bigbluebutton/commit/8c8c8d5ec318fd06cc7d93fbf6798824aa731320) 
  - The check to determine whether a device was previously set was pulling
directly from AudioManager's inputDeviceID getter. That getter is
updated regardless of whether a device was joined with. This causes an
issue with the skipEchoIfPreviousDevice where the modal might be skipped
even it a device wasn't previously configured for the current
session/domain.
  - Pull the device ID from the storage instead to guarantee that only those
that were actively used for audio are taken into account. Additionally,
make the check always evaluate to boolean for consistenc

### Closes Issue(s)

