### PR TITLE
Add Focus/Unfocus Webcam Automated Tests

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
@@ -194,7 +194,7 @@ const UserActions: React.FC<UserActionProps> = (props) => {
         label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),
         description: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Desc`]),
         onClick: () => onHandleVideoFocus?.(cameraId),
-        dataTest: 'focusWebcamBtn',
+        dataTest: !focused ? 'focusWebcamBtn' : 'unfocusWebcamBtn',
       });
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/user-actions/component.tsx
@@ -194,7 +194,7 @@ const UserActions: React.FC<UserActionProps> = (props) => {
         label: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Label`]),
         description: intl.formatMessage(intlMessages[`${isFocusedIntlKey}Desc`]),
         onClick: () => onHandleVideoFocus?.(cameraId),
-        dataTest: 'FocusWebcamBtn',
+        dataTest: 'focusWebcamBtn',
       });
     }
 

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -453,7 +453,7 @@ exports.webcamVideoItem = 'div[data-test="webcamVideoItem"]';
 exports.videoDropdownMenu = 'button[data-test="videoDropdownMenu"]';
 exports.advancedVideoSettingsBtn = 'li[data-test="advancedVideoSettingsButton"]';
 exports.mirrorWebcamBtn = 'li[data-test="mirrorWebcamBtn"]';
-exports.focusWebcamBtn = 'li[data-test="FocusWebcamBtn"]';
+exports.focusWebcamBtn = 'li[data-test="focusWebcamBtn"]';
 exports.pinWebcamBtn = 'li[data-test="pinWebcamBtn"]';
 exports.pinVideoButton = 'button[data-test="pinVideoButton"]';
 exports.webcamsFullscreenButton = 'li[data-test="webcamsFullscreenButton"]';

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -454,6 +454,7 @@ exports.videoDropdownMenu = 'button[data-test="videoDropdownMenu"]';
 exports.advancedVideoSettingsBtn = 'li[data-test="advancedVideoSettingsButton"]';
 exports.mirrorWebcamBtn = 'li[data-test="mirrorWebcamBtn"]';
 exports.focusWebcamBtn = 'li[data-test="focusWebcamBtn"]';
+exports.unfocusWebcamBtn = 'li[data-test="unfocusWebcamBtn"]';
 exports.pinWebcamBtn = 'li[data-test="pinWebcamBtn"]';
 exports.pinVideoButton = 'button[data-test="pinVideoButton"]';
 exports.webcamsFullscreenButton = 'li[data-test="webcamsFullscreenButton"]';

--- a/bigbluebutton-tests/playwright/core/elements.js
+++ b/bigbluebutton-tests/playwright/core/elements.js
@@ -453,7 +453,7 @@ exports.webcamVideoItem = 'div[data-test="webcamVideoItem"]';
 exports.videoDropdownMenu = 'button[data-test="videoDropdownMenu"]';
 exports.advancedVideoSettingsBtn = 'li[data-test="advancedVideoSettingsButton"]';
 exports.mirrorWebcamBtn = 'li[data-test="mirrorWebcamBtn"]';
-exports.focusWebcamBtn = 'li[data-test="focusWebcamBtn"]';
+exports.focusWebcamBtn = 'li[data-test="FocusWebcamBtn"]';
 exports.pinWebcamBtn = 'li[data-test="pinWebcamBtn"]';
 exports.pinVideoButton = 'button[data-test="pinVideoButton"]';
 exports.webcamsFullscreenButton = 'li[data-test="webcamsFullscreenButton"]';

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -223,32 +223,31 @@ class MultiUsers {
     await this.modPage.shareWebcam();
     await this.userPage2.shareWebcam();
 
-    await this.modPage.getLocator(e.dropdownWebcamButton)
-      .filter({ hasText: this.userPage2.username })
-      .click();
+    const user2DropdownWebcamButtonForModerator =
+      await this.modPage.getLocator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username })
+
+    await user2DropdownWebcamButtonForModerator.click();
 
     await this.modPage.wasRemoved(e.focusWebcamBtn, 'should not display the focus webcam button for the moderator');
 
     await this.userPage.shareWebcam();
 
