### PR TITLE
Fix(html5): Add support to audio elements on external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -247,6 +247,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       const internalPlayer = player.getInternalPlayer();
       if (internalPlayer instanceof HTMLVideoElement) {
         internalPlayer.pause();
+      } else if (internalPlayer instanceof HTMLAudioElement) {
+        internalPlayer.pause();
       } else if (internalPlayer.pauseVideo) {
         internalPlayer.pauseVideo();
       } else if (internalPlayer.pause) {
@@ -259,6 +261,8 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (player) {
       const internalPlayer = player.getInternalPlayer();
       if (internalPlayer instanceof HTMLVideoElement) {
+        internalPlayer.play();
+      } else if (internalPlayer instanceof HTMLAudioElement) {
         internalPlayer.play();
       } else if (internalPlayer.playVideo) {
         internalPlayer.playVideo();
@@ -274,6 +278,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       if (internalPlayer instanceof HTMLVideoElement) {
         return internalPlayer.currentTime;
       }
+
+      if (internalPlayer instanceof HTMLAudioElement) {
+        return internalPlayer.currentTime;
+      }
+
       // Vimeo player returns a promise for getCurrentTime
       try {
         return (await internalPlayer?.getCurrentTime?.()) ?? 0;
@@ -291,6 +300,11 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       if (internalPlayer instanceof HTMLVideoElement) {
         return internalPlayer.playbackRate;
       }
+
+      if (internalPlayer instanceof HTMLAudioElement) {
+        return internalPlayer.playbackRate;
+      }
+
       return internalPlayer?.getPlaybackRate?.() ?? 1;
     }
     return 1;
@@ -300,6 +314,10 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (player) {
       const internalPlayer = player.getInternalPlayer();
       if (internalPlayer instanceof HTMLVideoElement) {
+        return internalPlayer.volume;
+      }
+
+      if (internalPlayer instanceof HTMLAudioElement) {
         return internalPlayer.volume;
       }
 
@@ -404,7 +422,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     const currentTime = getServerCurrentTime();
     const playerCurrentTime = await getPlayerCurrentTime(playerRef.current as ReactPlayer);
     if (isPresenter && !playing) {
-      const rate = internalPlayer instanceof HTMLVideoElement
+      const rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
@@ -426,7 +444,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     const url = new URL(videoUrl);
     const isTwitch = url.hostname === 'twitch.tv' || url.hostname === 'www.twitch.tv';
     if (isPresenter && !playing) {
-      const rate = internalPlayer instanceof HTMLVideoElement
+      const rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
@@ -459,7 +477,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     setReactPlayerPlaying(false);
     if (isPresenter && playing) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
-      let rate = internalPlayer instanceof HTMLVideoElement
+      let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
 
@@ -506,7 +524,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const handleOnSeek = async (cursor: { position: number } | number) => {
     if (isPresenter) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
-      let rate = internalPlayer instanceof HTMLVideoElement
+      let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
       if (rate instanceof Promise) {
@@ -531,7 +549,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const handlePlaybackRateChange = async () => {
     if (isPresenter) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
-      let rate = internalPlayer instanceof HTMLVideoElement
+      let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
         : internalPlayer?.getPlaybackRate?.() ?? 1;
       if (rate instanceof Promise) {
@@ -757,7 +775,6 @@ const ExternalVideoPlayerContainer: React.FC = () => {
       `${UI_DATA_LISTENER_SUBSCRIBED}-${PluginSdk.ExternalVideoVolumeUiDataNames.IS_VOLUME_MUTED}`,
       updateUiDataHookIsMutedPlugin,
     );
-
     // Before component unmount, remove event listeners for plugin ui data hooks
     return () => {
       window.removeEventListener(


### PR DESCRIPTION
### What does this PR do?
The missing MP3 verification caused the mutation to always send a zeroed value to the server, resulting in the audio resetting for all users.

### Closes Issue(s)

Closes #23555

### How to test
- Play a .mp3 file (I used `https://github.com/rafaelreis-hotmart/Audio-Sample-files/raw/refs/heads/master/sample.mp3`)
- Pause as presenter 
- Look at time on othe clients.


### More
[Screencast from 31-07-2025 10:34:25.webm](https://github.com/user-attachments/assets/9df0a1d2-b4fc-4d39-bdb0-dacab42c0672)

