### PR TITLE
ci (aut-tests): Use cache to download BBB dependencies from apt

### DIFF
--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -7,6 +7,17 @@ runs:
       uses: ./.github/actions/merge-branches
     - run: ./build/get_external_dependencies.sh
       shell: bash
+    - name: Apt update
+      shell: bash
+      run: |
+        sudo LC_CTYPE=C.UTF-8 add-apt-repository -y ppa:rmescandon/yq
+        sudo LC_CTYPE=C.UTF-8 add-apt-repository -y ppa:bigbluebutton/support
+        sudo LC_CTYPE=C.UTF-8 add-apt-repository -y ppa:martin-uni-mainz/coturn
+        sudo apt update
+    - name: Download all BBB dependencies from cache
+      uses: Eeems-Org/apt-cache-action@v1
+      with:
+        packages: cairosvg ffmpeg fonts-arkpandora fonts-crosextra-caladea fonts-crosextra-carlito fonts-droid-fallback fonts-noto fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-core fonts-noto-extra fonts-noto-mono fonts-noto-ui-core fonts-noto-ui-extra fonts-noto-unhinted fonts-urw-base35 ghostscript gir1.2-harfbuzz-0.0 gir1.2-pango-1.0 i965-va-driver intel-media-va-driver libaacs0 libass9 libasyncns0 libavc1394-0 libavcodec58 libavdevice58 libavfilter7 libavformat58 libavutil56 libbdplus0 libbluray2 libbs2b0 libcaca0 libcdio-cdda2 libcdio-paranoia2 libcdio19 libchromaprint1 libcodec2-1.0 libdc1394-25 libdecor-0-0 libdecor-0-plugin-1-cairo libflac8 libflite1 libgme0 libgs9 libgs9-common libgsm1 libidn12 libiec61883-0 libigdgmm12 libijs-0.35 libimagequant0 libjack-jackd2-0 libjbig2dec0 libjemalloc2 libldns3 liblilv-0-0 liblua5.1-0 liblua5.2-0 liblzf1 libmfx1 libmp3lame0 libmpg123-0 libmysofa1 libncurses5 libopenal-data libopenal1 libopenmpt0 libopus0 libopusenc0 libopusfile0 libpangoxft-1.0-0 libpocketsphinx3 libpoppler118 libpostproc55 libpotrace0 libpulse0 libraqm0 libraw1394-11 librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0 libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1 libspeexdsp1 libsphinxbase3 libsratom-0-0 libsrt1.4-gnutls libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtinfo5 libtwolame0 libudfread0 libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvorbisenc2 libvpx7 libx264-163 libxvidcore4 libzimg2 libzvbi-common libzvbi0 lua-bitop lua-cjson mesa-va-drivers mesa-vdpau-drivers nodejs ocl-icd-libopencl1 openjdk-17-jdk openjdk-17-jdk-headless pocketsphinx-en-us poppler-data poppler-utils postgresql-contrib potrace python-tinycss2-common python3-bs4 python3-cairo python3-cairocffi python3-cairosvg python3-cffi python3-cssselect2 python3-defusedxml python3-gi-cairo python3-html5lib python3-icu python3-lxml python3-olefile python3-pil python3-ply python3-pycparser python3-soupsieve python3-tinycss2 python3-webencodings python3-xcffib redis-server redis-tools ruby-bundler stun-client va-driver-all vdpau-driver-all xmlstarlet autopoint cmake cmake-data dh-autoreconf dh-elpa-helper libdbus-1-dev libdebhelper-perl libjsoncpp25 libncurses5-dev libpcap-dev libpcap0.8-dev librhash0 libsctp-dev libsctp1 lksctp-tools pkg-config apparmor-utils python3-apparmor python3-libapparmor yq gnupg-agent ca-certificates-java libatk-wrapper-java libatk-wrapper-java-jni libpcsclite1 libxcb-shape0 libxv1 libxxf86dga1 openjdk-17-jre openjdk-17-jre-headless x11-utils
     - name: Download all BBB artifacts
       uses: actions/download-artifact@v4
       with:
@@ -18,16 +29,20 @@ runs:
         set -e
         echo "----ls artifacts/----"
         ls artifacts/
-        echo "Done"
-    - name: Download bbb-libreoffice artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: bbb-libreoffice-image-cache
-    - name: Load bbb-libreoffice image
+    - name: Set libreoffice cache-key vars
       shell: bash
       run: |
-        set -e
-        docker load -i bbb-libreoffice.tar
+        echo "BBB_LIBREOFFICE_IMAGE_NAME=$(head -n 1 bbb-libreoffice/docker/Dockerfile | cut -d ' ' -f 2)" >> $GITHUB_ENV
+    - name: Restore base image cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: bbb-libreoffice.tar
+        key: ${{ env.BBB_LIBREOFFICE_IMAGE_NAME }}
+    - name: Load docker image from bbb-libreoffice.tar
+      shell: bash
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: docker load -i bbb-libreoffice.tar
     - name: Generate CA
       shell: bash
       run: |
