### PR TITLE
fix(test): Add assertion for video elements count on `Enforce Layout - VIDEO_FOCUS`

### DIFF
--- a/bigbluebutton-tests/playwright/parameters/customparameters.js
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.js
@@ -478,6 +478,7 @@ class CustomParameters extends MultiUsers {
         
     await this.modPage.waitForSelector(e.webcamMirroredVideoContainer, VIDEO_LOADING_WAIT_TIME);
     await this.modPage.waitForSelector(e.leaveVideo, VIDEO_LOADING_WAIT_TIME);
+    await this.modPage.hasNElements('video', 2, 'should display the 2 video elements after both users shared their webcams');
 
     await checkScreenshots(this, 'should be the video focus layout', [e.webcamContainer, e.webcamMirroredVideoContainer], 'enforce-video-focus');
   }


### PR DESCRIPTION
### What does this PR do?
Adds a `video` element count assertion before checking screenshots to avoid failures (mask not applied on screenshot due to webcam video not loaded yet)