### PR TITLE
feat(html5/bbb-web): layout engine wait for enforcedLayout finish loading 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -49,6 +49,7 @@ const initState = {
   deviceType: null,
   isRTL: DEFAULT_VALUES.isRTL,
   layoutType: DEFAULT_VALUES.layoutType,
+  layoutLoading: true,
   fontSize: DEFAULT_VALUES.fontSize,
   idChatOpen: '',
   fullscreen: {
@@ -1229,6 +1230,18 @@ const reducer = (state, action) => {
             display,
           },
         },
+      };
+    }
+
+    // LAYOUT TYPE MANAGEMENT
+    case ACTIONS.SET_LAYOUT_LOADING: {
+      const { layoutLoading } = state;
+      if (layoutLoading === action.value) {
+        return state;
+      }
+      return {
+        ...state,
+        layoutLoading: action.value,
       };
     }
 

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -51,6 +51,8 @@ export const SYNC = {
 };
 
 export const ACTIONS = {
+  SET_LAYOUT_LOADING: 'setLayoutLoading',
+
   SET_IS_RTL: 'setIsRTL',
   SET_LAYOUT_TYPE: 'setLayoutType',
   SET_DEVICE_TYPE: 'setDeviceType',

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -14,6 +14,7 @@ import { useIsPresentationEnabled } from '/imports/ui/services/features';
 import Session from '/imports/ui/services/storage/in-memory';
 import MediaOnlyLayout from './mediaOnlyLayout';
 import { usePrevious } from '../../whiteboard/utils';
+import { getShouldWaitForLayout } from '../utils';
 
 const LayoutEngine = () => {
   const bannerBarInput = layoutSelectInput((i) => i.bannerBar);
@@ -29,6 +30,10 @@ const LayoutEngine = () => {
   const genericMainContentInput = layoutSelectInput((i) => i.genericMainContent);
   const screenShareInput = layoutSelectInput((i) => i.screenShare);
   const sharedNotesInput = layoutSelectInput((i) => i.sharedNotes);
+
+  const shouldWaitForLayout = getShouldWaitForLayout();
+  const layoutLoading = layoutSelect((i) => i.layoutLoading);
+  const skipLayoutEngineRender = shouldWaitForLayout && layoutLoading;
 
   const fullscreen = layoutSelect((i) => i.fullscreen);
   const isRTL = layoutSelect((i) => i.isRTL);
@@ -345,7 +350,7 @@ const LayoutEngine = () => {
   };
 
   const layout = document.getElementById('layout');
-
+  if (skipLayoutEngineRender) return null;
   switch (selectedLayout) {
     case LAYOUT_TYPE.CUSTOM_LAYOUT:
       layout?.setAttribute('data-layout', LAYOUT_TYPE.CUSTOM_LAYOUT);

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/layoutEngine.jsx
@@ -14,7 +14,7 @@ import { useIsPresentationEnabled } from '/imports/ui/services/features';
 import Session from '/imports/ui/services/storage/in-memory';
 import MediaOnlyLayout from './mediaOnlyLayout';
 import { usePrevious } from '../../whiteboard/utils';
-import { getShouldWaitForLayout } from '../utils';
+import { getWaitLayout } from '../utils';
 
 const LayoutEngine = () => {
   const bannerBarInput = layoutSelectInput((i) => i.bannerBar);
@@ -31,7 +31,7 @@ const LayoutEngine = () => {
   const screenShareInput = layoutSelectInput((i) => i.screenShare);
   const sharedNotesInput = layoutSelectInput((i) => i.sharedNotes);
 
-  const shouldWaitForLayout = getShouldWaitForLayout();
+  const shouldWaitForLayout = getWaitLayout();
   const layoutLoading = layoutSelect((i) => i.layoutLoading);
   const skipLayoutEngineRender = shouldWaitForLayout && layoutLoading;
 

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -418,11 +418,19 @@ const PushLayoutEngineContainer = (props) => {
 
   const { isOpen: presentationIsOpen } = presentationInput;
 
-  const { data: currentUserData } = useCurrentUser((user) => ({
+  const { data: currentUserData, loading: enforcedLayoutLoading } = useCurrentUser((user) => ({
     enforceLayout: user.sessionCurrent?.enforceLayout,
     isModerator: user.isModerator,
     presenter: user.presenter,
   }));
+
+  useEffect(() => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_LAYOUT_LOADING,
+      value: enforcedLayoutLoading,
+    });
+  }, [enforcedLayoutLoading]);
+
   const isModerator = currentUserData?.isModerator;
   const isPresenter = currentUserData?.presenter;
 

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -8,7 +8,7 @@ import {
 const phoneUpperBoundary = 600;
 const tabletPortraitUpperBoundary = 900;
 const tabletLandscapeUpperBoundary = 1200;
-const SHOULD_WAIT_FOR_LAYOUT_PARAMETER = 'shouldWaitForLayout';
+const WAIT_LAYOUT_PARAMETER = 'waitLayout';
 
 const windowSize = () => window.document.documentElement.clientWidth;
 const isMobile = () => windowSize() <= (phoneUpperBoundary - 1);
@@ -20,9 +20,9 @@ const isTablet = () => windowSize() >= phoneUpperBoundary
   && windowSize() <= (tabletLandscapeUpperBoundary - 1);
 const isDesktop = () => windowSize() >= tabletLandscapeUpperBoundary;
 
-const getShouldWaitForLayout = () => {
+const getWaitLayout = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get(SHOULD_WAIT_FOR_LAYOUT_PARAMETER) || true;
+  return urlParams.get(WAIT_LAYOUT_PARAMETER) || false;
 };
 
 const device = {
@@ -130,4 +130,4 @@ const LAYOUTS_SYNC = {
     ],
   },
 };
-export { suportedLayouts, LAYOUTS_SYNC, getShouldWaitForLayout };
+export { suportedLayouts, LAYOUTS_SYNC, getWaitLayout };

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -8,6 +8,7 @@ import {
 const phoneUpperBoundary = 600;
 const tabletPortraitUpperBoundary = 900;
 const tabletLandscapeUpperBoundary = 1200;
+const SHOULD_WAIT_FOR_LAYOUT_PARAMETER = 'shouldWaitForLayout';
 
 const windowSize = () => window.document.documentElement.clientWidth;
 const isMobile = () => windowSize() <= (phoneUpperBoundary - 1);
@@ -18,6 +19,11 @@ const isTabletLandscape = () => windowSize() >= tabletPortraitUpperBoundary
 const isTablet = () => windowSize() >= phoneUpperBoundary
   && windowSize() <= (tabletLandscapeUpperBoundary - 1);
 const isDesktop = () => windowSize() >= tabletLandscapeUpperBoundary;
+
+const getShouldWaitForLayout = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get(SHOULD_WAIT_FOR_LAYOUT_PARAMETER) || true;
+};
 
 const device = {
   isMobile, isTablet, isTabletPortrait, isTabletLandscape, isDesktop,
@@ -124,4 +130,4 @@ const LAYOUTS_SYNC = {
     ],
   },
 };
-export { suportedLayouts, LAYOUTS_SYNC };
+export { suportedLayouts, LAYOUTS_SYNC, getShouldWaitForLayout };

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -19,7 +19,6 @@
 package org.bigbluebutton.web.controllers
 
 import com.google.gson.Gson
-import com.google.gson.JsonObject
 import grails.web.context.ServletContextHolder
 import groovy.json.JsonBuilder
 import groovy.xml.MarkupBuilder
@@ -32,7 +31,6 @@ import org.bigbluebutton.api.*
 import org.bigbluebutton.api.domain.GuestPolicy
 import org.bigbluebutton.api.domain.Meeting
 import org.bigbluebutton.api.domain.UserSession
-import org.bigbluebutton.api.domain.UserSessionBasicData
 import org.bigbluebutton.api.service.ValidationService
 import org.bigbluebutton.api.service.ServiceUtils
 import org.bigbluebutton.api.util.ParamsUtil
@@ -548,7 +546,7 @@ class ApiController {
     // Keep track of the client url in case this needs to wait for
     // approval as guest. We need to be able to send the user to the
     // client after being approved by moderator.
-    us.clientUrl = clientURL + "?sessionToken=" + sessionToken
+    us.clientUrl = handleCreateUserClientUrl(sessionToken, us)
 
     session[sessionToken] = sessionToken
     meetingService.addUserSession(sessionToken, us)
@@ -561,7 +559,7 @@ class ApiController {
 
     // Process if we send the user directly to the client or
     // have it wait for approval.
-    String destUrl = clientURL + "?sessionToken=" + sessionToken
+    String destUrl = us.clientUrl
     if (guestStatusVal == GuestPolicy.DENY) {
       invalid("guestDeniedAccess", "You have been denied access to this meeting based on the meeting's guest policy", redirectClient, errorRedirectUrl)
       return
@@ -583,7 +581,7 @@ class ApiController {
 
     if (redirectClient) {
       log.info("Redirecting to ${destUrl}");
-      handleRedirectJoinedUser(destUrl, us);
+      redirect(url: destUrl);
     } else {
       log.info("Successfully joined. Sending XML response.");
       response.addHeader("Cache-Control", "no-cache")
@@ -678,7 +676,7 @@ class ApiController {
     // Keep track of the client url in case this needs to wait for
     // approval as guest. We need to be able to send the user to the
     // client after being approved by moderator.
-    us.clientUrl = clientURL + "?sessionToken=" + sessionToken
+    us.clientUrl = handleCreateUserClientUrl(sessionToken, us)
 
     session[sessionToken] = sessionToken
     meetingService.addUserSession(sessionToken, us)
@@ -691,7 +689,7 @@ class ApiController {
 
     // Process if we send the user directly to the client or
     // have it wait for approval.
-    String destUrl = clientURL + "?sessionToken=" + sessionToken
+    String destUrl = us.clientUrl
 
     Map<String, Object> logData = new HashMap<String, Object>();
     logData.put("meetingid", us.meetingID);
@@ -709,7 +707,7 @@ class ApiController {
 
     if (redirectClient) {
       log.info("Redirecting to ${destUrl}");
-      handleRedirectJoinedUser(destUrl, us);
+      redirect(url: destUrl);
     } else {
       log.info("Successfully joined. Sending XML response.");
       response.addHeader("Cache-Control", "no-cache")
@@ -721,10 +719,15 @@ class ApiController {
     }
   }
 
-  def handleRedirectJoinedUser(String destination, UserSession session) {
-    Boolean waitForLayoutLoadFlag = !StringUtils.isEmpty(session.getEnforceLayout())
-    String redirectUrl = destination + "&shouldWaitForLayout=" + String.valueOf(waitForLayoutLoadFlag)
-    redirect(url: redirectUrl)
+  String handleCreateUserClientUrl(String sessionToken, UserSession session) {
+    String clientUrl = paramsProcessorUtil.getDefaultHTML5ClientUrl()
+    String redirectUrl = clientUrl
+    if (!StringUtils.isEmpty(session.getEnforceLayout())) {
+      redirectUrl = redirectUrl + "?waitLayout=1&sessionToken=" + sessionToken
+    } else {
+      redirectUrl = redirectUrl + "?sessionToken=" + sessionToken
+    }
+    return redirectUrl
   }
 
   /*******************************************

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -583,7 +583,7 @@ class ApiController {
 
     if (redirectClient) {
       log.info("Redirecting to ${destUrl}");
-      redirect(url: destUrl);
+      handleRedirectJoinedUser(destUrl, us);
     } else {
       log.info("Successfully joined. Sending XML response.");
       response.addHeader("Cache-Control", "no-cache")
@@ -709,7 +709,7 @@ class ApiController {
 
     if (redirectClient) {
       log.info("Redirecting to ${destUrl}");
-      redirect(url: destUrl);
+      handleRedirectJoinedUser(destUrl, us);
     } else {
       log.info("Successfully joined. Sending XML response.");
       response.addHeader("Cache-Control", "no-cache")
@@ -719,6 +719,12 @@ class ApiController {
         }
       }
     }
+  }
+
+  def handleRedirectJoinedUser(String destination, UserSession session) {
+    Boolean waitForLayoutLoadFlag = !StringUtils.isEmpty(session.getEnforceLayout())
+    String redirectUrl = destination + "&shouldWaitForLayout=" + String.valueOf(waitForLayoutLoadFlag)
+    redirect(url: redirectUrl)
   }
 
   /*******************************************


### PR DESCRIPTION
### What does this PR do?

This PR adds a feature that makes the layout engine wait for the whole layout information to come.

Before, we had a problem that even though  the `enforceLayout` was defined, for the first few milliseconds, the custom layout would be the selected (default) and then, when the client received the information about the `enforcedLayout`, it changed, if necessary.

Now, the client just waits until every layout information is available, so that it can decide what layout type to apply, this ensures that the first layout that appears - as soon as the client loads - is the desired one.

### Motivation

This will be specially useful in PLUGIN_ONLY layout types scenarios.

### How to test

Just enter with `enforceLayout` defined with a different layout than the default, and you'll see that it loads ASAP. I'd recommend PRESENTATION_ONLY, to better see the feature working.


### More
It's worth mentioning that I also added a query parameter into the client's URL called `waitLayout`, that gives a hint for the client if the `enforceLayout` has been passed or not (this way, if the `enforceLayout` is not set up, we can mount the client a little faster). If you guys disagree or have any suggestions about the logic or naming of that parameter, feel free to comment your concerns! They will be more than welcome!

Now here is a demo:

https://github.com/user-attachments/assets/4b1bb7f5-0473-4c86-b57a-f59287218d8d

