### PR TITLE
fix (bbb-web): Some presentation-related configs not being respected

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResizerImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResizerImp.java
@@ -59,7 +59,7 @@ public class ImageResizerImp implements ImageResizer {
 
         NuProcess process = imgResize.start();
         try {
-            process.waitFor(wait, TimeUnit.SECONDS);
+            process.waitFor(wait + 1, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             log.error(e.getMessage());
             conversionSuccess = false;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -45,7 +45,7 @@ public class ImageResolutionService {
 
     NuProcess process = imageResolution.start();
     try {
-      process.waitFor(wait, TimeUnit.SECONDS);
+      process.waitFor(wait + 1, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       log.error("InterruptedException while identifying image resolution {}", presentationFile.getName(), e);
     }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfPageCounter.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfPageCounter.java
@@ -40,14 +40,14 @@ public class PdfPageCounter implements PageCounter {
     int numPages = 0; // total numbers of this pdf
 
     NuProcessBuilder pdfInfo = new NuProcessBuilder(
-        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh","10","pdfinfo", presentationFile.getAbsolutePath()));
+        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh",String.valueOf(wait),"pdfinfo", presentationFile.getAbsolutePath()));
 
     PdfPageCounterHandler pHandler = new PdfPageCounterHandler("pdfpagecount-" + presentationFile.getName());
     pdfInfo.setProcessListener(pHandler);
 
     NuProcess process = pdfInfo.start();
     try {
-      process.waitFor(wait, TimeUnit.SECONDS);
+      process.waitFor(wait + 1, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       log.error("InterruptedException while counting PDF pages {}", presentationFile.getName(), e);
     }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -48,7 +48,6 @@ public class PngCreatorImp implements PngCreator {
 	private String BLANK_PNG;
 	private int slideWidth = 800;
 	private int convTimeout = 7;
-	private int wait = 7;
 	private long execTimeout = 10000;
 
 	private static final String TEMP_PNG_NAME = "temp-png";
@@ -108,7 +107,7 @@ public class PngCreatorImp implements PngCreator {
 
 			NuProcess process = convertImgToSvg.start();
 			try {
-				process.waitFor(wait, TimeUnit.SECONDS);
+				process.waitFor(convTimeout + 1, TimeUnit.SECONDS);
 			} catch (InterruptedException e) {
 				log.error("InterruptedException while converting to PDF {}", dest, e);
 				return false;
@@ -218,16 +217,12 @@ public class PngCreatorImp implements PngCreator {
 		BLANK_PNG = blankPng;
 	}
 
-	public void setSlideWidth(int width) {
-		slideWidth = width;
+	public void setSlideWidth(int slideWidth) {
+		this.slideWidth = slideWidth;
 	}
 
 	public void setConvTimeout(int convTimeout) {
 		this.convTimeout = convTimeout;
-	}
-
-	public void setWait(int wait) {
-		this.wait = wait;
 	}
 
 	public void setExecTimeout(long execTimeout) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -162,8 +162,6 @@ presDownloadReadTimeoutInMs=60000
 # Presentation upload and conversion timeouts in seconds
 #------------------------------------
 pngCreationConversionTimeout=7
-pngCreationWait=7
-pdfToSvgTimeout=60
 imageResizeWait=7
 officeDocumentValidationTimeout=20
 presOfficeConversionTimeout=60

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -42,6 +42,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     </bean>
 
     <bean id="officeDocumentValidator" class="org.bigbluebutton.presentation.imp.OfficeDocumentValidator2">
+        <property name="presCheckTimeout" value="${officeDocumentValidationTimeout}"/>
+        <property name="execTimeout" value="${officeDocumentValidationExecTimeoutInMs}"/>
         <property name="presCheckExec" value="${presCheckExec}"/>
     </bean>
 
@@ -62,11 +64,17 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="presOfficeConversionMaxConcurrents" value="${officeToPdfMaxConcurrentConversions}"/>
     </bean>
 
-    <bean id="pageExtractor" class="org.bigbluebutton.presentation.imp.PageExtractorImp"/>
+    <bean id="pageExtractor" class="org.bigbluebutton.presentation.imp.PageExtractorImp">
+        <property name="extractTimeoutInMs" value="${extractTimeoutInMs}"/>
+    </bean>
 
-    <bean id="pageCounter" class="org.bigbluebutton.presentation.imp.PdfPageCounter"/>
+    <bean id="pageCounter" class="org.bigbluebutton.presentation.imp.PdfPageCounter">
+        <property name="wait" value="${pdfPageCountWait}"/>
+    </bean>
 
-    <bean id="imageResizer" class="org.bigbluebutton.presentation.imp.ImageResizerImp"/>
+    <bean id="imageResizer" class="org.bigbluebutton.presentation.imp.ImageResizerImp">
+        <property name="wait" value="${imageResizeWait}"/>
+    </bean>
 
     <bean id="pageCounterService" class="org.bigbluebutton.presentation.imp.PageCounterService">
         <property name="pageCounter" ref="pageCounter"/>
@@ -75,14 +83,19 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <bean id="thumbCreator" class="org.bigbluebutton.presentation.imp.ThumbnailCreatorImp">
         <property name="imageMagickDir" value="${imageMagickDir}"/>
         <property name="blankThumbnail" value="${BLANK_THUMBNAIL}"/>
+        <property name="execTimeout" value="${thumbnailCreationExecTimeoutInMs}"/>
     </bean>
 
     <bean id="pngCreator" class="org.bigbluebutton.presentation.imp.PngCreatorImp">
         <property name="blankPng" value="${BLANK_PNG}"/>
         <property name="slideWidth" value="${pngSlideWidth}"/>
+        <property name="convTimeout" value="${pngCreationConversionTimeout}"/>
+        <property name="execTimeout" value="${pngCreationExecTimeoutInMs}"/>
     </bean>
 
-    <bean id="textFileCreator" class="org.bigbluebutton.presentation.imp.TextFileCreatorImp"/>
+    <bean id="textFileCreator" class="org.bigbluebutton.presentation.imp.TextFileCreatorImp">
+        <property name="execTimeout" value="${textFileCreationExecTimeoutInMs}"/>
+    </bean>
 
     <bean id="svgImageCreator" class="org.bigbluebutton.presentation.imp.SvgImageCreatorImp">
     	<property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -232,48 +232,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="scanUploadedPresentationFiles" value="${scanUploadedPresentationFiles}"/>
     </bean>
 
-    <bean id="pageExtractorImp" class="org.bigbluebutton.presentation.imp.PageExtractorImp">
-        <property name="extractTimeoutInMs" value="${extractTimeoutInMs}"/>
-    </bean>
-
-    <bean id="pngCreatorImp" class="org.bigbluebutton.presentation.imp.PngCreatorImp">
-        <property name="convTimeout" value="${pngCreationConversionTimeout}"/>
-        <property name="wait" value="${pngCreationWait}"/>
-        <property name="execTimeout" value="${pngCreationExecTimeoutInMs}"/>
-    </bean>
-
-    <bean id="thumbnailCreatorImp" class="org.bigbluebutton.presentation.imp.ThumbnailCreatorImp">
-        <property name="execTimeout" value="${thumbnailCreationExecTimeoutInMs}"/>
-    </bean>
-
     <bean id="pdfPageDownscaler" class="org.bigbluebutton.presentation.imp.PdfPageDownscaler">
         <property name="execTimeout" value="${pdfPageDownscaleExecTimeoutInMs}"/>
-    </bean>
-
-    <bean id="imageResizerImp" class="org.bigbluebutton.presentation.imp.ImageResizerImp">
-        <property name="wait" value="${imageResizeWait}"/>
-    </bean>
-
-    <bean id="officeDocumentValidator2" class="org.bigbluebutton.presentation.imp.OfficeDocumentValidator2">
-        <property name="presCheckTimeout" value="${officeDocumentValidationTimeout}"/>
-        <property name="execTimeout" value="${officeDocumentValidationExecTimeoutInMs}"/>
-    </bean>
-
-    <bean id="officeToPdfConversionService" class="org.bigbluebutton.presentation.imp.OfficeToPdfConversionService">
-        <property name="presOfficeConversionTimeout" value="${presOfficeConversionTimeout}"/>
-    </bean>
-
-    <bean id="pdfPageCounter" class="org.bigbluebutton.presentation.imp.PdfPageCounter">
-        <property name="wait" value="${pdfPageCountWait}"/>
-    </bean>
-
-    <bean id="svgImageCreatorImp" class="org.bigbluebutton.presentation.imp.SvgImageCreatorImp">
-        <property name="convPdfToSvgTimeout" value="${pdfToSvgTimeout}"/>
-        <property name="pdfFontsTimeout" value="${pdfFontsTimeout}"/>
-    </bean>
-
-    <bean id="textFileCreatorImp" class="org.bigbluebutton.presentation.imp.TextFileCreatorImp">
-        <property name="execTimeout" value="${textFileCreationExecTimeoutInMs}"/>
     </bean>
 
     <import resource="doc-conversion.xml"/>

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -370,8 +370,6 @@ Added
 - `textFileCreationExecTimeoutInMs` added
 - `presDownloadReadTimeoutInMs` added
 - `pngCreationConversionTimeout` added
-- `pngCreationWait` added
-- `pdfToSvgTimeout` added
 - `imageResizeWait` added
 - `officeDocumentValidationTimeout` added
 - `presOfficeConversionTimeout` added


### PR DESCRIPTION
I noticed that some `bbb-web` presentation-related configs were not being respected. This was happening because they were being set from the wrong file.

This update will:

* Set the configs correctly.
* Remove duplicate entries like `pngCreationWait` and `pdfToSvgTimeout`, as their equivalents `pngCreationConversionTimeout` and `svgConversionTimeout` already exist.
* Add a 1-second buffer to `process.waitFor` compared to the `run-in-systemd.sh` call, allowing time for the script to return a proper timeout error.
