### PR TITLE
feat(screnshare): add ParticipantStatusChange event for screen sharing, +

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/ScreenshareModel.scala
@@ -4,6 +4,7 @@ import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 
 object ScreenshareModel {
   def resetDesktopSharingParams(status: ScreenshareModel) = {
+    status.userId = ""
     status.broadcastingRTMP = false
     status.screenshareStarted = false
     status.rtmpBroadcastingUrl = ""
@@ -13,6 +14,14 @@ object ScreenshareModel {
     status.screenshareConf = ""
     status.timestamp = ""
     status.hasAudio = false
+  }
+
+  def getUserId(status: ScreenshareModel): String = {
+    status.userId
+  }
+
+  def setUserId(status: ScreenshareModel, userId: String) = {
+    status.userId = userId
   }
 
   def getScreenshareStarted(status: ScreenshareModel): Boolean = {
@@ -101,6 +110,7 @@ object ScreenshareModel {
 }
 
 class ScreenshareModel {
+  private var userId: String = ""
   private var rtmpBroadcastingUrl: String = ""
   private var screenshareStarted = false
   private var screenshareVideoWidth = 0

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenshareStatusReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenshareStatusReqMsgHdlr.scala
@@ -21,6 +21,7 @@ trait GetScreenshareStatusReqMsgHdlr {
 
       val voiceConf = ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel)
       val screenshareConf = ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel)
+      val ownerUserId = ScreenshareModel.getUserId(liveMeeting.screenshareModel)
       val stream = ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel)
       val vidWidth = ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel)
       val vidHeight = ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel)
@@ -28,7 +29,7 @@ trait GetScreenshareStatusReqMsgHdlr {
       val hasAudio = ScreenshareModel.getHasAudio(liveMeeting.screenshareModel)
       val contentType = ScreenshareModel.getContentType(liveMeeting.screenshareModel)
 
-      val body = ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf, screenshareConf,
+      val body = ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf, screenshareConf, ownerUserId,
         stream, vidWidth, vidHeight, timestamp, hasAudio, contentType)
       val event = ScreenshareRtmpBroadcastStartedEvtMsg(header, body)
       BbbCommonEnvCoreMsg(envelope, event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -13,6 +13,7 @@ object ScreenshareApp2x {
       val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
         liveMeeting.props.meetingProp.intId,
         ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
+        ScreenshareModel.getUserId(liveMeeting.screenshareModel),
         ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
       )
 
@@ -22,16 +23,25 @@ object ScreenshareApp2x {
 
   def broadcastStopped(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
     if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      val voiceConf = ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel)
+      val screenShareConf = ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel)
+      val ownerUserId = ScreenshareModel.getUserId(liveMeeting.screenshareModel)
+      val url = ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel)
+      val width = ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel)
+      val height = ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel)
+      val ts = ScreenshareModel.getTimestamp(liveMeeting.screenshareModel)
+
       ScreenshareModel.resetDesktopSharingParams(liveMeeting.screenshareModel)
 
       val event = MsgBuilder.buildStopScreenshareRtmpBroadcastEvtMsg(
         liveMeeting.props.meetingProp.intId,
-        ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
-        ScreenshareModel.getScreenshareConf(liveMeeting.screenshareModel),
-        ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
-        ScreenshareModel.getScreenshareVideoWidth(liveMeeting.screenshareModel),
-        ScreenshareModel.getScreenshareVideoHeight(liveMeeting.screenshareModel),
-        ScreenshareModel.getTimestamp(liveMeeting.screenshareModel)
+        voiceConf,
+        screenShareConf,
+        ownerUserId,
+        url,
+        width,
+        height,
+        ts
       )
       outGW.send(event)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
