### PR TITLE
fix(akka): Add optional around eventPersistence.rateLimiting and eventPersistence.maximumPayloadSize

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -18,8 +18,8 @@ case class RateLimiting(
 
 case class EventPersistence(
     isEnabled:                 Boolean,
-    maximumPayloadSizeInBytes: Int,
-    rateLimiting:              RateLimiting
+    maximumPayloadSizeInBytes: Option[Int],
+    rateLimiting:              Option[RateLimiting]
 )
 
 case class DataChannel(


### PR DESCRIPTION
### What does this PR do?

Add optional around eventPersistence.rateLimiting and eventPersistence.maximumPayloadSize since those are not implemented yet. (Removing it is not ideal, because it could break certain plugins as previously those 2 properties were mandatory in eventPersistence).

### More

This PR is in line with https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/195