### PR TITLE
docs: Add instructions when the proxy server uses a different root domain than the BBB server

### DIFF
--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -108,6 +108,8 @@ graphqlWebsocketUrl=wss://bbb-01.example.com/graphql
 graphqlApiUrl=https://bbb-01.example.com/api/rest
 ```
 
+---
+
 Add the following options to `/etc/bigbluebutton/bbb-html5.yml`:
 
 ```yaml
@@ -133,6 +135,8 @@ public:
     url: 'https://bbb-01.example.com/pad'
 ```
 
+---
+
 Create a new file in `/etc/bigbluebutton/nginx/bbb-cluster.nginx`
 and prepend the mount point of bbb-html5 in all location sections:
 
@@ -153,8 +157,10 @@ location /bbb-01/html5client/locales {
 
 ```
 
-**Note:** It is important that the location configuration is equal between the
-BigBlueButton server and the proxy.
+_**Note:** It is important that the location configuration is equal between the
+BigBlueButton server and the proxy._
+
+---
 
 Add a route for the locales handler for the guest lobby. The guest lobby is served directly from the BBB node.
 
@@ -164,6 +170,8 @@ location =/html5client/locale {
   return 301 /bbb-01$request_uri;
 }
 ```
+
+---
 
 Create the file `/etc/bigbluebutton/etherpad.json` with the following content:
 
@@ -175,12 +183,16 @@ Create the file `/etc/bigbluebutton/etherpad.json` with the following content:
 }
 ```
 
+---
+
 Create the file `/etc/systemd/system/bbb-web.service.d/override.conf` and add the following Environment setting:
 
 ```shell
 [Service]
 Environment="JDK_JAVA_OPTIONS=-Dgrails.cors.enabled=true -Dgrails.cors.allowCredentials=true -Dgrails.cors.allowedOrigins=https://bbb-proxy.example.com,https://bbb-01.example.com"
 ```
+
+---
 
 Create the file `/etc/bigbluebutton/bbb-graphql-middleware.yml` with the following content:
 
@@ -191,7 +203,9 @@ server:
   authorized_cross_origin: bbb-proxy.example.com
 ```
 
-Pay attention that this one is without protocol, just the hostname.
+_**Note:** Pay attention that this one is without protocol, just the hostname._
+
+---
 
 Adjust the CORS setting in `/etc/bigbluebutton/bbb-graphql-server.env`:
 
@@ -199,7 +213,9 @@ Adjust the CORS setting in `/etc/bigbluebutton/bbb-graphql-server.env`:
 HASURA_GRAPHQL_CORS_DOMAIN="https://bbb-proxy.example.com"
 ```
 
-This one includes the protocol.
+_**Note:** This one includes the protocol._
+
+---
 
 If your proxy server uses a different root domain than your BBB server, you’ll need an additional configuration.
 Add the following settings to `/usr/share/bbb-web/WEB-INF/classes/application.yml`:
@@ -212,6 +228,9 @@ server:
         secure: true
         SameSite: none
 ```
+_**Note:** This change will be reverted with subsequent bbb-web updates. If you rely on the override, look to include it in a post-installation routine._
+
+---
 
 Reload systemd and restart BigBlueButton:
 

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -133,7 +133,7 @@ public:
     url: 'https://bbb-01.example.com/pad'
 ```
 
-Create a new file in `/etc/bigbluebutton/nginx/bbb-cluster.nginx` 
+Create a new file in `/etc/bigbluebutton/nginx/bbb-cluster.nginx`
 and prepend the mount point of bbb-html5 in all location sections:
 
 ```
@@ -200,6 +200,18 @@ HASURA_GRAPHQL_CORS_DOMAIN="https://bbb-proxy.example.com"
 ```
 
 This one includes the protocol.
+
+If your proxy server uses a different root domain than your BBB server, you’ll need an additional configuration.
+Add the following settings to `/usr/share/bbb-web/WEB-INF/classes/application.yml`:
+
+```yaml
+server:
+  servlet:
+    session:
+      cookie:
+        secure: true
+        SameSite: none
+```
 
 Reload systemd and restart BigBlueButton:
 


### PR DESCRIPTION
Following the discussion in #23637, I identified that the `JSESSIONID` cookie set by **bbb-web** must include `SameSite=None; Secure;` for the proxy to work when the proxy server uses a different root domain than the BBB server.

This PR updates the documentation to include the necessary configuration instructions.

<img width="1762" height="640" alt="image" src="https://github.com/user-attachments/assets/3a283f42-a342-45b6-9ef9-2221aa3fb660" />


More:

> [None](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#none)
Send the cookie with both cross-site and same-site requests. The Secure attribute must also be set when using this value.


Closes: #23637
