### PR TITLE
feat(html5/chat): Filter out unallowed emojis from search results

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/raise-hand-button/component.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 import PropTypes from 'prop-types';
-import data from '@emoji-mart/data';
 import withShortcutHelper from '/imports/ui/components/shortcut-help/service';
-import { init } from 'emoji-mart';
 import { SET_RAISE_HAND } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useMutation } from '@apollo/client';
 import Styled from './styles';
@@ -15,9 +13,6 @@ const RaiseHandButton = (props) => {
     raiseHand,
     shortcuts,
   } = props;
-
-  // initialize emoji-mart data, need for the new version
-  init({ data });
 
   const [setRaiseHand] = useMutation(SET_RAISE_HAND);
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -3,8 +3,6 @@ import { defineMessages } from 'react-intl';
 import PropTypes from 'prop-types';
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import { convertRemToPixels } from '/imports/utils/dom-utils';
-import data from '@emoji-mart/data';
-import { init } from 'emoji-mart';
 import { SET_REACTION_EMOJI } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useMutation } from '@apollo/client';
 import Styled from './styles';
@@ -19,9 +17,6 @@ const ReactionsButton = (props) => {
   } = props;
 
   const REACTIONS = window.meetingClientSettings.public.userReaction.reactions;
-
-  // initialize emoji-mart data, need for the new version
-  init({ data });
 
   const [setReactionEmoji] = useMutation(SET_REACTION_EMOJI);
 
@@ -68,11 +63,15 @@ const ReactionsButton = (props) => {
     padding: '4px',
   };
 
-  let actions = [];
+  const actions = [];
 
   REACTIONS.forEach(({ id, native }) => {
     actions.push({
-      label: <Styled.ButtonWrapper active={currentUserReaction === native}><em-emoji key={native} native={native} {...emojiProps} /></Styled.ButtonWrapper>,
+      label: (
+        <Styled.ButtonWrapper active={currentUserReaction === native}>
+          <em-emoji key={native} native={native} {...emojiProps} />
+        </Styled.ButtonWrapper>
+      ),
       key: id,
       onClick: () => handleReactionSelect(native),
       customStyles: actionCustomStyles,
@@ -109,7 +108,14 @@ const ReactionsButton = (props) => {
   let customIcon = null;
 
   if (!svgIcon) {
-    customIcon = <em-emoji key={currentUserReactionEmoji?.id} native={currentUserReactionEmoji?.native} emoji={{ id: currentUserReactionEmoji?.id }} {...emojiProps} />;
+    customIcon = (
+      <em-emoji
+        key={currentUserReactionEmoji?.id}
+        native={currentUserReactionEmoji?.native}
+        emoji={{ id: currentUserReactionEmoji?.id }}
+        {...emojiProps}
+      />
+    );
   }
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/reactions-button/component.jsx
@@ -17,6 +17,7 @@ const ReactionsButton = (props) => {
   } = props;
 
   const REACTIONS = window.meetingClientSettings.public.userReaction.reactions;
+  const DISABLE_EMOJIS = window.meetingClientSettings.public.chat.disableEmojis;
 
   const [setReactionEmoji] = useMutation(SET_REACTION_EMOJI);
 
@@ -66,6 +67,7 @@ const ReactionsButton = (props) => {
   const actions = [];
 
   REACTIONS.forEach(({ id, native }) => {
+    if (DISABLE_EMOJIS.includes(id)) return;
     actions.push({
       label: (
         <Styled.ButtonWrapper active={currentUserReaction === native}>

--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -163,6 +163,8 @@ class App extends Component {
     if (!isJoinLogged) {
       this.logJoin();
     }
+
+    AppService.initializeEmojiData();
   }
 
   componentDidUpdate(prevProps) {

--- a/bigbluebutton-html5/imports/ui/components/app/service.js
+++ b/bigbluebutton-html5/imports/ui/components/app/service.js
@@ -1,4 +1,6 @@
 import * as DarkReader from 'darkreader';
+import data from '@emoji-mart/data';
+import { init } from 'emoji-mart';
 import Styled from './styles';
 import logger from '/imports/startup/client/logger';
 import useMeeting from '../../core/hooks/useMeeting';
@@ -51,8 +53,27 @@ export const setDarkTheme = (value) => {
 
 export const isDarkThemeEnabled = () => DarkReader.isEnabled();
 
+export const initializeEmojiData = () => {
+  const DISABLE_EMOJIS = window.meetingClientSettings.public.chat.disableEmojis;
+  const emojis = Object.values(data.emojis);
+  const allowedEmojis = {};
+
+  // We manually filter it here because there's a bug in the Picker component.
+  // See: https://github.com/missive/emoji-mart/issues/810
+  const filteredEmojis = emojis.filter((e) => !DISABLE_EMOJIS.includes(e.id));
+
+  filteredEmojis.forEach((e) => {
+    allowedEmojis[e.id] = e;
+  });
+
+  data.emojis = allowedEmojis;
+
+  init({ data });
+};
+
 export default {
   setDarkTheme,
   isDarkThemeEnabled,
   useMeetingIsBreakout,
+  initializeEmojiData,
 };

--- a/bigbluebutton-html5/imports/ui/components/app/service.js
+++ b/bigbluebutton-html5/imports/ui/components/app/service.js
@@ -66,9 +66,12 @@ export const initializeEmojiData = () => {
     allowedEmojis[e.id] = e;
   });
 
-  data.emojis = allowedEmojis;
+  const filteredData = {
+    ...data,
+    emojis: allowedEmojis,
+  };
 
-  init({ data });
+  init({ data: filteredData });
 };
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-picker/component.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
-import data from '@emoji-mart/data';
 import Picker from '@emoji-mart/react';
 
 const propTypes = {
@@ -60,7 +59,6 @@ const EmojiPicker = (props) => {
 
   return (
     <Picker
-      data={data}
       onEmojiSelect={(emojiObject, event) => onEmojiSelect(emojiObject, event)}
       emojiSize={24}
       i18n={i18n}


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

Filter out unallowed emojis from search results of the chat input emoji picker by manually filtering the emoji data before initializing it.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23293

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

See the linked issue. `tomato` emoji  (and any other specified in the `disableEmojis` option) should not be shown when searching for them.