### PR TITLE
fix(bbb-export-annotations): Remove useless hotfix

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -279,38 +279,6 @@ function overlayAnnotations(svg, slideAnnotations) {
 }
 
 /**
- * Resize an SVG image if it contains an embedded base64 image.
- * 
- * `WARNING`: This function is intended to be a hotfix for bad generated SVG's.
- * It should be removed in the future.
- * @param {string} file Path of the file.
- * @param {number} width The new width of the image.
- * @param {number} height The new height of the image.
- * @param {number} oldWidth The old width of the image.
- * @param {number} oldHeight The old height of the image.
- * @param {number} page Page number.
- */
-function resizeAssetIfBase64Image(file, width, height, oldWidth, oldHeight, page) {
-  const BASE_64_HREF_REGEX = /href="data:image\/(png|jpg|jpeg);base64,[^"]+"/;
-  const isSvg = file.endsWith('.svg');
-
-  if (!isSvg) return;
-
-  try {
-    let svg = fs.readFileSync(file, { encoding: 'utf-8' });
-    const hasBase64Image = BASE_64_HREF_REGEX.test(svg);
-    if (hasBase64Image) {
-      svg = svg.replaceAll(`width="${oldWidth}"`, `width="${width}"`);
-      svg = svg.replaceAll(`height="${oldHeight}"`, `height="${height}"`);
-      fs.writeFileSync(file, svg);
-    }
-  } catch (error) {
-    logger.error(`Resizing slide ${page}
-      failed for job ${jobId}: ${error.message}`);
-  }
-}
-
-/**
  * Processes presentation slides and associated annotations into
  * a single PDF file.
  * @async
@@ -388,16 +356,6 @@ async function processPresentationAnnotations() {
           'xmlns': 'http://www.w3.org/2000/svg',
           'xmlns:xlink': 'http://www.w3.org/1999/xlink',
         });
-
-    // Resize the image element
-    resizeAssetIfBase64Image(
-      `${dropbox}/slide${currentSlide.page}.${backgroundFormat}`,
-      scaledWidth,
-      scaledHeight,
-      slideWidth,
-      slideHeight,
-      currentSlide.page,
-    );
 
     // Add the image element
     canvas


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

As of https://github.com/bigbluebutton/bigbluebutton/pull/22794, the fix introduced in https://github.com/bigbluebutton/bigbluebutton/pull/22807 is no longer needed. This PR removes it.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23229

### How to test

1. Upload a presentation that requires rasterization.
2. In the presentation upload modal, export the presentation to the chat.
3. Download the file and see that the presentation was converted as expected.