### PR TITLE
Fix(html5): Ensure audio autoplay permission for playAlertSound method

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -67,6 +67,22 @@ const checkMediaDevicesTarget = () => {
 };
 
 class AudioManager {
+  static playAudioElement(element) {
+    return new Promise((resolve) => {
+      if (!(element instanceof HTMLMediaElement)) {
+        // Provided element is not a valid audio/video element.
+        resolve(false);
+        return;
+      }
+
+      element.play().then(() => {
+        resolve(true);
+      }).catch(() => {
+        resolve(false);
+      });
+    });
+  }
+
   constructor() {
     this._breakoutAudioTransferStatus = {
       status: BREAKOUT_AUDIO_TRANSFER_STATES.DISCONNECTED,
@@ -1303,29 +1319,10 @@ class AudioManager {
     if (outputDeviceId && typeof audioAlert.setSinkId === 'function') {
       return audioAlert
         .setSinkId(outputDeviceId)
-        .then(() => this.canAutoplayAudioElement(audioAlert));
+        .then(() => AudioManager.playAudioElement(audioAlert));
     }
 
-    return this.canAutoplayAudioElement(audioAlert);
-  }
-
-  canAutoplayAudioElement(element) {
-    return new Promise((resolve) => {
-      if (!(element instanceof HTMLMediaElement)) {
-        // Provided element is not a valid audio/video element.
-        resolve(false);
-        return;
-      }
-
-      element.play().then(() => {
-        resolve(true);
-      }).catch(() => {
-        this.handlePlayElementFailed({
-          detail: { mediaElement: element, callback: resolve },
-        });
-        resolve(false);
-      });
-    });
+    return AudioManager.playAudioElement(audioAlert);
   }
 
   async updateAudioConstraints(constraints) {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1301,10 +1301,31 @@ class AudioManager {
     const { outputDeviceId } = this.bridge;
 
     if (outputDeviceId && typeof audioAlert.setSinkId === 'function') {
-      return audioAlert.setSinkId(outputDeviceId).then(() => audioAlert.play());
+      return audioAlert
+        .setSinkId(outputDeviceId)
+        .then(() => this.canAutoplayAudioElement(audioAlert));
     }
 
-    return audioAlert.play();
+    return this.canAutoplayAudioElement(audioAlert);
+  }
+
+  canAutoplayAudioElement(element) {
+    return new Promise((resolve) => {
+      if (!(element instanceof HTMLMediaElement)) {
+        // Provided element is not a valid audio/video element.
+        resolve(false);
+        return;
+      }
+
+      element.play().then(() => {
+        resolve(true);
+      }).catch(() => {
+        this.handlePlayElementFailed({
+          detail: { mediaElement: element, callback: resolve },
+        });
+        resolve(false);
+      });
+    });
   }
 
   async updateAudioConstraints(constraints) {


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new method, `canAutoplayAudioElement`, which returns a `Promise<boolean>` that resolves to `true` if the audio was successfully played, and `false` otherwise. This approach was chosen as a reliable way to determine whether audio playback is permitted by the browser, without relying on any newer or experimental APIs.

There are two potential options for future refactoring:

1. [`userActivation.hasBeenActive`](https://developer.mozilla.org/en-US/docs/Web/API/UserActivation/hasBeenActive):  
   This property returns `true` if the user has interacted with the page. Since media playback is often gated by user interaction, this could help anticipate autoplay behavior. However, browser support only became widely available in 2023, which limits compatibility with older browsers.

2. [`navigator.getAutoplayPolicy()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getAutoplayPolicy):  
   This method returns the autoplay policy for different types of media. While promising, it is currently only supported in Firefox, making it unsuitable for cross-browser use at this time.

### Closes Issue(s)
Closes #23196

