### PR TITLE
fix(audio-captions): check for Speech Recognition API support before accessing voices + empty list of available captions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/component.tsx
@@ -7,6 +7,7 @@ import {
   setUserLocaleProperty,
 } from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
 import { AudioCaptionsTextControlsProps } from './types';
+import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import Styled from './styles';
 import AudioCaptionsTextSelector from './selector/component';
 
@@ -15,15 +16,25 @@ const intlMessages = defineMessages({
     id: 'app.audio.captions.speech.captions',
     description: 'Audio captions title',
   },
+  availableCaptionsTooltip: {
+    id: 'app.audio.captions.speech.captionsToggleTooltip',
+    description: 'Audio captions text track selector tooltip',
+  },
+  noAvailableCaptions: {
+    id: 'app.audio.captions.speech.noAvailableCaptions',
+    description: 'Warning about no available captions at the moment',
+  },
 });
 
 const AudioCaptionsTextControls = ({
   intl,
   textActive,
   captionLocale,
-  speechVoices,
+  availableCaptions,
 }: AudioCaptionsTextControlsProps) => {
   const [setCaptionLocaleMutation] = useMutation(SET_CAPTION_LOCALE);
+  const noAvailableCaption = availableCaptions.length === 0;
+  const hasAvailableCaptions = availableCaptions.length > 0;
 
   const setUserCaptionLocale = (captionLocale: string, provider: string) => {
     setCaptionLocaleMutation({
@@ -42,27 +53,54 @@ const AudioCaptionsTextControls = ({
     }
     setAudioCaptions(value);
   };
+  const renderSubCaptionInfo = () => {
+    if (noAvailableCaption) {
+      return (
+        <div
+          data-test="noAvailableCaptions"
+          style={{
+            padding: '1rem 0',
+          }}
+        >
+          {`*${intl.formatMessage(intlMessages.noAvailableCaptions)}`}
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <Styled.CaptionsToggleContainer>
-      <Styled.SwitchTitle
-        sx={{ margin: 0 }}
-        control={(
-          <Styled.MaterialSwitch
-            sx={{ marginRight: '1rem' }}
-            checked={textActive}
-            onChange={(_: unknown, checked: boolean) => {
-              onCaptionsToggleClick(checked);
-            }}
-          />
-        )}
-        label={intl.formatMessage(intlMessages.captions)}
-      />
-      <AudioCaptionsTextSelector
-        speechVoices={speechVoices}
-        captionLocale={currentCaptionLocale}
-        captionActive={textActive}
-      />
+      <TooltipContainer
+        title={intl.formatMessage(intlMessages.availableCaptionsTooltip)}
+      >
+        <Styled.SwitchTitle
+          sx={{ margin: 0 }}
+          control={(
+            <Styled.MaterialSwitch
+              sx={{ marginRight: '1rem' }}
+              // Can't select a transcription text track while there is no user
+              // with transcription enabled.
+              // Transcription text tracks become available as there are users
+              // transcribing on that language
+              disabled={noAvailableCaption}
+              checked={textActive}
+              onChange={(_: unknown, checked: boolean) => {
+                onCaptionsToggleClick(checked);
+              }}
+            />
+          )}
+          label={intl.formatMessage(intlMessages.captions)}
+        />
+      </TooltipContainer>
+      {renderSubCaptionInfo()}
+      {hasAvailableCaptions && (
+        <AudioCaptionsTextSelector
+          availableCaptions={availableCaptions}
+          captionLocale={currentCaptionLocale}
+          captionActive={textActive}
+        />
+      )}
     </Styled.CaptionsToggleContainer>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/selector/component.tsx
@@ -38,7 +38,7 @@ Object.keys(TRANSCRIPTION_LOCALE).forEach((key: string) => {
 
 const AudioCaptionsTextSelector: React.FC<AudioCaptionsTextSelectorProps> = ({
   captionLocale,
-  speechVoices,
+  availableCaptions,
   captionActive,
 }) => {
   const useLocaleHook = useFixedLocale();
@@ -91,14 +91,14 @@ const AudioCaptionsTextSelector: React.FC<AudioCaptionsTextSelectorProps> = ({
         }}
         value={captionLocale || ''}
       >
-        {speechVoices.map((voice) => (
+        {availableCaptions.map((caption) => (
           <MenuItem
-            key={voice}
-            value={voice}
+            key={caption}
+            value={caption}
           >
-            {intlMessages[voice as keyof typeof intlMessages]
-              ? intl.formatMessage(intlMessages[voice as keyof typeof intlMessages])
-              : getLocaleName(voice)}
+            {intlMessages[caption as keyof typeof intlMessages]
+              ? intl.formatMessage(intlMessages[caption as keyof typeof intlMessages])
+              : getLocaleName(caption)}
           </MenuItem>
         ))}
       </Styled.CaptionsSelector>

--- a/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/selector/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/selector/types.ts
@@ -1,5 +1,5 @@
 export interface AudioCaptionsTextSelectorProps {
   captionLocale: string;
-  speechVoices: string[];
+  availableCaptions: string[];
   captionActive: boolean;
 }

--- a/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio-captions/panel/text/types.ts
@@ -4,5 +4,5 @@ export interface AudioCaptionsTextControlsProps {
   intl: IntlShape;
   textActive: boolean;
   captionLocale: string;
-  speechVoices: string[];
+  availableCaptions: string[];
 }

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/component.tsx
@@ -15,7 +15,7 @@ import useAudioCaptionEnable from '/imports/ui/core/local-states/useAudioCaption
 import { User } from '/imports/ui/Types/user';
 import { SET_CAPTION_LOCALE } from '/imports/ui/core/graphql/mutations/userMutations';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
-import { ActiveCaptionsResponse, getactiveCaptions } from './queries';
+import { ActiveCaptionsResponse, GET_ACTIVE_CAPTIONS } from './queries';
 import AudioCaptionsService from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { TRANSCRIPTION_LOCALE } from '/imports/ui/components/audio/audio-graphql/audio-captions/transcriptionLocale';
@@ -293,7 +293,7 @@ const AudioCaptionsButtonContainer: React.FC = () => {
   const {
     data: activeCaptionsData,
     loading: activeCaptionsLoading,
-  } = useDeduplicatedSubscription<ActiveCaptionsResponse>(getactiveCaptions);
+  } = useDeduplicatedSubscription<ActiveCaptionsResponse>(GET_ACTIVE_CAPTIONS);
 
   if (currentUserLoading) return null;
   if (currentMeetingLoading) return null;

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/queries.ts
@@ -14,7 +14,7 @@ export interface ActiveCaptionsResponse {
   }>;
 }
 
-export const getactiveCaptions = gql`
+export const GET_ACTIVE_CAPTIONS = gql`
   subscription activeCaptions {
     caption_activeLocales {
       locale
@@ -34,5 +34,5 @@ export const GET_AUDIO_CAPTIONS_COUNT = gql`
 
 export default {
   GET_AUDIO_CAPTIONS_COUNT,
-  getactiveCaptions,
+  GET_ACTIVE_CAPTIONS,
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -4,6 +4,7 @@ import { useIsLiveTranscriptionEnabled } from '/imports/ui/services/features';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import { Caption } from './live/queries';
 import Session from '/imports/ui/services/storage/in-memory';
+import { hasSpeechRecognitionSupport } from './speech/service';
 
 export const splitTranscript = (obj: Caption) => {
   const CAPTIONS_CONFIG = window.meetingClientSettings.public.captions;
@@ -67,8 +68,7 @@ export const isGladia = () => getSpeechProvider() === 'gladia';
 export const getSpeechVoices = () => {
   const LANGUAGES = window.meetingClientSettings.public.app.audioCaptions.language.available;
   if (!isWebSpeechApi()) return LANGUAGES;
-
-  if (!window.speechSynthesis) return null;
+  if (!hasSpeechRecognitionSupport()) return null;
 
   return unique(
     window

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/service.ts
@@ -17,6 +17,7 @@ export const hasSpeechRecognitionSupport = () => {
   const VALID_ENVIRONMENT = !deviceInfo.isMobile || CONFIG.mobile;
 
   return typeof SpeechRecognitionAPI !== 'undefined'
+  && typeof window.speechSynthesis !== 'undefined'
   && VALID_ENVIRONMENT;
 };
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -879,6 +879,8 @@
     "app.audio.captions.speech.title": "Automatic transcription",
     "app.audio.captions.speech.tip": "For other users to see your captions, you need to enable transcription.",
     "app.audio.captions.speech.captions": "Captions",
+    "app.audio.captions.speech.captionsToggleTooltip": "Caption language tracks become available as users enable their transcription.",
+    "app.audio.captions.speech.noAvailableCaptions": "No captions available. Language tracks become available as users enable transcription.",
     "app.audio.captions.speech.transcriptionDescription": "For other users to see your captions, you need to enable transcription.",
     "app.audio.captions.speech.disabled": "Disabled",
     "app.audio.captions.speech.unsupported": "Your browser doesn't support speech recognition. Your audio won't be transcribed",


### PR DESCRIPTION
### What does this PR do?
- Ports the [fix](https://github.com/bigbluebutton/bigbluebutton/pull/23348) for 3.1;
- Fixes a bug where the list of available captions stayed empty for users on browsers without this API support, leaving them unable to select any captions to be displayed.

### Closes Issue(s)

Closes #23316

### How to test
1. Enable audio captions and create meeting;
2. Join with two users: one in Chrome and other in Firefox;
3. On Firefox user: check the transcriptions panel;
    3.1. It should display a tooltip over the captions toggle and a warning message below it saying that no captions are currently available;
5. On Chrome user: enable the transcription in the panel;
6. Go back to Firefox user and check that the warning message on the captions toggle has vanished and that the user can select a caption language track to be displayed;
