### PR TITLE
fix(livekit): block audio subscription if playback is blocked, autoplay handling is not always triggered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/autoplay-modal/component.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
 import AudioAutoplayPrompt from '/imports/ui/components/audio/autoplay/component';
+import type { AutoplayHandler } from './hooks';
 
 const intlMessages = defineMessages({
   title: {
@@ -11,7 +12,7 @@ const intlMessages = defineMessages({
 });
 
 interface LKAutoplayModalProps {
-  autoplayHandler: () => Promise<void>;
+  autoplayHandler: AutoplayHandler;
   isOpen: boolean;
   onRequestClose: () => void;
   priority: string;

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -25,6 +25,7 @@ import {
 } from '/imports/ui/components/livekit/selective-subscription/types';
 import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
 import AudioManager from '/imports/ui/services/audio-manager';
+import { useAutoplayState } from '/imports/ui/components/livekit/autoplay-modal/hooks';
 
 const useAudioGroupStreamsSubscription = createUseSubscription(
   AUDIO_GROUP_STREAMS_SUBSCRIPTION,
@@ -114,9 +115,11 @@ interface RetryState {
 }
 
 export const useAudioSubscriptions = () => {
+  const [autoplayState] = useAutoplayState(liveKitRoom);
   /* eslint no-underscore-dangle: 0 */
   // @ts-ignore
-  const deafened = useReactiveVar(AudioManager._isDeafened.value) as boolean;
+  const willinglyDeafened = useReactiveVar(AudioManager._isDeafened.value) as boolean;
+  const deafened = willinglyDeafened || !autoplayState.canPlayAudio;
   const remoteParticipants = useRemoteParticipants({
     updateOnlyOn: PARTICIPANTS_UPDATE_FILTER,
   });


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): block audio subscription if playback is blocked](fb44531e4c02c94f3879722b01325e465bbc34d0) 
  - Audio subscriptions made prior to the autoplay routine being run are
_not_ played afterwards, which causes early subscriptions to be
"muted" even when autoplay is properly handled.
  - Block audio subscriptions in selective subscription logic when audio
playback is not possible. The internal behavior is the same as the
deafened (i.e. leave audio) state.
- [fix(livekit): playback status going true->false doesn't trigger autop…](cee495dfd35dc201bdc3074fb762167073a90543) 
  - There are some scenarios where playback state might unexpectedly
transition from true (allowed) to false (blocked). This might have to do
with the SDK's optimistic view on playback status. Whenever that happens
and an attempt has already run, the autoplay prompt will not pop up
to users and may cause subsequent audio subscriptions to fail (i.e.
muted).
  - Guarantee the autoplay prompt will be triggered via:
    - Make the indirect autoplay handling call (no user interaction) not
    count as an attempt. This is an internal try that frequently
    fails and blocks further attempts if flagged.
    - Reset the attempted state to false if playback transitioned from
    true to false


### Closes Issue(s)

None