### PR TITLE
fix(bbb-web): URL encode presentation name

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -12,6 +12,8 @@ import org.bigbluebutton.core.util.RandomStringGenerator
 import org.bigbluebutton.core.models.{ PresentationInPod, PresentationPage, PresentationPod }
 
 import java.io.File
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
@@ -172,8 +174,8 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
         bus.outGW.send(buildStoreAnnotationsInRedisSysMsg(annotations, liveMeeting))
       } else {
         // Return existing uploaded file directly
-        val convertedFileName = currentPres.get.filenameConverted
-        val originalFilename = currentPres.get.name
+        val convertedFileName = URLEncoder.encode(currentPres.get.filenameConverted, StandardCharsets.UTF_8)
+        val originalFilename = URLEncoder.encode(currentPres.get.name, StandardCharsets.UTF_8)
         val originalFileExt = originalFilename.split("\\.").last
         val convertedFileExt = if (convertedFileName != "") convertedFileName.split("\\.").last else ""
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -1,19 +1,18 @@
 package org.bigbluebutton.core.apps.presentationpod
 
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.api.{ CapturePresentationReqInternalMsg }
+import org.bigbluebutton.core.api.CapturePresentationReqInternalMsg
 import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.db.{ ChatMessageDAO, PresPresentationDAO }
 import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.{ PresentationInPod, PresentationPage, PresentationPod }
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.util.RandomStringGenerator
-import org.bigbluebutton.core.models.{ PresentationInPod, PresentationPage, PresentationPod }
 
 import java.io.File
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
+import java.net.URI
 
 trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
@@ -174,16 +173,16 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
         bus.outGW.send(buildStoreAnnotationsInRedisSysMsg(annotations, liveMeeting))
       } else {
         // Return existing uploaded file directly
-        val convertedFileName = URLEncoder.encode(currentPres.get.filenameConverted, StandardCharsets.UTF_8)
-        val originalFilename = URLEncoder.encode(currentPres.get.name, StandardCharsets.UTF_8)
+        val convertedFileName = new URI(null, null, currentPres.get.filenameConverted, null).getRawPath
+        val originalFilename = new URI(null, null, currentPres.get.name, null).getRawPath
         val originalFileExt = originalFilename.split("\\.").last
         val convertedFileExt = if (convertedFileName != "") convertedFileName.split("\\.").last else ""
 
         val convertedFileURI = if (convertedFileName != "") List("presentation", "download", meetingId,
-          s"${presId}?presFilename=${presId}.${convertedFileExt}&filename=${convertedFileName}").mkString("", File.separator, "")
+          s"${presId}?presFilename=${presId}.${convertedFileExt}&filename=$convertedFileName").mkString("", File.separator, "")
         else ""
         val originalFileURI = List("presentation", "download", meetingId,
-          s"${presId}?presFilename=${presId}.${originalFileExt}&filename=${originalFilename}").mkString("", File.separator, "")
+          s"${presId}?presFilename=${presId}.${originalFileExt}&filename=$originalFilename").mkString("", File.separator, "")
 
         val event = buildNewPresFileAvailable("", originalFileURI, convertedFileURI, presId,
           m.body.fileStateType)

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -24,7 +24,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.apache.commons.io.FilenameUtils;
-import scala.xml.Null;
 
 public final class UploadedPresentation {
   private final String podId;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -20,8 +20,11 @@
 package org.bigbluebutton.presentation;
 
 import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.apache.commons.io.FilenameUtils;
+import scala.xml.Null;
 
 public final class UploadedPresentation {
   private final String podId;
@@ -61,7 +64,13 @@ public final class UploadedPresentation {
     this.meetingId = meetingId;
     this.id = id;
     this.temporaryPresentationId = temporaryPresentationId;
-    this.name = name;
+    
+    String encodedName = "";
+    try {
+      encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+    } catch (NullPointerException ignored) {}
+    this.name = encodedName;
+    
     this.baseUrl = baseUrl;
     this.isDownloadable = false;
     this.current = current;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -63,13 +63,7 @@ public final class UploadedPresentation {
     this.meetingId = meetingId;
     this.id = id;
     this.temporaryPresentationId = temporaryPresentationId;
-    
-    String encodedName = "";
-    try {
-      encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
-    } catch (NullPointerException ignored) {}
-    this.name = encodedName;
-    
+    this.name = name;
     this.baseUrl = baseUrl;
     this.isDownloadable = false;
     this.current = current;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -20,8 +20,6 @@
 package org.bigbluebutton.presentation;
 
 import java.io.File;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import org.apache.commons.io.FilenameUtils;
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -30,6 +30,8 @@ import org.bigbluebutton.presentation.UploadedPresentation
 import org.bigbluebutton.web.services.PresentationService
 import org.grails.web.mime.DefaultMimeUtility
 
+import java.nio.charset.StandardCharsets
+
 class PresentationController {
   MeetingService meetingService
   PresentationService presentationService
@@ -354,10 +356,13 @@ class PresentationController {
         def mimeType = grailsMimeUtility.getMimeTypeForURI(responseName)
         def mimeName = mimeType != null ? mimeType.name : 'application/octet-stream'
 
+        def encoded = URLEncoder.encode(responseName, StandardCharsets.UTF_8).replace("+", "%20")
+
         response.contentType = mimeName
         response.addHeader(
                 "content-disposition",
-                "attachment; filename=" + new URI(null, null, responseName, null).getRawPath()
+                "attachment; filename=\"" + responseName + "\"; " +
+                "filename*=UTF-8''" + encoded
         )
         response.addHeader("Cache-Control", "no-cache")
         response.outputStream << bytes;

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -18,20 +18,17 @@
  */
 package org.bigbluebutton.web.controllers
 
-import grails.converters.*
+
+import org.apache.commons.io.FilenameUtils
+import org.bigbluebutton.api.MeetingService
+import org.bigbluebutton.api.ParamsProcessorUtil
+import org.bigbluebutton.api.Util
 import org.bigbluebutton.api.messaging.messages.PresentationUploadToken
+import org.bigbluebutton.api.util.ParamsUtil
 import org.bigbluebutton.presentation.SupportedFileTypes
-import org.grails.web.mime.DefaultMimeUtility
-import org.bigbluebutton.api.ParamsProcessorUtil;
-
-import java.nio.charset.StandardCharsets
-
-import org.apache.commons.io.FilenameUtils;
-import org.bigbluebutton.web.services.PresentationService
 import org.bigbluebutton.presentation.UploadedPresentation
-import org.bigbluebutton.api.MeetingService;
-import org.bigbluebutton.api.util.ParamsUtil;
-import org.bigbluebutton.api.Util;
+import org.bigbluebutton.web.services.PresentationService
+import org.grails.web.mime.DefaultMimeUtility
 
 class PresentationController {
   MeetingService meetingService
@@ -358,7 +355,10 @@ class PresentationController {
         def mimeName = mimeType != null ? mimeType.name : 'application/octet-stream'
 
         response.contentType = mimeName
-        response.addHeader("content-disposition", "attachment; filename=" + URLEncoder.encode(responseName, StandardCharsets.UTF_8.name()))
+        response.addHeader(
+                "content-disposition",
+                "attachment; filename=" + new URI(null, null, responseName, null).getRawPath()
+        )
         response.addHeader("Cache-Control", "no-cache")
         response.outputStream << bytes;
       } else {


### PR DESCRIPTION
### What does this PR do?

URL encodes presentation names in BBB Web so that a proper presentation download URI can be generated for document download. This is an alternative solution to #23230.

### Closes Issue(s)

Closes #19235 
Closes #22932

### How to test

1. Upload a PDF file presentation file with special characters in the file name, like the right bracket character ]
2. Enable downloading of the file for participants
3. Download the document successfully
