### PR TITLE
chore: Again show participants list on page load

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -814,7 +814,7 @@ public:
     pinnable: true
   layout:
     hidePresentationOnJoin: false
-    showParticipantsOnLogin: false
+    showParticipantsOnLogin: true
     showPushLayoutButton: true
     showPushLayoutToggle: true
     showSessionDetailsOnJoin: true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Reinstates the participants list as the panel to be visible on page load

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
We've received feedback on difficulty figuring out who is in the room upon entry.

### More
This partially reverts @Arthurk12 's https://github.com/bigbluebutton/bigbluebutton/pull/22204

> Changes the default settings flag
> 'public.layout.showParticipantsOnLogin' to false, so the default panel
> is opening the chat.
