### PR TITLE
style: use the same font for firefox and chrome toasts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
@@ -120,6 +120,7 @@ const ToastMessage = styled.div`
   max-height: 15vh;
   overflow: auto;
   color: black !important;
+  font-family: Arial, sans-serif;
 
   ${({ small }) => small && `
     font-size: 80%;


### PR DESCRIPTION
### What does this PR do?

Adjusts font used for the toast notifications, so they look the same on Chrome and Firefox browsers.

#### before
##### chrome
<img width="343" height="89" alt="chrome-before" src="https://github.com/user-attachments/assets/7f58508b-5039-43f5-9a83-8ccfd37b4a22" />

##### firefox
<img width="333" height="93" alt="firefox-before" src="https://github.com/user-attachments/assets/c5899c2c-1434-41aa-b78d-cf215e0d958c" />

#### after
##### chrome
<img width="357" height="150" alt="chrome-after" src="https://github.com/user-attachments/assets/463c5b04-0ff9-4f77-bf75-4e71d8e883e9" />

##### firefox 
<img width="345" height="100" alt="firefox-after" src="https://github.com/user-attachments/assets/bb5de426-1ec8-4dd1-9637-b799a6108975" />

### Motivation
reported by the testing team

### How to test
1. join a meeting with two users: user A with Firefox, user B with Chrome
2. use "Snapshot of current slide" feature
3. notifications for user A and user B should use the same font family and size