### PR TITLE
Ref(akka): Add field isCorrectAnswer to answers prop on annotations

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -318,13 +318,14 @@ object Polls {
       for {
         answer <- result.answers
       } yield {
-        if (showAnswer && answer.key == result.correctAnswer.getOrElse("")) {
-          // temporarily adding a check mark to the correct answer
-          // while the whiteboard doesn't know how to handle the correct answer
-          answer.copy(key = s"✅ ${answer.key}")
-        } else {
-          answer
-        }
+        val isCorrect =
+          showAnswer && result.correctAnswer.contains(answer.key)
+        Map(
+          "id" -> answer.id,
+          "key" -> answer.key,
+          "numVotes" -> answer.numVotes,
+          "isCorrectAnswer" -> isCorrect
+        )
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the Akka portion by removing the modification of the correct answer label previously used to add a check mark. Instead, it introduces a new field, isCorrectAnswer, in all answers to signal correctness to the client side. Corresponding changes have been made on the client side to support this new approach.

depends on https://github.com/bigbluebutton/tldraw/pull/31


### Closes Issue(s)
N/A

### How to test
- Publish a quiz showing the correct answer

