### PR TITLE
fix(html5): Open presentation+annotations in a new tab

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/component.tsx
@@ -67,6 +67,7 @@ const ChatMessagePresentationContent: React.FC<ChatMessagePresentationContentPro
         type="application/pdf"
         rel="noopener, noreferrer"
         download={`${parsedFileName}.pdf`}
+        target="_blank"
       >
         {intl.formatMessage(intlMessages.download)}
       </Styled.ChatLink>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- When running a cluster setup, the download domain of the presentation is different from the domain of the client. Thus, the download attribute doesn't work for that case. Instead, open the presentation in a new tab by specifying the target attribute.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23240

### How to test

1. Spin up a cluster setup of BBB servers.
2. Try out the **Send out a download link for the presentation including whiteboard annotations** feature.