### PR TITLE
fix(bbb-export-annotations): Mangled slide background

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -291,14 +291,18 @@ function overlayAnnotations(svg, slideAnnotations) {
  * @param {number} page Page number.
  */
 function resizeAssetIfBase64Image(file, width, height, oldWidth, oldHeight, page) {
-  const BASE_64_HREF_REGEX = /href="data:image\/(png|jpg|jpeg);base64,[^"]+"/;
+  const BASE_64_HREF_REGEX = /href="data:image\/(png|jpg|jpeg);base64,[^"]+"/g;
   const isSvg = file.endsWith('.svg');
 
   if (!isSvg) return;
 
   try {
     let svg = fs.readFileSync(file, { encoding: 'utf-8' });
-    const hasBase64Image = BASE_64_HREF_REGEX.test(svg);
+    let count = 0;
+    while (BASE_64_HREF_REGEX.exec(svg) !== null) {
+      count++;
+    }
+    const hasBase64Image = count === 1;
     if (hasBase64Image) {
       svg = svg.replaceAll(`width="${oldWidth}"`, `width="${width}"`);
       svg = svg.replaceAll(`height="${oldHeight}"`, `height="${height}"`);

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -129,7 +129,7 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await join.exportBreakoutNotes();
     });
 
-    test('Export breakout room whiteboard annotations', { tag: '@flaky' }, async ({ browser, context, page }) => {
+    test('Export breakout room whiteboard annotations', async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);
       await join.create(false, true);

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -259,6 +259,7 @@ class Join extends Create {
     const wbLocator = await this.modPage.getLocator(e.whiteboard);
     await expect(wbLocator).toHaveScreenshot('capture-breakout-whiteboard.png', {
       maxDiffPixels: 1500,
+      timeout: 10000,
     });
   }
 

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -259,7 +259,7 @@ class Join extends Create {
     const wbLocator = await this.modPage.getLocator(e.whiteboard);
     await expect(wbLocator).toHaveScreenshot('capture-breakout-whiteboard.png', {
       maxDiffPixels: 1500,
-      timeout: 10000,
+      timeout: 20000,
     });
   }
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Fix a bug where the slide background gets mangled when the slide asset is resized.
- test: Remove **flaky** from **Export breakout room whiteboard annotations** and add 10000ms timeout for the whiteboard to load.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23229

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

See the linked issue.