### PR TITLE
Fix(html5): Remove list and index params from youtube url for external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
@@ -40,6 +40,8 @@ const intlMessages = defineMessages({
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
 const PANOPTO_MATCH_URL = /https?:\/\/([^/]+\/Panopto)(\/Pages\/Viewer\.aspx\?id=)([-a-zA-Z0-9]+)/;
 
+const YOUTUBE_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com|youtu.be)\/.+$/);
+
 interface ExternalVideoPlayerModalProps {
   onRequestClose: () => void,
   priority: string,
@@ -71,6 +73,13 @@ const ExternalVideoPlayerModal: React.FC<ExternalVideoPlayerModalProps> = ({
       if (m && m.length >= 4) {
         externalVideoUrl = `https://${m[1]}/Podcast/Social/${m[3]}.mp4`;
       }
+    }
+
+    if (YOUTUBE_REGEX.test(externalVideoUrl)) {
+      const YTUrl = new URL(externalVideoUrl);
+      YTUrl.searchParams.delete('list');
+      YTUrl.searchParams.delete('index');
+      externalVideoUrl = YTUrl.toString();
     }
 
     startExternalVideo({ variables: { externalVideoUrl } });


### PR DESCRIPTION
### What does this PR do?
Sharing a video from a YouTube playlist was causing an odd bug where the shared video wasn’t being displayed correctly. Instead, the first video in alphabetical order was shown. Since BBB only supports playing a single video at a time and doesn’t handle playlists, I resolved the issue by removing the list and index parameters from the YouTube URL, keeping only the video ID. This ensures that the correct video is played.


### Closes Issue(s)
Closes #23414

### How to test
- Join a Meeting
- Share a video from a private list from youtube



### More
[Screencast from 19-06-2025 10:28:45.webm](https://github.com/user-attachments/assets/e5c5020c-4df8-4b58-a95e-4a0d459ea31c)

