### PR TITLE
fix: typingIndicator.showNames: false does not work

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
@@ -27,6 +27,7 @@ const DEBUG_CONSOLE = false;
 interface TypingIndicatorProps {
   typingUsers: Array<User>,
   intl: IntlShape,
+  showNames: boolean,
 }
 
 const messages = defineMessages({
@@ -34,68 +35,96 @@ const messages = defineMessages({
     id: 'app.chat.multi.typing',
     description: 'displayed when 4 or more users are typing',
   },
+  someoneTyping: {
+    id: 'app.chat.someone.typing',
+    description: 'label used when one user is typing with disabled name',
+  },
 });
 
 const TypingIndicator: React.FC<TypingIndicatorProps> = ({
   typingUsers,
   intl,
+  showNames,
 }) => {
   const { length } = typingUsers;
-  const isSingleTyper = length === 1;
-  const isCoupleTyper = length === 2;
-  const isMultiTypers = length > 2;
 
   let element = null;
 
-  if (isSingleTyper) {
-    const name = typingUsers[0]?.name;
+  if (showNames) {
+    const isSingleTyper = length === 1;
+    const isCoupleTyper = length === 2;
+    const isMultiTypers = length > 2;
 
-    element = (
-      <FormattedMessage
-        id="app.chat.one.typing"
-        description="label used when one user is typing"
-        values={{
-          userName:
-  <Styled.SingleTyper>
-    {`${name}`}
-    &nbsp;
-  </Styled.SingleTyper>,
-        }}
-      />
-    );
-  }
+    if (isSingleTyper) {
+      const name = typingUsers[0]?.name;
 
-  if (isCoupleTyper) {
-    const name = typingUsers[0]?.name;
-    const name2 = typingUsers[1]?.name;
+      element = (
+        <FormattedMessage
+          id="app.chat.one.typing"
+          description="label used when one user is typing"
+          values={{
+            userName:
+              <Styled.SingleTyper>
+                {`${name}`}
+                &nbsp;
+              </Styled.SingleTyper>,
+          }}
+        />
+      );
+    }
 
-    element = (
-      <FormattedMessage
-        id="app.chat.two.typing"
-        description="label used when two users are typing"
-        values={{
-          userName1:
-  <Styled.CoupleTyper>
-    {`${name}`}
-    &nbsp;
-  </Styled.CoupleTyper>,
-          userName2:
-  <Styled.CoupleTyper>
-    &nbsp;
-    {`${name2}`}
-    &nbsp;
-  </Styled.CoupleTyper>,
-        }}
-      />
-    );
-  }
+    if (isCoupleTyper) {
+      const name = typingUsers[0]?.name;
+      const name2 = typingUsers[1]?.name;
 
-  if (isMultiTypers) {
-    element = (
-      <span>
-        {`${intl.formatMessage(messages.severalPeople)}`}
-      </span>
-    );
+      element = (
+        <FormattedMessage
+          id="app.chat.two.typing"
+          description="label used when two users are typing"
+          values={{
+            userName1:
+              <Styled.CoupleTyper>
+                {`${name}`}
+                &nbsp;
+              </Styled.CoupleTyper>,
+            userName2:
+              <Styled.CoupleTyper>
+                &nbsp;
+                {`${name2}`}
+                &nbsp;
+              </Styled.CoupleTyper>,
+          }}
+        />
+      );
+    }
+
+    if (isMultiTypers) {
+      element = (
+        <span>
+          {`${intl.formatMessage(messages.severalPeople)}`}
+        </span>
+      );
+    }
+  } else {
+    // Show no names in typing indicator
+    const isSingleTyper = length === 1;
+    const isMultiTypers = length > 1;
+
+    if (isSingleTyper) {
+      element = (
+        <span>
+          {`${intl.formatMessage(messages.someoneTyping)}`}
+        </span>
+      );
+    }
+
+    if (isMultiTypers) {
+      element = (
+        <span>
+          {`${intl.formatMessage(messages.severalPeople)}`}
+        </span>
+      );
+    }
   }
 
   return (
@@ -150,6 +179,7 @@ const TypingIndicatorContainer: React.FC = () => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_KEY = CHAT_CONFIG.public_group_id;
   const TYPING_INDICATOR_ENABLED = CHAT_CONFIG.typingIndicator.enabled;
+  const TYPING_SHOW_NAMES = CHAT_CONFIG.typingIndicator.showNames;
 
   // eslint-disable-next-line no-unused-expressions, no-console
   DEBUG_CONSOLE && console.log('TypingIndicatorContainer:chat', chat);
@@ -195,6 +225,7 @@ const TypingIndicatorContainer: React.FC = () => {
     <TypingIndicator
       typingUsers={typingUsersArray}
       intl={intl}
+      showNames={TYPING_SHOW_NAMES}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
@@ -63,11 +63,12 @@ const TypingIndicator: React.FC<TypingIndicatorProps> = ({
           id="app.chat.one.typing"
           description="label used when one user is typing"
           values={{
-            userName:
+            userName: (
               <Styled.SingleTyper>
                 {`${name}`}
                 &nbsp;
-              </Styled.SingleTyper>,
+              </Styled.SingleTyper>
+            ),
           }}
         />
       );
@@ -82,17 +83,19 @@ const TypingIndicator: React.FC<TypingIndicatorProps> = ({
           id="app.chat.two.typing"
           description="label used when two users are typing"
           values={{
-            userName1:
+            userName1: (
               <Styled.CoupleTyper>
                 {`${name}`}
                 &nbsp;
-              </Styled.CoupleTyper>,
-            userName2:
+              </Styled.CoupleTyper>
+            ),
+            userName2: (
               <Styled.CoupleTyper>
                 &nbsp;
                 {`${name2}`}
                 &nbsp;
-              </Styled.CoupleTyper>,
+              </Styled.CoupleTyper>
+            ),
           }}
         />
       );


### PR DESCRIPTION
### What does this PR do?

Reimplement typing indicator show names setting for 3.0

### Closes Issue(s)
Closes #23455

### How to test
1. set public.chat.typingIndicator.showNames: false
2. join a meeting with 2 users
3. start typing with user 1
4. check typing indicator for user 2