@@ -141,65 +156,7 @@ runs:
         sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
         chmod +x bbb-install.sh
 
-        COMMAND="./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/"
-        TIMEOUT=1500  # 25 minutes
-        MAX_RETRIES=3
-        RETRY_INTERVAL=60
-        RETRY_COUNT=0
-        SUCCESS=0
-
-        while [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
-          echo "Attempt $((RETRY_COUNT + 1)) of $MAX_RETRIES to install BBB..."
-
-          # Run the command with timeout and handle its exit code
-          # Capture both stdout and stderr
-          COMMAND_EXIT_CODE=0
-          timeout $TIMEOUT $COMMAND || COMMAND_EXIT_CODE=$?
-
-          if [[ $COMMAND_EXIT_CODE -eq 0 ]]; then
-            SUCCESS=1
-            break
-          elif [[ $COMMAND_EXIT_CODE -eq 124 ]]; then
-            echo "Installation timed out after ${TIMEOUT} seconds. Retrying..."
-          else
-            echo "Installation failed with exit code $COMMAND_EXIT_CODE"
-            echo "Retrying installation within $RETRY_INTERVAL seconds..."
-            sleep $RETRY_INTERVAL
-          fi
-
-          echo "Check if there is some process still locking:1"
-          ps aux | grep -E 'dpkg|apt'
-
-          echo "Stop any ongoing processes related to apt-get or dpkg that might be stuck"
-          # Use -q to suppress "no process found" messages
-          # Kill any apt-get or dpkg processes that might be hanging
-          killall -9 -q apt-get || true
-          killall -9 -q dpkg || true
-
-          echo "Remove the lock files that may have been left behind"
-          # Group lock file removal for better readability
-          rm -f /var/lib/dpkg/lock-frontend
-          rm -f /var/lib/dpkg/lock
-          rm -f /var/cache/apt/archives/lock
-          rm -f /var/cache/debconf/config.dat
-
-          echo "Reconfigure the package manager"
-          dpkg --configure -a
-
-          echo "Clean up any partially installed packages"
-          apt-get clean
-          apt-get autoremove
-
-          echo "Check if there is some process still locking:2"
-          ps aux | grep -E 'dpkg|apt'
-
-          RETRY_COUNT=$((RETRY_COUNT + 1))
-        done
-
-        if [[ $SUCCESS -eq 0 ]]; then
-          echo "All attempts to install BBB failed."
-          exit 1
-        fi
+        ./bbb-install.sh -v jammy-30-dev -s bbb-ci.test -j -d /certs/
 
         bbb-conf --salt bbbci
         sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json

--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: ./.github/actions/merge-branches
     - run: ./build/get_external_dependencies.sh
       shell: bash
-    - name: Apt update
+    - name: Add apt ppa for BBB dependencies
       shell: bash
       run: |
         sudo LC_CTYPE=C.UTF-8 add-apt-repository -y ppa:rmescandon/yq
@@ -17,7 +17,7 @@ runs:
     - name: Download all BBB dependencies from cache
       uses: Eeems-Org/apt-cache-action@v1
       with:
-        packages: cairosvg ffmpeg fonts-arkpandora fonts-crosextra-caladea fonts-crosextra-carlito fonts-droid-fallback fonts-noto fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-core fonts-noto-extra fonts-noto-mono fonts-noto-ui-core fonts-noto-ui-extra fonts-noto-unhinted fonts-urw-base35 ghostscript gir1.2-harfbuzz-0.0 gir1.2-pango-1.0 i965-va-driver intel-media-va-driver libaacs0 libass9 libasyncns0 libavc1394-0 libavcodec58 libavdevice58 libavfilter7 libavformat58 libavutil56 libbdplus0 libbluray2 libbs2b0 libcaca0 libcdio-cdda2 libcdio-paranoia2 libcdio19 libchromaprint1 libcodec2-1.0 libdc1394-25 libdecor-0-0 libdecor-0-plugin-1-cairo libflac8 libflite1 libgme0 libgs9 libgs9-common libgsm1 libidn12 libiec61883-0 libigdgmm12 libijs-0.35 libimagequant0 libjack-jackd2-0 libjbig2dec0 libjemalloc2 libldns3 liblilv-0-0 liblua5.1-0 liblua5.2-0 liblzf1 libmfx1 libmp3lame0 libmpg123-0 libmysofa1 libncurses5 libopenal-data libopenal1 libopenmpt0 libopus0 libopusenc0 libopusfile0 libpangoxft-1.0-0 libpocketsphinx3 libpoppler118 libpostproc55 libpotrace0 libpulse0 libraqm0 libraw1394-11 librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0 libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1 libspeexdsp1 libsphinxbase3 libsratom-0-0 libsrt1.4-gnutls libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtinfo5 libtwolame0 libudfread0 libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvorbisenc2 libvpx7 libx264-163 libxvidcore4 libzimg2 libzvbi-common libzvbi0 lua-bitop lua-cjson mesa-va-drivers mesa-vdpau-drivers nodejs ocl-icd-libopencl1 openjdk-17-jdk openjdk-17-jdk-headless pocketsphinx-en-us poppler-data poppler-utils postgresql-contrib potrace python-tinycss2-common python3-bs4 python3-cairo python3-cairocffi python3-cairosvg python3-cffi python3-cssselect2 python3-defusedxml python3-gi-cairo python3-html5lib python3-icu python3-lxml python3-olefile python3-pil python3-ply python3-pycparser python3-soupsieve python3-tinycss2 python3-webencodings python3-xcffib redis-server redis-tools ruby-bundler stun-client va-driver-all vdpau-driver-all xmlstarlet autopoint cmake cmake-data dh-autoreconf dh-elpa-helper libdbus-1-dev libdebhelper-perl libjsoncpp25 libncurses5-dev libpcap-dev libpcap0.8-dev librhash0 libsctp-dev libsctp1 lksctp-tools pkg-config apparmor-utils python3-apparmor python3-libapparmor yq gnupg-agent ca-certificates-java libatk-wrapper-java libatk-wrapper-java-jni libpcsclite1 libxcb-shape0 libxv1 libxxf86dga1 openjdk-17-jre openjdk-17-jre-headless x11-utils
+        packages: cairosvg ffmpeg fonts-arkpandora fonts-crosextra-caladea fonts-crosextra-carlito fonts-droid-fallback fonts-noto fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-core fonts-noto-extra fonts-noto-mono fonts-noto-ui-core fonts-noto-ui-extra fonts-noto-unhinted fonts-urw-base35 ghostscript gir1.2-harfbuzz-0.0 gir1.2-pango-1.0 i965-va-driver intel-media-va-driver libaacs0 libass9 libasyncns0 libavc1394-0 libavcodec58 libavdevice58 libavfilter7 libavformat58 libavutil56 libbdplus0 libbluray2 libbs2b0 libcaca0 libcdio-cdda2 libcdio-paranoia2 libcdio19 libchromaprint1 libcodec2-1.0 libdc1394-25 libdecor-0-0 libdecor-0-plugin-1-cairo libflac8 libflite1 libgme0 libgs9 libgs9-common libgsm1 libidn12 libiec61883-0 libigdgmm12 libijs-0.35 libimagequant0 libjack-jackd2-0 libjbig2dec0 libjemalloc2 libldns3 liblilv-0-0 liblua5.1-0 liblua5.2-0 liblzf1 libmfx1 libmp3lame0 libmpg123-0 libmysofa1 libncurses5 libopenal-data libopenal1 libopenmpt0 libopus0 libopusenc0 libopusfile0 libpangoxft-1.0-0 libpocketsphinx3 libpoppler118 libpostproc55 libpotrace0 libpulse0 libraqm0 libraw1394-11 librubberband2 libsamplerate0 libsdl2-2.0-0 libserd-0-0 libshine3 libsndfile1 libsndio7.0 libsord-0-0 libsoxr0 libspeex1 libspeexdsp1 libsphinxbase3 libsratom-0-0 libsrt1.4-gnutls libssh-gcrypt-4 libswresample3 libswscale5 libtheora0 libtinfo5 libtwolame0 libudfread0 libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvorbisenc2 libvpx7 libx264-163 libxvidcore4 libzimg2 libzvbi-common libzvbi0 lua-bitop lua-cjson mesa-va-drivers mesa-vdpau-drivers nodejs ocl-icd-libopencl1 openjdk-17-jdk openjdk-17-jdk-headless pocketsphinx-en-us poppler-data poppler-utils postgresql-contrib potrace python-tinycss2-common python3-bs4 python3-cairo python3-cairocffi python3-cairosvg python3-cffi python3-cssselect2 python3-defusedxml python3-gi-cairo python3-html5lib python3-icu python3-lxml python3-olefile python3-pil python3-ply python3-pycparser python3-soupsieve python3-tinycss2 python3-webencodings python3-xcffib redis-server redis-tools ruby-bundler stun-client va-driver-all vdpau-driver-all xmlstarlet autopoint cmake cmake-data dh-autoreconf dh-elpa-helper libdbus-1-dev libdebhelper-perl libjsoncpp25 libncurses5-dev libpcap-dev libpcap0.8-dev librhash0 libsctp-dev libsctp1 lksctp-tools pkg-config apparmor-utils python3-apparmor python3-libapparmor yq gnupg-agent ca-certificates-java libatk-wrapper-java libatk-wrapper-java-jni libpcsclite1 libxcb-shape0 libxv1 libxxf86dga1 openjdk-17-jre openjdk-17-jre-headless x11-utils build-essential
     - name: Download all BBB artifacts
       uses: actions/download-artifact@v4
       with:
@@ -29,11 +29,11 @@ runs:
         set -e
         echo "----ls artifacts/----"
         ls artifacts/
-    - name: Set libreoffice cache-key vars
+    - name: Set libreoffice docker image cache-key vars
       shell: bash
       run: |
         echo "BBB_LIBREOFFICE_IMAGE_NAME=$(head -n 1 bbb-libreoffice/docker/Dockerfile | cut -d ' ' -f 2)" >> $GITHUB_ENV
-    - name: Restore base image cache
+    - name: Restore bbb-libreoffice.tar from cache
       id: cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -252,8 +252,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install BBB
-        timeout-minutes: 25
+        timeout-minutes: 30
         uses: ./.github/actions/install-bbb
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          cache-dependency-path: bigbluebutton-tests/playwright/package-lock.json
       - name: Install test dependencies
         working-directory: ./bigbluebutton-tests/playwright
         timeout-minutes: 25
@@ -349,7 +353,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'npm'
-          cache-dependency-path: bigbluebutton-html-plugin-sdk/package-lock.json
+          cache-dependency-path: |
+                bigbluebutton-tests/bigbluebutton-html-plugin-sdk/package-lock.json
+                bigbluebutton-tests/bigbluebutton-html-plugin-sdk/samples/**/package-lock.json
       - name: Plugins SDK - Install node dependencies
         working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
         run: |
@@ -391,7 +397,7 @@ jobs:
               echo "Sample not found: $sample"
             fi
           done
-      - name: Install test dependencies
+      - name: Install test dependencies for plugins SDK
         working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
         timeout-minutes: 25
         run: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -339,13 +339,18 @@ jobs:
             SDK_VERSION=$(jq -r '.packages["node_modules/bigbluebutton-html-plugin-sdk"]["version"]' package-lock.json)
             echo "SDK_URL=https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/archive/refs/tags/v${SDK_VERSION}.tar.gz" >> $GITHUB_ENV
           fi
-      - name: Download plugins SDK
+      - name: Plugins SDK - Download bigbluebutton-html-plugin-sdk.tar.gz
         working-directory: bigbluebutton-tests
         run: |
           wget -O bigbluebutton-html-plugin-sdk.tar.gz $SDK_URL
           mkdir -p bigbluebutton-html-plugin-sdk
           tar -xzf bigbluebutton-html-plugin-sdk.tar.gz -C bigbluebutton-html-plugin-sdk --strip-components=1
-      - name: Install plugins SDK dependencies
+      - name: Plugins SDK - Cache node dependencies
+        uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          cache-dependency-path: bigbluebutton-html-plugin-sdk/package-lock.json
+      - name: Plugins SDK - Install node dependencies
         working-directory: ./bigbluebutton-tests/bigbluebutton-html-plugin-sdk
         run: |
           echo "Installing plugins SDK dependencies"

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -136,14 +136,9 @@ jobs:
       - name: Pull (first time / cache miss)
         if: steps.cache.outputs.cache-hit != 'true'
         run: docker pull docker.io/${{ env.BBB_LIBREOFFICE_IMAGE_NAME }}
-      - name: Save image to cache (first time)
+      - name: Save docker image to cache (first time)
         if: steps.cache.outputs.cache-hit != 'true'
         run: docker save docker.io/${{ env.BBB_LIBREOFFICE_IMAGE_NAME }} -o bbb-libreoffice.tar
-      - name: Archive packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: bbb-libreoffice-image-cache
-          path: bbb-libreoffice.tar
   unify-artifacts:
     needs: build-package
     runs-on: ubuntu-22.04
@@ -257,6 +252,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install BBB
+        timeout-minutes: 25
         uses: ./.github/actions/install-bbb
       - name: Install test dependencies
         working-directory: ./bigbluebutton-tests/playwright


### PR DESCRIPTION
The BBB installation step is often slow due to downloading apt packages. 
This PR adds a new step that will either pull all packages from cache or install the dependencies and populate the cache if it doesn’t exist. 
This should speed up the process and prevent it from getting stuck during installation.

Additional changes:

* Add cache for npm libs (for Playright, Plugins SDK, Plugins SDK samples)
* Remove the RETRY logic, since it wasn’t providing any benefit
* Switch from artifacts to cache for downloading the `bbb-libreoffice-image`