### PR TITLE
Change publish poll button text to publish results

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -416,7 +416,7 @@
     "app.poll.activePollInstruction": "Leave this panel open to see live responses to your poll. When you are ready, select 'Publish polling results' to publish the results and end the poll.",
     "app.poll.dragDropPollInstruction": "To fill the poll values, drag a text file with the poll values onto the highlighted field",
     "app.poll.customPollTextArea": "Fill poll values",
-    "app.poll.publishLabel": "Publish poll",
+    "app.poll.publishLabel": "Publish results",
     "app.poll.cancelPollLabel": "Cancel",
     "app.poll.backLabel": "Start A Poll",
     "app.poll.closeLabel": "Close",


### PR DESCRIPTION
### What does this PR do?

Adjusts poll publish button text to be "Publish results" instead of "Publish poll"

### Closes Issue(s)
Closes #23335