### PR TITLE
fix(html5): Add regex to handle missing question text in smart slides

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -81,6 +81,7 @@ const QuickPollDropdown = (props) => {
   } = currentSlide;
 
   const questionPattern = /^[a-zA-Z0-9][.)]\s+.*/;
+  const basicQuestionPattern = /^.*\?\s*$/;
 
   const yesNoPatt = createPattern([yesValue, noValue]);
   const trueFalsePatt = createPattern([trueValue, falseValue]);
@@ -103,6 +104,7 @@ const QuickPollDropdown = (props) => {
       // We've found explicit options (e.g., "a) Yes" or "Yes / No")
       isOptionSection = true;
       options.push(trimmedLine);
+      if (basicQuestionPattern.test(trimmedLine)) questionLines.push(trimmedLine);
     } else if (!isOptionSection && trimmedLine.length > 0) {
       // Any non-empty line before options is considered question text
       questionLines.push(trimmedLine);


### PR DESCRIPTION
### What does this PR do?
This pr fixes an issue where the smart poll doesn't get / display the full question text in some cases.

### Motivation

Given a slide with text like this

```
Poll:
All work with asbestos can only be carried out
by a specialist licensed contractor (True/False)?
```

the smart slide would show the question as

```
Poll:
All work with asbestos can only be carried out
```
