### PR TITLE
feat(html5): Add global error listeners for runtime, resource, and unhandled errors

### DIFF
--- a/bigbluebutton-html5/client/main.tsx
+++ b/bigbluebutton-html5/client/main.tsx
@@ -45,6 +45,7 @@ const Main: React.FC = () => {
               Fallback={ErrorScreen}
               logMetadata={STARTUP_CRASH_METADATA}
               isCritical
+              captureGlobalLogs
             >
               <LoadingScreenHOC>
                 <ConnectionManager>

--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/component.jsx
@@ -13,10 +13,8 @@ const propTypes = {
     logCode: PropTypes.string,
     logMessage: PropTypes.string,
   }),
-  // isCritical: flags this error boundary as critical for the app's lifecycle,
-  // which means that the app should not continue to run if this error boundary
-  // is triggered. If true, terminates RTC audio connections and the Apollo client.
   isCritical: PropTypes.bool,
+  captureGlobalLogs: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -27,21 +25,110 @@ const defaultProps = {
     logMessage: 'generic error boundary logger',
   },
   isCritical: false,
+  captureGlobalLogs: false,
 };
 
 class ErrorBoundary extends Component {
+  static installClientErrorListeners() {
+    //  Normalize different error objects (Error, plain object, string) into a consistent shape
+    //  for structured logging
+    const toErrorInfo = (e) => {
+      if (e instanceof Error) {
+        return { errorMessage: e.message, errorName: e.name, errorStack: e.stack };
+      }
+      if (e && typeof e === 'object') {
+        return {
+          errorMessage: e.message || String(e),
+          errorName: e.name,
+          errorStack: e.stack,
+        };
+      }
+      return { errorMessage: String(e) };
+    };
+
+    // Handles `window.error` events.
+    // Two main cases:
+    //  - Resource load errors:
+    //    <script>, <img>, <link> failed to load → ev.target points to element
+    //  - Runtime JS errors: uncaught exceptions → ErrorEvent on window
+    const onErrorCapture = (ev) => {
+      // Resource error (img/script/css not loading)
+      if (ev && ev.target && ev.target !== window) {
+        const el = ev.target;
+        const tag = el.tagName?.toLowerCase?.() || 'unknown';
+        const src = el.getAttribute?.('src') || el.getAttribute?.('href') || '';
+        logger.warn(
+          {
+            logCode: 'resource_load_error',
+            extraInfo: { tag, src, currentUrl: window.location.href },
+          },
+          `Resource load error: <${tag}> src=${src}`,
+        );
+        return;
+      }
+
+      // JS runtime error (uncaught exception bubbling to window)
+      if (ev instanceof ErrorEvent) {
+        logger.error(
+          {
+            logCode: 'runtime_error',
+            extraInfo: {
+              filename: ev.filename,
+              lineno: ev.lineno,
+              colno: ev.colno,
+              ...toErrorInfo(ev.error),
+            },
+          },
+          `Runtime error: ${ev.message} (${ev.filename}:${ev.lineno}:${ev.colno})`,
+        );
+      }
+    };
+
+    // Handles unhandled promise rejections (e.g., fetch().then() chain throwing without catch).
+    const onUnhandledRejection = (ev) => {
+      const info = toErrorInfo(ev.reason);
+      logger.error(
+        {
+          logCode: 'unhandled_rejection',
+          extraInfo: {
+            ...info,
+            reasonType: typeof ev.reason,
+            currentUrl: window.location.href,
+          },
+        },
+        `Unhandled rejection: ${info.errorMessage || String(ev.reason)}`,
+      );
+    };
+
+    window.addEventListener('error', onErrorCapture, true);
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+
+    return () => {
+      window.removeEventListener('error', onErrorCapture, true);
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    };
+  }
+
   constructor(props) {
     super(props);
     this.state = { error: '', errorInfo: null };
+    this.uninstallListeners = null;
   }
 
   componentDidMount() {
+    const {
+      captureGlobalLogs,
+    } = this.props;
     const data = window.meetingClientSettings.public;
     const logConfig = data?.clientLog;
+    const { enableRuntimeErrorLogging } = window.meetingClientSettings.public.clientLog.console;
     if (logConfig && logger?.getStreams().length === 0) {
-      generateLoggerStreams(logConfig).forEach((stream) => {
-        logger.addStream(stream);
-      });
+      generateLoggerStreams(logConfig).forEach((stream) => logger.addStream(stream));
+    }
+    // captureGlobalLogs its meant for only the main error boundary on top level capture the errors
+    // and not all the error boundaries around the client
+    if (captureGlobalLogs && enableRuntimeErrorLogging) {
+      this.uninstallListeners = ErrorBoundary.installClientErrorListeners();
     }
   }
 
@@ -49,16 +136,22 @@ class ErrorBoundary extends Component {
     const { error, errorInfo } = this.state;
     const { logMetadata: { logCode, logMessage } } = this.props;
     if (error || errorInfo) {
+      // eslint-disable-next-line no-console
       console.log('%cErrorBoundary caught an error: ', 'color: red', error);
+      // eslint-disable-next-line no-console
       console.log('ErrorInfo: ', errorInfo);
-      logger.error({
-        logCode,
-        extraInfo: {
-          errorMessage: error?.message,
-          errorStack: error?.stack,
-          errorInfo,
+
+      logger.error(
+        {
+          logCode,
+          extraInfo: {
+            errorMessage: error?.message,
+            errorStack: error?.stack,
+            errorInfo,
+          },
         },
-      }, logMessage);
+        logMessage,
+      );
     }
   }
 
@@ -67,21 +160,19 @@ class ErrorBoundary extends Component {
 
     if (isCritical) {
       window.dispatchEvent(new Event('StopAudioTracks'));
-      const data = window.meetingClientSettings.public.media;
-      const mediaElement = document.querySelector(data?.mediaTag || '#remote-media');
+
+      const mediaCfg = window.meetingClientSettings.public.media;
+      const mediaElement = document.querySelector(mediaCfg?.mediaTag || '#remote-media');
       if (mediaElement) {
         mediaElement.pause();
         mediaElement.srcObject = null;
       }
-      const apolloClient = apolloContextHolder.getClient();
 
-      if (apolloClient) {
-        apolloClient.stop();
-      }
+      const apolloClient = apolloContextHolder.getClient();
+      if (apolloClient) apolloClient.stop();
 
       const ws = apolloContextHolder.getLink();
       if (ws) {
-        // delay to termintate the connection, for user receive the end eject message
         setTimeout(() => {
           apolloClient.setLink(ApolloLink.empty());
           ws.terminate();
@@ -93,10 +184,14 @@ class ErrorBoundary extends Component {
       Session.setItem('errorMessageDescription', error.cause);
     }
 
-    this.setState({
-      error,
-      errorInfo,
-    });
+    this.setState({ error, errorInfo });
+  }
+
+  componentWillUnmount() {
+    if (this.uninstallListeners) {
+      this.uninstallListeners();
+      this.uninstallListeners = null;
+    }
   }
 
   render() {
@@ -104,10 +199,10 @@ class ErrorBoundary extends Component {
     const { children, Fallback, errorMessage } = this.props;
 
     const fallbackElement = Fallback && error
-      ? <Fallback error={error || {}} /> : <div>{errorMessage}</div>;
-    return (error
-      ? fallbackElement
-      : children);
+      ? <Fallback error={error || {}} />
+      : <div>{errorMessage}</div>;
+
+    return error ? fallbackElement : children;
   }
 }
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1148,7 +1148,7 @@ public:
     locales: ['ar', 'ca', 'cs', 'da', 'de', 'en', 'es', 'fa', 'fi', 'fr', 'gl', 'he', 'hi-in', 'hu', 'it', 'ja', 'ko-kr', 'ku', 'main', 'my', 'ne', 'no', 'pl', 'pt-br', 'pt-pt', 'ro', 'ru', 'sv', 'te', 'th', 'tr', 'uk', 'vi', 'zh-cn', 'zh-tw']
   clientLog:
     console:
-      enableRuntimeErrorLogging: true
+      enableRuntimeErrorLogging: false
       enabled: true
       level: debug
     external:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1148,6 +1148,7 @@ public:
     locales: ['ar', 'ca', 'cs', 'da', 'de', 'en', 'es', 'fa', 'fi', 'fr', 'gl', 'he', 'hi-in', 'hu', 'it', 'ja', 'ko-kr', 'ku', 'main', 'my', 'ne', 'no', 'pl', 'pt-br', 'pt-pt', 'ro', 'ru', 'sv', 'te', 'th', 'tr', 'uk', 'vi', 'zh-cn', 'zh-tw']
   clientLog:
     console:
+      enableRuntimeErrorLogging: true
       enabled: true
       level: debug
     external:

--- a/docs/docs/administration/configuration-files.md
+++ b/docs/docs/administration/configuration-files.md
@@ -105,12 +105,18 @@ The client logger accepts two targets for the logs: `console` and `external`.
 | level  | "info"        | "debug", "info", "warn", "error" | The lowest log level that will be sent. Any log level higher than this will also be sent to the target. |
 | url    | -             | -                                | The end point where logs will be sent to when the target is set to "external".                          |
 | method | -             | "POST", "PUT"                    | HTTP method being used when using the target "external".                                                |
+| enableRuntimeErrorLogging | false | true / false          | When true, the client installs global listeners to capture runtime errors, unhandled rejections, and resource load failures. |
 
 The default values are:
 
 ```yaml
 clientLog:
-  console: { enabled: true, level: debug }
+  console:
+    {
+      enabled: true,
+      level: debug,
+      enableRuntimeErrorLogging: false,
+    }
   external:
     {
       enabled: false,


### PR DESCRIPTION
### What does this PR do?
This PR adds global error logging to the `ErrorBoundary` component. It implements error listeners for runtime JavaScript errors, resource load errors, and unhandled promise rejections. A new setting, `enableRuntimeErrorLogging`, allows enabling or disabling this error logging functionality.

:




### Closes Issue(s)
N/A

### How to test
Some triggers 

Resource failed to load: 
```
const s = document.createElement('script');
s.src = '/404-does-not-exist.js';
document.head.appendChild(s);
```
const promise = new Promise((_, reject) => reject(new Error('Unhandled rejection error')));


unhandled rejection

```
const promise = new Promise((_, reject) => reject(new Error('Unhandled rejection error')));

```

Error on render
```
const ErrorComponent = () => {
  throw new Error('This is a test runtime error');
};
```

runtime error
```
setTimeout(() => { throw new Error("test: runtime error"); }, 0);
```

