### PR TITLE
fix: wrong zoom position on slide change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1648,11 +1648,8 @@ const Whiteboard = React.memo((props) => {
       const centeredCameraY = -slideShape.y
         + (viewportHeight - slideShape.props.h * zoomCamera) / (2 * zoomCamera);
 
-      // use stored values if slide has just changed and zoom/offset is not default
-      const hasOffset = currentPresentationPageRef.current.xOffset !== 0
-        || currentPresentationPageRef.current.yOffset !== 0;
-
-      if(camera.x === 0 && camera.y === 0 && zoomValueRef.current !== HUNDRED_PERCENT && hasOffset) {
+      // use stored values if slide has just changed and zoom is not default
+      if(camera.x === 0 && camera.y === 0 && zoomValueRef.current !== HUNDRED_PERCENT) {
         newCamera = {
           x: currentPresentationPageRef.current.xOffset,
           y: currentPresentationPageRef.current.yOffset,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1648,11 +1648,23 @@ const Whiteboard = React.memo((props) => {
       const centeredCameraY = -slideShape.y
         + (viewportHeight - slideShape.props.h * zoomCamera) / (2 * zoomCamera);
 
-      newCamera = {
-        x: centeredCameraX + panningOffsetX,
-        y: centeredCameraY + panningOffsetY,
-        z: zoomCamera,
-      };
+      // use stored values if slide has just changed and zoom/offset is not default
+      const hasOffset = currentPresentationPageRef.current.xOffset !== 0
+        || currentPresentationPageRef.current.yOffset !== 0;
+
+      if(camera.x === 0 && camera.y === 0 && zoomValueRef.current !== HUNDRED_PERCENT && hasOffset) {
+        newCamera = {
+          x: currentPresentationPageRef.current.xOffset,
+          y: currentPresentationPageRef.current.yOffset,
+          z: zoomCamera,
+        };
+      } else {
+        newCamera = {
+          x: centeredCameraX + panningOffsetX,
+          y: centeredCameraY + panningOffsetY,
+          z: zoomCamera,
+        };
+      }
     } else {
       newCamera = {
         x: camera.x + ((viewportWidth / 2) / camera.z - (viewportWidth / 2) / zoomCamera),

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -61,7 +61,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.hidePresentationToolbar();
   });
 
-  test('Zoom In, Zoom Out, Reset Zoom', async ({ browser, context, page }) => {
+  test('Zoom In, Zoom Out, Reset Zoom', { tag: '@flaky' }, async ({ browser, context, page }) => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page);
     await presentation.zoom();


### PR DESCRIPTION
### What does this PR do?

Adjusts zoom position when a presenter switches between two zoomed slide pages

### Closes Issue(s)
Closes #23810

### How to test
1. join a meeting
2. zoom slide 1 using the mouse
3. go to slide 2 and zoom to a different position using the mouse
4. go back to slide 1
5. check if the zoom position is the same as before

### More
It is worth noting that this fix changes the behavior of the zoom when using the presenter toolbar: now the zoom will start from top left corner (position 0,0) instead of the center of the slide. Does not affect zoom when using mouse scroll