### PR TITLE
fix(tests): Remove flaky tag from audio mute and lock viewers tests

### DIFF
--- a/bigbluebutton-tests/playwright/audio/audio.spec.js
+++ b/bigbluebutton-tests/playwright/audio/audio.spec.js
@@ -27,8 +27,7 @@ test.describe('Audio', { tag: '@ci' }, () => {
   });
 
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#muteunmute
-  // Ci failure: not being muted when clicking the mute button (isTalking element keep displayed)
-  test('Mute yourself by clicking the mute button', { tag: '@flaky' }, async () => {
+  test('Mute yourself by clicking the mute button', async () => {
     await audio.muteYourselfByButton();
   });
 

--- a/bigbluebutton-tests/playwright/user/lockViewers.js
+++ b/bigbluebutton-tests/playwright/user/lockViewers.js
@@ -212,7 +212,7 @@ class LockViewers extends MultiUsers {
     await sleep(1000);   // timeout to ensure that the userPage presentation is zoomed in stabilized
     await drawArrow(this.userPage);
     const screenshotOptions = {
-      maxDiffPixels: 250,
+      maxDiffPixels: 500,
     };
     // lock the viewers annotations
     await openLockViewers(this.modPage);

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -223,7 +223,7 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
         await lockViewers.lockSeeOtherViewersUserList();
       });
 
-      test('Lock see other viewers annotations', { tag: '@flaky' }, async ({ browser, context, page }) => {
+      test('Lock see other viewers annotations', async ({ browser, context, page }) => {
         const lockViewers = new LockViewers(browser, context);
         await lockViewers.initPages(page);
         await lockViewers.lockSeeOtherViewersAnnotations();


### PR DESCRIPTION
### What does this PR do?
Routine PR to check current flaky tests and check which can be re-added on CI

- `Mute yourself by clicking the mute button`: https://github.com/bigbluebutton/bigbluebutton/pull/22100 fixed, but the flag was missing to be removed
- `Lock see other viewers annotations`: slight pixels diff tolerance was enough to have it passing