### PR TITLE
fix: Fullscreen by ENTER not working inside of the presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -205,6 +205,11 @@ class PresentationToolbar extends PureComponent {
   switchSlide(event) {
     const { target, which } = event;
     const isBody = target.nodeName === 'BODY';
+    const isWhiteboard = target.classList.contains('tl-container');
+
+    if (which === KEY_CODES.ENTER && (isWhiteboard || isBody)) {
+      return this.fullscreenToggleHandler();
+    }
 
     if (isBody) {
       switch (which) {
@@ -215,9 +220,6 @@ class PresentationToolbar extends PureComponent {
         case KEY_CODES.ARROW_RIGHT:
         case KEY_CODES.PAGE_DOWN:
           this.nextSlideHandler();
-          break;
-        case KEY_CODES.ENTER:
-          this.fullscreenToggleHandler();
           break;
         default:
       }


### PR DESCRIPTION
### What does this PR do?

Adjusts presentation area fullscreen handler to also work when the whiteboard is focused

### Closes Issue(s)
Closes #23676

### How to test
1. start a meeting
2. work a bit with slide (keyboard focus is on the whiteboard)
3. push ENTER at inside of the slide