### PR TITLE
feat(html5,akka): Add disable feature for quiz

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StartPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/StartPollReqMsgHdlr.scala
@@ -28,6 +28,10 @@ trait StartPollReqMsgHdlr extends RightsManagementTrait {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "Polling is disabled for this meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    } else if (msg.body.quiz && liveMeeting.props.meetingProp.disabledFeatures.contains("quiz")) {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val reason = "Quiz is disabled for this meeting."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
     } else if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to start poll."

--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -27,6 +27,7 @@ import Session from '/imports/ui/services/storage/in-memory';
 import SessionStorage from '/imports/ui/services/storage/session';
 import { useStorageKey } from '../../services/storage/hooks';
 import QuizAndPollTabSelector from './components/QuizAndPollTabSelector';
+import { useIsQuizEnabled } from '../../services/features';
 
 const intlMessages = defineMessages({
   pollPaneTitle: {
@@ -240,7 +241,7 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
   hasPoll,
 }) => {
   const POLL_SETTINGS = window.meetingClientSettings.public.poll;
-  const QUIZ_ENABLED = POLL_SETTINGS.quiz.enabled;
+  const isQuizEnabled = useIsQuizEnabled();
   const ALLOW_CUSTOM_INPUT = POLL_SETTINGS.allowCustomResponseInput;
   const MAX_CUSTOM_FIELDS = POLL_SETTINGS.maxCustom;
   const [stopPoll] = useMutation(POLL_CANCEL);
@@ -601,7 +602,7 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
     return (
       <>
         {
-          QUIZ_ENABLED && (
+          isQuizEnabled && (
             <QuizAndPollTabSelector
               isQuiz={isQuiz}
               onTabChange={(isQuiz: boolean) => {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { useMutation } from '@apollo/client';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
-import { useIsInfiniteWhiteboardEnabled, useIsPollingEnabled } from '/imports/ui/services/features';
+import { useIsInfiniteWhiteboardEnabled, useIsPollingEnabled, useIsQuizEnabled } from '/imports/ui/services/features';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import { POLL_CANCEL, POLL_CREATE } from '/imports/ui/components/poll/mutations';
 import { PRESENTATION_SET_ZOOM, PRESENTATION_SET_PAGE, PRESENTATION_SET_PAGE_INFINITE_WHITEBOARD } from '../mutations';
@@ -86,8 +86,7 @@ const PresentationToolbarContainer = (props) => {
   const { pluginsExtensibleAreasAggregatedState } = pluginsContext;
 
   const WHITEBOARD_CONFIG = window.meetingClientSettings.public.whiteboard;
-  const POLL_SETTINGS = window.meetingClientSettings.public.poll;
-  const QUIZ_ENABLED = POLL_SETTINGS.quiz.enabled;
+  const isQuizEnabled = useIsQuizEnabled();
 
   const {
     userIsPresenter,
@@ -188,8 +187,8 @@ const PresentationToolbarContainer = (props) => {
         question,
         multipleResponse,
         answers,
-        isQuiz: QUIZ_ENABLED ? isQuiz : false,
-        correctAnswer: QUIZ_ENABLED ? correctAnswer : '',
+        isQuiz: isQuizEnabled ? isQuiz : false,
+        correctAnswer: isQuizEnabled ? correctAnswer : '',
       });
     } else {
       createPoll({
@@ -201,8 +200,8 @@ const PresentationToolbarContainer = (props) => {
           multipleResponse,
           quiz: false,
           answers,
-          isQuiz: QUIZ_ENABLED ? isQuiz : false,
-          correctAnswer: QUIZ_ENABLED ? correctAnswer : '',
+          isQuiz: isQuizEnabled ? isQuiz : false,
+          correctAnswer: isQuizEnabled ? correctAnswer : '',
         },
       });
     }

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -20,6 +20,10 @@ export function useIsPollingEnabled() {
   return useDisabledFeatures().indexOf('polls') === -1 && window.meetingClientSettings.public.poll.enabled;
 }
 
+export function useIsQuizEnabled() {
+  return useDisabledFeatures().indexOf('quiz') === -1 && window.meetingClientSettings.public.poll.quiz.enabled;
+}
+
 export function useIsPresentationEnabled() {
   return useDisabledFeatures().indexOf('presentation') === -1;
 }

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -440,6 +440,9 @@ const createEndpointTableData = [
             <li>
               <code className="language-plaintext highlighter-rouge">chatEmojiPicker</code> - <b>Enable/Disable chat emoji picker (added in BigBlueButton 3.0)</b>
             </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">quiz</code> - <b>Quiz  (added in BigBlueButton 3.0)</b>
+            </li>
           </ul>
         </>
     ),


### PR DESCRIPTION
### What does this PR do?
- Adds a new option (`Quiz`) to `disabledFeatures` to disable the emoji picker in the chat.
- Update related docs.

### Closes Issue(s)
Closes #23465

### How to test
1. Update https://github.com/bigbluebutton/bigbluebutton/blob/v3.0.x-release/bigbluebutton-html5/private/config/settings.yml#L588
 to be `true`.
2. Create a meeting with `disabledFeatures=quiz`.
3. Users should not see the quiz anyway.

### More: 
[Screencast from 08-07-2025 11:12:41.webm](https://github.com/user-attachments/assets/292f1ec4-1d5f-4fcf-9d3e-30a37b287e9e)
