### PR TITLE
chore: Temporarily disable merging and uploading blob reports in CI workflow

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -420,13 +420,19 @@ jobs:
       hasReportData: ${{ needs.install-and-run-bbb-tests.result == 'success' || needs.install-and-run-bbb-tests.result == 'failure' && needs.install-and-run-plugin-tests.result == 'success' || needs.install-and-run-plugin-tests.result == 'failure' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Merge and upload the blob reports
-        if: ${{ env.hasReportData }}
-        uses: ./.github/actions/merge-and-upload-blob-reports
-      - name: Remove unnecessary artifact
+      # temporarily disabled as merged blob reports are not being used
+      # - name: Merge and upload the blob reports
+      # if: ${{ env.hasReportData }}
+      #   uses: ./.github/actions/merge-and-upload-blob-reports
+      # - name: Remove unnecessary artifact
+      #   uses: geekyeggo/delete-artifact@v5
+      #   with:
+      #     name: all-blob-reports
+      #     failOnError: false
+      - name: Remove unnecessary blob artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: all-blob-reports
+          name: blob-report-*
           failOnError: false
       - name: Write PR data for auto-comment
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### What does this PR do?
This PR temporarily skips the merge blob reports + upload into the HTML reporter in order to decrease the workflow's total time of execution. Once we implement the report publishing into a remote server (eg. digital ocean), it should be re-added as well

![image](https://github.com/user-attachments/assets/6464d165-2455-4be7-8e38-d1bfb37fe0ad)
