### PR TITLE
chore: bump record-and-playback version to 3.0.9

### DIFF
--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '3.0.0'
+bbb_version: '3.0.9'
 raw_audio_src: /var/freeswitch/meetings
 mediasoup_video_src: /var/mediasoup/recordings
 mediasoup_screenshare_src: /var/mediasoup/screenshare


### PR DESCRIPTION
### What does this PR do?

- [chore: bump record-and-playback version to 3.0.9](https://github.com/bigbluebutton/bigbluebutton/commit/67d75725774a0800164670e474b236606c326150) 
  - The ParticipantStatusChange event was recently extended
to support screen sharing - see https://github.com/bigbluebutton/bigbluebutton/commit/b24d5a85ab665e5746c84aa22e83bdfa137d2790, https://github.com/bigbluebutton/bigbluebutton/pull/23326 for rationale
and implementation details.
  - Bump record-and-playback's version to `3.0.9` so we can identify
in which recordings those new events are present.

### Closes Issue(s)

None

### Motivation

#23326