### PR TITLE
build(livekit): build livekit-server from source, +

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,7 @@ get_external_dependencies:
       - bbb-pads
       - bbb-playback
       - bbb-transcription-controller
+      - bbb-livekit
     expire_in: 1h 30min
 
 # template job for build step

--- a/bbb-livekit.placeholder.sh
+++ b/bbb-livekit.placeholder.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# livekit-server
+git clone --branch v1.8.4 --depth 1 https://github.com/livekit/livekit-server bbb-livekit/livekit-server
+# livekit-sip
+git clone --branch v0.9.0 --depth 1 https://github.com/livekit/sip bbb-livekit/livekit-sip

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -1,61 +1,68 @@
 #!/bin/bash -ex
 
-TARGET=`basename $(pwd)`
+TARGET=$(basename "$(pwd)")
 
 SERVER_VERSION=1.8.4
 CLI_VERSION=2.3.1
 SIP_VERSION=0.9.0
 
-PACKAGE=$(echo $TARGET | cut -d'_' -f1)
-VERSION=$(echo $TARGET | cut -d'_' -f2)
-DISTRO=$(echo $TARGET | cut -d'_' -f3)
+PACKAGE=$(echo "$TARGET" | cut -d'_' -f1)
+VERSION=$(echo "$TARGET" | cut -d'_' -f2)
+DISTRO=$(echo "$TARGET" | cut -d'_' -f3)
 
-BUILDDIR=$PWD
-DESTDIR=$BUILDDIR/staging
+BUILDDIR="$PWD"
+DESTDIR="$BUILDDIR/staging"
 
 #
 # Clear staging directory for build
 
-rm -rf $DESTDIR
-mkdir -p $DESTDIR
+rm -rf "$DESTDIR"
+mkdir -p "$DESTDIR"
 
-. ./opts-$DISTRO.sh
+# shellcheck disable=SC1090
+. "./opts-$DISTRO.sh"
 
-mkdir -p $DESTDIR/usr/share/bigbluebutton/nginx
-cp livekit.nginx $DESTDIR/usr/share/bigbluebutton/nginx
+mkdir -p "$DESTDIR/usr/share/bigbluebutton/nginx"
+cp livekit.nginx "$DESTDIR/usr/share/bigbluebutton/nginx"
 
-mkdir -p $DESTDIR/lib/systemd/system/
-cp livekit-server.service livekit-sip.service $DESTDIR/lib/systemd/system
+mkdir -p "$DESTDIR/lib/systemd/system/"
+cp livekit-server.service livekit-sip.service "$DESTDIR/lib/systemd/system"
 
-mkdir -p $DESTDIR/usr/share/livekit-server
-cp livekit.yaml livekit-sip.yaml $DESTDIR/usr/share/livekit-server
-chmod 644 $DESTDIR/usr/share/livekit-server/livekit*.yaml
+mkdir -p "$DESTDIR/usr/share/livekit-server"
+cp livekit.yaml livekit-sip.yaml "$DESTDIR/usr/share/livekit-server"
+chmod 644 "$DESTDIR/usr/share/livekit-server/livekit"*.yaml
 
-mkdir -p $DESTDIR/usr/bin
+mkdir -p "$DESTDIR/usr/bin"
 
-curl https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz  -Lo - | tar -C $DESTDIR/usr/bin -xzf - livekit-server
-curl https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz -Lo - | tar -C $DESTDIR/usr/bin -xzf - lk
+curl "https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - livekit-server
+curl "https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - lk
 
 apt update && apt install -y pkg-config libopus-dev libopusfile-dev libsoxr-dev
 
 buildbase=$(mktemp -d)
-curl https://github.com/livekit/sip/archive/refs/tags/v${SIP_VERSION}.tar.gz -Lo - | tar -xzf - -C $buildbase
-pushd $buildbase/sip-${SIP_VERSION}
+curl "https://github.com/livekit/sip/archive/refs/tags/v${SIP_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
+pushd "$buildbase/sip-${SIP_VERSION}" > /dev/null
 
-if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
+if [ "$TARGETPLATFORM" = "linux/arm64" ]; then
+    GOARCH=arm64
+else
+    GOARCH=amd64
+fi
 
-cp livekit-sip $DESTDIR/usr/bin
+CGO_ENABLED=1 GOOS=linux GOARCH="${GOARCH}" GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
 
-popd
-rm -rf $buildbase
+cp livekit-sip "$DESTDIR/usr/bin"
 
-fpm -s dir -C $DESTDIR -n $PACKAGE \
-    --version $VERSION --epoch 2 \
-    --before-install before-install.sh      \
-    --after-install after-install.sh        \
-    --before-remove before-remove.sh        \
-    --after-remove after-remove.sh         \
+popd > /dev/null
+rm -rf "$buildbase"
+
+# shellcheck disable=SC2086
+fpm -s dir -C "$DESTDIR" -n "$PACKAGE" \
+    --version "$VERSION" --epoch 2 \
+    --before-install before-install.sh \
+    --after-install after-install.sh \
+    --before-remove before-remove.sh \
+    --after-remove after-remove.sh \
     --description "BigBlueButton build of LiveKit Server" \
