### PR TITLE
fix(actions-bar): add back separator between presentation and media area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -237,6 +237,8 @@ class ActionsBar extends PureComponent {
                     isDarkThemeEnabled={isDarkThemeEnabled}
                   />
                 )}
+              {((amIPresenter || amIModerator)
+                && shouldShowOptionsButton) && (<Styled.Divider />)}
               <MediaAreaContainer {...{
                 amIPresenter,
                 amIModerator,


### PR DESCRIPTION
### What does this PR do?
Adds back https://github.com/bigbluebutton/bigbluebutton/pull/23577 the separator between the presentation toggle button and the media area button. Also, adds a new check to hide the separator when there is no presentation.

