### PR TITLE
fix(media-area): Remove uneeded separator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -237,7 +237,6 @@ class ActionsBar extends PureComponent {
                     isDarkThemeEnabled={isDarkThemeEnabled}
                   />
                 )}
-              {(amIPresenter || amIModerator) && (<Styled.Divider />)}
               <MediaAreaContainer {...{
                 amIPresenter,
                 amIModerator,


### PR DESCRIPTION
Remove uneeded `|` separator next to the new Media Area button. 