### PR TITLE
refactor (Learning Dashboard): Add info `ended` for Polls/Quizzes to LAD json

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -850,7 +850,7 @@ class LearningDashboardActor(
         outGW.send(event)
         meetingsLastJsonHash += (meeting.intId -> activityJsonHash)
 
-        log.info("Learning Dashboard data sent for meeting {}", meeting.intId)
+        log.debug("Learning Dashboard data sent for meeting {}", meeting.intId)
       }
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -137,7 +137,7 @@ class LearningDashboardActor(
   private var meetingPresentations : Map[String,Map[String,PresentationVO]] = Map()
   private var meetingExcludedUserIds : Map[String,Vector[String]] = Map()
 
-  system.scheduler.schedule(10.seconds, 10.seconds, self, SendPeriodicReport)
+  system.scheduler.scheduleWithFixedDelay(0.seconds, 5.seconds, self, SendPeriodicReport)
 
   def receive = {
     //=============================
@@ -832,7 +832,7 @@ class LearningDashboardActor(
   }
 
   private def sendPeriodicReport(): Unit = {
-    meetings.map(meeting => {
+    meetings.foreach(meeting => {
       sendReport(meeting._2)
     })
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -53,7 +53,7 @@ public class LearningDashboardService {
             fileOutput = new FileOutputStream(jsonFile);
             fileOutput.write(activityJson.getBytes(StandardCharsets.UTF_8));
 
-            log.info("Learning Dashboard ({}) updated for meeting {}.",jsonFile.getAbsolutePath(),meetingId);
+            log.debug("Learning Dashboard ({}) updated for meeting {}.",jsonFile.getAbsolutePath(),meetingId);
         } catch(Exception e) {
             log.error("Error on updating Learning Dashboard file for meeting [{}]: {}",meetingId, e.getMessage());
         } finally {

--- a/bbb-learning-dashboard/src/components/QuizzesTable.jsx
+++ b/bbb-learning-dashboard/src/components/QuizzesTable.jsx
@@ -285,6 +285,7 @@ const QuizzesTable = (props) => {
     const symbols = {
       success: (
         <span
+          className="select-none"
           title={intl.formatMessage({
             id: 'app.learningDashboard.quizzes.successIndicator',
             defaultMessage: 'Correct answer',
@@ -299,6 +300,7 @@ const QuizzesTable = (props) => {
       ),
       error: (
         <span
+          className="select-none"
           title={intl.formatMessage({
             id: 'app.learningDashboard.quizzes.errorIndicator',
             defaultMessage: 'Incorrect answer',
@@ -313,6 +315,7 @@ const QuizzesTable = (props) => {
       ),
       unknown: (
         <span
+          className="select-none"
           title={intl.formatMessage({
             id: 'app.learningDashboard.quizzes.unknownIndicator',
             defaultMessage: 'Results not published yet',
@@ -327,6 +330,7 @@ const QuizzesTable = (props) => {
       ),
       locked: (
         <span
+          className="select-none"
           title={intl.formatMessage({
             id: 'app.learningDashboard.quizzes.lockedIndicator',
             defaultMessage: 'Correct answer not revealed',
@@ -458,21 +462,21 @@ const QuizzesTable = (props) => {
       renderCell: (params) => {
         let type = 'default';
         const {
-          published, userAnswers, correctOption,
+          ended, userAnswers, correctOption,
         } = params?.row[params?.field];
         const userResponded = !!userAnswers.length;
         const hasCorrectOption = !!correctOption;
-        if (userResponded && published) {
+        if (userResponded && ended) {
           if (hasCorrectOption) {
             type = userAnswers.includes(correctOption) ? 'success' : 'error';
           } else {
             type = 'locked';
           }
-        } else if (userResponded && !published) {
+        } else if (userResponded && !ended) {
           type = 'unknown';
-        } else if (!userResponded && published) {
+        } else if (!userResponded && ended) {
           type = 'default';
-        } else if (!userResponded && !published) {
+        } else if (!userResponded && !ended) {
           type = 'waiting';
         }
         return (
@@ -499,7 +503,7 @@ const QuizzesTable = (props) => {
           quizId,
           {
             userAnswers,
-            published: quiz.published,
+            ended: quiz.ended,
             correctOption: quiz.correctOption,
           },
         ];


### PR DESCRIPTION
- Add info `ended` for Polls/Quizzes in the Learning Dashboard data file
- Make emojis not selectable
- Make Dashboard receives the first data immediately when the meeting is created (it had a delay of 10 seconds before)
- Reduce the refresh time to 5 seconds (was 10)