### PR TITLE
feat(common-web): added plugin_ parameters and default value support for manifest.json placeholders

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -20,6 +20,7 @@ package org.bigbluebutton.api;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.MalformedParametersException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -426,6 +427,8 @@ public class MeetingService implements MessageListener {
           log.error("I/O error when fetching URL: {}", pluginManifestUrlString, e);
         } catch (NoSuchFieldException e) {
           log.error("Missing required metadata (meta_ or plugin_ parameter) in plugin manifest URL [{}]. Plugin not loaded.", pluginManifestUrlString, e);
+        } catch (MalformedParametersException e) {
+          log.error("Malformed metadata parameter for plugin manifest URL [{}]. Plugin not loaded.", pluginManifestUrlString, e);
         } catch (Exception e) {
           log.error("Unexpected error processing plugin manifest from URL: {}", pluginManifestUrlString, e);
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -375,6 +375,7 @@ public class MeetingService implements MessageListener {
     ExecutorService executorService = Executors.newFixedThreadPool(numPluginManifestsFetchingThreads);
     for (PluginManifest pluginManifest : m.getPluginManifests()) {
       String pluginManifestUrlString = pluginManifest.getUrl();
+      log.info("Fetching plugin [{}].", pluginManifestUrlString);
       CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
         try {
           URL url = new URL(pluginManifestUrlString);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -61,8 +61,6 @@ import com.google.gson.Gson;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.*;
@@ -368,41 +366,10 @@ public class MeetingService implements MessageListener {
       : Collections.unmodifiableCollection(sessions.values());
   }
 
-  public String replaceMetaParametersIntoManifestTemplate(String manifestContent, Map<String, String> metadata)
-          throws NoSuchFieldException {
-    // Pattern to match ${variable} in the input string
-    Pattern pattern = Pattern.compile("\\$\\{([\\w\\-]+)\\}");
-
-    Matcher matcher = pattern.matcher(manifestContent);
-
-    StringBuilder result = new StringBuilder();
-
-    // Iterate over all matches
-    while (matcher.find()) {
-
-      String variableName = matcher.group(1);
-      if (variableName.startsWith("meta_") && variableName.length() > 5) {
-        // Remove "meta_" and convert to lower case
-        variableName = variableName.substring(5).toLowerCase();
-      } else {
-        throw new NoSuchFieldException("Metadata " + variableName + " is malformed, please provide a valid one");
-      }
-
-      String replacement;
-      if (metadata.containsKey(variableName))
-        replacement = metadata.get(variableName);
-      else throw new NoSuchFieldException("Metadata " + variableName + " not found in URL parameters");
-
-      // Replace the placeholder with the value from the map
-      matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
-    }
-    matcher.appendTail(result);
-
-    return result.toString();
-  }
   public Map<String, Object> requestPluginManifests(Meeting m) {
     Map<String, Object> urlContents = new ConcurrentHashMap<>();
     Map<String, String> metadata = m.getMetadata();
+    Map<String, String> pluginMetadataParameter = m.getPluginMetadataParametersMap();
     List<CompletableFuture<Void>> futures = new ArrayList<>();
     // The maximum number of threads can be adjusted later on
     ExecutorService executorService = Executors.newFixedThreadPool(numPluginManifestsFetchingThreads);
@@ -431,17 +398,18 @@ public class MeetingService implements MessageListener {
           }
 
           // Get the "name" field
-          String name;
+          String pluginName;
           if (jsonNode.has("name")) {
-            name = jsonNode.get("name").asText();
+            pluginName = jsonNode.get("name").asText();
           } else {
             throw new NoSuchFieldException("For url " + pluginManifestUrlString + " there is no name field configured.");
           }
 
-          String pluginKey = name;
+          String pluginKey = pluginName;
           HashMap<String, Object> manifestObject = new HashMap<>();
           manifestObject.put("url", pluginManifestUrlString);
-          String manifestContent = replaceMetaParametersIntoManifestTemplate(content, metadata);
+          String manifestContent = PluginUtils.replaceMetadataParametersIntoManifestTemplate(
+                  pluginName, content, metadata, pluginMetadataParameter);
 
           Map<String, Object> mappedManifestContent = objectMapper.readValue(manifestContent, new TypeReference<Map<String, Object>>() {});
           manifestObject.put("content", mappedManifestContent);
@@ -455,6 +423,8 @@ public class MeetingService implements MessageListener {
           log.error("Failed to parse JSON from URL: {}", pluginManifestUrlString, e);
         } catch (IOException e) {
           log.error("I/O error when fetching URL: {}", pluginManifestUrlString, e);
+        } catch (NoSuchFieldException e) {
+          log.error("Missing required metadata (meta_ or plugin_ parameter) in plugin manifest URL [{}]. Plugin not loaded.", pluginManifestUrlString, e);
         } catch (Exception e) {
           log.error("Unexpected error processing plugin manifest from URL: {}", pluginManifestUrlString, e);
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -278,13 +278,9 @@ public class ParamsProcessorUtil {
         return false;
 	}
 
-	public static String removeMetaString(String param) {
-		return StringUtils.removeStart(param, "meta_");
-	}
-
-    public static String removePluginPrefixString(String param) {
-		return StringUtils.removeStart(param, "plugin_");
-	}
+    public static String removePrefixString(String param, String prefix) {
+        return StringUtils.removeStart(param, prefix);
+    }
 
     public static Map<String, String> processMetaParam(Map<String, String> params) {
         Map<String, String> metas = new HashMap<>();
@@ -292,7 +288,7 @@ public class ParamsProcessorUtil {
             if (isMetaValid(entry.getKey())) {
                 // Need to lowercase to maintain backward compatibility with
                 // 0.81
-                String metaName = removeMetaString(entry.getKey()).toLowerCase();
+                String metaName = removePrefixString(entry.getKey(), "meta_").toLowerCase();
                 metas.put(metaName, entry.getValue());
             }
         }
@@ -306,7 +302,7 @@ public class ParamsProcessorUtil {
             if (isPluginParameterValid(entry.getKey())) {
                 // Need to lowercase to maintain backward compatibility with
                 // 0.81
-                String pluginMetaName = removePluginPrefixString(entry.getKey()).toLowerCase();
+                String pluginMetaName = removePrefixString(entry.getKey(), "plugin_").toLowerCase();
                 pluginParams.put(pluginMetaName, entry.getValue());
             }
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -269,8 +269,21 @@ public class ParamsProcessorUtil {
 		return false;
 	}
 
+    private static final Pattern PLUGIN_PREFIX_PATTERN = Pattern.compile("plugin_[a-zA-Z][a-zA-Z0-9-_]*$");
+	public static Boolean isPluginParameterValid(String param) {
+		Matcher pluginPrefixMatcher = PLUGIN_PREFIX_PATTERN.matcher(param);
+        if (pluginPrefixMatcher.matches()) {
+            return true;
+        }
+        return false;
+	}
+
 	public static String removeMetaString(String param) {
 		return StringUtils.removeStart(param, "meta_");
+	}
+
+    public static String removePluginPrefixString(String param) {
+		return StringUtils.removeStart(param, "plugin_");
 	}
 
     public static Map<String, String> processMetaParam(Map<String, String> params) {
@@ -285,6 +298,20 @@ public class ParamsProcessorUtil {
         }
 
         return metas;
+    }
+
+    public static Map<String, String> processPluginMetaParam(Map<String, String> params) {
+        Map<String, String> pluginParams  = new HashMap<>();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (isPluginParameterValid(entry.getKey())) {
+                // Need to lowercase to maintain backward compatibility with
+                // 0.81
+                String pluginMetaName = removePluginPrefixString(entry.getKey()).toLowerCase();
+                pluginParams.put(pluginMetaName, entry.getValue());
+            }
+        }
+
+        return pluginParams;
     }
 
 		private BreakoutRoomsParams processBreakoutRoomsParams(Map<String, String> params) {
@@ -847,6 +874,10 @@ public class ParamsProcessorUtil {
         // store if meeting is recorded.
         Map<String, String> meetingInfo = processMetaParam(params);
 
+        // Collect plugin metadata for this meeting that the third-party app wants to
+        // replace manifest.json placeholders.
+        Map<String, String> pluginMetadataParameters = processPluginMetaParam(params);
+
         // Create a unique internal id by appending the current time. This way,
         // the 3rd-party
         // app can reuse the external meeting id.
@@ -904,6 +935,7 @@ public class ParamsProcessorUtil {
                 .withScreenShareBridge(screenShareBridge)
                 .withAudioBridge(audioBridge)
                 .withMetadata(meetingInfo)
+                .withPluginMetadataParameters(pluginMetadataParameters)
                 .withWelcomeMessageTemplate(welcomeMessageTemplate)
                 .withWelcomeMessage(welcomeMessage)
                 .withIsBreakout(isBreakout)

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -93,7 +93,7 @@ public class Meeting {
 	private boolean userHasJoined = false;
 	private Map<String, String> guestUsersWithPositionInWaitingLine;
 	private Map<String, String> metadata;
-	private Map<String, String> pluginMetadataParametersMap;
+	private final Map<String, String> pluginMetadataParametersMap;
 	private Map<String, Object> userCustomData;
 	private final ConcurrentMap<String, User> users;
 	private final ConcurrentMap<String, RegisteredUser> registeredUsers;
@@ -181,7 +181,9 @@ public class Meeting {
         welcomeMsg = builder.welcomeMsg;
         dialNumber = builder.dialNumber;
         metadata = builder.metadata;
-		pluginMetadataParametersMap = builder.pluginMetadataParametersMap;
+		pluginMetadataParametersMap = builder.pluginMetadataParametersMap != null
+			? new HashMap<>(builder.pluginMetadataParametersMap)
+			: new HashMap<>();
         createdTime = builder.createdTime;
         isBreakout = builder.isBreakout;
         guestPolicy = builder.guestPolicy;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -93,6 +93,7 @@ public class Meeting {
 	private boolean userHasJoined = false;
 	private Map<String, String> guestUsersWithPositionInWaitingLine;
 	private Map<String, String> metadata;
+	private Map<String, String> pluginMetadataParametersMap;
 	private Map<String, Object> userCustomData;
 	private final ConcurrentMap<String, User> users;
 	private final ConcurrentMap<String, RegisteredUser> registeredUsers;
@@ -180,6 +181,7 @@ public class Meeting {
         welcomeMsg = builder.welcomeMsg;
         dialNumber = builder.dialNumber;
         metadata = builder.metadata;
+		pluginMetadataParametersMap = builder.pluginMetadataParametersMap;
         createdTime = builder.createdTime;
         isBreakout = builder.isBreakout;
         guestPolicy = builder.guestPolicy;
@@ -963,6 +965,10 @@ public class Meeting {
 	public void setMaxNumPages(int maxNumPages) { this.maxNumPages = maxNumPages; }
 	public int getMaxNumPages() { return maxNumPages; }
 
+    public Map<String, String> getPluginMetadataParametersMap() {
+        return pluginMetadataParametersMap;
+    }
+
     /***
 	 * Meeting Builder
 	 *
@@ -1005,6 +1011,7 @@ public class Meeting {
 			private String audioBridge;
     	private int logoutTimer;
     	private Map<String, String> metadata;
+    	private Map<String, String> pluginMetadataParametersMap;
     	private String dialNumber;
     	private String defaultAvatarURL;
     	private String defaultBotAvatarURL;
@@ -1228,6 +1235,11 @@ public class Meeting {
 
     	public Builder withMetadata(Map<String, String> m) {
     		metadata = m;
+    		return this;
+    	}
+
+		public Builder withPluginMetadataParameters(Map<String, String> m) {
+			pluginMetadataParametersMap = m;
     		return this;
     	}
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -43,7 +43,7 @@ public class PluginUtils {
     }
 
     private static boolean matchesPluginParameterFormat(String pluginParameter, String pluginName) {
-        Pattern PLUGIN_PREFIX_PATTERN = Pattern.compile("plugin_" + pluginName + "_[a-zA-Z][a-zA-Z0-9-_]*$");
+        Pattern PLUGIN_PREFIX_PATTERN = Pattern.compile("plugin_" + pluginName + "-[a-zA-Z][a-zA-Z0-9_]*$");
         Matcher pluginPrefixMatcher = PLUGIN_PREFIX_PATTERN.matcher(pluginParameter);
         return pluginPrefixMatcher.matches();
     }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -7,6 +7,7 @@ import org.bigbluebutton.api.domain.PluginManifest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.MalformedParametersException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,7 +79,7 @@ public class PluginUtils {
         Map<String, String> metadata,
         Map<String, String> pluginMetadata,
         StringBuilder result
-    ) throws NoSuchFieldException {
+    ) throws NoSuchFieldException, MalformedParametersException {
         // First capturing group of regex is parameterName
         String metadataParameterName = matcher.group(1);
         // Second capturing group of regex is default value if exists
@@ -110,7 +111,7 @@ public class PluginUtils {
             );
 
         } else {
-            throw new NoSuchFieldException("Metadata " + metadataParameterName + " is malformed, please provide a valid one");
+            throw new MalformedParametersException("Metadata " + metadataParameterName + " is malformed, please provide a valid one");
         }
         // Replace the placeholder with the value from the map
         matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
@@ -122,7 +123,7 @@ public class PluginUtils {
         String manifestContent,
         Map<String, String> metadataParametersMap,
         Map<String, String> pluginMetadataParametersMap
-    ) throws NoSuchFieldException {
+    ) throws NoSuchFieldException, MalformedParametersException {
         Matcher matcher = METADATA_PLACEHOLDER_PATTERN.matcher(manifestContent);
         StringBuilder result = new StringBuilder();
         // Iterate over all matches

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -2,12 +2,21 @@ package org.bigbluebutton.api.util;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.bigbluebutton.api.ParamsProcessorUtil;
 import org.bigbluebutton.api.domain.PluginManifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class PluginUtils {
+    private static Logger log = LoggerFactory.getLogger(PluginUtils.class);
     private static final String HTML5_PLUGIN_SDK_VERSION = "%%HTML5_PLUGIN_SDK_VERSION%%";
     private static final String BBB_VERSION = "%%BBB_VERSION%%";
     private static final String MEETING_ID = "%%MEETING_ID%%";
+    private static final Pattern METADATA_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([\\w\\-]+)\\}");
     private static String bbbVersion;
     private String html5PluginSdkVersion;
 
@@ -31,6 +40,65 @@ public class PluginUtils {
             }
         }
         return null;
+    }
+
+    private static boolean matchesPluginParameterFormat(String pluginParameter, String pluginName) {
+        Pattern PLUGIN_PREFIX_PATTERN = Pattern.compile("plugin_" + pluginName + "_[a-zA-Z][a-zA-Z0-9-_]*$");
+        Matcher pluginPrefixMatcher = PLUGIN_PREFIX_PATTERN.matcher(pluginParameter);
+        return pluginPrefixMatcher.matches();
+    }
+
+    private static void validateAndReplaceMetadataParameters(
+        String pluginName,
+        Matcher matcher,
+        Map<String, String> metadata,
+        Map<String, String> pluginMetadata,
+        StringBuilder result
+    ) throws NoSuchFieldException {
+        String metadataParameterName = matcher.group(1);
+        String replacement;
+        // Checking if placeholder is a meta_ parameter
+        if (ParamsProcessorUtil.isMetaValid(metadataParameterName)) {
+            // Remove "meta_" and convert to lower case
+            metadataParameterName = ParamsProcessorUtil.removeMetaString(metadataParameterName).toLowerCase();
+            if (metadata.containsKey(metadataParameterName)) {
+                replacement = metadata.get(metadataParameterName);
+                log.debug("meta_ parameter [{}] identified, value: [{}]", metadataParameterName, replacement);
+            }
+            else throw new NoSuchFieldException("Metadata " + metadataParameterName + " not found in URL parameters");
+
+        // Checking if placeholder is a plugin_ parameter
+        } else if (matchesPluginParameterFormat(metadataParameterName, pluginName)) {
+            // Remove "plugin_" and convert to lower case
+            metadataParameterName = ParamsProcessorUtil.removePluginPrefixString(metadataParameterName).toLowerCase();
+            if (pluginMetadata.containsKey(metadataParameterName)) {
+                replacement = pluginMetadata.get(metadataParameterName);
+                log.debug("plugin_ parameter [{}] identified, value: [{}]", metadataParameterName, replacement);
+            }
+            else throw new NoSuchFieldException("Plugin metadata parameter named " + metadataParameterName + " not found in URL parameters");
+
+        } else {
+            throw new NoSuchFieldException("Metadata " + metadataParameterName + " is malformed, please provide a valid one");
+        }
+        // Replace the placeholder with the value from the map
+        matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+        log.debug("Metadata [{}] replaced in manifest of plugin [{}]", metadataParameterName, pluginName);
+    }
+
+    static public String replaceMetadataParametersIntoManifestTemplate(
+        String pluginName,
+        String manifestContent,
+        Map<String, String> metadataParametersMap,
+        Map<String, String> pluginMetadataParametersMap
+    ) throws NoSuchFieldException {
+        Matcher matcher = METADATA_PLACEHOLDER_PATTERN.matcher(manifestContent);
+        StringBuilder result = new StringBuilder();
+        // Iterate over all matches
+        while (matcher.find()) {
+            validateAndReplaceMetadataParameters(pluginName, matcher, metadataParametersMap, pluginMetadataParametersMap, result);
+        }
+        matcher.appendTail(result);
+        return result.toString();
     }
 
     public void setHtml5PluginSdkVersion(String html5PluginSdkVersion) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -43,7 +43,7 @@ public class PluginUtils {
     }
 
     private static boolean matchesPluginParameterFormat(String pluginParameter, String pluginName) {
-        Pattern PLUGIN_PREFIX_PATTERN = Pattern.compile("plugin_" + pluginName + "-[a-zA-Z][a-zA-Z0-9_]*$");
+        Pattern PLUGIN_PREFIX_PATTERN = Pattern.compile("plugin_" + pluginName + "_[a-zA-Z][a-zA-Z0-9-]*$");
         Matcher pluginPrefixMatcher = PLUGIN_PREFIX_PATTERN.matcher(pluginParameter);
         return pluginPrefixMatcher.matches();
     }

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -981,7 +981,7 @@ plugin_<pluginName>_<parameter-name>
 ```
 
 - `<pluginName>` — The name of the plugin as defined in `manifest.json`.  
-- `<parameter-name>` — The parameter's name. It may include letters (uppercase or lowercase), numbers, hyphens (`-`), and underscores (`_`).
+- `<parameter-name>` — The parameter's name. It may include letters (uppercase or lowercase), numbers and hyphens (`-`).
 
 This naming convention ensures that each plugin has its own namespace for parameters. Other plugins cannot access values outside their own namespace. For example:
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -960,13 +960,17 @@ pluginApi.getRemoteData('allUsers').then((response: Response) => {
 });
 ```
 
-### Meta_ parameters
+### Customize manifest.json
+
+The following sections explain how you can dynamically customize your manifest.json for different runs.
+
+#### Meta_ parameters
 
 This is not part of the API, but it's a way of passing information to the manifest. Any value can be passed like this, one just needs to put something like `${meta_nameOfParameter}` in a specific config of the manifest, and in the `/create` call, set this meta-parameter to whatever is preferred, like `meta_nameOfParameter="Sample message"`
 
 This feature is mainly used for security purposes, see [external data section](#external-data-resources). But can be used for customization reasons as well.
 
-### Plugin_ parameters
+#### Plugin_ parameters
 
 `plugin_` parameters work similarly to `meta_` parameters, allowing data to be passed dynamically to the manifest. While they can serve the same purposes — like security or customization — they are specifically scoped to individual plugins.
 
@@ -986,6 +990,29 @@ plugin_pickRandomUserPlugin_url-to-fetch-data=https://...
 ```
 
 This isolates the parameter to `pickRandomUserPlugin` and avoids conflicts with other plugins.
+
+#### Comments
+
+If a plugin expects a placeholder (via `meta_ `or `plugin_`) but doesn't receive a value, the plugin will fail to load. To prevent this, both types of placeholders support default values. This allows the system administrator to define fallback values, ensuring the plugin loads correctly.
+
+**Example with a default value (`manifest.json`):**
+```json
+{
+  "requiredSdkVersion": "~0.0.77",
+  "name": "MyPlugin",
+  "javascriptEntrypointUrl": "MyPlugin.js",
+  "localesBaseUrl": "https://cdn.domain.com/my-plugin/", // Optional
+  "dataChannels":[
+    {
+      "name": "${plugin_MyPlugin_data-channel-name:storeState}",
+      "pushPermission": ["moderator","presenter"], // "moderator","presenter", "all"
+      "replaceOrDeletePermission": ["moderator", "creator"] // "moderator", "presenter","all", "creator"
+    }
+  ]
+}
+```
+
+In this example, if the parameter `plugin_MyPlugin_data-channel-name` is not provided during the `/create` call, it will fallback to "storeState".
 
 ### Event persistence
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -1012,7 +1012,7 @@ If a plugin expects a placeholder (via `meta_ `or `plugin_`) but doesn't receive
 }
 ```
 
-In this example, if the parameter `plugin_MyPlugin_data-channel-name` is not provided during the `/create` call, it will fallback to "storeState".
+In this example, if the parameter `plugin_MyPlugin_data-channel-name` is not provided during the `/create` call, it will fall back to "storeState".
 
 ### Event persistence
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -966,6 +966,27 @@ This is not part of the API, but it's a way of passing information to the manife
 
 This feature is mainly used for security purposes, see [external data section](#external-data-resources). But can be used for customization reasons as well.
 
+### Plugin_ parameters
+
+`plugin_` parameters work similarly to `meta_` parameters, allowing data to be passed dynamically to the manifest. While they can serve the same purposes — like security or customization — they are specifically scoped to individual plugins.
+
+**Format:**
+
+```
+plugin_<pluginName>_<parameter-name>
+```
+
+- `<pluginName>` — The name of the plugin as defined in `manifest.json`.  
+- `<parameter-name>` — The parameter's name. It may include letters (uppercase or lowercase), numbers, hyphens (`-`), and underscores (`_`).
+
+This naming convention ensures that each plugin has its own namespace for parameters. Other plugins cannot access values outside their own namespace. For example:
+
+```
+plugin_pickRandomUserPlugin_url-to-fetch-data=https://...
+```
+
+This isolates the parameter to `pickRandomUserPlugin` and avoids conflicts with other plugins.
+
 ### Event persistence
 
 This feature will allow the developer to save an information (which is basically an event) in the `event.xml` file of the meeting if it's being recorded.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -991,7 +991,7 @@ plugin_pickRandomUserPlugin_url-to-fetch-data=https://...
 
 This isolates the parameter to `pickRandomUserPlugin` and avoids conflicts with other plugins.
 
-#### Comments
+#### Default value (fallback) for missing placeholder's parameters
 
 If a plugin expects a placeholder (via `meta_ `or `plugin_`) but doesn't receive a value, the plugin will fail to load. To prevent this, both types of placeholders support default values. This allows the system administrator to define fallback values, ensuring the plugin loads correctly.
 


### PR DESCRIPTION
### What does this PR do?

- Adds support for `plugin_` parameters which is a metadata `create` parameter to replace values into `manifest.json` placeholders - They have a rigid structure of plugin_<pluginName>_<parameter-name>, so that no other plugin can request that same parameter;
- Adds support for fallback default values for when a `manifest.json` placeholder is not set in the `create`, this avoids errors like not loading the `plugin`; 

### Motivation

This creates an even more secure way to pass metadata to plugin manifests.

### How to test

There are plenty of scenarios to explore, I am going to list some here, but first some **premises** for these test cases:

- We are going to use 2 plugins: one is going to be pickRandomUser and the other is genericLinkShare;
- both will have 2 placeholders each one being `meta_` parameter and the other is `plugin_` parameter;
- one of the placeholders will have default value (say the `plugin_` param for the pick-random-user and the `meta_` param for the generic-link);

see the pick-random-user's `manifest.json` file as an example:

```json
{
  "requiredSdkVersion": "~0.0.79",
  "name": "PickRandomUserPlugin",
  "javascriptEntrypointUrl": "PickRandomUserPlugin.js?q=${plugin_PickRandomUserPlugin_name:Guilherme}",
  "localesBaseUrl": "locales",
  "dataChannels": [
    {
      "name": "modalInformationFromPresenter",
      "pushPermission": ["presenter"],
      "replaceOrDeletePermission": ["creator", "moderator"]
    },
    {
      "name": "pickRandomUser",
      "pushPermission": ["presenter"],
      "replaceOrDeletePermission": ["creator", "moderator"]
    },
    {
      "name": "${meta_abc123}",
      "pushPermission": ["all"],
      "replaceOrDeletePermission": ["moderator"]
    }
  ]
}
```

with these premises let's try the following **test cases**:

- happy path: all parameters defined - Both plugins should load;
- all parameters defined, except for the ones with fallback - Both plugins should load (but with the default values - it can be seen in the debug log of bbb-web);
- no parameters are defined - Both plugins should not load (remember that if a placeholder is created but not populated, it should fail its loading process);
- all parameters of pick-random-user are set, but no parameters of generic link are set - pick-random-user should appear;
- do the above for the generic link - only the generic-link should load;

Lastly as a security check, - lets add an additional `plugin_` placeholder for pick-random-user with the generic-link name in it (ideally this should be the same placeholder defined in the generic-link's manifest file). E.g.: "localesBaseUrl": "${plugin_GenericLinkSharePlugin_abc}".

With this last change, you'll see that pick-random-user will not load for any case, because no parameter `plugin_GenericLinkSharePlugin_abc` is defined for it (which is correct, since one plugin should not get info on the other one - unless we use `meta_` parameters for that).

