### PR TITLE
fix: whiteboard toolbar fade not working after enabling auto hide

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2111,6 +2111,15 @@ const Whiteboard = React.memo((props) => {
     SessionStorage.setItem('whiteboardToolbarSavedState', getToolbarCurrentState());
   }, [getToolbarCurrentState]);
 
+  React.useEffect(() => {
+    if (!whiteboardToolbarAutoHide) {
+      const optionsDropdown = document.getElementById('WhiteboardOptionButton');
+      if (optionsDropdown?.classList.contains('fade-in')) {
+        optionsDropdown.classList.remove('fade-in');
+      }
+    }
+  }, [whiteboardToolbarAutoHide]);
+
   return (
     <div
       ref={whiteboardRef}


### PR DESCRIPTION
### What does this PR do?

Fix whiteboard toolbar options button incorrect behavior after disabling auto hide setting.

### Closes Issue(s)
Closes #23877

### How to test
1. turn the 'hide whiteboard toolbar' function on from the presentation menu
2. The WB toolbar is hidden. Confirm the WB option button becomes opaque for a better presentation visibility
3. Then turn on the option 'toolbar autohide' from the three-dots button on the upper-right corner
4. Confirm the toolbar and the WB option button is hidden with a nice fade-out animation
5. Turn off the 'toolbar autohide' option
6. Check the button visibility is the same as before turning auto hide setting on