### PR TITLE
chore (html5): Disable error overlay for `react-refresh` feature

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -67,7 +67,9 @@ const config = {
       'process.env.NODE_ENV': JSON.stringify(env),
       'process.env.DETAILED_LOGS': detailedLogs,
     }),
-    isDev && new ReactRefreshWebpackPlugin(),
+    isDev && new ReactRefreshWebpackPlugin({
+      overlay: false,
+    }),
   ],
   resolve: {
     modules: ['node_modules', 'src'],


### PR DESCRIPTION
The `react-refresh` feature includes an error overlay that displays uncaught errors in full screen. This becomes particularly disruptive when an audio playback attempt fails before user interaction, which is common in my case.

This PR disables the overlay to prevent these interruptions and allow development to continue without needing to manually dismiss the error screen.

<img width="2048" height="1529" alt="image" src="https://github.com/user-attachments/assets/9af75a2e-071b-4dc5-9e9a-aa4face529a4" />

More info about overlay:
https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/API.md

Related: #23560