### PR TITLE
fix(html5): Typed responses are cut off in the poll results

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -6,6 +6,8 @@ import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
 import CustomizedAxisTick from '/imports/ui/components/poll/components/CustomizedAxisTick';
+import { layoutSelectOutput, layoutSelect } from '/imports/ui/components/layout/context';
+import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 
 interface ChatPollContentProps {
   metadata: string;
@@ -93,6 +95,8 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
   height = undefined,
 }) => {
   const intl = useIntl();
+  const sidebarContent: Output['sidebarContent'] = layoutSelectOutput((i: Output) => i.sidebarContent);
+  const fontSize: Layout['fontSize'] = layoutSelect((i: Layout) => i.fontSize);
 
   const pollData = JSON.parse(string) as unknown;
   assertAsMetadata(pollData);
@@ -126,7 +130,7 @@ const ChatPollContent: React.FC<ChatPollContentProps> = ({
               type="number"
               allowDecimals={false}
             />
-            <YAxis width={100} type="category" dataKey="pollAnswerWithNumVotes" tick={<CustomizedAxisTick />} />
+            <YAxis width={sidebarContent.width / 3} fontSize={fontSize} type="category" dataKey="pollAnswerWithNumVotes" tick={CustomizedAxisTick} />
             <Bar dataKey="numVotes" fill="#0C57A7" />
           </BarChart>
         </ResponsiveContainer>

--- a/bigbluebutton-html5/imports/ui/components/poll/components/CustomizedAxisTick.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/CustomizedAxisTick.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-function getAverageCharacterWidth(text: string, font: string) {
+function getAverageCharacterWidth(text: string, font: string, fontSize: number) {
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
 
   if (!ctx) return null;
 
-  ctx.font = font;
+  ctx.font = `normal ${fontSize}px ${font}`;
 
   const textWidth = ctx.measureText(text).width;
   const averageAdvance = textWidth / text.length;
@@ -15,14 +15,14 @@ function getAverageCharacterWidth(text: string, font: string) {
 }
 
 const TICK_SIZE = 6;
-const AVERAGE_CHAR_WIDTH = getAverageCharacterWidth('0', 'Source Sans Pro') ?? 6;
 const ELLIPSIS = '...';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const CustomizedAxisTick = (props: any) => {
   const { payload, ...restProps } = props;
-  const { width } = restProps;
-  const numberOfChars = Math.floor((width - TICK_SIZE) / AVERAGE_CHAR_WIDTH);
+  const { width, fontSize } = restProps;
+  const averageCharWidth = getAverageCharacterWidth(payload.value, 'Source Sans Pro', fontSize) ?? 6;
+  const numberOfChars = Math.floor((width - TICK_SIZE) / averageCharWidth);
   const restValue = payload.value.substring(numberOfChars, payload.value.length);
 
   return (


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Makes it possible to resize the sidebar content panel to see larger texts of poll responses.

[Screencast from 2025-09-09 09-33-37.webm](https://github.com/user-attachments/assets/b77274a5-9402-48f3-a5ff-ed52f5f000aa)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23830
