### PR TITLE
feat(guest-management): add "Remember Choice" option to waiting panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/component.tsx
@@ -32,7 +32,6 @@ interface WaitingUserSectionProps {
   authedGuestUsers: GuestWaitingUser[];
   unauthedGuestUsers: GuestWaitingUser[];
   guestLobbyMessage: string | null;
-  guestLobbyEnabled: boolean;
   guestPolicy: string;
 }
 
@@ -89,13 +88,9 @@ const intlMessages = defineMessages({
 const WaitingUserSection: React.FC<WaitingUserSectionProps> = ({
   authedGuestUsers,
   unauthedGuestUsers,
-  guestLobbyEnabled,
   guestLobbyMessage,
   guestPolicy,
 }) => {
-  if (!guestLobbyEnabled) {
-    return null;
-  }
   const isGuestLobbyMessageEnabled = window.meetingClientSettings.public.app.enableGuestLobbyMessage;
   const intl = useIntl();
   const { isChrome } = browserInfo;
@@ -302,6 +297,13 @@ const WaitingUserSectionContainer: React.FC = () => {
       </div>
     );
   }
+  const guestPolicy = currentMeeting?.usersPolicies?.guestPolicy;
+  const guestLobbyEnabled = (guestPolicy === ASK_MODERATOR)
+        || !!(guestWaitingUsersData?.user_guest?.length);
+
+  if (!guestLobbyEnabled) {
+    return null;
+  }
 
   const separateGuestUsersByAuthed = guestWaitingUsersData
     ?.user_guest
@@ -314,15 +316,11 @@ const WaitingUserSectionContainer: React.FC = () => {
       return acc;
     }, { authed: [], unauthed: [] }) ?? { authed: [], unauthed: [] };
 
-  const guestPolicy = currentMeeting?.usersPolicies?.guestPolicy;
-
   return (
     <WaitingUserSection
       authedGuestUsers={separateGuestUsersByAuthed.authed}
       unauthedGuestUsers={separateGuestUsersByAuthed.unauthed}
       guestLobbyMessage={currentMeeting?.usersPolicies?.guestLobbyMessage ?? null}
-      guestLobbyEnabled={(guestPolicy === ASK_MODERATOR)
-        || !!(guestWaitingUsersData?.user_guest?.length)}
       guestPolicy={guestPolicy || ''}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/styles.ts
@@ -142,7 +142,7 @@ const WaitingUsersHeader = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
-  align-self: stretch; 
+  align-self: stretch;
   cursor: pointer;
 `;
 
@@ -171,12 +171,11 @@ const GuestOptionsContainer = styled.div`
   height: 1.5rem;
 `;
 
-const AcceptDenyButtonsContainer = styled.div`
-  display: inline-flex;
-  justify-content: space-between
+export const AcceptDenyButtonsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
   align-items: center;
   padding: 0px 0.5rem 0.5rem;
-  gap: 1.5rem;
 `;
 
 const AcceptDenyButtonText = styled.div`
@@ -220,12 +219,9 @@ const GuestLobbyMessageContainer = styled.div`
 `;
 
 const SwitchTitle = styled(FormControlLabel)`
-  //height: 1.5rem;
-  //width: 1.5rem;
-  //flex-shrink: 0;
   .MuiFormControlLabel-label {
     color: ${colorText};
-    font-size: ${fontSizeBase}
+    font-size: ${fontSizeBase};
     font-weight: ${textFontWeight};
     line-height: normal;
   }
@@ -237,9 +233,7 @@ const MessageSwitch = materialStyled(Switch)(({ theme }) => ({
   padding: 0,
   display: 'flex',
   '&:active': {
-    '& .MuiSwitch-thumb': {
-      // width: 10,
-    },
+    '& .MuiSwitch-thumb': {},
     '& .MuiSwitch-switchBase.Mui-checked': {
       transform: 'translateX(9px)',
     },
@@ -292,11 +286,7 @@ const SendButton = styled(Button)`
     border-radius: 0 0.75rem 0.75rem 0;
   }
 
-  [dir="rtl"]  & {
-    -webkit-transform: scale(-1, 1);
-    -moz-transform: scale(-1, 1);
-    -ms-transform: scale(-1, 1);
-    -o-transform: scale(-1, 1);
+  [dir="rtl"] & {
     transform: scale(-1, 1);
   }
 `;
@@ -362,7 +352,7 @@ const NoMessageText = styled.div`
 const GuestLobbyMessage = styled.div`
   color: ${colorText};
   font-size: ${fontSizeSmall};
-  font-style: italic;  
+  font-style: italic;
 `;
 
 export const ToggleButton = styled(ButtonBase)`
@@ -420,6 +410,20 @@ export const TitleText = styled.span`
   padding-right: 1rem;
 `;
 
+export const RememberChoiceContainer = styled.div`
+  .MuiFormControlLabel-label {
+    font-size: ${fontSizeSmall};
+    color: ${colorGrayDark};
+    font-weight: ${textFontWeight};
+  }
+`;
+
+export const ActionButtonsWrapper = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 1.5rem;
+`;
+
 export default {
   TitleText,
   ExpandIcon,
@@ -451,4 +455,6 @@ export default {
   NoMessageText,
   GuestLobbyMessage,
   WaitingUsersContainer,
+  RememberChoiceContainer,
+  ActionButtonsWrapper,
 };


### PR DESCRIPTION
### What does this PR do?
Implements a "Remember Choice" checkbox that allows moderators to update the meeting's guest policy directly from the waiting panel, streamlining access management.

- If checked, clicking "Allow All" or "Deny All" updates the meeting policy to "Always Accept" or "Always Deny," respectively.
- The checkbox state is automatically reset if the policy is manually changed back to "Ask Moderator."

### Closes Issue(s)
Closes None


### More
[Screencast from 16-07-2025 14:58:11.webm](https://github.com/user-attachments/assets/24d3ea52-219b-4afd-ba93-3961c160dbaa)

