### PR TITLE
refactor (akka): Improve Middleware Health‑check and include INFO logs when database execution is slow

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/Boot.scala
@@ -66,7 +66,7 @@ object Boot extends App with SystemConfiguration {
   )
 
   val graphqlConnectionsActor = system.actorOf(
-    GraphqlConnectionsActor.props(system, eventBus, outGW),
+    GraphqlConnectionsActor.props(eventBus, outGW),
     "GraphqlConnectionsActor"
   )
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -70,7 +70,11 @@ object DatabaseConnection {
         case scala.util.Success(_) =>
           val endTime = System.nanoTime()
           val duration = (endTime - startTime) / 1e6 // convert to milliseconds
-          logger.debug(s"${batch.size} actions executed in the database in $duration ms.")
+          if (duration > 2000) {
+            logger.warn(s"${batch.size} actions executed in the database in $duration ms.")
+          } else {
+            logger.debug(s"${batch.size} actions executed in the database in $duration ms.")
+          }
           isProcessing.set(false)
           if (!queue.isEmpty) tryProcessBatch()
         case scala.util.Failure(e) =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/GraphqlConnectionsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/GraphqlConnectionsActor.scala
@@ -1,104 +1,163 @@
 package org.bigbluebutton.endpoint.redis
 
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorSystem, Props}
+import org.apache.pekko.actor.{ Actor, ActorLogging, Props, Timers }
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.OutMessageGateway
-import org.bigbluebutton.core.api.{UserClosedAllGraphqlConnectionsInternalMsg, UserEstablishedGraphqlConnectionInternalMsg}
-import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
+import org.bigbluebutton.core.api.{ UserClosedAllGraphqlConnectionsInternalMsg, UserEstablishedGraphqlConnectionInternalMsg }
+import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
 import org.bigbluebutton.core.db.UserGraphqlConnectionDAO
 import org.bigbluebutton.core2.message.senders.MsgBuilder
-import java.time.Instant
 
 import scala.concurrent.duration._
-import org.apache.pekko.actor.Timers
+import java.time.Instant
 
-case object MiddlewareHealthCheckScheduler10Sec
+/**
+ * Health‑check logic
+ * ------------------
+ * • Ping every middleware every 5s (PingInterval).
+ * • Each ping increments an attempt counter.
+ * • A middleware is considered inactive when it reaches 3 attempts (≈15s) without any pong;
+ *   the check happens at the beginning of the next cycle.
+ */
+
+case object MiddlewareHealthCheckScheduler5Sec
 
 object GraphqlConnectionsActor {
-  def props(system: ActorSystem,
-            eventBus:       InternalEventBus,
-            outGW:          OutMessageGateway,
-           ): Props =
-    Props(
-      classOf[GraphqlConnectionsActor],
-      system,
-      eventBus,
-      outGW,
-    )
+  def props(
+      eventBus: InternalEventBus,
+      outGW:    OutMessageGateway
+  ): Props =
+    Props(classOf[GraphqlConnectionsActor], eventBus, outGW)
 }
 