-    await this.modPage.getLocator(e.dropdownWebcamButton)
-      .filter({ hasText: this.userPage2.username })
-      .click();
+    await user2DropdownWebcamButtonForModerator.click();
     await this.modPage.getVisibleLocator(e.focusWebcamBtn).click();
 
     await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the focused webcam for Mod');
     await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User1');
 
-    await this.userPage.getLocator(e.dropdownWebcamButton)
-      .filter({ hasText: this.userPage2.username })
-      .click();
+    const user2DropdownWebcamButtonForUser =
+      await this.userPage.getLocator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username })
+      
+    await user2DropdownWebcamButtonForUser.click()
+
     await this.userPage.getVisibleLocator(e.focusWebcamBtn).click();
 
     await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the focused webcam for User2');
 
-    await this.modPage.getLocator(e.dropdownWebcamButton)
-      .filter({ hasText: this.userPage2.username })
-      .click();
+    await user2DropdownWebcamButtonForModerator.click();
     await this.modPage.getVisibleLocator(e.focusWebcamBtn).click(); // Unfocus webcam is the same button as focus webcam
 
     await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage.username, 'should display the username of Mod on the first webcam for Mod');

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -228,32 +228,30 @@ class MultiUsers {
 
     await user2DropdownWebcamButtonForModerator.click();
 
-    await this.modPage.wasRemoved(e.focusWebcamBtn, 'should not display the focus webcam button for the moderator');
+    await this.modPage.wasRemoved(e.focusWebcamBtn, 'should not display the focus webcam button to the moderator when there are less than 3 webcams shared');
 
     await this.userPage.shareWebcam();
 
     await user2DropdownWebcamButtonForModerator.click();
     await this.modPage.getVisibleLocator(e.focusWebcamBtn).click();
 
-    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the focused webcam for Mod');
-    await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User1');
+    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the focused webcam for Moderator');
+    await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User2');
 
-    const user2DropdownWebcamButtonForUser =
+    const user2DropdownWebcamButtonForUser1 =
       await this.userPage.getLocator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username })
-      
-    await user2DropdownWebcamButtonForUser.click()
 
+    await user2DropdownWebcamButtonForUser1.click()
     await this.userPage.getVisibleLocator(e.focusWebcamBtn).click();
 
-    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the focused webcam for User2');
+    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the focused webcam for User1');
 
     await user2DropdownWebcamButtonForModerator.click();
     await this.modPage.getVisibleLocator(e.focusWebcamBtn).click(); // Unfocus webcam is the same button as focus webcam
 
-    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage.username, 'should display the username of Mod on the first webcam for Mod');
-
-    await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the first webcam for User1');
-    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the first webcam for User2');
+    await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage.username, 'should display the username of Moderator on the first webcam for Moderator');
+    await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User2');
+    await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User1');
   }
 
   async giveAndRemoveWhiteboardAccess() {

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -247,7 +247,7 @@ class MultiUsers {
     await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the focused webcam for User1');
 
     await user2DropdownWebcamButtonForModerator.click();
-    await this.modPage.getVisibleLocator(e.focusWebcamBtn).click(); // Unfocus webcam is the same button as focus webcam
+    await this.modPage.getVisibleLocator(e.unfocusWebcamBtn).click();
 
     await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage.username, 'should display the username of Moderator on the first webcam for Moderator');
     await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User2');

--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -220,62 +220,42 @@ class MultiUsers {
   }
 
   async focusUnfocusWebcam() {
-    // Action: Create and join a meeting with 1 mod and 2 users;
-    // Action: Mod and User1 share webcam;
     await this.modPage.shareWebcam();
     await this.userPage2.shareWebcam();
 
-    // Action: Mod clicks on User1 video item dropdown:
     await this.modPage.getLocator(e.dropdownWebcamButton)
       .filter({ hasText: this.userPage2.username })
       .click();
 
-    // (Mod) Assert focus option is not displayed (assert other option first to avoid false-positives eg. fullscreen webcam);
     await this.modPage.wasRemoved(e.focusWebcamBtn, 'should not display the focus webcam button for the moderator');
 
-    // Action: User2 shares webcam;
     await this.userPage.shareWebcam();
 
-    // Action: Mod focus User1 webcam;
     await this.modPage.getLocator(e.dropdownWebcamButton)
       .filter({ hasText: this.userPage2.username })
       .click();
     await this.modPage.getVisibleLocator(e.focusWebcamBtn).click();
 
-    // Assert focused webcam on mod view (should be first item; should be bigger than the others);
     await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the focused webcam for Mod');
-
-    // Assert no propagation on webcam focus for User1 and User2;
     await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User2 on the first webcam for User1');
 
-    // Action: User2 focus User1;
     await this.userPage.getLocator(e.dropdownWebcamButton)
       .filter({ hasText: this.userPage2.username })
       .click();
     await this.userPage.getVisibleLocator(e.focusWebcamBtn).click();
 
-    // Assert focused webcam on User2 view (should be first item; should be bigger than the others);
     await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the focused webcam for User2');
 
-    // Action: Mod unfocus focused webcam
     await this.modPage.getLocator(e.dropdownWebcamButton)
       .filter({ hasText: this.userPage2.username })
       .click();
     await this.modPage.getVisibleLocator(e.focusWebcamBtn).click(); // Unfocus webcam is the same button as focus webcam
 
-    // Assert webcam list should be the default (first item should be the current user; all webcams with the same sizes)
     await this.modPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.modPage.username, 'should display the username of Mod on the first webcam for Mod');
 
-    // Assert no propagation when unfocusing (other users' webcam state should remain the same)
     await this.userPage2.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the first webcam for User1');
     await this.userPage.hasText(`:nth-match(${e.dropdownWebcamButton}, 1)`, this.userPage2.username, 'should display the username of User1 on the first webcam for User2');
-
   }
