### PR TITLE
fix: reintroduce meta_hack-record-viewer-video

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetRecordingStatusReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetRecordingStatusReqMsgHdlr.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.core.apps.users
 
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.models.{ Users2x, Roles }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
 
@@ -17,23 +18,62 @@ trait GetRecordingStatusReqMsgHdlr {
         userId:                  String,
         recorded:                Boolean,
         recording:               Boolean,
-        recordFullDurationMedia: Boolean
+        recordFullDurationMedia: Boolean,
+        recordUserAudio:         Boolean,
+        recordUserCameras:       Boolean,
+        recordUserScreenShare:   Boolean
     ): BbbCommonEnvCoreMsg = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.DIRECT, meetingId, userId)
       val envelope = BbbCoreEnvelope(GetRecordingStatusRespMsg.NAME, routing)
-      val body = GetRecordingStatusRespMsgBody(recorded, recording, recordFullDurationMedia, userId)
+      val body = GetRecordingStatusRespMsgBody(recorded, recording, recordFullDurationMedia, userId,
+        recordUserAudio,
+        recordUserCameras,
+        recordUserScreenShare)
       val header = BbbClientMsgHeader(GetRecordingStatusRespMsg.NAME, meetingId, userId)
       val event = GetRecordingStatusRespMsg(header, body)
 
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
+    // `recordUserAudio`, `recordUserScreenShare`, and `recordUserCameras`
+    // relate to media-specific recording consents for the user requesting the
+    // recording status. If meeting recording is disabled by a combination of
+    // any of `recorded`, `recording`, or `recordFullDurationMedia` flags, then
+    // these user-specific flags will not be used.
+    // Audio and screenshare variants are not fully implemented yet.
+    val recordUserAudio = true
+    val recordUserScreenShare = true
+
+    val userOption = Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
+    val recordVideoFromUserMetadata: Boolean = userOption
+      .flatMap(_.userMetadata.get("bbb_record_video"))
+      .map(_.toBoolean)
+      .getOrElse(true)
+
+    val globalRecordViewerVideoSetting: Boolean = liveMeeting.props.metadataProp.metadata
+      .get("hack-record-viewer-video")
+      .map(_.toBoolean)
+      .getOrElse(true)
+    val recordViewerVideoFromUserMetadata: Boolean = userOption.map { user =>
+      // Moderators always have recording permission unless explicitly disabled via userdata
+      if (user.role == Roles.MODERATOR_ROLE) {
+        true
+      } else {
+        // For non-moderators, use globalRecordViewerVideoSetting
+        globalRecordViewerVideoSetting
+      }
+    }.getOrElse(true)
+
+    val recordUserCameras = recordVideoFromUserMetadata && recordViewerVideoFromUserMetadata
     val event = buildGetRecordingStatusRespMsg(
       liveMeeting.props.meetingProp.intId,
       msg.body.requestedBy,
       liveMeeting.props.recordProp.record,
       MeetingStatus2x.isRecording(liveMeeting.status),
-      liveMeeting.props.recordProp.recordFullDurationMedia
+      liveMeeting.props.recordProp.recordFullDurationMedia,
+      recordUserAudio,
+      recordUserCameras,
+      recordUserScreenShare
     )
 
     outGW.send(event)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -130,7 +130,10 @@ case class GetRecordingStatusRespMsgBody(
     recorded:                Boolean,
     recording:               Boolean,
     recordFullDurationMedia: Boolean,
-    requestedBy:             String
+    requestedBy:             String,
+    recordUserAudio:         Boolean,
+    recordUserCameras:       Boolean,
+    recordUserScreenShare:   Boolean
 )
 
 /**

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.19.0-beta.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.19.0-beta.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [fix: reintroduce meta_hack-record-viewer-video](https://github.com/bigbluebutton/bigbluebutton/pull/23366/commits/cf8523fac1ecd04488ae24048fb77cf978142851)
  - Metadata support was removed from the client and
meta_hack-record-viewer-video was removed alongside it. There are still
some users of that metaparam, so it needs to be reintroduced.
  - Extend the GetRecordingStatus server-side probe made between webrtc-sfu
and akka-apps so that it responds with media-specific recording consent
states for audio, cameras and screen sharing. Audio and screen sharing
are unimplemented right now (default to true), but cameras work as
follows:
    - Factor meta_hack-record-viewer-video and userdata-bbb_record_video
    into the consent resolution for the requester
    - Respond with the appropriate consent state for cameras via the
    recordUserCameras field.
  - Actually handling of these consent booleans is done by bbb-webrtc-sfu.
- [build(bbb-webrtc-sfu): v2.19.0-beta.2](https://github.com/bigbluebutton/bigbluebutton/pull/23366/commits/f4903997753b1de7fbe07cd4909269e3d2f16afc) 
  - feat: add support for camera recording consent flag

### Closes Issue(s)

None