### PR TITLE
fix(chat): "Start a private chat" menu option is still shown when chat is disabled

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -47,6 +47,8 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
         } else {
           chatLocked = true
         }
+      } else {
+        hasModMembers = true
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -23,6 +23,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
     var privateChatDisabled: Boolean = false
     var chatLocked: Boolean = false
     var hasModMembers: Boolean = false
+    val isPrivateChat: Boolean = msg.body.access == GroupChatAccess.PRIVATE
 
     if (msg.body.access == GroupChatAccess.PRIVATE) {
       privateChatDisabled = liveMeeting.props.meetingProp.disabledFeatures.contains("privateChat")
@@ -55,7 +56,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
     // Check if this message was sent while the lock settings was being changed.
     val isDelayedMessage = System.currentTimeMillis() - MeetingStatus2x.getPermissionsChangedOn(liveMeeting.status) < 5000
 
-    if ((privateChatDisabled && !hasModMembers) ||
+    if ((isPrivateChat && privateChatDisabled && !hasModMembers) ||
       (
         applyPermissionCheck &&
         chatLocked &&

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -22,7 +22,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
 
     var privateChatDisabled: Boolean = false
     var chatLocked: Boolean = false
-    var hasModMembers: Boolean = true
+    var hasModMembers: Boolean = false
 
     if (msg.body.access == GroupChatAccess.PRIVATE) {
       privateChatDisabled = liveMeeting.props.meetingProp.disabledFeatures.contains("privateChat")
@@ -41,7 +41,8 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
           // don't lock creation of private chats that involve a moderator
           if (modMembers.length == 0) {
             chatLocked = user.locked && permissions.disablePrivChat
-            hasModMembers = false
+          } else {
+            hasModMembers = true
           }
         } else {
           chatLocked = true

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/CreateGroupChatReqMsgHdlr.scala
@@ -22,6 +22,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
 
     var privateChatDisabled: Boolean = false
     var chatLocked: Boolean = false
+    var hasModMembers: Boolean = true
 
     if (msg.body.access == GroupChatAccess.PRIVATE) {
       privateChatDisabled = liveMeeting.props.meetingProp.disabledFeatures.contains("privateChat")
@@ -40,6 +41,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
           // don't lock creation of private chats that involve a moderator
           if (modMembers.length == 0) {
             chatLocked = user.locked && permissions.disablePrivChat
+            hasModMembers = false
           }
         } else {
           chatLocked = true
@@ -50,7 +52,7 @@ trait CreateGroupChatReqMsgHdlr extends SystemConfiguration {
     // Check if this message was sent while the lock settings was being changed.
     val isDelayedMessage = System.currentTimeMillis() - MeetingStatus2x.getPermissionsChangedOn(liveMeeting.status) < 5000
 
-    if (privateChatDisabled ||
+    if ((privateChatDisabled && !hasModMembers) ||
       (
         applyPermissionCheck &&
         chatLocked &&

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -30,6 +30,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
     var chatLocked: Boolean = false
     var chatLockedForUser: Boolean = false
     var hasModMembers: Boolean = false
+    var isPrivateChat: Boolean = false
 
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
@@ -37,6 +38,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
     } yield {
       if (groupChat.access == GroupChatAccess.PRIVATE) {
         privateChatDisabled = liveMeeting.props.meetingProp.disabledFeatures.contains("privateChat")
+        isPrivateChat = true
       }
 
       if (groupChat.access == GroupChatAccess.PUBLIC && user.userLockSettings.disablePublicChat && user.role != Roles.MODERATOR_ROLE) {
@@ -64,8 +66,8 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
       }
     }
 
-    if (!chatDisabled &&
-      !(privateChatDisabled && !hasModMembers) &&
+    if (!(!isPrivateChat && chatDisabled) &&
+      !(isPrivateChat && privateChatDisabled && !hasModMembers) &&
       !(applyPermissionCheck && chatLocked) &&
       !chatLockedForUser) {
       val newState = for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -59,6 +59,8 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
         } else {
           chatLocked = permissions.disablePubChat
         }
+      } else {
+        hasModMembers = true
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -29,7 +29,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
     val replyChatMessageDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("replyChatMessage")
     var chatLocked: Boolean = false
     var chatLockedForUser: Boolean = false
-    var hasModMembers: Boolean = true
+    var hasModMembers: Boolean = false
 
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
@@ -53,7 +53,8 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
           // don't lock private chats that involve a moderator
           if (modMembers.isEmpty) {
             chatLocked = permissions.disablePrivChat
-            hasModMembers = false
+          } else {
+            hasModMembers = true
           }
         } else {
           chatLocked = permissions.disablePubChat

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageMsgHdlr.scala
@@ -29,6 +29,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
     val replyChatMessageDisabled: Boolean = liveMeeting.props.meetingProp.disabledFeatures.contains("replyChatMessage")
     var chatLocked: Boolean = false
     var chatLockedForUser: Boolean = false
+    var hasModMembers: Boolean = true
 
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
@@ -52,6 +53,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
           // don't lock private chats that involve a moderator
           if (modMembers.isEmpty) {
             chatLocked = permissions.disablePrivChat
+            hasModMembers = false
           }
         } else {
           chatLocked = permissions.disablePubChat
@@ -60,7 +62,7 @@ trait SendGroupChatMessageMsgHdlr extends HandlerHelpers {
     }
 
     if (!chatDisabled &&
-      !privateChatDisabled &&
+      !(privateChatDisabled && !hasModMembers) &&
       !(applyPermissionCheck && chatLocked) &&
       !chatLockedForUser) {
       val newState = for {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -16,7 +16,9 @@ import { ChatFormUiDataPayloads } from 'bigbluebutton-html-plugin-sdk/dist/cjs/u
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { defineMessages, useIntl } from 'react-intl';
-import { useIsChatEnabled, useIsEditChatMessageEnabled, useIsEmojiPickerEnabled } from '/imports/ui/services/features';
+import {
+  useIsEditChatMessageEnabled, useIsEmojiPickerEnabled,
+} from '/imports/ui/services/features';
 import { checkText } from 'smile2emoji';
 import { findDOMNode } from 'react-dom';
 
@@ -696,7 +698,6 @@ const ChatMessageFormContainer: React.FC = () => {
   const idChatOpen: string = layoutSelect((i: Layout) => i.idChatOpen);
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
   const isConnected = useReactiveVar(connectionStatus.getConnectedStatusVar());
-  const isChatEnabled = useIsChatEnabled();
   const { data: chat } = useChat((c: Partial<Chat>) => ({
     participant: c?.participant,
     chatId: c?.chatId,
@@ -772,7 +773,6 @@ const ChatMessageFormContainer: React.FC = () => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
 
   const disabled = locked && !isModerator && disablePrivateChat && !isPublicChat && !chat?.participant?.isModerator;
-  if (!isChatEnabled) return null;
 
   return (
     <ChatMessageForm

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/component.jsx
@@ -38,7 +38,6 @@ class UserContent extends PureComponent {
       currentUser,
       isTimerActive,
       compact,
-      isChatEnabled,
     } = this.props;
 
     const ROLE_MODERATOR = window.meetingClientSettings.public.user.role_moderator;
@@ -48,7 +47,7 @@ class UserContent extends PureComponent {
         {isMobile || (isMobile && isPortrait) ? (
           <Styled.ScrollableList role="tabpanel" tabIndex={0}>
             <Styled.List>
-              {isChatEnabled ? <ChatList /> : null}
+              <ChatList />
               <UserNotesContainer />
               {isTimerActive
               && <TimerContainer isModerator={currentUser?.role === ROLE_MODERATOR} />}
@@ -62,7 +61,7 @@ class UserContent extends PureComponent {
           </Styled.ScrollableList>
         ) : (
           <>
-            {isChatEnabled ? <ChatList /> : null}
+            <ChatList />
             <UserNotesContainer />
             {isTimerActive && <TimerContainer isModerator={currentUser?.role === ROLE_MODERATOR} />}
             {currentUser?.role === ROLE_MODERATOR ? <GuestPanelOpenerContainer /> : null}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/component.tsx
@@ -8,6 +8,7 @@ import { Chat } from '/imports/ui/Types/chat';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import deviceInfo from '/imports/utils/deviceInfo';
 import roveBuilder from '/imports/ui/core/utils/keyboardRove';
+import { useIsChatEnabled } from '/imports/ui/services/features';
 
 const { isMobile } = deviceInfo;
 
@@ -79,9 +80,13 @@ const ChatList: React.FC<ChatListProps> = ({ chats }) => {
 
 const ChatListContainer: React.FC = () => {
   const { data: chats } = useChat((chat) => chat) as GraphqlDataHookSubscriptionResponse<Chat[]>;
-  if (chats) {
+  const isChatEnabled = useIsChatEnabled();
+  const CHAT_CONFIG = window.meetingClientSettings.public.chat;
+  const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
+  const allowedChats = isChatEnabled ? chats : chats?.filter((c) => c.chatId !== PUBLIC_GROUP_CHAT_ID);
+  if (allowedChats && allowedChats.length) {
     return (
-      <ChatList chats={chats} />
+      <ChatList chats={allowedChats} />
     );
   } return <></>;
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -395,6 +395,7 @@ const UserActions: React.FC<UserActionsProps> = ({
         const moderatorOverride = currentUser.isModerator
           && allowedToChatPrivately;
         const regularUserCondition = (isPrivateChatEnabled
+          && isChatEnabled
           && !lockSettings?.disablePrivateChat
           && !isVoiceOnlyUser(user.userId)
           && !isBreakout)

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -26,7 +26,7 @@ import {
   isVoiceOnlyUser,
 } from './service';
 
-import { useIsChatEnabled } from '/imports/ui/services/features';
+import { useIsChatEnabled, useIsPrivateChatEnabled } from '/imports/ui/services/features';
 import { layoutDispatch } from '/imports/ui/components/layout/context';
 import { PANELS, ACTIONS } from '/imports/ui/components/layout/enums';
 
@@ -234,6 +234,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   );
   const voiceToggle = useToggleVoice();
   const isChatEnabled = useIsChatEnabled();
+  const isPrivateChatEnabled = useIsPrivateChatEnabled();
 
   const handleWhiteboardAccessChange = async () => {
     // There is no presentation available, so access cannot be granted.
@@ -393,14 +394,13 @@ const UserActions: React.FC<UserActionsProps> = ({
         const preventSelfChat = user.userId !== currentUser.userId;
         const moderatorOverride = currentUser.isModerator
           && allowedToChatPrivately;
-        const regularUserCondition = (isChatEnabled
+        const regularUserCondition = (isPrivateChatEnabled
           && !lockSettings?.disablePrivateChat
           && !isVoiceOnlyUser(user.userId)
           && !isBreakout)
           || user.isModerator;
 
-        const isAllowed = isChatEnabled
-          && preventSelfChat
+        const isAllowed = preventSelfChat
           && (moderatorOverride || regularUserCondition || !currentUser.locked);
 
         return isAllowed;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Fixes a bug where the "Start a private chat" user option is shown even though private chating is disabled through the `disabledFeatures` parameter.
- Fixes the condition for bypassing `disabledFeatures=privateChat` when the group chat involves a moderator.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23371

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

See the linked issue.
