### PR TITLE
Fix(html5): Audio output change causing user to not hear other users

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -27,7 +27,7 @@ const reloadAudioElement = (audioElement) => {
     if (audioElement.paused) {
       audioElement.play().catch((error) => {
         logger.error({
-          logCode: 'audio_element_play_error',
+          logCode: 'audio_reload_element_play_error',
           extraInfo: {
             errorName: error.name,
             errorMessage: error.message,

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -25,7 +25,15 @@ const reloadAudioElement = (audioElement) => {
   if (audioElement && (audioElement.readyState > 0)) {
     audioElement.load();
     if (audioElement.paused) {
-      audioElement.play();
+      audioElement.play().catch((error) => {
+        logger.error({
+          logCode: 'audio_element_play_error',
+          extraInfo: {
+            errorName: error.name,
+            errorMessage: error.message,
+          },
+        }, 'Error playing audio element after reload');
+      });
     }
     return true;
   }

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -24,6 +24,9 @@ const getCurrentAudioSessionNumber = () => sessionStorage.getItem(AUDIO_SESSION_
 const reloadAudioElement = (audioElement) => {
   if (audioElement && (audioElement.readyState > 0)) {
     audioElement.load();
+    if (audioElement.paused) {
+      audioElement.play();
+    }
     return true;
   }
 


### PR DESCRIPTION
### What does this PR do?
The issue was being caused by the audio.load that was being called after changing the output, but it quoting the mdn page `load() will reset the element and rescan the available sources` ([source](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/load)), it was changing the state of the element to paused, calling a `play()` after the load solved the issue.


### Closes Issue(s)
Closes #23052

### How to test
(It requires more than a output device, one bluetooth headphone and one cable headphone or anythig available)
- Join user U1 and U2
- Join audio with both 
- unmute user U2
- Change audio output on user U1 
- Talk on U2