-
-  // TODO:
-  // - remove comments
-  // - change 'user1/2' to attendee
-  // - validate test correctly before pushing
 
   async giveAndRemoveWhiteboardAccess() {
     await this.modPage.waitForSelector(e.whiteboard);

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.js
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.js
@@ -31,7 +31,7 @@ test.describe.parallel('Webcam', { tag: '@ci' }, () => {
     await webcam.pinningWebcams();
   });
 
-  test('Change video quality', { tag: '@flaky' } , async ({ browser, page }) => {
+  test('Change video quality', { tag: '@flaky' }, async ({ browser, page }) => {
     // Current approach is not reliable enough to ensure the video quality is changed
     const webcam = new Webcam(browser, page);
     await webcam.init(true, true);
@@ -49,6 +49,15 @@ test.describe.parallel('Webcam', { tag: '@ci' }, () => {
     await webcam.init(true, true);
     await webcam.disableSelfView();
   });
+
+  test('Focus and Unfocus webcam', async ({ browser, context, page }) => {
+    const webcam = new MultiUsers(browser, context);
+    await webcam.initModPage(page, true);
+    await webcam.initUserPage();
+    await webcam.initUserPage2();
+    await webcam.focusUnfocusWebcam()
+  });
+
 
   test.describe('Webcam background', () => {
     test('Select one of the default backgrounds', async ({ browser, page }) => {


### PR DESCRIPTION
### What does this PR do?
This PR implements automated tests for the webcam focus/unfocus functionality in BigBlueButton. The tests verify that users can properly focus on specific webcams in multi-user scenarios and unfocus them to return to the normal view.

#### Changes Made
•  Added focusUnfocusWebcam() method in MultiUsers class that tests the complete focus/unfocus workflow
•  Added new test case "Focus and Unfocus webcam" in webcam.spec.js
•  Fixed element selector for focusWebcamBtn in elements.js (updated from focusWebcamBtn to FocusWebcamBtn to match the actual DOM attribute)

#### Video examples of the tests running
- [for moderator ](https://github.com/user-attachments/assets/b210382b-9c6d-4239-a05f-ea8184804d08)
- [for attendee](https://github.com/user-attachments/assets/24c2f23a-5ba5-4cfd-8754-1f1ac2ab01de)


### Closes Issue(s)
Closes #23679 

### How to test
run playwright tests with:
`npm run test webcam` 
or 
`npx playwright test webcam`
for specific testing you can run the filter
`npm run test:filter "Focus and Unfocus webcam"`

