### PR TITLE
fix(timer): fix reset on timer panel when reopen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/indicator/component.tsx
@@ -123,7 +123,7 @@ const TimerIndicator: React.FC<TimerIndicatorProps> = ({
         <Styled.TimerButton
           running={running}
           disabled={!isModerator}
-          hide={sidebarNavigationIsOpen && sidebarContentIsOpen}
+    hide={sidebarNavigationIsOpen && sidebarContentIsOpen && !running}
           role="button"
           tabIndex={0}
           onClick={isModerator ? onClick : () => {}}

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -24,6 +24,9 @@ import {
 import humanizeSeconds from '/imports/utils/humanizeSeconds';
 import useTimer from '/imports/ui/core/hooks/useTimer';
 import { TimerData } from '/imports/ui/core/graphql/queries/timer';
+import logger from '/imports/startup/client/logger';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import Auth from '/imports/ui/services/auth';
 
 const MAX_HOURS = 23;
 const MILLI_IN_HOUR = 3600000;
@@ -197,7 +200,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
     const value = parseInt(event.target.value || (hasHourOrMinutes ? '0' : '1'), 10);
     if (Number.isNaN(value)) return;
     const newSeconds = Math.max(hasHourOrMinutes ? 0 : 1, Math.min(value, 59));
-    syncTimeWithBackend(hours, hours, newSeconds);
+  syncTimeWithBackend(hours, minutes, newSeconds);
   };
 
   const changeTime = useCallback((amountInSeconds: number) => {
@@ -482,44 +485,45 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
 
 const TimerPanelContaier: React.FC = () => {
   const [timerActivate] = useMutation(TIMER_ACTIVATE);
-  const [hasActivated, setHasActivated] = useState(() => {
-    return localStorage.getItem('timer-has-activated') === 'true';
-  });
-
   const { data: timerData } = useTimer();
+  const { data: currentUser } = useCurrentUser();
+
+  const amIModerator = !!currentUser?.isModerator;
 
   const activateTimer = useCallback(() => {
-    if (hasActivated) {
+  if ((timerData?.active) || !amIModerator) return;
+
+    const TIMER_CONFIG = window.meetingClientSettings.public.timer;
+    const meetingId = Auth.meetingID;
+    if (!meetingId) {
+      logger.warn({ logCode: 'timer_activate_no_meetingid' }, 'Timer activation skipped: no meetingId');
       return;
     }
-    
-    const TIMER_CONFIG = window.meetingClientSettings.public.timer;
-    const stopwatch = false;
-    const running = false;
-    const time = TIMER_CONFIG.time * MILLI_IN_MINUTE;
-    
-    timerActivate({ variables: { stopwatch, running, time } })
-      .then(() => {
-        setHasActivated(true);
-        localStorage.setItem('timer-has-activated', 'true');
-      })
-      .catch((error) => {
-        console.error('Erro ao ativar timer:', error);
-      });
-  }, [timerActivate, hasActivated]);
+
+    timerActivate({
+      variables: {
+        stopwatch: false,
+        running: false,
+        time: TIMER_CONFIG.time * MILLI_IN_MINUTE,
+        meetingId,
+      },
+    }).catch((error) => {
+      if (!error.message?.includes('already active')) {
+        logger.error(
+          { logCode: 'timer_activate_failed', extraInfo: { errorMessage: error?.message } },
+          `Timer activation failed: ${error?.message}`
+        );
+      }
+    });
+  }, [timerActivate, timerData, amIModerator]);
 
   useEffect(() => {
-    if (timerData && !timerData.active && hasActivated) {
-      localStorage.removeItem('timer-has-activated');
-      setHasActivated(false);
-    }
-  }, [timerData?.active, hasActivated]);
-
-  useEffect(() => {
-    if (!timerData?.active && !hasActivated) {
+    if ((timerData == null || timerData?.active === false) && amIModerator) {
       activateTimer();
     }
-  }, [timerData?.active, hasActivated, activateTimer]);
+  }, [timerData?.active, amIModerator, activateTimer]);
+
+
 
   const currentTimer = timerData;
 

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
@@ -86,7 +86,7 @@ const TimerCurrent = styled.span`
   display: flex;
   font-size: 2.5rem;
   justify-content: center;
-  padding: 0.5rem 0;
+  padding: 0.5rem 0 1.45rem 0;
 `;
 
 const TimerType = styled.div`
@@ -111,7 +111,7 @@ const TimeInputWrapper = styled.div`
   margin-top: 0;
   width: 100%;
   border-bottom: 1px solid ${colorBorder};
-  padding: 0.5rem 0;
+  padding: 0.5rem 0 1.3rem 0;
 `;
 
 const TimeInputGroup = styled.div`
@@ -125,12 +125,12 @@ const TimeInputGroup = styled.div`
 // @ts-ignore - JS code
 const IncrementDecrementButton = styled(Button)`
   border-radius: ${lgBorderRadius};
-  width: 2.5rem;
-  height: 2rem;
+  width: 2.6rem;
+  height: 1.2rem;
   min-width: 0;
   padding: 0;
   font-size: 1rem;
-  line-height: 1;
+  line-height: 0.9;
 `;
 
 const TimeInputColon = styled.span`

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/styles.ts
@@ -30,8 +30,12 @@ const UserItemContents = styled.div<UserItemContentsProps>`
   position: static;
   padding-right: 0.5rem;
   padding-left: 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
   width: 100%;
   overflow: hidden;
+  min-height: 3rem;
+
 
   ${({ selected }) => selected && `
     background-color: ${listItemBgHover};

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/styles.ts
@@ -97,7 +97,6 @@ const pulse = (color: string) => keyframes`
 const VirtualizedList = styled.div`
   display: flex;
   flex-flow: column;
-  gap: 1rem;
   padding: 0px;
 `;
 
@@ -110,3 +109,5 @@ export default {
   VirtualizedList,
   UserListItem,
 };
+
+


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR resolves a bug where the timer would reset its state every time the timer panel was minimized and then reopened. The issue occurred because the component was being unmounted/remounted, causing the timer to reactivate and lose its previous state.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Test Case 1: Timer Persistence
Start timer (5 min) and let run for 30 seconds
Minimize panel → Reopen panel
Expected: Timer continues from ~4:30, doesn't reset to 5:00

Test Case 2: Stopwatch Persistence
Start stopwatch, let run for 30 seconds
Minimize → Reopen
Expected: Stopwatch continues counting up

Test Case 3: Reactivation After Deactivate
Start timer → Click "Deactivate"
Reopen panel
Expected: Timer initializes properly


### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added localStorage-based state persistence to track timer activation
