### PR TITLE
fix(html5): Quiz information isn't saved when navigating between tabs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -28,7 +28,6 @@ import SessionStorage from '/imports/ui/services/storage/session';
 import { useStorageKey } from '../../services/storage/hooks';
 import QuizAndPollTabSelector from './components/QuizAndPollTabSelector';
 import { useIsQuizEnabled } from '../../services/features';
-import { set } from 'ramda';
 
 const intlMessages = defineMessages({
   pollPaneTitle: {

--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -28,6 +28,7 @@ import SessionStorage from '/imports/ui/services/storage/session';
 import { useStorageKey } from '../../services/storage/hooks';
 import QuizAndPollTabSelector from './components/QuizAndPollTabSelector';
 import { useIsQuizEnabled } from '../../services/features';
+import { set } from 'ramda';
 
 const intlMessages = defineMessages({
   pollPaneTitle: {
@@ -394,10 +395,12 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
       secretPoll,
       warning,
       type,
+      isQuiz,
+      correctAnswer,
     };
   }, [
     customInput, question, questionAndOptions, optList,
-    multipleResponse, secretPoll, warning, type, error,
+    multipleResponse, secretPoll, warning, type, error, isQuiz, correctAnswer,
   ]);
 
   useEffect(() => () => {
@@ -415,6 +418,11 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
       secretPoll: boolean;
       warning: string;
       type: string;
+      isQuiz: boolean;
+      correctAnswer: {
+        text: string;
+        index: number;
+      };
     };
 
     if (pollSavedState) {
@@ -428,6 +436,8 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
         secretPoll,
         type,
         warning,
+        isQuiz = false,
+        correctAnswer = { text: '', index: -1 },
       } = pollSavedState;
 
       setCustomInput(customInput);
@@ -439,6 +449,8 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
       setSecretPoll(secretPoll);
       setType(type);
       setWarning(warning);
+      setIsQuiz(isQuiz);
+      setCorrectAnswer(correctAnswer);
     }
   }, []);
 


### PR DESCRIPTION
### What does this PR do?
Fix the issue where edits made to a quiz are not persisted when navigating to another tab and returning.


### Closes Issue(s)
N/a

### How to test
- Open poll tab
- Select quiz
- Select one response option 
- Select the correct answer
- Navigate to chat
- navigate back to polls


### More
[Screencast from 10-07-2025 09:46:30.webm](https://github.com/user-attachments/assets/9fbebdba-ba20-4159-a896-252f95aefa56)
