### PR TITLE
build(livekit): livekit/sip@v1.1.1, bbb-webrtc-sfu@v2.19.0-beta.4, bypass guest lobby for dial-ins when using LK audio 

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -3,13 +3,13 @@ package org.bigbluebutton.core.apps.voice
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.db.NotificationDAO
-import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter, HandlerHelpers }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.util.ColorPicker
 import org.bigbluebutton.core2.MeetingStatus2x
 
-trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
+trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelpers {
   this: MeetingActor =>
 
   val liveMeeting: LiveMeeting
@@ -137,9 +137,14 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration {
       outGW.send(event)
     } else {
       if (isDialInUser) {
+        // Guest lobby is always disabled for dial-in users joining via LiveKit
+        // as it's not fully supported yet.
+        val enforceGuestPolicy = dialInEnforceGuestPolicy && !isUsingLiveKitAudio(liveMeeting)
+
         registerUserInRegisteredUsers()
         registerUserInUsers2x()
-        if (dialInEnforceGuestPolicy) {
+
+        if (enforceGuestPolicy) {
           guestPolicy match {
             case GuestPolicy(policy, setBy) => {
               policy match {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -347,9 +347,13 @@ trait HandlerHelpers extends SystemConfiguration {
   }
 
   def isUsingLiveKit(liveMeeting: LiveMeeting): Boolean = {
-    liveMeeting.props.meetingProp.audioBridge == "livekit" ||
+    isUsingLiveKitAudio(liveMeeting) ||
     liveMeeting.props.meetingProp.cameraBridge == "livekit" ||
     liveMeeting.props.meetingProp.screenShareBridge == "livekit"
+  }
+
+  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean = {
+    liveMeeting.props.meetingProp.audioBridge == "livekit"
   }
 
   def buildLiveKitTokenGrant(

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.19.0-beta.3 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.19.0-beta.4 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu

--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -4,7 +4,7 @@ TARGET=$(basename "$(pwd)")
 
 SERVER_VERSION=v1.9.0
 CLI_VERSION=2.3.1
-SIP_VERSION=v0.9.0
+SIP_VERSION=v1.1.1
 
 PACKAGE=$(echo "$TARGET" | cut -d'_' -f1)
 VERSION=$(echo "$TARGET" | cut -d'_' -f2)


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): bypass guest lobby for dial-ins when using LK audio](https://github.com/bigbluebutton/bigbluebutton/commit/bc22e1c10f636a4f48e17d9d048167975ddc5e0b) 
  - The LK integration currently does not support guest lobbies for
  dial-in/SIP endpoints. It'll be fixed in the future, but right
  now it's problematic to keep this enabled as it does not reflect
  the participants correct state.
  - Bypass guest lobby for dial-in/SIP endpoints only when LiveKit is the
  meeting's audio bridge.
- [build(bbb-webrtc-sfu): v2.19.0-beta.4](https://github.com/bigbluebutton/bigbluebutton/commit/9fb4f20c1f99e105f5815fa91d1b27656630d90a) 
  - fix(livekit): don't create RTC clients for non-BBB meetings
  - fix(livekit): incorrect metadata override for external participants
- [build(livekit): livekit/sip@v1.1.1 (up from v0.9.0)](https://github.com/bigbluebutton/bigbluebutton/commit/aa02661125d5e38c42df6943b1eaf7c181189b18)

### Closes Issue(s)

None