### PR TITLE
fix(actions-bar): wrong buttons hover color

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area-dropdown/component.jsx
@@ -6,7 +6,7 @@ import LayoutModalContainer from '/imports/ui/components/layout/modal/container'
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import { ActionButtonDropdownItemType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/action-button-dropdown-item/enums';
 import Styled from './styles';
-import { colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
+import { colorPrimary, listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 import { LAYOUT_TYPE } from '../../layout/enums';
 import { uniqueId } from '/imports/utils/string-utils';
 import VideoPreviewContainer from '/imports/ui/components/video-preview/container';
@@ -355,7 +355,7 @@ class MediaAreaDropdown extends PureComponent {
               size="lg"
               circle
               onClick={this.handleToggleMenu}
-              actionsBarButton
+              hoverColor={listItemBgHover}
             />
           )}
           actions={children}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area-dropdown/component.jsx
@@ -355,6 +355,7 @@ class MediaAreaDropdown extends PureComponent {
               size="lg"
               circle
               onClick={this.handleToggleMenu}
+              actionsBarButton
             />
           )}
           actions={children}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -8,6 +8,7 @@ import {
   layoutSelectInput, layoutSelect,
 } from '/imports/ui/components/layout/context';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -110,7 +111,7 @@ const PresentationOptionsContainer = ({
       disabled={!isThereCurrentPresentation}
       data-test={!presentationIsOpen ? 'restorePresentation' : 'minimizePresentation'}
       isDarkThemeEnabled={isDarkThemeEnabled}
-      actionsBarButton
+      hoverColor={listItemBgHover}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -110,6 +110,7 @@ const PresentationOptionsContainer = ({
       disabled={!isThereCurrentPresentation}
       data-test={!presentationIsOpen ? 'restorePresentation' : 'minimizePresentation'}
       isDarkThemeEnabled={isDarkThemeEnabled}
+      actionsBarButton
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
@@ -6,6 +6,7 @@ import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
 import { init } from 'emoji-mart';
 import { SET_RAISE_HAND } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useMutation } from '@apollo/client';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 import Styled from './styles';
 
 const RaiseHandButton = (props) => {
@@ -57,7 +58,7 @@ const RaiseHandButton = (props) => {
       hideLabel
       circle
       size="lg"
-      actionsBarButton
+      hoverColor={listItemBgHover}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
@@ -57,6 +57,7 @@ const RaiseHandButton = (props) => {
       hideLabel
       circle
       size="lg"
+      actionsBarButton
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -128,6 +128,7 @@ const ReactionsButton = (props) => {
             hideLabel
             circle
             size="lg"
+            actionsBarButton
           />
         </Styled.ReactionsDropdown>
       )}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -7,6 +7,7 @@ import data from '@emoji-mart/data';
 import { init } from 'emoji-mart';
 import { SET_REACTION_EMOJI } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useMutation } from '@apollo/client';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 import Styled from './styles';
 
 const ReactionsButton = (props) => {
@@ -128,7 +129,7 @@ const ReactionsButton = (props) => {
             hideLabel
             circle
             size="lg"
-            actionsBarButton
+            hoverColor={listItemBgHover}
           />
         </Styled.ReactionsDropdown>
       )}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -249,6 +249,7 @@ const ScreenshareButton = ({
                     }
                   }}
                 id={amIBroadcasting ? 'unshare-screen-button' : 'share-screen-button'}
+                actionsBarButton
               />
             </Styled.Container>
           ) : null

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -16,6 +16,7 @@ import {
 } from '/imports/ui/components/screenshare/service';
 import { SCREENSHARING_ERRORS } from '/imports/api/screenshare/client/bridge/errors';
 import Button from '/imports/ui/components/common/button/component';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 import { EXTERNAL_VIDEO_STOP } from '../../external-video-player/mutations';
 
 const { isMobile } = deviceInfo;
@@ -249,7 +250,7 @@ const ScreenshareButton = ({
                     }
                   }}
                 id={amIBroadcasting ? 'unshare-screen-button' : 'share-screen-button'}
-                actionsBarButton
+                hoverColor={listItemBgHover}
               />
             </Styled.Container>
           ) : null

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/swap-presentation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/swap-presentation/component.tsx
@@ -40,6 +40,7 @@ const SwapPresentationButton = () => {
       hideLabel
       circle
       size="lg"
+      actionsBarButton
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/swap-presentation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/swap-presentation/component.tsx
@@ -5,6 +5,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { CURRENT_PRESENTATION_PAGE_SUBSCRIPTION } from '../../whiteboard/queries';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 
 const SwapPresentationButton = () => {
   const [showScreenShare, swapPresentation] = usePresentationSwap();
@@ -40,7 +41,7 @@ const SwapPresentationButton = () => {
       hideLabel
       circle
       size="lg"
-      actionsBarButton
+      hoverColor={listItemBgHover}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -100,6 +100,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
         circle
         accessKey={joinAudioShortcut}
         loading={isConnecting}
+        actionsBarButton
       />
     );
   }, [isConnected, disabled, joinAudioShortcut, away, intl.locale]);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -17,6 +17,7 @@ import InputStreamLiveSelectorContainer from './input-stream-live-selector/compo
 import { UPDATE_ECHO_TEST_RUNNING } from './queries';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import useIsAudioConnected from '/imports/ui/components/audio/audio-graphql/hooks/useIsAudioConnected';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 
 const intlMessages = defineMessages({
   joinAudio: {
@@ -100,7 +101,7 @@ const AudioControls: React.FC<AudioControlsProps> = ({
         circle
         accessKey={joinAudioShortcut}
         loading={isConnecting}
-        actionsBarButton
+        hoverColor={listItemBgHover}
       />
     );
   }, [isConnected, disabled, joinAudioShortcut, away, intl.locale]);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/listenOnly.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/listenOnly.tsx
@@ -49,6 +49,7 @@ export const ListenOnly: React.FC<ListenOnlyProps> = ({
           e.stopPropagation();
           handleLeaveAudio(meetingIsBreakout);
         }}
+      actionsBarButton
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/listenOnly.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/listenOnly.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 import { defineMessages, useIntl } from 'react-intl';
 import Button from '/imports/ui/components/common/button/component';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 
 const intlMessages = defineMessages({
   leaveAudio: {
@@ -49,7 +50,7 @@ export const ListenOnly: React.FC<ListenOnlyProps> = ({
           e.stopPropagation();
           handleLeaveAudio(meetingIsBreakout);
         }}
-      actionsBarButton
+      hoverColor={listItemBgHover}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -163,6 +163,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
       animations={animations}
       loading={isMuteLoading}
       data-test={muted ? 'unmuteMicButton' : 'muteMicButton'}
+      actionsBarButton
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -16,6 +16,7 @@ import {
   muteLoadingState,
   useIsMuteLoading,
 } from '/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 
 const intlMessages = defineMessages({
   muteAudio: {
@@ -163,7 +164,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
       animations={animations}
       loading={isMuteLoading}
       data-test={muted ? 'unmuteMicButton' : 'muteMicButton'}
-      actionsBarButton
+      hoverColor={listItemBgHover}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -88,7 +88,11 @@ const propTypes = {
    */
   loading: PropTypes.bool,
 
-  actionsBarButton: PropTypes.bool,
+  /*
+  * Defines a custom hover color
+  * @defaultValue undefined
+  */
+  hovercolor: PropTypes.string,
 };
 
 const defaultProps = {
@@ -102,7 +106,6 @@ const defaultProps = {
   hideLabel: false,
   tooltipLabel: '',
   loading: false,
-  actionsBarButton: false,
 };
 
 export default class Button extends BaseButton {
@@ -118,6 +121,7 @@ export default class Button extends BaseButton {
     delete remainingProps.block;
     delete remainingProps.hideLabel;
     delete remainingProps.tooltipLabel;
+    delete remainingProps.hoverColor;
 
     return remainingProps;
   }
@@ -174,7 +178,7 @@ export default class Button extends BaseButton {
       circle,
       block,
       loading,
-      actionsBarButton,
+      hoverColor,
       ...otherProps
     } = this.props;
 
@@ -190,7 +194,7 @@ export default class Button extends BaseButton {
         className={className}
         iconRight={iconRight}
         loading={loading}
-        actionsBarButton={actionsBarButton}
+        hoverColor={hoverColor}
         {...remainingProps}
       >
         {this.renderIcon()}
@@ -210,7 +214,7 @@ export default class Button extends BaseButton {
       circle,
       block,
       loading,
-      actionsBarButton,
+      hoverColor,
       ...otherProps
     } = this.props;
 
@@ -238,7 +242,7 @@ export default class Button extends BaseButton {
           ghost={ghost}
           circle={circle}
           block={block}
-          actionsBarButton={actionsBarButton}
+          hoverColor={hoverColor}
         >
           {this.renderIcon()}
         </Styled.ButtonSpan>

--- a/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/button/component.jsx
@@ -87,6 +87,8 @@ const propTypes = {
    * @defaultValue false
    */
   loading: PropTypes.bool,
+
+  actionsBarButton: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -100,6 +102,7 @@ const defaultProps = {
   hideLabel: false,
   tooltipLabel: '',
   loading: false,
+  actionsBarButton: false,
 };
 
 export default class Button extends BaseButton {
@@ -171,6 +174,7 @@ export default class Button extends BaseButton {
       circle,
       block,
       loading,
+      actionsBarButton,
       ...otherProps
     } = this.props;
 
@@ -186,6 +190,7 @@ export default class Button extends BaseButton {
         className={className}
         iconRight={iconRight}
         loading={loading}
+        actionsBarButton={actionsBarButton}
         {...remainingProps}
       >
         {this.renderIcon()}
@@ -205,6 +210,7 @@ export default class Button extends BaseButton {
       circle,
       block,
       loading,
+      actionsBarButton,
       ...otherProps
     } = this.props;
 
@@ -232,6 +238,7 @@ export default class Button extends BaseButton {
           ghost={ghost}
           circle={circle}
           block={block}
+          actionsBarButton={actionsBarButton}
         >
           {this.renderIcon()}
         </Styled.ButtonSpan>

--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -56,6 +56,7 @@ import {
   btnMutedBg,
   colorWhite,
   colorGray,
+  listItemBgHover,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import BaseButton from './base/component';
 
@@ -394,7 +395,8 @@ const ButtonSpan = styled.span`
     outline-style: dotted;
     outline-width: ${borderSize};
     text-decoration: none;
-    background-color: ${btnPrimaryHoverBg};
+    ${({ actionsBarButton }) => actionsBarButton
+      && `background-color: ${listItemBgHover};`}
   }
 
   &:active,

--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -395,8 +395,8 @@ const ButtonSpan = styled.span`
     outline-style: dotted;
     outline-width: ${borderSize};
     text-decoration: none;
-    ${({ actionsBarButton }) => actionsBarButton
-      && `background-color: ${listItemBgHover};`}
+    ${({ hoverColor }) => hoverColor
+      && `background-color: ${hoverColor};`}
   }
 
   &:active,

--- a/bigbluebutton-html5/imports/ui/components/common/button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/button/styles.js
@@ -56,7 +56,6 @@ import {
   btnMutedBg,
   colorWhite,
   colorGray,
-  listItemBgHover,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import BaseButton from './base/component';
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.tsx
@@ -230,6 +230,7 @@ const JoinVideoButton: React.FC<JoinVideoButtonProps> = ({
           circle
           disabled={!!disableReason}
           loading={videoConnecting}
+          actionsBarButton
         />
         {renderUserActions()}
       </Styled.OffsetBottom>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.tsx
@@ -11,6 +11,7 @@ import PreviewService from '/imports/ui/components/video-preview/service';
 import { CameraSettingsDropdownItemType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/camera-settings-dropdown-item/enums';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import { CameraSettingsDropdownInterface } from 'bigbluebutton-html-plugin-sdk';
+import { listItemBgHover } from '/imports/ui/stylesheets/styled-components/palette';
 import VideoService from '../service';
 import Styled from './styles';
 
@@ -230,7 +231,7 @@ const JoinVideoButton: React.FC<JoinVideoButtonProps> = ({
           circle
           disabled={!!disableReason}
           loading={videoConnecting}
-          actionsBarButton
+          hoverColor={listItemBgHover}
         />
         {renderUserActions()}
       </Styled.OffsetBottom>

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -61,7 +61,7 @@ const btnDefaultGhostActiveBg = 'var(--btn-default-active-bg, rgba(255, 255, 255
 const btnPrimaryBorder = 'var(--btn-primary-border, rgba(15, 112, 215, 0.5))'; // colorPrimary, 50%
 const btnPrimaryColor = `var(--btn-primary-color, ${colorWhite})`;
 const btnPrimaryBg = `var(--btn-primary-bg, ${colorPrimary})`;
-const btnPrimaryHoverBg = `var(--btn-primary-hover-bg, ${colorBlueAux})`;
+const btnPrimaryHoverBg = 'var(--btn-primary-hover-bg, #0C57A7)';
 const btnPrimaryActiveBg = 'var(--btn-primary-active-bg, #0A4B8F)';
 
 const btnSuccessBorder = `var(--btn-success-border, ${colorSuccess})`;


### PR DESCRIPTION
### What does this PR do?
This PR fixes an incorrect change made in [PR #23219](https://github.com/bigbluebutton/bigbluebutton/pull/23219) that altered the default hover color of primary buttons, causing visual inconsistencies. It reverts the original color and adds a prop to conditionally apply hover styles, used only in the action bar buttons.

### Closes Issue(s)
Closes #none
