### PR TITLE
fix(audio-captions): transcription stops after a long period of silence

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -35,6 +35,11 @@ const THROTTLE_TIMEOUT = 200;
 type SpeechRecognitionEvent = {
   resultIndex: number;
   results: SpeechRecognitionResult[];
+  target: Target;
+}
+
+type Target = {
+  lang: string;
 }
 
 type SpeechRecognitionErrorEvent = {
@@ -59,6 +64,7 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
     id: generateId(),
     transcript: '',
     isFinal: true,
+    lang: '',
   });
 
   const localeRef = useRef(locale);
@@ -194,23 +200,26 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
     const {
       resultIndex,
       results,
+      target,
     } = event;
 
-    logger.debug('Transcription event', event);
+    logger.debug('Transcription event', resultIndex, results, target);
 
     const { id } = resultRef.current;
 
     const { transcript } = results[resultIndex][0];
     const { isFinal } = results[resultIndex];
+    const { lang } = target;
 
     resultRef.current.transcript = transcript;
     resultRef.current.isFinal = isFinal;
+    resultRef.current.lang = lang;
 
     if (isFinal) {
-      updateFinalTranscript(id, transcript, speechRecognitionRef.current.lang);
+      updateFinalTranscript(id, transcript, lang);
       resultRef.current.id = generateId();
     } else {
-      transcriptUpdate(id, transcript, speechRecognitionRef.current.lang, false);
+      transcriptUpdate(id, transcript, lang, false);
     }
   }, [localeRef]);
 
@@ -224,11 +233,12 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
       const {
         isFinal,
         transcript,
+        lang,
       } = resultRef.current;
 
       if (!isFinal) {
         const { id } = resultRef.current;
-        updateFinalTranscript(id, transcript, localeRef.current);
+        updateFinalTranscript(id, transcript, lang);
         resultRef.current.isFinal = true;
         speechRecognitionRef.current.abort();
       } else {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -159,13 +159,28 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
       logCode: 'captions_speech_recognition_ended',
     }, 'Captions speech recognition ended by browser');
 
-    stop();
+    speechHasStarted.started = false;
     if (!mutedRef.current) {
-      logger.debug("Speech recogniction ended by browser, but we're not muted. Restart it");
-      start(localeRef.current);
+      logger.debug("Speech recognition ended by browser, but we're not muted. Restart it");
+      const timeSinceLastStart = new Date().getTime() - lastStartedAt.current;
+      if (timeSinceLastStart < 1000) {
+        setTimeout(() => {
+          start(localeRef.current);
+        }, 1000 - timeSinceLastStart);
+      } else {
+        start(localeRef.current);
+      }
     }
   }, []);
   const onError = useCallback((event: SpeechRecognitionErrorEvent) => {
+    if (isLocaleChangeRef.current && event.error === 'aborted') return;
+
+    // This error 'no-speech' is expected because speech recognition is set to automatically
+    // restart whenever the browser stops it — tipically due to silence timeout. As a result,
+    // while the user is unmuted, recognition will keep running even if they're silent and
+    // there's nothing to transcribe.
+    if (event.error === 'no-speech') return;
+
     logger.error({
       logCode: 'captions_speech_recognition_error',
       extraInfo: {
@@ -192,10 +207,10 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
     resultRef.current.isFinal = isFinal;
 
     if (isFinal) {
-      updateFinalTranscript(id, transcript, localeRef.current);
+      updateFinalTranscript(id, transcript, speechRecognitionRef.current.lang);
       resultRef.current.id = generateId();
     } else {
-      transcriptUpdate(id, transcript, localeRef.current, false);
+      transcriptUpdate(id, transcript, speechRecognitionRef.current.lang, false);
     }
   }, [localeRef]);
 
@@ -225,7 +240,7 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
 
   const start = (settedLocale: string) => {
     if (speechRecognitionRef.current && isLocaleValid(settedLocale)) {
-      logger.debug('Starting browser speech recognition');
+      logger.debug('Starting browser speech recognition for locale: ', settedLocale);
       speechRecognitionRef.current.lang = settedLocale;
 
       if (speechHasStarted.started) {
@@ -233,10 +248,12 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
         return;
       }
 
+      lastStartedAt.current = new Date().getTime();
       try {
         resultRef.current.id = generateId();
         speechRecognitionRef.current.start();
         speechHasStarted.started = true;
+        isLocaleChangeRef.current = false;
       } catch (event: unknown) {
         onError(event as SpeechRecognitionErrorEvent);
       }
@@ -257,6 +274,8 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
 
   const connectedRef = useRef(connected);
   const mutedRef = useRef(muted);
+  const isLocaleChangeRef = useRef(false);
+  const lastStartedAt = useRef<number>(0);
 
   useEffect(() => {
     // Disabled
@@ -273,8 +292,8 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
 
       // Locale changed
       if (connectedRef.current && connected) {
+        isLocaleChangeRef.current = true;
         stop();
-        start(locale);
         localeRef.current = locale;
       }
     }


### PR DESCRIPTION
### What does this PR do?
When user is unmuted and there is not mic activity, the automatic transcriptions simply stops working for that user until he/she toggles mic. This commit fixes this issue by automatically restarting the speech recognition when the browser automatically stops and also by adding a mechanism to prevent the speech recognition from being started more than once a second. Approach inspired in: https://github.com/TalAter/annyang/blob/46d3f1c212d43cae147e633ff9c52b36605c5728/src/annyang.js#L606-L629

Additionally fixes another issue where changing the transcription language during speech would cause it to stop working.

Also prevents undefined locales by using the lang of the speech recognition event.

### Closes Issue(s)
dc633898d5cc8cdb6f8830720c39021223306f17 Should fix this one #19178

