### PR TITLE
fix(livekit): stopping one local camera un-shares all instead

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -205,7 +205,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       if (!videoTrackPublications || !track) return;
 
       videoTrackPublications.forEach((publication: LocalTrackPublication) => {
-        if (lkIsCameraSource(publication) && publication.track) {
+        if (lkIsCameraSource(publication) && publication.track && track.sid === publication.track.sid) {
           liveKitRoom.localParticipant.unpublishTrack(publication.track)
             .then(() => {
               logger.debug({
@@ -518,6 +518,16 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       const newTracks = mediaStream.getVideoTracks();
       track.replaceTrack(newTracks[0]).then(() => {
         attachLiveKitStream(streamId);
+      }).catch((error) => {
+        logger.error({
+          logCode: 'livekit_camera_replace_track_error',
+          extraInfo: {
+            cameraId: streamId,
+            trackSid: track?.sid,
+            errorMessage: error.message,
+            errorStack: error.stack,
+          },
+        }, `LiveKit: failed to replace camera track - ${error.message}`);
       });
     }
   };


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): stopping one local cameras un-shares all instead](https://github.com/bigbluebutton/bigbluebutton/commit/06c23b3b1be4562f656c61925783a2ca27a3d828) 
  - When using LiveKit, stopping a single local camera un-shares all local
cameras instead (i.e. multiple camera sharing scenario).
  - Properly filter the target publication when unpublishing camera tracks.
  - Additionally, add error handling to a LocalTrack replaceTrack call that
may throw and is causing whiteboard reloads according to canary server
logs.

### Closes Issue(s)

None
