### PR TITLE
[3.0] fix(audio-captions): transcription stops after a long period of silence 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -35,6 +35,11 @@ const THROTTLE_TIMEOUT = 200;
 type SpeechRecognitionEvent = {
   resultIndex: number;
   results: SpeechRecognitionResult[];
+  target: Target;
+}
+
+type Target = {
+  lang: string;
 }
 
 type SpeechRecognitionErrorEvent = {
@@ -59,6 +64,7 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
     id: generateId(),
     transcript: '',
     isFinal: true,
+    lang: '',
   });
 
   const localeRef = useRef(locale);
@@ -200,23 +206,26 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
     const {
       resultIndex,
       results,
+      target,
     } = event;
 
-    logger.debug('Transcription event', event);
+    logger.debug('Transcription event', resultIndex, results, target);
 
     const { id } = resultRef.current;
 
     const { transcript } = results[resultIndex][0];
     const { isFinal } = results[resultIndex];
+    const { lang } = target;
 
     resultRef.current.transcript = transcript;
     resultRef.current.isFinal = isFinal;
+    resultRef.current.lang = lang;
 
     if (isFinal) {
-      updateFinalTranscript(id, transcript, speechRecognitionRef.current.lang);
+      updateFinalTranscript(id, transcript, lang);
       resultRef.current.id = generateId();
     } else {
-      transcriptUpdate(id, transcript, speechRecognitionRef.current.lang, false);
+      transcriptUpdate(id, transcript, lang, false);
     }
   }, [localeRef]);
 
@@ -230,11 +239,12 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
       const {
         isFinal,
         transcript,
+        lang,
       } = resultRef.current;
 
       if (!isFinal) {
         const { id } = resultRef.current;
-        updateFinalTranscript(id, transcript, localeRef.current);
+        updateFinalTranscript(id, transcript, lang);
         resultRef.current.isFinal = true;
         speechRecognitionRef.current.abort();
       } else {


### PR DESCRIPTION
This is a backport of: https://github.com/bigbluebutton/bigbluebutton/pull/23423

### What does this PR do?
When user is unmuted and there is not mic activity, the automatic transcriptions simply stops working for that user until he/she toggles mic. This commit fixes this issue by automatically restarting the speech recognition when the browser automatically stops and also by adding a mechanism to prevent the speech recognition from being started more than once a second. Approach inspired in: https://github.com/TalAter/annyang/blob/46d3f1c212d43cae147e633ff9c52b36605c5728/src/annyang.js#L606-L629

Additionally fixes another issue where changing the transcription language during speech would cause it to stop working.

Also prevents undefined locales by using the lang of the speech recognition event.

Closes Issue(s)
https://github.com/bigbluebutton/bigbluebutton/commit/dc633898d5cc8cdb6f8830720c39021223306f17 Should fix this one https://github.com/bigbluebutton/bigbluebutton/issues/19178


