### PR TITLE
fix(screenshare): remove instability UI

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -7,7 +7,6 @@ import BridgeService from '/imports/api/screenshare/client/bridge/service';
 import logger from '/imports/startup/client/logger';
 import AudioService from '/imports/ui/components/audio/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
-import ConnectionStatusService from '/imports/ui/components/connection-status/service';
 import browserInfo from '/imports/utils/browserInfo';
 import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
 import { SCREENSHARE_SUBSCRIPTION } from './queries';
@@ -400,21 +399,8 @@ export const getStats = async (statsTypes = DEFAULT_SCREENSHARE_STATS_TYPES) => 
   return { screenshareStats };
 };
 
-// This method may throw errors
-export const isMediaFlowing = (previousStats, currentStats) => {
-  const bpsData = ConnectionStatusService.calculateBitsPerSecond(
-    currentStats?.screenshareStats,
-    previousStats?.screenshareStats,
-  );
-  const bpsDataAggr = Object.values(bpsData)
-    .reduce((sum, partialBpsData = 0) => sum + parseFloat(partialBpsData), 0);
-
-  return bpsDataAggr > 0;
-};
-
 export default {
   SCREENSHARE_MEDIA_ELEMENT_NAME,
-  isMediaFlowing,
   screenshareHasEnded,
   screenshareHasStarted,
   shareScreen,


### PR DESCRIPTION
### What does this PR do?

- [fix(screenshare): remove instability UI](https://github.com/bigbluebutton/bigbluebutton/pull/23232/commits/1daa125fd2841e51334ebb367ccd57fef28715cd) 
  - Screen sharing has a dedicated instability UI that is rendered
whenever the peer state transitions to an unhealthy state and packets
stop flowing for an specified interval. We've heard multiple feedbacks
from both admins and end users alike that this is too sensitive and
disruptive to be of any help. Additionally:
    - It's redundant as the conn status component already pulls similar
    data (including other RTC sources) and reacts to it accordingly
    - It's inconsistent as neither cameras nor audio have such dedicated
    UIs (both rely on conn status as well)
    - ICE restart being implemented means reconns happen faster - so the
    UI is less useful
  - Remove screen share's instability UI completely which should decrease the
number of unwarranted disruptions during screen sharing sessions.
Further improvements to reconn detection and notification should be done
later with the assistance of the design team, preferably.

### Closes Issue(s)

Closes #23200 