### PR TITLE
Ref(html5): Reduce user_current usage through the client.

### DIFF
--- a/bbb-graphql-middleware/config/Config.go
+++ b/bbb-graphql-middleware/config/Config.go
@@ -115,6 +115,7 @@ var AllowedSubscriptionsForNotInMeetingUsers = []string{
 	"getUserInfo",
 	"getMeetingEndData",
 	"PluginConfigurationQuery",
-	"getUserCurrent",
+	"getGuestLobbyInfo",
 	"userCurrentSubscription",
+	"Patched_userCurrentSubscription",
 }

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_writers.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_writers.yaml
@@ -6,11 +6,21 @@ configuration:
   custom_column_names: {}
   custom_name: pres_page_writers
   custom_root_fields: {}
+object_relationships:
+  - name: user
+    using:
+      manual_configuration:
+        column_mapping:
+          meetingId: meetingId
+          userId: userId
+        insertion_order: null
+        remote_table:
+          name: v_user_ref
+          schema: public
 select_permissions:
   - role: bbb_client
     permission:
       columns:
-        - changedModeOn
         - isCurrentPage
         - pageId
         - presentationId
@@ -21,7 +31,6 @@ select_permissions:
   - role: bbb_client_not_in_meeting
     permission:
       columns:
-        - changedModeOn
         - isCurrentPage
         - pageId
         - presentationId

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -28,6 +28,13 @@ export interface BreakoutRoomsSummary {
   totalOfJoinURL: number;
 }
 
