### PR TITLE
refactor (bbb-web): Run presentation conversion in sandboxed systemd process (with limited resources)

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/PdfPageCounterHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/PdfPageCounterHandler.java
@@ -41,7 +41,7 @@ public class PdfPageCounterHandler extends AbstractCommandHandler {
       m.find();
       return Integer.parseInt(m.group(1).trim());
     } catch (Exception e) {
-      log.error("Exception counting images", e);
+      log.error("Exception counting pages", e);
       return 0;
     }
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResizerImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResizerImp.java
@@ -49,7 +49,7 @@ public class ImageResizerImp implements ImageResizer {
 
         log.debug("Rescaling file {} with {} ratio", path, ratio);
         NuProcessBuilder imgResize = new NuProcessBuilder(Arrays.asList(
-                        "/usr/share/bbb-web/run-in-systemd.sh", "60",
+                        "/usr/share/bbb-web/run-in-systemd.sh", String.valueOf(wait),
                         "convert", "-resize", ratio, path, path
                 ));
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResizerImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResizerImp.java
@@ -48,8 +48,10 @@ public class ImageResizerImp implements ImageResizer {
         Boolean conversionSuccess = true;
 
         log.debug("Rescaling file {} with {} ratio", path, ratio);
-        NuProcessBuilder imgResize = new NuProcessBuilder(Arrays.asList("convert", "-resize", ratio,
-                path, path));
+        NuProcessBuilder imgResize = new NuProcessBuilder(Arrays.asList(
+                        "/usr/share/bbb-web/run-in-systemd.sh", "60",
+                        "convert", "-resize", ratio, path, path
+                ));
 
         ImageResizerHandler pHandler = new ImageResizerHandler();
         imgResize.setProcessListener(pHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -37,7 +37,7 @@ public class ImageResolutionService {
   public ImageResolution identifyImageResolution(File presentationFile) {
 
     NuProcessBuilder imageResolution = new NuProcessBuilder(
-        Arrays.asList("identify", "-format","%w %h", presentationFile.getAbsolutePath()));
+        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh","10","identify", "-format","%w %h", presentationFile.getAbsolutePath()));
 
     ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler();
     imageResolution.setProcessListener(imgResHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -37,7 +37,8 @@ public class ImageResolutionService {
   public ImageResolution identifyImageResolution(File presentationFile) {
 
     NuProcessBuilder imageResolution = new NuProcessBuilder(
-        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh","10","identify", "-format","%w %h", presentationFile.getAbsolutePath()));
+        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", String.valueOf(wait),
+                "identify", "-format","%w %h", presentationFile.getAbsolutePath()));
 
     ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler();
     imageResolution.setProcessListener(imgResHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/Office2PdfPageConverter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/Office2PdfPageConverter.java
@@ -61,7 +61,7 @@ public abstract class Office2PdfPageConverter {
 
       log.info(String.format("Calling conversion script %s.", presOfficeConversionExec));
 
-      NuProcessBuilder officeConverterExec = new NuProcessBuilder(Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", conversionTimeout + "s", "/bin/sh", "-c",
+      NuProcessBuilder officeConverterExec = new NuProcessBuilder(Arrays.asList("timeout", conversionTimeout + "s", "/bin/sh", "-c",
               "\""+presOfficeConversionExec + "\" \"" + presentationFile.getAbsolutePath() + "\" \"" + output.getAbsolutePath()+"\" pdf " + conversionTimeout));
       Office2PdfConverterHandler office2PdfConverterHandler  = new Office2PdfConverterHandler();
       officeConverterExec.setProcessListener(office2PdfConverterHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/Office2PdfPageConverter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/Office2PdfPageConverter.java
@@ -61,7 +61,7 @@ public abstract class Office2PdfPageConverter {
 
       log.info(String.format("Calling conversion script %s.", presOfficeConversionExec));
 
-      NuProcessBuilder officeConverterExec = new NuProcessBuilder(Arrays.asList("timeout", conversionTimeout + "s", "/bin/sh", "-c",
+      NuProcessBuilder officeConverterExec = new NuProcessBuilder(Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", conversionTimeout + "s", "/bin/sh", "-c",
               "\""+presOfficeConversionExec + "\" \"" + presentationFile.getAbsolutePath() + "\" \"" + output.getAbsolutePath()+"\" pdf " + conversionTimeout));
       Office2PdfConverterHandler office2PdfConverterHandler  = new Office2PdfConverterHandler();
       officeConverterExec.setProcessListener(office2PdfConverterHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfPageCounter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfPageCounter.java
@@ -40,7 +40,7 @@ public class PdfPageCounter implements PageCounter {
     int numPages = 0; // total numbers of this pdf
 
     NuProcessBuilder pdfInfo = new NuProcessBuilder(
-        Arrays.asList("pdfinfo", presentationFile.getAbsolutePath()));
+        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh","10","pdfinfo", presentationFile.getAbsolutePath()));
 
     PdfPageCounterHandler pHandler = new PdfPageCounterHandler();
     pdfInfo.setProcessListener(pHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -101,7 +101,7 @@ public class PngCreatorImp implements PngCreator {
 			dest = pngsDir.getAbsolutePath() + File.separator + "slide-1.pdf";
 
 			NuProcessBuilder convertImgToSvg = new NuProcessBuilder(
-					Arrays.asList("timeout", convTimeout + "s", "convert", source, "-auto-orient", dest));
+					Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", convTimeout + "s", "convert", source, "-auto-orient", dest));
 
 			Png2SvgConversionHandler pHandler = new Png2SvgConversionHandler();
 			convertImgToSvg.setProcessListener(pHandler);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -99,7 +99,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             dest = imagePresentationDir.getAbsolutePath() + File.separator + "slide-1.pdf";
 
             NuProcessBuilder convertImgToSvg = new NuProcessBuilder(
-                    Arrays.asList("timeout", convPdfToSvgTimeout + "s", "convert", source, "-auto-orient", dest));
+                    Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", convPdfToSvgTimeout + "s", "convert", source, "-auto-orient", dest));
 
             Png2SvgConversionHandler pHandler = new Png2SvgConversionHandler();
             convertImgToSvg.setProcessListener(pHandler);
@@ -284,7 +284,8 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                 if(destsvg.length() > 0) {
                     // Step 3: Add SVG namespace to the destination file
                     // Check : https://phabricator.wikimedia.org/T43174
-                    NuProcessBuilder addNameSpaceToSVG = new NuProcessBuilder(Arrays.asList("timeout", convPdfToSvgTimeout + "s",
+                    NuProcessBuilder addNameSpaceToSVG = new NuProcessBuilder(Arrays.asList(
+                            "/usr/share/bbb-web/run-in-systemd.sh", convPdfToSvgTimeout + "s",
                             "/bin/sh", "-c",
                             "sed -i "
                                     + "'4s|>| xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.2\">|' "
@@ -353,7 +354,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             rawCommand += " | egrep 'data:image/png;base64|<path' | sed 's/  / /g' | cut -d' ' -f 1 | sort | uniq -cw 2";
         }
 
-        return new NuProcessBuilder(Arrays.asList("timeout", convPdfToSvgTimeout + "s", "/bin/sh", "-c", rawCommand));
+        return new NuProcessBuilder(Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", convPdfToSvgTimeout + "s", "/bin/sh", "-c", rawCommand));
     }
 
     private NuProcessBuilder createDetectFontType3Process(String source, int page) {
@@ -361,7 +362,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         rawCommand += " | grep -m 1 'Type 3'";
         rawCommand += " | wc -l";
 
-        return new NuProcessBuilder(Arrays.asList("timeout", pdfFontsTimeout + "s", "/bin/sh", "-c", rawCommand));
+        return new NuProcessBuilder(Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", pdfFontsTimeout + "s", "/bin/sh", "-c", rawCommand));
     }
 
     private File determineSvgImagesDirectory(File presentationFile) {

--- a/bigbluebutton-config/slides/blank-svg.svg
+++ b/bigbluebutton-config/slides/blank-svg.svg
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+    width="841.89px" height="595.28px"
 	 viewBox="0 0 841.89 595.28" style="enable-background:new 0 0 841.89 595.28;" xml:space="preserve">
 </svg>

--- a/bigbluebutton-web/run-in-systemd.sh
+++ b/bigbluebutton-web/run-in-systemd.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# run-in-systemd.sh
+# Run a command in a hardened transient user-level systemd unit.
+#
+# Usage:  run-in-systemd.sh <timeout-seconds> <command> [args …]
+#
+# Environment variables (override as needed creating a file at /etc/bigbluebutton/bbb-web.env):
+#   BBB_PRESENTATION_DIR   Extra directory that must stay writable (default: /var/bigbluebutton/)
+#   BBB_PRESENTATION_CONVERSION_MEMORY_HIGH        Soft memory limit in bytes or systemd size suffix (default: 512M)
+#   BBB_PRESENTATION_CONVERSION_MEMORY_MAX         Hard memory limit (default: 640M)
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <timeout-seconds> <command> [args …]" >&2
+  exit 1
+fi
+
+timeout_secs="$1"; shift
+
+: "${BBB_PRESENTATION_DIR:=/var/bigbluebutton/}"
+: "${BBB_PRESENTATION_CONVERSION_MEMORY_HIGH:=512M}"
+: "${BBB_PRESENTATION_CONVERSION_MEMORY_MAX:=640M}"
+
+systemd-run --user --pipe --wait --quiet --same-dir                   \
+  --property=RuntimeMaxSec="${timeout_secs}"                          \
+  --property=ProtectSystem=strict                                     \
+  --property=ProtectHome=yes                                          \
+  --property=PrivateTmp=true                                          \
+  --property=ReadWritePaths="${BBB_PRESENTATION_DIR}"                 \
+  --property=NoNewPrivileges=true                                     \
+  --property=RestrictRealtime=true                                    \
+  --property=SystemCallFilter=~@mount                                 \
+  --property=MemoryHigh="${BBB_PRESENTATION_CONVERSION_MEMORY_HIGH}"  \
+  --property=MemoryMax="${BBB_PRESENTATION_CONVERSION_MEMORY_MAX}"    \
+  --property=MemorySwapMax=0                                          \
+  "$@"
+
+exit $?   # propagate the child’s exit status

--- a/build/packages-template/bbb-web/after-install.sh
+++ b/build/packages-template/bbb-web/after-install.sh
@@ -60,6 +60,36 @@ bbb_config() {
 
   update-java-alternatives -s java-1.17.0-openjdk-amd64
 
+  # This drop-in configures the `bbb-web` system service to support `systemd-run --user` in headless environments.
+  # It sets the required `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` environment variables so the Java process
+  # can communicate with the per-user systemd instance via D-Bus. Additionally, it declares `Wants=` and `After=`
+  # dependencies on `user@UID.service` to ensure the user manager is started before the service attempts to interact with it.
+  SERVICE_NAME="bbb-web.service"
+  DROPIN_DIR="/etc/systemd/system/${SERVICE_NAME}.d"
+  DROPIN_FILE="${DROPIN_DIR}/10-user-session.conf"
+  BIGBLUEBUTTON_UID=$(id -u bigbluebutton)
+
+  echo "Creating drop-in for $SERVICE_NAME..."
+
+  if [ -f $DROPIN_FILE ]; then
+      echo "Removing old drop-in for $SERVICE_NAME: $DROPIN_FILE"
+      rm $DROPIN_FILE
+  fi
+
+  sudo mkdir -p "$DROPIN_DIR"
+
+  sudo tee "$DROPIN_FILE" > /dev/null <<EOF
+[Service]
+Environment="XDG_RUNTIME_DIR=/run/user/${BIGBLUEBUTTON_UID}"
+Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${BIGBLUEBUTTON_UID}/bus"
+[Unit]
+Wants=user@${BIGBLUEBUTTON_UID}.service
+After=user@${BIGBLUEBUTTON_UID}.service
+EOF
+
+  echo "Drop-in created sucessfuly: $DROPIN_FILE"
+  systemctl daemon-reexec
+
   # Restart bbb-web to deploy new 
   startService bbb-web.service || echo "bbb-web.service could not be registered or started"
 }

--- a/build/packages-template/bbb-web/after-install.sh
+++ b/build/packages-template/bbb-web/after-install.sh
@@ -71,14 +71,14 @@ bbb_config() {
 
   echo "Creating drop-in for $SERVICE_NAME..."
 
-  if [ -f $DROPIN_FILE ]; then
+  if [ -f "$DROPIN_FILE" ]; then
       echo "Removing old drop-in for $SERVICE_NAME: $DROPIN_FILE"
       rm $DROPIN_FILE
   fi
 
-  sudo mkdir -p "$DROPIN_DIR"
+  mkdir -p "$DROPIN_DIR"
 
-  sudo tee "$DROPIN_FILE" > /dev/null <<EOF
+  tee "$DROPIN_FILE" > /dev/null <<EOF
 [Service]
 Environment="XDG_RUNTIME_DIR=/run/user/${BIGBLUEBUTTON_UID}"
 Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${BIGBLUEBUTTON_UID}/bus"

--- a/build/packages-template/bbb-web/bbb-web.service
+++ b/build/packages-template/bbb-web/bbb-web.service
@@ -11,6 +11,7 @@ User=bigbluebutton
 Group=bigbluebutton
 WorkingDirectory=/usr/share/bbb-web
 EnvironmentFile=/etc/default/bbb-web
+EnvironmentFile=-/etc/bigbluebutton/bbb-web.env
 ExecStart=java -Dgrails.env=${ENV} -Dserver.address=${LISTEN_ADDRESS} -Dserver.port=${LISTEN_PORT} -Dspring.main.allow-circular-references=true -Xms${INITIAL_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${HEAP_DUMP_PATH} -cp WEB-INF/lib/*:/:WEB-INF/classes/:. org.springframework.boot.loader.WarLauncher
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/build/packages-template/bbb-web/build.sh
+++ b/build/packages-template/bbb-web/build.sh
@@ -95,6 +95,9 @@ mkdir -p "$STAGING"/usr/share/bigbluebutton/nginx
 cp bbb-web.nginx "$STAGING"/usr/share/bigbluebutton/nginx/web
 cp loadbalancer.nginx "$STAGING"/usr/share/bigbluebutton/nginx/loadbalancer.nginx
 
+# Copy script to run commands through `system-run --user`
+cp run-in-systemd.sh "$STAGING"/usr/share/bbb-web
+
 mkdir -p "$STAGING"/var/log/bigbluebutton
 # Copy directive for serving SVG files (HTML5) from nginx
 if [ -f nginx-confs/presentation-slides.nginx ]; then


### PR DESCRIPTION
This refactor improves how conversion commands are executed by wrapping them in a `systemd-run` unit with resource restrictions. The change is straightforward—it preserves the existing flow but routes all conversion commands through a new shell script, `run-in-systemd.sh`. This script takes the original command and executes it using `systemd-run --user` with a set of parameters that restrict resource usage and system access.

Resource limits are now configurable via the following environment variables:

* `/etc/bigbluebutton/bbb-web.env` (this file is optional and acts as an override):

```bash
BBB_PRESENTATION_DIR=/var/bigbluebutton/
BBB_PRESENTATION_CONVERSION_MEMORY_HIGH=512M
BBB_PRESENTATION_CONVERSION_MEMORY_MAX=640M
```

With this update, all conversion commands in `bbb-web` are invoked via `/usr/share/bbb-web/run-in-systemd.sh`.

**Usage:**

```bash
/usr/share/bbb-web/run-in-systemd.sh <timeout-seconds> <command> [args …]
```

Commands that previously used `timeout <duration> command` have been updated to use `run-in-systemd.sh` instead.

### Testing (in a docker-dev environment):

```bash
sudo cp /home/bigbluebutton/src/bigbluebutton-web/run-in-systemd.sh /usr/share/bbb-web
```
