### PR TITLE
fix(apps-gallery): properly truncate apps entries

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -51,7 +51,12 @@ const PinnedAppsWrapper = styled.div`
 const UnpinnedAppsWrapper = PinnedAppsWrapper;
 
 const AppTitle = styled.div`
-  flex-grow: 1;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const RegisteredAppContent = styled.div`
@@ -91,6 +96,7 @@ const ClickableArea = styled.div`
   align-items: center;
   gap: ${lgPadding};
   cursor: pointer;
+  overflow: hidden;
 
   &:hover > ${OpenButton} {
     filter: brightness(90%);


### PR DESCRIPTION
### What does this PR do?
Trucates titles in apps gallery entries, so they don't overflow its containing box neither the whole sidebar panel.

![example](https://github.com/user-attachments/assets/6a038e18-eb94-4d5a-b8b3-16f60b19ba2e)


### Closes Issue(s)
Closes #23799 