### PR TITLE
refactor: remove emoji id from chat reactions

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReactionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReactionReqMsgHdlr.scala
@@ -52,9 +52,9 @@ trait DeleteGroupChatMessageReactionReqMsgHdlr extends HandlerHelpers {
           val userIsAParticipant = groupChat.users.exists(u => u.id == user.intId)
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-            val event = buildGroupChatMessageReactionDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji, msg.body.reactionEmojiId)
+            val event = buildGroupChatMessageReactionDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji)
             bus.outGW.send(event)
-            ChatMessageReactionDAO.delete(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji, msg.body.reactionEmojiId)
+            ChatMessageReactionDAO.delete(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji)
           } else {
             val reason = "User isn't a participant of the chat"
             PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageReactionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/SendGroupChatMessageReactionReqMsgHdlr.scala
@@ -52,9 +52,9 @@ trait SendGroupChatMessageReactionReqMsgHdlr extends HandlerHelpers {
           val userIsAParticipant = groupChat.users.exists(u => u.id == user.intId)
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-            val event = buildGroupChatMessageReactionSentEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji, msg.body.reactionEmojiId)
+            val event = buildGroupChatMessageReactionSentEvtMsg(liveMeeting.props.meetingProp.intId, msg.header.userId, msg.body.chatId, gcMessage.id, msg.body.reactionEmoji)
             bus.outGW.send(event)
-            ChatMessageReactionDAO.insert(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji, msg.body.reactionEmojiId)
+            ChatMessageReactionDAO.insert(liveMeeting.props.meetingProp.intId, gcMessage.id, msg.header.userId, msg.body.reactionEmoji)
           } else {
             val reason = "User isn't a participant of the chat"
             PermissionCheck.ejectUserForFailedPermission(msg.header.meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageReactionDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ChatMessageReactionDAO.scala
@@ -4,12 +4,11 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{ ProvenShape }
 
 case class ChatMessageReactionDbModel(
-    meetingId:       String,
-    messageId:       String,
-    userId:          String,
-    reactionEmoji:   String,
-    reactionEmojiId: String,
-    createdAt:       java.sql.Timestamp
+    meetingId:     String,
+    messageId:     String,
+    userId:        String,
+    reactionEmoji: String,
+    createdAt:     java.sql.Timestamp
 )
 
 class ChatMessageReactionDbTableDef(tag: Tag) extends Table[ChatMessageReactionDbModel](tag, "chat_message_reaction") {
@@ -17,14 +16,13 @@ class ChatMessageReactionDbTableDef(tag: Tag) extends Table[ChatMessageReactionD
   val messageId = column[String]("messageId", O.PrimaryKey)
   val userId = column[String]("userId", O.PrimaryKey)
   val reactionEmoji = column[String]("reactionEmoji", O.PrimaryKey)
-  val reactionEmojiId = column[String]("reactionEmojiId")
   val createdAt = column[java.sql.Timestamp]("createdAt")
 
-  override def * : ProvenShape[ChatMessageReactionDbModel] = (meetingId, messageId, userId, reactionEmoji, reactionEmojiId, createdAt) <> (ChatMessageReactionDbModel.tupled, ChatMessageReactionDbModel.unapply)
+  override def * : ProvenShape[ChatMessageReactionDbModel] = (meetingId, messageId, userId, reactionEmoji, createdAt) <> (ChatMessageReactionDbModel.tupled, ChatMessageReactionDbModel.unapply)
 }
 
 object ChatMessageReactionDAO {
-  def insert(meetingId: String, messageId: String, userId: String, reactionEmoji: String, reactionEmojiId: String) = {
+  def insert(meetingId: String, messageId: String, userId: String, reactionEmoji: String) = {
     DatabaseConnection.enqueue(
       TableQuery[ChatMessageReactionDbTableDef].forceInsert(
         ChatMessageReactionDbModel(
@@ -32,21 +30,19 @@ object ChatMessageReactionDAO {
           messageId = messageId,
           userId = userId,
           reactionEmoji = reactionEmoji,
-          reactionEmojiId = reactionEmojiId,
           createdAt = new java.sql.Timestamp(System.currentTimeMillis())
         )
       )
     )
   }
 
-  def delete(meetingId: String, messageId: String, userId: String, reactionEmoji: String, reactionEmojiId: String) = {
+  def delete(meetingId: String, messageId: String, userId: String, reactionEmoji: String) = {
     DatabaseConnection.enqueue(
       TableQuery[ChatMessageReactionDbTableDef]
         .filter(_.meetingId === meetingId)
         .filter(_.messageId === messageId)
         .filter(_.userId === userId)
         .filter(_.reactionEmoji === reactionEmoji)
-        .filter(_.reactionEmojiId === reactionEmojiId)
         .delete
     )
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -328,20 +328,20 @@ trait HandlerHelpers extends SystemConfiguration {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildGroupChatMessageReactionSentEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String): BbbCommonEnvCoreMsg = {
+  def buildGroupChatMessageReactionSentEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(GroupChatMessageReactionSentEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(GroupChatMessageReactionSentEvtMsg.NAME, meetingId, userId)
-    val body = GroupChatMessageReactionSentEvtMsgBody(chatId, messageId, reactionEmoji, reactionEmojiId)
+    val body = GroupChatMessageReactionSentEvtMsgBody(chatId, messageId, reactionEmoji)
     val event = GroupChatMessageReactionSentEvtMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
-  def buildGroupChatMessageReactionDeletedEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String): BbbCommonEnvCoreMsg = {
+  def buildGroupChatMessageReactionDeletedEvtMsg(meetingId: String, userId: String, chatId: String, messageId: String, reactionEmoji: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(GroupChatMessageReactionDeletedEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(GroupChatMessageReactionDeletedEvtMsg.NAME, meetingId, userId)
-    val body = GroupChatMessageReactionDeletedEvtMsgBody(chatId, messageId, reactionEmoji, reactionEmojiId)
+    val body = GroupChatMessageReactionDeletedEvtMsgBody(chatId, messageId, reactionEmoji)
     val event = GroupChatMessageReactionDeletedEvtMsg(header, body)
     BbbCommonEnvCoreMsg(envelope, event)
   }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/GroupChatMsg.scala
@@ -139,19 +139,19 @@ case class GroupChatMessageDeletedEvtMsgBody(chatId: String, messageId: String)
 
 object SendGroupChatMessageReactionReqMsg { val NAME = "SendGroupChatMessageReactionReqMsg" }
 case class SendGroupChatMessageReactionReqMsg(header: BbbClientMsgHeader, body: SendGroupChatMessageReactionReqMsgBody) extends StandardMsg
-case class SendGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
+case class SendGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String)
 
 object GroupChatMessageReactionSentEvtMsg { val NAME = "GroupChatMessageReactionSentEvtMsg" }
 case class GroupChatMessageReactionSentEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageReactionSentEvtMsgBody) extends BbbCoreMsg
-case class GroupChatMessageReactionSentEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
+case class GroupChatMessageReactionSentEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String)
 
 object DeleteGroupChatMessageReactionReqMsg { val NAME = "DeleteGroupChatMessageReactionReqMsg" }
 case class DeleteGroupChatMessageReactionReqMsg(header: BbbClientMsgHeader, body: DeleteGroupChatMessageReactionReqMsgBody) extends StandardMsg
-case class DeleteGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
+case class DeleteGroupChatMessageReactionReqMsgBody(chatId: String, messageId: String, reactionEmoji: String)
 
 object GroupChatMessageReactionDeletedEvtMsg { val NAME = "GroupChatMessageReactionDeletedEvtMsg" }
 case class GroupChatMessageReactionDeletedEvtMsg(header: BbbClientMsgHeader, body: GroupChatMessageReactionDeletedEvtMsgBody) extends BbbCoreMsg
-case class GroupChatMessageReactionDeletedEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String, reactionEmojiId: String)
+case class GroupChatMessageReactionDeletedEvtMsgBody(chatId: String, messageId: String, reactionEmoji: String)
 
 object UserTypingPubMsg { val NAME = "UserTypingPubMsg" }
 case class UserTypingPubMsg(header: BbbClientMsgHeader, body: UserTypingPubMsgBody) extends StandardMsg

--- a/bbb-graphql-actions/src/actions/chatDeleteMessageReaction.ts
+++ b/bbb-graphql-actions/src/actions/chatDeleteMessageReaction.ts
@@ -7,7 +7,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'chatId', type: 'string', required: true},
         {name: 'messageId', type: 'string', required: true},
         {name: 'reactionEmoji', type: 'string', required: true},
-        {name: 'reactionEmojiId', type: 'string', required: true},
       ]
   )
 
@@ -27,7 +26,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     chatId: input.chatId,
     messageId: input.messageId,
     reactionEmoji: input.reactionEmoji,
-    reactionEmojiId: input.reactionEmojiId,
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
+++ b/bbb-graphql-actions/src/actions/chatSendMessageReaction.ts
@@ -9,7 +9,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'chatId', type: 'string', required: true},
         {name: 'messageId', type: 'string', required: true},
         {name: 'reactionEmoji', type: 'string', required: true},
-        {name: 'reactionEmojiId', type: 'string', required: true},
       ]
   )
 
@@ -33,7 +32,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     chatId: input.chatId,
     messageId: input.messageId,
     reactionEmoji: input.reactionEmoji,
-    reactionEmojiId: input.reactionEmojiId,
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-server/bbb-graphql-schema.md
+++ b/bbb-graphql-server/bbb-graphql-schema.md
@@ -152,7 +152,6 @@ Permission: Restricted to User Viewing Self-Related Data
 - `reactions: Array` **Type chat_message_reaction**
   - `createdAt`
   - `reactionEmoji`
-  - `reactionEmojiId`
   - `userId`
   - `user: Object` [Type User](#type-user)
 - `replyToMessage: Object` [Type chat_message_private](#type-chat_message_private)
@@ -179,7 +178,6 @@ Permission: Restricted to User Viewing Self-Related Data
 - `reactions: Array` **Type chat_message_reaction**
   - `createdAt`
   - `reactionEmoji`
-  - `reactionEmojiId`
   - `userId`
   - `user: Object` [Type User](#type-user)
 - `replyToMessage: Object` [Type type-chat_message_public](#type-chat_message_public)

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1264,7 +1264,6 @@ CREATE UNLOGGED TABLE "chat_message_reaction" (
 	"messageId" varchar(100) REFERENCES "chat_message"("messageId") ON DELETE CASCADE,
 	"userId" varchar(100) not null,
 	"reactionEmoji" varchar(25),
-    "reactionEmojiId" varchar(50),
 	"createdAt" timestamp with time zone,
     CONSTRAINT chat_message_reaction_pk PRIMARY KEY ("messageId", "userId", "reactionEmoji"),
     FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -149,7 +149,6 @@ type Mutation {
     chatId: String!
     messageId: String!
     reactionEmoji: String!
-    reactionEmojiId: String!
   ): Boolean
 }
 
@@ -185,7 +184,6 @@ type Mutation {
     chatId: String!
     messageId: String!
     reactionEmoji: String!
-    reactionEmojiId: String!
   ): Boolean
 }
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_reaction.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat_message_reaction.yaml
@@ -23,7 +23,6 @@ select_permissions:
       columns:
         - createdAt
         - reactionEmoji
-        - reactionEmojiId
         - userId
       filter:
         meetingId:

--- a/bigbluebutton-html5/imports/ui/Types/message.ts
+++ b/bigbluebutton-html5/imports/ui/Types/message.ts
@@ -38,7 +38,6 @@ export interface Message {
   reactions: {
     createdAt: string;
     reactionEmoji: string;
-    reactionEmojiId: string;
     user: {
       name: string;
       userId: string;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -250,7 +250,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
 
   const sendReaction = useCallback((
     reactionEmoji: string,
-    reactionEmojiId: string,
     chatId: string,
     messageId: string,
   ) => {
@@ -259,7 +258,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         chatId,
         messageId,
         reactionEmoji,
-        reactionEmojiId,
       },
     }).catch((e) => {
       logger.error({
@@ -274,7 +272,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
 
   const deleteReaction = useCallback((
     reactionEmoji: string,
-    reactionEmojiId: string,
     chatId: string,
     messageId: string,
   ) => {
@@ -283,7 +280,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
         chatId,
         messageId,
         reactionEmoji,
-        reactionEmojiId,
       },
     }).catch((e) => {
       logger.error({

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -71,8 +71,8 @@ interface ChatMessageProps {
   chatEditEnabled: boolean;
   chatReactionsEnabled: boolean;
   focused: boolean;
-  sendReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
-  deleteReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
+  sendReaction: (reactionEmoji: string, chatId: string, messageId: string) => void;
+  deleteReaction: (reactionEmoji: string, chatId: string, messageId: string) => void;
 }
 
 export interface ChatMessageRef {
@@ -657,8 +657,8 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
     }
   }, [deactivateFocusTrap, keyboardFocused]);
 
-  const onEmojiSelected = useCallback((emoji: { id: string; native: string }) => {
-    sendReaction(emoji.native, emoji.id, message.chatId, message.messageId);
+  const onEmojiSelected = useCallback((emoji: { native: string }) => {
+    sendReaction(emoji.native, message.chatId, message.messageId);
     setIsToolbarReactionPopoverOpen(false);
     deactivateFocusTrap();
   }, [message.chatId, message.messageId, sendReaction]);

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-reactions/reaction-item/component.tsx
@@ -21,10 +21,9 @@ interface ReactionItemProps {
   userNames: string[];
   reactedByMe: boolean;
   reactionEmoji: string;
-  reactionEmojiId: string;
   shortcodes: string;
-  sendReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
-  deleteReaction(reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string): void;
+  sendReaction(reactionEmoji: string, chatId: string, messageId: string): void;
+  deleteReaction(reactionEmoji: string, chatId: string, messageId: string): void;
   chatId: string;
   messageId: string;
 }
@@ -34,7 +33,6 @@ const ReactionItem: React.FC<ReactionItemProps> = (props) => {
     count,
     reactedByMe,
     reactionEmoji,
-    reactionEmojiId,
     userNames,
     shortcodes,
     chatId,
@@ -64,7 +62,7 @@ const ReactionItem: React.FC<ReactionItemProps> = (props) => {
   });
 
   return (
-    <TooltipContainer title={label} key={reactionEmojiId}>
+    <TooltipContainer title={label} key={reactionEmoji}>
       <Styled.EmojiWrapper
         data-test="messageReactionItem"
         tabIndex={-1}
@@ -72,9 +70,9 @@ const ReactionItem: React.FC<ReactionItemProps> = (props) => {
         highlighted={reactedByMe}
         onClick={() => {
           if (reactedByMe) {
-            deleteReaction(reactionEmoji, reactionEmojiId, chatId, messageId);
+            deleteReaction(reactionEmoji, chatId, messageId);
           } else {
-            sendReaction(reactionEmoji, reactionEmojiId, chatId, messageId);
+            sendReaction(reactionEmoji, chatId, messageId);
           }
         }}
       >
@@ -83,7 +81,6 @@ const ReactionItem: React.FC<ReactionItemProps> = (props) => {
             window.getComputedStyle(document.documentElement).fontSize,
           )}
           emoji={{
-            id: reactionEmojiId,
             native: reactionEmoji,
           }}
           native={reactionEmoji}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/mutations.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/mutations.ts
@@ -13,23 +13,21 @@ const CHAT_DELETE_MESSAGE_MUTATION = gql`
 `;
 
 const CHAT_SEND_REACTION_MUTATION = gql`
-  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!, $reactionEmojiId: String!) {
+  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!) {
     chatSendMessageReaction(
       chatId: $chatId,
       messageId: $messageId,
       reactionEmoji: $reactionEmoji,
-      reactionEmojiId: $reactionEmojiId
     )
   }
 `;
 
 const CHAT_DELETE_REACTION_MUTATION = gql`
-  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!, $reactionEmojiId: String!) {
+  mutation($chatId: String!, $messageId: String!, $reactionEmoji: String!) {
     chatDeleteMessageReaction(
       chatId: $chatId,
       messageId: $messageId,
       reactionEmoji: $reactionEmoji,
-      reactionEmojiId: $reactionEmojiId
     )
   }
 `;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -48,8 +48,8 @@ interface ChatListPageCommonProps {
   chatEditEnabled: boolean;
   chatReactionsEnabled: boolean;
   focusedSequence: number;
-  sendReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
-  deleteReaction: (reactionEmoji: string, reactionEmojiId: string, chatId: string, messageId: string) => void;
+  sendReaction: (reactionEmoji: string, chatId: string, messageId: string) => void;
+  deleteReaction: (reactionEmoji: string, chatId: string, messageId: string) => void;
   allPagesLoaded: boolean;
 }
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries.ts
@@ -29,7 +29,6 @@ export const CHAT_MESSAGE_PUBLIC_SUBSCRIPTION = gql`
       reactions(order_by: { createdAt: asc }) {
         createdAt
         reactionEmoji
-        reactionEmojiId
         user {
           name
           userId
@@ -86,7 +85,6 @@ export const CHAT_MESSAGE_PRIVATE_SUBSCRIPTION = gql`
       reactions {
         createdAt
         reactionEmoji
-        reactionEmojiId
         user {
           name
           userId

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/list-item/component.tsx
@@ -54,7 +54,7 @@ const messages = defineMessages({
 const { isChrome, isFirefox, isEdge } = browserInfo;
 
 interface EmojiProps {
-  emoji: { id: string; native: string; };
+  emoji: { native: string; };
   native: string;
   size: number;
 }


### PR DESCRIPTION
### What does this PR do?

removes reactionEmojiId from all chat reaction-related mutations and components, reducing code complexity

### How to test
1. join a meeting with chat reactions enabled
2. send a message
3. react to that message