### PR TITLE
refactor (akka-apps, gql-middleware): General improvements to prevent system stalling and enhance debugging

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/BigBlueButtonActor.scala
@@ -107,7 +107,7 @@ class BigBlueButtonActor(
         } else {
           RunningMeetings.findWithId(meetings, sessionTokenInfo.meetingId) match {
             case Some(m) =>
-              log.debug("handleGetUserApiMsg ({}): {}.", msg.sessionToken, m)
+              log.debug("handleGetUserApiMsg ({}): Meeting: {}.", msg.sessionToken, m.props.meetingProp.intId)
               m.actorRef forward (msg)
 
             case None =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDeleteEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelDeleteEntryMsgHdlr.scala
@@ -9,6 +9,8 @@ import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, LogHelper }
 trait PluginDataChannelDeleteEntryMsgHdlr extends HandlerHelpers with LogHelper {
 
   def handle(msg: PluginDataChannelDeleteEntryMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
+    log.debug("RECEIVED PluginDataChannelDeleteEntryMsg msg {}", msg)
+
     dataChannelCheckingLogic(liveMeeting, msg.header.userId, msg.body.pluginName, msg.body.channelName, (user, dc, meetingId) => {
       val hasPermission = checkPermission(user, dc.replaceOrDeletePermission, defaultCreatorCheck(
         meetingId, msg.body, msg.header.userId

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelReplaceEntryMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/plugin/PluginDataChannelReplaceEntryMsgHdlr.scala
@@ -9,6 +9,7 @@ import org.bigbluebutton.core.running.{HandlerHelpers, LiveMeeting, LogHelper}
 trait PluginDataChannelReplaceEntryMsgHdlr extends HandlerHelpers with LogHelper {
 
   def handle(msg: PluginDataChannelReplaceEntryMsg, state: MeetingState2x, liveMeeting: LiveMeeting): Unit = {
+    log.debug("RECEIVED PluginDataChannelReplaceEntryMsg msg {}", msg)
 
     dataChannelCheckingLogic(liveMeeting, msg.header.userId, msg.body.pluginName, msg.body.channelName, (user, dc, meetingId) => {
       val hasPermission = checkPermission(user, dc.replaceOrDeletePermission, defaultCreatorCheck(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetUserApiMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/GetUserApiMsgHdlr.scala
@@ -15,10 +15,10 @@ trait GetUserApiMsgHdlr extends HandlerHelpers {
   def handleGetUserApiMsg(msg: GetUserApiMsg, actorRef: ActorRef): Unit = {
     RegisteredUsers.findWithSessionToken(msg.sessionToken, liveMeeting.registeredUsers) match {
       case Some(regUser) =>
-        log.debug("replying GetUserApiMsg with success")
+        log.debug("replying GetUserApiMsg with success ({}). User: {}", msg.sessionToken, regUser.id)
         actorRef ! ApiResponseSuccess("User found!", UserInfosApiMsg(getUserInfoResponse(regUser, msg.sessionToken)))
       case None =>
-        log.debug("User not found, sending failure message")
+        log.debug("User not found, sending failure message ({}).", msg.sessionToken)
         actorRef ! ApiResponseFailure("User not found", "user_not_found", Map())
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PluginDataChannelEntryDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/PluginDataChannelEntryDAO.scala
@@ -4,7 +4,7 @@ import PostgresProfile.api._
 import org.bigbluebutton.core.db.DatabaseConnection.{db, logger}
 import org.bigbluebutton.core.util.RandomStringGenerator
 import spray.json.JsValue
-import scala.concurrent.{Await}
+import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 object Permission {

--- a/bbb-graphql-middleware/internal/bbb_web/client.go
+++ b/bbb-graphql-middleware/internal/bbb_web/client.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// authHookUrl is the authentication hook URL obtained from an environment variable.
+// authHookUrl is the authentication hook URL obtained from config file.
 var authHookUrl = config.GetConfig().AuthHook.Url
 
 func BBBWebCheckAuthorization(browserConnectionId string, sessionToken string, cookies []*http.Cookie) (string, string, error) {
@@ -31,7 +31,7 @@ func BBBWebCheckAuthorization(browserConnectionId string, sessionToken string, c
 
 	// Check if the authentication hook URL is set.
 	if authHookUrl == "" {
-		return "", "", fmt.Errorf("BBB_GRAPHQL_MIDDLEWARE_AUTH_HOOK_URL not set")
+		return "", "", fmt.Errorf("Config auth_hook.url not set")
 	}
 
 	// Create a new HTTP request to the authentication hook URL.

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -412,11 +412,11 @@ func connectionInitHandler(browserConnection *common.BrowserConnection) (error, 
 			}
 
 			if errCheckAuthorization != nil {
-				return fmt.Errorf("error on trying to check authorization"), "user_not_found"
+				return fmt.Errorf("error on trying to check authorization"), "check_authorization_error"
 			}
 
 			if meetingId == "" {
-				return fmt.Errorf("error on trying to check authorization"), "user_not_found"
+				return fmt.Errorf("error on trying to check authorization"), "meeting_not_found"
 			}
 			browserConnection.Logger = browserConnection.Logger.WithField("meetingId", meetingId)
 

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -83,7 +83,7 @@ func StartRedisListener() {
 			messageBodyAsMap := messageCoreAsMap["body"].(map[string]interface{})
 			middlewareUID := messageBodyAsMap["middlewareUID"]
 			if middlewareUID == common.GetUniqueID() {
-				log.Debugf("Received ping message from akka-apps")
+				log.Infof("Received ping message from akka-apps")
 				go SendCheckGraphqlMiddlewareAlivePongSysMsg()
 			}
 		}
@@ -127,6 +127,9 @@ func sendBbbCoreMsgToRedis(name string, body map[string]interface{}) {
 		return
 	}
 
+	if bodyAsJson, err := json.Marshal(body); err == nil {
+		log.Infof("Redis message sent %s: %s", name, bodyAsJson)
+	}
 	log.Tracef("JSON message sent to channel %s:\n%s\n", channelName, string(messageJSON))
 }
 

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -127,8 +127,10 @@ func sendBbbCoreMsgToRedis(name string, body map[string]interface{}) {
 		return
 	}
 
-	if bodyAsJson, err := json.Marshal(body); err == nil {
-		log.Infof("Redis message sent %s: %s", name, bodyAsJson)
+	if log.IsLevelEnabled(log.DebugLevel) {
+		if bodyAsJson, err := json.Marshal(body); err == nil {
+			log.Debugf("Redis message sent %s: %s", name, bodyAsJson)
+		}
 	}
 	log.Tracef("JSON message sent to channel %s:\n%s\n", channelName, string(messageJSON))
 }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -61,6 +61,8 @@ class ConnectionController {
   }
 
   def checkGraphqlAuthorization = {
+    String sessionToken = ""
+
     try {
       /* the graphql connection in cluster setups is a CORS request. The OPTIONS
        * call is done as a preflight quest by the browser and does not contain
@@ -75,7 +77,7 @@ class ConnectionController {
           response.outputStream << 'graphql-success';
           return;
       }
-      String sessionToken = request.getHeader("x-session-token")
+      sessionToken = request.getHeader("x-session-token")
 
       UserSession userSession = meetingService.getUserSessionWithSessionToken(sessionToken)
       Boolean allowRequestsWithoutSession = meetingService.getAllowRequestsWithoutSession(sessionToken)
@@ -144,7 +146,7 @@ class ConnectionController {
         throw new Exception("Invalid sessionToken")
       }
     } catch (Exception e) {
-      log.debug("Error while authenticating graphql connection: " + e.getMessage())
+      log.debug("Error while authenticating graphql connection {"+sessionToken+"}: " + e.getMessage())
       response.setStatus(401)
       withFormat {
         json {

--- a/build/packages-template/bbb-graphql-middleware/bbb-graphql-middleware.service
+++ b/build/packages-template/bbb-graphql-middleware/bbb-graphql-middleware.service
@@ -13,7 +13,7 @@ WorkingDirectory=/usr/bin
 ExecStart=/usr/bin/bbb-graphql-middleware
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
-RestartSec=60
+RestartSec=1
 SuccessExitStatus=143
 TimeoutStopSec=5
 PermissionsStartOnly=true
@@ -21,4 +21,3 @@ LimitNOFILE=4096
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target
-


### PR DESCRIPTION
ad5893d
```
By using a Timer inside the GraphqlConnectionsActor, the scheduled health check runs 
within the actor's own mailbox, ensuring it is serialized and not affected by external thread pool contention.
This guarantees that ping messages are sent on time, even if the global execution context is under heavy load.
```

07e25aa
```
By using a dedicated ExecutionContext backed by Executors.newSingleThreadExecutor() for DatabaseConnection,
all database operations and their callbacks execute in a single, isolated thread.
This prevents interference from other concurrent tasks, ensuring that database actions 
are processed in the correct order and their logs are written promptly,
avoiding delayed or out-of-order log entries.
```

678c1c8
```
Set RestartSec=1 for the graphql-middleware service to ensure it restarts quickly after a crash.
```

a421d6c
```
Improve overall logging to better trace the user's journey through the system.
```