### PR TITLE
fix: Dark mode chat message cursor

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -62,7 +62,7 @@ const DtfInvert = `
   .tl-note__scrim,.tl-arrow-label[data-isediting="true"] > .tl-arrow-label__inner {
     background-color: unset !important;
   }
-  textarea {
+  .tl-container textarea {
     caret-color: black !important;
   }
 `;


### PR DESCRIPTION
### What does this PR do?

Adjusts textarea css selector to only target whiteboard text tool

### Closes Issue(s)
Closes #23835

### How to test
1. Activate dark mode in BBB
2. Click in the "Message Public Chat" box to write a chat message
3. Check chat message input cursor blinking