### PR TITLE
chore: improve `app.externalVideo.urlInput` locale

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1454,7 +1454,7 @@
     "app.externalVideo.start": "Share a new video",
     "app.externalVideo.title": "Share an external video",
     "app.externalVideo.input": "External Video URL",
-    "app.externalVideo.urlInput": "Copy and paste a video link to upload",
+    "app.externalVideo.urlInput": "Copy and paste a video link to share",
     "app.externalVideo.urlError": "This video URL isn't supported",
     "app.externalVideo.close": "Close",
     "app.externalVideo.autoPlayWarning": "Play the video to enable media synchronization",


### PR DESCRIPTION
### What does this PR do?

- [chore: improve app.externalVideo.urlInput locale](https://github.com/bigbluebutton/bigbluebutton/commit/b8f8ce2b4bdd02ce87f58f82988be6b6cad259e4) 
  - The `app.externalVideo.urlInput` locale uses "upload" to describe
sharing links for external video playback. This gives the false
impression that a video is uploaded to BBB servers.
  - Replace the term "upload" with "share" in
`app.externalVideo.urlInput` to more accurately reflect the
functionality. This change has been greenlit by the UI/UX team.

### Closes Issue(s)

None

### Motivation

Follow up to https://github.com/bigbluebutton/bigbluebutton/pull/23753