### PR TITLE
fix(tests): add dataTest to media area plugin buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
@@ -222,7 +222,7 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
             .map((item) => (
               <MediaButton
                 key={item.id}
-                dataTest={`media-sharing-plugin-${item.id}`}
+                dataTest={item.dataTest}
                 color="default"
                 text={item.label || ''}
                 icon={item.icon ? <Icon iconName={item.icon} /> : undefined}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/media-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/media-button/component.tsx
@@ -30,8 +30,8 @@ export const MediaButton: FunctionComponent<MediaButtonProps> = ({
   }
 
   return (
-    <Styled.MediaButtonContainer>
-      <Styled.ButtonFrame color={color} onClick={onClick} data-test={dataTest}>
+    <Styled.MediaButtonContainer data-test={dataTest}>
+      <Styled.ButtonFrame color={color} onClick={onClick}>
         {showSettingsIcon && (
           <Styled.SettingsContainer>
             <IconButton

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/types.ts
@@ -8,6 +8,7 @@ export interface MediaButtonPluginItem {
   label?: string;
   onClick?: () => void;
   allowed: boolean;
+  dataTest: string;
 }
 
 export interface MediaAreaContainerProps {


### PR DESCRIPTION
### What does this PR do?
- Add the dataTest to media area plugin buttons so the plugin tests can work.