-    $DIRECTORIES                            \
+    $DIRECTORIES \
     $OPTS

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -2,9 +2,9 @@
 
 TARGET=$(basename "$(pwd)")
 
-SERVER_VERSION=1.8.4
+SERVER_VERSION=v1.8.4
 CLI_VERSION=2.3.1
-SIP_VERSION=0.9.0
+SIP_VERSION=v0.9.0
 
 PACKAGE=$(echo "$TARGET" | cut -d'_' -f1)
 VERSION=$(echo "$TARGET" | cut -d'_' -f2)
@@ -34,14 +34,54 @@ chmod 644 "$DESTDIR/usr/share/livekit-server/livekit"*.yaml
 
 mkdir -p "$DESTDIR/usr/bin"
 
-curl "https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - livekit-server
+# Pull built lk cli from github
 curl "https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - lk
 
+# Build livekit-server
+buildbase=$(mktemp -d)
+curl "https://github.com/livekit/livekit/archive/${SERVER_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
+# Get livekit-server's directory name from the extracted archive
+LIVEKIT_DIR=$(find "$buildbase" -maxdepth 1 -type d -name "livekit-*" | head -n 1)
+
+if [ -z "$LIVEKIT_DIR" ]; then
+    echo "Error: Could not find livekit-server directory in extracted archive"
+    exit 1
+fi
+
+# Build in an isolated shell as the GO* envs need to be overridden and I'd
+# prefer not to leak them to the main shell.- prlanzarin
+(
+    # These are needed by the mage build
+    export GOPATH="/tmp/go-${TARGET}"
+    export GOBIN="$GOPATH/bin"
+    mkdir -p "$GOBIN"
+    export PATH="$GOBIN:$PATH"
+
+    pushd "$LIVEKIT_DIR" > /dev/null
+    ./bootstrap.sh
+    mage
+    popd > /dev/null
+)
+
+cp "$LIVEKIT_DIR/bin/livekit-server" "$DESTDIR/usr/bin"
+rm -rf "$buildbase"
+
+# End of livekit-server build
+
+# Build livekit-sip
 apt update && apt install -y pkg-config libopus-dev libopusfile-dev libsoxr-dev
 
 buildbase=$(mktemp -d)
-curl "https://github.com/livekit/sip/archive/refs/tags/v${SIP_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
-pushd "$buildbase/sip-${SIP_VERSION}" > /dev/null
+curl "https://github.com/livekit/sip/archive/${SIP_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
+# Get livekit-sip's directory name from the extracted archive
+SIP_DIR=$(find "$buildbase" -maxdepth 1 -type d -name "sip-*" | head -n 1)
+
+if [ -z "$SIP_DIR" ]; then
+    echo "Error: Could not find livekit-sip directory in extracted archive"
+    exit 1
+fi
+
+pushd "$SIP_DIR" > /dev/null
 
 if [ "$TARGETPLATFORM" = "linux/arm64" ]; then
     GOARCH=arm64
@@ -52,9 +92,9 @@ fi
 CGO_ENABLED=1 GOOS=linux GOARCH="${GOARCH}" GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
 
 cp livekit-sip "$DESTDIR/usr/bin"
-
 popd > /dev/null
 rm -rf "$buildbase"
+# End of livekit-sip build
 
 # shellcheck disable=SC2086
 fpm -s dir -C "$DESTDIR" -n "$PACKAGE" \


### PR DESCRIPTION
### What does this PR do?

- [refactor: shellcheck over bbb-livekit`s build script](https://github.com/bigbluebutton/bigbluebutton/commit/50249aecf97c4644999ed93e4a03200f21a166e7)
- [build(livekit): build livekit-server from source instead of pulling bin](https://github.com/bigbluebutton/bigbluebutton/commit/59132999ae0b475f399c93ff0b20eb3ad431017f) 
  - livekit-server's binary is currently pulled directly from GitHub. This
works, but we'd like to have the ability to test LiveKit builds that are
not necessarily tied to tags (e.g.: commits).
  - Adjust bbb-livekit's build script so that livekit-server is built from
source. Upstream's build instructions (via mage) are followed.
- [build(livekit): pull sources via get_external_dependencies](https://github.com/bigbluebutton/bigbluebutton/commit/39f9f9a4611abe3a90bb9ed3ecc1b1081f00609e) 
  - Adjust bbb-livekit's build scripts so that livekit/server and
livekit/sip follow the same pattern as other external packages: versions
in placeholder files, code is pulled via get_external_dependencies.
  - This should make things consistent with the exception of `lk`
(livekit-cli) which is not built from source yet.
  - Additionally: one less thing we download at build time

### Closes Issue(s)

None, ref a couple of items in #21059 

### Motivation

#21059