### PR TITLE
fix: skip invalid quick polls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -379,6 +379,17 @@ const QuickPollDropdown = (props) => {
         return c;
       }).join('/');
 
+      // if the poll is letter and it does not start with A then we skip it
+      // same if it does follow the order (if it starts with A it has to be followed by B, C, D...)
+      if (type.startsWith(_pollTypes.Letter)) {
+        if (!itemLabel.startsWith('A')) return null;
+
+        const letters = itemLabel.split('/');
+        for (let i = 0; i < letters.length; i += 1) {
+          if (letters[i] !== numChars[i + 1]) return null;
+        }
+      }
+
       return (
         <Dropdown.DropdownListItem
           label={itemLabel}
@@ -404,7 +415,7 @@ const QuickPollDropdown = (props) => {
           multiResp={pollData?.multiResp}
         />
       );
-    });
+    }).filter(Boolean);
 
     const sizes = [];
     return pollItemElements.filter((el) => {
@@ -419,7 +430,7 @@ const QuickPollDropdown = (props) => {
     slideId, quickPollOptions, startPoll, pollTypes, layoutContextDispatch,
   );
 
-  if (quickPollOptions.length === 0) return <Styled.QuickPollButtonPlaceholder aria-hidden />;
+  if (quickPolls.length === 0) return <Styled.QuickPollButtonPlaceholder aria-hidden />;
 
   let answers = null;
   let quickPollLabel = '';


### PR DESCRIPTION
### What does this PR do?

Adjusts quick poll component so invalid polls are not displayed

### How to test
try different presentations with quick polls

---

example of a file with text that should not trigger a quick poll: [example.txt](https://github.com/user-attachments/files/22012490/example.txt)
