### PR TITLE
fix(media-area): improvements to Camera as Content and Media Area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/camera-as-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/camera-as-content/component.tsx
@@ -16,6 +16,7 @@ import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import ProfileStyled from '/imports/ui/components/profile-settings/styles';
 import ModalStyled from '../styles';
 import * as ScreenShareService from '/imports/ui/components/screenshare/service';
+import { useHasVideoStream, useStopVideo, useStreams } from '/imports/ui/components/video-provider/hooks';
 
 interface CameraAsContentViewProps {
   intl: IntlShape;
@@ -130,6 +131,12 @@ const CameraAsContentView: React.FC<CameraAsContentViewProps> = ({
   const isMounted = useRef<boolean>(true);
   const currentVideoStream = useRef<BBBVideoStream | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  const hasVideoStream = useHasVideoStream();
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  const allStreams = useStreams();
+  const stopVideo = useStopVideo();
 
   const initializeCameras = async () => {
     isMounted.current = true;
@@ -447,11 +454,20 @@ const CameraAsContentView: React.FC<CameraAsContentViewProps> = ({
     }
   }
 
-  const handleStartCameraAsContent = () => {
-    if (!PreviewService.storeStream(webcamDeviceId, currentVideoStream.current)) {
-      currentVideoStream.current?.stop();
+  const startCameraAsContent = () => {
+    const videoStream = currentVideoStream.current;
+
+    if (!videoStream || !videoStream.mediaStream) {
+      logger.error({
+        logCode: 'camera_as_content_missing_stream',
+        extraInfo: { deviceId: webcamDeviceId },
+      }, 'Camera as content failed: preview stream is not available at sharing time.');
+      initializeCameras();
+      return;
     }
-    cleanupStreamAndVideo();
+
+    PreviewService.storeStream(webcamDeviceId, videoStream);
+
     const handleFailure = (error: unknown) => {
       const {
         // @ts-ignore - jsx code
@@ -471,9 +487,43 @@ const CameraAsContentView: React.FC<CameraAsContentViewProps> = ({
       hasCameraAsContent,
       stopExternalVideoShare,
       // eslint-disable-next-line no-underscore-dangle
-      true, handleFailure, { stream: PreviewService.getStream(webcamDeviceId)._mediaStream },
+      true,
+      handleFailure,
+      { stream: videoStream.mediaStream },
     );
+
     ScreenShareService.setCameraAsContentDeviceId(webcamDeviceId);
+
+    cleanupStreamAndVideo();
+
+    onActionCompleted();
+  };
+
+  useEffect(() => {
+    if (!isTransitioning) return;
+
+    if (!hasVideoStream) {
+      logger.info({
+        logCode: 'camera_as_content_transition_safe',
+      }, 'Video stream is confirmed stopped. Proceeding to share as content.');
+
+      startCameraAsContent();
+      setIsTransitioning(false);
+    }
+  }, [isTransitioning, hasVideoStream]);
+
+  /** Clones the preview stream for a smooth transition */
+  const clonePreviewStream = () => {
+    if (!currentVideoStream.current || !currentVideoStream.current.originalStream) {
+      logger.error({
+        logCode: 'camera_as_content_clone_failed',
+      }, 'Failed to clone preview stream: stream is missing.');
+      return;
+    }
+
+    const cloned = currentVideoStream.current.originalStream.clone();
+    const newStream = new BBBVideoStream(cloned);
+    setCurrentVideoStream(newStream);
   };
 
   return (
@@ -502,15 +552,33 @@ const CameraAsContentView: React.FC<CameraAsContentViewProps> = ({
             ? formatMessage(intlMessages.shareLabel) : formatMessage(intlMessages.stopSharingLabel)}
           color={!hasCameraAsContent ? 'primary' : 'danger'}
           onClick={async () => {
-            if (!hasCameraAsContent) {
-              handleStartCameraAsContent();
-              onActionCompleted();
-            } else {
+            if (hasCameraAsContent) {
               ScreenShareService.screenshareHasEnded();
               initializeCameras();
+              return;
+            }
+
+            if (isTransitioning) return;
+
+            const myActiveStreams = allStreams.filter((s) => VideoService.isLocalStream(s.stream));
+            const targetStream = myActiveStreams.find((s) => s.deviceId === webcamDeviceId);
+
+            if (targetStream) {
+              clonePreviewStream();
+
+              logger.info({
+                logCode: 'camera_as_content_transition_start',
+                extraInfo: { streamToStop: targetStream.stream },
+              }, 'Matching camera stream found. Transitioning to content share.');
+
+              setIsTransitioning(true);
+              await stopVideo(targetStream.stream);
+            } else {
+              logger.info({ logCode: 'camera_as_content_no_video' }, 'No active video matching preview. Sharing as content directly.');
+              startCameraAsContent();
             }
           }}
-          disabled={isCameraLoading || !availableWebcams || availableWebcams.length === 0}
+          disabled={isCameraLoading || !availableWebcams || availableWebcams.length === 0 || isTransitioning}
           icon={hasCameraAsContent ? 'video_off' : undefined}
         />
       </ModalStyled.FooterContainer>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/camera-as-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/camera-as-content/component.tsx
@@ -438,9 +438,9 @@ const CameraAsContentView: React.FC<CameraAsContentViewProps> = ({
                   )
                   : (
                     <ProfileStyled.VideoPreview
-                      mirroredVideo={VideoService.mirrorOwnWebcam()}
+                      mirroredVideo={false}
                       id="preview"
-                      data-test={VideoService.mirrorOwnWebcam() ? 'mirroredVideoPreview' : 'videoPreview'}
+                      data-test="videoPreview"
                       ref={videoRef}
                       autoPlay
                       playsInline

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
@@ -180,7 +180,7 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
   const renderContent = () => {
     if (currentView === 'main') {
       return (
-        <Styled.MediaGrid>
+        <Styled.MediaGrid isMobile={isMobile}>
           <ScreenshareButtonContainer {...{
             amIPresenter,
             isMeteorConnected,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/media-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/media-button/styles.ts
@@ -10,7 +10,7 @@ const btnBorder = 'var(--btn-default-border, #B0BDC9)';
 
 // Outer container for the media button.
 const MediaButtonContainer = styled.div`
-  width: 108px;
+  width: 5rem;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -23,8 +23,8 @@ interface ButtonFrameProps {
 }
 
 const ButtonFrame = styled(ButtonBase)<ButtonFrameProps>`
-  width: 100%;
-  height: 6.75rem;
+  width: 4.5rem;
+  height: 4.5rem;
   border-radius: 16px !important;
   border: 1px solid ${btnBorder} !important;
   padding: 0.5rem !important;
@@ -114,7 +114,7 @@ const IconWrapper = styled.div`
   flex: 1;
 
   > i {
-    font-size: 340%;
+    font-size: 200%;
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/media-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/media-button/styles.ts
@@ -35,6 +35,7 @@ const ButtonFrame = styled(ButtonBase)<ButtonFrameProps>`
   align-items: center;
   text-transform: none;
   position: relative;
+  transition: opacity 0.2s ease-in-out;
 
   ${({ color }) => color === 'default' && `
     color: ${btnDefaultColor} !important;
@@ -49,8 +50,8 @@ const ButtonFrame = styled(ButtonBase)<ButtonFrameProps>`
       box-shadow: 0 0 0 ${borderSize} ${btnPrimaryBg};
     }
 
-    &:hover & {
-      color: ${colorGrayUserListToolbar} !important;
+    &:hover {
+      opacity: 0.8;
     }
   `}
 
@@ -66,14 +67,13 @@ const ButtonFrame = styled(ButtonBase)<ButtonFrameProps>`
       background-clip: padding-box;
       box-shadow: 0 0 0 ${borderSize} ${btnPrimaryBg};
     }
-    &:hover,
-    .buttonWrapper:hover & {
-      color: ${btnPrimaryColor} !important;
+
+    &:hover {
+      opacity: 0.8;
     }
   `}
 
   ${({ color }) => color === 'active' && `
-    //color: ${colorBlueAux} !important;
     background-color: ${colorBlueAux} !important;
     border: 0 !important;
 
@@ -84,9 +84,9 @@ const ButtonFrame = styled(ButtonBase)<ButtonFrameProps>`
       background-clip: padding-box;
       box-shadow: 0 0 0 ${borderSize} ${btnPrimaryBg};
     }
-    &:hover,
-    .buttonWrapper:hover & {
-      color: ${btnPrimaryColor} !important;
+
+    &:hover {
+      opacity: 0.8;
     }
   `}
 `;
@@ -123,7 +123,6 @@ const ButtonText = styled.div`
   color: ${colorText};
   width: 100%;
   text-align: center;
-  //font-size: 0.75rem;
   line-height: 1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/styles.ts
@@ -5,10 +5,10 @@ import {
   colorText, colorGrayIcons, appsPanelTextColor,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
-import { fontSizeLarge, titlesFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
+import { fontSizeBase, headingsFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
 import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown';
 
-const MODAL_WIDTH = '420px';
+const MODAL_WIDTH = '26.25rem';
 const MODAL_WIDTH_REDUCED = '250px';
 
 // This overlay covers the entire viewport and is used to catch outside clicks.
@@ -87,13 +87,13 @@ const HeaderContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem;
+  padding: 1rem;
   border-bottom: 1px solid ${appsGalleryOutlineColor};
 
   h2 {
     margin: 0;
-    font-size: ${fontSizeLarge};
-    font-weight: ${titlesFontWeight};
+    font-size: ${fontSizeBase};
+    font-weight: ${headingsFontWeight};
     text-transform: uppercase;
   }
 `;
@@ -108,17 +108,16 @@ const ContentContainer = styled.div`
 
 // Grid layout for displaying media options.
 const MediaGrid = styled.div`
-  padding: 1.5rem;
+  padding: 1rem;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
+  grid-template-columns: repeat(4, 1fr);
   text-align: center;
   justify-items: center;
 `;
 
 // Footer container for the start/stop sharing button.
 const FooterContainer = styled.div`
-  padding: 1.5rem;
+  padding: 1rem;
   border-top: 1px solid ${appsGalleryOutlineColor};
   display: flex;
   justify-content: center;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/styles.ts
@@ -67,9 +67,9 @@ const ModalContainer = styled.div<{
   ${({
     isMobile, isRTL, reducedWidth,
   }) => (isMobile ? `
-    left: 0;
-    right: 0;
-    width: 100%;
+    width: 70%;
+    right: 6%;
+    left: auto;
   ` : `
     width: ${reducedWidth ? MODAL_WIDTH_REDUCED : MODAL_WIDTH};
     ${isRTL ? `
@@ -107,10 +107,10 @@ const ContentContainer = styled.div`
 `;
 
 // Grid layout for displaying media options.
-const MediaGrid = styled.div`
-  padding: 1rem;
+const MediaGrid = styled.div<{ isMobile: boolean }>`
+  padding: ${({ isMobile }) => (isMobile ? '0.5rem' : '1rem')};
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: ${({ isMobile }) => (isMobile ? 'repeat(3, 1fr)' : 'repeat(4, 1fr)')};
   text-align: center;
   justify-items: center;
 `;


### PR DESCRIPTION
### What does this PR do?
This PR bundles a series of fixes and improvements focused on the user experience when interacting with the "camera as content" feature and the general media area.

### Changes made:
#### Camera as Content (camera-as-content):
 - Fixes the camera view so the preview is not mirrored when pinned as content, ensuring a correct presentation.
 - Implements the logic to switch the camera between its view and a presentation.

#### Media Area (media-area):
 - Adds a hover effect to media buttons, improving visual feedback for the user.
 - Performs several other fine-tuning design adjustments to enhance the area's appearance.


### Closes Issue(s)
Closes None

### More
[Screencast from 07-08-2025 17:14:39.webm](https://github.com/user-attachments/assets/3627bbea-a9c3-4f98-afaf-e5236204002c)
