### PR TITLE
chore (gql-middleware): Add more logs to clarify the reasons behind WebSocket disconnections from the browser and Hasura

### DIFF
--- a/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
@@ -32,7 +32,7 @@ func HasuraConnectionReader(hc *common.HasuraConnection, wg *sync.WaitGroup) {
 				hc.BrowserConn.Logger.Debugf("Closing Hasura ws connection as Context was cancelled!")
 			} else if errors.As(err, &closeError) {
 				hc.WebsocketCloseError = closeError
-				hc.BrowserConn.Logger.Debug("WebSocket connection closed: status = %v, reason = %s", closeError.Code, closeError.Reason)
+				hc.BrowserConn.Logger.Debug("Hasura WebSocket connection closed: status = %v, reason = %s", closeError.Code, closeError.Reason)
 				//TODO check if it should send {"type":"connection_error","payload":"Authentication hook unauthorized this request"}
 			} else {
 				if websocket.CloseStatus(err) == -1 {

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -125,10 +125,10 @@ func ConnectionHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		BrowserConnectionsMutex.Unlock()
 
-		thisConnection.Logger.Infof("connection removed")
+		thisConnection.Logger.Infof("browser connection removed")
 	}()
 
-	thisConnection.Logger.Infof("connection accepted")
+	thisConnection.Logger.Infof("browser connection accepted")
 
 	// Configure the wait group (to hold this routine execution until both are completed)
 	var wgAll sync.WaitGroup

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -35,13 +35,18 @@ func BrowserConnectionReader(
 
 	for {
 		messageType, message, err := browserConnection.Websocket.Read(browserConnection.Context)
-
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				browserConnection.Logger.Debugf("Closing Browser ws connection as Context was cancelled!")
-			} else {
-				browserConnection.Logger.Debugf("Browser is disconnected, skipping reading of ws message: %v", err)
+			} else if websocket.CloseStatus(err) != -1 {
+				if websocket.CloseStatus(err) == websocket.StatusGoingAway {
+					browserConnection.Logger.Infof("Browser disconnected voluntarily with status: %v (closed by the browser as the window was closed)", websocket.CloseStatus(err))
+				} else {
+					browserConnection.Logger.Infof("Browser disconnected voluntarily with status: %v", websocket.CloseStatus(err))
+				}
 			}
+
+			browserConnection.Logger.Debugf("Browser is disconnected, skipping reading of ws message: %v", err)
 			return
 		}
 

--- a/bbb-graphql-middleware/internal/websrv/reconnectionHandler.go
+++ b/bbb-graphql-middleware/internal/websrv/reconnectionHandler.go
@@ -19,7 +19,7 @@ func ReconnectionHandler(w http.ResponseWriter, r *http.Request) {
 
 	reason := r.URL.Query().Get("reason")
 
-	log.Debugf("Reconnection request received for sessionToken: %s, reason: %s", sessionToken, reason)
+	log.Infof("Reconnection request received for sessionToken: %s, reason: %s", sessionToken, reason)
 
 	go InvalidateSessionTokenHasuraConnections(sessionToken)
 }

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -59,7 +59,7 @@ func StartRedisListener() {
 			messageBodyAsMap := messageCoreAsMap["body"].(map[string]interface{})
 			sessionTokenToInvalidate := messageBodyAsMap["sessionToken"]
 			reason := messageBodyAsMap["reason"]
-			log.Debugf("Received reconnection request for sessionToken %v (%v)", sessionTokenToInvalidate, reason)
+			log.Infof("Received reconnection request for sessionToken %v (%v)", sessionTokenToInvalidate, reason)
 
 			go InvalidateSessionTokenHasuraConnections(sessionTokenToInvalidate.(string))
 		}
@@ -70,7 +70,7 @@ func StartRedisListener() {
 			sessionTokenToInvalidate := messageBodyAsMap["sessionToken"]
 			reason := messageBodyAsMap["reason"]
 			reasonMsgId := messageBodyAsMap["reasonMessageId"]
-			log.Debugf("Received disconnection request for sessionToken %v (%s - %s)", sessionTokenToInvalidate, reasonMsgId, reason)
+			log.Infof("Received disconnection request for sessionToken %v (%s - %s)", sessionTokenToInvalidate, reasonMsgId, reason)
 
 			//Not being used yet
 			go InvalidateSessionTokenBrowserConnections(sessionTokenToInvalidate.(string), reasonMsgId.(string), reason.(string))


### PR DESCRIPTION
Add more `INFO`-level logs to clarify the reasons behind WebSocket disconnections from the browser and Hasura reconnections.

Previously, the logs contained only vague messages such as:
```
connected with Hasura
connected with Hasura
connected with Hasura
connection removed
```

Now, more descriptive logs are added beforehand, for example:
```
Reconnection request received for sessionToken: 0uonekvpyhp7y0v4, reason: assigned_presenter
connected with Hasura

Reconnection request received for sessionToken: xzbhdr5n3zpcwc7n, reason: assigned_presenter
connected with Hasura

Reconnection request received for sessionToken: xzbhdr5n3zpcwc7n, reason: lockSettings_changed
connected with Hasura

Browser disconnected voluntarily with status: StatusGoingAway (closed by the browser as the window was closed)
browser connection removed

Browser disconnected voluntarily with status: StatusNormalClosure
browser connection removed
```

Examples:

![image](https://github.com/user-attachments/assets/086d4153-cd12-4701-8403-93d4847e35ef)