### PR TITLE
Chore: Add support to typescript on Husky

### DIFF
--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -10,11 +10,12 @@
     "tscheck": "tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lint:file": "eslint"
+    "lint:file": "eslint",
+    "tscheck:staged": "tsc --noEmit"
   },
   "lint-staged": {
-    "*.{js,jsx}": [
-      "eslint --fix"
+    "*.{js,jsx,ts,tsx}": [
+      "eslint"
     ]
   },
   "overrides": {
@@ -172,7 +173,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && npm run tscheck:staged"
     }
   }
 }

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:file": "eslint",
-    "tscheck:staged": "tsc --noEmit"
+    "tscheck:staged": "tsc --noEmit --incremental"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/bigbluebutton-html5/tsconfig.json
+++ b/bigbluebutton-html5/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule":true,
     "skipLibCheck": true,
     "types": [],
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
 
     /* Strict Type-Checking Options */
     "strict": true,


### PR DESCRIPTION
### What does this PR do?
This PR adds TypeScript support to Husky, preventing commits with linting or TypeScript errors, instead of catching them later in CI.

### Closes Issue(s)
N/A

### How to test
- Change a file to include a error
- try to commit it


