### PR TITLE
build(livekit): livekit-server@v1.9.0 and build it from source, +

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -70,6 +70,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.handleTrackSubscribed = this.handleTrackSubscribed.bind(this);
     this.handleTrackUnsubscribed = this.handleTrackUnsubscribed.bind(this);
     this.handleTrackSubscriptionFailed = this.handleTrackSubscriptionFailed.bind(this);
+    this.handleTrackSubscriptionStatusChanged = this.handleTrackSubscriptionStatusChanged.bind(this);
     this.handleLocalTrackMuted = this.handleLocalTrackMuted.bind(this);
     this.handleLocalTrackUnmuted = this.handleLocalTrackUnmuted.bind(this);
     this.handleLocalTrackPublished = this.handleLocalTrackPublished.bind(this);
@@ -206,6 +207,26 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     }, `LiveKit: failed to subscribe to microphone - ${trackSid}`);
   }
 
+  private handleTrackSubscriptionStatusChanged(
+    publication: RemoteTrackPublication,
+    status: TrackPublication.SubscriptionStatus,
+  ): void {
+    if (!LiveKitAudioBridge.isMicrophonePublication(publication)) return;
+
+    const { trackSid, trackName } = publication;
+
+    logger.debug({
+      logCode: 'livekit_audio_subscription_status_changed',
+      extraInfo: {
+        bridgeName: this.bridgeName,
+        trackSid,
+        trackName,
+        role: this.role,
+        status,
+      },
+    }, `LiveKit: microphone subscription status changed - ${trackSid} to ${status}`);
+  }
+
   private handleLocalTrackMuted(publication: TrackPublication): void {
     if (!LiveKitAudioBridge.isMicrophonePublication(publication)) return;
 
@@ -283,6 +304,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.liveKitRoom.on(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
     this.liveKitRoom.on(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     this.liveKitRoom.on(RoomEvent.TrackSubscriptionFailed, this.handleTrackSubscriptionFailed);
+    this.liveKitRoom.on(RoomEvent.TrackSubscriptionStatusChanged, this.handleTrackSubscriptionStatusChanged);
     this.liveKitRoom.localParticipant.on(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
     this.liveKitRoom.localParticipant.on(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
     this.liveKitRoom.localParticipant.on(ParticipantEvent.LocalTrackPublished, this.handleLocalTrackPublished);
@@ -295,6 +317,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.liveKitRoom.off(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
     this.liveKitRoom.off(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     this.liveKitRoom.off(RoomEvent.TrackSubscriptionFailed, this.handleTrackSubscriptionFailed);
+    this.liveKitRoom.off(RoomEvent.TrackSubscriptionStatusChanged, this.handleTrackSubscriptionStatusChanged);
     this.liveKitRoom.localParticipant.off(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
     this.liveKitRoom.localParticipant.off(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
     this.liveKitRoom.localParticipant.off(ParticipantEvent.LocalTrackPublished, this.handleLocalTrackPublished);

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -33,8 +33,16 @@ const useAudioGroupStreamsSubscription = createUseSubscription(
 );
 
 const PARTICIPANTS_UPDATE_FILTER = [
+  RoomEvent.ParticipantConnected,
+  RoomEvent.ParticipantDisconnected,
+  RoomEvent.ConnectionStateChanged,
   RoomEvent.TrackPublished,
   RoomEvent.TrackUnpublished,
+  RoomEvent.TrackSubscriptionPermissionChanged,
+  RoomEvent.TrackSubscriptionStatusChanged,
+  RoomEvent.TrackSubscribed,
+  RoomEvent.TrackUnsubscribed,
+  RoomEvent.TrackSubscriptionFailed,
 ];
 
 const isValidSource = (source: Track.Source) => (

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -103,6 +103,8 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     updateOnlyOn: [
       RoomEvent.TrackPublished, RoomEvent.TrackUnpublished,
       RoomEvent.TrackSubscribed, RoomEvent.TrackUnsubscribed,
+      RoomEvent.TrackSubscriptionStatusChanged, RoomEvent.TrackSubscriptionPermissionChanged,
+      RoomEvent.TrackSubscriptionFailed,
     ],
   });
   const [meetingSettings] = useMeetingSettings();

--- a/bigbluebutton-html5/imports/utils/media-stream-utils.js
+++ b/bigbluebutton-html5/imports/utils/media-stream-utils.js
@@ -74,6 +74,7 @@ const getMediaStreamLogData = (stream) => {
     const videoTracks = getVideoTracks(stream);
 
     return {
+      valid: true,
       active: stream.active,
       id: stream.id,
       audio: audioTracks.map((track) => ({
@@ -90,7 +91,7 @@ const getMediaStreamLogData = (stream) => {
       })),
     };
   } catch (error) {
-    return { audio: [], video: [] };
+    return { audio: [], video: [], valid: false };
   }
 };
 

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -2,7 +2,7 @@
 
 TARGET=$(basename "$(pwd)")
 
-SERVER_VERSION=v1.8.4
+SERVER_VERSION=v1.9.0
 CLI_VERSION=2.3.1
 SIP_VERSION=v0.9.0
 

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -1,61 +1,68 @@
 #!/bin/bash -ex
 
-TARGET=`basename $(pwd)`
+TARGET=$(basename "$(pwd)")
 
 SERVER_VERSION=1.8.4
 CLI_VERSION=2.3.1
 SIP_VERSION=0.9.0
 
-PACKAGE=$(echo $TARGET | cut -d'_' -f1)
-VERSION=$(echo $TARGET | cut -d'_' -f2)
-DISTRO=$(echo $TARGET | cut -d'_' -f3)
+PACKAGE=$(echo "$TARGET" | cut -d'_' -f1)
+VERSION=$(echo "$TARGET" | cut -d'_' -f2)
+DISTRO=$(echo "$TARGET" | cut -d'_' -f3)
 
-BUILDDIR=$PWD
-DESTDIR=$BUILDDIR/staging
+BUILDDIR="$PWD"
+DESTDIR="$BUILDDIR/staging"
 
 #
 # Clear staging directory for build
 
-rm -rf $DESTDIR
-mkdir -p $DESTDIR
+rm -rf "$DESTDIR"
+mkdir -p "$DESTDIR"
 
-. ./opts-$DISTRO.sh
+# shellcheck disable=SC1090
+. "./opts-$DISTRO.sh"
 
-mkdir -p $DESTDIR/usr/share/bigbluebutton/nginx
-cp livekit.nginx $DESTDIR/usr/share/bigbluebutton/nginx
+mkdir -p "$DESTDIR/usr/share/bigbluebutton/nginx"
+cp livekit.nginx "$DESTDIR/usr/share/bigbluebutton/nginx"
 
-mkdir -p $DESTDIR/lib/systemd/system/
-cp livekit-server.service livekit-sip.service $DESTDIR/lib/systemd/system
+mkdir -p "$DESTDIR/lib/systemd/system/"
+cp livekit-server.service livekit-sip.service "$DESTDIR/lib/systemd/system"
 
-mkdir -p $DESTDIR/usr/share/livekit-server
-cp livekit.yaml livekit-sip.yaml $DESTDIR/usr/share/livekit-server
-chmod 644 $DESTDIR/usr/share/livekit-server/livekit*.yaml
+mkdir -p "$DESTDIR/usr/share/livekit-server"
+cp livekit.yaml livekit-sip.yaml "$DESTDIR/usr/share/livekit-server"
+chmod 644 "$DESTDIR/usr/share/livekit-server/livekit"*.yaml
 
-mkdir -p $DESTDIR/usr/bin
+mkdir -p "$DESTDIR/usr/bin"
 
-curl https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz  -Lo - | tar -C $DESTDIR/usr/bin -xzf - livekit-server
-curl https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz -Lo - | tar -C $DESTDIR/usr/bin -xzf - lk
+curl "https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - livekit-server
+curl "https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - lk
 
 apt update && apt install -y pkg-config libopus-dev libopusfile-dev libsoxr-dev
 
 buildbase=$(mktemp -d)
-curl https://github.com/livekit/sip/archive/refs/tags/v${SIP_VERSION}.tar.gz -Lo - | tar -xzf - -C $buildbase
-pushd $buildbase/sip-${SIP_VERSION}
+curl "https://github.com/livekit/sip/archive/refs/tags/v${SIP_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
+pushd "$buildbase/sip-${SIP_VERSION}" > /dev/null
 
-if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
+if [ "$TARGETPLATFORM" = "linux/arm64" ]; then
+    GOARCH=arm64
+else
+    GOARCH=amd64
+fi
 
-cp livekit-sip $DESTDIR/usr/bin
+CGO_ENABLED=1 GOOS=linux GOARCH="${GOARCH}" GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
 
-popd
-rm -rf $buildbase
+cp livekit-sip "$DESTDIR/usr/bin"
 
-fpm -s dir -C $DESTDIR -n $PACKAGE \
-    --version $VERSION --epoch 2 \
-    --before-install before-install.sh      \
-    --after-install after-install.sh        \
-    --before-remove before-remove.sh        \
-    --after-remove after-remove.sh         \
+popd > /dev/null
+rm -rf "$buildbase"
+
+# shellcheck disable=SC2086
+fpm -s dir -C "$DESTDIR" -n "$PACKAGE" \
+    --version "$VERSION" --epoch 2 \
+    --before-install before-install.sh \
+    --after-install after-install.sh \
+    --before-remove before-remove.sh \
+    --after-remove after-remove.sh \
     --description "BigBlueButton build of LiveKit Server" \
-    $DIRECTORIES                            \
+    $DIRECTORIES \
     $OPTS

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -2,9 +2,9 @@
 
 TARGET=$(basename "$(pwd)")
 
-SERVER_VERSION=1.8.4
+SERVER_VERSION=v1.8.4
 CLI_VERSION=2.3.1
-SIP_VERSION=0.9.0
+SIP_VERSION=v0.9.0
 
 PACKAGE=$(echo "$TARGET" | cut -d'_' -f1)
 VERSION=$(echo "$TARGET" | cut -d'_' -f2)
@@ -34,14 +34,54 @@ chmod 644 "$DESTDIR/usr/share/livekit-server/livekit"*.yaml
 
 mkdir -p "$DESTDIR/usr/bin"
 
-curl "https://github.com/livekit/livekit/releases/download/v${SERVER_VERSION}/livekit_${SERVER_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - livekit-server
+# Pull built lk cli from github
 curl "https://github.com/livekit/livekit-cli/releases/download/v${CLI_VERSION}/lk_${CLI_VERSION}_linux_amd64.tar.gz" -Lo - | tar -C "$DESTDIR/usr/bin" -xzf - lk
 
+# Build livekit-server
+buildbase=$(mktemp -d)
+curl "https://github.com/livekit/livekit/archive/${SERVER_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
+# Get livekit-server's directory name from the extracted archive
+LIVEKIT_DIR=$(find "$buildbase" -maxdepth 1 -type d -name "livekit-*" | head -n 1)
+
+if [ -z "$LIVEKIT_DIR" ]; then
+    echo "Error: Could not find livekit-server directory in extracted archive"
+    exit 1
+fi
+
+# Build in an isolated shell as the GO* envs need to be overridden and I'd
+# prefer not to leak them to the main shell.- prlanzarin
+(
+    # These are needed by the mage build
+    export GOPATH="/tmp/go-${TARGET}"
+    export GOBIN="$GOPATH/bin"
+    mkdir -p "$GOBIN"
+    export PATH="$GOBIN:$PATH"
+
+    pushd "$LIVEKIT_DIR" > /dev/null
+    ./bootstrap.sh
+    mage
+    popd > /dev/null
+)
+
+cp "$LIVEKIT_DIR/bin/livekit-server" "$DESTDIR/usr/bin"
+rm -rf "$buildbase"
+
+# End of livekit-server build
+
+# Build livekit-sip
 apt update && apt install -y pkg-config libopus-dev libopusfile-dev libsoxr-dev
 
 buildbase=$(mktemp -d)
-curl "https://github.com/livekit/sip/archive/refs/tags/v${SIP_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
-pushd "$buildbase/sip-${SIP_VERSION}" > /dev/null
+curl "https://github.com/livekit/sip/archive/${SIP_VERSION}.tar.gz" -Lo - | tar -xzf - -C "$buildbase"
+# Get livekit-sip's directory name from the extracted archive
+SIP_DIR=$(find "$buildbase" -maxdepth 1 -type d -name "sip-*" | head -n 1)
+
+if [ -z "$SIP_DIR" ]; then
+    echo "Error: Could not find livekit-sip directory in extracted archive"
+    exit 1
+fi
+
+pushd "$SIP_DIR" > /dev/null
 
 if [ "$TARGETPLATFORM" = "linux/arm64" ]; then
     GOARCH=arm64
@@ -52,9 +92,9 @@ fi
 CGO_ENABLED=1 GOOS=linux GOARCH="${GOARCH}" GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
 
 cp livekit-sip "$DESTDIR/usr/bin"
-
 popd > /dev/null
 rm -rf "$buildbase"
+# End of livekit-sip build
 
 # shellcheck disable=SC2086
 fpm -s dir -C "$DESTDIR" -n "$PACKAGE" \

--- a/build/packages-template/bbb-livekit/livekit.yaml
+++ b/build/packages-template/bbb-livekit/livekit.yaml
@@ -5,6 +5,7 @@ rtc:
   port_range_end: 32768
   use_external_ip: false
   tcp_port: 0
+  allow_tcp_fallback: false
   interfaces:
     excludes:
       - docker0
@@ -14,12 +15,14 @@ webhook:
   urls:
     - http://127.0.0.1:3040/livekit-webhook
 audio:
-  active_level: 55
+  active_level: 50
   min_percentile: 10
   update_interval: 500
   smooth_intervals: 0
 room:
   enabled_codecs:
     - mime: audio/opus
+    - mime: audio/red
     - mime: video/vp8
+    - mime: video/rtx
   enable_remote_unmute: true


### PR DESCRIPTION
### What does this PR do?

- [build(livekit): livekit-server@v1.9.0](https://github.com/bigbluebutton/bigbluebutton/commit/877555a3c9d90365c22ce2c3b50832332b259c94)
- [refactor: shellcheck over bbb-livekit`s build script](https://github.com/bigbluebutton/bigbluebutton/commit/989ae3c43ff191997bfe6ed70a8bed9fe2d8863b)
- [build(livekit): build livekit-server from source instead of pulling bin](https://github.com/bigbluebutton/bigbluebutton/commit/c0786a57c129686ea0234a484b0535ba5fe854fb) 
  - livekit-server's binary is currently pulled directly from GitHub. This
works, but we'd like to have the ability to test LiveKit builds that are
not necessarily tied to tags (e.g.: commits).
  - Adjust bbb-livekit's build script so that livekit-server is built from
source. Upstream's build instructions (via mage) were followed
- [fix(livekit): outdated participants in selective audio subscription](https://github.com/bigbluebutton/bigbluebutton/commit/a881bd9d7d324effec80a7aa8bf2c5a3cf51a102) 
  - The selective subscription hooks currently rely on remote participants
only for defining the desired vs current subscription maps.
  - Those remote participants are filtered to avoid spurious updates, but
the filter is too restrictive and may be impacting our ability to react
to subscription failures, upstream publication state changes et al.
  - Extend the participant filters with additional events so that the local
refs are more frequently updated. We'll track metrics and log data to see
if this improves the subscription situation.
- [chore(livekit): add more information to screen share logs](https://github.com/bigbluebutton/bigbluebutton/commit/08daafd494849e857b24f855b69c6a9166e1380b)
- [build(livekit): enable RED/RTX by default, disable TCP fallback](https://github.com/bigbluebutton/bigbluebutton/pull/23351/commits/0a73d386c35ba5a0bebc87c277f15b3016d3534d)

### Closes Issue(s)

None

### Motivation

#21059 


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->


### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
