### PR TITLE
fix(html5): remove leading blank spaces from correct answer lines

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -126,7 +126,7 @@ const QuickPollDropdown = (props) => {
   // Join lines into a single question string
   const question = [questionLines.join(' ').trim()];
 
-  const correctAnswer = lines.find((line) => line.endsWith(QUICK_POLL_CORRECT_ANSWER_SUFFIX)
+  const correctAnswer = lines.map(line => line.trimStart()).find((line) => line.endsWith(QUICK_POLL_CORRECT_ANSWER_SUFFIX)
   && !question.includes(line))?.slice(0, -QUICK_POLL_CORRECT_ANSWER_SUFFIX.length);
 
   // Check explicitly if options exist or if the question ends with '?'


### PR DESCRIPTION
### What does this PR do?
This PR fixes an edge case where the smart poll doesn't always detect the correct answer.

### Motivation
There were cases where leading blank spaces were breaking the correct answer detection.
example: 
[test2.pdf](https://github.com/user-attachments/files/21917304/test2.pdf)

