### PR TITLE
perf (gql-server): Optimize Meeting data fetching with new `meetingStaticData` endpoint and Nginx caching

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -191,19 +191,35 @@ select_permissions:
   - role: bbb_client_not_in_meeting
     permission:
       columns:
+        - audioBridge
         - bannerColor
         - bannerText
-        - customLogoUrl
+        - cameraBridge
+        - createdAt
+        - createdTime
         - customDarkLogoUrl
+        - customLogoUrl
+        - disabledFeatures
+        - durationInSeconds
+        - endWhenNoModerator
+        - endWhenNoModeratorDelayInMinutes
         - ended
         - endedAt
         - endedBy
         - endedByUserName
         - endedReasonCode
+        - extId
         - isBreakout
+        - loginUrl
         - logoutUrl
+        - maxPinnedCameras
+        - meetingCameraCap
         - meetingId
         - name
+        - notifyRecordingIsOn
+        - presentationUploadExternalDescription
+        - presentationUploadExternalUrl
+        - screenShareBridge
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_breakoutPolicies.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_breakoutPolicies.yaml
@@ -23,3 +23,20 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - breakoutRooms
+        - captureNotes
+        - captureNotesFilename
+        - captureSlides
+        - captureSlidesFilename
+        - freeJoin
+        - parentId
+        - privateChatEnabled
+        - record
+        - sequence
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_recordingPolicies.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_recordingPolicies.yaml
@@ -17,3 +17,14 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - allowStartStopRecording
+        - autoStartRecording
+        - keepEvents
+        - record
+      filter:
+        meetingId:
+          _eq: X-Hasura-UserId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_usersPolicies.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_usersPolicies.yaml
@@ -26,3 +26,23 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - allowModsToEjectCameras
+        - allowModsToUnmuteUsers
+        - allowPromoteGuestToModerator
+        - authenticatedGuest
+        - guestLobbyMessage
+        - guestPolicy
+        - maxUserConcurrentAccesses
+        - maxUsers
+        - meetingLayout
+        - moderatorsCanMuteAudio
+        - moderatorsCanUnmuteAudio
+        - userCameraCap
+        - webcamsOnlyForModerator
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_voiceSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_voiceSettings.yaml
@@ -17,3 +17,14 @@ select_permissions:
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - dialNumber
+        - muteOnStart
+        - telVoice
+        - voiceConf
+      filter:
+        meetingId:
+          _eq: X-Hasura-MeetingId
+    comment: ""

--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -16,3 +16,72 @@
               value
             }
           }
+      - name: meetingStaticData
+        query: |
+          query meetingStaticData {
+            meeting {
+              meetingId
+              extId
+              name
+              disabledFeatures
+              isBreakout
+              endWhenNoModerator
+              endWhenNoModeratorDelayInMinutes
+              createdTime
+              maxPinnedCameras
+              meetingCameraCap
+              cameraBridge
+              screenShareBridge
+              audioBridge
+              loginUrl
+              logoutUrl
+              bannerColor
+              bannerText
+              customLogoUrl
+              customDarkLogoUrl
+              notifyRecordingIsOn
+              presentationUploadExternalDescription
+              presentationUploadExternalUrl
+              recordingPolicies {
+                allowStartStopRecording
+                autoStartRecording
+                record
+                keepEvents
+              }
+              usersPolicies {
+                allowModsToEjectCameras
+                allowModsToUnmuteUsers
+                authenticatedGuest
+                guestPolicy
+                maxUserConcurrentAccesses
+                maxUsers
+                meetingLayout
+                moderatorsCanMuteAudio
+                moderatorsCanUnmuteAudio
+                userCameraCap
+                webcamsOnlyForModerator
+                guestLobbyMessage
+              }
+              breakoutPolicies {
+                breakoutRooms
+                captureNotes
+                captureNotesFilename
+                captureSlides
+                captureSlidesFilename
+                freeJoin
+                parentId
+                privateChatEnabled
+                record
+                sequence
+              }
+              voiceSettings {
+                dialNumber
+                muteOnStart
+                voiceConf
+                telVoice
+              }
+              clientSettings {
+                clientSettingsJson
+              }
+            }
+          }

