### PR TITLE
Fix(html5): Video preview modal keeps frozen when using bbb_auto_share_webcam and bbb_skip_video_preview

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -262,12 +262,12 @@ const AudioContainer = (props) => {
 
   return (
     <>
-      {isAudioModalOpen ? (
+      {isAudioModalOpen && !isVideoPreviewModalOpen ? (
         <AudioModalContainer
           {...{
             priority: 'medium',
             setIsOpen: setAudioModalIsOpen,
-            isOpen: isAudioModalOpen,
+            isOpen: isAudioModalOpen && !isVideoPreviewModalOpen,
           }}
         />
       ) : null}


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where the video preview controls become unresponsive when both the `bbb_auto_share_webcam` (true) and `bbb_skip_video_preview` (false) settings are used together. The bug is caused by the focus-trap, which is unable to determine the active element and continues focusing on the first modal (audio modal) instead.


### Closes Issue(s)
Closes #23725 

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test
- Create a Meeting with the parameters
 
```
userdata-bbb_auto_share_webcam=true
userdata-bbb_skip_video_preview=false
```
- Join an user 
- Close both modals 



### More
[Screencast from 18-08-2025 16:13:32.webm](https://github.com/user-attachments/assets/fd77e324-9c2a-4153-8988-5855f742e00b)
