### PR TITLE
fix: quick external video share not working at fullscreen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/component.jsx
@@ -132,8 +132,12 @@ class Dropdown extends Component {
   }
 
   handleContextMenu(event) {
-    event.preventDefault();
-    this.handleHide();
+    const { isOpen } = this.state;
+
+    if (isOpen) {
+      event.preventDefault();
+      this.handleHide();
+    }
   }
 
   handleShow() {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
@@ -3,6 +3,11 @@ import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints
 import Button from '/imports/ui/components/common/button/component';
 
 const LeaveButton = styled(Button)`
+  border-radius: 1.1rem;
+  font-size: 1rem;
+  line-height: 1.1rem;
+  font-weight: 400;
+
   ${({ state }) => state === 'open' && `
     @media ${smallOnly} {
       display: none;
@@ -16,16 +21,12 @@ const LeaveButton = styled(Button)`
   }
 `}
 
-  ${({ state, isMobile }) => state === 'closed' && !isMobile && `
+  ${({ isMobile }) => !isMobile && `
     margin-left: 1.0rem;
     margin-right: 0.5rem;
   `}
 
   ${({ state }) => state === 'closed' && `
-    border-radius: 1.1rem;
-    font-size: 1rem;
-    line-height: 1.1rem;
-    font-weight: 400;
     z-index: 3;
   `}
 `;

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/component.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages } from 'react-intl';
-import { safeMatch } from '/imports/utils/string-utils';
+import { safeMatch, uniqueId } from '/imports/utils/string-utils';
 import { isUrlValid } from '/imports/ui/components/external-video-player/service';
-import BBBMenu from '/imports/ui/components/common/menu/component';
 import Styled from './styles';
+import Dropdown from '/imports/ui/components/dropdown/component';
 
 const intlMessages = defineMessages({
   externalVideo: {
@@ -17,19 +17,22 @@ const createAction = (url, startWatching) => {
   const finalUrl = hasHttps ? url : `https://${url}`;
   const label = hasHttps ? url?.replace('https://', '') : url;
 
-  if (isUrlValid(finalUrl)) {
-    return {
-      label,
-      onClick: () => startWatching(finalUrl),
-    };
-  }
+  if (!isUrlValid(finalUrl)) return null;
+
+  return (
+    <Dropdown.DropdownListItem
+      label={label}
+      key={uniqueId('quick-external-video-item')}
+      onClick={() => {
+        startWatching(finalUrl);
+      }}
+    />
+  );
 };
 
 export const SmartMediaShare = ({
   currentSlide = undefined,
   intl,
-  isMobile,
-  isRTL,
   startWatching,
 }) => {
   const linkPatt = /(https?:\/\/.*?)(?=\s|$)/g;
@@ -45,12 +48,9 @@ export const SmartMediaShare = ({
 
   if (actions?.length === 0) return null;
 
-  const customStyles = { top: '-1rem' };
-
   return (
-    <BBBMenu
-      customStyles={!isMobile ? customStyles : null}
-      trigger={(
+    <Dropdown>
+      <Dropdown.DropdownTrigger tabIndex={0}>
         <Styled.QuickVideoButton
           role="button"
           label={intl.formatMessage(intlMessages.externalVideo)}
@@ -61,19 +61,13 @@ export const SmartMediaShare = ({
           onClick={() => null}
           hideLabel
         />
-      )}
-      actions={actions}
-      opts={{
-        id: 'external-video-dropdown-menu',
-        keepMounted: true,
-        transitionDuration: 0,
-        elevation: 3,
-        getcontentanchorel: null,
-        fullwidth: 'true',
-        anchorOrigin: { vertical: 'top', horizontal: isRTL ? 'right' : 'left' },
-        transformOrigin: { vertical: 'bottom', horizontal: isRTL ? 'right' : 'left' },
-      }}
-    />
+      </Dropdown.DropdownTrigger>
+      <Dropdown.DropdownContent>
+        <Dropdown.DropdownList>
+          {actions}
+        </Dropdown.DropdownList>
+      </Dropdown.DropdownContent>
+    </Dropdown>
   );
 };
 
@@ -86,6 +80,4 @@ SmartMediaShare.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
-  isMobile: PropTypes.bool.isRequired,
-  isRTL: PropTypes.bool.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { useMutation } from '@apollo/client';
 import { SmartMediaShare } from './component';
 import Panopto from '../../../external-video-player/custom-players/panopto';
-import { layoutSelect } from '/imports/ui/components/layout/context';
-import { isMobile } from '/imports/ui/components/layout/utils';
 import { EXTERNAL_VIDEO_START } from '../../../external-video-player/mutations';
 
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
@@ -24,13 +22,9 @@ const SmartMediaShareContainer = (props) => {
     startExternalVideo({ variables: { externalVideoUrl } });
   };
 
-  const isRTL = layoutSelect((i) => i.isRTL);
-
   return (
     <SmartMediaShare {...{
       startWatching,
-      isRTL,
-      isMobile: isMobile(),
       ...props,
     }}
     />


### PR DESCRIPTION
### What does this PR do?

Updates quick external video dropdown to use the existing Dropdown component, so it works even when the presentation is fullscreen

### Closes Issue(s)
Closes #23728

### How to test
1. Upload a presentation file with a Youtube link
2. make the presentation fullscreen
3. Click the quick external video share button at the presentation toolbar
4. Dropdown menu should appear