### PR TITLE
Fix(html5): Add support to numeric TLD

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -204,8 +204,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
 
   const logoutButton = useMemo(() => {
     const { locale } = intl;
-    
-    console.log("🚀 -> logoutButton -> learningDashboardAccessToken:", isURL(logoutUrl, { allow_numeric_tld: true }))
+
     return (
       (
         <Styled.Wrapper>
@@ -380,8 +379,6 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
   } = clientSettings;
 
   const allowRedirect = allowRedirectToLogoutURL(logoutUrl);
-  console.log("🚀 -> allowRedirect:", allowRedirect)
-  console.log("🚀 -> logoutUrl:", logoutUrl)
 
   return (
     <MeetingEnded

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -193,24 +193,19 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
 
   const confirmRedirect = (isBreakout: boolean, allowRedirect: boolean) => {
     if (isBreakout) window.close();
-
     if (allowRedirect) {
-      if (isURL(logoutUrl)) {
-        const reason = generateEndMessage(joinErrorCode, meetingEndedCode, endedBy);
-        const finalUrl = reason
-          ? `${logoutUrl}${logoutUrl.includes('?') ? '&' : '?'}reason=${encodeURIComponent(reason)}`
-          : logoutUrl;
-        window.location.href = finalUrl;
-      } else {
-        logger.warn(`logout URL "${logoutUrl}" is not a valid URL: `);
-      }
-    } else {
-      logger.warn('Redirect to logout URL is not allowed');
+      const reason = generateEndMessage(joinErrorCode, meetingEndedCode, endedBy);
+      const finalUrl = reason
+        ? `${logoutUrl}${logoutUrl.includes('?') ? '&' : '?'}reason=${encodeURIComponent(reason)}`
+        : logoutUrl;
+      window.location.href = finalUrl;
     }
   };
 
   const logoutButton = useMemo(() => {
     const { locale } = intl;
+    
+    console.log("🚀 -> logoutButton -> learningDashboardAccessToken:", isURL(logoutUrl, { allow_numeric_tld: true }))
     return (
       (
         <Styled.Wrapper>
@@ -243,20 +238,29 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
           <Styled.Text>
             {intl.formatMessage(intlMessage.messageEnded)}
           </Styled.Text>
+          {
+            isURL(logoutUrl, {
+              // This option is merged with isFQDN
+              // so it's not a valid ts error /validator/lib/isURL.js line 153
+              // @ts-ignore
+              allow_numeric_tld: true,
+            }) ? (
+              <Styled.MeetingEndedButton
+                color="primary"
+                onClick={() => confirmRedirect(isBreakout, allowRedirect)}
+                /* @eslint-disable-next-line */
+                aria-details={intl.formatMessage(intlMessage.confirmDesc)}
+                data-test="redirectButton"
+              >
+                {intl.formatMessage(intlMessage.buttonOkay)}
+              </Styled.MeetingEndedButton>
+              ) : null
+          }
 
-          <Styled.MeetingEndedButton
-            color="primary"
-            onClick={() => confirmRedirect(isBreakout, allowRedirect)}
-            /* @eslint-disable-next-line */
-            aria-details={intl.formatMessage(intlMessage.confirmDesc)}
-            data-test="redirectButton"
-          >
-            {intl.formatMessage(intlMessage.buttonOkay)}
-          </Styled.MeetingEndedButton>
         </Styled.Wrapper>
       )
     );
-  }, [learningDashboardAccessToken, isModerator, meetingId, authToken, learningDashboardBase]);
+  }, [learningDashboardAccessToken, isModerator, meetingId, authToken, learningDashboardBase, logoutUrl]);
 
   useEffect(() => {
     // Sets Loading to falsed and removes loading splash screen
@@ -376,6 +380,8 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
   } = clientSettings;
 
   const allowRedirect = allowRedirectToLogoutURL(logoutUrl);
+  console.log("🚀 -> allowRedirect:", allowRedirect)
+  console.log("🚀 -> logoutUrl:", logoutUrl)
 
   return (
     <MeetingEnded

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
@@ -1,5 +1,3 @@
-import logger from '/imports/startup/client/logger';
-
 export const JoinErrorCodeTable = {
   NOT_EJECT: 'not_eject_reason',
   DUPLICATE_USER: 'duplicate_user_in_meeting_eject_reason',
@@ -107,16 +105,12 @@ export const allowRedirectToLogoutURL = (logoutURL: string) => {
     const urlWithoutProtocolForAuthLogout = logoutURL.replace(protocolPattern, '');
     const urlWithoutProtocolForLocationOrigin = window.location.origin.replace(protocolPattern, '');
     if (urlWithoutProtocolForAuthLogout === urlWithoutProtocolForLocationOrigin) {
-      if (!ALLOW_DEFAULT_LOGOUT_URL) {
-        logger.warn('Default logout url is not allowed for this session.');
-      }
       return ALLOW_DEFAULT_LOGOUT_URL;
     }
     // custom logoutURL
     return true;
   }
 
-  logger.warn('logoutURL is not defined.', logoutURL);
   // no logout url
   return false;
 };


### PR DESCRIPTION
### What does this PR do?
This PR adds an optional parameter to the `isURL` function to allow domains with numeric TLDs.  
Previously, this caused an issue where users were unable to redirect to the logout URL.

Additionally, I updated the logic to prevent rendering the logout button if the URL is not valid.


### Closes Issue(s)
Closes #22982

### How to test
- Set a logout url with numeric TLD on meeting creation
- Join a user
- Leave the meeting 
- Click to redirect


### More
[Screencast from 10-06-2025 15:46:22.webm](https://github.com/user-attachments/assets/6abb051a-97a7-4c79-a54c-e05ca2b5b3f3)

