### PR TITLE
fix(whiteboard): Stop frame rename dropping characters when typing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -294,6 +294,10 @@ const Whiteboard = React.memo((props) => {
       prevShapesRef.current = shapes;
       tlEditorRef.current?.store.mergeRemoteChanges(() => {
         const remoteShapesArray = Object.values(prevShapesRef.current).reduce((acc, shape) => {
+          const isOwnerUpdate = shape.meta?.updatedBy === currentUser?.userId;
+          // if the remote shape was last updated by the owner, skip because it is already in the tldraw store.
+          if (isOwnerUpdate) return acc
+
           if (
             shape.meta?.presentationId === presentationIdRef.current
             || shape?.whiteboardId?.includes(presentationIdRef.current)


### PR DESCRIPTION
### What does this PR do?
This PR fixes the frame shape rename dropping characters when typing.

### Closes Issue(s)
Closes #23511 
