### PR TITLE
tests: Add support for SDK flaky test exclusions in CI workflow

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -369,6 +369,26 @@ jobs:
           npm ci
           npx playwright install-deps
           npx playwright install
+      - name: Prepare flaky test exclusions
+        working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
+        run: |
+          # Read flaky tests from core repo and build grep-invert parameter
+          FLAKY_TESTS_FILE="../playwright/sdk-flaky-tests.txt"
+          if [ -f "$FLAKY_TESTS_FILE" ]; then
+            echo "Reading flaky tests from $FLAKY_TESTS_FILE"
+            # Read non-empty, non-comment lines and process them
+            FLAKY_TESTS=$(grep -v '^#' "$FLAKY_TESTS_FILE" | grep -v '^[[:space:]]*$' | sed 's/ › /.*/' | tr '\n' '|' | sed 's/|$//')
+            if [ -n "$FLAKY_TESTS" ]; then
+              echo "GREP_INVERT_PARAM=$FLAKY_TESTS" >> $GITHUB_ENV
+              echo "Will skip flaky tests: $FLAKY_TESTS"
+            else
+              echo "GREP_INVERT_PARAM=" >> $GITHUB_ENV
+              echo "No flaky tests to skip"
+            fi
+          else
+            echo "GREP_INVERT_PARAM=" >> $GITHUB_ENV
+            echo "Flaky tests file not found, running all tests"
+          fi
       - name: Run tests
         working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
         timeout-minutes: 25
@@ -377,7 +397,7 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           BBB_URL: https://bbb-ci.test/bigbluebutton/
           BBB_SECRET: bbbci
-        run: npm run test-chromium-ci
+        run: npm run test-chromium-ci -- --grep-invert "$GREP_INVERT_PARAM"
       - if: always()
         name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -372,23 +372,41 @@ jobs:
       - name: Prepare flaky test exclusions
         working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
         run: |
-          # Read flaky tests from core repo and build grep-invert parameter
-          FLAKY_TESTS_FILE="../playwright/sdk-flaky-tests.txt"
+          # Read flaky tests from core repo and build a grep-invert parameter
+          FLAKY_TESTS_FILE="sdk-flaky-tests.txt"
+          FLAKY_TESTS_LINES=""
+
           if [ -f "$FLAKY_TESTS_FILE" ]; then
             echo "Reading flaky tests from $FLAKY_TESTS_FILE"
-            # Read non-empty, non-comment lines and process them
-            FLAKY_TESTS=$(grep -v '^#' "$FLAKY_TESTS_FILE" | grep -v '^[[:space:]]*$' | sed 's/ › /.*/' | tr '\n' '|' | sed 's/|$//')
-            if [ -n "$FLAKY_TESTS" ]; then
-              echo "GREP_INVERT_PARAM=$FLAKY_TESTS" >> $GITHUB_ENV
-              echo "Will skip flaky tests: $FLAKY_TESTS"
+
+            # Process the file:
+            # - remove CRLF if present (Windows line endings)
+            # - ignore comments (#...) and empty lines
+            # - escape regex metacharacters to avoid breaking grep
+            # - replace " › " with ".*" to allow flexible matching
+            # - join all patterns into a single alternation regex separated by '|'
+
+            FLAKY_TESTS_LINES="$(
+              sed 's/\r$//' "$FLAKY_TESTS_FILE" \
+              | grep -Ev '^[[:space:]]*(#|$)' \
+              | sed -E 's/[][(){}.^$*+?|\]/\\&/g' \
+              | sed 's/ › /.*/g' \
+              | paste -sd'|' -
+            )"
+
+            # If we have patterns, print them; otherwise, say none found
+            if [ -n "$FLAKY_TESTS_LINES" ]; then
+              echo "Will skip flaky tests: $FLAKY_TESTS_LINES"
             else
-              echo "GREP_INVERT_PARAM=" >> $GITHUB_ENV
               echo "No flaky tests to skip"
             fi
           else
-            echo "GREP_INVERT_PARAM=" >> $GITHUB_ENV
+            # If the file does not exist, just run all tests
             echo "Flaky tests file not found, running all tests"
           fi
+
+          # Export the variable so it can be used in later GitHub Actions steps
+          echo "SDK_FLAKY_TESTS=$FLAKY_TESTS_LINES" >> "$GITHUB_ENV"
       - name: Run tests
         working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
         timeout-minutes: 25
@@ -397,7 +415,7 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           BBB_URL: https://bbb-ci.test/bigbluebutton/
           BBB_SECRET: bbbci
-        run: npm run test-chromium-ci -- --grep-invert "$GREP_INVERT_PARAM"
+        run: npm run test-chromium-ci -- --grep-invert "$SDK_FLAKY_TESTS"
       - if: always()
         name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4

--- a/bigbluebutton-tests/playwright/sdk-flaky-tests.txt
+++ b/bigbluebutton-tests/playwright/sdk-flaky-tests.txt
@@ -1,0 +1,3 @@
+# List of flaky SDK tests to skip in CI
+# Format: Test Suite › Test Spec (one per line)
+# Example: Custom Subscription Hook › should display the button with icon and log when clicked


### PR DESCRIPTION
### What does this PR do?
This pull request introduces a mechanism to handle flaky tests in the automated test workflow for the BigBlueButton SDK. The goal is to have an easier way to set the flaky flag without the need to push changes to the SDK repo, done by reading flaky tests from a file and using `--grep-invert` playwright parameter in CI.

- Without these changes:
  - SDK PR 
  - merge 
  - SDK version release 
  - core PR bumps SDK version 
  - re-run CI;
- With these changes:
  - core PR adding test into `bigbluebutton-tests/playwright/sdk-flaky-tests.txt` file 
  - merge 
  - re-run CI;



