### PR TITLE
feat(ui-commands): allow enabling display of audio captions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/captions/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/captions/handler.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { CaptionsEnum, CaptionsLanguageEnum } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/captions/enums';
+import { SetDisplayAudioCaptionsCommandArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/captions/types';
+import {
+  setAudioCaptions,
+  setUserLocaleProperty,
+} from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
+import { useMutation } from '@apollo/client/react/hooks/useMutation';
+import { SET_CAPTION_LOCALE } from '/imports/ui/core/graphql/mutations/userMutations';
+
+const PluginCaptionsUiCommandsHandler = () => {
+  const [setCaptionLocaleMutation] = useMutation(SET_CAPTION_LOCALE);
+  const setUserCaptionLocale = (captionLocale: string, provider: string) => {
+    setCaptionLocaleMutation({
+      variables: {
+        locale: captionLocale,
+        provider,
+      },
+    });
+  };
+
+  const handleSetDisplayAudioCaptions = (event: CustomEvent<SetDisplayAudioCaptionsCommandArguments>) => {
+    const { displayAudioCaptions } = event.detail;
+
+    setUserLocaleProperty(
+      displayAudioCaptions,
+      setUserCaptionLocale,
+    );
+    setAudioCaptions(displayAudioCaptions !== CaptionsLanguageEnum.NONE);
+  };
+
+  useEffect(() => {
+    window.addEventListener(
+      CaptionsEnum.SET_DISPLAY_AUDIO_CAPTIONS,
+      handleSetDisplayAudioCaptions as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        CaptionsEnum.SET_DISPLAY_AUDIO_CAPTIONS,
+        handleSetDisplayAudioCaptions as EventListener,
+      );
+    };
+  }, []);
+  return null;
+};
+
+export default PluginCaptionsUiCommandsHandler;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -9,6 +9,7 @@ import { PluginLayoutUiCommandsHandler } from './layout/handler';
 import PluginNavBarUiCommandsHandler from './nav-bar/handler';
 import PluginActionsBarUiCommandsHandler from './actions-bar/handler';
 import PluginCameraUiCommandsHandler from './camera/handler';
+import PluginCaptionsUiCommandsHandler from './captions/handler';
 
 const PluginUiCommandsHandler = () => (
   <>
@@ -16,6 +17,7 @@ const PluginUiCommandsHandler = () => (
     <PluginLayoutUiCommandsHandler />
     <PluginChatUiCommandsHandler />
     <PluginCameraUiCommandsHandler />
+    <PluginCaptionsUiCommandsHandler />
     <PluginNavBarUiCommandsHandler />
     <PluginSidekickOptionsContainerUiCommandsHandler />
     <PluginPresentationAreaUiCommandsHandler />


### PR DESCRIPTION
### What does this PR do?
This is the core part of the new ui command to allow plugins toggling the display of audio captions.


### Closes Issue(s)
Closes #none

### More
SDK Pr: 
- https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/196
