### PR TITLE
chore (Learning Dashboard): Improve run-dev and deploy scripts

### DIFF
--- a/bbb-learning-dashboard/Readme.md
+++ b/bbb-learning-dashboard/Readme.md
@@ -15,7 +15,7 @@ chown bigbluebutton /var/bigbluebutton/learning-dashboard/
 ./deploy.sh
 ```
 
-## Devlopment instructions
+## Development instructions
 
 ```
 ./run-dev.sh

--- a/bbb-learning-dashboard/Readme.md
+++ b/bbb-learning-dashboard/Readme.md
@@ -12,17 +12,11 @@ chown bigbluebutton /var/bigbluebutton/learning-dashboard/
 ## Build instructions
 
 ```
-# verify we are in the bbb-learning-dashboard directory ~/src/bbb-learning-dashboard
-pwd
-
-if [ -d node_modules ]; then rm -r node_modules; fi
-npm install
-npm run build
-cp -r build/* /var/bigbluebutton/learning-dashboard
+./deploy.sh
 ```
 
-## Update nginx config
+## Devlopment instructions
 
 ```
-cp learning-dashboard.nginx /usr/share/bigbluebutton/nginx/
+./run-dev.sh
 ```

--- a/bbb-learning-dashboard/deploy.sh
+++ b/bbb-learning-dashboard/deploy.sh
@@ -9,12 +9,15 @@ do
     fi
 done
 
-if [ ! -d ./node_modules ] ; then
-	npm install
+# Check for missing dependencies
+if [ ! -d ./node_modules ] || ! npm ls --depth=0 > /dev/null 2>&1; then
+  echo "Running npm install..."
+  npm install
 fi
 
 npm run build
-cp -r build/* /var/bigbluebutton/learning-dashboard
+sudo cp -r build/* /var/bigbluebutton/learning-dashboard
+sudo cp learning-dashboard.nginx /usr/share/bigbluebutton/nginx/learning-dashboard.nginx
 sudo systemctl restart nginx
 echo ''
 echo ''

--- a/bbb-learning-dashboard/learning-dashboard-dev.nginx
+++ b/bbb-learning-dashboard/learning-dashboard-dev.nginx
@@ -1,0 +1,6 @@
+location /learning-analytics-dashboard {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+}

--- a/bbb-learning-dashboard/learning-dashboard-dev.nginx
+++ b/bbb-learning-dashboard/learning-dashboard-dev.nginx
@@ -1,5 +1,5 @@
 location /learning-analytics-dashboard {
-    proxy_pass http://127.0.0.1:3000;
+    proxy_pass http://127.0.0.1:3100;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/bbb-learning-dashboard/learning-dashboard-dev.nginx
+++ b/bbb-learning-dashboard/learning-dashboard-dev.nginx
@@ -4,3 +4,10 @@ location /learning-analytics-dashboard {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
 }
+
+location /learning-analytics-dashboard/ws {
+    proxy_pass http://127.0.0.1:3100/ws;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+}

--- a/bbb-learning-dashboard/run-dev.sh
+++ b/bbb-learning-dashboard/run-dev.sh
@@ -28,14 +28,14 @@ if [ -e public/test/test/learning_dashboard_data.json ]; then
 	echo ""
 	tput setaf 2;
 	echo "To test the Dashboard using the mock json:"
-	echo "${BBB_URL}/learning-analytics-dashboard?meeting=test&report=test"
+	echo "${BBB_URL}/learning-analytics-dashboard/?meeting=test&report=test"
 	echo ""
 	tput sgr0
 fi
 
 tput setaf 2;
 echo "Dashboard address:"
-echo "${BBB_URL}/learning-analytics-dashboard"
+echo "${BBB_URL}/learning-analytics-dashboard/"
 echo ""
 tput sgr0
 

--- a/bbb-learning-dashboard/run-dev.sh
+++ b/bbb-learning-dashboard/run-dev.sh
@@ -42,4 +42,4 @@ tput sgr0
 sudo cp learning-dashboard-dev.nginx /usr/share/bigbluebutton/nginx/learning-dashboard.nginx
 sudo systemctl restart nginx
 
-PORT=3100 npm start | cat
+PORT=3100 WDS_SOCKET_PORT=443 WDS_SOCKET_PATH=learning-analytics-dashboard/ws npm start | cat

--- a/bbb-learning-dashboard/run-dev.sh
+++ b/bbb-learning-dashboard/run-dev.sh
@@ -1,32 +1,45 @@
 #!/usr/bin/env bash
 cd "$(dirname "$0")"
 
+if [ $(whoami) != 'bigbluebutton' ]; then
+	echo "Run run-dev.sh inside the container"
+	exit 1
+fi
+
 for var in "$@"
 do
     if [[ $var == --reset ]] ; then
     	echo "Performing a full reset..."
-      rm -rf node_modules
+      sudo rm -rf build
+      sudo rm -rf node_modules
     fi
 done
 
-if [ ! -d ./node_modules ] ; then
-	npm install
+# Check for missing dependencies
+if [ ! -d ./node_modules ] || ! npm ls --depth=0 > /dev/null 2>&1; then
+  echo "Running npm install..."
+  npm install
 fi
 
-mkdir -p public/test/test
+BBB_URL=$(bbb-conf --secret | grep '^ *URL:' | cut -d' ' -f6 | sed 's|/bigbluebutton/||')
 
 if [ -e public/test/test/learning_dashboard_data.json ]; then
 	echo "Json found in public/test/test/learning_dashboard_data.json"
 	echo ""
 	tput setaf 2;
-	echo "To test the Dashboard access:"
-	echo "http://localhost:3000/learning-analytics-dashboard?meeting=test&report=test"
+	echo "To test the Dashboard using the mock json:"
+	echo "${BBB_URL}/learning-analytics-dashboard?meeting=test&report=test"
 	echo ""
 	tput sgr0
-else
-	echo "ERROR: Before running, copy a Dashboard data .json from a meeting and save in $(pwd)/public/test/test/learning_dashboard_data.json"
-	echo "This file can be found in /var/bigbluebutton/learning-dashboard/\$meetingId/"
-  exit 1
 fi
+
+tput setaf 2;
+echo "Dashboard address:"
+echo "${BBB_URL}/learning-analytics-dashboard"
+echo ""
+tput sgr0
+
+sudo cp learning-dashboard-dev.nginx /usr/share/bigbluebutton/nginx/learning-dashboard.nginx
+sudo systemctl restart nginx
 
 npm start | cat

--- a/bbb-learning-dashboard/run-dev.sh
+++ b/bbb-learning-dashboard/run-dev.sh
@@ -42,4 +42,4 @@ tput sgr0
 sudo cp learning-dashboard-dev.nginx /usr/share/bigbluebutton/nginx/learning-dashboard.nginx
 sudo systemctl restart nginx
 
-npm start | cat
+PORT=3100 npm start | cat


### PR DESCRIPTION
* Adds a reverse proxy when using `./run-dev.sh`, removing the need for a mock JSON during development. It now replaces the Dashboard when accessed from a locally running meeting.
* Automatically detects missing dependencies and runs `npm install` if needed.
* Verifies that the script is being run as the `bigbluebutton` user (since it should now run inside the container).
* Automatically prepends `sudo` when copying files to the deployment directory.
