### PR TITLE
fix: multi user pen only not working

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -209,7 +209,7 @@ const Whiteboard = React.memo((props) => {
 
       const bbbMultiUserPenOnly = getFromUserSettings(
         'bbb_multi_user_pen_only',
-        false,
+        window.meetingClientSettings.public.whiteboard.toolbar.multiUserPenOnly,
       );
       const bbbPresenterTools = getFromUserSettings(
         'bbb_presenter_tools',


### PR DESCRIPTION
### What does this PR do?

fix `multi_user_pen_only` config not working when adjusted in settings.yml.

### How to test
1. set `multiUserPenOnly` to true in settings.yml
2. join a meeting and enable multi user whiteboard
3. users that are not the presenter should only be able to use the pen tool