### PR TITLE
Fix(html5): External video unsync when presenter resume session

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -375,7 +375,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     }
 
     if (currentTime > playerCurrentTime) {
-      playerRef?.current?.seekTo(currentTime);
+      playerRef?.current?.seekTo(currentTime, 'seconds');
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -387,10 +387,13 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
-      const currentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
+      const currentTime = getCurrentTime();
+      const playerCurrentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
       sendMessage('play', {
         rate,
-        time: currentTime,
+        // if currentTime is greater than playerCurrentTime, means the video was already played
+        // and the presenter refreshed his client
+        time: currentTime > playerCurrentTime ? currentTime : playerCurrentTime,
       });
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where players became unsynchronized when the presenter refreshed their client and resumed the session.

The root cause was that a `play` event was being emitted after the session start due to the presenter interacting with the page (e.g., pressing play). However, the time reference used by the `handleOnPlay` function was incorrect — it did not reflect the actual session start time — which caused the desynchronization among participants.

The fix ensures that the `handleOnPlay` function uses the correct, updated time reference after the presenter resumes the session. This prevents `play` events from triggering with misaligned timing and keeps all players properly synchronized.


### Closes Issue(s)
N/A

### How to test
- Join two users 
- On Presenter's client pauses the video 
- Refresh the presenter's client 
- Click to play the video 


### More
[Screencast from 26-05-2025 10:13:16.webm](https://github.com/user-attachments/assets/6acde05c-8e7e-4f5f-a72c-dcc557aec6d3)

