### PR TITLE
chore (html5): Add temporary logs to the EndMeeting component to debug OK button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -193,6 +193,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
 
   const confirmRedirect = (isBreakout: boolean, allowRedirect: boolean) => {
     if (isBreakout) window.close();
+
     if (allowRedirect) {
       if (isURL(logoutUrl)) {
         const reason = generateEndMessage(joinErrorCode, meetingEndedCode, endedBy);
@@ -200,7 +201,11 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
           ? `${logoutUrl}${logoutUrl.includes('?') ? '&' : '?'}reason=${encodeURIComponent(reason)}`
           : logoutUrl;
         window.location.href = finalUrl;
+      } else {
+        logger.warn(`logout URL "${logoutUrl}" is not a valid URL: `);
       }
+    } else {
+      logger.warn('Redirect to logout URL is not allowed');
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
@@ -1,3 +1,5 @@
+import logger from '/imports/startup/client/logger';
+
 export const JoinErrorCodeTable = {
   NOT_EJECT: 'not_eject_reason',
   DUPLICATE_USER: 'duplicate_user_in_meeting_eject_reason',
@@ -105,11 +107,16 @@ export const allowRedirectToLogoutURL = (logoutURL: string) => {
     const urlWithoutProtocolForAuthLogout = logoutURL.replace(protocolPattern, '');
     const urlWithoutProtocolForLocationOrigin = window.location.origin.replace(protocolPattern, '');
     if (urlWithoutProtocolForAuthLogout === urlWithoutProtocolForLocationOrigin) {
+      if (!ALLOW_DEFAULT_LOGOUT_URL) {
+        logger.warn('Default logout url is not allowed for this session.');
+      }
       return ALLOW_DEFAULT_LOGOUT_URL;
     }
     // custom logoutURL
     return true;
   }
+
+  logger.warn('logoutURL is not defined.', logoutURL);
   // no logout url
   return false;
 };


### PR DESCRIPTION
Add temporary logs to the EndMeeting component to help debug why the OK button isn't working.
These logs will be removed once we understand the issue tracked in #22982.

In the long term, this button shouldn't be displayed if it has no associated actions.