### PR TITLE
fix: Device settings window disappears when recording permission prompt appears

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
@@ -80,7 +80,7 @@ class ModalSimple extends Component {
 
   handleOutsideClick(e) {
     const { modalIsOpen } = this.props;
-    if (this.modalRef.current && !this.modalRef.current.contains(e.target) && modalIsOpen) {
+    if (this.modalRef.current && e.target?.contains(this.modalRef.current) && modalIsOpen) {
       this.handleRequestClose(e);
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
@@ -81,6 +81,7 @@ const RecordingNotifyModal: React.FC<RecordingNotifyModalProps> = ({
       {...{
         isOpen,
         priority,
+        modalIsOpen: isOpen,
       }}
     >
       <Styled.Container>


### PR DESCRIPTION
### What does this PR do?
Updates recording notification modal props and refines modal close condition to fix focus trap behavior

### Closes Issue(s)
Closes #23635

### How to test
set `listenOnlyMode: false` in settings file

use the following parameters:
```
notifyRecordingIsOn=true
record=true
```

1. Join a room where a recording is in progress
2. Select "continue" in the recording notification modal
3. Audio modal should appear after the recording notification modal is closed