### PR TITLE
test: Adds as flaky export annotations breakout rooms test

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -143,7 +143,7 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await join.userCanChooseRoom();
     });
     
-    test('Breakout rooms can use different presentations', async ({ browser, context, page }) => {
+    test('Breakout rooms can use different presentations', { tag: '@flaky' }, async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);
       await join.breakoutWithDifferentPresentations();

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -129,7 +129,7 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await join.exportBreakoutNotes();
     });
 
-    test('Export breakout room whiteboard annotations', async ({ browser, context, page }) => {
+    test('Export breakout room whiteboard annotations', { tag: '@flaky' }, async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);
       await join.create(false, true);
@@ -143,7 +143,7 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await join.userCanChooseRoom();
     });
     
-    test('Breakout rooms can use different presentations', { tag: '@flaky' }, async ({ browser, context, page }) => {
+    test('Breakout rooms can use different presentations', async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);
       await join.breakoutWithDifferentPresentations();


### PR DESCRIPTION
### What does this PR do?
Adds the flaky flag to the test export annotations breakout rooms test. The test is failing on CI, but I have not been able to reproduce the same error yet. I will keep checking this test.