### PR TITLE
feat(breakout-room): added new flag in settings to set the minimum limit of breakouts room

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -20,7 +20,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
   def handleCreateBreakoutRoomsCmdMsg(msg: CreateBreakoutRoomsCmdMsg, state: MeetingState2x): MeetingState2x = {
 
 
-    val minOfRooms = 2
+    val minOfRooms = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomMinimum", 2)
     val maxOfRooms = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomLimit", 16)
 
     if (liveMeeting.props.meetingProp.disabledFeatures.contains("breakoutRooms")) {

--- a/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
@@ -18,8 +18,8 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   )
 
     const breakoutRooms = input['rooms'] as Array<Record<string, unknown>>;
-    if(breakoutRooms.length < 2) {
-        throw new ValidationError('It is required to set two or more rooms.', 400);
+    if(breakoutRooms.length < 1) {
+        throw new ValidationError('It is required to set at least one room.', 400);
     }
 
   throwErrorIfInvalidInput(breakoutRooms[0],

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -158,6 +158,7 @@ export interface Breakouts {
   captureWhiteboardByDefault: boolean
   captureSharedNotesByDefault: boolean
   sendInvitationToAssignedModeratorsByDefault: boolean
+  breakoutRoomMinimum: number
   breakoutRoomLimit: number
   allowPresentationManagementInBreakouts: boolean
 }

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -35,7 +35,6 @@ import { notify } from '/imports/ui/services/notification';
 import useTimeSync from '/imports/ui/core/local-states/useTimeSync';
 import { getRemainingMeetingTime, isNewTimeValid } from '/imports/ui/core/utils/calculateRemaingTime';
 
-const MIN_BREAKOUT_ROOMS = 2;
 const MIN_BREAKOUT_TIME = 5;
 const DEFAULT_BREAKOUT_TIME = 15;
 const CURRENT_SLIDE_PREFIX = 'current-';
@@ -255,20 +254,29 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   const intl = useIntl();
   const layoutContextDispatch = layoutDispatch();
 
-  const initialNumberOfRooms = runningRooms.length > 0 ? runningRooms.length : MIN_BREAKOUT_ROOMS;
-
   const isImportPresentationWithAnnotationsEnabled = useIsImportPresentationWithAnnotationsFromBreakoutRoomsEnabled();
   const isImportSharedNotesEnabled = useIsImportSharedNotesFromBreakoutRoomsEnabled();
 
   // @ts-ignore
   const BREAKOUT_SETTINGS = window.meetingClientSettings.public.app.breakouts;
 
-  const { allowUserChooseRoomByDefault, recordRoomByDefault, offerRecordingForBreakouts } = BREAKOUT_SETTINGS;
+  const {
+    allowUserChooseRoomByDefault,
+    recordRoomByDefault,
+    offerRecordingForBreakouts,
+    breakoutRoomLimit: BREAKOUT_LIM,
+    breakoutRoomMinimum: MIN_BREAKOUT_ROOMS,
+    sendInvitationToAssignedModeratorsByDefault: inviteModsByDefault,
+  } = BREAKOUT_SETTINGS;
+
+  const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
+
+  const initialNumberOfRooms = runningRooms.length > 0 ? runningRooms.length : MIN_BREAKOUT_ROOMS;
+
   const captureWhiteboardByDefault = BREAKOUT_SETTINGS.captureWhiteboardByDefault
     && isImportPresentationWithAnnotationsEnabled;
   const captureSharedNotesByDefault = BREAKOUT_SETTINGS.captureSharedNotesByDefault
     && isImportPresentationWithAnnotationsEnabled;
-  const inviteModsByDefault = BREAKOUT_SETTINGS.sendInvitationToAssignedModeratorsByDefault;
 
   const [numberOfRoomsIsValid, setNumberOfRoomsIsValid] = React.useState(true);
   const [durationIsValid, setDurationIsValid] = React.useState(true);
@@ -478,9 +486,6 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   const form = useMemo(() => {
     if (isUpdate) return null;
 
-    // @ts-ignore
-    const BREAKOUT_LIM = window.meetingClientSettings.public.app.breakouts.breakoutRoomLimit;
-    const MAX_BREAKOUT_ROOMS = BREAKOUT_LIM > MIN_BREAKOUT_ROOMS ? BREAKOUT_LIM : MIN_BREAKOUT_ROOMS;
     const leastOneUserIsValid = roomsRef.current[0]?.users?.length < users.length;
 
     return (

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -100,6 +100,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         captureWhiteboardByDefault: false,
         captureSharedNotesByDefault: false,
         sendInvitationToAssignedModeratorsByDefault: false,
+        breakoutRoomMinimum: 2,
         breakoutRoomLimit: 16,
         allowPresentationManagementInBreakouts: true,
       },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -152,6 +152,7 @@ public:
       captureWhiteboardByDefault: false
       captureSharedNotesByDefault: false
       sendInvitationToAssignedModeratorsByDefault: false
+      breakoutRoomMinimum: 2
       breakoutRoomLimit: 16
       allowPresentationManagementInBreakouts: true
     showAllAvailableLocales: true


### PR DESCRIPTION
### What does this PR do?
This pull request adds the ability to configure the minimum number of breakout rooms via the new `breakoutRoomMinimum` flag in the settings file.

Previously, this value was hardcoded to `2`, which limited flexibility in certain use cases. With this change, it is now possible to adjust this limit as needed. The default value remains `2` to ensure backward compatibility and avoid impacting current setups.

### How to Use

To change the minimum number of breakout rooms, set the desired value for the `breakoutRoomMinimum` flag.

### Closes Issue(s)
Closes None


### More
[Screencast from 15-07-2025 13:41:54.webm](https://github.com/user-attachments/assets/bbc46fa6-ba0c-4d33-a80c-84cd5ef999f8)

