### PR TITLE
Fix(html5): poll form fields clean up on poll start

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -703,6 +703,9 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
             setQuestionAndOptions('');
             setCorrectAnswer({ text: '', index: -1 });
             setIsQuiz(false);
+            setCustomInput(false);
+            setSecretPoll(false);
+            setMultipleResponse(false);
           }}
           handleToggle={handleToggle}
           error={error}


### PR DESCRIPTION
### What does this PR do?
Add a few more fields to be clean up on poll start.

Fields:
 - Custom input
 - Secret poll
 - multiple Responses


### Closes Issue(s)
N/A


### How to test
- Start a Poll
- Cancel it 

