### PR TITLE
fix: make emoji auto convert ignore shortcodes from disableEmojis setting

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -22,6 +22,7 @@ import { findDOMNode } from 'react-dom';
 
 import Styled from './styles';
 import deviceInfo from '/imports/utils/deviceInfo';
+import { getAllShortCodes } from '/imports/utils/emoji-utils';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 import useChat from '/imports/ui/core/hooks/useChat';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
@@ -144,6 +145,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const emojiPickerButtonRef = useRef(null);
   const [isTextAreaFocused, setIsTextAreaFocused] = React.useState(false);
   const [repliedMessageId, setRepliedMessageId] = React.useState<string | null>(null);
+  const [emojisToExclude, setEmojisToExclude] = React.useState<string[]>([]);
   const editingMessage = React.useRef<EditingMessage | null>(null);
   const textAreaRef: RefObject<TextareaAutosize> = useRef<TextareaAutosize>(null);
   const { isMobile } = deviceInfo;
@@ -173,6 +175,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const AUTO_CONVERT_EMOJI = window.meetingClientSettings.public.chat.autoConvertEmoji;
   const ENABLE_EMOJI_PICKER = window.meetingClientSettings.public.chat.emojiPicker.enable;
   const ENABLE_TYPING_INDICATOR = CHAT_CONFIG.typingIndicator.enabled;
+  const DISABLE_EMOJIS = CHAT_CONFIG.disableEmojis;
 
   const handleUserTyping = (hasError?: boolean) => {
     if (hasError || !ENABLE_TYPING_INDICATOR) return;
@@ -201,6 +204,20 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
       const unsentMessage = messageRef.current;
       updateUnsentMessages(chatId, unsentMessage);
     };
+  }, []);
+
+  useEffect(() => {
+    // load all shortcodes and aliases for emojis to exclude
+    let emojisToExclude = [
+      ...DISABLE_EMOJIS,
+    ];
+
+    emojisToExclude.forEach(async (shortcode) => {
+      const shortcodes = await getAllShortCodes(shortcode);
+
+      emojisToExclude = Array.from(new Set([...emojisToExclude, ...shortcodes]));
+      setEmojisToExclude(emojisToExclude);
+    });
   }, []);
 
   useEffect(() => {
@@ -267,11 +284,31 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
     setTimeout(() => txtArea.setSelectionRange(newCursor, newCursor), 10);
   };
 
+  const customCheckText = (input: string): string => {
+    const placeholderMap: Record<string, string> = {};
+
+    emojisToExclude.forEach((shortcode, index) => {
+      const placeholder = `__EXCLUDE_${index}__`;
+      const target = `:${shortcode}:`;
+      placeholderMap[placeholder] = target;
+      // eslint-disable-next-line no-param-reassign
+      input = input.split(target).join(placeholder);
+    });
+
+    let result = checkText(input);
+
+    Object.entries(placeholderMap).forEach(([placeholder, original]) => {
+      result = result.split(placeholder).join(original);
+    });
+
+    return result;
+  };
+
   const handleMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     let newMessage = null;
     let newError = null;
     if (AUTO_CONVERT_EMOJI) {
-      newMessage = checkText(e.target.value);
+      newMessage = customCheckText(e.target.value);
     } else {
       newMessage = e.target.value;
     }

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -221,6 +221,27 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   }, []);
 
   useEffect(() => {
+    const loadExcludedEmojis = async () => {
+      let allExcluded = [...DISABLE_EMOJIS];
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const shortcode of DISABLE_EMOJIS) {
+        // eslint-disable-next-line no-await-in-loop
+        const shortcodes = await getAllShortCodes(shortcode);
+        allExcluded = [...allExcluded, ...shortcodes];
+      }
+
+      const newEmojisToExclude = Array.from(new Set(allExcluded));
+
+      setEmojisToExclude(newEmojisToExclude);
+    };
+
+    if (DISABLE_EMOJIS?.length > 0) {
+      loadExcludedEmojis();
+    }
+  }, [DISABLE_EMOJIS]);
+
+  useEffect(() => {
     const unsentMessages = Storage.getItem('unsentMessages') as Record<string, string> || {};
 
     if (prevChatId) {

--- a/bigbluebutton-html5/imports/utils/emoji-utils.js
+++ b/bigbluebutton-html5/imports/utils/emoji-utils.js
@@ -4,6 +4,7 @@ export const getAllShortCodes = async (shortcode) => {
   const shortcodes = [];
 
   const emoji = await getEmojiDataFromNative(shortcode);
+  if (!emoji) return shortcodes;
 
   if (emoji.aliases && emoji.aliases.length > 0) {
     emoji.aliases.forEach((alias) => {
@@ -21,8 +22,9 @@ export const getAllShortCodes = async (shortcode) => {
       }
     } else if (Array.isArray(emoji.shortcodes)) {
       emoji.shortcodes.forEach((code) => {
-        if (!shortcodes.includes(code)) {
-          shortcodes.push(shortcode.replace(/^:|:$/g, ''));
+        const normalizedCode = code.replace(/^:|:$/g, '');
+        if (!shortcodes.includes(normalizedCode)) {
+          shortcodes.push(normalizedCode);
         }
       });
     }

--- a/bigbluebutton-html5/imports/utils/emoji-utils.js
+++ b/bigbluebutton-html5/imports/utils/emoji-utils.js
@@ -1,0 +1,36 @@
+import { getEmojiDataFromNative } from 'emoji-mart';
+
+export const getAllShortCodes = async (shortcode) => {
+  const shortcodes = [];
+
+  const emoji = await getEmojiDataFromNative(shortcode);
+
+  if (emoji.aliases && emoji.aliases.length > 0) {
+    emoji.aliases.forEach((alias) => {
+      if (!shortcodes.includes(alias)) {
+        shortcodes.push(alias);
+      }
+    });
+  }
+
+  if (emoji.shortcodes && emoji.shortcodes.length > 0) {
+    // shortcodes might be an array of strings or a single string
+    if (typeof emoji.shortcodes === 'string') {
+      if (!shortcodes.includes(emoji.shortcodes)) {
+        shortcodes.push(emoji.shortcodes.replace(/^:|:$/g, ''));
+      }
+    } else if (Array.isArray(emoji.shortcodes)) {
+      emoji.shortcodes.forEach((code) => {
+        if (!shortcodes.includes(code)) {
+          shortcodes.push(shortcode.replace(/^:|:$/g, ''));
+        }
+      });
+    }
+  }
+
+  return shortcodes;
+};
+
+export default {
+  getAllShortCodes,
+};


### PR DESCRIPTION
### What does this PR do?

This PR updates the auto convert emoji feature to respect the `disableEmojis` setting. Previously, emojis were being converted regardless of settings. With this change, when disableEmojis is enabled, automatic conversion for the disabled emojis is bypassed as expected.

### Closes Issue(s)
Closes #23294

### How to test
1. disable emojis in public.chat.disableEmojis config: `disableEmojis: ['tomato']`
2. Start a session and join as moderator
3. In the chat start typing `:tomato` 
4. When adding the remaining `:`, it should not be converted to the tomato emoji
