### PR TITLE
build: Fix umask issues for systems which run 0077 instead of 0022

### DIFF
--- a/bigbluebutton-web/run-in-systemd.sh
+++ b/bigbluebutton-web/run-in-systemd.sh
@@ -34,6 +34,7 @@ systemd-run --user --pipe --wait --quiet --same-dir                   \
   --property=MemoryHigh="${BBB_PRESENTATION_CONVERSION_MEMORY_HIGH}"  \
   --property=MemoryMax="${BBB_PRESENTATION_CONVERSION_MEMORY_MAX}"    \
   --property=MemorySwapMax=0                                          \
+  --property=UMask=0022                                               \
   "$@"
 
 exit $?   # propagate the child’s exit status

--- a/build/packages-template/bbb-playback-presentation/build.sh
+++ b/build/packages-template/bbb-playback-presentation/build.sh
@@ -23,6 +23,8 @@ done
 
 mkdir -p staging/usr/local/bigbluebutton/core
 cp -r scripts staging/usr/local/bigbluebutton/core
+chmod -R a+rX staging/usr/local/bigbluebutton/core
+chmod 755 staging/usr/local/bigbluebutton/core/scripts/*/*.rb
 
 mkdir -p staging/var/bigbluebutton
 cp -r playback staging/var/bigbluebutton

--- a/build/packages-template/bbb-playback-video/build.sh
+++ b/build/packages-template/bbb-playback-video/build.sh
@@ -24,6 +24,8 @@ done
 mkdir -p staging/usr/local/bigbluebutton/core
 cp -r scripts staging/usr/local/bigbluebutton/core
 cp -r playback staging/usr/local/bigbluebutton/core
+chmod -R a+rX staging/usr/local/bigbluebutton/core
+chmod 755 staging/usr/local/bigbluebutton/core/scripts/*/*.rb
 
 mkdir -p staging/usr/share/bigbluebutton/nginx
 mv staging/usr/local/bigbluebutton/core/scripts/playback-video.nginx staging/usr/share/bigbluebutton/nginx

--- a/build/packages-template/bbb-web/build.sh
+++ b/build/packages-template/bbb-web/build.sh
@@ -97,6 +97,7 @@ cp loadbalancer.nginx "$STAGING"/usr/share/bigbluebutton/nginx/loadbalancer.ngin
 
 # Copy script to run commands through `system-run --user`
 cp run-in-systemd.sh "$STAGING"/usr/share/bbb-web
+chmod 755 "$STAGING"/usr/share/bbb-web
 
 mkdir -p "$STAGING"/var/log/bigbluebutton
 # Copy directive for serving SVG files (HTML5) from nginx


### PR DESCRIPTION
### What does this PR do?

Fix issues with umask on systems which are setup with `umask 0077`.  The build scripts produce broken packages if the packages are created on systems with a `0077` umask.

`run-in-systemd.sh` needs umask `0022` because it produces files in presentation conversion which should be delivered by nginx. Without the umask the files are created with `0660` permissions if the system has `umask 0077` set.

### Motivation

`umask 0077` hardens the system. We use that in our environment.

### More

similar fixes on other places:  #22085 #21366 #21362 #20498 #20347