### PR TITLE
fix: External video plays behind pinned notes on the whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -80,6 +80,7 @@ const AppContainer = (props) => {
   const genericMainContent = layoutSelectInput((i) => i.genericMainContent);
   const captionsStyle = layoutSelectOutput((i) => i.captions);
   const presentation = layoutSelectInput((i) => i.presentation);
+  const sharedNotesInput = layoutSelectInput((i) => i.sharedNotes);
   const { hideNotificationToasts } = layoutSelectInput((i) => i.notificationsBar);
   const layoutType = layoutSelect((i) => i.layoutType);
   const isNonMediaLayout = [
@@ -90,7 +91,9 @@ const AppContainer = (props) => {
   const { data: pinnedPadData } = useDeduplicatedSubscription(PINNED_PAD_SUBSCRIPTION);
   const isSharedNotesPinnedFromGraphql = !!pinnedPadData
     && pinnedPadData.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
-  const isSharedNotesPinned = isSharedNotesPinnedFromGraphql && presentation.isOpen;
+  const isSharedNotesPinned = sharedNotesInput?.isPinned
+    && isSharedNotesPinnedFromGraphql
+    && presentation.isOpen;
   const isExternalVideoEnabled = useIsExternalVideoEnabled();
   const isPresentationEnabled = useIsPresentationEnabled();
   const isRaiseHandEnabled = useIsRaiseHandEnabled();

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
@@ -5,6 +5,7 @@ import Styled from './styles';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import { isUrlValid } from './service';
 import { EXTERNAL_VIDEO_START } from '../../mutations';
+import { PIN_NOTES } from '/imports/ui/components/notes/mutations';
 
 const intlMessages = defineMessages({
   start: {
@@ -59,6 +60,7 @@ const ExternalVideoPlayerModal: React.FC<ExternalVideoPlayerModalProps> = ({
   const { animations } = Settings.application;
   const [videoUrl, setVideoUrl] = React.useState('');
   const [startExternalVideo] = useMutation(EXTERNAL_VIDEO_START);
+  const [pinSharedNotes] = useMutation(PIN_NOTES);
 
   const startWatching = (url: string) => {
     let externalVideoUrl = url;
@@ -72,6 +74,8 @@ const ExternalVideoPlayerModal: React.FC<ExternalVideoPlayerModalProps> = ({
         externalVideoUrl = `https://${m[1]}/Podcast/Social/${m[3]}.mp4`;
       }
     }
+    // stop pinned notes so they don't interfere with the video
+    pinSharedNotes({ variables: { pinned: false } });
 
     startExternalVideo({ variables: { externalVideoUrl } });
   };


### PR DESCRIPTION
### What does this PR do?

adjusts shared notes behavior to automatically unpin shared notes when an external video is shared.

### Closes Issue(s)
Closes #23274

### How to test
1. Create a meeting
2. Pin the shared notes
3. Start the external video
4. Shared notes should be unpinned