+export interface Meeting {
+  ended: boolean;
+  endedReasonCode: string;
+  endedByUserName: string;
+  logoutUrl: string;
+}
+
 export interface Voice {
   joined: boolean;
   listenOnly: boolean;
@@ -61,6 +68,7 @@ export interface Livekit {
 }
 
 export interface User {
+  logoutUrl: string;
   authToken: string;
   userId: string;
   extId: string;
@@ -108,6 +116,7 @@ export interface User {
   userLockSettings: userLockSettings;
   sessionCurrent: sessionCurrent;
   livekit?: Livekit;
+  meeting: Meeting;
 }
 
 export interface UserBasicInfo {

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -28,7 +28,7 @@ export interface BreakoutRoomsSummary {
   totalOfJoinURL: number;
 }
 
-export interface Meeting {
+export interface UserMeeting {
   ended: boolean;
   endedReasonCode: string;
   endedByUserName: string;
@@ -116,7 +116,7 @@ export interface User {
   userLockSettings: userLockSettings;
   sessionCurrent: sessionCurrent;
   livekit?: Livekit;
-  meeting: Meeting;
+  meeting: UserMeeting;
 }
 
 export interface UserBasicInfo {

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -4,8 +4,8 @@ import Bowser from 'bowser';
 import { isBrowserSupported } from 'livekit-client';
 import Session from '/imports/ui/services/storage/in-memory';
 import {
-  getUserCurrent,
-  GetUserCurrentResponse,
+  GetGuestLobbyInfo,
+  getGuestLobbyInfo,
   getUserInfo,
   GetUserInfoResponse,
   userJoinMutation,
@@ -20,6 +20,7 @@ import deviceInfo from '/imports/utils/deviceInfo';
 import GuestWaitContainer, { GUEST_STATUSES } from '../guest-wait/component';
 import Legacy from '/imports/ui/components/legacy/component';
 import PluginTopLevelManager from '/imports/ui/components/plugin-top-level-manager/component';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
 const connectionTimeout = 60000;
 const MESSAGE_TIMEOUT = 3000;
@@ -221,7 +222,27 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
 };
 
 const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ children }) => {
-  const { loading, error, data } = useDeduplicatedSubscription<GetUserCurrentResponse>(getUserCurrent);
+  const {
+    data: currentUserData,
+    loading: currentUserLoading,
+    errors: currentUserErrors,
+  } = useCurrentUser((u) => ({
+    authToken: u.authToken,
+    joinErrorCode: u.joinErrorCode,
+    joinErrorMessage: u.joinErrorMessage,
+    joined: u.joined,
+    ejectReasonCode: u.ejectReasonCode,
+    loggedOut: u.loggedOut,
+    guestStatus: u.guestStatus,
+    meeting: u.meeting,
+    name: u.name,
+    extId: u.extId,
+    userId: u.userId,
+  }));
+
+  const { error, data } = useDeduplicatedSubscription<GetGuestLobbyInfo>(getGuestLobbyInfo, {
+    skip: !!currentUserLoading || !!currentUserErrors || (!!currentUserData && currentUserData.guestStatus === 'ALLOW'),
+  });
 
   const {
     loading: userInfoLoading,
@@ -230,7 +251,7 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
   } = useQuery<GetUserInfoResponse>(getUserInfo);
 
   const loadingContextInfo = useContext(LoadingContext);
-  if (loading || userInfoLoading) return null;
+  if (userInfoLoading) return null;
   if (error || userInfoError) {
     loadingContextInfo.setLoading(false);
     logger.debug(`Error on user authentication: ${error}`);
@@ -238,26 +259,30 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
 
   if (
     !userInfoLoading
-    && (userInfoData?.meeting.length === 0 && userInfoData?.user_current.length === 0)
+    && (userInfoData?.meeting.length === 0)
   ) {
     throw new Error('Meeting Not Found.', { cause: 'meeting_not_found' });
   }
 
-  if (!data || data.user_current.length === 0) return null;
+  if (!currentUserData) return null;
   if (!userInfoData
-      || userInfoData.meeting.length === 0
-      || userInfoData.user_current.length === 0) return null;
+      || userInfoData.meeting.length === 0) return null;
   const {
     authToken,
     joinErrorCode,
     joinErrorMessage,
     joined,
     ejectReasonCode,
-    meeting,
     loggedOut,
-    guestStatusDetails,
     guestStatus,
-  } = data.user_current[0];
+    meeting,
+    userId,
+    extId,
+    name,
+  } = currentUserData;
+
+  const guestStatusDetails = data?.user_current?.[0]?.guestStatusDetails;
+
   const {
     logoutUrl,
     meetingId,
@@ -267,7 +292,6 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
     customLogoUrl,
     customDarkLogoUrl,
   } = userInfoData.meeting[0];
-  const { extId, name: userName, userId } = userInfoData.user_current[0];
 
   const MIN_BROWSER_CONFIG = window.meetingClientSettings.public.minBrowserVersions;
   const userAgent = window.navigator?.userAgent;
@@ -276,28 +300,28 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
 
   return (
     <PresenceManager
-      authToken={authToken}
-      logoutUrl={logoutUrl}
-      meetingId={meetingId}
-      meetingName={meetingName}
-      userName={userName}
-      extId={extId}
-      userId={userId}
-      joined={joined}
-      joinErrorCode={joinErrorCode}
-      joinErrorMessage={joinErrorMessage}
-      meetingEnded={meeting.ended}
-      endedReasonCode={meeting.endedReasonCode}
-      endedBy={meeting.endedByUserName}
-      ejectReasonCode={ejectReasonCode}
-      bannerColor={bannerColor}
-      bannerText={bannerText}
-      loggedOut={loggedOut}
-      customLogoUrl={customLogoUrl}
-      customDarkLogoUrl={customDarkLogoUrl}
+      authToken={authToken ?? ''}
+      logoutUrl={logoutUrl ?? ''}
+      meetingId={meetingId ?? ''}
+      meetingName={meetingName ?? ''}
+      userName={name ?? ''}
+      extId={extId ?? ''}
+      userId={userId ?? ''}
+      joined={joined ?? false}
+      joinErrorCode={joinErrorCode ?? ''}
+      joinErrorMessage={joinErrorMessage ?? ''}
+      meetingEnded={meeting?.ended ?? false}
+      endedReasonCode={meeting?.endedReasonCode ?? ''}
+      endedBy={meeting?.endedByUserName ?? ''}
+      ejectReasonCode={ejectReasonCode ?? ''}
+      bannerColor={bannerColor ?? ''}
+      bannerText={bannerText ?? ''}
+      loggedOut={loggedOut ?? false}
+      customLogoUrl={customLogoUrl ?? ''}
+      customDarkLogoUrl={customDarkLogoUrl ?? ''}
       guestLobbyMessage={guestStatusDetails?.guestLobbyMessage ?? null}
       positionInWaitingQueue={guestStatusDetails?.positionInWaitingQueue ?? null}
-      guestStatus={guestStatus}
+      guestStatus={guestStatus ?? ''}
       isSupportedBrowser={isSupportedBrowser}
       hasWebrtcSupport={hasWebrtcSupport}
     >

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/queries.ts
@@ -1,25 +1,11 @@
 import { gql } from '@apollo/client';
 
-export interface GetUserCurrentResponse {
+export interface GetGuestLobbyInfo {
   user_current: Array<{
-    userId: string;
-    authToken: string;
-    joined: boolean;
-    joinErrorCode: string;
-    joinErrorMessage: string;
-    ejectReasonCode: string;
-    loggedOut: boolean;
-    guestStatus: string;
     guestStatusDetails: {
       guestLobbyMessage: string | null;
       positionInWaitingQueue: number;
       isAllowed: boolean;
-    } | null;
-    meeting: {
-      ended: boolean;
-      endedReasonCode: string;
-      endedByUserName: string;
-      logoutUrl: string;
     };
   }>;
 }
@@ -52,31 +38,12 @@ query getUserInfo {
     customLogoUrl
     customDarkLogoUrl
   }
-  user_current {
-    extId
-    name
-    userId
-  }
 }
 `;
 
-export const getUserCurrent = gql`
-subscription getUserCurrent {
+export const getGuestLobbyInfo = gql`
+subscription getGuestLobbyInfo {
     user_current {
-      userId
-      authToken
-      joinErrorCode
-      joinErrorMessage
-      joined
-      ejectReasonCode
-      loggedOut
-      guestStatus
-      meeting {
-        ended
-        endedReasonCode
-        endedByUserName
-        logoutUrl
-      }
       guestStatusDetails {
         guestLobbyMessage
         positionInWaitingQueue
@@ -95,7 +62,6 @@ mutation UserJoin($authToken: String!, $clientType: String!, $clientIsMobile: Bo
 }
 `;
 export default {
-  getUserCurrent,
   userJoinMutation,
   getUserInfo,
 };

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/queries.ts
@@ -2,18 +2,10 @@ import { gql } from '@apollo/client';
 
 export interface MeetingEndDataResponse {
   user_current: Array<{
-    isModerator: boolean;
-    logoutUrl: string;
     meeting: {
       learningDashboard: {
         learningDashboardAccessToken: string;
       }
-      isBreakout: boolean;
-      clientSettings: {
-        skipMeetingEnded: boolean,
-        allowDefaultLogoutUrl: boolean;
-        learningDashboardBase: string;
-      };
     };
   }>;
 }
@@ -21,17 +13,9 @@ export interface MeetingEndDataResponse {
 export const getMeetingEndData = gql`
 query getMeetingEndData {
   user_current {
-    isModerator
-    logoutUrl
     meeting {
       learningDashboard {
         learningDashboardAccessToken
-      }
-      isBreakout
-      clientSettings {
-        skipMeetingEnded: clientSettingsJson(path: "$.public.app.skipMeetingEnded")
-        allowDefaultLogoutUrl: clientSettingsJson(path: "$.public.app.allowDefaultLogoutUrl")
-        learningDashboardBase: clientSettingsJson(path: "$.public.app.learningDashboardBase")
       }
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/queries.ts
@@ -45,17 +45,6 @@ subscription MeetingPermissions {
   }
 }`;
 
-export const CURRENT_USER_SUBSCRIPTION = gql`
-subscription UserListCurrUser {
-  user_current {
-    userId 
-    isModerator
-    guest
-    presenter
-    locked
-  }
-}`;
-
 export const USER_AGGREGATE_COUNT_SUBSCRIPTION = gql`
 subscription UsersCount {
   user_aggregate {
@@ -68,6 +57,5 @@ subscription UsersCount {
 
 export default {
   MEETING_PERMISSIONS_SUBSCRIPTION,
-  CURRENT_USER_SUBSCRIPTION,
   USER_AGGREGATE_COUNT_SUBSCRIPTION,
 };

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -21,6 +21,7 @@ subscription userCurrentSubscription {
     inactivityWarningTimeoutSecs
     isDialIn
     isModerator
+    logoutUrl
     currentlyInMeeting
     joinErrorCode
     joinErrorMessage
@@ -38,6 +39,12 @@ subscription userCurrentSubscription {
     speechLocale
     captionLocale
     userId
+    meeting {
+      ended
+      endedReasonCode
+      endedByUserName
+      logoutUrl
+    }
     lastBreakoutRoom {
       currentlyInRoom
       sequence


### PR DESCRIPTION
### What does this PR do?
**Depends on #23767**  
**Follow-up from #23758**

This PR reduces redundant GraphQL subscriptions and improves data flow consistency by consolidating `user_current` usage. Currently, subscriptions to `user_current` are filtered by `userId`, which means each subscription is unique per user and prevents Hasura from leveraging multiplexing.  

### 🔄 Changes

- **Presence Manager**
  - Removed 12 fields from the `getUserCurrent` subscription; now reusing data already exposed by `useCurrentUser`.
  - Renamed the subscription from `getUserCurrent` to `GetGuestLobbyInfo`.
  - Restricted `GetGuestLobbyInfo` so it only executes when the user is a guest and not allowed into the meeting.

- **Meeting End Data**
  - Removed 8 fields from the `getMeetingEndData` query.
  - These fields are now sourced from `useCurrentUser`, `useMeeting`, and `meetingClientSettings`.

- **Subscriptions Cleanup**
  - Removed the `UserListCurrUser` subscription.
