### PR TITLE
Fix(html5): external video desync on player seek

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -197,6 +197,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const presenterRef = useRef(isPresenter);
   const [reactPlayerPlaying, setReactPlayerPlaying] = React.useState(false);
   const clientReloadedRef = useRef(false);
+  const firstPlayRef = useRef(true);
 
   let currentTime = getCurrentTime();
 
@@ -385,7 +386,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (isPresenter && !playing && !clientReloadedRef.current) {
       const rate = internalPlayer instanceof HTMLVideoElement
         ? internalPlayer.playbackRate
-        : internalPlayer?.getPlaybackRate?.() ?? 1;
+        : internalPlayer?.c?.() ?? 1;
 
       const currentTime = getCurrentTime();
       const playerCurrentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
@@ -393,7 +394,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         rate,
         // if currentTime is greater than playerCurrentTime, means the video was already played
         // and the presenter refreshed his client
-        time: currentTime > playerCurrentTime ? currentTime : playerCurrentTime,
+        time: (currentTime > playerCurrentTime) && firstPlayRef.current ? currentTime : playerCurrentTime,
       });
     }
 
@@ -405,6 +406,10 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       if (!mute && isPresenter) {
         playerRef.current?.getInternalPlayer().unMute();
       }
+    }
+
+    if (firstPlayRef.current) {
+      firstPlayRef.current = false;
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -384,7 +384,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (isPresenter && !playing) {
       const rate = internalPlayer instanceof HTMLVideoElement
         ? internalPlayer.playbackRate
-        : internalPlayer?.c?.() ?? 1;
+        : internalPlayer?.getPlaybackRate?.() ?? 1;
 
       const currentTime = getCurrentTime();
       const playerCurrentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);


### PR DESCRIPTION
### What does this PR do?
This PR addresses a bug causing desynchronization when the presenter rolls back the player time.
The issue stemmed from a condition that checked for the greater played time, which was originally intended to handle synchronization during the initial play event. However, this logic was incorrectly applied in all scenarios, leading to sync issues during rollbacks.

### Closes Issue(s)
N/A

### How to test
- Join two users
- Share a video 
- Seek to 50%> of the video
- Pauses the video
- Seek to 10% of the video
- Play again


### More

[Screencast from 28-05-2025 10:46:19.webm](https://github.com/user-attachments/assets/dc56951b-56dc-4faa-8dce-3888f9699a9a)
