### PR TITLE
Fix(html5): Audio captions get stucked when hardware muted

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -234,6 +234,10 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
       logger.debug('Starting browser speech recognition');
       speechRecognitionRef.current.lang = settedLocale;
 
+      if (settedLocale !== localeRef.current) {
+        localeRef.current = settedLocale;
+      }
+
       if (speechHasStarted.started) {
         logger.warn('Already starting return');
         return;


### PR DESCRIPTION
### What does this PR do?
Fix audio getting stuck when mic is muted or by the system or by hardware, for some reason the localeRed wasn't being initialized on first start.


### Closes Issue(s)
Closes #22657

### How to test
- Join meeting and open dev tools in the console tab
- Join audio with enabled CC
- start talking 
- mute mic
- when the log `Speech recogniction ended by browser, but we're not muted. Restart it` appear unmute and start talking.

### More
[Screencast from 22-05-2025 10:27:56.webm](https://github.com/user-attachments/assets/b1337930-3d7c-4486-b790-b9cd6c2542e2)