@@ -13,7 +13,7 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
   this: ScreenshareApp2x =>
 
   def handle(msg: ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-    def broadcastEvent(voiceConf: String, screenshareConf: String, stream: String, vidWidth: Int, vidHeight: Int,
+    def broadcastEvent(voiceConf: String, screenshareConf: String, userId: String, stream: String, vidWidth: Int, vidHeight: Int,
                        timestamp: String, hasAudio: Boolean, contentType: String): BbbCommonEnvCoreMsg = {
 
       val routing = Routing.addMsgToClientRouting(
@@ -26,7 +26,7 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         liveMeeting.props.meetingProp.intId, "not-used"
       )
 
-      val body = ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf, screenshareConf,
+      val body = ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf, screenshareConf, userId,
         stream, vidWidth, vidHeight, timestamp, hasAudio, contentType)
       val event = ScreenshareRtmpBroadcastStartedEvtMsg(header, body)
       BbbCommonEnvCoreMsg(envelope, event)
@@ -59,6 +59,7 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         ScreenshareModel.setTimestamp(liveMeeting.screenshareModel, msg.body.timestamp)
         ScreenshareModel.setHasAudio(liveMeeting.screenshareModel, msg.body.hasAudio)
         ScreenshareModel.setContentType(liveMeeting.screenshareModel, msg.body.contentType)
+        ScreenshareModel.setUserId(liveMeeting.screenshareModel, msg.body.userId)
 
         log.info("START broadcast ALLOWED when isBroadcastingRTMP=false")
 
@@ -74,7 +75,7 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         }
 
         // Notify viewers in the meeting that there's an rtmp stream to view
-        val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.stream,
+        val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.userId, msg.body.stream,
           msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp, msg.body.hasAudio, msg.body.contentType)
         bus.outGW.send(msgEvent)
       } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -122,6 +122,7 @@ object MsgBuilder {
   def buildStopScreenshareRtmpBroadcastEvtMsg(
       meetingId: String,
       voiceConf: String, screenshareConf: String,
+      userId: String,
       stream: String, vidWidth: Int, vidHeight: Int,
       timestamp: String
   ): BbbCommonEnvCoreMsg = {
@@ -129,7 +130,7 @@ object MsgBuilder {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, "not-used")
     val envelope = BbbCoreEnvelope(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, meetingId, "not-used")
-    val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf, screenshareConf, stream, vidWidth, vidHeight, timestamp)
+    val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf, screenshareConf, userId, stream, vidWidth, vidHeight, timestamp)
     val event = ScreenshareRtmpBroadcastStoppedEvtMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }
