### PR TITLE
gql-server (perf): Workaround to prevent Hasura from adding redundant nullability checks

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2433,3 +2433,17 @@ CREATE INDEX "idx_user_audioGroup_userId" ON "user_audioGroup"("meetingId", "use
 CREATE INDEX "idx_user_audioGroup_userId_reverse" ON "user_audioGroup"("userId", "meetingId");
 CREATE INDEX "idx_user_audioGroup_groupId_participantType" ON "user_audioGroup"("meetingId", "groupId", "participantType");
 CREATE OR REPLACE VIEW "v_user_audioGroup" AS SELECT * FROM "user_audioGroup";
+
+-- Workaround to prevent Hasura from appending "OR IS NULL" to filters on view columns
+-- By marking certain columns in views as NOT NULL, Hasura treats them as non-nullable and avoids adding unnecessary null checks
+-- This updates columns commonly used in filters (e.g., IDs, sessionToken, isModerator) across all views (tables starting with "v_")
+UPDATE pg_attribute
+SET attnotnull = true
+WHERE attrelid IN (
+  SELECT oid FROM pg_class WHERE relname LIKE 'v_%'
+)
+AND (
+	attname like '%Id'
+	or attname = 'sessionToken'
+	or attname = 'isModerator'
+);

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2440,10 +2440,12 @@ CREATE OR REPLACE VIEW "v_user_audioGroup" AS SELECT * FROM "user_audioGroup";
 UPDATE pg_attribute
 SET attnotnull = true
 WHERE attrelid IN (
-  SELECT oid FROM pg_class WHERE relname LIKE 'v_%'
+  SELECT c.oid
+  FROM pg_class c
+  JOIN pg_namespace  n ON n.oid = c.relnamespace
+  where c.relkind LIKE 'v' --view only
+  and c.relname LIKE 'v_%' --view only
+  and n.nspname = 'public' -- restrict to public schema
 )
-AND (
-	attname like '%Id'
-	or attname = 'sessionToken'
-	or attname = 'isModerator'
-);
+AND (attname ~ 'Id$' or attname in ('sessionToken', 'isModerator'))
+AND attnotnull IS FALSE; -- skip already set


### PR DESCRIPTION
Hasura does not correctly infer `NOT NULL` constraints for view columns, so it treats all of them as nullable and automatically appends `OR IS NULL` to filters. This can lead to unnecessarily expensive queries, especially on large views.

More info: https://github.com/hasura/graphql-engine/issues/9637

This PR works around the issue by manually marking selected columns in views as `NOT NULL` (at the `pg_attribute` level), which prevents Hasura from adding these redundant nullability checks.

Before / After for two queries:

![image](https://github.com/user-attachments/assets/cb40271f-1de4-4e60-886d-856516bb55b6)

![image](https://github.com/user-attachments/assets/bdb79af5-8638-43b7-a40e-02b5678db5d4)
