### PR TITLE
fix (build): Tweak mkclean url

### DIFF
--- a/build/packages-template/bbb-mkclean/build.sh
+++ b/build/packages-template/bbb-mkclean/build.sh
@@ -14,7 +14,7 @@ DISTRO=$(echo $TARGET | cut -d'_' -f3)
 rm -rf staging
 
 if [ ! -f mkclean-0.8.10.tar.bz2 ]; then
-    wget https://phoenixnap.dl.sourceforge.net/project/matroska/mkclean/mkclean-0.8.10.tar.bz2 -O mkclean-0.8.10.tar.bz2
+    wget https://sourceforge.net/projects/matroska/files/mkclean/mkclean-0.8.10.tar.bz2/download -O mkclean-0.8.10.tar.bz2
 fi
 if ! sha256sum -c mkclean.sha256sum ; then
     exit 1


### PR DESCRIPTION
BBB packaging is failing during `bbb-mkclean` with this error:
```
https://phoenixnap.dl.sourceforge.net/project/matroska/mkclean/mkclean-0.8.10.tar.bz2
Resolving phoenixnap.dl.sourceforge.net (phoenixnap.dl.sourceforge.net)... 184.164.141.26
Connecting to phoenixnap.dl.sourceforge.net (phoenixnap.dl.sourceforge.net)|184.164.141.26|:443... connected.
ERROR: cannot verify phoenixnap.dl.sourceforge.net's certificate, issued by 'CN=ZeroSSL RSA Domain Secure Site CA,O=ZeroSSL,C=AT':
Issued certificate has expired.
To connect to phoenixnap.dl.sourceforge.net insecurely, use `--no-check-certificate'.
```

This PR will remove the fixed mirror and use a sourceforge download page to download mkclean instead.

Related: https://github.com/bigbluebutton/bigbluebutton/pull/22271#issuecomment-2653840216