### PR TITLE
fix: startup crash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
@@ -139,7 +139,7 @@ class ModalSimple extends Component {
         style={modalStyles}
         {...otherProps}
       >
-        <FocusTrap active={modalIsOpen} focusTrapOptions={{ initialFocus: false }}>
+        <FocusTrap active={modalIsOpen} focusTrapOptions={{ initialFocus: false, fallbackFocus: '#fallback-element' }}>
           <div ref={this.modalRef}>
             <Styled.Header
               hideBorder={hideBorder}
@@ -156,6 +156,7 @@ class ModalSimple extends Component {
             </Styled.Header>
             <Styled.Content>
               {children}
+              <div id="fallback-element" tabIndex="-1" />
             </Styled.Content>
           </div>
         </FocusTrap>


### PR DESCRIPTION
### What does this PR do?

Prevents an error in the focusTrap component when multiple modals open in sequence by adding a fallback element to modals

### Closes Issue(s)
Closes #23576

### How to test
1. set `public.kurento.autoShareWebcam=true` in settings file
2. join a meeting
3. wait for the video preview modal to open