### PR TITLE
docs: add information on codeload PR reference in the plugin documentation

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -539,15 +539,29 @@ Example:
 }
 ```
  
-You can obtain the commit hash via `git log` or from the commit summary on your GitHub `bigbluebutton-html-plugin-sdk` PR.
+You can get the commit hash from `git log` or directly from the commit list in your `bigbluebutton-html-plugin-sdk` pull request.
+
+Alternatively, it is possible to reference the PR from the `bigbluebutton-html-plugin-sdk` directly. (This implies that you need to first send the PR for this repository and then the PR for `bigbluebutton/bigbluebutton`)
+
+The resulting `package.json` would be:
+
+```json
+"dependencies": {
+  ...
+  "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/refs/pull/<pr-number>/head"
+}
+```
+
+Replace <pr-number> with your actual pull request number.
 
 After adding it, run:
 
 ```bash
+# From bigbluebutton-html5
 npm install
 ```
 
-This will update `package-lock.json` accordingly.
+This will update the `bigbluebutton-html5/package-lock.json` accordingly.
 
 - Publish the branches to the origin by running `git push --set-upstream origin <branch-name>` for both repositories;
 - Submit a **separate pull request for each repository** (`bigbluebutton-html-plugin-sdk` and `bigbluebutton`).


### PR DESCRIPTION
### What does this PR do?

It just follows the [discussion](https://github.com/bigbluebutton/bigbluebutton/pull/23231#discussion_r2100760435) in the previous PR from the plugin documentation

### Motivation

This change provides an alternative way for developers to reference the SDK PR when submitting a PR to the main repository. The main benefit is that it allows using the latest commit from the SDK PR without needing to update the main repo PR manually. However, it also has some drawbacks: it won’t automatically trigger the CI when new commits are pushed to the SDK PR, and it may reuse cached results from previous runs even if an empty commit is pushed to manually trigger the CI.