### PR TITLE
Fix(html5): fix video stuttering on vimeo

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -503,7 +503,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (playing && isPresenter) {
       currentTime = getServerCurrentTime();
     }
-    const interPlayerPlaybackRate = getPlaybackRate(playerRef.current as ReactPlayer);
+    const interPlayerPlaybackRate = await getPlaybackRate(playerRef.current as ReactPlayer);
     if (isPresenter && interPlayerPlaybackRate !== playerPlaybackRate) {
       sendMessage('seek', {
         rate: interPlayerPlaybackRate,

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -424,7 +424,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (isPresenter && !playing) {
       const rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
-        : internalPlayer?.getPlaybackRate?.() ?? 1;
+        : await internalPlayer?.getPlaybackRate?.() ?? 1;
 
       sendMessage('start', {
         rate,
@@ -446,7 +446,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (isPresenter && !playing) {
       const rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
-        : internalPlayer?.getPlaybackRate?.() ?? 1;
+        : await internalPlayer?.getPlaybackRate?.() ?? 1;
 
       const currentTime = getServerCurrentTime();
 
@@ -479,7 +479,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       const internalPlayer = playerRef.current?.getInternalPlayer();
       let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
-        : internalPlayer?.getPlaybackRate?.() ?? 1;
+        : await internalPlayer?.getPlaybackRate?.() ?? 1;
 
       if (rate instanceof Promise) {
         rate = await rate;
@@ -526,7 +526,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       const internalPlayer = playerRef.current?.getInternalPlayer();
       let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
         ? internalPlayer.playbackRate
-        : internalPlayer?.getPlaybackRate?.() ?? 1;
+        : await internalPlayer?.getPlaybackRate?.() ?? 1;
       if (rate instanceof Promise) {
         rate = await rate;
       }


### PR DESCRIPTION
### What does this PR do?
The issue occurred because the playback rate method was returning a Promise instead of a number. As a result, the presenter’s player was repeatedly sending a new video position update with the playback rate every second, instead of only when it changed.

### Closes Issue(s)
Closes #23736

### How to test
- Join a Mod and a viewer
- Share a extenal video from vimeo (https://vimeo.com/1027493928/3cf86de876)
- See both users playing the video synced and audio running smooth 


### More
[Screencast from 02-09-2025 10:28:34.webm](https://github.com/user-attachments/assets/7452c25c-ac29-417f-a249-72a0651ea054)

