### PR TITLE
fix(virtual-bg): virtual backgrounds not appearing in dark mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -34,7 +34,6 @@ const DtfInvert = `
     --darkreader-text--color-primary: ${colorPrimaryDarkTheme} !important;
     --darkreader-bg--item-focus-border: ${colorPrimaryDarkTheme} !important;
   }
-  }
   body {
     background-color: var(--darkreader-bg-neutral-background) !important;
   }
@@ -108,6 +107,17 @@ const DtfInvert = `
       color: var(--darkreader-text--btn-default-color) !important;
     }
   }
+  [data-test="selectDefaultBackground"],
+  [data-test="selectCustomBackground"] {
+    background-image: var(--original-background-image) !important;
+  }
+  [data-test="selectDefaultBackground"][style*="background-image"],
+  [data-test="selectCustomBackground"][style*="background-image"] {
+    background-image: inherit !important;
+  }
+  button[data-test*="Background"][style*="background-image"] {
+    background-image: var(--original-background-image, inherit) !important;
+  }
 `;
 
 const DtfBrandingInvert = `
@@ -134,11 +144,19 @@ const DtfCss = `
   .tl-note__container,
   .tl-text.tl-text-content,
   .tl-arrow-label,
-  .tl-arrow-label__inner
+  .tl-arrow-label__inner,
+  [data-test="selectDefaultBackground"],
+  [data-test="selectCustomBackground"],
+  [data-test="noneBackgroundButton"],
+  [data-test="inputBackgroundButton"]
 `;
 
 const DtfImages = `
-  svg
+  svg,
+  [data-test="selectDefaultBackground"],
+  [data-test="selectCustomBackground"],
+  [data-test="noneBackgroundButton"],
+  [data-test="inputBackgroundButton"]
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/virtual-background/component.jsx
@@ -286,11 +286,11 @@ const VirtualBgSelector = ({
           disabled={disabled}
           ref={(ref) => { inputElementsRef.current[index] = ref; }}
           onClick={() => _virtualBgSelected(EFFECT_TYPES.BLUR_TYPE, 'Blur', index)}
+          style={{ '--original-background-image': `url(${getVirtualBackgroundThumbnail(BLUR_FILENAME)})` }}
         />
         <div aria-hidden className="sr-only" id="vr-cam-btn-blur">
-          {intl.formatMessage(
-            intlMessages.camBgAriaDesc, { backgroundName: EFFECT_TYPES.BLUR_TYPE },
-          )}
+          {intl.formatMessage(intlMessages.camBgAriaDesc,
+            { backgroundName: EFFECT_TYPES.BLUR_TYPE })}
         </div>
       </Styled.ThumbnailButtonWrapper>
     );
@@ -319,6 +319,7 @@ const VirtualBgSelector = ({
             disabled={disabled}
             background={getVirtualBackgroundThumbnail(imageName)}
             data-test="selectDefaultBackground"
+            style={{ '--original-background-image': `url(${getVirtualBackgroundThumbnail(imageName)})` }}
           />
           <div aria-hidden className="sr-only" id={`vr-cam-btn-${index + 1}`}>
             {intl.formatMessage(intlMessages.camBgAriaDesc, { backgroundName: label })}
@@ -356,6 +357,7 @@ const VirtualBgSelector = ({
             disabled={disabled}
             background={data}
             data-test="selectCustomBackground"
+            style={{ '--original-background-image': `url(${data})` }}
           />
           <Styled.ButtonWrapper>
             <Styled.ButtonRemove
@@ -429,9 +431,8 @@ const VirtualBgSelector = ({
           data-test="noneBackgroundButton"
         />
         <div aria-hidden className="sr-only" id="vr-cam-btn-none">
-          {intl.formatMessage(
-            intlMessages.camBgAriaDesc, { backgroundName: EFFECT_TYPES.NONE_TYPE },
-          )}
+          {intl.formatMessage(intlMessages.camBgAriaDesc,
+            { backgroundName: EFFECT_TYPES.NONE_TYPE })}
         </div>
       </>
     );


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
This PR fixes virtual background thumbnails not displaying correctly in Dark Mode by preventing DarkReader interference. It adds CSS custom properties to preserve original image URLs and configures DarkReader to ignore virtual background buttons, ensuring thumbnails remain visible when Dark Mode is active.



### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Join a BigBlueButton meeting
Enable Dark Mode in BBB settings
Open camera settings and enable virtual backgrounds
Verify thumbnails display correctly (make sure the images are in the correct directories)
Check browser DevTools styles for any DarkReader-related changes
Test with DarkReader extension enabled/disabled to ensure compatibility

Expected Behavior
- Virtual background thumbnails load properly in Dark Mode
- No broken/invisible images
- DarkReader compatibility maintained
- Light mode functionality unchanged



