### PR TITLE
Fix(html5): chat Emoji picker not being diabled when lock settings enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -603,6 +603,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
                 hideLabel
                 label={intl.formatMessage(messages.emojiButtonLabel)}
                 data-test="emojiPickerButton"
+                disabled={disabled || partnerIsLoggedOut || chatSendMessageLoading}
               />
             ) : null}
           </Styled.InputWrapper>


### PR DESCRIPTION
### What does this PR do?
Emoji piccker on chat form wasn't disabled when lock settings `Send Public chat messages` was active allowing the viewer fill the chat form, but not send it.


### Closes Issue(s)
Closes #23266

### How to test
- Enable Emoji Picker on Settings.yml `public.chat.emojiPicker.enable`
- Join with a mod and a viewer
- Enable the lock settings `Send Public chat messages` as a mod
- Try to open the emojipicker as a viewer


### More
[Screencast from 28-05-2025 13:54:08.webm](https://github.com/user-attachments/assets/6d490515-24df-4155-8469-44c858419928)

