### PR TITLE
docs: Correct values for removable and downloadable api.md

### DIFF
--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -394,12 +394,12 @@ In the body part, you would append a simple XML like the example below:
 
 When you need to provide a document using a URL, and the document URL does not contain an extension, you can use the `filename` parameter, such as `filename=test-results.pdf` to help the BigBlueButton server determine the file type (in this example it would be a PDF file).
 
-**From `2.5.x` and on** there is also 2 parameters one can provide the payload to ensure that the document they are uploading can be downloaded or removed from the meeting, those parameters are:
+**From `2.5.x` and on** there are also 2 parameters one can provide the payload to ensure that the document they are uploading can be downloaded or removed from the meeting, those parameters are:
 
 | Parameter      | Description                                    | Default Value |
 | -------------- | ---------------------------------------------- | ------------- |
-| `downloadable` | Dictates if the presentation can be downloaded | `true`        |
-| `removable`    | dictates if one can remove the presentation.   | `false`       |
+| `downloadable` | Dictates if the presentation can be downloaded | `false`        |
+| `removable`    | dictates if one can remove the presentation.   | `true`       |
 
 In the payload the variables are passed inside each `<document>` tag of the xml, as follows:
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
`removable` and `downloadable` had incorrect (flipped) default values in the docs, not matching the source code (i.e. the actual behavior)
<img width="1048" alt="c8f9b4b1-11fb-4cd4-b79d-d61a847c798d" src="https://github.com/user-attachments/assets/1f4c6e48-48e3-49b8-a5e1-b22e01673358" />
<img width="1032" alt="e1be6581-06ca-4066-8209-8270859045a6" src="https://github.com/user-attachments/assets/1ab4d5ee-104f-40a3-928f-2c4f8749a25b" />


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Reported by @SamuelWei - Thanks!!
