### PR TITLE
fix(bbb-learning-dashboard): Quizzes table sorting toggling doesn't work

### DIFF
--- a/bbb-learning-dashboard/src/components/QuizzesTable.jsx
+++ b/bbb-learning-dashboard/src/components/QuizzesTable.jsx
@@ -383,11 +383,7 @@ const QuizzesTable = (props) => {
             <>
               {symbols[type]}
               &nbsp;
-              {responses.map((response) => {
-                const key = pollAnswerIds[response.toLowerCase()]
-                  ? [intl.formatMessage(pollAnswerIds[response.toLowerCase()])] : response;
-                return key;
-              }).join(', ')}
+              {responses}
             </>
           )}
           {type === 'default' && intl.formatMessage({
@@ -406,13 +402,7 @@ const QuizzesTable = (props) => {
           >
             <Paper elevation={1}>
               <Typography variant="body2" style={{ padding: 8, whiteSpace: 'nowrap' }}>
-                {responses.length ? (
-                  responses.map((response) => {
-                    const key = pollAnswerIds[response.toLowerCase()]
-                      ? [intl.formatMessage(pollAnswerIds[response.toLowerCase()])] : response;
-                    return key;
-                  }).join(', ')
-                ) : intl.formatMessage({
+                {responses.length ? responses : intl.formatMessage({
                   id: 'app.learningDashboard.quizzes.noResponse',
                   defaultMessage: 'No response',
                 })}
@@ -457,7 +447,11 @@ const QuizzesTable = (props) => {
       sortable: true,
       valueGetter: (params) => {
         const { userAnswers } = params?.value;
-        return userAnswers || [];
+        return userAnswers.map((response) => {
+          const key = pollAnswerIds[response.toLowerCase()]
+            ? [intl.formatMessage(pollAnswerIds[response.toLowerCase()])] : response;
+          return key;
+        }).join(', ');
       },
       renderCell: (params) => {
         let type = 'default';
@@ -483,7 +477,7 @@ const QuizzesTable = (props) => {
           <GridCellExpand
             type={type}
             anonymous={v?.anonymous}
-            responses={params?.value || []}
+            responses={params?.value || ''}
             width={params?.colDef?.computedWidth}
           />
         );

--- a/bbb-learning-dashboard/src/components/QuizzesTable.jsx
+++ b/bbb-learning-dashboard/src/components/QuizzesTable.jsx
@@ -448,8 +448,9 @@ const QuizzesTable = (props) => {
       valueGetter: (params) => {
         const { userAnswers } = params?.value;
         return userAnswers.map((response) => {
-          const key = pollAnswerIds[response.toLowerCase()]
-            ? [intl.formatMessage(pollAnswerIds[response.toLowerCase()])] : response;
+          const responseInLowerCase = response.toLowerCase();
+          const key = pollAnswerIds[responseInLowerCase]
+            ? intl.formatMessage(pollAnswerIds[responseInLowerCase]) : response;
           return key;
         }).join(', ');
       },


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Fixes a bug in the LAD where we aren't able to toggle the sorting order of the Quizzes table based on the answers columns.

[Screencast from 2025-08-13 15-33-31.webm](https://github.com/user-attachments/assets/9f1bcc82-9800-4ddb-8e7d-bb4ceb5a2157)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none