### PR TITLE
fix: hardcoded default camera position

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Layouts.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Layouts.scala
@@ -82,7 +82,7 @@ class Layouts {
   private var pushLayout: Boolean = false;
   private var presentationIsOpen: Boolean = true;
   private var isResizing: Boolean = false;
-  private var cameraPosition: String = "contentTop";
+  private var cameraPosition: String = "";
   private var focusedCamera: String = "none";
   private var presentationVideoRate: Double = 0;
   private var screenshareAsContent: Boolean = false;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -165,7 +165,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
-                position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
+                position: cameraDock.position || DEFAULT_VALUES.cameraPosition,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {
@@ -224,7 +224,7 @@ const CustomLayout = (props) => {
                 },
               },
               cameraDock: {
-                position: cameraDock.position || CAMERADOCK_POSITION.CONTENT_TOP,
+                position: cameraDock.position || DEFAULT_VALUES.cameraPosition,
                 numCameras: cameraDock.numCameras,
               },
               externalVideo: {

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -33,6 +33,7 @@ import { setEnforcedLayout } from '/imports/ui/components/plugins-engine/ui-comm
 import { useIsChatEnabled } from '/imports/ui/services/features';
 import Auth from '/imports/ui/services/auth';
 import Storage from '/imports/ui/services/storage/session';
+import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 
 const equalDouble = (n1, n2) => {
   const precision = 0.01;
@@ -148,7 +149,7 @@ const PushLayoutEngine = (props) => {
 
         layoutContextDispatch({
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
-          value: meetingLayoutCameraPosition || 'contentTop',
+          value: meetingLayoutCameraPosition || DEFAULT_VALUES.cameraPosition,
         });
         if (shouldOpenChat && !hasLayoutEngineLoadedOnce) {
           layoutContextDispatch({


### PR DESCRIPTION
### What does this PR do?

Fix issue where changing the default camera position doesn't work — it's currently hardcoded, and updating `defaultValues` file in the client code has no effect.

### Motivation
Discovered while testing if #21230 still happens on BBB 3.0 (it does not)

### How to test
1. `bigbluebutton-html5/imports/ui/components/layout/defaultValues.js` Change from cameraPosition: CAMERADOCK_POSITION.CONTENT_TOP, to cameraPosition: CAMERADOCK_POSITION.CONTENT_LEFT,
2. restart BBB
3. join a meeting
4. share webcam