### PR TITLE
test: add test to verify stopping screenshare functionality

### DIFF
--- a/bigbluebutton-tests/playwright/screenshare/screenshare.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.js
@@ -52,7 +52,7 @@ class ScreenShare extends Page {
     await this.hasElement(e.whiteboard, 'should display the whiteboard');
   }
 
-  async screenshareIsStopped() {
+  async stopScreenshareAndVerify() {
     const { screensharingEnabled } = getSettings();
 
     if (!screensharingEnabled) {

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.js
@@ -13,7 +13,7 @@ class ScreenShare extends Page {
   async startSharing() {
     const { screensharingEnabled } = getSettings();
 
-    if(!screensharingEnabled) {
+    if (!screensharingEnabled) {
       await this.hasElement(e.joinVideo, 'should display the join video button');
       return this.wasRemoved(e.startScreenSharing, 'should not display the start screenshare button');
     }
@@ -30,7 +30,7 @@ class ScreenShare extends Page {
 
     await this.waitForSelector(e.whiteboard);
 
-    if(!screensharingEnabled) {
+    if (!screensharingEnabled) {
       await this.hasElement(e.joinVideo, 'should display the join video button');
       return this.wasRemoved(e.startScreenSharing, 'should not display the screenshare button');
     }
@@ -51,6 +51,29 @@ class ScreenShare extends Page {
     await this.waitAndClick(e.stopScreenSharing);
     await this.hasElement(e.whiteboard, 'should display the whiteboard');
   }
+
+  async screenshareIsStopped() {
+    const { screensharingEnabled } = getSettings();
+
+    if (!screensharingEnabled) {
+      await this.hasElement(e.joinVideo, 'should display the join video button');
+      return this.wasRemoved(e.startScreenSharing, 'should not display the start screenshare button');
+    }
+
+    // Start screenshare first
+    await startScreenshare(this);
+    await this.hasElement(e.isSharingScreen, 'should display the screenshare element');
+    await this.hasElement(e.stopScreenSharing, 'should display the stop screenshare button');
+
+    // Stop screenshare
+    await this.waitAndClick(e.stopScreenSharing);
+
+    // Verify screenshare is stopped
+    await this.wasRemoved(e.isSharingScreen, 'should not display the screenshare element after stopping');
+    await this.wasRemoved(e.stopScreenSharing, 'should not display the stop screenshare button after stopping');
+    await this.hasElement(e.startScreenSharing, 'should display the start screenshare button after stopping');
+    await this.hasElement(e.whiteboard, 'should display the whiteboard after stopping screenshare');
+  }
 }
 
 class MultiUserScreenShare extends MultiUsers {
@@ -61,7 +84,7 @@ class MultiUserScreenShare extends MultiUsers {
   async startSharing(page) {
     const { screensharingEnabled } = getSettings();
 
-    if(!screensharingEnabled) {
+    if (!screensharingEnabled) {
       await this.hasElement(e.joinVideo, 'should display the join video button');
       return this.wasRemoved(e.startScreenSharing, 'should not display the start screenshare button');
     }

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.js
@@ -52,19 +52,7 @@ class ScreenShare extends Page {
     await this.hasElement(e.whiteboard, 'should display the whiteboard');
   }
 
-  async stopScreenshareAndVerify() {
-    const { screensharingEnabled } = getSettings();
-
-    if (!screensharingEnabled) {
-      await this.hasElement(e.joinVideo, 'should display the join video button');
-      return this.wasRemoved(e.startScreenSharing, 'should not display the start screenshare button');
-    }
-
-    // Start screenshare first
-    await startScreenshare(this);
-    await this.hasElement(e.isSharingScreen, 'should display the screenshare element');
-    await this.hasElement(e.stopScreenSharing, 'should display the stop screenshare button');
-
+  async stopSharing() {
     // Stop screenshare
     await this.waitAndClick(e.stopScreenSharing);
 

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -20,4 +20,13 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.init(true, true);
     await screenshare.screenshareStopsExternalVideo();
   });
+
+  test('Verify screenshare is stopped', async ({ browser, browserName, page }) => {
+    test.skip(browserName === 'firefox',
+      'Screenshare tests not able in Firefox browser without desktop',
+    );
+    const screenshare = new ScreenShare(browser, page);
+    await screenshare.init(true, true);
+    await screenshare.screenshareIsStopped();
+  });
 });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -27,6 +27,6 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     );
     const screenshare = new ScreenShare(browser, page);
     await screenshare.init(true, true);
-    await screenshare.screenshareIsStopped();
+    await screenshare.stopScreenshareAndVerify();
   });
 });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.js
@@ -4,13 +4,14 @@ const { linkIssue } = require('../core/helpers');
 
 test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#sharing-screen-in-full-screen-mode-automated
-  test('Share screen', async ({ browser, browserName, page }) => {
+  test('Start and Stop Share screen', async ({ browser, browserName, page }) => {
     test.skip(browserName === 'firefox',
       'Screenshare tests not able in Firefox browser without desktop',
     );
     const screenshare = new ScreenShare(browser, page);
     await screenshare.init(true, true);
     await screenshare.startSharing();
+    await screenshare.stopSharing();
   });
 
   test('Start screenshare stops external video', { tag: '@flaky' }, async ({ browser, page }) => {
@@ -19,14 +20,5 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     const screenshare = new ScreenShare(browser, page);
     await screenshare.init(true, true);
     await screenshare.screenshareStopsExternalVideo();
-  });
-
-  test('Verify screenshare is stopped', async ({ browser, browserName, page }) => {
-    test.skip(browserName === 'firefox',
-      'Screenshare tests not able in Firefox browser without desktop',
-    );
-    const screenshare = new ScreenShare(browser, page);
-    await screenshare.init(true, true);
-    await screenshare.stopScreenshareAndVerify();
   });
 });

--- a/bigbluebutton-tests/playwright/screenshare/util.js
+++ b/bigbluebutton-tests/playwright/screenshare/util.js
@@ -1,5 +1,5 @@
 const e = require('../core/elements');
-const { VIDEO_LOADING_WAIT_TIME, ELEMENT_WAIT_EXTRA_LONG_TIME } = require('../core/constants');
+const { ELEMENT_WAIT_EXTRA_LONG_TIME } = require('../core/constants');
 
 async function startScreenshare(test) {
   await test.waitAndClick(e.startScreenSharing);


### PR DESCRIPTION
### What does this PR do?
This pull request adds Playwright test coverage for the screenshare feature, specifically verifying that stopping screenshare restores the expected UI state.

### Motivation
Verifying that the UI updates as expected when stopping screenshare helps prevent regressions and improves the reliability of the screensharing experience.
