### PR TITLE
feat(meeting-end): skip logout URL redirection for bot users

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -271,6 +271,7 @@ select_permissions:
         - registeredAt
         - registeredOn
         - userId
+        - bot
       filter:
         _and:
           - meetingId:

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -53,6 +53,7 @@ interface PresenceManagerProps extends PresenceManagerContainerProps {
     positionInWaitingQueue: number | null;
     isSupportedBrowser: boolean | undefined;
     hasWebrtcSupport: boolean;
+    isBot: boolean;
 }
 
 const PresenceManager: React.FC<PresenceManagerProps> = ({
@@ -81,6 +82,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
   positionInWaitingQueue,
   isSupportedBrowser,
   hasWebrtcSupport,
+  isBot,
 }) => {
   const [allowToRender, setAllowToRender] = React.useState(false);
   const [dispatchUserJoin] = useMutation(userJoinMutation);
@@ -200,6 +202,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
               meetingEndedCode={endedReasonCode}
               endedBy={endedBy}
               joinErrorCode={errorCode}
+              isBot={isBot}
             />
           )
           : null
@@ -267,7 +270,12 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
     customLogoUrl,
     customDarkLogoUrl,
   } = userInfoData.meeting[0];
-  const { extId, name: userName, userId } = userInfoData.user_current[0];
+  const {
+    extId,
+    name: userName,
+    userId,
+    bot,
+  } = userInfoData.user_current[0];
 
   const MIN_BROWSER_CONFIG = window.meetingClientSettings.public.minBrowserVersions;
   const userAgent = window.navigator?.userAgent;
@@ -300,6 +308,7 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
       guestStatus={guestStatus}
       isSupportedBrowser={isSupportedBrowser}
       hasWebrtcSupport={hasWebrtcSupport}
+      isBot={bot}
     >
       {children}
     </PresenceManager>

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/queries.ts
@@ -38,6 +38,7 @@ export interface GetUserInfoResponse {
     extId: string;
     name: string;
     userId: string;
+    bot: boolean;
   }>;
 }
 
@@ -56,6 +57,7 @@ query getUserInfo {
     extId
     name
     userId
+    bot
   }
 }
 `;

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -150,9 +150,13 @@ interface MeetingEndedContainerProps {
   endedBy: string;
   meetingEndedCode: string;
   joinErrorCode: string;
+  isBot: boolean;
 }
 
-interface MeetingEndedProps extends MeetingEndedContainerProps {
+interface MeetingEndedProps {
+  endedBy: string;
+  meetingEndedCode: string;
+  joinErrorCode: string;
   skipMeetingEnded: boolean;
   learningDashboardAccessToken: string;
   isModerator: boolean;
@@ -329,6 +333,7 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
   endedBy,
   meetingEndedCode,
   joinErrorCode,
+  isBot,
 }) => {
   const {
     loading: meetingEndLoading,
@@ -378,7 +383,7 @@ const MeetingEndedContainer: React.FC<MeetingEndedContainerProps> = ({
     learningDashboardBase,
   } = clientSettings;
 
-  const allowRedirect = allowRedirectToLogoutURL(logoutUrl);
+  const allowRedirect = allowRedirectToLogoutURL(logoutUrl) && !isBot;
 
   return (
     <MeetingEnded


### PR DESCRIPTION
### What does this PR do?
Add a check in the meeting end component to avoid redirecting bot users to the logout URL after a meeting ends. This prevents bots from being redirected to the feedback form configured as the logout URL.

### How to test
1. Create meeting with logoutUrl=...
2. Join meeting as M1
3. Add bot=true and join as B1
4. End meeting in M1 session
5. Check that M1 is redirected to logoutUrl and B1 isn't
