### PR TITLE
fix: Error 404 when downloading presentation if name contains special characters

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -228,6 +228,11 @@ const PresentationContainer = (props) => {
 
   if (layoutType === 'videoFocus' && presentation?.width === 0) return null;
 
+  const presentationUri = currentPresentationPage?.downloadFileUri?.replace(
+    /(filename=)([^&]+)/,
+    (_, prefix, filename) => prefix + encodeURIComponent(filename),
+  );
+
   return (
     <Presentation
       {
@@ -244,7 +249,7 @@ const PresentationContainer = (props) => {
           currentSlide,
           slidePosition,
           hasWBAccess: multiUserData.hasAccess,
-          downloadPresentationUri: `${APP_CONFIG.bbbWebBase}/${currentPresentationPage?.downloadFileUri}`,
+          downloadPresentationUri: `${APP_CONFIG.bbbWebBase}/${presentationUri}`,
           multiUser: (multiUserData.hasAccess || multiUserData.active) && presentationIsOpen,
           presentationIsDownloadable: currentPresentationPage?.downloadable,
           mountPresentation: !!currentSlide,


### PR DESCRIPTION
### What does this PR do?

Implements client-side encoding of presentation filename, allowing the users to download a file that contains special characters

### Closes Issue(s)
Closes #22932

### How to test
1. Upload a PDF file presentation file with special characters in the file name, like the right bracket character ]
2. Enable downloading of the file for participants
3. Attempt to download the file as a participant