### PR TITLE
fix(chat): ensure message sender is always displayed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -558,12 +558,10 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
       || lastSenderPreviousPage) === message?.user?.userId) && pluginMessageNotCustom;
 
   const shouldRenderAvatar = messageContent.showAvatar
-    && !sameSender
-    && !isCustomPluginMessage;
+    && !sameSender;
 
   const shouldRenderHeader = messageContent.showHeading
-    && !sameSender
-    && !isCustomPluginMessage;
+    && !sameSender;
 
   const deactivateFocusTrap = useCallback(() => {
     setKeyboardFocused(false);
@@ -682,7 +680,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
       className="chat-message-content"
       ref={messageContentRef}
       sameSender={message?.user ? sameSender : false}
-      isCustomPluginMessage={isCustomPluginMessage}
       $isSystemSender={messageContent.isSystemSender}
       data-chat-message-id={message?.messageId}
       $highlight={hasToolbar && messageContent.showToolbar && !deleteTime}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -38,7 +38,6 @@ interface ChatWrapperProps {
 
 interface ChatContentProps {
   sameSender: boolean;
-  isCustomPluginMessage: boolean;
   $isSystemSender: boolean;
   $editing: boolean;
   $highlight: boolean;


### PR DESCRIPTION
### What does this PR do?
Messages sent by plugins may include a `custom` attribute meant to render a raw message without name or avatar, leaving room for the plugin to style it afterwards.

However, since plugin messages are triggered by custom window events, anyone aware of the event format could forge such events and inject chat messages with arbitrary data. In the UI, these messages would not display the sender’s name or avatar, making the source unidentifiable to moderators during a conference.

This commit enforces that messages with the `custom` attribute also render the sender’s name and avatar. With this change, the purpose of the `custom` attribute becomes outdated, and we may revisit whether to maintain it or introduce more subtle ways of identifying the sender, such as on hover.


Closely related to [bigbluebutton/bigbluebutton-plugin-questions#41](https://github.com/bigbluebutton/bigbluebutton-plugin-questions/pull/41)