### PR TITLE
Revert "fix(whiteboard): Stop frame rename dropping characters when typing"

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -315,10 +315,6 @@ const Whiteboard = React.memo((props) => {
       prevShapesRef.current = shapes;
       tlEditorRef.current?.store.mergeRemoteChanges(() => {
         const remoteShapesArray = Object.values(prevShapesRef.current).reduce((acc, shape) => {
-          const isOwnerUpdate = shape.meta?.updatedBy === currentUser?.userId;
-          // if the remote shape was last updated by the owner, skip because it is already in the tldraw store.
-          if (isOwnerUpdate) return acc
-
           if (
             shape.meta?.presentationId === presentationIdRef.current
             || shape?.whiteboardId?.includes(presentationIdRef.current)


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#23543

---

the changes made in this PR caused a bug in the annotations:

1. join a meeting
2. draw a line in the first slide
3. go to slide 2
4. return to slide 1
5. the annotation does not appear


https://github.com/user-attachments/assets/b2b9a17a-ffe9-40e1-a4d7-a93ff583b417

