### PR TITLE
feat: flag for leave button label

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -595,6 +595,7 @@ export interface Layout {
   showPushLayoutButton: boolean
   showPushLayoutToggle: boolean
   showScreenshareQuickSwapButton: boolean
+  showLeaveSessionLabel: boolean
 }
 
 export interface Pads {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -150,6 +150,7 @@ class LeaveMeetingButton extends PureComponent {
     } = this.props;
 
     const { isEndMeetingConfirmationModalOpen } = this.state;
+    const enableExitLabel = window?.meetingClientSettings?.public?.layout?.showLeaveSessionLabel;
 
     const customStyles = { top: '1rem' };
 
@@ -170,7 +171,7 @@ class LeaveMeetingButton extends PureComponent {
               icon="logout"
               color="danger"
               size="lg"
-              hideLabel
+              hideLabel={!enableExitLabel}
               // FIXME: Without onClick react proptypes keep warning
               // even after the DropdownTrigger inject an onClick handler
               onClick={() => null}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
@@ -26,6 +26,7 @@ const LeaveButton = styled(Button)`
     line-height: 1.1rem;
     font-weight: 400;
     z-index: 3;
+    display: flex;
   `}
 `;
 const LeaveButtonWrapper = styled.div`

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -625,6 +625,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       showPushLayoutButton: true,
       showPushLayoutToggle: true,
       showScreenshareQuickSwapButton: true,
+      showLeaveSessionLabel: false,
     },
     pads: {
       url: 'ETHERPAD_HOST',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -818,6 +818,7 @@ public:
     showPushLayoutToggle: true
     showSessionDetailsOnJoin: true
     showScreenshareQuickSwapButton: false
+    showLeaveSessionLabel: false
   pads:
     url: ETHERPAD_HOST
   media:


### PR DESCRIPTION
### What does this PR do?

Added a flag to make exit button label visible when desired.
Default is preserved (no label).


### Closes Issue(s)
Closes None

### More
![image](https://github.com/user-attachments/assets/0edd1ef5-c2ae-48e5-876e-3a3b7eca564a)
Flag location:
![image](https://github.com/user-attachments/assets/74b3dfe8-7ed5-49a1-9f95-def938344a00)

