### PR TITLE
fix(livekit): cached output device isn't correctly applied on join

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -346,9 +346,9 @@ class AudioManager {
     this.userData = userData;
     this.inputDeviceId = getStoredAudioInputDeviceId() || DEFAULT_INPUT_DEVICE_ID;
     this.outputDeviceId = getCurrentAudioSinkId();
-    this._applyCachedOutputDeviceId();
     this._trackPermissionStatus();
     this.loadBridges(bridges, userData);
+    this._applyCachedOutputDeviceId();
     this.transparentListenOnlySupported = this.supportsTransparentListenOnly();
     this.audioEventHandler = audioEventHandler;
     this.observeVoiceActivity();


### PR DESCRIPTION
### What does this PR do?

[fix(livekit): cached output device isn't correctly applied on join](https://github.com/bigbluebutton/bigbluebutton/commit/b14baf646229c2f58a97ba69d43dc345f6bc914c) 
  - LiveKit's output device change depends on the bridge being loaded for it
to work correctly. The procedure that applies cached (ie local/session
storage) output devices runs before bridges are loaded, which causes the
initial device to be incorrect internally (even though the UI displays
the correct device).
  - Move the cached output device enforcement call after the bridges are
loaded. This guarantees LiveKit will pick up the correct one on audio
join.

### Closes Issue(s)

None