### PR TITLE
Fix(html5): Whiteboard cursor deteriorates near border

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1392,6 +1392,14 @@ const Whiteboard = React.memo((props) => {
     pollInnerWrapperDimensionsUntilStable(() => {
       adjustCameraOnMount(!isPresenterRef.current);
     });
+
+    // New cursor hint shape: circle
+    const newD = 'M 8,5 A 3,3 0 1,0 2,5 A 3,3 0 1,0 8,5';
+    // Fetch the cursor hint element and update its path
+    const cursorHint = document.getElementById('cursor_hint');
+    if (cursorHint) {
+      cursorHint.setAttribute('d', newD);
+    }
   };
 
   const syncCameraOnPresenterZoom = () => {


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where the cursor changed its shape near a border. The problem occurred because Tldraw applied a different shape to the cursor in that context, switching it to an arrow. Since I couldn’t find a native way to disable this behavior in Tldraw, I overrode the cursor shape manually by applying a standard red circle instead.


### Closes Issue(s)
Closes #23043

### How to test
- Join a meeting with two users
- With presenter moves the cursor near the border of the WB
- See the red circle

### More
[Screencast from 13-05-2025 13:09:40.webm](https://github.com/user-attachments/assets/f3591391-67c3-43c0-9b07-486837fc85a5)
