### PR TITLE
Fix(html5): Race condition leading to an error in conditionally rendered chat hooks.

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -135,8 +135,6 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   isRTL,
   getUserLastSentMessage,
 }) => {
-  const isChatEnabled = useIsChatEnabled();
-  if (!isChatEnabled) return null;
   const intl = useIntl();
   const [hasErrors, setHasErrors] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -718,6 +716,8 @@ const ChatMessageFormContainer: React.FC = () => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
 
   const disabled = locked && !isModerator && disablePrivateChat && !isPublicChat && !chat?.participant?.isModerator;
+  const isChatEnabled = useIsChatEnabled();
+  if (!isChatEnabled) return null;
 
   return (
     <ChatMessageForm

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -641,6 +641,7 @@ const ChatMessageFormContainer: React.FC = () => {
   const idChatOpen: string = layoutSelect((i: Layout) => i.idChatOpen);
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
   const isConnected = useReactiveVar(connectionStatus.getConnectedStatusVar());
+  const isChatEnabled = useIsChatEnabled();
   const { data: chat } = useChat((c: Partial<Chat>) => ({
     participant: c?.participant,
     chatId: c?.chatId,
@@ -716,7 +717,6 @@ const ChatMessageFormContainer: React.FC = () => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
 
   const disabled = locked && !isModerator && disablePrivateChat && !isPublicChat && !chat?.participant?.isModerator;
-  const isChatEnabled = useIsChatEnabled();
   if (!isChatEnabled) return null;
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -219,7 +219,7 @@ const LayoutObserver: React.FC = () => {
 
   useEffect(() => {
     if (layoutIsReady) {
-      if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
+      if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed) && !deviceInfo.isPhone) {
         const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
         layoutContextDispatch({
           type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -217,53 +217,52 @@ const LayoutObserver: React.FC = () => {
   }, [videoStream.length]);
 
   useEffect(() => {
-    if (Session.equals('layoutReady', true) && (sidebarContentPanel === PANELS.NONE)) {
+    if ((Session.equals('layoutReady', true) && (sidebarContentPanel === PANELS.NONE))) {
       if (!checkedUserSettings.current) {
         const Settings = getSettingsSingletonInstance();
         Settings.save(setLocalSettings);
+        checkedUserSettings.current = true;
+      }
 
-        if (getFromUserSettings('bbb_show_participants_on_login', window.meetingClientSettings.public.layout.showParticipantsOnLogin) && !deviceInfo.isPhone) {
-          if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
-            const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
+      if (getFromUserSettings('bbb_show_participants_on_login', window.meetingClientSettings.public.layout.showParticipantsOnLogin) && !deviceInfo.isPhone) {
+        if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
+          const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
 
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-              value: true,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-              value: true,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-              value: PANELS.CHAT,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_ID_CHAT_OPEN,
-              value: PUBLIC_CHAT_ID,
-            });
-          } else {
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-              value: true,
-            });
-            layoutContextDispatch({
-              type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-              value: false,
-            });
-          }
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+            value: true,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+            value: true,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+            value: PANELS.CHAT,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_ID_CHAT_OPEN,
+            value: PUBLIC_CHAT_ID,
+          });
         } else {
           layoutContextDispatch({
             type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-            value: false,
+            value: true,
           });
           layoutContextDispatch({
             type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
             value: false,
           });
         }
-
-        checkedUserSettings.current = true;
+      } else {
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+          value: false,
+        });
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+          value: false,
+        });
       }
     }
   });

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -34,6 +34,7 @@ const LayoutObserver: React.FC = () => {
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
   const { sidebarContentPanel } = sidebarContent;
 
+  const [layoutIsReady, setLayoutIsReady] = useState(false);
   const [, setEnableResize] = useState(!window.matchMedia(MOBILE_MEDIA).matches);
   const { selectedLayout } = useSettings(SETTINGS.APPLICATION) as { selectedLayout: string };
   const {
@@ -217,43 +218,37 @@ const LayoutObserver: React.FC = () => {
   }, [videoStream.length]);
 
   useEffect(() => {
-    if ((Session.equals('layoutReady', true) && (sidebarContentPanel === PANELS.NONE))) {
-      if (!checkedUserSettings.current) {
-        const Settings = getSettingsSingletonInstance();
-        Settings.save(setLocalSettings);
-        checkedUserSettings.current = true;
+    if (layoutIsReady) {
+      if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
+        const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+          value: true,
+        });
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+          value: PANELS.CHAT,
+        });
+        layoutContextDispatch({
+          type: ACTIONS.SET_ID_CHAT_OPEN,
+          value: PUBLIC_CHAT_ID,
+        });
+      } else {
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+          value: false,
+        });
       }
+    }
+  }, [isChatEnabled, layoutIsReady]);
 
+  useEffect(() => {
+    if (layoutIsReady && sidebarContentPanel === PANELS.NONE) {
       if (getFromUserSettings('bbb_show_participants_on_login', window.meetingClientSettings.public.layout.showParticipantsOnLogin) && !deviceInfo.isPhone) {
-        if (isChatEnabled && getFromUserSettings('bbb_show_public_chat_on_login', !window.meetingClientSettings.public.chat.startClosed)) {
-          const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
-
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-            value: true,
-          });
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-            value: true,
-          });
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-            value: PANELS.CHAT,
-          });
-          layoutContextDispatch({
-            type: ACTIONS.SET_ID_CHAT_OPEN,
-            value: PUBLIC_CHAT_ID,
-          });
-        } else {
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-            value: true,
-          });
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-            value: false,
-          });
-        }
+        layoutContextDispatch({
+          type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+          value: true,
+        });
       } else {
         layoutContextDispatch({
           type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
@@ -263,6 +258,20 @@ const LayoutObserver: React.FC = () => {
           type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
           value: false,
         });
+      }
+    }
+  }, [layoutIsReady]);
+
+  useEffect(() => {
+    if (Session.equals('layoutReady', true)) {
+      if (!checkedUserSettings.current) {
+        const Settings = getSettingsSingletonInstance();
+        Settings.save(setLocalSettings);
+        checkedUserSettings.current = true;
+      }
+
+      if (!layoutIsReady) {
+        setLayoutIsReady(true);
       }
     }
   });


### PR DESCRIPTION
### What does this PR do?
The error occurred because the observer wasn't functioning correctly. A condition `checkedUserSettings` was added around the logic that determines whether to render the `Chat` component based on disabled features. This condition was originally intended to ensure the settings singleton was loaded only once.

However, it unintentionally caused the observer to check whether the `Chat` component should be rendered only a single time. Splitting this logic into two separate conditions resolved the issue by allowing proper re-evaluation of both the settings and the chat render condition.

### Closes Issue(s)

Closes #23243

### How to test
- Join a user and join webcam 
- Join a second user 


### More
[Screencast from 22-05-2025 16:25:30.webm](https://github.com/user-attachments/assets/de5a84be-bb72-44c0-985f-a2abe73588b6)

