### PR TITLE
Assorted layout fixes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/presentationFocusLayout.jsx
@@ -56,6 +56,7 @@ const PresentationFocusLayout = (props) => {
   const prevDeviceType = usePrevious(deviceType);
   const isTabletLandscape = deviceType === DEVICE_TYPE.TABLET_LANDSCAPE;
   const { isPresentationEnabled, prevLayout } = props;
+  const isSidebarlessClient = getFromUserSettings('bbb_hide_sidebar_navigation', false);
 
   const throttledCalculatesLayout = throttle(() => calculatesLayout(),
     50, { trailing: true, leading: true });
@@ -241,9 +242,11 @@ const PresentationFocusLayout = (props) => {
       cameraDockBounds.minHeight = cameraDockMinHeight;
       cameraDockBounds.height = mediaAreaBounds.height - mediaBounds.height;
       cameraDockBounds.maxHeight = mediaAreaBounds.height - mediaBounds.height;
-    } else if (isTabletLandscape && presentationInput.isOpen) {
+    } else if ((isSidebarlessClient || isTabletLandscape) && presentationInput.isOpen) {
       // don't show camera dock if presentation is open in tablet landscape mode
       // the sidebar height gets too small, so only one or the other is shown
+      // Also, make camera dock and presentation mutually exclusive on
+      // sidebarless clients.
       cameraDockBounds.top = 0;
       cameraDockBounds.left = 0;
       cameraDockBounds.right = 0;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/videoFocusLayout.jsx
@@ -56,6 +56,7 @@ const VideoFocusLayout = (props) => {
   const prevDeviceType = usePrevious(deviceType);
   const isTabletLandscape = deviceType === DEVICE_TYPE.TABLET_LANDSCAPE;
   const { isPresentationEnabled } = props;
+  const isSidebarlessClient = getFromUserSettings('bbb_hide_sidebar_navigation', false);
 
   const throttledCalculatesLayout = throttle(() => calculatesLayout(), 50, {
     trailing: true,
@@ -244,9 +245,11 @@ const VideoFocusLayout = (props) => {
     cameraDockBounds.maxWidth = mediaAreaBounds.width;
     cameraDockBounds.zIndex = 1;
 
-    if (isTabletLandscape && presentationInput.isOpen) {
+    if ((isSidebarlessClient || isTabletLandscape) && presentationInput.isOpen) {
       // don't show camera dock if presentation is open in tablet landscape mode
       // the sidebar height gets too small, so only one or the other is shown
+      // Also, make camera dock and presentation mutually exclusive on
+      // sidebarless clients.
       cameraDockBounds.width = 0;
       cameraDockBounds.height = 0;
       cameraDockBounds.minWidth = 0;
@@ -290,8 +293,8 @@ const VideoFocusLayout = (props) => {
       mediaBounds.top = mediaAreaBounds.top + cameraDockBounds.height;
       mediaBounds.width = mediaAreaBounds.width;
     } else if (presentationInput.isOpen) {
-      // in tablet landscape, the presentation is shown in the media area
-      if (isTabletLandscape) {
+      // in tablet landscape or sidebarless client, the presentation is shown in the media area
+      if (isTabletLandscape || isSidebarlessClient) {
         mediaBounds.height = mediaAreaBounds.height;
         mediaBounds.width = mediaAreaBounds.width;
         mediaBounds.top = DEFAULT_VALUES.navBarHeight + bannerAreaHeight();

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -164,6 +164,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
         </>
       ) : renderHeaderOnMedia()}
       <PadContainer
+        isOnMediaArea={isOnMediaArea}
         externalId={NOTES_CONFIG.id}
         hasPermission={hasPermission}
         isResizing={isResizing}

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
@@ -26,6 +26,7 @@ interface PadContainerGraphqlProps {
   isResizing: boolean;
   isRTL: boolean;
   amIPresenter: boolean;
+  isOnMediaArea?: boolean;
 }
 
 interface PadGraphqlProps extends Omit<PadContainerGraphqlProps, 'hasPermission'> {
@@ -33,6 +34,7 @@ interface PadGraphqlProps extends Omit<PadContainerGraphqlProps, 'hasPermission'
   sessionIds: Array<string>;
   padId: string | undefined;
   amIPresenter: boolean;
+  isOnMediaArea: boolean;
 }
 
 const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
@@ -44,6 +46,7 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
     sessionIds,
     padId,
     amIPresenter,
+    isOnMediaArea,
   } = props;
   const [padURL, setPadURL] = useState<string | undefined>();
   const intl = useIntl();
@@ -57,7 +60,7 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
   }, [isRTL, hasSession, intl.locale]);
 
   if (!hasSession) {
-    return <PadContent externalId={externalId} />;
+    return <PadContent externalId={externalId} isOnMediaArea={isOnMediaArea} />;
   }
 
   return (
@@ -88,6 +91,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
     isRTL,
     isResizing,
     amIPresenter,
+    isOnMediaArea = false,
   } = props;
 
   const { data: hasPadData } = useDeduplicatedSubscription<HasPadSubscriptionResponse>(
@@ -120,6 +124,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
       sessionIds={Array.from(sessionIds)}
       padId={session?.sharedNotes?.padId}
       amIPresenter={amIPresenter}
+      isOnMediaArea={isOnMediaArea}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/component.tsx
@@ -40,7 +40,7 @@ const PadContent: React.FC<PadContentProps> = ({
   );
 };
 
-const PadContentContainer: React.FC<PadContentContainerProps> = ({ externalId, isOnMediaArea}) => {
+const PadContentContainer: React.FC<PadContentContainerProps> = ({ externalId, isOnMediaArea }) => {
   const [content, setContent] = useState('');
   const { data: contentDiffData } = useDeduplicatedSubscription<GetPadContentDiffStreamResponse>(
     GET_PAD_CONTENT_DIFF_STREAM,

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/component.tsx
@@ -6,14 +6,17 @@ import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedS
 
 interface PadContentProps {
   content: string;
+  isOnMediaArea: boolean;
 }
 
 interface PadContentContainerProps {
   externalId: string;
+  isOnMediaArea: boolean;
 }
 
 const PadContent: React.FC<PadContentProps> = ({
   content,
+  isOnMediaArea,
 }) => {
   const contentSplit = content.split('<body>');
   const contentStyle = `
@@ -31,12 +34,13 @@ const PadContent: React.FC<PadContentProps> = ({
         title="shared notes viewing mode"
         srcDoc={contentWithStyle}
         data-test="sharedNotesViewingMode"
+        isOnMediaArea={isOnMediaArea}
       />
     </Styled.Wrapper>
   );
 };
 
-const PadContentContainer: React.FC<PadContentContainerProps> = ({ externalId }) => {
+const PadContentContainer: React.FC<PadContentContainerProps> = ({ externalId, isOnMediaArea}) => {
   const [content, setContent] = useState('');
   const { data: contentDiffData } = useDeduplicatedSubscription<GetPadContentDiffStreamResponse>(
     GET_PAD_CONTENT_DIFF_STREAM,
@@ -54,7 +58,7 @@ const PadContentContainer: React.FC<PadContentContainerProps> = ({ externalId })
   }, [contentDiffData]);
 
   return (
-    <PadContent content={content} />
+    <PadContent content={content} isOnMediaArea={isOnMediaArea} />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/styles.ts
@@ -1,8 +1,10 @@
 import styled from 'styled-components';
 import {
-  colorGray,
+  colorGrayLight,
   colorBorder,
+  colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
+import { lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
 
 const Wrapper = styled.div`
   display: flex;
@@ -12,39 +14,41 @@ const Wrapper = styled.div`
 `;
 
 const contentText = `
-font-family: Verdana, Arial, Helvetica, sans-serif;
-font-size: 15px;
-color: ${colorGray};
-bottom: 0;
-box-sizing: border-box;
-display: block;
-overflow-x: hidden;
-overflow-wrap: break-word;
-overflow-y: auto;
-padding-top: 1rem;
-position: absolute;
-right: 0;
-left:0;
-top: 0;
-white-space: normal;
+  font-family: Verdana, Arial, Helvetica, sans-serif;
+  font-size: 15px;
+  background-color: ${colorWhite};
+  color: ${colorGrayLight};
+  bottom: 0;
+  box-sizing: border-box;
+  display: block;
+  overflow-x: hidden;
+  overflow-wrap: break-word;
+  overflow-y: auto;
+  padding-top: 1rem;
+  position: absolute;
+  right: 0;
+  left:0;
+  top: 0;
+  white-space: normal;
 
 
-[dir="ltr"] & {
-  padding-left: 1rem;
-  padding-right: .5rem;
-}
+  [dir="ltr"] & {
+    padding-left: 1rem;
+    padding-right: .5rem;
+  }
 
-[dir="rtl"] & {
-  padding-left: .5rem;
-  padding-right: 1rem;
-}
+  [dir="rtl"] & {
+    padding-left: .5rem;
+    padding-right: 1rem;
+  }
 `;
 
-const Iframe = styled.iframe`
+const Iframe = styled.iframe<{isOnMediaArea: boolean}>`
   border-width: 0;
   width: 100%;
   border-top: 1px solid ${colorBorder};
   border-bottom: 1px solid ${colorBorder};
+  border-radius: ${({ isOnMediaArea }) => (isOnMediaArea ? lgBorderRadius : `0 0 ${lgBorderRadius}`)};
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import Icon from '/imports/ui/components/common/icon/component';
 import NotesService from '/imports/ui/components/notes/service';
-import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import { PANELS } from '/imports/ui/components/layout/enums';
 import { notify } from '/imports/ui/services/notification';
 import { layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
@@ -55,7 +54,6 @@ const intlMessages = defineMessages({
 
 interface UserNotesGraphqlProps {
   isPinned: boolean,
-  disableNotes: boolean,
   sidebarContentPanel: string,
   layoutContextDispatch: DispatcherFunction,
   hasUnreadNotes: boolean,
@@ -65,15 +63,9 @@ interface UserNotesGraphqlProps {
   isEnabled: boolean,
 }
 
-interface UserNotesContainerGraphqlProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userLocks: any;
-}
-
 const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
   const {
     isPinned,
-    disableNotes,
     sidebarContentPanel,
     layoutContextDispatch,
     isEnabled,
@@ -116,11 +108,7 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
 
   const renderNotes = () => {
     let tooltipMessage = '';
-    if (disableNotes) {
-      tooltipMessage = `${intl.formatMessage(intlMessages.sharedNotes)}`
-        + ` ${intl.formatMessage(intlMessages.locked)}`
-        + ` ${intl.formatMessage(intlMessages.byModerator)}`;
-    } else if (isPinned) {
+    if (isPinned) {
       tooltipMessage = intl.formatMessage(intlMessages.sharedNotesPinned);
     } else {
       tooltipMessage = intl.formatMessage(intlMessages.sharedNotes);
@@ -139,7 +127,7 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
           tabIndex={0}
           active={notesOpen}
           data-test="sharedNotesSidebarButton"
-          onClick={() => (!(isPinned || disableNotes)
+          onClick={() => (!isPinned
             ? toggleNotesPanel(sidebarContentPanel, layoutContextDispatch)
             : null)}
           // @ts-ignore
@@ -149,7 +137,7 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
             }
           }}
           hasNotification={unread && !isPinned}
-          $disabled={isPinned || disableNotes}
+          $disabled={isPinned}
         >
           <Icon iconName="shared_notes" />
         </Styled.ListItem>
@@ -162,9 +150,7 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
   return renderNotes();
 };
 
-const UserNotesListItemContainerGraphql: React.FC<UserNotesContainerGraphqlProps> = (props) => {
-  const { userLocks } = props;
-  const disableNotes = userLocks.userNotes;
+const UserNotesListItemContainerGraphql: React.FC = () => {
   const { data: pinnedPadData } = useDeduplicatedSubscription(
     PINNED_PAD_SUBSCRIPTION,
   );
@@ -186,7 +172,6 @@ const UserNotesListItemContainerGraphql: React.FC<UserNotesContainerGraphqlProps
   const isPinned = !!pinnedPadData && pinnedPadData?.sharedNotes[0]?.sharedNotesExtId === NOTES_CONFIG.id;
   return (
     <UserNotesGraphql
-      disableNotes={disableNotes}
       isPinned={isPinned}
       layoutContextDispatch={layoutContextDispatch}
       sidebarContentPanel={sidebarContentPanel}
@@ -198,4 +183,4 @@ const UserNotesListItemContainerGraphql: React.FC<UserNotesContainerGraphqlProps
   );
 };
 
-export default lockContextContainer(UserNotesListItemContainerGraphql);
+export default UserNotesListItemContainerGraphql;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
@@ -8,6 +8,7 @@ import UserListParticipantsPageContainer from './page/component';
 import IntersectionWatcher from './intersection-watcher/intersectionWatcher';
 import { setLocalUserList } from '/imports/ui/core/hooks/useLoadedUserList';
 import roveBuilder from '/imports/ui/core/utils/keyboardRove';
+import { USERS_PER_USER_LIST_PAGE } from '/imports/ui/components/user-list/user-list-participants/constants';
 
 interface UserListParticipantsContainerProps {
   count: number;
@@ -77,7 +78,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   }, []);
   // --- End of plugin related code ---
 
-  const amountOfPages = Math.ceil(count / 50);
+  const amountOfPages = Math.ceil(count / USERS_PER_USER_LIST_PAGE);
   return (
     (
       <Styled.UserListColumn
@@ -90,7 +91,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
           {
             Array.from({ length: amountOfPages }).map((_, i) => {
               const isLastItem = amountOfPages === (i + 1);
-              const restOfUsers = count % 50;
+              const restOfUsers = count % USERS_PER_USER_LIST_PAGE;
               const key = i;
               return i === 0
                 ? (
@@ -98,7 +99,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                     key={key}
                     index={i}
                     isLastItem={isLastItem}
-                    restOfUsers={isLastItem ? restOfUsers : 50}
+                    restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
                     setVisibleUsers={setVisibleUsers}
                   />
                 )
@@ -108,13 +109,13 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                     key={i}
                     ParentRef={userListRef}
                     isLastItem={isLastItem}
-                    restOfUsers={isLastItem ? restOfUsers : 50}
+                    restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
                   >
                     <UserListParticipantsPageContainer
                       key={key}
                       index={i}
                       isLastItem={isLastItem}
-                      restOfUsers={isLastItem ? restOfUsers : 50}
+                      restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
                       setVisibleUsers={setVisibleUsers}
                     />
                   </IntersectionWatcher>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/constants.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/constants.ts
@@ -1,0 +1,3 @@
+export const USERS_PER_USER_LIST_PAGE = 50;
+
+export default USERS_PER_USER_LIST_PAGE;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/intersection-watcher/intersectionWatcher.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/intersection-watcher/intersectionWatcher.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import useIntersectionObserver from '/imports/ui/hooks/useIntersectionObserver';
 import SkeletonUserListItem from '../list-item/skeleton/component';
+import USERS_PER_USER_LIST_PAGE from '/imports/ui/components/user-list/user-list-participants/constants';
 
 const MOUNT_DELAY = 1000;
 
@@ -48,13 +49,16 @@ const IntersectionWatcher: React.FC<IntersectionWatcherProps> = ({
     }
   }, [intersecting]);
 
+  if (renderPage) {
+    return children;
+  }
+
   return (
     <div ref={childRefProxy}>
       {
-        renderPage ? children
-          : Array.from({ length: isLastItem ? restOfUsers : 50 }).map((_, index) => (
-            <SkeletonUserListItem key={`not-visible-item-${index + 1}`} enableAnimation={intersecting} />
-          ))
+        Array.from({ length: isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE }).map((_, index) => (
+          <SkeletonUserListItem key={`not-visible-item-${index + 1}`} enableAnimation={intersecting} />
+        ))
       }
     </div>
   );

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
@@ -14,6 +14,7 @@ import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import SkeletonUserListItem from '../list-item/skeleton/component';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
+import USERS_PER_USER_LIST_PAGE from '../constants';
 
 interface UserListParticipantsContainerProps {
   index: number;
@@ -79,8 +80,8 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   restOfUsers,
   setVisibleUsers,
 }) => {
-  const offset = index * 50;
-  const limit = useRef(50);
+  const offset = index * USERS_PER_USER_LIST_PAGE;
+  const limit = useRef(USERS_PER_USER_LIST_PAGE);
 
   const {
     data: meetingData,
@@ -147,7 +148,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   }, []);
 
   if (usersLoading || meetingLoading || currentUserLoading || presentationLoading) {
-    return Array.from({ length: isLastItem ? restOfUsers : 50 }).map((_, i) => (
+    return Array.from({ length: isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE }).map((_, i) => (
       <Styled.UserListItem key={`not-visible-item-${i + 1}`}>
         {/* eslint-disable-next-line */}
         <SkeletonUserListItem enableAnimation={true} />


### PR DESCRIPTION
### What does this PR do?
- [fix(layout): adjust presentation and video handling for sidebarless clients](https://github.com/bigbluebutton/bigbluebutton/commit/3aa0ea5d91e133f165f57bbac02384d62a39bfff) 
  This commit introduces specific handling for clients without a sidebar (i.e., those with 'userdata-bbb_hide_sidebar_navigation=true'), which do not accommodate layouts where presentation and camera dock are placed at the bottom of the sidebar content(presentation focus and video focus).
  To address this, the layout now mimics the behavior used on landscape tablets: the presentation and the camera dock are mutually exclusive and share the same space in the media area. When the presentation is hidden, the camera dock is shown in its place.

- [fix(shared-notes): improve readability and visual cues in read-only mode](https://github.com/bigbluebutton/bigbluebutton/commit/ff1359720fed1927220562c6d26229a977912127) 
  This commit addresses low contrast issues in the shared notes panel when in read-only mode, especially under the dark theme. It enforces a white background to ensure readability. Additionally, it introduces rounded borders and updates the text color to a lighter green to better communicate the read-only state visually.

- [fix(shared-notes): allow attendees to open panel when editing is disabled](https://github.com/bigbluebutton/bigbluebutton/commit/6dc997514dd97df52a027e18fa62462ce499113e) 
  Attendees can now open the shared notes panel even when the "Edit shared notes" lock setting is disabled. In this case, the panel is displayed in read-only mode.
- [fix(user-list): uneven spacing on paginated user list](https://github.com/bigbluebutton/bigbluebutton/commit/4cd2ac83d10578b5d4cd9539bacf4fb9f00ba2db) 
  Fixes an issue where users were not evenly spaced on user list pages beyond the first one (i.e., when the meeting has more than 50 users). The problem was caused by an extra `<div>` leftover from the skeleton loading state, which was not removed after the page was fully loaded.

### Closes Issue(s)
Closes #23261 
Closes #23445 
Closes #23446 

