### PR TITLE
fix: Breakout room numbers not showing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -161,7 +161,7 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
                 key={breakoutRoomId}
                 value={breakoutRoomId}
               >
-                {isDefaultName ? intl.formatMessage(intlMessages.breakoutRoom, { 0: sequence }) : shortName}
+                {isDefaultName ? intl.formatMessage(intlMessages.breakoutRoom, { roomNumber: sequence }) : shortName}
               </option>
             ))
           }


### PR DESCRIPTION
### What does this PR do?

Adjusts breakout dropdown localization message displayed when using default rooms names and allowing users to choose a room

### Closes Issue(s)
Closes #23525

### How to test
1. Create breakout rooms, select Allow users to choose rooms
2. Start Breakout Rooms