### PR TITLE
feat (gql-server): Add new graphql flag `componentFlags.hasSharedNotes`

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2384,6 +2384,12 @@ select "meeting"."meetingId",
             select 1
             from "sharedNotes"
             where "sharedNotes"."meetingId" = "meeting"."meetingId"
+            and "sharedNotesExtId" = 'notes'
+        ) as "hasSharedNotes",
+        exists (
+            select 1
+            from "sharedNotes"
+            where "sharedNotes"."meetingId" = "meeting"."meetingId"
             and "sharedNotes"."pinned" is true
         ) as "isSharedNotedPinned",
         exists (

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -649,6 +649,12 @@ type Mutation {
 }
 
 type Mutation {
+  userSetListenOnlyInput(
+    listenOnlyInputDevice: Boolean!
+  ): Boolean
+}
+
+type Mutation {
   userSetLocked(
     userId: String!
     locked: Boolean!
@@ -659,12 +665,6 @@ type Mutation {
   userSetMuted(
     userId: String
     muted: Boolean!
-  ): Boolean
-}
-
-type Mutation {
-  userSetListenOnlyInput(
-    listenOnlyInputDevice: Boolean!
   ): Boolean
 }
 

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -582,6 +582,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: userSetListenOnlyInput
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: userSetLocked
     definition:
       kind: synchronous
@@ -589,12 +595,6 @@ actions:
     permissions:
       - role: bbb_client
   - name: userSetMuted
-    definition:
-      kind: synchronous
-      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
-    permissions:
-      - role: bbb_client
-  - name: userSetListenOnlyInput
     definition:
       kind: synchronous
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_componentsFlags.yaml
@@ -18,6 +18,7 @@ select_permissions:
         - hasPoll
         - hasScreenshare
         - hasScreenshareAsContent
+        - hasSharedNotes
         - hasTimer
         - isSharedNotedPinned
         - showRemainingTime


### PR DESCRIPTION
Introduce a new graphql field `componentFlags.hasSharedNotes`.

Motivation: Remove this subscription created specifically for it 
https://github.com/gustavotrott/bigbluebutton/blob/2004667668f7bbb29aa235943275ee76226bad4d/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/queries.ts#L10