-case class GraphqlUser(
-               intId:              String,
-               meetingId:          String,
-               sessionToken:       String,
-               )
+case class GraphqlUser(intId: String, meetingId: String, sessionToken: String)
 
 case class GraphqlUserConnection(
-                 middlewareUID:       String,
-                 browserConnectionId: String,
-                 sessionToken:        String,
-                 clientSessionUUID:   String,
-                 clientType:          String,
-                 clientIsMobile:      Boolean,
-                 user:                GraphqlUser,
-               )
+    middlewareUID:       String,
+    browserConnectionId: String,
+    sessionToken:        String,
+    clientSessionUUID:   String,
+    clientType:          String,
+    clientIsMobile:      Boolean,
+    user:                GraphqlUser
+)
+
+private case class PendingPing(sentAt: Long, attempts: Int)
 
 class GraphqlConnectionsActor(
-    system:         ActorSystem,
-    val eventBus:   InternalEventBus,
-    val outGW:      OutMessageGateway,
-) extends Actor with ActorLogging with Timers {
+    val eventBus: InternalEventBus,
+    val outGW:    OutMessageGateway
+)
+  extends Actor with ActorLogging with Timers {
 
-  private var users: Map[String, GraphqlUser] = Map()
-  private var graphqlConnections: Map[String, GraphqlUserConnection] = Map()
-  private var pendingResponseMiddlewareUIDs: Map[String, BigInt] = Map()
+  /* ---------------- Mutable state ---------------- */
+  private var users: Map[String, GraphqlUser] = Map.empty
+  private var graphqlConnections: Map[String, GraphqlUserConnection] = Map.empty
+  private var pending: Map[String, PendingPing] = Map.empty
 
-  override def preStart(): Unit = {
-    timers.startTimerAtFixedRate("graphql-middleware-health-check", MiddlewareHealthCheckScheduler10Sec, 10.seconds)
+  /* ---------------- Constants -------------------- */
+  private val PingInterval = 5.seconds
+  private val MaxAttempts = 3 // 3 pings ≈ 15s
+
+  override def preStart(): Unit =
+    timers.startTimerAtFixedRate(
+      "graphql-middleware-health-check",
+      MiddlewareHealthCheckScheduler5Sec, PingInterval
+    )
+
+  def receive: Receive = {
+    case msg: BbbCommonEnvCoreMsg           => handleBbbCommonEnvCoreMsg(msg)
+    case MiddlewareHealthCheckScheduler5Sec => runHealthCheck()
+    case _                                  => // ignore
   }
 
-  private val maxMiddlewareInactivityInMillis = 11000
+  /* ---------------- Health‑check ----------------- */
 
-  def receive = {
-    //=============================
-    // 2x messages
-    case msg: BbbCommonEnvCoreMsg             => handleBbbCommonEnvCoreMsg(msg)
-    case MiddlewareHealthCheckScheduler10Sec  => runMiddlewareHealthCheck()
-    case _                                    => // do nothing
+  private def runHealthCheck(): Unit = {
+    val now = System.currentTimeMillis()
+
+    // 1) Check for time‑outs before sending new pings
+    pending.foreach { case (mw, pp) =>
+      val elapsed = now - pp.sentAt
+      if (pp.attempts >= MaxAttempts && elapsed >= (MaxAttempts * PingInterval).toMillis) {
+        markMiddlewareInactive(mw, pp)
+      }
+    }
+
+    // 2) Send ping to every still‑active middleware
+    val middlewares = graphqlConnections.values.map(_.middlewareUID).toSet
+    middlewares.foreach(sendPing)
   }
 
-  private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = {
-    msg.core match {
-      case m: RegisterUserReqMsg                      => handleUserRegisteredRespMsg(m)
-      case m: RegisterUserSessionTokenReqMsg          => handleRegisterUserSessionTokenReqMsg(m)
-      case m: DestroyMeetingSysCmdMsg                 => handleDestroyMeetingSysCmdMsg(m)
-      // Messages from bbb-graphql-middleware
-      case m: UserGraphqlConnectionEstablishedSysMsg  => handleUserGraphqlConnectionEstablishedSysMsg(m)
-      case m: UserGraphqlConnectionClosedSysMsg       => handleUserGraphqlConnectionClosedSysMsg(m)
-      case m: CheckGraphqlMiddlewareAlivePongSysMsg   => handleCheckGraphqlMiddlewareAlivePongSysMsg(m)
-      case _                                          => // message not to be handled.
+  private def sendPing(middlewareUID: String): Unit = {
+    val newPending = pending.get(middlewareUID) match {
+      case Some(p) => p.copy(attempts = p.attempts + 1) // Re‑ping; keep original sentAt
+      case None    => PendingPing(System.currentTimeMillis(), 1) // First ping
+    }
+
+    pending += (middlewareUID -> newPending)
+
+    outGW.send(MsgBuilder.buildCheckGraphqlMiddlewareAlivePingSysMsg(middlewareUID))
+    if (newPending.attempts > 1) {
+      log.warning("Sent ping {} attempt #{}", middlewareUID, newPending.attempts)
+    } else {
+      log.debug("Sent ping {} attempt #{}", middlewareUID, newPending.attempts)
     }
   }
 
-  private def handleUserRegisteredRespMsg(msg: RegisterUserReqMsg): Unit = {
-    users += (msg.body.sessionToken -> GraphqlUser(
-      msg.body.intUserId,
-      msg.body.meetingId,
-      msg.body.sessionToken
-    ))
+  private def markMiddlewareInactive(mw: String, status: PendingPing): Unit = {
+    log.info(
+      "Middleware {} considered INACTIVE after {} attempts (since {}).",
+      mw, status.attempts, Instant.ofEpochMilli(status.sentAt)
+    )
+
+    // Close connections and emit events
+    graphqlConnections.values
+      .filter(_.middlewareUID == mw)
+      .foreach { conn =>
+        handleUserGraphqlConnectionClosed(conn.sessionToken, conn.middlewareUID, conn.browserConnectionId)
+      }
+
+    pending -= mw
   }
 
-  private def handleRegisterUserSessionTokenReqMsg(msg: RegisterUserSessionTokenReqMsg): Unit = {
-    users += (msg.body.sessionToken -> GraphqlUser(
-      msg.body.userId,
-      msg.body.meetingId,
-      msg.body.sessionToken
-    ))
+  /* ---------------- Pong response --------------- */
+
+  private def handleCheckGraphqlMiddlewareAlivePongSysMsg(msg: CheckGraphqlMiddlewareAlivePongSysMsg): Unit = {
+    pending.get(msg.body.middlewareUID).foreach { pp =>
+      val rtt = System.currentTimeMillis() - pp.sentAt
+      if (rtt > 1000) {
+        log.warning("Received pong from {} after {}ms (attempt {}).", msg.body.middlewareUID, rtt, pp.attempts)
+      } else {
+        log.debug("Received pong from {} after {}ms (attempt {}).", msg.body.middlewareUID, rtt, pp.attempts)
+      }
+    }
+    pending -= msg.body.middlewareUID
   }
+
+  /* ----------- Core message handlers ------------ */
+
+  private def handleBbbCommonEnvCoreMsg(msg: BbbCommonEnvCoreMsg): Unit = msg.core match {
+    case m: RegisterUserReqMsg                     => handleUserRegisteredRespMsg(m)
+    case m: RegisterUserSessionTokenReqMsg         => handleRegisterUserSessionTokenReqMsg(m)
+    case m: DestroyMeetingSysCmdMsg                => handleDestroyMeetingSysCmdMsg(m)
+    case m: UserGraphqlConnectionEstablishedSysMsg => handleUserGraphqlConnectionEstablishedSysMsg(m)
+    case m: UserGraphqlConnectionClosedSysMsg      => handleUserGraphqlConnectionClosedSysMsg(m)
+    case m: CheckGraphqlMiddlewareAlivePongSysMsg  => handleCheckGraphqlMiddlewareAlivePongSysMsg(m)
+    case _                                         => // ignore
+  }
+
+  /* ----------- User / connection tracking ------- */
+
+  private def handleUserRegisteredRespMsg(msg: RegisterUserReqMsg): Unit =
+    users += (msg.body.sessionToken -> GraphqlUser(msg.body.intUserId, msg.body.meetingId, msg.body.sessionToken))
+
+  private def handleRegisterUserSessionTokenReqMsg(msg: RegisterUserSessionTokenReqMsg): Unit =
+    users += (msg.body.sessionToken -> GraphqlUser(msg.body.userId, msg.body.meetingId, msg.body.sessionToken))
 
   private def handleDestroyMeetingSysCmdMsg(msg: DestroyMeetingSysCmdMsg): Unit = {
-    users = users.filter(u => u._2.meetingId != msg.body.meetingId)
-    graphqlConnections = graphqlConnections.filter(c => c._2.user.meetingId != msg.body.meetingId)
+    users = users.filterNot { case (_, u) => u.meetingId == msg.body.meetingId }
+    graphqlConnections = graphqlConnections.filterNot { case (_, c) => c.user.meetingId == msg.body.meetingId }
   }
 
   private def handleUserGraphqlConnectionEstablishedSysMsg(msg: UserGraphqlConnectionEstablishedSysMsg): Unit = {
@@ -108,91 +167,44 @@ class GraphqlConnectionsActor(
       msg.body.clientType,
       msg.body.clientIsMobile,
       msg.body.middlewareUID,
-      msg.body.browserConnectionId)
+      msg.body.browserConnectionId
+    )
 
-    for {
-      user <- users.get(msg.body.sessionToken)
-    } yield {
-
-      //Send internal message informing user has connected
-        eventBus.publish(BigBlueButtonEvent(user.meetingId,
-          UserEstablishedGraphqlConnectionInternalMsg(
-            user.intId,
-            msg.body.clientType,
-            msg.body.clientIsMobile)
-        ))
-
-      graphqlConnections += (msg.body.browserConnectionId -> GraphqlUserConnection(
-        msg.body.middlewareUID,
-        msg.body.browserConnectionId,
-        msg.body.sessionToken,
-        msg.body.clientSessionUUID,
-        msg.body.clientType,
-        msg.body.clientIsMobile,
-        user
+    users.get(msg.body.sessionToken).foreach { user =>
+      eventBus.publish(BigBlueButtonEvent(
+        user.meetingId,
+        UserEstablishedGraphqlConnectionInternalMsg(user.intId, msg.body.clientType, msg.body.clientIsMobile)
       ))
+
+      graphqlConnections += (msg.body.browserConnectionId ->
+        GraphqlUserConnection(
+          msg.body.middlewareUID,
+          msg.body.browserConnectionId,
+          msg.body.sessionToken,
+          msg.body.clientSessionUUID,
+          msg.body.clientType,
+          msg.body.clientIsMobile,
+          user
+        ))
     }
   }
 
-  private def handleUserGraphqlConnectionClosedSysMsg(msg: UserGraphqlConnectionClosedSysMsg): Unit = {
+  private def handleUserGraphqlConnectionClosedSysMsg(msg: UserGraphqlConnectionClosedSysMsg): Unit =
     handleUserGraphqlConnectionClosed(msg.body.sessionToken, msg.body.middlewareUID, msg.body.browserConnectionId)
-  }
 
   private def handleUserGraphqlConnectionClosed(sessionToken: String, middlewareUID: String, browserConnectionId: String): Unit = {
     UserGraphqlConnectionDAO.updateClosed(sessionToken, middlewareUID, browserConnectionId)
 
-    for {
-      user <- users.get(sessionToken)
-    } yield {
-      graphqlConnections = graphqlConnections.-(browserConnectionId)
+    users.get(sessionToken).foreach { user =>
+      graphqlConnections -= browserConnectionId
 
-      //Send internal message informing user disconnected
-      if (!graphqlConnections.values.exists(c => c.sessionToken == sessionToken
-        || (c.user.meetingId == user.meetingId && c.user.intId == user.intId))) {
+      val userStillConnected = graphqlConnections.values.exists { c =>
+        c.sessionToken == sessionToken || (c.user.meetingId == user.meetingId && c.user.intId == user.intId)
+      }
+
+      if (!userStillConnected) {
         eventBus.publish(BigBlueButtonEvent(user.meetingId, UserClosedAllGraphqlConnectionsInternalMsg(user.intId)))
       }
     }
   }
-
-  private def runMiddlewareHealthCheck(): Unit = {
-    removeInactiveConnections()
-    sendPingMessageToAllMiddlewareServices()
-  }
-
-  private def sendPingMessageToAllMiddlewareServices(): Unit = {
-    graphqlConnections.map(c => {
-      c._2.middlewareUID
-    }).toVector.distinct.foreach(middlewareUID => {
-      val event = MsgBuilder.buildCheckGraphqlMiddlewareAlivePingSysMsg(middlewareUID)
-      outGW.send(event)
-      log.debug("Sent ping message to graphql middleware {}.", middlewareUID)
-      pendingResponseMiddlewareUIDs.get(middlewareUID) match {
-        case None => pendingResponseMiddlewareUIDs += (middlewareUID -> System.currentTimeMillis)
-        case Some(pingSentAt) => log.debug("There is already a pending response from middleware {} since {}.", middlewareUID, Instant.ofEpochMilli(pingSentAt.longValue))
-      }
-    })
-  }
-
-  private def removeInactiveConnections(): Unit = {
-    for {
-      (middlewareUid, pingSentAt) <- pendingResponseMiddlewareUIDs
-      if (System.currentTimeMillis - pingSentAt) > maxMiddlewareInactivityInMillis
-    } yield {
-      log.info("Removing connections from the middleware {} due to inactivity of the service (waiting response since {}).",middlewareUid, Instant.ofEpochMilli(pingSentAt.longValue))
-      for {
-        (_, graphqlConn) <- graphqlConnections
-        if graphqlConn.middlewareUID == middlewareUid
-      } yield {
-        handleUserGraphqlConnectionClosed(graphqlConn.sessionToken, graphqlConn.middlewareUID, graphqlConn.browserConnectionId)
-      }
-
-      pendingResponseMiddlewareUIDs -= middlewareUid
-    }
-  }
-
-  private def handleCheckGraphqlMiddlewareAlivePongSysMsg(msg: CheckGraphqlMiddlewareAlivePongSysMsg): Unit = {
-    log.debug("Received pong message from graphql middleware {}.",msg.body.middlewareUID)
-    pendingResponseMiddlewareUIDs -= msg.body.middlewareUID
-  }
-
 }


### PR DESCRIPTION
* Add INFO logs when the database execution took more than 2 seconds

Graphql Middleware Health‑check logic:
* Ping interval reduced to **5 s**.
* Tracks missed pongs; middleware declared inactive after **3 consecutive failures** (\~20 s).
* Added INFO logs when the Pong takes more than 1s or the attempt is >= 2  

_Before it would consider the Middleware INACTIVE after 11 seconds, now it will consider after 20 seconds._
