### PR TITLE
fix: adjust locale dropdown to not display fallback id + include ru-RU en string

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/locales-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/locales-dropdown/component.jsx
@@ -66,12 +66,12 @@ class LocalesDropdown extends PureComponent {
         {availableLocales.map((localeItem) => {
           const localizedName = localeItem.locale !== value && intl.formatMessage({
             id: `app.submenu.application.localeDropdown.${localeItem.locale}`,
-            defaultMessage: ``,
+            defaultMessage: '-',
           });
 
           return (
             <option key={localeItem.locale} value={localeItem.locale} lang={localeItem.locale}>
-              {localeItem.name}{localizedName && ` - ${localizedName}`}
+              {localeItem.name}{localizedName && localizedName !== '-' && ` - ${localizedName}`}
             </option>
           );
         })}

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -617,6 +617,7 @@
     "app.submenu.application.localeDropdown.pt-BR": "Portuguese (Brazil)",
     "app.submenu.application.localeDropdown.ro-RO": "Romanian",
     "app.submenu.application.localeDropdown.ru": "Russian",
+    "app.submenu.application.localeDropdown.ru-RU": "Russian",
     "app.submenu.application.localeDropdown.sk-SK": "Slovak (Slovakia)",
     "app.submenu.application.localeDropdown.sl": "Slovenian",
     "app.submenu.application.localeDropdown.sr": "Serbian",


### PR DESCRIPTION
### What does this PR do?
- adds ru-RU string in en.json (english translation for russian language name)
- adjusts locale dropdown menu to not display the fallback message id when the translation for a language name is not available

#### before
<img width="590" height="390" alt="ru-before" src="https://github.com/user-attachments/assets/e984d585-e039-4238-a520-e919c705ec4c" />

#### after
<img width="546" height="400" alt="ru-after" src="https://github.com/user-attachments/assets/e94f376e-e8bc-41fb-8070-aa348be857aa" />

### How to test
1. join a meeting
2. open `Options` menu
3. open `Application Language` dropdown and scroll until the **Russian** item is visible (the first item after **Romanian**)