### PR TITLE
refactor (akka-apps): Ignore unknown properties when reading plugins manifests

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -11,15 +11,8 @@ import com.github.zafarkhaja.semver.Version
 
 import java.util
 
-case class RateLimiting(
-    messagesAllowedPerSecond: Int,
-    messagesAllowedPerMinute: Int
-)
-
 case class EventPersistence(
     isEnabled:                 Boolean,
-    maximumPayloadSizeInBytes: Int,
-    rateLimiting:              RateLimiting
 )
 
 case class DataChannel(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -1,7 +1,7 @@
 package org.bigbluebutton.core.models
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
+import com.fasterxml.jackson.databind.{DeserializationFeature, JsonMappingException, ObjectMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.bigbluebutton.ClientSettings
 import org.bigbluebutton.ClientSettings.getPluginsFromConfig
@@ -70,6 +70,7 @@ object PluginModel {
   private val objectMapper: ObjectMapper = new ObjectMapper()
 
   objectMapper.registerModule(new DefaultScalaModule())
+  objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
   def getPluginByName(instance: PluginModel, pluginName: String): Option[Plugin] = {
     instance.plugins.get(pluginName)
   }


### PR DESCRIPTION
The manifest sample was recently updated to remove two properties:

* `eventPersistence.rateLimiting`
* `eventPersistence.maximumPayloadSize`
See: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/195

It's likely that some plugin manifests were created based on the previous sample and still include these properties.
We want to avoid handling these two fields explicitly, as that would introduce unnecessary complexity into the akka-apps code.

Instead, this PR takes a cleaner approach by disabling the `FAIL_ON_UNKNOWN_PROPERTIES` option when parsing the JSON, allowing us to safely ignore any unrecognized fields and only process the relevant ones.
