### PR TITLE
fix: improve initial zoom calculation time

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1441,6 +1441,11 @@ const Whiteboard = React.memo((props) => {
 
     if (slideShape) {
       const prevZoomCamera = camera.z;
+
+      if (zoomValueRef.current === prevZoomValueRef.current) {
+        return;
+      }
+
       const prevCenteredCameraX = -slideShape.x
         + (viewportWidth - slideShape.props.w * prevZoomCamera) / (2 * prevZoomCamera);
       const prevCenteredCameraY = -slideShape.y
@@ -1641,7 +1646,7 @@ const Whiteboard = React.memo((props) => {
       && isPresenter
       && !isWheelZoomRef.current
     ) {
-      if (!isMounting && prevZoomValueRef.current !== zoomValue) {
+      if (!isMounting) {
         syncCameraOnPresenterZoom();
       }
     }


### PR DESCRIPTION
### What does this PR do?

aims to improve zoom calculation time by redoing #23133 inside syncCameraOnPresenterZoom function, instead of skipping its call entirely

### Motivation
automated (and manual) tests indicated that the initial zoom calculation is taking more time, likely caused by changes made in #23133
