### PR TITLE
fix: Clear all reactions missing

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -210,6 +210,7 @@
     "app.userList.userOptions.usersJoinMutedDisableDesc": "Joining users are not muted by default",
     "app.userList.userOptions.clearAllReactionsLabel": "Clear all reactions",
     "app.userList.userOptions.clearAllReactionsDesc": "Clears all reaction emojis from users",
+    "app.userList.userOptions.clearedReactions": "Cleared all user reactions",
     "app.userList.userOptions.muteAllExceptPresenterLabel": "Mute all users except presenter",
     "app.userList.userOptions.muteAllExceptPresenterDesc": "Mutes all users in the session except the presenter",
     "app.userList.userOptions.lockViewersLabel": "Lock viewers",


### PR DESCRIPTION
### What does this PR do?
restores "clear all reactions" menu item in userlist dropdown

### Closes Issue(s)
Closes #23296

### How to test
1. Start a session.
2. Join as a moderator.
3. Hit the Gear ⚙ icon.