### PR TITLE
feat: persist whiteboard tools on unmount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -38,8 +38,28 @@ import { useMouseEvents, useCursor } from './hooks';
 import { notifyShapeNumberExceeded, getCustomEditorAssetUrls, getCustomAssetUrls } from './service';
 import NoopTool from './custom-tools/noop-tool/component';
 import DeleteSelectedItemsTool from './custom-tools/delete-selected-items/component';
+import SessionStorage from '/imports/ui/services/storage/session';
 
 const CAMERA_TYPE = 'camera';
+
+const colorStyles = [
+  'black',
+  'blue',
+  'green',
+  'grey',
+  'light-blue',
+  'light-green',
+  'light-red',
+  'light-violet',
+  'orange',
+  'red',
+  'violet',
+  'yellow',
+];
+const dashStyles = ['dashed', 'dotted', 'draw', 'solid'];
+const fillStyles = ['none', 'pattern', 'semi', 'solid'];
+const fontStyles = ['draw', 'mono', 'sans', 'serif'];
+const sizeStyles = ['l', 'm', 's', 'xl'];
 
 // Helper functions
 const deleteLocalStorageItemsWithPrefix = (prefix) => {
@@ -376,6 +396,8 @@ const Whiteboard = React.memo((props) => {
   React.useEffect(() => {
     hasWBAccessRef.current = hasWBAccess;
 
+    const toolbarSavedState = SessionStorage.getItem('whiteboardToolbarSavedState');
+
     if (!hasWBAccess && !isPresenter) {
       tlEditorRef?.current?.setCurrentTool('noop');
     } else if (hasWBAccess && !isPresenter) {
@@ -383,12 +405,22 @@ const Whiteboard = React.memo((props) => {
         initialSelectedTool: initialSelectedToolFromConfig,
         multiUserTools,
       } = window.meetingClientSettings.public.whiteboard.toolbar;
-      const initialSelectedTool = getFromUserSettings(
+      let initialSelectedTool = getFromUserSettings(
         'bbb_initial_selected_tool',
         initialSelectedToolFromConfig,
       );
-      const initialTool = multiUserTools.includes(initialSelectedTool) ? initialSelectedTool : 'draw';
-      tlEditorRef?.current?.setCurrentTool(initialTool);
+
+      if (toolbarSavedState) {
+        const {
+          selectedTool: savedSelectedTool,
+        } = toolbarSavedState;
+
+        if (savedSelectedTool && multiUserTools.includes(savedSelectedTool)) {
+          initialSelectedTool = savedSelectedTool;
+        }
+      }
+
+      tlEditorRef?.current?.setCurrentTool(initialSelectedTool);
     }
   }, [hasWBAccess]);
 
@@ -1108,6 +1140,57 @@ const Whiteboard = React.memo((props) => {
     setTldrawAPI(editor);
     setEditor(editor);
 
+    let initialColorStyle = colorStyle;
+    let initialDashStyle = dashStyle;
+    let initialFillStyle = fillStyle;
+    let initialFontStyle = fontStyle;
+    let initialSizeStyle = sizeStyle;
+
+    const toolbarSavedState = SessionStorage.getItem('whiteboardToolbarSavedState');
+
+    if (toolbarSavedState) {
+      const {
+        colorStyle: savedColorStyle,
+        dashStyle: savedDashStyle,
+        fillStyle: savedFillStyle,
+        fontStyle: savedFontStyle,
+        sizeStyle: savedSizeStyle,
+        selectedTool: savedSelectedTool,
+      } = toolbarSavedState;
+
+      if (savedColorStyle) {
+        if (colorStyles.includes(savedColorStyle)) {
+          initialColorStyle = savedColorStyle;
+        }
+      }
+      if (savedDashStyle) {
+        if (dashStyles.includes(savedDashStyle)) {
+          initialDashStyle = savedDashStyle;
+        }
+      }
+      if (savedFillStyle) {
+        if (fillStyles.includes(savedFillStyle)) {
+          initialFillStyle = savedFillStyle;
+        }
+      }
+      if (savedFontStyle) {
+        if (fontStyles.includes(savedFontStyle)) {
+          initialFontStyle = savedFontStyle;
+        }
+      }
+      if (savedSizeStyle) {
+        if (sizeStyles.includes(savedSizeStyle)) {
+          initialSizeStyle = savedSizeStyle;
+        }
+      }
+      if (savedSelectedTool) {
+        const { multiUserTools } = window.meetingClientSettings.public.whiteboard.toolbar;
+        if (multiUserTools.includes(savedSelectedTool)) {
+          editor.setCurrentTool(savedSelectedTool);
+        }
+      }
+    }
+
     DefaultHorizontalAlignStyle.defaultValue = isRTL ? 'end' : 'start';
     DefaultVerticalAlignStyle.defaultValue = 'start';
 
@@ -1116,39 +1199,20 @@ const Whiteboard = React.memo((props) => {
       editor?.updateInstanceState({ isToolLocked: true });
     }
 
-    const colorStyles = [
-      'black',
-      'blue',
-      'green',
-      'grey',
-      'light-blue',
-      'light-green',
-      'light-red',
-      'light-violet',
-      'orange',
-      'red',
-      'violet',
-      'yellow',
-    ];
-    const dashStyles = ['dashed', 'dotted', 'draw', 'solid'];
-    const fillStyles = ['none', 'pattern', 'semi', 'solid'];
-    const fontStyles = ['draw', 'mono', 'sans', 'serif'];
-    const sizeStyles = ['l', 'm', 's', 'xl'];
-
-    if (colorStyles.includes(colorStyle)) {
-      editor.setStyleForNextShapes(DefaultColorStyle, colorStyle);
+    if (colorStyles.includes(initialColorStyle)) {
+      editor.setStyleForNextShapes(DefaultColorStyle, initialColorStyle);
     }
-    if (dashStyles.includes(dashStyle)) {
-      editor.setStyleForNextShapes(DefaultDashStyle, dashStyle);
+    if (dashStyles.includes(initialDashStyle)) {
+      editor.setStyleForNextShapes(DefaultDashStyle, initialDashStyle);
     }
-    if (fillStyles.includes(fillStyle)) {
-      editor.setStyleForNextShapes(DefaultFillStyle, fillStyle);
+    if (fillStyles.includes(initialFillStyle)) {
+      editor.setStyleForNextShapes(DefaultFillStyle, initialFillStyle);
     }
-    if (fontStyles.includes(fontStyle)) {
-      editor.setStyleForNextShapes(DefaultFontStyle, fontStyle);
+    if (fontStyles.includes(initialFontStyle)) {
+      editor.setStyleForNextShapes(DefaultFontStyle, initialFontStyle);
     }
-    if (sizeStyles.includes(sizeStyle)) {
-      editor.setStyleForNextShapes(DefaultSizeStyle, sizeStyle);
+    if (sizeStyles.includes(initialSizeStyle)) {
+      editor.setStyleForNextShapes(DefaultSizeStyle, initialSizeStyle);
     }
 
     editor.store.listen(
@@ -1486,10 +1550,21 @@ const Whiteboard = React.memo((props) => {
           presenterTools,
           multiUserTools,
         } = window.meetingClientSettings.public.whiteboard.toolbar;
-        const initialSelectedTool = getFromUserSettings(
+        let initialSelectedTool = getFromUserSettings(
           'bbb_initial_selected_tool',
           initialSelectedToolFromConfig,
         );
+
+        if (toolbarSavedState) {
+          const {
+            selectedTool: savedSelectedTool,
+          } = toolbarSavedState;
+
+          if (savedSelectedTool && multiUserTools.includes(savedSelectedTool)) {
+            initialSelectedTool = savedSelectedTool;
+          }
+        }
+
         if (isPresenterRef.current) {
           const initialPresenterTool = presenterTools.includes(initialSelectedTool) ? initialSelectedTool : 'noop';
           editor?.setCurrentTool(initialPresenterTool);
@@ -2000,6 +2075,24 @@ const Whiteboard = React.memo((props) => {
     const newCursor = hasWBAccessRef.current || currentUser?.presenter ? TOOL_CURSORS[currentTool] || '' : 'inherit';
     setCursorType(newCursor);
   }, [tlEditorRef.current?.getCurrentToolId()]);
+
+  const getToolbarCurrentState = useCallback(() => {
+    return {
+      colorStyle: tlEditorRef.current?.getInstanceState().stylesForNextShape[DefaultColorStyle.id],
+      dashStyle: tlEditorRef.current?.getInstanceState().stylesForNextShape[DefaultDashStyle.id],
+      fillStyle: tlEditorRef.current?.getInstanceState().stylesForNextShape[DefaultFillStyle.id],
+      fontStyle: tlEditorRef.current?.getInstanceState().stylesForNextShape[DefaultFontStyle.id],
+      sizeStyle: tlEditorRef.current?.getInstanceState().stylesForNextShape[DefaultSizeStyle.id],
+      selectedTool: tlEditorRef.current?.getCurrentToolId(),
+    };
+  }, [
+    tlEditorRef.current?.getInstanceState().stylesForNextShape,
+    tlEditorRef.current?.getCurrentToolId(),
+  ]);
+
+  React.useEffect(() => () => {
+    SessionStorage.setItem('whiteboardToolbarSavedState', getToolbarCurrentState());
+  }, [getToolbarCurrentState]);
 
   return (
     <div


### PR DESCRIPTION
### What does this PR do?

saves whiteboard toolbar selected items, and restores when the component is mounted again

#### before


https://github.com/user-attachments/assets/1d2151b9-f51c-4d4e-a133-7437650cda43


#### after

https://github.com/user-attachments/assets/bfd3c592-066e-4cd5-aa87-7b036aa4a81a

### How to test
1. join a meeting
2. change whiteboard toolbar settings (color, tool, tool size, ...)
3. click on "fit to width" button
4. whiteboard toolbar should not switch back to default settings (selected items should still be the ones the user selected)