### PR TITLE
fix(layout): allow custom layout for tablets & allow interaction with media while propagating layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -75,6 +75,7 @@ interface ExternalVideoPlayerProps {
   isBot: boolean;
   videoUrl: string;
   isResizing: boolean;
+  isLocalChange: boolean;
   fullscreenContext: boolean;
   externalVideo: ExternalVideo;
   playing: boolean;
@@ -104,6 +105,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   currentVolume,
   isMuted,
   isResizing,
+  isLocalChange,
   externalVideo,
   fullscreenContext,
   videoUrl,
@@ -468,7 +470,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         right,
         zIndex: externalVideo.zIndex,
       }}
-      isResizing={isResizing}
+      preventInteraction={isResizing && isLocalChange}
       isMinimized={isMinimized}
     >
       <Styled.VideoPlayerWrapper
@@ -676,7 +678,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
   const cameraDock = layoutSelectInput((i: Input) => i.cameraDock);
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
   const { isOpen: isSidebarContentOpen } = sidebarContent;
-  const { isResizing } = cameraDock;
+  const { isResizing, isLocalChange } = cameraDock;
   const layoutContextDispatch = layoutDispatch();
   const fullscreen = layoutSelect((i: Layout) => i.fullscreen);
   const { element } = fullscreen;
