### PR TITLE
fix(html5/whiteboard): Do not run resync code on change page

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -345,7 +345,6 @@ const WhiteboardContainer = (props) => {
     }, RECONNECT_SYNC_DELAY_MS);
   }, [
     connectedStatus,
-    curPageId,
     isMultiUserActive,
     hasWBAccess,
     presenterChanged,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Do not run shape resync code every time the current page changes, as it is intended to run on reconnect.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23703


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

See the linked ticket.
