### PR TITLE
fix(apps-gallery): show apps in alphabetical order

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/container.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import AppsGallery from './component';
 import { layoutSelectInput } from '/imports/ui/components/layout/context';
 import { Input } from '/imports/ui/components/layout/layoutTypes';
-import useMeeting from '/imports/ui/core/hooks/useMeeting';
 
 const AppsGalleryContainer: React.FC = () => {
   const {
@@ -10,24 +9,10 @@ const AppsGalleryContainer: React.FC = () => {
     pinnedApps: originalPinnedApps,
   } = layoutSelectInput((i: Input) => i.sidebarNavigation);
 
-  const { data: currentMeeting } = useMeeting((m) => ({
-    isBreakout: m.isBreakout,
-  }));
-
-  const filteredApps = currentMeeting?.isBreakout
-    ? Object.fromEntries(
-      Object.entries(originalRegisteredApps).filter(([key]) => key !== 'breakoutroom'),
-    )
-    : originalRegisteredApps;
-
-  const filteredPinnedApps = currentMeeting?.isBreakout
-    ? originalPinnedApps.filter((appKey: string) => appKey !== 'breakoutroom')
-    : originalPinnedApps;
-
   return (
     <AppsGallery
-      pinnedApps={filteredPinnedApps}
-      registeredApps={filteredApps}
+      pinnedApps={originalPinnedApps}
+      registeredApps={originalRegisteredApps}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?
Pinned and unpinned apps are now each sorted alphabetically within their respective sections. 
This sorting also applies to the navigation sidebar.

### Closes Issue(s)
Close  None

### More
[Screencast from 23-05-2025 12:22:19.webm](https://github.com/user-attachments/assets/924b8cf9-a652-4ac7-9c24-bd9024b8579d)

