### PR TITLE
Fix: console warnings in the client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -20,8 +20,6 @@ import {
   useIsEditChatMessageEnabled, useIsEmojiPickerEnabled,
 } from '/imports/ui/services/features';
 import { checkText } from 'smile2emoji';
-import { findDOMNode } from 'react-dom';
-
 import Styled from './styles';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { getAllShortCodes } from '/imports/utils/emoji-utils';
@@ -140,7 +138,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const [message, setMessage] = React.useState('');
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false);
   const emojiPickerRef = useRef<HTMLDivElement>(null);
-  const emojiPickerButtonRef = useRef(null);
+  const emojiPickerButtonRef = useRef<HTMLDivElement>(null);
   const [isTextAreaFocused, setIsTextAreaFocused] = React.useState(false);
   const [repliedMessageId, setRepliedMessageId] = React.useState<string | null>(null);
   const [emojisToExclude, setEmojisToExclude] = React.useState<string[]>([]);
@@ -604,8 +602,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
 
     useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {
-        // eslint-disable-next-line react/no-find-dom-node
-        const button = findDOMNode(emojiPickerButtonRef.current);
+        const button = emojiPickerButtonRef.current;
         if (
           (emojiPickerRef.current && !emojiPickerRef.current.contains(event.target as Node))
           && (button && !button.contains(event.target as Node))
@@ -671,19 +668,20 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
               async
             />
             {ENABLE_EMOJI_PICKER ? (
-              <Styled.EmojiButton
-                ref={emojiPickerButtonRef}
-                onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-                icon="happy"
-                color="light"
-                ghost
-                type="button"
-                circle
-                hideLabel
-                label={intl.formatMessage(messages.emojiButtonLabel)}
-                data-test="emojiPickerButton"
-                disabled={disabled || partnerIsLoggedOut || chatSendMessageLoading}
-              />
+              <div ref={emojiPickerButtonRef}>
+                <Styled.EmojiButton
+                  onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+                  icon="happy"
+                  color="light"
+                  ghost
+                  type="button"
+                  circle
+                  hideLabel
+                  label={intl.formatMessage(messages.emojiButtonLabel)}
+                  data-test="emojiPickerButton"
+                  disabled={disabled || partnerIsLoggedOut || chatSendMessageLoading}
+                />
+              </div>
             ) : null}
           </Styled.InputWrapper>
           <div style={{ zIndex: 10 }}>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -626,7 +626,7 @@ WhiteboardContainer.propTypes = {
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
   zoomChanger: PropTypes.func.isRequired,
-  fitToWidth: PropTypes.func.isRequired,
+  fitToWidth: PropTypes.bool.isRequired,
 };
 
 export default WhiteboardContainer;


### PR DESCRIPTION
### What does this PR do?

fix warnings displayed in browser console when the client loads

incorrect propType for fitToWidth prop:
<img width="470" height="68" alt="Screenshot from 2025-09-08 15-02-13" src="https://github.com/user-attachments/assets/8ad9d024-edfe-414a-939a-01aa3744e7bb" />

remove deprecated findDOMNode from emoji picker:
<img width="476" height="72" alt="Screenshot from 2025-09-08 16-37-46" src="https://github.com/user-attachments/assets/55a7af18-2105-4cb1-bb26-2bd8a34788ab" />
