### PR TITLE
fix(layout): tweaks over default settings and initial values

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -184,14 +184,18 @@ export interface Transcription {
 }
 
 export interface DefaultSettings {
+  layout: LayoutSettings
   application: Application
   audio: Audio
   dataSaving: DataSaving
   transcription: Transcription
 }
+export interface LayoutSettings {
+  selectedLayout: string
+  pushLayout: boolean
+}
 
 export interface Application {
-  selectedLayout: string
   animations: boolean
   chatAudioAlerts: boolean
   chatPushAlerts: boolean

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -85,7 +85,7 @@ const LayoutObserver: React.FC = () => {
   );
 
   useEffect(() => {
-    if (deviceType !== previousDeviceType) {
+    if (deviceType && deviceType !== previousDeviceType) {
       const Settings = getSettingsSingletonInstance();
       const currentLayout = Settings.layout.selectedLayout;
       if (!isLayoutSupported(deviceType, currentLayout)) {
@@ -213,6 +213,7 @@ const LayoutObserver: React.FC = () => {
   }, [meetingLayout, layoutContextDispatch, layoutType]);
 
   useEffect(() => {
+    if (!deviceType) return;
     const layoutSupported = isLayoutSupported(deviceType, selectedLayout);
     if (layoutSupported) {
       layoutContextDispatch({

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -227,8 +227,8 @@ const LayoutObserver: React.FC = () => {
       });
       const Settings = getSettingsSingletonInstance();
       updateSettings({
-        application: {
-          ...Settings.application,
+        layout: {
+          ...Settings.layout,
           selectedLayout: LAYOUT_TYPE.SMART_LAYOUT,
         },
       }, null, setLocalSettings);

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -195,10 +195,12 @@ const PushLayoutEngine = (props) => {
 
   useEffect(() => {
     if (!selectedLayout) return () => { };
-    const meetingLayoutDidChange = meetingLayout !== prevProps.meetingLayout;
+    const meetingLayoutDidChange = prevProps.meetingLayout !== undefined
+      && meetingLayout !== prevProps.meetingLayout;
     const pushLayoutMeetingDidChange = prevProps.pushLayoutMeeting !== undefined
       && pushLayoutMeeting !== prevProps.pushLayoutMeeting;
-    const enforceLayoutDidChange = enforceLayoutResult !== prevProps.enforceLayoutResult;
+    const enforceLayoutDidChange = enforceLayoutResult !== undefined
+      && enforceLayoutResult !== prevProps.enforceLayoutResult;
     const shouldSwitchLayout = isPresenter
       ? meetingLayoutDidChange || enforceLayoutDidChange
       : ((meetingLayoutDidChange || pushLayoutMeetingDidChange) && pushLayoutMeeting)
@@ -392,7 +394,7 @@ const PushLayoutEngineContainer = (props) => {
 
   const validatePluginLayout = (layout) => {
     const layoutTypes = Object.keys(LAYOUT_TYPE);
-    return layout && layoutTypes.includes(layout) ? layout : null;
+    return layout && layoutTypes.includes(layout) ? layout : undefined;
   };
   const pluginEnforcedLayout = validatePluginLayout(
     pluginLayoutChange.pluginEnforcedLayout,
@@ -437,7 +439,7 @@ const PushLayoutEngineContainer = (props) => {
   const validateEnforceLayout = (currUser) => {
     const layoutTypes = Object.keys(LAYOUT_TYPE);
     const enforceLayout = currUser?.enforceLayout;
-    return enforceLayout && layoutTypes.includes(enforceLayout) ? enforceLayout : null;
+    return enforceLayout && layoutTypes.includes(enforceLayout) ? enforceLayout : undefined;
   };
 
   const enforceLayout = validateEnforceLayout(currentUserData);

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -198,7 +198,8 @@ const PushLayoutEngine = (props) => {
   useEffect(() => {
     if (!selectedLayout) return () => { };
     const meetingLayoutDidChange = meetingLayout !== prevProps.meetingLayout;
-    const pushLayoutMeetingDidChange = pushLayoutMeeting !== prevProps.pushLayoutMeeting;
+    const pushLayoutMeetingDidChange = prevProps.pushLayoutMeeting !== undefined
+      && pushLayoutMeeting !== prevProps.pushLayoutMeeting;
     const enforceLayoutDidChange = enforceLayoutResult !== prevProps.enforceLayoutResult;
     const shouldSwitchLayout = isPresenter
       ? meetingLayoutDidChange || enforceLayoutDidChange

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -108,23 +108,21 @@ const PushLayoutEngine = (props) => {
 
   useEffect(() => {
     const Settings = getSettingsSingletonInstance();
+    let { selectedLayout: currentLayout } = Settings.layout;
     const hasLayoutEngineLoadedOnce = Session.getItem('hasLayoutEngineLoadedOnce');
 
     const changeLayout = LAYOUT_TYPE[getFromUserSettings('bbb_change_layout', null)];
     const defaultLayout = LAYOUT_TYPE[getFromUserSettings('bbb_default_layout', null)];
     const enforcedLayout = LAYOUT_TYPE[enforceLayoutResult] || null;
 
-    Settings.layout.selectedLayout = enforcedLayout
-      || changeLayout
-      || defaultLayout
-      || meetingLayout;
+    Settings.layout.selectedLayout = enforcedLayout || changeLayout || defaultLayout
+      || meetingLayout || currentLayout;
 
-    let { selectedLayout: actualLayout } = Settings.layout;
     if (isMobile()) {
-      actualLayout = actualLayout === 'custom' ? 'smart' : actualLayout;
-      Settings.layout.selectedLayout = actualLayout;
+      currentLayout = currentLayout === 'custom' ? 'smart' : currentLayout;
+      Settings.layout.selectedLayout = currentLayout;
     }
-    Session.setItem('isGridEnabled', actualLayout === LAYOUT_TYPE.VIDEO_FOCUS);
+    Session.setItem('isGridEnabled', currentLayout === LAYOUT_TYPE.VIDEO_FOCUS);
 
     Settings.save(setLocalSettings);
 
@@ -139,7 +137,7 @@ const PushLayoutEngine = (props) => {
     MediaService.setPresentationIsOpen(layoutContextDispatch, presentationLastState);
     Session.setItem('presentationLastState', presentationLastState);
 
-    if (actualLayout === 'custom') {
+    if (currentLayout === 'custom') {
       setTimeout(() => {
         layoutContextDispatch({
           type: ACTIONS.SET_FOCUSED_CAMERA_ID,
@@ -183,7 +181,7 @@ const PushLayoutEngine = (props) => {
         }
       }, 0);
     }
-    if (actualLayout === 'participantsAndChatOnly') {
+    if (currentLayout === 'participantsAndChatOnly') {
       layoutContextDispatch({
         type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
         value: true,

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -116,7 +116,7 @@ const PushLayoutEngine = (props) => {
     const enforcedLayout = LAYOUT_TYPE[enforceLayoutResult] || null;
 
     Settings.layout.selectedLayout = enforcedLayout || changeLayout || defaultLayout
-      || meetingLayout || currentLayout;
+      || (pushLayoutMeeting ? (meetingLayout || currentLayout) : (currentLayout));
 
     if (isMobile()) {
       currentLayout = currentLayout === 'custom' ? 'smart' : currentLayout;

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -118,8 +118,11 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       enableCopyNetworkStatsButton: true,
       userSettingsStorage: 'session',
       defaultSettings: {
-        application: {
+        layout: {
           selectedLayout: 'custom',
+          pushLayout: false,
+        },
+        application: {
           animations: true,
           chatAudioAlerts: false,
           chatPushAlerts: false,


### PR DESCRIPTION
### What does this PR do?
- [fix(layout): validate device type before layout support check](https://github.com/bigbluebutton/bigbluebutton/commit/761593b24c59232ea3aa7bc7bdbed5c83ded74da)
- [fix(layout): ensure initial values are undefined when unset](https://github.com/bigbluebutton/bigbluebutton/commit/8059d882016586b06a878608858f8ab466c3dea4)
- [fix(layout): apply meeting layout only when pushed](https://github.com/bigbluebutton/bigbluebutton/commit/ebf4e27570fb888149380ad6b8793a69c89e413a)
- [fix(layout): incorrectly assigning local layout to undefined](https://github.com/bigbluebutton/bigbluebutton/commit/d1f0180e586c10ca96589395bf3429b2a84df1d5)
- [fix(layout): local push layout being ovewritten](https://github.com/bigbluebutton/bigbluebutton/commit/088cb6c09a0535eea7e6d9e49ae51977fe6d2c94)
- [fix(layout): update settings key to update](https://github.com/bigbluebutton/bigbluebutton/commit/e9bf36d12208015667c8738d5f80e6c2b81edd4f)
- [fix: add layout default settings to initial values](https://github.com/bigbluebutton/bigbluebutton/commit/f56cb4f2e17e0933662a2d0f4c572f2635875d58)

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/23532

### How to test
Follow steps to reproduce issue
