### PR TITLE
Fix(html5): prevent poll options from being hidden when the number of options was 10 or greater

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/LiveResult.tsx
@@ -168,7 +168,7 @@ const LiveResult: React.FC<LiveResultProps> = ({
           {usersCount !== numberOfAnswerCount
             ? <Styled.ConnectingAnimation animations={animations} /> : null}
         </Styled.Status>
-        <ResponsiveContainer width="90%" height={250}>
+        <ResponsiveContainer width="90%" height={translatedResponses.length * 50}>
           <BarChart
             data={translatedResponses}
             layout="vertical"

--- a/bigbluebutton-html5/imports/ui/components/poll/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/poll/queries.ts
@@ -71,7 +71,7 @@ subscription getCurrentPollData {
         }
         optionDescIds
       }
-      responses {
+      responses(order_by: {optionId: asc}) {
         correctOption
         optionResponsesCount
         optionDesc

--- a/bigbluebutton-html5/imports/ui/components/polling/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/polling/queries.ts
@@ -37,7 +37,7 @@ export const hasPendingPoll = gql`
           responded
           userId
         }
-        options {
+        options(order_by: {optionId: asc}) {
           optionDesc
           optionId
           pollId


### PR DESCRIPTION
### What does this PR do?
Live results previously had a fixed height of 250px, which caused issues when polls contained many options. To resolve this, I applied the same dynamic height approach used in the chat and whiteboard components—scaling the height based on the number of options (options × 50).

Also add a `order_by` for poll options on Live Results and polling to ensure the options will be shown in order on ui.


### Closes Issue(s)
Closes #23597 

### How to test
- Set public.poll.maxCustom to 10 
- Start a pol with 10 options 
or 
- Start a typed Response 
- Respond it with 10 different users and answers


### More
<img width="227" height="771" alt="image" src="https://github.com/user-attachments/assets/2d7a5496-a4af-40b8-b768-a105068e0301" />
