### PR TITLE
fix: Update custom poll shortcut to prevent mac conflict with print dialog

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -231,10 +231,14 @@ class App extends Component {
 
   customPollShortcutHandler(e) {
     const {
-      altKey, ctrlKey, metaKey, keyCode,
+      altKey, ctrlKey, shiftKey, keyCode,
     } = e;
     const { layoutContextDispatch } = this.props;
-    const isPollShortcut = altKey && keyCode === KEY_CODES.P && (ctrlKey || metaKey);
+
+    const isPollShortcut =
+      ctrlKey &&
+      altKey &&
+      keyCode === KEY_CODES.P;
 
     if (isPollShortcut) {
       if (Session.equals('pollInitiated', true)) {
@@ -254,6 +258,7 @@ class App extends Component {
       Session.setItem('customPollShortcut', true);
     }
   }
+
 
   logJoin() {
     const { isJoinLogged } = this.state;

--- a/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/shortcut-help/component.jsx
@@ -343,7 +343,7 @@ const ShortcutHelpComponent = ({
   generalShortcutItems.splice(3, 0, ptt);
   generalShortcutItems.push( renderItem(
     `${intl.formatMessage(intlMessages.openCustomPoll)}`,
-    isMacos ? `Cmd + Opt + P` : `Ctrl + Alt + P`
+    isMacos ? `Ctrl + Opt + P` : `Ctrl + Alt + P`
   ));
 
   const shortcutItems = [];


### PR DESCRIPTION
### What does this PR do?
Updates the custom poll keyboard shortcut to avoid triggering the print dialog on macOS by adding an additional modifier key.

### Closes Issue(s)
Closes #23436 