--- a/bbb-graphql-server/metadata/rest_endpoints.yaml
+++ b/bbb-graphql-server/metadata/rest_endpoints.yaml
@@ -11,6 +11,15 @@
   definition:
     query:
       collection_name: allowed-queries
+      query_name: meetingStaticData
+  methods:
+    - GET
+  name: meetingStaticData
+  url: meetingStaticData
+- comment: ""
+  definition:
+    query:
+      collection_name: allowed-queries
       query_name: userMetadata
   methods:
     - GET

--- a/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
@@ -10,8 +10,10 @@ import BBBWeb from '/imports/api/bbb-web-api';
 const connectionTimeout = 60000;
 
 interface Response {
-  meeting_clientSettings: Array<{
-    clientSettingsJson: MeetingClientSettings,
+  meeting: Array<{
+    clientSettings: {
+        clientSettingsJson: MeetingClientSettings,
+    }
   }>;
 }
 
@@ -56,7 +58,7 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
 
     BBBWeb.index(controller.signal)
       .then(({ data }) => {
-        const url = new URL(`${data.graphqlApiUrl}/clientSettings`);
+        const url = new URL(`${data.graphqlApiUrl}/meetingStaticData`);
         fetch(url, {
           method: 'get',
           credentials: 'include',
@@ -68,7 +70,7 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
           .then((resp) => resp.json())
           .then((data: Response) => {
             clearTimeout(timeoutRef.current);
-            const settings = data?.meeting_clientSettings[0].clientSettingsJson;
+            const settings = data?.meeting[0].clientSettings.clientSettingsJson;
             window.meetingClientSettings = JSON.parse(JSON.stringify(settings));
             setMeetingSettings(settings);
             setLoading(false);

--- a/build/packages-template/bbb-graphql-middleware/graphql.nginx
+++ b/build/packages-template/bbb-graphql-middleware/graphql.nginx
@@ -8,8 +8,29 @@ location /graphql {
 	proxy_pass         http://127.0.0.1:8378; #Graphql Middleware
 }
 
-#Set cache system for client settings
+#DEPRECATED:
+#This endpoint is being replaced by /api/rest/meetingStaticData (which contain clientSettings and more)
+#It will be removed in BBB 3.1
 location /api/rest/clientSettings {
+    auth_request /bigbluebutton/connection/checkGraphqlAuthorization;
+    auth_request_set $meeting_id $sent_http_meeting_id;
+
+    proxy_cache client_settings_cache;
+    proxy_cache_key "$uri|$meeting_id";
+    proxy_cache_use_stale updating;
+    proxy_cache_valid 24h;
+    proxy_cache_lock on;
+    add_header X-Cached $upstream_cache_status;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    proxy_pass http://127.0.0.1:8185; #Hasura
+}
+
+#Set cache system for meeting static data
+location /api/rest/meetingStaticData {
     auth_request /bigbluebutton/connection/checkGraphqlAuthorization;
     auth_request_set $meeting_id $sent_http_meeting_id;
 


### PR DESCRIPTION
Currently, there’s a large subscription used to fetch Meeting Data. https://github.com/bigbluebutton/bigbluebutton/blob/d53d13c998cd5dd9c7a96c5211259b5f5a12aa8f/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts#L4
Most of this data is actually static (it doesn’t change during the meeting), yet the client keeps fetching it continuously. A better approach is for the client to fetch this data once at the beginning of the meeting and reuse it afterwards.

Since all clients fetch the exact same data, this PR introduces a new endpoint, `/api/rest/meetingStaticData`, which provides the static data. Nginx will cache responses for this endpoint (using `$uri|$meeting_id` as the cache key), allowing it to serve the data directly without hitting Hasura each time.

Together, these changes significantly reduce the load on Hasura.

- Release notes:
The endpoint `/api/rest/clientSettings` will be removed soon and it should be replaced by `/api/rest/meetingStaticData` which provide clientSettings and more.