### PR TITLE
fix(html5): Place polling modal at the end of the DOM tree

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -197,4 +197,5 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
   <audio id="remote-media"></audio>
   <audio id="local-media"></audio>
   <div id="modals-container"></div>
+  <div id="polling-container"></div>
 </body>

--- a/bigbluebutton-html5/imports/ui/components/polling/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.tsx
@@ -96,24 +96,11 @@ const PollingGraphql: React.FC<PollingGraphqlProps> = (props) => {
   const responseInput = useRef<HTMLInputElement>(null);
   const pollingContainer = useRef<HTMLElement>(null);
 
-  if (!document.getElementById('pollingContainer')) {
-    const container = document.createElement('div');
-    container.id = 'pollingContainer';
-    document.body.appendChild(container);
-  }
-
   useEffect(() => {
     playAlert();
     if (pollingContainer.current) {
       pollingContainer.current.focus();
     }
-
-    return () => {
-      const container = document.getElementById('pollingContainer');
-      if (container) {
-        document.body.removeChild(container);
-      }
-    };
   }, []);
 
   const handleUpdateResponseInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -341,7 +328,7 @@ const PollingGraphql: React.FC<PollingGraphqlProps> = (props) => {
           : renderButtonAnswers()}
       </Styled.PollingContainer>
     </Styled.Overlay>,
-    document.getElementById('pollingContainer')!,
+    document.getElementById('polling-container') || document.body,
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/polling/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/polling/component.tsx
@@ -1,6 +1,7 @@
 import React, {
   useEffect, useMemo, useRef, useState,
 } from 'react';
+import ReactDOM from 'react-dom';
 import { useMutation } from '@apollo/client';
 import { defineMessages, useIntl } from 'react-intl';
 import Checkbox from '/imports/ui/components/common/checkbox/component';
@@ -95,11 +96,24 @@ const PollingGraphql: React.FC<PollingGraphqlProps> = (props) => {
   const responseInput = useRef<HTMLInputElement>(null);
   const pollingContainer = useRef<HTMLElement>(null);
 
+  if (!document.getElementById('pollingContainer')) {
+    const container = document.createElement('div');
+    container.id = 'pollingContainer';
+    document.body.appendChild(container);
+  }
+
   useEffect(() => {
     playAlert();
     if (pollingContainer.current) {
       pollingContainer.current.focus();
     }
+
+    return () => {
+      const container = document.getElementById('pollingContainer');
+      if (container) {
+        document.body.removeChild(container);
+      }
+    };
   }, []);
 
   const handleUpdateResponseInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -303,7 +317,7 @@ const PollingGraphql: React.FC<PollingGraphqlProps> = (props) => {
     );
   };
 
-  return (
+  return ReactDOM.createPortal(
     <Styled.Overlay>
       <Styled.PollingContainer
         autoWidth={poll.stackOptions}
@@ -326,7 +340,8 @@ const PollingGraphql: React.FC<PollingGraphqlProps> = (props) => {
           ? renderCheckboxAnswers()
           : renderButtonAnswers()}
       </Styled.PollingContainer>
-    </Styled.Overlay>
+    </Styled.Overlay>,
+    document.getElementById('pollingContainer')!,
   );
 };
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

Places polling modal at the end of the DOM tree. This aims to facilitate discoverability of the polling container by screenreaders.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #20621

### Motivation

Accessibility issue.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Start a poll.
2. Using a screenreader, try reading the open polling modal.
3. Jumping to the end of the DOM tree should work.