### PR TITLE
fix(html5/chat): Messages cannot be selected in the chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useMemo,
   useCallback,
+  useState,
 } from 'react';
 import { useLazyQuery, useMutation, useReactiveVar } from '@apollo/client';
 import TextareaAutosize from 'react-autosize-textarea';
@@ -413,6 +414,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const renderForm = () => {
     const formRef = useRef<HTMLFormElement | null>(null);
     const CHAT_EDIT_ENABLED = useIsEditChatMessageEnabled();
+    const [hasSelectedTextInChat, setHasSelectedTextInChat] = useState(false);
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLInputElement> | Event) => {
       e.preventDefault();
@@ -562,15 +564,37 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
       };
     }, []);
 
-    document.addEventListener('click', (event) => {
-      const chatList = document.getElementById('chat-list');
-      if (chatList?.contains(event.target as Node)) {
-        const selection = window.getSelection()?.toString();
-        if (selection?.length === 0) {
-          textAreaRef.current?.textarea.focus();
+    useEffect(() => {
+      const handleClick = (event: MouseEvent) => {
+        const chatList = document.getElementById('chat-list');
+        if (chatList?.contains(event.target as Node)) {
+          const selection = window.getSelection()?.toString();
+          if (selection?.length === 0 && !hasSelectedTextInChat) {
+            textAreaRef.current?.textarea.focus();
+          }
         }
-      }
-    });
+      };
+
+      /**
+       * Workaround for Firefox. `Selection.toString()` always returns empty string.
+       */
+      const handleSelectionChange = () => {
+        const selection = window.getSelection();
+        const chatList = document.getElementById('chat-list');
+        setHasSelectedTextInChat(
+          selection?.direction !== 'none'
+          && Boolean(chatList?.contains(selection?.anchorNode as Node)),
+        );
+      };
+
+      document.addEventListener('click', handleClick);
+      document.addEventListener('selectionchange', handleSelectionChange);
+
+      return () => {
+        document.removeEventListener('click', handleClick);
+        document.removeEventListener('selectionchange', handleSelectionChange);
+      };
+    }, [hasSelectedTextInChat]);
 
     useEffect(() => {
       if (chatSendMessageError && error == null) {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -6,7 +6,6 @@ import React, {
   useRef,
   useMemo,
   useCallback,
-  useState,
 } from 'react';
 import { useLazyQuery, useMutation, useReactiveVar } from '@apollo/client';
 import TextareaAutosize from 'react-autosize-textarea';
@@ -414,7 +413,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const renderForm = () => {
     const formRef = useRef<HTMLFormElement | null>(null);
     const CHAT_EDIT_ENABLED = useIsEditChatMessageEnabled();
-    const [hasSelectedTextInChat, setHasSelectedTextInChat] = useState(false);
+    const hasSelectedTextInChat = useRef(false);
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement> | React.KeyboardEvent<HTMLInputElement> | Event) => {
       e.preventDefault();
@@ -569,7 +568,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
         const chatList = document.getElementById('chat-list');
         if (chatList?.contains(event.target as Node)) {
           const selection = window.getSelection()?.toString();
-          if (selection?.length === 0 && !hasSelectedTextInChat) {
+          if (selection?.length === 0 && !hasSelectedTextInChat.current) {
             textAreaRef.current?.textarea.focus();
           }
         }
@@ -581,9 +580,9 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
       const handleSelectionChange = () => {
         const selection = window.getSelection();
         const chatList = document.getElementById('chat-list');
-        setHasSelectedTextInChat(
-          selection?.direction !== 'none'
-          && Boolean(chatList?.contains(selection?.anchorNode as Node)),
+        hasSelectedTextInChat.current = (
+          (selection?.focusOffset ?? 0) > 0
+          && Boolean(chatList?.contains(selection?.anchorNode as Node))
         );
       };
 
@@ -594,7 +593,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
         document.removeEventListener('click', handleClick);
         document.removeEventListener('selectionchange', handleSelectionChange);
       };
-    }, [hasSelectedTextInChat]);
+    }, []);
 
     useEffect(() => {
       if (chatSendMessageError && error == null) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

Fixes a bug where text selection in the chat is lost as soon as the button of the mouse is relesead. For some reason,  [Selection.toString](https://developer.mozilla.org/en-US/docs/Web/API/Selection/toString) seems always returns an empty string on Firefox. So this PR implements an alternative way to know when there is some text selected in the chat.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23634