### PR TITLE
fix(bbb-web): Add Presentation Upload Concurrency Explanation

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
@@ -22,6 +22,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 
+// Presentation files are processed using two separate thread pools.
+// One thread pool handles the preparation of PDF and image documents
+// for conversion along with the actual conversion of image documents.
+// The second thread pool handles the conversion of PDF document pages.
+// A PDF with multiple pages that take a long time to convert may saturate
+// the second thread pool effectively blocking the upload of further PDF
+// documents. There is a trade-off between converting multiple pages at once
+// versus uploading multiple documents at once and BBB has chosen to convert
+// pages more quickly at the expense of possibly not being able to upload
+// multiple documents at once.
+
 public class PresentationFileProcessor {
     private static Logger log = LoggerFactory.getLogger(PresentationFileProcessor.class);
 


### PR DESCRIPTION
### What does this PR do?

Adds a comment explaining the functionality of concurrent presentation uploads and trade-off decisions that have been made.

### Motivation

Gives developers more insight into how presentation upload works in case of future questions regarding expected upload behaviour.
