### PR TITLE
fix(bbb-export-annotations): Text wrapping in text shapes

### DIFF
--- a/bbb-export-annotations/shapes/TextShape.js
+++ b/bbb-export-annotations/shapes/TextShape.js
@@ -52,14 +52,14 @@ export class TextShape extends Shape {
         })
         .fill(this.shapeColor);
 
-    const lines = this.wrapText(this.text, this.w);
+    const lines = this.wrapText(this.text ?? '', this.w ?? 200);
 
-    lines.forEach((line) => {
+    lines.forEach((line, idx) => {
       const tspan = new Tspan()
           .text(line)
           .attr({
             x,
-            dy: this.fontSize,
+            dy: idx === 0 ? 0 : this.fontSize,
           });
 
       textElement.add(tspan);

--- a/bbb-export-annotations/shapes/TextShape.js
+++ b/bbb-export-annotations/shapes/TextShape.js
@@ -1,4 +1,4 @@
-import {Text} from '@svgdotjs/svg.js';
+import {Text, Tspan} from '@svgdotjs/svg.js';
 import {Shape} from './Shape.js';
 
 /**
@@ -42,7 +42,6 @@ export class TextShape extends Shape {
 
     const textGroup = this.shapeGroup;
     const textElement = new Text()
-        .text(this.text)
         .attr({'xml:space': 'preserve'})
         .move(x, y)
         .font({
@@ -52,6 +51,19 @@ export class TextShape extends Shape {
           'alignment-baseline': 'middle',
         })
         .fill(this.shapeColor);
+
+    const lines = this.wrapText(this.text, this.w);
+
+    lines.forEach((line) => {
+      const tspan = new Tspan()
+          .text(line)
+          .attr({
+            x,
+            dy: this.fontSize,
+          });
+
+      textElement.add(tspan);
+    });
 
     textGroup.add(textElement);
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Fixes a bug where the text in text shapes doesn't wrap, causing it to overflow its bounding box.

#### Whiteboard in the session:
<img width="1146" height="713" alt="Screenshot from 2025-08-08 10-06-52" src="https://github.com/user-attachments/assets/7482836a-982a-42cc-a9a4-adb1ba5cc2fb" />

#### Resulting exported presentation:
[default (5).pdf](https://github.com/user-attachments/files/21684595/default.5.pdf)



### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23668