### PR TITLE
fix(ui-command): correct event listener removal for presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/presentation/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/presentation/handler.tsx
@@ -27,8 +27,8 @@ const PluginPresentationAreaUiCommandsHandler = () => {
     window.addEventListener(PresentationAreaEnum.CLOSE, handlePresentationAreaClose);
 
     return () => {
-      window.addEventListener(PresentationAreaEnum.OPEN, handlePresentationAreaOpen);
-      window.addEventListener(PresentationAreaEnum.OPEN, handlePresentationAreaClose);
+      window.removeEventListener(PresentationAreaEnum.OPEN, handlePresentationAreaOpen);
+      window.removeEventListener(PresentationAreaEnum.CLOSE, handlePresentationAreaClose);
     };
   }, []);
   return null;


### PR DESCRIPTION
### What does this PR do?
Fixes the event listener for the presentation ui command that was not being properly removed.

### Closes Issue(s)
Closes #none