### PR TITLE
Fix(html5): Correct answer marker clipping on long options

### DIFF
--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/globalStyles.js
@@ -147,6 +147,10 @@ const GlobalStyle = createGlobalStyle`
       left: none !important;
     }
   }
+    
+  .recharts-surface {
+    overflow: visible;
+  }
 
   .raiseHandToast {
     background-color: ${colorWhite};


### PR DESCRIPTION
### What does this PR do?
Fix clipping issue on the correct response marker when the option text is too long.

### Closes Issue(s)
Closes #23592 

### How to test
- Create a quiz with long options (I used `123456789123456789123456789` and `987654321987654321987654321`)
- Publish the quiz 


### More
Before:
<img width="310" height="391" alt="image" src="https://github.com/user-attachments/assets/6c5f0fbd-f3f5-4c4d-a9fa-b4e8ead16c57" />

After:
<img width="310" height="391" alt="image" src="https://github.com/user-attachments/assets/fa537f49-40d9-4d6f-8508-f5b7d3c9dead" />

