### PR TITLE
[3.1] fix(layout): ensure the camera position is not undefined

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -90,18 +90,6 @@ const reducer = (state, action) => {
       };
     }
 
-    case ACTIONS.SET_AUTO_ARRANGE_LAYOUT: {
-      const { autoarrAngeLayout } = state.input;
-      if (autoarrAngeLayout === action.value) return state;
-      return {
-        ...state,
-        input: {
-          ...state.input,
-          autoarrAngeLayout: action.value,
-        },
-      };
-    }
-
     case ACTIONS.SET_IS_RTL: {
       const { isRTL } = state;
       if (isRTL === action.value) return state;

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -51,7 +51,6 @@ export const SYNC = {
 };
 
 export const ACTIONS = {
-  SET_AUTO_ARRANGE_LAYOUT: 'setAutoArrangeLayout',
   SET_IS_RTL: 'setIsRTL',
   SET_LAYOUT_TYPE: 'setLayoutType',
   SET_DEVICE_TYPE: 'setDeviceType',

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -364,9 +364,6 @@ const CamerasOnlyLayout = (props) => {
               width: 0,
               height: 0,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: false,
             },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -107,11 +107,9 @@ const CamerasOnlyLayout = (props) => {
     const sidebarNavBounds = calculatesSidebarNavBounds(sidebarNavHeight);
     const sidebarContentBounds = calculatesSidebarContentBounds(
       sidebarNavWidth.horizontalSpaceOccupied,
-      sidebarNavWidth.width,
     );
     const mediaAreaBounds = calculatesMediaAreaBounds(
       sidebarNavWidth.horizontalSpaceOccupied,
-      sidebarNavWidth.width,
       sidebarContentWidth.width,
     );
     const navbarBounds = calculatesNavbarBounds(mediaAreaBounds);

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -243,7 +243,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
-                position: CAMERADOCK_POSITION.CONTENT_TOP,
+                position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -179,6 +179,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
+                position: CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {
@@ -242,6 +243,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
+                position: CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -179,7 +179,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
-                position: CAMERADOCK_POSITION.CONTENT_TOP,
+                position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -171,9 +171,6 @@ const CustomLayout = (props) => {
                 isOpen: overrideOpenSidebarPanel,
                 sidebarContentPanel: sidebarContent.sidebarContentPanel,
               },
-              sidebarContentHorizontalResizer: {
-                isOpen: false,
-              },
               presentation: {
                 isOpen: presentation.isOpen,
                 slidesLength: presentation.slidesLength,
@@ -236,9 +233,6 @@ const CustomLayout = (props) => {
               sidebarContent: {
                 isOpen: overrideOpenSidebarPanel,
                 sidebarContentPanel: sidebarContentPanelOverride,
-              },
-              sidebarContentHorizontalResizer: {
-                isOpen: false,
               },
               presentation: {
                 isOpen: presentation.isOpen,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -470,7 +470,7 @@ const MediaOnlyLayout = (props) => {
               },
             },
             cameraDock: {
-              position: CAMERADOCK_POSITION.CONTENT_LEFT,
+              position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_LEFT,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -461,9 +461,6 @@ const MediaOnlyLayout = (props) => {
               isOpen: false,
               sidebarContentPanel: PANELS.NONE,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -118,6 +118,7 @@ const MediaOnlyLayout = (props) => {
     const cameraDockBounds = {};
 
     cameraDockBounds.isCameraHorizontal = false;
+    cameraDockBounds.position = CAMERADOCK_POSITION.CONTENT_TOP;
 
     const mediaBoundsWidth = mediaBounds.width > presentationToolbarMinWidth
       && !isMobile
@@ -469,6 +470,7 @@ const MediaOnlyLayout = (props) => {
               },
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.CONTENT_LEFT,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
@@ -398,6 +398,7 @@ const ParticipantsAndChatOnlyLayout = (props) => {
               height: 0,
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
               numCameras: 0,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
@@ -388,9 +388,6 @@ const ParticipantsAndChatOnlyLayout = (props) => {
               isOpen: true,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: false,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -129,7 +129,7 @@ const PresentationFocusLayout = (props) => {
               },
             },
             cameraDock: {
-              position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
+              position: cameraDock.position || CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
               numCameras: cameraDock.numCameras,
               height: 0,
               width: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -129,6 +129,7 @@ const PresentationFocusLayout = (props) => {
               },
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
               numCameras: cameraDock.numCameras,
               height: 0,
               width: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -121,9 +121,6 @@ const PresentationFocusLayout = (props) => {
               isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -357,9 +357,6 @@ const PresentationOnlyLayout = (props) => {
               width: 0,
               height: 0,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: true,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -121,7 +121,7 @@ const SmartLayout = (props) => {
               },
             },
             cameraDock: {
-              position: CAMERADOCK_POSITION.CONTENT_TOP,
+              position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -121,6 +121,7 @@ const SmartLayout = (props) => {
               },
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.CONTENT_TOP,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {
@@ -176,6 +177,7 @@ const SmartLayout = (props) => {
     const cameraDockBounds = {};
 
     cameraDockBounds.isCameraHorizontal = false;
+    cameraDockBounds.position = CAMERADOCK_POSITION.CONTENT_TOP;
 
     const mediaBoundsWidth = mediaBounds.width > presentationToolbarMinWidth && !isMobile
       ? mediaBounds.width

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -113,9 +113,6 @@ const SmartLayout = (props) => {
               isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -122,9 +122,6 @@ const VideoFocusLayout = (props) => {
               isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: isTabletLandscape ? false : presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -87,11 +87,11 @@ const LayoutObserver: React.FC = () => {
   useEffect(() => {
     if (deviceType !== previousDeviceType) {
       const Settings = getSettingsSingletonInstance();
-      const currentLayout = Settings.application.selectedLayout;
+      const currentLayout = Settings.layout.selectedLayout;
       if (!isLayoutSupported(deviceType, currentLayout)) {
         updateSettings({
-          application: {
-            ...Settings.application,
+          layout: {
+            ...Settings.layout,
             selectedLayout: LAYOUT_TYPE.SMART_LAYOUT,
           },
         }, null, setLocalSettings);


### PR DESCRIPTION
### What does this PR do?
- [fix(layout): remove unused action](https://github.com/bigbluebutton/bigbluebutton/commit/aeb003a26868d6885de51d3ef136b05d320cd2e8) 
Removes layout context action to set layout autoarrange option that was never used.
- [fix(layout): removes unused property](https://github.com/bigbluebutton/bigbluebutton/commit/775fa353ea27ea34314d963650412a9d8c17ee4b) 
Removes unused property called SidebarContentHorizontalResizer that was not set or changed anywere in the code.
- [fix(layout): camerasOnly passing wrong arguments to function](https://github.com/bigbluebutton/bigbluebutton/commit/fafb4ad6d1b82317cedb10f9829259b18a4411bf) 
Fixes the arguments that the layout manager 'camerasOnly' was passing to the function that calculates the media area bounds. It was passing the navigation sidebar width as it were the content sidebar width.
- [fix(layout): access selected layout from correct settings key](https://github.com/bigbluebutton/bigbluebutton/commit/d3c3041f982f5a66e142447430b785aed45e200d) 
Selected layout is now under `layout` instead of `application`.
- [fix(layout): ensure the camera position is not undefined](https://github.com/bigbluebutton/bigbluebutton/commit/d5efc613d41219b4b03e521ab00ab498c29d3b98) 
When changing from one layout to another, there is a merge of the previous input values with some of new values of the new layout. It happens that sometimes the previous layout didn't initialized the value for the camera dock position, leaving it as undefined and causing it to insert an inconsistent state to the next layout state. So this commit fixes it by initializing the camera position in all layouts types, to ensure its value in the layout input is not undefined.


### Closes Issue(s)
Closes #23398

### How to test
Steps are given in the issue report.

### More
This will be Backported to 3.0 soon.
