### PR TITLE
perf (gql-server): Add more permissions for Hasura role `bbb_client_not_in_meeting`

### DIFF
--- a/bbb-graphql-middleware/config/Config.go
+++ b/bbb-graphql-middleware/config/Config.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"dario.cat/mergo"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"dario.cat/mergo"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -15,8 +16,10 @@ var (
 	once     sync.Once
 )
 
-var DefaultConfigPath = "/usr/share/bbb-graphql-middleware/config.yml"
-var OverrideConfigPath = "/etc/bigbluebutton/bbb-graphql-middleware.yml"
+var (
+	DefaultConfigPath  = "/usr/share/bbb-graphql-middleware/config.yml"
+	OverrideConfigPath = "/etc/bigbluebutton/bbb-graphql-middleware.yml"
+)
 
 type Config struct {
 	Server struct {
@@ -113,4 +116,5 @@ var AllowedSubscriptionsForNotInMeetingUsers = []string{
 	"getMeetingEndData",
 	"PluginConfigurationQuery",
 	"getUserCurrent",
+	"userCurrentSubscription",
 }

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_recordingPolicies.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_recordingPolicies.yaml
@@ -26,5 +26,5 @@ select_permissions:
         - record
       filter:
         meetingId:
-          _eq: X-Hasura-UserId
+          _eq: X-Hasura-MeetingId
     comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -248,27 +248,52 @@ select_permissions:
       columns:
         - authToken
         - authed
+        - avatar
+        - away
         - banned
+        - captionLocale
+        - clientType
         - color
+        - currentlyInMeeting
         - disconnected
+        - echoTestRunningAt
         - ejectReason
         - ejectReasonCode
         - ejected
+        - enforceLayout
         - expired
-        - logoutUrl
-        - currentlyInMeeting
-        - isModerator
         - extId
+        - firstName
+        - firstNameSortable
         - guest
         - guestStatus
+        - hasDrawPermissionOnCurrentPage
+        - inactivityWarningDisplay
+        - inactivityWarningTimeoutSecs
+        - isDialIn
+        - isModerator
+        - isRunningEchoTest
         - joinErrorCode
         - joinErrorMessage
         - joined
+        - lastName
+        - lastNameSortable
+        - locked
         - loggedOut
+        - logoutUrl
+        - mobile
         - name
+        - nameSortable
+        - pinned
+        - presenter
+        - raiseHand
+        - reactionEmoji
         - registeredAt
         - registeredOn
+        - role
+        - speechLocale
         - userId
+        - webcamBackground
       filter:
         _and:
           - meetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_session_current.yaml
@@ -22,3 +22,18 @@ select_permissions:
           - sessionToken:
               _eq: X-Hasura-SessionToken
     comment: ""
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - enforceLayout
+        - sessionName
+        - sessionToken
+      filter:
+        _and:
+          - meetingId:
+              _eq: X-Hasura-MeetingId
+          - userId:
+              _eq: X-Hasura-UserId
+          - sessionToken:
+              _eq: X-Hasura-SessionToken
+    comment: ""


### PR DESCRIPTION
Right now, a user can fetch restricted data before joining a meeting. The issue is that the client needs to start one subscription before joining, then another afterward, and sometimes even run multiple subscriptions concurrently, which is heavy and inefficient.

After reviewing this, we realized there’s actually no sensitive information in `user_current` that should be hidden before the user joins. If they were able to establish a GraphqL connection, it means they already have a valid `/join` link and should be allowed to fetch their own data.

This PR extends the permissions for the `bbb_client_not_in_meeting` role so that users can call the `useCurrentUser` hook at any time. This avoids the need for multiple subscriptions to `user_current`, which is especially problematic since each user has an individual query for this endpoint.