### PR TITLE
feat(common-web): Add Main version replacements for placeholders in plugin manifest URLs

### DIFF
--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -21,6 +21,8 @@ object Dependencies {
     val apacheHttp = "4.5.13"
     val apacheHttpAsync = "4.1.4"
     val jsoup = "1.14.3"
+    val semver = "0.10.2"
+
 
     // Office and document conversion
     val apachePoi = "5.1.0"
@@ -57,6 +59,7 @@ object Dependencies {
     val apacheHttp = "org.apache.httpcomponents" % "httpclient" % Versions.apacheHttp
     val apacheHttpAsync = "org.apache.httpcomponents" % "httpasyncclient" % Versions.apacheHttpAsync
     val jsoup = "org.jsoup" % "jsoup" % Versions.jsoup
+    val semver = "com.github.zafarkhaja" % "java-semver" % Versions.semver
 
     val poiXml = "org.apache.poi" % "poi-ooxml" % Versions.apachePoi
     val nuProcess = "com.zaxxer" % "nuprocess" % Versions.nuProcess
@@ -97,6 +100,7 @@ object Dependencies {
     Compile.apacheHttp,
     Compile.apacheHttpAsync,
     Compile.jsoup,
+    Compile.semver,
     Compile.poiXml,
     Compile.nuProcess,
     Compile.tika,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -6,6 +6,7 @@ import org.bigbluebutton.api.ParamsProcessorUtil;
 import org.bigbluebutton.api.domain.PluginManifest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.github.zafarkhaja.semver.Version;
 
 import java.lang.reflect.MalformedParametersException;
 import java.util.Map;
@@ -15,7 +16,9 @@ import java.util.regex.Pattern;
 public class PluginUtils {
     private static Logger log = LoggerFactory.getLogger(PluginUtils.class);
     private static final String HTML5_PLUGIN_SDK_VERSION = "%%HTML5_PLUGIN_SDK_VERSION%%";
+    private static final String HTML5_PLUGIN_SDK_MAJOR_VERSION = "%%HTML5_PLUGIN_SDK_MAJOR_VERSION%%";
     private static final String BBB_VERSION = "%%BBB_VERSION%%";
+    private static final String BBB_MAJOR_VERSION = "%%BBB_MAJOR_VERSION%%";
     private static final String MEETING_ID = "%%MEETING_ID%%";
     private static final Pattern METADATA_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([\\w-]+)(?::([^}]*))?\\}");
     private static String bbbVersion;
@@ -23,7 +26,11 @@ public class PluginUtils {
 
     public String replaceAllPlaceholdersInManifestUrls(String url, String meetingId) {
         return url.replace(HTML5_PLUGIN_SDK_VERSION, html5PluginSdkVersion)
+                .replace(HTML5_PLUGIN_SDK_MAJOR_VERSION,
+                        String.valueOf(Version.parse(html5PluginSdkVersion).majorVersion()))
                 .replace(BBB_VERSION, bbbVersion)
+                .replace(BBB_MAJOR_VERSION,
+                        String.valueOf(Version.parse(bbbVersion).majorVersion()))
                 .replace(MEETING_ID, meetingId);
     }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -16,21 +16,24 @@ import java.util.regex.Pattern;
 public class PluginUtils {
     private static Logger log = LoggerFactory.getLogger(PluginUtils.class);
     private static final String HTML5_PLUGIN_SDK_VERSION = "%%HTML5_PLUGIN_SDK_VERSION%%";
-    private static final String HTML5_PLUGIN_SDK_MAJOR_VERSION = "%%HTML5_PLUGIN_SDK_MAJOR_VERSION%%";
+    private static final String HTML5_PLUGIN_SDK_MAIN_VERSION = "%%HTML5_PLUGIN_SDK_MAIN_VERSION%%";
     private static final String BBB_VERSION = "%%BBB_VERSION%%";
-    private static final String BBB_MAJOR_VERSION = "%%BBB_MAJOR_VERSION%%";
+    private static final String BBB_MAIN_VERSION = "%%BBB_MAIN_VERSION%%";
     private static final String MEETING_ID = "%%MEETING_ID%%";
     private static final Pattern METADATA_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([\\w-]+)(?::([^}]*))?\\}");
     private static String bbbVersion;
     private String html5PluginSdkVersion;
 
+    private String getMainVersion(String version) {
+        Version parsedVersion = Version.parse(version);
+        return parsedVersion.majorVersion() + "." + parsedVersion.minorVersion();
+    }
+
     public String replaceAllPlaceholdersInManifestUrls(String url, String meetingId) {
         return url.replace(HTML5_PLUGIN_SDK_VERSION, html5PluginSdkVersion)
-                .replace(HTML5_PLUGIN_SDK_MAJOR_VERSION,
-                        String.valueOf(Version.parse(html5PluginSdkVersion).majorVersion()))
+                .replace(HTML5_PLUGIN_SDK_MAIN_VERSION, getMainVersion(html5PluginSdkVersion))
                 .replace(BBB_VERSION, bbbVersion)
-                .replace(BBB_MAJOR_VERSION,
-                        String.valueOf(Version.parse(bbbVersion).majorVersion()))
+                .replace(BBB_MAIN_VERSION, getMainVersion(bbbVersion))
                 .replace(MEETING_ID, meetingId);
     }
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -132,9 +132,9 @@ All plugin sources are combined into a single list with duplicates removed. This
 You can use placeholders in the plugin URLs defined in any of the previously mentioned configurations. Currently, the only supported placeholder is:
 
 - `%%HTML5_PLUGIN_SDK_VERSION%%` – This will be automatically replaced by the version of the `bigbluebutton-html-plugin-sdk` used by `bigbluebutton-html5`.
-- `%%HTML5_PLUGIN_SDK_MAJOR_VERSION%%` – This will be automatically replaced by the Major version of the `bigbluebutton-html-plugin-sdk` used by `bigbluebutton-html5`.
+- `%%HTML5_PLUGIN_SDK_MAIN_VERSION%%` – This will be automatically replaced by the Main version of the `bigbluebutton-html-plugin-sdk` - Composed by Major + Minor (e.g.: `0.0` for `0.0.84`) - used by `bigbluebutton-html5`.
 - `%%BBB_VERSION%%` – This will be automatically replaced by the complete BigBlueButton server version (e.g.: `3.0.6`) from which the URL is called.
-- `%%BBB_MAJOR_VERSION%%` – This will be automatically replaced by the complete BigBlueButton server Major version (e.g.: `3` for `3.0.6`) from which the URL is called.
+- `%%BBB_MAIN_VERSION%%` – This will be automatically replaced by the current BigBlueButton server Main version - Composed by Major + Minor (e.g.: `3.0` for `3.0.6`) from which the URL is called.
 - `%%MEETING_ID%%` – This will be automatically replaced by the external meeting ID.
 
 This is useful for referencing versioned plugin files without hardcoding the SDK version.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -132,7 +132,9 @@ All plugin sources are combined into a single list with duplicates removed. This
 You can use placeholders in the plugin URLs defined in any of the previously mentioned configurations. Currently, the only supported placeholder is:
 
 - `%%HTML5_PLUGIN_SDK_VERSION%%` – This will be automatically replaced by the version of the `bigbluebutton-html-plugin-sdk` used by `bigbluebutton-html5`.
+- `%%HTML5_PLUGIN_SDK_MAJOR_VERSION%%` – This will be automatically replaced by the Major version of the `bigbluebutton-html-plugin-sdk` used by `bigbluebutton-html5`.
 - `%%BBB_VERSION%%` – This will be automatically replaced by the complete BigBlueButton server version (e.g.: `3.0.6`) from which the URL is called.
+- `%%BBB_MAJOR_VERSION%%` – This will be automatically replaced by the complete BigBlueButton server Major version (e.g.: `3` for `3.0.6`) from which the URL is called.
 - `%%MEETING_ID%%` – This will be automatically replaced by the external meeting ID.
 
 This is useful for referencing versioned plugin files without hardcoding the SDK version.


### PR DESCRIPTION
### What does this PR do?

It adds new placeholders for the plugin-manifests URLs:
- `%%BBB_MAIN_VERSION%%`;
- `%%HTML5_PLUGIN_SDK_MAIN_VERSION%%`;

### Motivation

Referring to main versions - Formed by Major + Minor - is sometimes needed, because the plugin doesn't need to change that often.

### How to test

To test, just send the following plugin Manifests which should both fetch the pick-random-user into the meeting:

Replacing by BBB main version
```
pluginManifests=[{"url":"https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/bbb-versioned-plugins/%%BBB_MAIN_VERSION%%/pick-random-user/manifest.json"}]
```

Replacing by html5-plugin-sdk main version
```
pluginManifests=[{"url":"https://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/sdk-versioned-plugins/%%HTML5_PLUGIN_SDK_MAIN_VERSION%%/pick-random-user/manifest.json"}]
```

For those placeholders, as one could guess, we currently have:
- HTML5_PLUGIN_SDK_MAIN_VERSION = 0.0 (from 0.0.84);
- BBB_MAIN_VERSION = 3.0 (from 3.0.9, for instance);

