### PR TITLE
build: Allow CORS for assets files under /plugins/ and its subdirectories

### DIFF
--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -49,6 +49,8 @@ mkdir -p staging/usr/share/bigbluebutton/nginx
 
 cp include_default.nginx staging/usr/share/bigbluebutton/
 
+cp plugins-locales-cors.nginx staging/usr/share/bigbluebutton/
+
 cp bigbluebutton.target staging/usr/lib/systemd/system/
 
 # inject dependency to bigbluebutton.target

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -49,7 +49,7 @@ mkdir -p staging/usr/share/bigbluebutton/nginx
 
 cp include_default.nginx staging/usr/share/bigbluebutton/
 
-cp plugins-locales-cors.nginx staging/usr/share/bigbluebutton/
+cp plugins-locales-cors.nginx staging/usr/share/bigbluebutton/nginx/
 
 cp bigbluebutton.target staging/usr/lib/systemd/system/
 

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -49,7 +49,7 @@ mkdir -p staging/usr/share/bigbluebutton/nginx
 
 cp include_default.nginx staging/usr/share/bigbluebutton/
 
-cp plugins-locales-cors.nginx staging/usr/share/bigbluebutton/nginx/
+cp plugins-assets-cors.nginx staging/usr/share/bigbluebutton/nginx/
 
 cp bigbluebutton.target staging/usr/lib/systemd/system/
 

--- a/build/packages-template/bbb-config/plugins-assets-cors.nginx
+++ b/build/packages-template/bbb-config/plugins-assets-cors.nginx
@@ -1,5 +1,5 @@
-# Allow CORS for all JSON files under the /plugins/ URL path (including subdirectories)
-location ~ ^/plugins/.+\.json$ {
+# Allow CORS for all assets under the /plugins/ URL path (including subdirectories)
+location ^~ /plugins/ {
   root /var/www/bigbluebutton-default/assets;
   try_files $uri =404;
 

--- a/build/packages-template/bbb-config/plugins-locales-cors.nginx
+++ b/build/packages-template/bbb-config/plugins-locales-cors.nginx
@@ -1,0 +1,16 @@
+# Allow CORS for all JSON files under the /plugins/ URL path (including subdirectories)
+location ~ ^/plugins/.+\.json$ {
+  root /var/www/bigbluebutton-default/assets;
+  try_files $uri =404;
+
+  add_header Access-Control-Allow-Origin "*" always;
+  add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+  add_header Access-Control-Allow-Headers "Origin, Content-Type, Accept" always;
+
+  if ($request_method = OPTIONS) {
+    add_header Access-Control-Max-Age 1728000;
+    add_header Content-Type "text/plain charset=UTF-8";
+    add_header Content-Length 0;
+    return 204;
+  }
+}


### PR DESCRIPTION
Add nginx rule to allow requesting files under the `/plugins` path from any origin.

This is especially important in cluster setups where the client and the `/plugins` host are on different domains. Browsers block `fetch()` requests for JSON files if the target server doesn't include appropriate CORS headers. This change ensures those requests are allowed.

It enables a convenient setup where plugins can be placed under `/var/www/bigbluebutton-default/assets/plugins/` without requiring additional configuration, just drop the plugin and its manifest there, and it will work.

Before:
<img width="2625" height="1728" alt="image" src="https://github.com/user-attachments/assets/bf9d82f2-f072-4fb5-8eeb-e126928e06f5" />

After:
<img width="2535" height="951" alt="image" src="https://github.com/user-attachments/assets/244d6043-8142-461e-aaad-37be59c1ea52" />


How to test:
Copy the file `build/packages-template/bbb-config/plugins-locales-cors.nginx` to `/usr/share/bigbluebutton/nginx/` and restart nginx.