### PR TITLE
[3.0] fix: inconsistent hook component remounting due to count-based keys

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-query/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-query/types.ts
@@ -2,6 +2,7 @@ import {
   CustomQueryArguments,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/domain/shared/custom-query/types';
 import React from 'react';
+import { EssentialHookInformation } from '../types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface QueryHookWithArgumentsContainerProps {
@@ -10,13 +11,12 @@ export interface QueryHookWithArgumentsContainerProps {
   resolveQuery: () => void;
 }
 
-export interface ObjectToCustomQueryHookContainerMap {
-  count: number;
+export interface ObjectToCustomQueryHookContainerMap extends EssentialHookInformation {
   hookArguments: CustomQueryArguments;
 }
 
 export interface QueryHookWithArgumentContainerToRender {
   componentToRender: React.FunctionComponent<QueryHookWithArgumentsContainerProps>;
   hookArguments: CustomQueryArguments;
-  numberOfUses: number;
+  version: number;
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/types.ts
@@ -2,6 +2,7 @@ import {
   CustomSubscriptionArguments,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-consumption/domain/shared/custom-subscription/types';
 import React from 'react';
+import { EssentialHookInformation } from '../types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface SubscriptionHookWithArgumentsContainerProps {
@@ -9,8 +10,7 @@ export interface SubscriptionHookWithArgumentsContainerProps {
   hookArguments: CustomSubscriptionArguments;
 }
 
-export interface ObjectToCustomSubscriptionHookContainerMap {
-  count: number;
+export interface ObjectToCustomSubscriptionHookContainerMap extends EssentialHookInformation {
   hookArguments: CustomSubscriptionArguments;
 }
 
@@ -18,4 +18,5 @@ export interface SubscriptionHookWithArgumentContainerToRender {
   componentToRender: React.FunctionComponent<SubscriptionHookWithArgumentsContainerProps>;
   hookArguments: CustomSubscriptionArguments;
   numberOfUses: number;
+  version: number;
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/types.ts
@@ -1,0 +1,4 @@
+export interface EssentialHookInformation {
+  version: number;
+  count: number;
+}

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/utils.ts
@@ -9,6 +9,7 @@ import {
 import { ObjectToCustomSubscriptionHookContainerMap } from './domain/shared/custom-subscription/types';
 import { ObjectToCustomQueryHookContainerMap } from './domain/shared/custom-query/types';
 import { ObjectToCustomHookContainerMap } from './types';
+import { EssentialHookInformation } from './domain/shared/types';
 
 const hookUsageSetStateCallback = (
   removeEntry: boolean, mapObj: Map<string, Map<string, ObjectToCustomHookContainerMap>>,
@@ -23,6 +24,7 @@ const hookUsageSetStateCallback = (
     } else {
       mapToBeSet.set(hookArgumentsAsKey, {
         count: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.count || 0) + delta,
+        version: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.version || 0) + 1,
         hookArguments,
       });
     }
@@ -35,7 +37,7 @@ const hookUsageSetStateCallback = (
 };
 
 const updateHookUsage = (
-  setHookUtilizationCount: React.Dispatch<React.SetStateAction<Map<string, number>>>,
+  setHookUtilizationCount: React.Dispatch<React.SetStateAction<Map<string, EssentialHookInformation>>>,
   setSubscriptionHookWithArgumentUtilizationCount: React.Dispatch<
     React.SetStateAction<Map<string, Map<string, ObjectToCustomSubscriptionHookContainerMap>>>>,
   setQueryHookWithArgumentUtilizationCount: React.Dispatch<
@@ -45,8 +47,11 @@ const updateHookUsage = (
   if (hookName !== DataConsumptionHooks.CUSTOM_SUBSCRIPTION
     && hookName !== DataConsumptionHooks.CUSTOM_QUERY) {
     setHookUtilizationCount((mapObj) => {
-      const newMap = new Map<string, number>(mapObj.entries());
-      newMap.set(hookName, (mapObj.get(hookName) || 0) + delta);
+      const newMap = new Map<string, EssentialHookInformation>(mapObj.entries());
+      newMap.set(hookName, {
+        count: (mapObj.get(hookName)?.count || 0) + delta,
+        version: (mapObj.get(hookName)?.version || 0) + 1,
+      });
       return newMap;
     });
   } else if (hookName === DataConsumptionHooks.CUSTOM_QUERY) {


### PR DESCRIPTION
### What does this PR do?
In scenarios with sequential subscribe/unsubscribe events, the subscription count may revert to the same value, causing the React component key to remain unchanged and preventing remounting, which leads to stale data and rendering inconsistencies in hook components and by consequence in the hooks data provided to plugins. So this commit fixes this by:
- Adding a 'version' field to data consumption hooks
- Incrementing version on each subscribe/unsubscribe event, independent of count
- Updating component keys to include version, forcing remounting when needed

### Closes Issue(s)
Closes #23814 