### PR TITLE
Validate endpoints and env variables before running all tests

### DIFF
--- a/bigbluebutton-tests/playwright/fixtures.js
+++ b/bigbluebutton-tests/playwright/fixtures.js
@@ -1,10 +1,48 @@
 const base = require('@playwright/test');
 const { fullyParallel } = require('./playwright.config');
+const parameters = require('./core/parameters');
+const helpers = require('./core/helpers');
 
 exports.test = base.test.extend({
-  sharedEachTestHook: [ async ({ browser }, use) => {
+  sharedEachTestHook: [async ({ browser, request }, use) => {
     // before test
+    
+    const BBB_URL_PATTERN = /^https:\/\/[^/]+\/bigbluebutton\/(?:api\/)?$/;
+    if (!parameters.secret) throw new Error('BBB_SECRET environment variable is not set');
+    if (!parameters.server) throw new Error('BBB_URL environment variable is not set');
+    if (!BBB_URL_PATTERN.test(parameters.server)) throw new Error('BBB_URL must follow the pattern "https://DOMAIN_NAME/bigbluebutton/"');
+
+    try {
+      // Test the /create endpoint with a temporary meeting
+      const testMeetingId = `validation-test-${Date.now()}`;
+      const createUrl = helpers.createMeetingUrl(parameters, undefined, testMeetingId);
+      const createResponse = await request.get(createUrl);
+
+      if (!createResponse.ok()) {
+        const msg = `Failed to validate /create endpoint. HTTP status: ${createResponse.status()}.`;
+        console.error(msg);
+        throw new Error(msg);
+      }
+
+      // Test the /join endpoint (will return an error for non-existent meeting, but validates the endpoint works)
+      const joinUrl = helpers.getJoinURL(testMeetingId, parameters, true);
+      const joinResponse = await request.get(joinUrl);
+
+      // For /join, we expect either success (200) or a valid BBB error response
+      if (!joinResponse.ok() && joinResponse.status() !== 404) {
+        const msg = `Failed to validate /join endpoint. HTTP status: ${joinResponse.status()}.`;
+        console.error(msg);
+        throw new Error(msg);
+      }
+
+      console.log('Endpoints validation okay: /create and /join are accessible !!!!');
+    } catch (error) {
+      console.error('Endpoints validation failed:', error.message);
+      throw error;
+    }
+
     await use();
+
     // after test
     if (fullyParallel) {
       while (browser.contexts().length > 0) {

--- a/bigbluebutton-tests/playwright/fixtures.js
+++ b/bigbluebutton-tests/playwright/fixtures.js
@@ -5,7 +5,7 @@ const helpers = require('./core/helpers');
 
 base.test.beforeAll(async ({ request }) => {
   // Validate environment variables and endpoints
-  const BBB_URL_PATTERN = /^https:\/\/[^/]+\/bigbluebutton\/(?:api\/)?$/;
+  const BBB_URL_PATTERN = /^https:\/\/[^/]+\/bigbluebutton\/(?:api\/?)?$/;
   if (!parameters.secret) throw new Error('BBB_SECRET environment variable is not set');
   if (!parameters.server) throw new Error('BBB_URL environment variable is not set');
   if (!BBB_URL_PATTERN.test(parameters.server)) throw new Error('BBB_URL must follow the pattern "https://{{DOMAIN_NAME}}/bigbluebutton/"');
@@ -33,7 +33,7 @@ base.test.beforeAll(async ({ request }) => {
       throw new Error(msg);
     }
 
-    console.log('Endpoints validation okay: /create and /join are accessible!!!!');
+    console.log('Endpoints validation okay: /create and /join are accessible!');
   } catch (error) {
     console.error('Endpoints validation failed:', error.message);
     throw error;

--- a/bigbluebutton-tests/playwright/fixtures.js
+++ b/bigbluebutton-tests/playwright/fixtures.js
@@ -3,46 +3,47 @@ const { fullyParallel } = require('./playwright.config');
 const parameters = require('./core/parameters');
 const helpers = require('./core/helpers');
 
-exports.test = base.test.extend({
-  sharedEachTestHook: [async ({ browser, request }, use) => {
-    // before test
-    
-    const BBB_URL_PATTERN = /^https:\/\/[^/]+\/bigbluebutton\/(?:api\/)?$/;
-    if (!parameters.secret) throw new Error('BBB_SECRET environment variable is not set');
-    if (!parameters.server) throw new Error('BBB_URL environment variable is not set');
-    if (!BBB_URL_PATTERN.test(parameters.server)) throw new Error('BBB_URL must follow the pattern "https://DOMAIN_NAME/bigbluebutton/"');
+base.test.beforeAll(async ({ request }) => {
+  // Validate environment variables and endpoints
+  const BBB_URL_PATTERN = /^https:\/\/[^/]+\/bigbluebutton\/(?:api\/)?$/;
+  if (!parameters.secret) throw new Error('BBB_SECRET environment variable is not set');
+  if (!parameters.server) throw new Error('BBB_URL environment variable is not set');
+  if (!BBB_URL_PATTERN.test(parameters.server)) throw new Error('BBB_URL must follow the pattern "https://{{DOMAIN_NAME}}/bigbluebutton/"');
 
-    try {
-      // Test the /create endpoint with a temporary meeting
-      const testMeetingId = `validation-test-${Date.now()}`;
-      const createUrl = helpers.createMeetingUrl(parameters, undefined, testMeetingId);
-      const createResponse = await request.get(createUrl);
+  try {
+    // Test the /create endpoint with a temporary meeting
+    const testMeetingId = `validation-test-${Date.now()}`;
+    const createUrl = helpers.createMeetingUrl(parameters, undefined, testMeetingId);
+    const createResponse = await request.get(createUrl);
 
-      if (!createResponse.ok()) {
-        const msg = `Failed to validate /create endpoint. HTTP status: ${createResponse.status()}.`;
-        console.error(msg);
-        throw new Error(msg);
-      }
-
-      // Test the /join endpoint (will return an error for non-existent meeting, but validates the endpoint works)
-      const joinUrl = helpers.getJoinURL(testMeetingId, parameters, true);
-      const joinResponse = await request.get(joinUrl);
-
-      // For /join, we expect either success (200) or a valid BBB error response
-      if (!joinResponse.ok() && joinResponse.status() !== 404) {
-        const msg = `Failed to validate /join endpoint. HTTP status: ${joinResponse.status()}.`;
-        console.error(msg);
-        throw new Error(msg);
-      }
-
-      console.log('Endpoints validation okay: /create and /join are accessible !!!!');
-    } catch (error) {
-      console.error('Endpoints validation failed:', error.message);
-      throw error;
+    if (!createResponse.ok()) {
+      const msg = `Failed to validate /create endpoint. HTTP status: ${createResponse.status()}.`;
+      console.error(msg);
+      throw new Error(msg);
     }
 
-    await use();
+    // Test the /join endpoint (will return an error for non-existent meeting, but validates the endpoint works)
+    const joinUrl = helpers.getJoinURL(testMeetingId, parameters, true);
+    const joinResponse = await request.get(joinUrl);
 
+    // For /join, we expect either success (200) or a valid BBB error response
+    if (!joinResponse.ok() && joinResponse.status() !== 404) {
+      const msg = `Failed to validate /join endpoint. HTTP status: ${joinResponse.status()}.`;
+      console.error(msg);
+      throw new Error(msg);
+    }
+
+    console.log('Endpoints validation okay: /create and /join are accessible!!!!');
+  } catch (error) {
+    console.error('Endpoints validation failed:', error.message);
+    throw error;
+  }
+});
+
+exports.test = base.test.extend({
+  sharedEachTestHook: [async ({ browser }, use) => {
+    // before test
+    await use();
     // after test
     if (fullyParallel) {
       while (browser.contexts().length > 0) {

--- a/bigbluebutton-tests/playwright/fixtures.js
+++ b/bigbluebutton-tests/playwright/fixtures.js
@@ -8,7 +8,7 @@ base.test.beforeAll(async ({ request }) => {
   const BBB_URL_PATTERN = /^https:\/\/[^/]+\/bigbluebutton\/(?:api\/?)?$/;
   if (!parameters.secret) throw new Error('BBB_SECRET environment variable is not set');
   if (!parameters.server) throw new Error('BBB_URL environment variable is not set');
-  if (!BBB_URL_PATTERN.test(parameters.server)) throw new Error('BBB_URL must follow the pattern "https://{{DOMAIN_NAME}}/bigbluebutton/"');
+  if (!BBB_URL_PATTERN.test(parameters.server)) throw new Error('BBB_URL must follow the pattern "https://{{DOMAIN_NAME}}/bigbluebutton/api"');
 
   try {
     // Test the /create endpoint with a temporary meeting


### PR DESCRIPTION
This pull request addresses [issue #23450](https://github.com/bigbluebutton/bigbluebutton/issues/23450) by improving the reliability and clarity of our test suite setup. Specifically, it ensures the /create and /join endpoints, as well as required environment variables, are validated before any tests run. This prevents excessive, unhelpful failure logs when endpoints are unavailable or misconfigured.

### What does this PR do?
- Make initial requests to both /create and /join endpoints.
- If either endpoint does not respond as expected, the test run is aborted early with a clear error message.
- Validates required environment variables at test startup,

### Closes Issue(s)
Closes #23450

