### PR TITLE
feat(html5): Add ui-command for hiding dialogs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/base/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/base/component.jsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
+import { setHideDialogs } from '/imports/ui/components/plugins-engine/ui-commands/dialogs/handler';
+import { useReactiveVar } from '@apollo/client';
 import Styled from './styles';
 
 const BaseModal = (props) => {
@@ -32,6 +34,10 @@ const BaseModal = (props) => {
     };
   }, []);
   const priorityValue = priority || 'low';
+
+  const shouldHideDialogs = useReactiveVar(setHideDialogs);
+
+  if (shouldHideDialogs) return null;
 
   return (
     <Styled.BaseModal

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/dialogs/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/dialogs/handler.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { makeVar } from '@apollo/client';
+import { DialogsEnum } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/dialogs/enums';
+import { SetHideDialogsCommandArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/dialogs/types';
+
+const setHideDialogs = makeVar<boolean>(false);
+
+const PluginDialogsUiCommandsHandler = () => {
+  const handleSetHideDialogs = (event: CustomEvent<SetHideDialogsCommandArguments>) => {
+    const { hidden } = event.detail;
+    setHideDialogs(hidden);
+  };
+
+  useEffect(() => {
+    window.addEventListener(
+      DialogsEnum.SET_HIDE_DIALOGS,
+      handleSetHideDialogs as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        DialogsEnum.SET_HIDE_DIALOGS,
+        handleSetHideDialogs as EventListener,
+      );
+    };
+  }, []);
+  return null;
+};
+
+export { PluginDialogsUiCommandsHandler, setHideDialogs };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -9,6 +9,7 @@ import { PluginLayoutUiCommandsHandler } from './layout/handler';
 import PluginNavBarUiCommandsHandler from './nav-bar/handler';
 import PluginActionsBarUiCommandsHandler from './actions-bar/handler';
 import PluginCameraUiCommandsHandler from './camera/handler';
+import { PluginDialogsUiCommandsHandler } from './dialogs/handler';
 
 const PluginUiCommandsHandler = () => (
   <>
@@ -22,6 +23,7 @@ const PluginUiCommandsHandler = () => (
     <PluginUserStatusUiCommandsHandler />
     <PluginConferenceUiCommandsHandler />
     <PluginNotificationUiCommandsHandler />
+    <PluginDialogsUiCommandsHandler />
   </>
 );
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

<!-- A brief description of each change being made with this pull request. -->

- Adds a new UI command for not rendering core modals.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none


### Motivation

Hiding the core dialogs will allow us to keep keyboard/mouse focus within plugin modals.

### More

Closely related to https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/229.