### PR TITLE
Add tests for "Leave meeting" Functionality 

### DIFF
--- a/bigbluebutton-tests/playwright/user/multiusers.js
+++ b/bigbluebutton-tests/playwright/user/multiusers.js
@@ -407,6 +407,37 @@ class MultiUsers {
     await this.modPage2.hasText(e.moderatorAvatar, 'mo', 'should not display the emoji after clearing all icons');
   }
 
+  async leaveMeeting() {
+    await this.modPage.waitForSelector(e.whiteboard);
+
+    const modPageUserList = await this.modPage.getLocator(e.userListItem);
+
+    await expect(modPageUserList).toHaveCount(2);
+    await this.modPage.hasElementCount(e.userListItem, 2, 'should display the two users on the user list for the moderator, self not included in the count');
+
+    await this.modPage.waitAndClick(e.leaveMeetingDropdown);
+    await this.modPage.waitAndClick(e.directLogoutButton);
+
+    await this.modPage.hasElement(e.meetingEndedModal, 'should display the meeting ended modal for the moderator');
+    await this.modPage.hasElement(e.redirectButton, 'should display the redirect button in the meeting ended modal');
+
+    const user1PageUserList = await this.userPage.getLocator(e.userListItem);
+
+    await expect(user1PageUserList).toHaveCount(1);
+    await this.userPage.hasElementCount(e.userListItem, 1, 'should display the two users on the user list for User1, self not included in the count');
+
+    await this.userPage.waitAndClick(e.leaveMeetingDropdown);
+    await this.userPage.waitAndClick(e.directLogoutButton);
+
+    await this.userPage.hasElement(e.meetingEndedModal, 'should display the meeting ended modal for the attendee');
+    await this.userPage.hasElement(e.redirectButton, 'should display the redirect button in the meeting ended modal');
+
+    const user2PageUserList = await this.userPage2.getLocator(e.userListItem);
+
+    await expect(user2PageUserList).toHaveCount(0);
+    await this.userPage2.hasElementCount(e.userListItem, 0, 'should display one user(self) for the User2, self not included in the count');
+  }
+
   async endMeeting() {
     await this.modPage.waitForSelector(e.whiteboard);
     await this.userPage.waitForSelector(e.whiteboard);

--- a/bigbluebutton-tests/playwright/user/user.spec.js
+++ b/bigbluebutton-tests/playwright/user/user.spec.js
@@ -39,6 +39,14 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await timer.initModPage(page, true);
       await timer.timerTest();
     });
+
+    test('Leave Meeting', async ({ browser, context, page }) => {
+      const multiusers = new MultiUsers(browser, context);
+      await multiusers.initModPage(page, true);
+      await multiusers.initUserPage(true, context);
+      await multiusers.initUserPage2(true, context);
+      await multiusers.leaveMeeting();
+    });
   });
 
   test.describe.parallel('Reactions', () => {


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new test for the "leave meeting" functionality in BigBlueButton.


#### Changes
Added a test to cover user leave meeting behavior.

#### Test steps:
- **Moderator** and **2 Attendees** sessions are initialized.
- The **Moderator** leaves the meeting.
- The **Attendee1** leaves the meeting.
- **Attendee2** checks if **Moderator** and **Attendee1** left the meeting by checking the users list
- The test checks that the **Moderator**  and **Attendee1** left the meeting and the UI shows the meeting ended modal for both users. 

#### Video examples of the test running

[moderator.webm](https://github.com/user-attachments/assets/9db8dfc3-225c-4b1f-8310-ec0dd98c98aa)


[attendee1.webm](https://github.com/user-attachments/assets/f16783bf-6850-4b6e-b283-595445426706)


[attendee2.webm](https://github.com/user-attachments/assets/119652fa-dc39-4aec-8407-a25799b2b004)


### Motivation
Automating the "Leave meeting" scenario helps guarantee that this workflow operates as expected.

### How to test
1. run playwright user tests with: 
`npm run test user` or `npx playwright test user`
you can also run the specific test using the command: 
`npm run test:filter "Leave Meeting"`
2. Confirm that the end meeting test passes and UI behaves as expected.


