### PR TITLE
fix: Poll Results in the pdf-File

### DIFF
--- a/bbb-export-annotations/shapes/Poll.js
+++ b/bbb-export-annotations/shapes/Poll.js
@@ -1,5 +1,4 @@
 import { Geo } from './Geo.js';
-import fs from 'fs';
 
 /**
  * Creates an SVG poll shape from Tldraw v2 JSON data.
@@ -171,8 +170,6 @@ export class Poll extends Geo {
   }
 
   draw() {
-    let pollText = '';
-
     const caseInsensitiveReducer = (acc, item) => {
       const index = acc.findIndex((ans) => ans.key.toLowerCase() === item.key.toLowerCase())
       if (index !== -1) {
@@ -190,14 +187,12 @@ export class Poll extends Geo {
 
     const answers = this.props?.answers.reduce(caseInsensitiveReducer, []);
 
-    pollText = pollText.concat(answers.map((ans) => `${ans.key}: ${ans.numVotes}`).join('<br/>'));
-
     const rectGroup = this.shapeGroup;
 
     let pollQuestion = '';
 
     if (this.props?.questionText.trim() !== '') {
-      pollQuestion = this.props.questionText.split('<br#>').join(' ');
+      pollQuestion = this.props.questionText.split('<br/>').join(' ');
     }
 
     const svg = this.generatePollSvg(answers, this.w, this.h + this.growY, pollQuestion);

--- a/bbb-export-annotations/shapes/Poll.js
+++ b/bbb-export-annotations/shapes/Poll.js
@@ -1,0 +1,196 @@
+import { Geo } from './Geo.js';
+
+/**
+ * Creates an SVG poll shape from Tldraw v2 JSON data.
+ *
+ * @class Poll
+ * @extends {Geo}
+ */
+export class Poll extends Geo {
+  /**
+   * Draws a poll shape based on the instance properties.
+   *
+   * @method draw
+   * @return {G} An SVG group element containing the drawn poll shape.
+   *
+ */
+  constructor(poll) {
+    super(poll);
+    this.props = poll?.props;
+    this.growY = 0;
+  }
+
+  getNiceAxisScale(values, maxTicks = 5) {
+    const maxValue = Math.max(0, ...values);
+
+    if (maxValue === 0) {
+      return {
+        min: 0,
+        max: 4,
+        ticks: [0,1,2,3,4]
+      };
+    }
+
+    const roughStep = maxValue / (maxTicks - 1);
+
+    const niceStep = this.getNiceNumber(roughStep);
+
+    const maxAxis = Math.ceil(maxValue / niceStep) * niceStep;
+
+    const ticks = [];
+    for (let v = 0; v <= maxAxis; v += niceStep) {
+      ticks.push(v);
+    }
+
+    return ticks;
+  }
+
+  getNiceNumber(value) {
+    const exponent = Math.floor(Math.log10(value));
+    const fraction = value / Math.pow(10, exponent);
+
+    let niceFraction;
+
+    if (fraction <= 1) {
+      niceFraction = 1;
+    } else if (fraction <= 2) {
+      niceFraction = 2;
+    } else if (fraction <= 5) {
+      niceFraction = 5;
+    } else {
+      niceFraction = 10;
+    }
+
+    return niceFraction * Math.pow(10, exponent);
+  }
+
+  breakTextIntoLines(text, fontSize, maxWidth) {
+    const words = text.split(' ');
+    const lines = [];
+    let currentLine = '';
+
+    for (const word of words) {
+      const testLine = currentLine + (currentLine ? ' ' : '') + word;
+      const testWidth = testLine.length * fontSize * 0.6;
+
+      if (testWidth > maxWidth) {
+        lines.push(currentLine);
+        currentLine = word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+
+    lines.push(currentLine);
+    return lines;
+  };
+
+  generatePollSvg(answers, width = 600, height = 300, questionText = '') {
+    const isQuiz = answers.some(a => a.isCorrectAnswer);
+
+    const labels = answers.map(a => a.key);
+    const values = answers.map(a => a.numVotes);
+
+    const titleFontSize = questionText ? 14 : 0;
+    const titleSpacing = questionText ? 20 : 0;
+
+    const titleLines = this.breakTextIntoLines(questionText, titleFontSize, width);
+
+    const padding = {
+      top: 20 + ((titleFontSize + titleSpacing) * titleLines.length),
+      right: 40,
+      bottom: 20,
+      left: 80
+    };
+
+    const innerWidth = width - padding.left - padding.right;
+    const innerHeight = height - padding.top - padding.bottom;
+
+    const uniqueValues = Array.from(new Set(values.map(v => Math.round(v))));
+
+    const expandedValues = this.getNiceAxisScale(uniqueValues);
+
+    const maxDisplayValue = Math.max(...uniqueValues, 1);
+
+    const count = labels.length;
+    const gap = 10;
+    const barHeight = Math.floor((innerHeight - gap * (count - 1)) / count);
+    const valueToWidth = v => Math.round((v / maxDisplayValue) * innerWidth);
+
+    let bars = '';
+
+    labels.forEach((label, i) => {
+      const val = values[i];
+      const w = valueToWidth(val);
+      const x = padding.left;
+      const y = padding.top + i * (barHeight + gap);
+      const displayText = (isQuiz && answers[i].isCorrectAnswer ? '✅ ' : '') + label;
+
+      bars += `
+        <rect x="${x}" y="${y}" width="${w}" height="${barHeight}" rx="4" ry="4" fill="#2b8cff" />
+        <text x="${x - 6}" y="${y + barHeight / 2 + 4}" font-size="12" text-anchor="end" fill="#333">${displayText}</text>
+      `;
+    });
+
+    const gridMarkup = expandedValues.map(v => {
+      const xPx = padding.left + Math.round((v / maxDisplayValue) * innerWidth);
+      return `<line x1="${xPx}" x2="${xPx}" y1="${padding.top}" y2="${height - padding.bottom}" stroke="#e6e6e6" />`;
+    }).join('');
+
+    const xLabels = expandedValues.map(v => {
+      const xPx = padding.left + Math.round((v / maxDisplayValue) * innerWidth);
+      return `<text x="${xPx}" y="${height - padding.bottom + 14}" font-size="11" text-anchor="middle" fill="#666">${v}</text>`;
+    }).join('');
+
+    const titleMarkup = titleLines.map((line, i) => {
+      return `<text x="${width / 2}" y="${20 + titleFontSize / 2 + i * titleFontSize}" font-size="${titleFontSize}" text-anchor="middle" fill="#000">${line}</text>`;
+    }).join('');
+
+    return `
+      <svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+        <rect width="100%" height="100%" fill="white" />
+        ${titleMarkup}
+        <g>${gridMarkup}</g>
+        <g>${xLabels}</g>
+        <g>${bars}</g>
+      </svg>
+    `.trim();
+  }
+
+  draw() {
+    let pollText = '';
+
+    const caseInsensitiveReducer = (acc, item) => {
+      const index = acc.findIndex((ans) => ans.key.toLowerCase() === item.key.toLowerCase())
+      if (index !== -1) {
+        if (acc[index].numVotes >= item.numVotes) acc[index].numVotes += item.numVotes
+        else {
+          const tempVotes = acc[index].numVotes
+          acc[index] = item
+          acc[index].numVotes += tempVotes
+        }
+      } else {
+        acc.push(item)
+      }
+      return acc
+    }
+
+    const answers = this.props?.answers.reduce(caseInsensitiveReducer, []);
+
+    pollText = pollText.concat(answers.map((ans) => `${ans.key}: ${ans.numVotes}`).join('<br/>'));
+
+    const rectGroup = this.shapeGroup;
+
+    let pollQuestion = '';
+
+    if (this.props?.questionText.trim() !== '') {
+      pollQuestion = this.props.questionText.split('<br#>').join(' ');
+    }
+
+    const svg = this.generatePollSvg(answers, this.w, this.h + this.growY, pollQuestion);
+
+    rectGroup.add(svg);
+
+    return rectGroup;
+  }
+}

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -18,6 +18,7 @@ import {TextShape} from '../shapes/TextShape.js';
 import {StickyNote} from '../shapes/StickyNote.js';
 import {createGeoObject} from '../shapes/geoFactory.js';
 import {Frame} from '../shapes/Frame.js';
+import {Poll} from '../shapes/Poll.js';
 
 const jobId = workerData.jobId;
 const logger = new Logger('presAnn Process Worker');
@@ -166,6 +167,19 @@ function overlayFrame(svg, annotation) {
 }
 
 /**
+ * Adds a poll shape to the canvas.
+ * @function overlayPoll
+ * @param {Object} svg - The SVG element where the poll will be added.
+ * @param {Object} annotation - JSON poll data.
+ * @return {void}
+ */
+function overlayPoll(svg, annotation) {
+  const pollShape = new Poll(annotation);
+  const poll = pollShape.draw();
+  svg.add(poll);
+}
+
+/**
  * Determines the annotation type and overlays the corresponding shape
  * onto the SVG element. It delegates the rendering to the specific
  * overlay function based on the annotation type.
@@ -200,6 +214,9 @@ export function overlayAnnotation(svg, annotation) {
         break;
       case 'frame':
         overlayFrame(svg, annotation);
+        break;
+      case 'poll':
+        overlayPoll(svg, annotation);
         break;
       default:
         logger.info(`Unknown annotation type ${annotation.type}.`);


### PR DESCRIPTION
### What does this PR do?

Reimplements poll results shape in bbb-export-annotations

<img width="725" height="457" alt="Screenshot from 2025-08-11 15-56-45" src="https://github.com/user-attachments/assets/dcf563a3-7ba0-4e6c-9b78-d6c905317362" />


### Closes Issue(s)
Closes #23678

### How to test
1. run bbb-export-annotations with the changes using `./run-dev.sh` in bbb-export annotations directory 
1. join a meeting with 2 users
2. start a poll
3. vote in the poll
4. publish results
5. open upload/manage presentations modal and select "Send out a download link for the presentation including whiteboard annotations" in the background menu
7. download and open the exported file 