### PR TITLE
build(bbb-webrtc-sfu): v2.19.1

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.19.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.19.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

#### v2.19.1

* fix(livekit): forcefully unpublish screenshare when server ejects it
* fix(screenshare): ignore eject requests in mediasoup module if using LiveKit
* fix(livekit): discard camera/screen events if meeting is not using LiveKit


### Closes Issue(s)

None