### PR TITLE
fix(audio-captions): check for Speech Recognition API support before accessing voices

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -4,6 +4,7 @@ import { useIsLiveTranscriptionEnabled } from '/imports/ui/services/features';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import { Caption } from './live/queries';
 import Session from '/imports/ui/services/storage/in-memory';
+import { hasSpeechRecognitionSupport } from './speech/service';
 
 export const splitTranscript = (obj: Caption) => {
   const CAPTIONS_CONFIG = window.meetingClientSettings.public.captions;
@@ -67,8 +68,7 @@ export const isGladia = () => getSpeechProvider() === 'gladia';
 export const getSpeechVoices = () => {
   const LANGUAGES = window.meetingClientSettings.public.app.audioCaptions.language.available;
   if (!isWebSpeechApi()) return LANGUAGES;
-
-  if (!window.speechSynthesis) return null;
+  if (!hasSpeechRecognitionSupport()) return null;
 
   return unique(
     window


### PR DESCRIPTION
### What does this PR do?
Add a missing check to ensure the browser supports the Speech Recognition API before attempting to access supported speech voices.


### Closes Issue(s)
Closes #23316
