### PR TITLE
fix: filter userlist items by meetingId

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -119,6 +119,7 @@ select_permissions:
         - role
         - speechLocale
         - userId
+        - meetingId
       filter:
         _and:
           - meetingId:

--- a/bigbluebutton-html5/imports/ui/Types/user.ts
+++ b/bigbluebutton-html5/imports/ui/Types/user.ts
@@ -70,6 +70,7 @@ export interface User {
   logoutUrl: string;
   authToken: string;
   userId: string;
+  meetingId: string;
   extId: string;
   name: string;
   nameSortable: string;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
@@ -110,7 +110,10 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
     data: usersData,
     loading: usersLoading,
   } = useLoadedUserList({ offset, limit: limit.current }, (u) => u) as GraphqlDataHookSubscriptionResponse<Array<User>>;
-  const users = usersData ?? [];
+
+  const users = meeting && usersData
+    ? (usersData as User[]).filter((u: User) => u.meetingId === meeting?.meetingId)
+    : [];
 
   const { data: currentUser, loading: currentUserLoading } = useCurrentUser((c: Partial<User>) => ({
     userId: c.userId,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
@@ -15,6 +15,7 @@ import SkeletonUserListItem from '../list-item/skeleton/component';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { LockSettings, Meeting, UsersPolicies } from '/imports/ui/Types/meeting';
+import logger from '/imports/startup/client/logger';
 
 interface UserListParticipantsContainerProps {
   index: number;
@@ -112,7 +113,27 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   } = useLoadedUserList({ offset, limit: limit.current }, (u) => u) as GraphqlDataHookSubscriptionResponse<Array<User>>;
 
   const users = meeting && usersData
-    ? (usersData as User[]).filter((u: User) => u.meetingId === meeting?.meetingId)
+    ? (usersData as User[]).filter((u: User) => {
+      const isInMeeting = u.meetingId === meeting?.meetingId;
+      if (!isInMeeting) {
+        logger.warn({
+          logCode: 'userlist_meetingid_mismatch',
+          extraInfo: {
+            name: u.name,
+            userId: u.userId,
+            meetingId: u.meetingId,
+            bot: u.bot,
+            disconnected: u.disconnected,
+            guest: u.guest,
+            isDialIn: u.isDialIn,
+            isModerator: u.isModerator,
+            loggedOut: u.loggedOut,
+            presenter: u.presenter,
+          },
+        }, 'userlist: meetingId mismatch, filtering out user');
+      }
+      return isInMeeting;
+    })
     : [];
 
   const { data: currentUser, loading: currentUserLoading } = useCurrentUser((c: Partial<User>) => ({

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -23,6 +23,7 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
                 ]) {
     isDialIn
     userId
+    meetingId
     extId
     name
     isModerator


### PR DESCRIPTION
### What does this PR do?

- filter users in the userlist by meetingId, so users with invalid meetingId are not listed
- adds new log (logcode: `userlist_meetingid_mismatch`) with information about filtered out users

### More
log example:
<img width="623" height="280" alt="Screenshot from 2025-09-10 13-11-10" src="https://github.com/user-attachments/assets/ffc21c24-8ab0-43d1-b099-b8abbee83978" />
