### PR TITLE
fix(sidebar-navigation): ensure scrollbar is visible on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
@@ -81,8 +81,9 @@ const NavigationToggleButton = styled(Button)`
 const NavigationSidebarListItemsContainer = styled(ScrollboxVertical)<{
   animations: boolean,
   isMobile: boolean,
-  hasScrollbar: boolean,
+  noVirtualScrollboxBackground: boolean,
   isExpanded: boolean,
+  enableScrollBar: boolean,
 }>`
   display: flex;
   flex-direction: column;
@@ -95,25 +96,27 @@ const NavigationSidebarListItemsContainer = styled(ScrollboxVertical)<{
   }
 
   ${({ isExpanded }) => (isExpanded ? `
-    mmax-height: 100%;
+    max-height: 100%;
     opacity: 1;
   ` : `
     height: 0;
     opacity: 0;
-    overflow: hidden;
     background: transparent !important;
   `)}
 
-  ${({ hasScrollbar }) => !hasScrollbar && `
+  ${({ noVirtualScrollboxBackground }) => noVirtualScrollboxBackground && `
     background: transparent !important;
   `}
 
   ${({ isMobile, animations }) => (animations && isMobile && `
-    overflow: hidden;
     transition: height 0.2s ease-out,
      opacity 0.2s ease-out,
      background 0.2s ease-out;
   `)}
+
+  ${({ enableScrollBar }) => !enableScrollBar && `
+    overflow: hidden;
+  `}
 `;
 
 const PositionedDiv = styled.div`


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where the scrollbar was permanently hidden on small screens due to incorrect logic meant to hide it only during the sidebar toggle animation. This made some navigation buttons inaccessible. Also restores the sidebar to its default state when not on mobile, preventing it from staying collapsed in some edge cases.

### Closes Issue(s)
Closes #23417 
