### PR TITLE
fix(video-preview): correct variable scope to prevent crash on unmount

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -855,9 +855,11 @@ class VideoPreview extends Component {
     this.terminateCameraStream(this.currentVideoStream, webcamDeviceId);
     this.cleanupStreamAndVideo();
 
+    let bbbVideoStream;
+
     try {
       // The return of doGUM is an instance of BBBVideoStream (a thin wrapper over a MediaStream)
-      let bbbVideoStream = await PreviewService.doGUM(deviceId, profile);
+      bbbVideoStream = await PreviewService.doGUM(deviceId, profile);
       this.currentVideoStream = bbbVideoStream;
       const updatedDevice = this.updateDeviceId(deviceId);
 


### PR DESCRIPTION
### What does this PR do?
Declares `bbbVideoStream` variable out of the try catch block to ensure it is on the acessible closure for the cleanup routine when the video preview component has unmounted.


### Closes Issue(s)
Closes #23664