### PR TITLE
refactor (gql-server): Remove unused indexes from the `bbb_graphql` database

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -307,7 +307,6 @@ CREATE UNLOGGED TABLE "user" (
 );
 CREATE INDEX "idx_user_pk_reverse" on "user" ("userId", "meetingId");
 CREATE INDEX "idx_user_meetingId_extId" ON "user"("meetingId", "extId");
-CREATE INDEX "idx_user_waiting" ON "user"("meetingId", "userId") where "isWaiting" is true;
 
 -- user (on update raiseHand or away: set new time)
 CREATE OR REPLACE FUNCTION update_user_raiseHand_away_time_trigger_func()
@@ -346,8 +345,10 @@ ALTER TABLE "user" ADD COLUMN "isDialIn" boolean GENERATED ALWAYS AS ("clientTyp
 ALTER TABLE "user" ADD COLUMN "isWaiting" boolean GENERATED ALWAYS AS ("guestStatus" = 'WAIT') STORED;
 ALTER TABLE "user" ADD COLUMN "isAllowed" boolean GENERATED ALWAYS AS ("guestStatus" = 'ALLOW') STORED;
 ALTER TABLE "user" ADD COLUMN "isDenied" boolean GENERATED ALWAYS AS ("guestStatus" = 'DENY') STORED;
-
 ALTER TABLE "user" ADD COLUMN "registeredAt" timestamp with time zone GENERATED ALWAYS AS (to_timestamp("registeredOn"::double precision / 1000)) STORED;
+
+CREATE INDEX "idx_user_waiting" ON "user"("meetingId", "userId") where "isWaiting" is true;
+
 
 --Populate column `firstJoinedAt` to register if the user has joined in the meeting (once column `joined` turn false when user leaves)
 CREATE OR REPLACE FUNCTION "set_user_firstJoinedAt_trigger_func"()

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -65,7 +65,6 @@ create unlogged table "meeting_breakout" (
     "captureNotesFilename" varchar(100),
     "captureSlidesFilename" varchar(100)
 );
-create index "idx_meeting_breakout_meetingId" on "meeting_breakout"("meetingId");
 create view "v_meeting_breakoutPolicies" as select * from meeting_breakout;
 
 create unlogged table "meeting_recordingPolicies" (
@@ -86,7 +85,6 @@ create unlogged table "meeting_recording" (
     "recordedTimeInSeconds" integer,
     CONSTRAINT "meeting_recording_pkey" PRIMARY KEY ("meetingId","startedAt")
 );
-create index "idx_meeting_recording_meetingId" on "meeting_recording"("meetingId");
 
 --Set recordedTimeInSeconds when stoppedAt is updated
 CREATE OR REPLACE FUNCTION "update_meeting_recording_trigger_func"() RETURNS TRIGGER AS $$
@@ -136,7 +134,6 @@ create unlogged table "meeting_welcome" (
 	"welcomeMsg" text,
 	"welcomeMsgForModerators" text
 );
-create index "idx_meeting_welcome_meetingId" on "meeting_welcome"("meetingId");
 
 create unlogged table "meeting_voice" (
 	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
@@ -145,7 +142,6 @@ create unlogged table "meeting_voice" (
 	"dialNumber" varchar(100),
 	"muteOnStart" boolean
 );
-create index "idx_meeting_voice_meetingId" on "meeting_voice"("meetingId");
 create view "v_meeting_voiceSettings" as select * from meeting_voice;
 
 create unlogged table "meeting_usersPolicies" (
@@ -162,7 +158,6 @@ create unlogged table "meeting_usersPolicies" (
     "authenticatedGuest"           boolean,
     "allowPromoteGuestToModerator" boolean
 );
-create index "idx_meeting_usersPolicies_meetingId" on "meeting_usersPolicies"("meetingId");
 
 CREATE OR REPLACE VIEW "v_meeting_usersPolicies" AS
 SELECT "meeting_usersPolicies"."meetingId",
@@ -183,7 +178,7 @@ SELECT "meeting_usersPolicies"."meetingId",
    JOIN "meeting" using("meetingId");
 
 create unlogged table "meeting_lockSettings" (
-	"meetingId" 		varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
+	"meetingId"              varchar(100) primary key references "meeting"("meetingId") ON DELETE CASCADE,
     "disableCam"             boolean,
     "disableMic"             boolean,
     "disablePrivateChat"     boolean,
@@ -195,7 +190,6 @@ create unlogged table "meeting_lockSettings" (
     "hideViewersCursor"      boolean,
     "hideViewersAnnotation"  boolean
 );
-create index "idx_meeting_lockSettings_meetingId" on "meeting_lockSettings"("meetingId");
 
 CREATE OR REPLACE VIEW "v_meeting_lockSettings" AS
 SELECT
@@ -251,7 +245,6 @@ create unlogged table "meeting_group" (
     "usersExtId" varchar[],
     CONSTRAINT "meeting_group_pkey" PRIMARY KEY ("meetingId","groupId")
 );
-create index "idx_meeting_group_meetingId" on "meeting_group"("meetingId");
 create view "v_meeting_group" as select * from meeting_group;
 
 -- ========== User tables
@@ -312,9 +305,9 @@ CREATE UNLOGGED TABLE "user" (
 	CONSTRAINT "user_pkey" PRIMARY KEY ("meetingId","userId"),
 	FOREIGN KEY ("meetingId", "guestStatusSetByModerator") REFERENCES "user"("meetingId","userId") ON DELETE SET NULL
 );
-create index "idx_user_pk_reverse" on "user" ("userId", "meetingId");
-CREATE INDEX "idx_user_meetingId" ON "user"("meetingId");
-CREATE INDEX "idx_user_extId" ON "user"("meetingId", "extId");
+CREATE INDEX "idx_user_pk_reverse" on "user" ("userId", "meetingId");
+CREATE INDEX "idx_user_meetingId_extId" ON "user"("meetingId", "extId");
+CREATE INDEX "idx_user_waiting" ON "user"("meetingId", "userId") where "isWaiting" is true;
 
 -- user (on update raiseHand or away: set new time)
 CREATE OR REPLACE FUNCTION update_user_raiseHand_away_time_trigger_func()
@@ -383,8 +376,6 @@ ALTER TABLE "user" ADD COLUMN "nameSortable" varchar(255) GENERATED ALWAYS AS (t
 ALTER TABLE "user" ADD COLUMN "firstNameSortable" varchar(255) GENERATED ALWAYS AS (trim(remove_emojis(immutable_lower_unaccent("firstName")))) STORED;
 ALTER TABLE "user" ADD COLUMN "lastNameSortable" varchar(255) GENERATED ALWAYS AS (trim(remove_emojis(immutable_lower_unaccent("lastName")))) STORED;
 
-CREATE INDEX "idx_user_waiting" ON "user"("meetingId") where "isWaiting" is true;
-
 ALTER TABLE "user" ADD COLUMN "isModerator" boolean GENERATED ALWAYS AS (CASE WHEN "role" = 'MODERATOR' THEN true ELSE false END) STORED;
 ALTER TABLE "user" ADD COLUMN "currentlyInMeeting" boolean GENERATED ALWAYS AS (
     CASE WHEN
@@ -441,11 +432,6 @@ AS SELECT "user"."userId",
   FROM "user"
   WHERE "user"."currentlyInMeeting" is true;
 
-CREATE INDEX "idx_v_user_meetingId" ON "user"("meetingId")
-                where "user"."loggedOut" IS FALSE
-                AND "user"."expired" IS FALSE
-                AND "user"."ejected" IS NOT TRUE
-                and "user"."joined" IS TRUE;
 
 CREATE INDEX "idx_v_user_meetingId_orderByColumns" ON "user"(
                         "meetingId",
@@ -595,15 +581,12 @@ CREATE UNLOGGED TABLE "user_sessionToken" (
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 
-CREATE INDEX "idx_user_sessionToken_sessionToken" ON "user_sessionToken"("sessionToken");
+CREATE INDEX "idx_user_sessionToken_pk_reverse" ON "user_sessionToken" ("sessionToken", "userId", "meetingId");
 
 --Index for v_user_session
-CREATE INDEX "idx_user_sessionToken_not_removed"
-ON "user_sessionToken" ("meetingId", "userId", "sessionToken")
-WHERE "removedAt" IS NULL;
+CREATE INDEX "idx_user_sessionToken_not_removed" ON "user_sessionToken" ("meetingId", "userId", "sessionToken") WHERE "removedAt" IS NULL;
 
---Index for v_user_metadata
-CREATE INDEX "idx_user_sessionToken_pk_reverse" ON "user_sessionToken" ("sessionToken", "userId", "meetingId");
+
 
 create view "v_user_sessionToken" as select * from "user_sessionToken";
 create view "v_user_session_current" as select * from "user_sessionToken";
@@ -620,11 +603,7 @@ CREATE UNLOGGED TABLE "user_graphqlConnection" (
 	"closedAt" timestamp with time zone
 );
 
-CREATE INDEX "idx_user_graphqlConnectionSessionToken" ON "user_graphqlConnection"("sessionToken");
-
---Index for v_user_session
-CREATE INDEX "idx_user_graphqlConnection_sessionToken_closedAt"
-ON "user_graphqlConnection" ("sessionToken", "closedAt");
+CREATE INDEX "idx_user_graphqlConnection_sessionToken_closedAt" ON "user_graphqlConnection" ("sessionToken", "closedAt");
 
 
 create view "v_user_session" as
@@ -643,8 +622,7 @@ create unlogged table "user_metadata"(
 	CONSTRAINT "user_metadata_pkey" PRIMARY KEY ("meetingId", "userId", "sessionToken", "parameter"),
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
-create index "idx_user_metadata_pk_reverse" on "user_metadata" ("userId", "meetingId");
-create index "idx_user_metadata_sessionToken" on "user_metadata" ("meetingId", "userId", "sessionToken");
+create index "idx_user_metadata_pk_reverse" on "user_metadata" ("userId", "meetingId", "sessionToken", "parameter");
 
 CREATE VIEW "v_user_metadata" AS
 SELECT DISTINCT ON (ust."sessionToken", ust."meetingId", ust."userId", umd."parameter")
@@ -817,7 +795,6 @@ CREATE UNLOGGED TABLE "user_connectionStatus" (
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 create index "idx_user_connectionStatus_pk_reverse" on "user_connectionStatus"("userId", "meetingId");
-create index "idx_user_connectionStatus_meetingId" on "user_connectionStatus"("meetingId");
 
 create view "v_user_connectionStatus" as select * from "user_connectionStatus";
 
@@ -960,7 +937,6 @@ CREATE UNLOGGED TABLE "user_clientSettings"(
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 CREATE INDEX "idx_user_clientSettings_pk_reverse" ON "user_clientSettings"("userId", "meetingId");
-CREATE INDEX "idx_user_clientSettings_meetingId" ON "user_clientSettings"("meetingId");
 
 create view "v_user_clientSettings" as select * from "user_clientSettings";
 
@@ -1015,7 +991,6 @@ CREATE UNLOGGED TABLE "user_transcriptionError"(
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
 CREATE INDEX "idx_user_transcriptionError_pk_reverse" ON "user_transcriptionError"("userId", "meetingId");
-CREATE INDEX "idx_user_transcriptionError_meetingId" ON "user_transcriptionError"("meetingId");
 
 create view "v_user_transcriptionError" as select * from "user_transcriptionError";
 
@@ -1043,7 +1018,6 @@ CREATE UNLOGGED TABLE "chat" (
 	CONSTRAINT "chat_pkey" PRIMARY KEY ("meetingId", "chatId")
 );
 CREATE INDEX "idx_chat_pk_reverse" ON "chat"("chatId","meetingId");
-CREATE INDEX "idx_chat_meetingId" ON "chat"("meetingId");
 
 CREATE UNLOGGED TABLE "chat_user" (
 	"chatId" varchar(100),
@@ -1088,10 +1062,6 @@ CREATE INDEX "idx_chat_user_typing_public" ON "chat_user"("meetingId", "lastTypi
 CREATE INDEX "idx_chat_user_typing_private" ON "chat_user"("meetingId", "userId", "chatId", "lastTypingAt")
         WHERE "chatId" != 'MAIN-PUBLIC-GROUP-CHAT'
         AND "visible" is true;
-
-CREATE INDEX "idx_chat_with_user_typing_private" ON "chat_user"("meetingId", "userId", "chatId", "lastTypingAt")
-        WHERE "chatId" != 'MAIN-PUBLIC-GROUP-CHAT'
-        AND "lastTypingAt" is not null;
 
 CREATE OR REPLACE VIEW "v_user_typing_public" AS
 SELECT "meetingId", "chatId", "userId", "lastTypingAt", "startedTypingAt",
@@ -1197,7 +1167,6 @@ CREATE UNLOGGED TABLE "chat_message_history" (
 	"movedToHistoryAt" timestamp with time zone default current_timestamp,
     CONSTRAINT chat_message_history_pk PRIMARY KEY ("messageId", "messageVersionSequence")
 );
-CREATE INDEX "chat_message_history_seq_idx" ON "chat_message_history"("messageId","messageVersionSequence");
 
 CREATE OR REPLACE VIEW "v_chat_message_history" AS SELECT * FROM "chat_message_history";
 
@@ -1332,9 +1301,8 @@ CREATE UNLOGGED TABLE "pres_presentation" (
     "exportToChatHasError" boolean,
     "createdAt" timestamp with time zone DEFAULT now()
 );
-CREATE INDEX "idx_pres_presentation_meetingId" ON "pres_presentation"("meetingId");
-CREATE INDEX "idx_pres_presentation_meetingId_curr" ON "pres_presentation"("meetingId") where "current" is true;
 CREATE INDEX "idx_pres_presentation_meetingId_uploadUserId" ON "pres_presentation"("meetingId","uploadUserId");
+CREATE INDEX "idx_pres_presentation_meetingId_curr" ON "pres_presentation"("meetingId") where "current" is true;
 
 --Populate preloadNextPages, which will be used to provide the SVG of next slides at pres_page_curr
 CREATE OR REPLACE FUNCTION "update_preloadNextPages"() RETURNS TRIGGER AS $$
@@ -1485,8 +1453,7 @@ CREATE UNLOGGED TABLE "pres_annotation" (
 	"annotationInfo" TEXT,
 	"lastUpdatedAt" timestamp with time zone
 );
-CREATE INDEX "idx_pres_annotation_pageId" ON "pres_annotation"("pageId");
-CREATE INDEX "idx_pres_annotation_updatedAt" ON "pres_annotation"("pageId","lastUpdatedAt");
+CREATE INDEX "idx_pres_annotation_pageId_updatedAt" ON "pres_annotation"("pageId","lastUpdatedAt");
 create index "idx_pres_annotation_user_meeting" on "pres_annotation" ("userId", "meetingId");
 
 CREATE UNLOGGED TABLE "pres_annotation_history" (
@@ -1654,10 +1621,9 @@ CREATE UNLOGGED TABLE "pres_page_cursor" (
     CONSTRAINT "pres_page_cursor_pkey" PRIMARY KEY ("pageId","meetingId","userId"),
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
-create index "idx_pres_page_cursor_pageId" on "pres_page_cursor"("pageId");
+create index "idx_pres_page_cursor_pageId_lastUpdatedAt" on "pres_page_cursor"("pageId","lastUpdatedAt");
 create index "idx_pres_page_cursor_userID" on "pres_page_cursor"("meetingId","userId");
 create index "idx_pres_page_cursor_userID_rev" on "pres_page_cursor"("userId", "meetingId");
-create index "idx_pres_page_cursor_lastUpdatedAt" on "pres_page_cursor"("pageId","lastUpdatedAt");
 
 CREATE VIEW "v_pres_page_cursor" AS
 SELECT pres_page."presentationId", c.*,
@@ -1686,10 +1652,8 @@ CREATE UNLOGGED TABLE "poll" (
 "createdAt" timestamp with time zone not null default current_timestamp,
 FOREIGN KEY ("meetingId", "ownerId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
-CREATE INDEX "idx_poll_meetingId" ON "poll"("meetingId");
-CREATE INDEX "idx_poll_ownerId" ON "poll"("meetingId","ownerId");
+CREATE INDEX "idx_poll_meetingId_ownerId" ON "poll"("meetingId","ownerId");
 CREATE INDEX "idx_poll_meetingId_active" ON "poll"("meetingId") where ended is false;
-CREATE INDEX "idx_poll_meetingId_published" ON "poll"("meetingId") where published is true;
 
 CREATE UNLOGGED TABLE "poll_option" (
 	"pollId" varchar(100) REFERENCES "poll"("pollId") ON DELETE CASCADE,
@@ -1698,7 +1662,6 @@ CREATE UNLOGGED TABLE "poll_option" (
 	"correctOption" boolean,
 	CONSTRAINT "poll_option_pkey" PRIMARY KEY ("pollId", "optionId")
 );
-CREATE INDEX "idx_poll_option_pollId" ON "poll_option"("pollId");
 
 CREATE UNLOGGED TABLE "poll_response" (
 	"pollId" varchar(100),
@@ -1708,10 +1671,9 @@ CREATE UNLOGGED TABLE "poll_response" (
 	FOREIGN KEY ("pollId", "optionId") REFERENCES "poll_option"("pollId", "optionId") ON DELETE CASCADE,
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
-CREATE INDEX "idx_poll_response_pollId" ON "poll_response"("pollId");
+CREATE INDEX "idx_poll_response_pollId_userId" ON "poll_response"("pollId", "meetingId", "userId");
 CREATE INDEX "idx_poll_response_userId" ON "poll_response"("meetingId", "userId");
 CREATE INDEX "idx_poll_response_userId_reverse" ON "poll_response"("userId", "meetingId");
-CREATE INDEX "idx_poll_response_pollId_userId" ON "poll_response"("pollId", "meetingId", "userId");
 
 CREATE OR REPLACE VIEW "v_poll_response" AS
 SELECT
@@ -2153,11 +2115,10 @@ create unlogged table "sharedNotes_session" (
     "sharedNotesExtId" varchar(25),
     "userId" varchar(50),
     "sessionId" varchar(50),
-    constraint "pk_sharedNotes_session" primary key ("meetingId", "sharedNotesExtId", "userId"),
+    constraint "pk_sharedNotes_session" primary key ("meetingId", "userId", "sharedNotesExtId"),
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
-create index "sharedNotes_session_userId" on "sharedNotes_session"("meetingId", "userId");
-create index "sharedNotes_session_userId_rev" on "sharedNotes_session"("userId", "meetingId");
+create index "sharedNotes_session_userId_rev" on "sharedNotes_session"("userId", "meetingId", "sharedNotesExtId");
 
 create view "v_sharedNotes" as
 SELECT sn.*, max(snr.rev) "lastRev"
@@ -2190,7 +2151,6 @@ CREATE UNLOGGED TABLE "caption_locale" (
     CONSTRAINT "caption_locale_pk" primary key ("meetingId","locale","captionType"),
     FOREIGN KEY ("meetingId", "createdBy") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
 );
-create index "idx_caption_locale_pk_reverse" on "caption_locale"("locale","meetingId","captionType");
 create index "idx_caption_locale_pk_reverse_b" on "caption_locale"("captionType","meetingId","locale");
 
 CREATE UNLOGGED TABLE "caption" (
@@ -2461,8 +2421,6 @@ CREATE UNLOGGED TABLE "user_audioGroup" (
 	FOREIGN KEY ("meetingId", "groupId") REFERENCES "audioGroup"("meetingId", "groupId") ON DELETE CASCADE
 );
 
-CREATE INDEX "idx_user_audioGroup_groupId" ON "user_audioGroup"("meetingId", "groupId");
-CREATE INDEX "idx_user_audioGroup_userId" ON "user_audioGroup"("meetingId", "userId");
 CREATE INDEX "idx_user_audioGroup_userId_reverse" ON "user_audioGroup"("userId", "meetingId");
 CREATE INDEX "idx_user_audioGroup_groupId_participantType" ON "user_audioGroup"("meetingId", "groupId", "participantType");
 CREATE OR REPLACE VIEW "v_user_audioGroup" AS SELECT * FROM "user_audioGroup";

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
@@ -52,12 +52,13 @@ export const getUser = gql`
     user(
       where: { bot: {_eq: false } }
       order_by: [
+        {presenter: desc},
         {role: asc},
         {raiseHandTime: asc_nulls_last},
-        {awayTime: asc_nulls_last},
         {isDialIn: desc},
         {hasDrawPermissionOnCurrentPage: desc},
         {nameSortable: asc},
+        {registeredAt: asc},
         {userId: asc}
       ]) {
       extId


### PR DESCRIPTION
Remove unused indexes from the `bbb_graphql` database.

The unused indexes were identified by running the following command across multiple servers and analyzing the results:

> sudo -u postgres psql --pset pager=off -d bbb_graphql -c "select indexrelname FROM pg_stat_user_indexes where idx_scan = 0 and idx_tup_read = 0 order by 1"

Additionally, some duplicated indexes were removed based on insights from the pgHero report (thanks @fcecagno):
<img width="1920" height="5325" alt="image (2)" src="https://github.com/user-attachments/assets/32e58fe3-4993-4772-8a1e-b467af80dd58" />
