### PR TITLE
fix(chat): loading spinner size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -249,7 +249,11 @@ const Chat: React.FC<ChatProps> = ({
 };
 
 export const ChatLoading: React.FC<ChatLoadingProps> = () => {
-  return <Styled.CircularProgressContainer />;
+  return (
+    <Styled.LoadingWrapper>
+      <Styled.CircularProgressContainer />
+    </Styled.LoadingWrapper>
+  );
 };
 
 const ChatContainer: React.FC = () => {

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts
@@ -81,6 +81,12 @@ const ButtonsWrapper = styled.div`
   justifyContent: space-between;
 `;
 
+const LoadingWrapper = styled.div`
+  justify-content: center;
+  display: flex;
+  flex-grow: 1;
+`;
+
 const CircularProgressContainer = styled(CircularProgress)`
   align-self: center;
 `;
@@ -98,6 +104,7 @@ export default {
   ChatMessages,
   Separator,
   ButtonsWrapper,
+  LoadingWrapper,
   CircularProgressContainer,
   ContentWrapper,
 };


### PR DESCRIPTION
### What does this PR do?
Adds a wrapper to the chat messages loading spinner, so it occupies the correct height, preventing the chat message input from going up.
Before:
![before-loading](https://github.com/user-attachments/assets/b190d2ef-d6cf-402f-b780-7940d30ff8f6)


After:
![after-loading](https://github.com/user-attachments/assets/78344f3d-cb5e-40a6-9ad6-19693811b13b)


### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/23684