### PR TITLE
fix: start private chat option is available when chat is disabled via disabledFeatures

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -395,7 +395,8 @@ const UserActions: React.FC<UserActionsProps> = ({
           && !isBreakout)
           || user.isModerator;
 
-        const isAllowed = preventSelfChat
+        const isAllowed = isChatEnabled
+          && preventSelfChat
           && (moderatorOverride || regularUserCondition || !currentUser.locked);
 
         return isAllowed;


### PR DESCRIPTION
### What does this PR do?
Updates user list dropdown permissions to hide the "Start a private chat" option when chat is disabled.

### How to test
1. create a meeting with `disabledFeatures=chat`
2. join the meeting with a moderator and a viewer
3. neither user should see the "Start a private chat" option when clicking on the other user's name in the user list