### PR TITLE
fix: Resolve missing or duplicated key problem in data-channel or custom-subscriptions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/manager.tsx
@@ -44,8 +44,8 @@ export const DataChannelItemManager: React.ElementType<DataChannelItemManagerPro
       {
         dataChannelTypes.map((type) => (
           <DataChannelItemManagerReader
+            key={identifier?.concat('::')?.concat(type)}
             {...{
-              key: identifier?.concat('::')?.concat(type),
               pluginName,
               channelName,
               dataChannelType: type,

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/manager.tsx
@@ -105,8 +105,8 @@ const PluginDataChannelManager: React.ElementType<PluginDataChannelManagerProps>
           );
           return (
             <DataChannelItemManager
+              key={identifier}
               {...{
-                key: identifier,
                 identifier,
                 pluginName: pluginNameInUse,
                 channelName,

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
@@ -186,6 +186,7 @@ const PluginDataConsumptionManager: React.FC = () => {
           const HookComponent = hookWithArguments.componentToRender;
           return (
             <CustomDataConsumptionHooksErrorBoundary
+              key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
               hookWithArguments={hookWithArguments}
               dataConsumptionHook={DataConsumptionHooks.CUSTOM_SUBSCRIPTION}
               setDataConsumptionHookWithArgumentUtilizationCount={setSubscriptionHookWithArgumentUtilizationCount}
@@ -204,6 +205,7 @@ const PluginDataConsumptionManager: React.FC = () => {
           const HookComponent = hookWithArguments.componentToRender;
           return (
             <CustomDataConsumptionHooksErrorBoundary
+              key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
               hookWithArguments={hookWithArguments}
               dataConsumptionHook={DataConsumptionHooks.CUSTOM_QUERY}
               setDataConsumptionHookWithArgumentUtilizationCount={setQueryHookWithArgumentUtilizationCount}


### PR DESCRIPTION
### What does this PR do?

This just fixes the warnings that react throws when there's a list of components without keys or with duplicated keys (it was happening to the data-channel manager and the custom-subscription manager).

### Motivation

Clear console warnings.

### How to test

- Create data-channels use them and see if any warning appears;
- Test the same with custom-subscriptions or other pluginApi hooks


