### PR TITLE
fix: SmartSlide Poll Option Removed When Editing Custom Input

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -274,11 +274,15 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
       } = quickPollVariables;
       const isCustom = pollType === pollTypes.Custom;
 
+      const questionAndOptionsList = isCustom
+        ? [question, ...answers].join('\n')
+        : '';
+
       setError(null);
       setWarning(null);
       setCustomInput(isCustom);
       setIsMultipleResponse(isMultipleResponse);
-      setQuestionAndOptions(isCustom ? answers.join('\n') : '');
+      setQuestionAndOptions(questionAndOptionsList);
       setQuestion(question);
       setSecretPoll(secretPoll);
       setType(


### PR DESCRIPTION
### What does this PR do?

Fix issue where smart slides poll option was removed when editing a custom input due to the poll question not being included in the custom input data

### Closes Issue(s)
Closes #23309

### How to test
1. On a slide with multiple-choice text (e.g., “A) 2222”, “B) 3333”, “C) 11111”), click the A/B/C SmartSlide button to auto-populate poll options.
2. Edit or append new content in the Custom Input text area (e.g., add “D) Test”).
