### PR TITLE
chore (gql-middleware): Add `clientSessionUUID` to all logs of gql-middleware

### DIFF
--- a/bbb-graphql-middleware/internal/akka_apps/client.go
+++ b/bbb-graphql-middleware/internal/akka_apps/client.go
@@ -15,10 +15,11 @@ var sessionVarsHookUrl = config.GetConfig().SessionVarsHook.Url
 var internalError = fmt.Errorf("server internal error")
 var internalErrorId = "internal_error"
 
-func AkkaAppsGetSessionVariablesFrom(browserConnectionId string, sessionToken string) (map[string]string, error, string) {
+func AkkaAppsGetSessionVariablesFrom(browserConnectionId string, sessionToken string, clientSessionUUID string) (map[string]string, error, string) {
 	logger := log.WithField("_routine", "AkkaAppsClient").
 		WithField("browserConnectionId", browserConnectionId).
-		WithField("sessionToken", sessionToken)
+		WithField("sessionToken", sessionToken).
+		WithField("clientSessionUUID", clientSessionUUID)
 
 	logger.Debug("Starting AkkaAppsClient")
 	defer logger.Debug("Finished AkkaAppsClient")

--- a/bbb-graphql-middleware/internal/bbb_web/client.go
+++ b/bbb-graphql-middleware/internal/bbb_web/client.go
@@ -14,10 +14,11 @@ import (
 // authHookUrl is the authentication hook URL obtained from config file.
 var authHookUrl = config.GetConfig().AuthHook.Url
 
-func BBBWebCheckAuthorization(browserConnectionId string, sessionToken string, cookies []*http.Cookie) (string, string, error) {
+func BBBWebCheckAuthorization(browserConnectionId string, sessionToken string, clientSessionUUID string, cookies []*http.Cookie) (string, string, error) {
 	logger := log.WithField("_routine", "BBBWebClient").
 		WithField("browserConnectionId", browserConnectionId).
-		WithField("sessionToken", sessionToken)
+		WithField("sessionToken", sessionToken).
+		WithField("clientSessionUUID", clientSessionUUID)
 
 	logger.Debug("Starting BBBWebClient")
 	defer logger.Debug("Finished BBBWebClient")

--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -324,7 +324,7 @@ func invalidateBrowserConnectionForSessionToken(bc *common.BrowserConnection, se
 
 func refreshUserSessionVariables(browserConnection *common.BrowserConnection) (error, string) {
 	// Check authorization
-	sessionVariables, err, errorId := akka_apps.AkkaAppsGetSessionVariablesFrom(browserConnection.Id, browserConnection.SessionToken)
+	sessionVariables, err, errorId := akka_apps.AkkaAppsGetSessionVariablesFrom(browserConnection.Id, browserConnection.SessionToken, browserConnection.ClientSessionUUID)
 	if err != nil {
 		browserConnection.Logger.Error(err)
 		return fmt.Errorf("error on checking sessionToken authorization: %s", err.Error()), errorId
@@ -382,6 +382,7 @@ func connectionInitHandler(browserConnection *common.BrowserConnection) (error, 
 			if !existsClientSessionUUID {
 				return fmt.Errorf("X-ClientSessionUUID header missing on init connection"), "param_missing"
 			}
+			browserConnection.Logger = browserConnection.Logger.WithField("clientSessionUUID", clientSessionUUID)
 
 			var clientType, existsClientType = headersAsMap["X-ClientType"].(string)
 			if !existsClientType {
@@ -399,7 +400,7 @@ func connectionInitHandler(browserConnection *common.BrowserConnection) (error, 
 			// Check authorization
 			var numOfAttempts = 0
 			for {
-				meetingId, userId, errCheckAuthorization = bbb_web.BBBWebCheckAuthorization(browserConnection.Id, sessionToken, browserConnection.BrowserRequestCookies)
+				meetingId, userId, errCheckAuthorization = bbb_web.BBBWebCheckAuthorization(browserConnection.Id, sessionToken, clientSessionUUID, browserConnection.BrowserRequestCookies)
 				if errCheckAuthorization != nil {
 					browserConnection.Logger.Error(errCheckAuthorization)
 				}


### PR DESCRIPTION
Add `clientSessionUUID` to all `graphql-middleware` logs to help identify when a user reconnects (e.g., by refreshing the browser and starting a new session). Unlike `sessionToken`, this value changes on each new session, making it a reliable indicator of reconnections.

![image](https://github.com/user-attachments/assets/ff9351a2-cc05-4253-8397-414bc4cdbf37)

Related: #23505