### PR TITLE
style: adjust snapshot of current slide and presentation uploader notification styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
@@ -1,6 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
 import Icon from '/imports/ui/components/common/icon/component';
-import { headingsFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
 import {
   colorDanger,
   colorGray,
@@ -9,8 +8,6 @@ import {
   colorOffWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
-  borderSizeLarge,
-  lgPaddingX,
   statusIconSize,
   borderSize,
   statusInfoHeight,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/styles.js
@@ -15,6 +15,7 @@ import {
   borderSize,
   statusInfoHeight,
 } from '/imports/ui/stylesheets/styled-components/general';
+import ToastStyles from '/imports/ui/components/common/toast/styles';
 
 const DropdownButton = styled.button`
   background-color: ${colorOffWhite};
@@ -65,20 +66,7 @@ const Right = styled.div`
   }
 `;
 
-const ToastText = styled.span`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-align: left;
-  white-space: nowrap;
-  position: relative;
-  top: ${borderSizeLarge};
-  width: auto;
-  font-weight: ${headingsFontWeight};
-
-  [dir="rtl"] & {
-    text-align: right;
-  }
-`;
+const ToastText = styled(ToastStyles.ToastMessage)``;
 
 const StatusIcon = styled.span`
   margin-left: auto;
@@ -135,7 +123,7 @@ const Line = styled.div`
   display: flex;
   width: 100%;
   flex-wrap: nowrap;
-  padding: ${lgPaddingX} 0;
+  padding: 0;
 `;
 
 const ButtonIcon = styled(Icon)`

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/styles.js
@@ -44,6 +44,7 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
+import ToastStyles from '/imports/ui/components/common/toast/styles';
 
 const barStripes = keyframes`
   from { background-position: 1rem 0; }
@@ -62,21 +63,19 @@ const UploadRow = styled.div`
 const FileLine = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: baseline;
   padding-bottom: ${iconPaddingMd};
   width: ${fileLineWidth};
 `;
 
-const ToastFileName = styled.span`
+const ToastFileName = styled(ToastStyles.ToastMessage)`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  height: 1.25rem !important;
   margin-left: ${mdPaddingY};
   height: 1rem;
   width: auto;
   text-align: left;
-  font-weight: ${headingsFontWeight};
 
   [dir="rtl"] & {
     margin-right: ${mdPaddingY};


### PR DESCRIPTION
### What does this PR do?

adjusts slide snapshot and presentation uploader notification styles to be the same as other notifications

#### before
![snapshot-before](https://github.com/user-attachments/assets/f24339a4-bf38-4ee1-835e-b19658de91dd)
![pres-uploader-before](https://github.com/user-attachments/assets/5dd7f33b-78b9-4428-88f2-e8fb11006a6f)

#### after

![snapshot-after](https://github.com/user-attachments/assets/bf85f2e4-63f6-480a-a21d-f49f25f7615c)
![pres-upload-after](https://github.com/user-attachments/assets/0c35962c-1e97-418c-9af8-76d31b5ef76e)

### Closes Issue(s)
Closes #23464

### How to test
