### PR TITLE
fix(html5): Fix useMeeting hook returning undefined

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/from-core/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/from-core/hook-manager.tsx
@@ -50,7 +50,7 @@ const MeetingHookContainer: React.FunctionComponent<
     if (numberOfUses > previousNumberOfUsesValue) {
       updateMeetingForPlugin();
     }
-  }, [previousNumberOfUses]);
+  }, [numberOfUses]);
 
   return null;
 };


### PR DESCRIPTION
### What does this PR do?

It just fixes the useMeeting returning undefined when multiple plugins start listening to this hook's events.

The problem ended up being a race condition that happened in the manager of useMeeting hook, so basically when the plugins connected in a timespan close enough, they both would receive the updating message, otherwise, the update wouldn't happen due to the check it does (correctly).

Investigating, I found that in #22161, I mistyped the `useEffect` dependencies to observe the previous value instead of the current count of uses (as it is done in the other hooks), when fixing almost the same issue but for the `useCurrentUser`.

### How to test

- Connect 2 plugins using the `useMeeting`;
- Watch for the result of the `useMeeting` hook for both plugins - Ideally the first plugin to connect would be fine, but the second would only get the result sometimes.