@@ -559,11 +560,12 @@ object MsgBuilder {
   def buildScreenBroadcastStopSysMsg(
       meetingId: String,
       voiceConf: String,
+      userId:    String,
       streamId:  String
   ): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(ScreenBroadcastStopSysMsg.NAME, routing)
-    val body = ScreenBroadcastStopSysMsgBody(meetingId, voiceConf, streamId)
+    val body = ScreenBroadcastStopSysMsgBody(meetingId, voiceConf, userId, streamId)
     val header = BbbCoreBaseHeader(ScreenBroadcastStopSysMsg.NAME)
     val event = ScreenBroadcastStopSysMsg(header, body)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -127,6 +127,8 @@ class RedisRecorderActor(
       case m: MeetingEndingEvtMsg                   => handleMeetingEndingEvtMsg(m)
       case m: MeetingCreatedEvtMsg                  => handleStarterConfigurations(m)
       case m: SetScreenshareAsContentEvtMsg         => handleSetScreenshareAsContent(m)
+      case m: ScreenshareRtmpBroadcastStartedEvtMsg => handleScreenshareRtmpBroadcastStartedEvtMsg(m)
+      case m: ScreenshareRtmpBroadcastStoppedEvtMsg => handleScreenshareRtmpBroadcastStoppedEvtMsg(m)
 
       // Recording
       case m: RecordingChapterBreakSysMsg           => handleRecordingChapterBreakSysMsg(m)
@@ -806,4 +808,21 @@ class RedisRecorderActor(
     record(msg.header.meetingId, ev.toMap().asJava)
   }
 
+  private def handleScreenshareRtmpBroadcastStartedEvtMsg(msg: ScreenshareRtmpBroadcastStartedEvtMsg): Unit = {
+    handleUserStatusChange(
+      msg.header.meetingId,
+      msg.body.userId,
+      "hasScreenShare",
+      s"true,stream=${msg.body.stream}"
+    )
+  }
+
+  private def handleScreenshareRtmpBroadcastStoppedEvtMsg(msg: ScreenshareRtmpBroadcastStoppedEvtMsg): Unit = {
+    handleUserStatusChange(
+      msg.header.meetingId,
+      msg.body.userId,
+      "hasScreenShare",
+      s"false,stream=${msg.body.stream}"
+    )
+  }
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -15,7 +15,7 @@ case class ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg(
     body:   ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgBody
 )
   extends VoiceStandardMsg
-case class ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgBody(voiceConf: String, screenshareConf: String,
+case class ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgBody(voiceConf: String, screenshareConf: String, userId: String,
                                                               stream: String, vidWidth: Int, vidHeight: Int,
                                                               timestamp: String, hasAudio: Boolean, contentType: String)
 
@@ -28,7 +28,7 @@ case class ScreenshareRtmpBroadcastStartedEvtMsg(
     body:   ScreenshareRtmpBroadcastStartedEvtMsgBody
 )
   extends BbbCoreMsg
-case class ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf: String, screenshareConf: String,
+case class ScreenshareRtmpBroadcastStartedEvtMsgBody(voiceConf: String, screenshareConf: String, userId: String,
                                                      stream: String, vidWidth: Int, vidHeight: Int,
                                                      timestamp: String, hasAudio: Boolean, contentType: String)
 
@@ -40,7 +40,7 @@ case class ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg(
     header: BbbCoreVoiceConfHeader,
     body:   ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgBody
 ) extends VoiceStandardMsg
-case class ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgBody(voiceConf: String, screenshareConf: String,
+case class ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgBody(voiceConf: String, screenshareConf: String, userId: String,
                                                               stream: String, vidWidth: Int, vidHeight: Int,
                                                               timestamp: String)
 
@@ -53,7 +53,7 @@ case class ScreenshareRtmpBroadcastStoppedEvtMsg(
     body:   ScreenshareRtmpBroadcastStoppedEvtMsgBody
 )
   extends BbbCoreMsg
-case class ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf: String, screenshareConf: String,
+case class ScreenshareRtmpBroadcastStoppedEvtMsgBody(voiceConf: String, screenshareConf: String, userId: String,
                                                      stream: String, vidWidth: Int, vidHeight: Int,
                                                      timestamp: String)
 
@@ -129,6 +129,7 @@ case class ScreenBroadcastStopSysMsg(
 case class ScreenBroadcastStopSysMsgBody(
     meetingId: String,
     voiceConf: String,
+    userId:    String,
     streamId:  String
 )
 

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.19.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.19.0-beta.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [feat(screnshare): add ParticipantStatusChange event for screen sharing](https://github.com/bigbluebutton/bigbluebutton/commit/b24d5a85ab665e5746c84aa22e83bdfa137d2790) 
  - Screen sharing only generates RAP events during capture.
For meetings with record=false or recordFullDurationMedia=false, screen sharing
sessions are not registered in Redis/events.xml if they occur outside the
capture window.
  - It has been requested that broadcast events should be registered as well
for analytics purposes - irrespective of capture status.
  - Add ParticipantStatusChange events on screenshare broadcast start/stop.
The event payload follows the same pattern as the existing ones for
cameras:
    - status: `hasScreenShare`
    - value: `${true|false},stream=${streamId}`
- [build(bbb-webrtc-sfu): v2.19.0-beta.1](https://github.com/bigbluebutton/bigbluebutton/commit/614964031fddb0473b8552dec17933ca7ffedb89) 
  - feat(livekit): token gen for breakout audio-only transfers
  - feat(screenshare): add userId to screenshare RPCs

### Closes Issue(s)

https://github.com/bigbluebutton/bigbluebutton/issues/23325
