### PR TITLE
Fix(html5): quickPollConfirmationStep turning quiz to poll

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -198,9 +198,8 @@ const PresentationToolbarContainer = (props) => {
           secretPoll: false,
           question,
           multipleResponse,
-          quiz: false,
           answers,
-          isQuiz: isQuizEnabled ? isQuiz : false,
+          quiz: isQuizEnabled ? isQuiz : false,
           correctAnswer: isQuizEnabled ? correctAnswer : '',
         },
       });


### PR DESCRIPTION
### What does this PR do?
Fix bug where disabling `quickPollConfirmationStep` (`false`) results in quizzes being incorrectly initiated as polls.


### Closes Issue(s)
N/A

### How to test
- Turn `quickPollConfirmationStep` to `false` on settings.yml
- Upload a slide with a quiz 
- use the quick poll to start the quiz


### More
[Screencast from 23-07-2025 10:20:11.webm](https://github.com/user-attachments/assets/27bb9277-6431-480c-8ad0-09d1858e6991)