@@ -709,6 +711,7 @@ const ExternalVideoPlayerContainer: React.FC = () => {
       playing={playing}
       playerPlaybackRate={playerPlaybackRate}
       isResizing={isResizing}
+      isLocalChange={isLocalChange}
       fullscreenContext={fullscreenContext}
       externalVideo={externalVideo}
       getCurrentTime={getCurrentTime}

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/styles.ts
@@ -9,7 +9,7 @@ type VideoPlayerWrapperProps = {
 };
 
 type ContainerProps = {
-  isResizing: boolean;
+  preventInteraction: boolean;
   isMinimized: boolean;
 };
 
@@ -20,7 +20,7 @@ export const Container = styled.span<ContainerProps>`
   overflow: hidden;
   border-radius: ${lgBorderRadius};
 
-  ${({ isResizing }) => isResizing && `
+  ${({ preventInteraction }) => preventInteraction && `
     pointer-events: none;
   `}
   ${({ isMinimized }) => isMinimized && `

--- a/bigbluebutton-html5/imports/ui/components/generic-content/generic-main-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/generic-main-content/component.tsx
@@ -5,6 +5,7 @@ import GenericContentItem from '../generic-content-item/component';
 
 const GenericMainContent: React.FC<GenericContentMainAreaProps> = ({
   isResizing,
+  isLocalChange,
   genericContentLayoutInformation,
   renderFunctionComponents,
   genericContentId,
@@ -29,7 +30,7 @@ const GenericMainContent: React.FC<GenericContentMainAreaProps> = ({
         left,
         right,
       }}
-      isResizing={isResizing}
+      preventInteraction={isResizing && isLocalChange}
       isMinimized={isMinimized}
     >
       <GenericContentItem

--- a/bigbluebutton-html5/imports/ui/components/generic-content/generic-main-content/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/generic-main-content/container.tsx
@@ -74,7 +74,7 @@ const GenericContentMainAreaContainer: React.FC<GenericContentMainAreaContainerP
   );
 
   const cameraDock = layoutSelectInput((i: Input) => i.cameraDock);
-  const { isResizing } = cameraDock;
+  const { isResizing, isLocalChange } = cameraDock;
 
   if (!genericContainerContentExtensibleArea
     || genericContainerContentExtensibleArea.length === 0
@@ -84,6 +84,7 @@ const GenericContentMainAreaContainer: React.FC<GenericContentMainAreaContainerP
       genericContentId={genericMainContentId}
       renderFunctionComponents={genericContainerContentExtensibleArea}
       isResizing={isResizing}
+      isLocalChange={isLocalChange}
       genericContentLayoutInformation={genericContentLayoutInformation}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/generic-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 type ContainerProps = {
-  isResizing: boolean;
+  preventInteraction: boolean;
   isMinimized: boolean;
 };
 
@@ -11,7 +11,7 @@ export const Container = styled.div<ContainerProps>`
   background: var(--color-black);
   z-index: 5;
   display: grid;
-  ${({ isResizing }) => isResizing && `
+  ${({ preventInteraction }) => preventInteraction && `
     pointer-events: none;
   `}
   ${({ isMinimized }) => isMinimized && `

--- a/bigbluebutton-html5/imports/ui/components/generic-content/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/types.ts
@@ -8,6 +8,7 @@ export interface GenericContentMainAreaContainerProps {
 
 export interface GenericContentMainAreaProps {
     isResizing: boolean;
+    isLocalChange: boolean;
     genericContentId: string;
     genericContentLayoutInformation: GenericContentMainAreaLayout;
     renderFunctionComponents: GenericContentMainArea[];

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -66,8 +66,9 @@ const reducer = (state, action) => {
     case ACTIONS.SET_FOCUSED_CAMERA_ID: {
       const { cameraDock } = state.input;
       const { focusedId } = cameraDock;
+      const { value, isLocalChange = true } = action;
 
-      if (focusedId === action.value) return state;
+      if (focusedId === value) return state;
 
       return {
         ...state,
@@ -75,7 +76,8 @@ const reducer = (state, action) => {
           ...state.input,
           cameraDock: {
             ...cameraDock,
-            focusedId: action.value,
+            focusedId: value,
+            isLocalChange,
           },
         },
       };
@@ -753,7 +755,8 @@ const reducer = (state, action) => {
     }
     case ACTIONS.SET_CAMERA_DOCK_IS_RESIZING: {
       const { cameraDock } = state.input;
-      if (cameraDock.isResizing === action.value) {
+      const { value, isLocalChange = true } = action;
+      if (cameraDock.isResizing === value) {
         return state;
       }
       return {
@@ -762,14 +765,16 @@ const reducer = (state, action) => {
           ...state.input,
           cameraDock: {
             ...cameraDock,
-            isResizing: action.value,
+            isResizing: value,
+            isLocalChange,
           },
         },
       };
     }
     case ACTIONS.SET_CAMERA_DOCK_POSITION: {
       const { cameraDock } = state.input;
-      if (cameraDock.position === action.value) {
+      const { value, isLocalChange = true } = action;
+      if (cameraDock.position === value) {
         return state;
       }
       return {
@@ -778,15 +783,17 @@ const reducer = (state, action) => {
           ...state.input,
           cameraDock: {
             ...cameraDock,
-            position: action.value,
+            position: value,
+            isLocalChange,
           },
         },
       };
     }
     case ACTIONS.SET_CAMERA_DOCK_SIZE: {
+      const { value, isLocalChange = true } = action;
       const {
         width, height, browserWidth, browserHeight,
-      } = action.value;
+      } = value;
       const { cameraDock } = state.input;
       if (cameraDock.width === width
         && cameraDock.height === height
@@ -804,6 +811,7 @@ const reducer = (state, action) => {
             height,
             browserWidth,
             browserHeight,
+            isLocalChange,
           },
         },
       };

--- a/bigbluebutton-html5/imports/ui/components/layout/initState.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/initState.ts
@@ -62,6 +62,7 @@ export const INITIAL_INPUT_STATE = {
     browserHeight: 0,
     isDragging: false,
     isResizing: false,
+    isLocalChange: true,
     cameraOptimalGridSize: {
       width: 0,
       height: 0,

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -149,6 +149,7 @@ const PushLayoutEngine = (props) => {
         layoutContextDispatch({
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
           value: meetingLayoutCameraPosition || 'contentTop',
+          isLocalChange: false,
         });
         if (shouldOpenChat && !hasLayoutEngineLoadedOnce) {
           layoutContextDispatch({
@@ -247,6 +248,7 @@ const PushLayoutEngine = (props) => {
         layoutContextDispatch({
           type: ACTIONS.SET_FOCUSED_CAMERA_ID,
           value: meetingLayoutFocusedCamera,
+          isLocalChange: false,
         });
       }
     };
@@ -257,6 +259,7 @@ const PushLayoutEngine = (props) => {
         layoutContextDispatch({
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
           value: meetingLayoutCameraPosition,
+          isLocalChange: false,
         });
       }
     };
@@ -277,6 +280,7 @@ const PushLayoutEngine = (props) => {
           layoutContextDispatch({
             type: ACTIONS.SET_CAMERA_DOCK_IS_RESIZING,
             value: isMeetingLayoutResizing,
+            isLocalChange: false,
           });
         }
 
@@ -288,6 +292,7 @@ const PushLayoutEngine = (props) => {
             browserWidth: window.innerWidth,
             browserHeight: window.innerHeight,
           },
+          isLocalChange: false,
         });
       }
     };

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -34,6 +34,9 @@ const suportedLayouts = [
     layoutKey: LAYOUT_TYPE.CUSTOM_LAYOUT,
     layoutName: 'Custom Layout',
     suportedDevices: [
+      DEVICE_TYPE.TABLET,
+      DEVICE_TYPE.TABLET_PORTRAIT,
+      DEVICE_TYPE.TABLET_LANDSCAPE,
       DEVICE_TYPE.DESKTOP,
     ],
   },

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -47,6 +47,7 @@ interface NotesGraphqlProps extends NotesContainerGraphqlProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   layoutContextDispatch: (action: any) => void;
   isResizing: boolean;
+  isLocalChange: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sidebarContent: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,6 +67,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     isRTL,
     layoutContextDispatch,
     isResizing,
+    isLocalChange,
     area,
     sidebarContent,
     sharedNotesOutput,
@@ -167,6 +169,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
         externalId={NOTES_CONFIG.id}
         hasPermission={hasPermission}
         isResizing={isResizing}
+        isLocalChange={isLocalChange}
         isRTL={isRTL}
         amIPresenter={amIPresenter}
       />
@@ -191,7 +194,7 @@ const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
   const sharedNotesOutput = layoutSelectOutput((i) => i.sharedNotes);
   // @ts-ignore Until everything in Typescript
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
-  const { isResizing } = cameraDock;
+  const { isResizing, isLocalChange } = cameraDock;
   const layoutContextDispatch = layoutDispatch();
   const amIPresenter = !!currentUserData?.presenter;
 
@@ -224,6 +227,7 @@ const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
       hasPermission={hasPermission}
       layoutContextDispatch={layoutContextDispatch}
       isResizing={isResizing}
+      isLocalChange={isLocalChange}
       sidebarContent={sidebarContent}
       sharedNotesOutput={sharedNotesOutput}
       amIPresenter={amIPresenter}

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
@@ -24,6 +24,7 @@ interface PadContainerGraphqlProps {
   externalId: string;
   hasPermission: boolean;
   isResizing: boolean;
+  isLocalChange: boolean;
   isRTL: boolean;
   amIPresenter: boolean;
 }
@@ -40,6 +41,7 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
     externalId,
     hasSession,
     isResizing,
+    isLocalChange,
     isRTL,
     sessionIds,
     padId,
@@ -66,10 +68,8 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
         title="pad"
         src={padURL}
         aria-describedby="padEscapeHint"
-        style={{
-          pointerEvents: isResizing ? 'none' : 'inherit',
-        }}
         amIPresenter={amIPresenter}
+        preventInteraction={isResizing && isLocalChange}
       />
       <Styled.Hint
         id="padEscapeHint"
@@ -87,6 +87,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
     hasPermission,
     isRTL,
     isResizing,
+    isLocalChange,
     amIPresenter,
   } = props;
 
@@ -117,6 +118,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
       externalId={externalId}
       isRTL={isRTL}
       isResizing={isResizing}
+      isLocalChange={isLocalChange}
       sessionIds={Array.from(sessionIds)}
       padId={session?.sharedNotes?.padId}
       amIPresenter={amIPresenter}

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/styles.ts
@@ -34,11 +34,12 @@ const Pad = styled.div`
   width: 100%;
 `;
 
-const IFrame = styled.iframe<{amIPresenter: boolean}>`
+const IFrame = styled.iframe<{amIPresenter: boolean, preventInteraction: boolean}>`
   width: 100%;
   height: auto;
   overflow: hidden;
   border-style: none;
+  pointer-events: ${({ preventInteraction }) => (preventInteraction ? 'none' : 'inherit')};
   border-bottom: 1px solid ${colorGrayLightest};
   border-radius: ${({ amIPresenter }) => (amIPresenter
     ? `0 0 ${lgBorderRadius} ${lgBorderRadius}`


### PR DESCRIPTION
### What does this PR do?
- Add 'isLocalChange' prop to camera dock actions to differentiate between actions performed by the local user and those triggered by layout propagation. This enables preventing user interaction (e.g., pointer-events: none) only when the change is local, addressing https://github.com/bigbluebutton/bigbluebutton/issues/12948, while still allowing users to interact with presentation area content during propagated layout changes.
- This commit re-adds tablets to the list of supported devices for custom layout. Removing tablet support previously caused the client to switch to smart layout prematurely on medium-sized screens, which was very annoying. Even a small resize on the presenter's client while pushing layout could unintentionally switch all users to smart layout.

### Closes Issue(s)
Closes #none
