### PR TITLE
fix(user-list): shorcut not opening panel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -34,8 +34,6 @@ const NavBarContainer = ({ children, ...props }) => {
 
   const { sidebarContentPanel } = sidebarContent;
 
-  const toggleUserList = useShortcut('toggleUserList');
-
   const hasUnreadNotes = sidebarContentPanel !== PANELS.SHARED_NOTES && unread && !notesIsPinned;
 
   const { data: chats } = useChat((chat) => ({
@@ -111,7 +109,6 @@ const NavBarContainer = ({ children, ...props }) => {
         layoutContextDispatch,
         currentUserId: Auth.userID,
         pluginNavBarItems,
-        shortcuts: toggleUserList,
         meetingId: meeting?.meetingId,
         presentationTitle: meetingTitle,
         breakoutNum,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-access-key */
 import React from 'react';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import { defineMessages, useIntl } from 'react-intl';
@@ -8,6 +9,7 @@ import { Input } from '/imports/ui/components/layout/layoutTypes';
 import Styled from '../styles';
 import { GET_GUEST_WAITING_USERS_SUBSCRIPTION, GuestWaitingUsers } from '../../user-list/guest-management/waiting-users/queries';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 
 const intlMessages = defineMessages({
   usersListLabel: {
@@ -18,6 +20,7 @@ const intlMessages = defineMessages({
 
 const UsersListItem = () => {
   const CURRENT_PANEL = PANELS.USERLIST;
+  const TOGGLE_USER_LIST_SHORTCUT = useShortcut('toggleUserList');
   const intl = useIntl();
   const layoutContextDispatch = layoutDispatch();
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
@@ -49,6 +52,7 @@ const UsersListItem = () => {
     >
       <Styled.ListItem
         id="users-list-toggle-button"
+        accessKey={TOGGLE_USER_LIST_SHORTCUT}
         aria-label={label}
         aria-describedby="usersList"
         active={sidebarContentPanel === CURRENT_PANEL}


### PR DESCRIPTION
### What does this PR do?
Removes the old 'toggleUserList' shortcut from navigation bar and adds it on the correct sidebar navigation button to trigger the opening of the user list panel when 'alt+u' is pressed.


### How to test
1. Join meeting
2. Press the key combination 'alt + u'
3. Certify that the user list panel has opened.
