### PR TITLE
Fix(html5): Player not emitting play event when Presenter changes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -535,7 +535,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         <Styled.VideoPlayer
           config={videoPlayConfig}
           autoPlay
-          // playsInline
           url={videoUrl}
           playing={playing}
           playbackRate={playerPlaybackRate}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -196,7 +196,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const presenterRef = useRef(isPresenter);
   const [reactPlayerPlaying, setReactPlayerPlaying] = React.useState(false);
-  const clientReloadedRef = useRef(false);
 
   let currentTime = getCurrentTime();
 
@@ -355,7 +354,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         setVolume(playerVolume > 1 ? playerVolume / 100 : playerVolume);
       }
 
-      clientReloadedRef.current = true;
       presenterRef.current = isPresenter;
     }
   }, [isPresenter]);
@@ -382,7 +380,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const handleOnPlay = async () => {
     setReactPlayerPlaying(true);
     const internalPlayer = playerRef.current?.getInternalPlayer();
-    if (isPresenter && !playing && !clientReloadedRef.current) {
+    if (isPresenter && !playing) {
       const rate = internalPlayer instanceof HTMLVideoElement
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
@@ -396,12 +394,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
 
     if (!playing && !isPresenter) {
       stopVideo(playerRef.current as ReactPlayer);
-    }
-    if (clientReloadedRef.current) {
-      clientReloadedRef.current = false;
-      if (!mute && isPresenter) {
-        playerRef.current?.getInternalPlayer().unMute();
-      }
     }
   };
 
@@ -543,7 +535,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         <Styled.VideoPlayer
           config={videoPlayConfig}
           autoPlay
-          playsInline
+          // playsInline
           url={videoUrl}
           playing={playing}
           playbackRate={playerPlaybackRate}


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the player was not emitting a `play` event when the presenter changed during an external video share session.

The root cause was a legacy fix that handled player remounting when a presenter was granted control — originally intended to ensure controls were properly added. However, since we no longer remount the client on presenter changes, this logic is no longer necessary and was preventing the expected `play` event from being emitted.

The outdated remount logic has been removed to allow the player to emit the `play` event correctly when the presenter changes mid-session.


### Closes Issue(s)
N/A

### How to test
- Join two users
- Share a video
- Pause it 
- change the presenter 
- WIth new Presenter presse to play.


### More
[Screencast from 27-05-2025 11:07:52.webm](https://github.com/user-attachments/assets/c590c682-3e9b-45d7-9c5b-ddc7b0414cbf)

