### PR TITLE
[3.0] fix(layout): ensure the camera position is not undefined

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -88,18 +88,6 @@ const reducer = (state, action) => {
       };
     }
 
-    case ACTIONS.SET_AUTO_ARRANGE_LAYOUT: {
-      const { autoarrAngeLayout } = state.input;
-      if (autoarrAngeLayout === action.value) return state;
-      return {
-        ...state,
-        input: {
-          ...state.input,
-          autoarrAngeLayout: action.value,
-        },
-      };
-    }
-
     case ACTIONS.SET_IS_RTL: {
       const { isRTL } = state;
       if (isRTL === action.value) return state;

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -51,7 +51,6 @@ export const SYNC = {
 };
 
 export const ACTIONS = {
-  SET_AUTO_ARRANGE_LAYOUT: 'setAutoArrangeLayout',
   SET_IS_RTL: 'setIsRTL',
   SET_LAYOUT_TYPE: 'setLayoutType',
   SET_DEVICE_TYPE: 'setDeviceType',

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/camerasOnly.jsx
@@ -370,9 +370,6 @@ const CamerasOnlyLayout = (props) => {
               width: 0,
               height: 0,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: false,
             },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -165,7 +165,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
-                position: CAMERADOCK_POSITION.CONTENT_TOP,
+                position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -224,7 +224,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
-                position: CAMERADOCK_POSITION.CONTENT_TOP,
+                position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -165,6 +165,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
+                position: CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {
@@ -223,6 +224,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
+                position: CAMERADOCK_POSITION.CONTENT_TOP,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -157,9 +157,6 @@ const CustomLayout = (props) => {
                 isOpen: sidebarContentPanel !== PANELS.NONE,
                 sidebarContentPanel: sidebarContent.sidebarContentPanel,
               },
-              sidebarContentHorizontalResizer: {
-                isOpen: false,
-              },
               presentation: {
                 isOpen: presentation.isOpen,
                 slidesLength: presentation.slidesLength,
@@ -217,9 +214,6 @@ const CustomLayout = (props) => {
               sidebarContent: {
                 isOpen: overrideOpenSidebarPanel,
                 sidebarContentPanel: sidebarContentPanelOverride,
-              },
-              sidebarContentHorizontalResizer: {
-                isOpen: false,
               },
               presentation: {
                 isOpen: presentation.isOpen,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -471,9 +471,6 @@ const MediaOnlyLayout = (props) => {
               isOpen: false,
               sidebarContentPanel: PANELS.NONE,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -118,6 +118,7 @@ const MediaOnlyLayout = (props) => {
     const cameraDockBounds = {};
 
     cameraDockBounds.isCameraHorizontal = false;
+    cameraDockBounds.position = CAMERADOCK_POSITION.CONTENT_TOP;
 
     const mediaBoundsWidth = mediaBounds.width > presentationToolbarMinWidth
       && !isMobile
@@ -479,6 +480,7 @@ const MediaOnlyLayout = (props) => {
               },
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.CONTENT_LEFT,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/mediaOnlyLayout.jsx
@@ -480,7 +480,7 @@ const MediaOnlyLayout = (props) => {
               },
             },
             cameraDock: {
-              position: CAMERADOCK_POSITION.CONTENT_LEFT,
+              position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_LEFT,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
@@ -404,6 +404,7 @@ const ParticipantsAndChatOnlyLayout = (props) => {
               height: 0,
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
               numCameras: 0,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/participantsAndChatOnlyLayout.jsx
@@ -394,9 +394,6 @@ const ParticipantsAndChatOnlyLayout = (props) => {
               isOpen: true,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: false,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -110,9 +110,6 @@ const PresentationFocusLayout = (props) => {
               isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -118,6 +118,7 @@ const PresentationFocusLayout = (props) => {
               },
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
               numCameras: cameraDock.numCameras,
               height: 0,
               width: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -118,7 +118,7 @@ const PresentationFocusLayout = (props) => {
               },
             },
             cameraDock: {
-              position: CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
+              position: cameraDock.position || CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM,
               numCameras: cameraDock.numCameras,
               height: 0,
               width: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationOnlyLayout.jsx
@@ -365,9 +365,6 @@ const PresentationOnlyLayout = (props) => {
               width: 0,
               height: 0,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: true,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -110,7 +110,7 @@ const SmartLayout = (props) => {
               },
             },
             cameraDock: {
-              position: CAMERADOCK_POSITION.CONTENT_TOP,
+              position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -110,6 +110,7 @@ const SmartLayout = (props) => {
               },
             },
             cameraDock: {
+              position: CAMERADOCK_POSITION.CONTENT_TOP,
               numCameras: cameraDock.numCameras,
             },
             externalVideo: {
@@ -165,6 +166,7 @@ const SmartLayout = (props) => {
     const cameraDockBounds = {};
 
     cameraDockBounds.isCameraHorizontal = false;
+    cameraDockBounds.position = CAMERADOCK_POSITION.CONTENT_TOP;
 
     const mediaBoundsWidth =
       mediaBounds.width > presentationToolbarMinWidth && !isMobile

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -102,9 +102,6 @@ const SmartLayout = (props) => {
               isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -112,9 +112,6 @@ const VideoFocusLayout = (props) => {
               isOpen: overrideOpenSidebarPanel,
               sidebarContentPanel: sidebarContentPanelOverride,
             },
-            SidebarContentHorizontalResizer: {
-              isOpen: false,
-            },
             presentation: {
               isOpen: presentation.isOpen,
               slidesLength: presentation.slidesLength,


### PR DESCRIPTION
### What does this PR do?
- [fix(layout): remove unused action](https://github.com/bigbluebutton/bigbluebutton/commit/d7d97645fc3e3dcba1504a5c92b7aa5e4133aa6d) 
Removes layout context action to set layout autoarrange option that was never used.
- [fix(layout): removes unused property](https://github.com/bigbluebutton/bigbluebutton/commit/a24781235141497132606d5aa70d9c3c61c52433) 
Removes unused property called SidebarContentHorizontalResizer that was not set or changed anywere in the code.
- [fix(layout): ensure the camera position is not undefined](https://github.com/bigbluebutton/bigbluebutton/commit/1c9482444f6db8f431283b30048b28219ffbe180) 

When changing from one layout to another, there is a merge of the previous input values with some of new values of the new layout. It happens that sometimes the previous layout didn't initialized the value for the camera dock position, leaving it as undefined and causing it to insert an inconsistent state to the next layout state. So this commit fixes it by initializing the camera position in all layouts types, to ensure its value in the layout input is not undefined. 

### Closes Issue(s)
Closes #23398


### How to test
Steps are given in the issue report.
