### PR TITLE
refactor(tests): Set default viewport size in the playwright config file

### DIFF
--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -66,7 +66,6 @@ class Page {
           font-family: 'Liberation Sans', Arial, sans-serif;
         }`,
     });
-    await this.setHeightWidthViewPortSize();
   }
 
   async handleDownload(locator, testInfo, timeout = ELEMENT_WAIT_TIME) {
@@ -368,10 +367,6 @@ class Page {
       }
     }
     await this.hasElementCount(e.toastContainer, 0, 'should not display any toast notification');
-  }
-
-  async setHeightWidthViewPortSize() {
-    await this.page.setViewportSize({ width: 1366, height: 768 });
   }
 
   async getYoutubeFrame() {

--- a/bigbluebutton-tests/playwright/playwright.config.js
+++ b/bigbluebutton-tests/playwright/playwright.config.js
@@ -20,6 +20,7 @@ const config = {
     screenshot: 'on',
     video: CI ? 'retain-on-failure' : 'on',
     actionTimeout: ELEMENT_WAIT_LONGER_TIME,
+    viewport: { width: 1366, height: 768 },
   },
   projects: [
     chromiumConfig,


### PR DESCRIPTION
### What does this PR do?
Instead of using the `setHeightWidthViewPortSize` function to set the default viewport, use the playwright config file.
- viewport needed to avoid screenshot comparison failures on small screens
- with the function call, mobile viewports were also affected (iphone 11 viewport screenshot of a mobile test):
![image](https://github.com/user-attachments/assets/421aafb2-bc07-4f5f-b91a-b2e9e27858ec)
