### PR TITLE
Fix(bbb-common-web): Change flag to priotize the text order on pdf to text conversion

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -99,7 +99,7 @@ public class TextFileCreatorImp implements TextFileCreator {
 
     } else {
       // sudo apt-get install xpdf-utils
-        COMMAND = "pdftotext -raw -nopgbrk -enc UTF-8 -f " + page + " -l " + page
+        COMMAND = "pdftotext -layout -nopgbrk -enc UTF-8 -f " + page + " -l " + page
             + " " + source + " " + dest;
 
         //System.out.println(COMMAND);


### PR DESCRIPTION


### What does this PR do?
Changes the parameter from `-raw` to `-layout` on pto favor the reading order of the physical layout of the file, it makes the slide content comes in the same order of slide exibition.

example:
Slide:
![image](https://github.com/user-attachments/assets/ffdd4f50-ec4f-4b5c-8d71-0781d6319104)


Using `-raw`

```
In 3.0.8 the slide is detected as a typed response,
but the question title contains all the text on the
slide.
What is your favourite food?
```
Using `-layout`

```
What is your favourite food?
The title is layered in front of the text.
In 3.0.8 the slide is dected as a typed response
but the question title contains all the text on the
slide.
```
Man descriptions of the parameters:
`-layout:  Maintain (as best as possible) the original physical layout of the text.  The default is to ´undo' physical layout (columns, hyphenation, etc.) and output the text in reading order.`

`-raw:  Keep the text in content stream order.  This is a hack which often "undoes" column formatting, etc.  Use of raw mode is no longer recommended.`
              

### Closes Issue(s)
Closes #23304

### How to test
I used these two files to test it
[smart slides test.pdf](https://github.com/user-attachments/files/20675272/smart.slides.test.pdf)
[test.presentation.pdf](https://github.com/user-attachments/files/20675274/test.presentation.pdf)

- Join as Presenter 
- Upload the slides 
- navigate through slides and test the quick polls
- That's it


