### PR TITLE
fix (ci / aut-tests): "Too Many Requests" issue when downloading Libreoffice docker image

### DIFF
--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -19,6 +19,15 @@ runs:
         echo "----ls artifacts/----"
         ls artifacts/
         echo "Done"
+    - name: Download bbb-libreoffice artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: bbb-libreoffice-image-cache
+    - name: Load bbb-libreoffice image
+      shell: bash
+      run: |
+        set -e
+        docker load -i bbb-libreoffice.tar
     - name: Generate CA
       shell: bash
       run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -120,6 +120,30 @@ jobs:
         with:
           name: artifacts_${{ matrix.package }}
           path: artifacts/
+  bbb-libreoffice-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set cache-key vars
+        run: |
+          echo "BBB_LIBREOFFICE_IMAGE_NAME=$(head -n 1 bbb-libreoffice/docker/Dockerfile | cut -d ' ' -f 2)" >> $GITHUB_ENV
+      - name: Restore base image cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: bbb-libreoffice.tar
+          key: ${{ env.BBB_LIBREOFFICE_IMAGE_NAME }}
+      - name: Pull (first time / cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: docker pull docker.io/${{ env.BBB_LIBREOFFICE_IMAGE_NAME }}
+      - name: Save image to cache (first time)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: docker save docker.io/${{ env.BBB_LIBREOFFICE_IMAGE_NAME }} -o bbb-libreoffice.tar
+      - name: Archive packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: bbb-libreoffice-image-cache
+          path: bbb-libreoffice.tar
   unify-artifacts:
     needs: build-package
     runs-on: ubuntu-22.04
@@ -219,7 +243,9 @@ jobs:
             artifacts_others
           failOnError: false
   install-and-run-bbb-tests:
-    needs: unify-artifacts
+    needs:
+      - unify-artifacts
+      - bbb-libreoffice-image
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -295,7 +321,9 @@ jobs:
           name: bbb-logs-${{ env.MATRIX_SHARD_UNDERSCORED }}
           path: ./bbb-logs.tar.gz
   install-and-run-plugin-tests:
-    needs: unify-artifacts
+    needs:
+      - unify-artifacts
+      - bbb-libreoffice-image
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Automated tests frequently fail during the `bbb-install` step because of a rate-limit issue when pulling the `bbb-libreoffice` Docker image. 

To address this, the automated-tests workflow will cache the image and retrieve it from the GitHub cache instead of downloading it from DockerHub each time.

---

- Issue:

<img width="2627" height="1150" alt="image" src="https://github.com/user-attachments/assets/d4938a39-8879-4af3-891e-80dd41e854c7" />


----

- Now the step `docker build -t bbb-soffice docker/` doesn't need to download anything, see the logs:

<img width="2198" height="650" alt="image" src="https://github.com/user-attachments/assets/2db309fa-718c-46ed-a9be-41fc74e815a5" />

Related: #21694