### PR TITLE
fix (gql-server): Type `user_typing_public` should not provide `userId` of who is typing when `showNames: false`

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -150,6 +150,7 @@ object MeetingDAO {
       )
     )
 
+    MeetingClientSettingsDAO.insert(meetingProps.meetingProp.intId, JsonUtils.mapToJson(clientSettings))
     ChatDAO.insert(meetingProps.meetingProp.intId, GroupChatApp.createDefaultPublicGroupChat())
     MeetingUsersPoliciesDAO.insert(meetingProps.meetingProp.intId, meetingProps.usersProp)
     MeetingLockSettingsDAO.insert(meetingProps.meetingProp.intId, meetingProps.lockSettingsProps)
@@ -160,7 +161,6 @@ object MeetingDAO {
     MeetingBreakoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.breakoutProps)
     LayoutDAO.insert(meetingProps.meetingProp.intId, meetingProps.usersProp.meetingLayout)
     PluginModel.persistPluginsForClient(meetingProps.meetingProp.intId, pluginProps)
-    MeetingClientSettingsDAO.insert(meetingProps.meetingProp.intId, JsonUtils.mapToJson(clientSettings))
   }
 
   def updateMeetingDurationByParentMeeting(parentMeetingId: String, newDurationInSeconds: Int) = {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-typing-indicator/component.tsx
@@ -219,8 +219,8 @@ const TypingIndicatorContainer: React.FC = () => {
   const typingUsers = privateTypingUsers.concat(publicTypingUsers);
 
   const typingUsersArray = typingUsers
-    .filter((user: { user: object; userId: string; }) => user?.user && user?.userId !== currentUser?.userId)
-    .map((user: { user: object; }) => user.user);
+    .filter((userTyping: { userId: string | null; }) => userTyping?.userId !== currentUser?.userId)
+    .map((user: { user: object | null; }) => user.user ?? { name: '' });
 
   if (locked || !TYPING_INDICATOR_ENABLED || !typingUsers) return null;
 


### PR DESCRIPTION
Make graphql stop providing `userIds` of who is typing when setting `public.chat.typingIndicator.showNames: false`.

Example for the query:
```gql
subscription IsTyping {
  user_typing_public(
      order_by: {startedTypingAt: asc}
      limit: 4,
      where: {
        isCurrentlyTyping: {_eq: true}
        chatId: {_eq: "MAIN-PUBLIC-GROUP-CHAT"}
      }
    ) {
    chatId
    userId
    isCurrentlyTyping
    user {
      name
    }
  }  
}
```

- Before:
```json
{
  "data": {
    "user_typing_public": [
      {
        "chatId": "MAIN-PUBLIC-GROUP-CHAT",
        "userId": "w_opphkefrciiy",
        "isCurrentlyTyping": true,
        "user": {
          "name": "student 1"
        }
      },
      {
        "chatId": "MAIN-PUBLIC-GROUP-CHAT",
        "userId": "w_j1iwtyl2dqsh",
        "isCurrentlyTyping": true,
        "user": {
          "name": "student 2"
        }
      }
    ]
  }
}
```

- After:
```json
{
  "data": {
    "user_typing_public": [
      {
        "chatId": "MAIN-PUBLIC-GROUP-CHAT",
        "userId": null,
        "isCurrentlyTyping": true,
        "user": null
      },
      {
        "chatId": "MAIN-PUBLIC-GROUP-CHAT",
        "userId": null,
        "isCurrentlyTyping": true,
        "user": null
      }
    ]
  }
}
```

Complement of https://github.com/bigbluebutton/bigbluebutton/pull/23463