### PR TITLE
fix (gql-server): Only moderators should see the current breakout room of users (in the userlist)

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_breakoutRoom.yaml
@@ -31,6 +31,6 @@ select_permissions:
       filter:
         _and:
           - meetingId:
-              _eq: X-Hasura-MeetingId
+              _eq: X-Hasura-ModeratorInMeeting
           - userId:
               _eq: X-Hasura-UserId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_breakoutRoom.yaml
@@ -18,7 +18,7 @@ select_permissions:
         - sequence
       filter:
         meetingId:
-          _eq: X-Hasura-MeetingId
+          _eq: X-Hasura-ModeratorInMeeting
   - role: bbb_client_not_in_meeting
     permission:
       columns:


### PR DESCRIPTION
Following the behavior of BBB 2.7, only moderators should be able to see in which breakout room the users joined (in the userlist).

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>

<img width="484" height="601" alt="image" src="https://github.com/user-attachments/assets/ea3d2327-1e11-4ee8-9a79-f444e26480eb" />

</td>
<td>

<img width="525" height="714" alt="image" src="https://github.com/user-attachments/assets/777c45e4-1830-4548-b556-76d5549e23fe" />


</td>
</tr>
</table>

----

Previously it used to show the LAST breakout room of each user. this information is available in Graphql.
But for some reason the client opts to not show the last, but only while the user is in the room.
If necessary it's easy to show the last (and maybe write online/offline as complement to make it clear that it is the last room instead of the current room)

