### PR TITLE
[3.0]  Extract multiple quick polls WITH text options

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -181,13 +181,18 @@ const QuickPollDropdown = (props) => {
     });
   }
 
+  const optionGroupsWithLabels = [];
   optionsPoll.reduce((acc, currentValue) => {
     const lastElement = acc[acc.length - 1];
+    const lastElementWithLabels = optionGroupsWithLabels[optionGroupsWithLabels.length - 1];
 
     if (!lastElement) {
       acc.push({
         options: [currentValue],
       });
+      optionGroupsWithLabels.push(
+        [optionsWithLabels.shift()]
+      );
       return acc;
     }
 
@@ -203,15 +208,22 @@ const QuickPollDropdown = (props) => {
     if (isLastOptionInteger === isCurrentValueInteger) {
       if (currentValue.toLowerCase().charCodeAt(1) > lastOption.toLowerCase().charCodeAt(1)) {
         options.push(currentValue);
+        lastElementWithLabels.push(optionsWithLabels.shift());
       } else {
         acc.push({
           options: [currentValue],
         });
+        optionGroupsWithLabels.push(
+          [optionsWithLabels.shift()]
+        );
       }
     } else {
       acc.push({
         options: [currentValue],
       });
+      optionGroupsWithLabels.push(
+        [optionsWithLabels.shift()]
+      );
     }
     return acc;
   }, []).filter(({
@@ -293,11 +305,13 @@ const QuickPollDropdown = (props) => {
   const getAvailableQuickPolls = (
     slideId, parsedSlides, funcStartPoll, _pollTypes, _layoutContextDispatch,
   ) => {
+    let idx = -1;
     const pollItemElements = parsedSlides.map((poll) => {
       const { poll: label } = poll;
       const { type, poll: pollData } = poll;
       let itemLabel = label;
-      const letterAnswers = [];
+      let letterAnswers = [];
+      idx += 1;
 
       if (type === 'R-') {
         return (
@@ -324,14 +338,7 @@ const QuickPollDropdown = (props) => {
         const { options } = itemLabel;
         itemLabel = options.join('/').replace(/[\n.)]/g, '');
         if (type === _pollTypes.Custom) {
-          for (let i = 0; i < options.length; i += 1) {
-            const letterOption = options[i]?.replace(/[\r.)]/g, '').toUpperCase();
-            if (letterAnswers.length < MAX_CUSTOM_FIELDS) {
-              letterAnswers.push(letterOption);
-            } else {
-              break;
-            }
-          }
+          letterAnswers = optionGroupsWithLabels[idx].slice(0, MAX_CUSTOM_FIELDS);
         }
       }
 
@@ -431,7 +438,7 @@ const QuickPollDropdown = (props) => {
             startPoll(
               pollTypes.Custom,
               currentSlide.id,
-              optionsWithLabels,
+              optionGroupsWithLabels[0],
               pollQuestion,
               multiResponse,
               correctAnswer?.length > 0,

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -338,7 +338,7 @@ const QuickPollDropdown = (props) => {
         const { options } = itemLabel;
         itemLabel = options.join('/').replace(/[\n.)]/g, '');
         if (type === _pollTypes.Custom) {
-          letterAnswers = optionGroupsWithLabels[idx].slice(0, MAX_CUSTOM_FIELDS);
+          letterAnswers = (optionGroupsWithLabels[idx] || []).slice(0, MAX_CUSTOM_FIELDS);
         }
       }
 
@@ -438,7 +438,7 @@ const QuickPollDropdown = (props) => {
             startPoll(
               pollTypes.Custom,
               currentSlide.id,
-              optionGroupsWithLabels[0],
+              (optionGroupsWithLabels[0] || []),
               pollQuestion,
               multiResponse,
               correctAnswer?.length > 0,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Enables the quickpolling to extract multiple polls from a slide WITH text options in case of the custom poll.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #

### Motivation
On v3.0, when you upload a slide with one poll with more than 5 options, BBB shows a quickpolling button which leads you to a poll with text options. This helps the users a lot for their polling decision.
When you upload a slide with multiple polls, BBB automatically extracts them and proposes them in the quickpolling dropdown, but without text (e.g. only 1), 2), 3)...), even for a poll with more than 5 options.
The expected behaviour would be showing text options for a poll with more than 5 options even when multiple polls are written in a slide.


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
- upload a slide with multiple polls like:
```
Select one:
1. Aaa
2. Cccc
3. Aaa
4. Cccc
5. Aaa
6. Cccc
7. Aaa
8. Cccc
9. Aaa

1. Aaa
2. Cccc
3. Aaak
4. Cccc
5. Xxxx

A) azxcvxz
B) dfasd
C) aaaa
D) aaa
E) aaa
F) aaa
G) aaa
H) dfasd
I) dfasd
```
- confirm that BBB shows texted options for the first and last polls.


### More
Easily mergeable with #23698 .
Why not showing the text options for all polls (even for those with 2-5 options)?
