### PR TITLE
fix(actions-bar): presentation button divider and hover

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -233,7 +233,7 @@ class ActionsBar extends PureComponent {
                   isDarkThemeEnabled={isDarkThemeEnabled}
                 />
               )}
-              { amIPresenter && (<Styled.Divider />)}
+              { (amIPresenter || amIModerator) && (<Styled.Divider />)}
               <MediaAreaDropdown {...{
                 amIPresenter,
                 amIModerator,

--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -394,6 +394,7 @@ const ButtonSpan = styled.span`
     outline-style: dotted;
     outline-width: ${borderSize};
     text-decoration: none;
+    background-color: ${btnPrimaryHoverBg};
   }
 
   &:active,

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -61,7 +61,7 @@ const btnDefaultGhostActiveBg = 'var(--btn-default-active-bg, rgba(255, 255, 255
 const btnPrimaryBorder = 'var(--btn-primary-border, rgba(15, 112, 215, 0.5))'; // colorPrimary, 50%
 const btnPrimaryColor = `var(--btn-primary-color, ${colorWhite})`;
 const btnPrimaryBg = `var(--btn-primary-bg, ${colorPrimary})`;
-const btnPrimaryHoverBg = 'var(--btn-primary-hover-bg, #0C57A7)';
+const btnPrimaryHoverBg = `var(--btn-primary-hover-bg, ${colorBlueAux})`;
 const btnPrimaryActiveBg = 'var(--btn-primary-active-bg, #0A4B8F)';
 
 const btnSuccessBorder = `var(--btn-success-border, ${colorSuccess})`;


### PR DESCRIPTION
### What does this PR do?
Fixes the condition to show the divider between presentation restore/collapse and media area drop-up. Also adjusts the buttons' hover color to enhance its visibility.

![Screenshot from 2025-05-19 15-41-11](https://github.com/user-attachments/assets/7f137da2-78af-402f-8a08-ba5ea35420d5)


### Closes Issue(s)
Closes #none
