### PR TITLE
fix(tests): Add timeout before export breakout tests to ensure the zoom is stabilized

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.js
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.js
@@ -129,7 +129,7 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await join.exportBreakoutNotes();
     });
 
-    test('Export breakout room whiteboard annotations', { tag: '@flaky' }, async ({ browser, context, page }) => {
+    test('Export breakout room whiteboard annotations', async ({ browser, context, page }) => {
       const join = new Join(browser, context);
       await join.initPages(page);
       await join.create(false, true);

--- a/bigbluebutton-tests/playwright/breakout/join.js
+++ b/bigbluebutton-tests/playwright/breakout/join.js
@@ -198,6 +198,7 @@ class Join extends Create {
     await shareNotesPDF.click();
     await hasCurrentPresentationToastElement(this.modPage, 'should display the current presentation toast when changing to the whiteboard exported file');
     // visual assertion
+    await sleep(2000); // ensure whiteboard zoom is stabilized
     const wbLocator = await this.modPage.getLocator(e.whiteboard);
     await expect(wbLocator).toHaveScreenshot('capture-breakout-notes.png', {
       maxDiffPixels: 1500,
@@ -256,6 +257,7 @@ class Join extends Create {
     await whiteboardPDF.click();
     await hasCurrentPresentationToastElement(this.modPage, 'should display the current presentation toast when changing to the whiteboard exported file');
     // visual assertion
+    await sleep(2000); // ensure whiteboard zoom is stabilized
     const wbLocator = await this.modPage.getLocator(e.whiteboard);
     await expect(wbLocator).toHaveScreenshot('capture-breakout-whiteboard.png', {
       maxDiffPixels: 1500,


### PR DESCRIPTION
### What does this PR do?
We've been facing snapshot comparison failures recently due to whiteboard zoom taking longer to stabilize. adding a static timeout should avoid this

![image](https://github.com/user-attachments/assets/d4d4cc5a-c9bf-4d44-bd1d-690b328b5ffb)
