### PR TITLE
chore: Ignore Metals cache directory in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ akka-bbb-apps/akka-bbb-apps*.log
 bigbluebutton-web/target-eclipse*
 record-and-playback/.loadpath
 **/.idea/*
+**/.metals/*
 *.iml
 *~
 cache/*


### PR DESCRIPTION
Added `**/.metals/*` to `.gitignore` to prevent committing IDE-generated files from the Metals language server.
The `.metals` directory is created automatically when opening Scala/sbt projects in Zed (or other editors using Metals) and only contains cache and build import data. It is not relevant to the source code and should not be tracked in version control.
