### PR TITLE
build: Fix 404 Error when loading Shared Notes

### DIFF
--- a/build/packages-template/bbb-html5/after-install.sh
+++ b/build/packages-template/bbb-html5/after-install.sh
@@ -15,6 +15,7 @@ fi
 
 
 WSURL=$(grep -v '#' /etc/bigbluebutton/bbb-web.properties | sed -n '/^bigbluebutton.web.serverURL/{s/.*=//;p}' | sed 's/https/wss/g' | sed s'/http/ws/g')
+PROTOCOL=$(awk -F '[=:]' '$1 == "bigbluebutton.web.serverURL" {print $2}' /etc/bigbluebutton/bbb-web.properties)
 
 yq e -i ".public.kurento.wsUrl = \"$WSURL/bbb-webrtc-sfu\"" $BBB_HTML5_SETTINGS_FILE
 


### PR DESCRIPTION
If the patch can be merged that would be awesome, if I can help in any way I would love to :tada: 

### What does this PR do?
This PR aims to patch the issue https://github.com/bigbluebutton/bigbluebutton/issues/21417

As https://github.com/stefanplk3 explained, the use of variable PROTOCOL in /var/lib/dpkg/info/bbb-html5.postinst ends up with bad pad url ( hence having 404 error ).

### Closes Issue(s)
Closes #21417

### Motivation
I got the same problem as in this issue, thanks to https://github.com/stefanplk3 I could pinpoint quickly how to fix my problem.


I've added a simple line to load up protocol based on how the HOST variable is loaded. I've allowed myself to use 'awk' as it is used at other places in that same file. I'm using 'F' param to allow 2 word separator : ':' and '=', that allows me to select and print out just the http/s member of the bigbluebutton.web.serverURL.

### How to test
install bbb-html5 debian package
see that /usr/share/bigbluebutton/html5-client/private/config/settings.yml  has a bad public.pad.url ( it should be lacking http/s parameter in URL )
install the bbb-html5 package with patch, use dpkg-reconfigure bbb-html5 to trigger a new postinst, and you now shoud have a valid URL for public.pad.url
