### PR TITLE
fix(layout): allow longer strings for `cameraWithFocus`

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2212,7 +2212,7 @@ CREATE UNLOGGED TABLE "layout" (
 	"cameraDockIsResizing"	boolean,
 	"cameraDockPlacement" 	varchar(100),
 	"cameraDockAspectRatio" numeric,
-	"cameraWithFocus" 		varchar(100),
+	"cameraWithFocus" 		varchar(255),
 	"propagateLayout" 		boolean,
 	"screenshareAsContent" 	boolean,
 	"updatedAt" 			timestamp with time zone


### PR DESCRIPTION
### What does this PR do?
Updates the `cameraWithFocus` field on postgresql schema to `varchar(255)` because the previous size was not sufficient to hold the ID of the focused camera. The camera ID is typically a long string constructed from the userID, a unique prefix and the deviceID. This often exceeds 100 characters.

### Closes Issue(s)
Closes #23375

