### PR TITLE
fix(virtual-backgrounds): restore MIME type for wasm files, configurable willReadFrequently

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
@@ -306,7 +306,10 @@ class VirtualBackgroundService {
         this._segmentationMaskCanvas = document.createElement('canvas');
         this._segmentationMaskCanvas.width = this._options.width;
         this._segmentationMaskCanvas.height = this._options.height;
-        this._segmentationMaskCtx = this._segmentationMaskCanvas.getContext('2d', { willReadFrequently: true });
+
+        const willReadFrequentlySetting = window.meetingClientSettings?.public?.virtualBackgrounds?.willReadFrequently;
+
+        this._segmentationMaskCtx = this._segmentationMaskCanvas.getContext('2d', { willReadFrequently: willReadFrequentlySetting });
 
         this._outputCanvasElement.width = parseInt(width, 10);
         this._outputCanvasElement.height = parseInt(height, 10);

--- a/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
+++ b/bigbluebutton-html5/imports/ui/services/virtual-background/index.js
@@ -306,7 +306,7 @@ class VirtualBackgroundService {
         this._segmentationMaskCanvas = document.createElement('canvas');
         this._segmentationMaskCanvas.width = this._options.width;
         this._segmentationMaskCanvas.height = this._options.height;
-        this._segmentationMaskCtx = this._segmentationMaskCanvas.getContext('2d');
+        this._segmentationMaskCtx = this._segmentationMaskCanvas.getContext('2d', { willReadFrequently: true });
 
         this._outputCanvasElement.width = parseInt(width, 10);
         this._outputCanvasElement.height = parseInt(height, 10);

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1176,6 +1176,9 @@ public:
     showThumbnails: true
     imagesPath: /resources/images/virtual-backgrounds/
     thumbnailsPath: /resources/images/virtual-backgrounds/thumbnails/
+    # willReadFrequently: Defines the optimization hint for the virtual background canvas.
+    # If commented out (default), the browser decides the best strategy.
+    #willReadFrequently: true
     fileNames:
       - home.jpg
       - coffeeshop.jpg

--- a/build/packages-template/bbb-html5/bbb-html5.nginx.static
+++ b/build/packages-template/bbb-html5/bbb-html5.nginx.static
@@ -11,3 +11,11 @@ location /html5client/locales {
   autoindex on;
   autoindex_format json;
 }
+
+location /html5client/wasm {
+    types {
+        application/wasm wasm;
+    }
+    gzip_static on;
+    alias /usr/share/bigbluebutton/html5-client/wasm;
+}


### PR DESCRIPTION
### What does this PR do?
Fixes the following 3 warnings that appear in the console when using virtual backgrounds:

- `Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently'`
- `wasm streaming compile failed: TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'`
- `falling back to ArrayBuffer instantiation`


### Closes Issue(s)
Closes None

