### PR TITLE
Fix(html5): Add localization to live polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
@@ -58,6 +58,26 @@ const intlMessages = defineMessages({
     id: 'app.poll.activePollInstruction',
     description: 'instructions displayed when a poll is active',
   },
+  true: {
+    id: 'app.poll.t',
+    description: 'Poll true option value',
+  },
+  false: {
+    id: 'app.poll.f',
+    description: 'Poll false option value',
+  },
+  yes: {
+    id: 'app.poll.y',
+    description: 'Poll yes option value',
+  },
+  no: {
+    id: 'app.poll.n',
+    description: 'Poll no option value',
+  },
+  abstention: {
+    id: 'app.poll.abstention',
+    description: 'Poll Abstention option value',
+  },
 });
 
 interface LiveResultProps {
@@ -97,6 +117,15 @@ const LiveResult: React.FC<LiveResultProps> = ({
     });
   }, []);
 
+  const translatedResponses = responses.map((response) => {
+    const translationKey = intlMessages[response.optionDesc.toLowerCase() as keyof typeof intlMessages];
+    const optionDesc = translationKey ? intl.formatMessage(translationKey) : response.optionDesc;
+    return {
+      ...response,
+      optionDesc,
+    };
+  });
+
   return (
     <div>
       <Styled.Instructions>
@@ -120,7 +149,7 @@ const LiveResult: React.FC<LiveResultProps> = ({
         </Styled.Status>
         <ResponsiveContainer width="90%" height={250}>
           <BarChart
-            data={responses}
+            data={translatedResponses}
             layout="vertical"
           >
             <XAxis type="number" allowDecimals={false} />

--- a/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
@@ -218,7 +218,14 @@ const LiveResult: React.FC<LiveResultProps> = ({
                   users.map((user) => (
                     <tr key={user.user.userId}>
                       <Styled.ResultLeft>{user.user.name}</Styled.ResultLeft>
-                      <Styled.ResultRight data-test="userVoteLiveResult">{user.optionDescIds.join()}</Styled.ResultRight>
+                      <Styled.ResultRight data-test="userVoteLiveResult">
+                        {
+                          user.optionDescIds.map((optDesc) => {
+                            const translationKey = intlMessages[optDesc.toLowerCase() as keyof typeof intlMessages];
+                            return translationKey ? intl.formatMessage(translationKey) : optDesc;
+                          }).join()
+                        }
+                      </Styled.ResultRight>
                     </tr>
                   ))
                 }


### PR DESCRIPTION
### What does this PR do?
Adds Translations to the live polls on presenters panel, the options descriptions are being passed raw instead of a translated key.


### Closes Issue(s)

Part of #23354
Tldraw part will come in a follow up, it needs changes on @bigblubutton/tldraw
### How to test
- Join a meeting 
- Change the locale 
- Start a poll 



### More
![image](https://github.com/user-attachments/assets/4d66453e-4ed6-4441-b255-36ffd9e37ccc)
