### PR TITLE
fix: Whiteboard context menu shortcuts missing key modifiers in Safari

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -164,6 +164,10 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     right: 10px !important;
   }
 
+  .tlui-kbd > span {
+    font-family: 'Arial', sans-serif !important;
+  }
+
   [data-side="bottom"][data-align="end"][data-state="open"][role="dialog"] {
     right: 3.5rem !important;
     bottom: 9.5rem !important;


### PR DESCRIPTION
### What does this PR do?

Adjusts whiteboard context menu font-family to correctly display macOS modifier icons.

### Closes Issue(s)
Closes #23442

### How to test
1. Access the whiteboard with Safari on a Mac
2. Right-click to open the context menu