### PR TITLE
build: compress rotated bbb-*-akka and bbb-web log files

### DIFF
--- a/akka-bbb-apps/src/universal/conf/logback.xml
+++ b/akka-bbb-apps/src/universal/conf/logback.xml
@@ -9,7 +9,7 @@
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <File>logs/bbb-apps-akka.log</File>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <FileNamePattern>logs/bbb-apps-akka.%d{yyyy-MM-dd}.log</FileNamePattern>
+      <FileNamePattern>logs/bbb-apps-akka.%d{yyyy-MM-dd}.log.gz</FileNamePattern>
       <!-- keep 14 days worth of history -->
       <MaxHistory>14</MaxHistory>
     </rollingPolicy>

--- a/akka-bbb-fsesl/src/universal/conf/logback.xml
+++ b/akka-bbb-fsesl/src/universal/conf/logback.xml
@@ -9,7 +9,7 @@
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <File>logs/bbb-fsesl-akka.log</File>
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <FileNamePattern>logs/bbb-fsesl-akka.%d{yyyy-MM-dd}.log</FileNamePattern>
+      <FileNamePattern>logs/bbb-fsesl-akka.%d{yyyy-MM-dd}.log.gz</FileNamePattern>
       <!-- keep 14 days worth of history -->
       <MaxHistory>14</MaxHistory>
     </rollingPolicy>

--- a/bigbluebutton-web/grails-app/conf/logback.xml
+++ b/bigbluebutton-web/grails-app/conf/logback.xml
@@ -12,7 +12,7 @@
 		<File>logs/bbb-web.log</File>
 		<rollingPolicy
 			class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-			<FileNamePattern>/var/log/bigbluebutton/bbb-web.%d{yyyy-MM-dd}.log
+			<FileNamePattern>/var/log/bigbluebutton/bbb-web.%d{yyyy-MM-dd}.log.gz
 			</FileNamePattern>
 			<!-- keep 14 days worth of history -->
 			<MaxHistory>14</MaxHistory>


### PR DESCRIPTION
### What does this PR do?

- [build: compress rotated bbb-*-akka and bbb-web log files](https://github.com/bigbluebutton/bigbluebutton/commit/757d92c34bbb9704c69df68b9e775ea2e46e3089) 
  - BBB >= 3.0 seems to be slightly more on the verbose side re. logging for
bbb-*-akka and bbb-web. This makes storage handling more sensitive in
setups with large log retention windows when compared to 2.7.
  - Enable compression of rotated log files for bbb-apps-akka, bbb-fsesl-akka
and bbb-web by default. Compression is done via logback's built-in rotation
appender.

### Closes Issue(s)

None