### PR TITLE
fix(audio): correct locales placeholder

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/device-selector/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/device-selector/component.jsx
@@ -76,7 +76,7 @@ class DeviceSelector extends Component {
     const { intl, kind } = this.props;
     const label = kind === 'audioinput' ? intlMessages.fallbackInputLabel : intlMessages.fallbackOutputLabel;
 
-    return intl.formatMessage(label, { 0: index });
+    return intl.formatMessage(label, { index });
   }
 
   render() {

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/audio-selectors/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/audio-selectors/component.tsx
@@ -220,7 +220,7 @@ const AudioSelectors: React.FC<AudioSelectorsProps> = ({
     const baseLabel = device?.kind === AUDIO_OUTPUT
       ? intlMessages.fallbackOutputLabel
       : intlMessages.fallbackInputLabel;
-    let label = intl.formatMessage(baseLabel, { 0: index });
+    let label = intl.formatMessage(baseLabel, { index });
 
     if (!device?.deviceId) {
       label = `${label} ${intl.formatMessage(intlMessages.fallbackNoPermissionLabel)}`;


### PR DESCRIPTION
### What does this PR do?
Reference the correct placoholder for 'app.audio.audioSettings.fallbackInputLabel' and 'app.audio.audioSettings.fallbackOutputLabel'.
