### PR TITLE
fix (gql-server): fix trigger to recount chat messages on delete

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1157,12 +1157,12 @@ RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP = 'INSERT' THEN
         UPDATE "chat"
-        SET "totalMessages" = "totalMessages" + 1
+        SET "totalMessages" = COALESCE("totalMessages", 0) + 1
         WHERE "meetingId" = NEW."meetingId"
         AND "chatId" = NEW."chatId";
 	ELSIF TG_OP = 'DELETE' THEN
         UPDATE "chat"
-        SET "totalMessages" = "totalMessages" - 1
+        SET "totalMessages" = GREATEST(COALESCE("totalMessages", 0) - 1, 0)
         WHERE "meetingId" = OLD."meetingId"
         AND "chatId" = OLD."chatId";
 	END IF;


### PR DESCRIPTION
As reported in https://github.com/bigbluebutton/bigbluebutton/pull/23494#issuecomment-3089071188,
the trigger responsible for updating the total number of chat messages wasn't functioning correctly when a message was deleted.