### PR TITLE
perf (gql-server): Optimize the user list subscription by aligning the index with the ORDER BY

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -428,24 +428,24 @@ AS SELECT "user"."userId",
     "user"."captionLocale",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     "user"."hasDrawPermissionOnCurrentPage",
-    CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
+    "user"."isModerator",
     "user"."currentlyInMeeting"
   FROM "user"
   WHERE "user"."currentlyInMeeting" is true;
 
-
 CREATE INDEX "idx_v_user_meetingId_orderByColumns" ON "user"(
-                        "meetingId",
-                        "presenter",
-                        "role",
-                        "raiseHandTime",
-                        "isDialIn",
-                        "hasDrawPermissionOnCurrentPage",
-                        "nameSortable",
-                        "registeredAt",
-                        "userId"
-                        )
-                where "user"."currentlyInMeeting" is true;
+    "meetingId",
+    "presenter" DESC NULLS FIRST,
+    "role" ASC NULLS LAST,
+    "raiseHandTime" ASC NULLS LAST,
+    "isDialIn" DESC NULLS FIRST,
+    "hasDrawPermissionOnCurrentPage" DESC NULLS FIRST,
+    "nameSortable" ASC NULLS LAST,
+    "registeredAt" ASC NULLS LAST,
+    "userId" ASC NULLS LAST
+)
+WHERE "currentlyInMeeting" IS TRUE;
+
 
 CREATE OR REPLACE VIEW "v_user_current"
 AS SELECT "user"."userId",
@@ -493,7 +493,7 @@ AS SELECT "user"."userId",
     "user"."hasDrawPermissionOnCurrentPage",
     "user"."echoTestRunningAt",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
-    CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
+    "user"."isModerator",
     "user"."currentlyInMeeting",
     "user"."inactivityWarningDisplay",
     "user"."inactivityWarningTimeoutSecs"
@@ -555,7 +555,7 @@ AS SELECT
     "user"."speechLocale",
     "user"."captionLocale",
     "user"."hasDrawPermissionOnCurrentPage",
-    CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
+    "user"."isModerator",
     "user"."currentlyInMeeting"
    FROM "user";
 
@@ -565,7 +565,7 @@ AS SELECT
     "user"."meetingId",
     "user"."userId",
     "user"."extId",
-    CASE WHEN "user"."role" = 'MODERATOR' THEN true ELSE false END "isModerator",
+    "user"."isModerator",
     "user"."currentlyInMeeting"
 FROM "user"
 where "firstJoinedAt" is not null;


### PR DESCRIPTION
Optimize the user list query by aligning the index with the `ORDER BY` used by Hasura’s multiplexed subscription.

### Why

The query filters by `meetingId`, only considers users `currentlyInMeeting = TRUE`, and orders by multiple columns with explicit directions / NULLS handling. The old index didn’t match that ordering, so Postgresql had to fetch many rows and perform a top-N sort, inflating latency.

### Change

Replace the partial index:

```sql
-- old
CREATE INDEX idx_v_user_meetingId_orderByColumns ON "user" (
  "meetingId",
  "presenter",
  "role",
  "raiseHandTime",
  "isDialIn",
  "hasDrawPermissionOnCurrentPage",
  "nameSortable",
  "registeredAt",
  "userId"
) WHERE "user"."currentlyInMeeting" IS TRUE;
```

with an index that *exactly* matches the query’s `ORDER BY` (directions + NULLS):

```sql
-- new
CREATE INDEX idx_v_user_meetingId_orderByColumns ON "user" (
  "meetingId",
  "presenter" DESC NULLS FIRST,
  "role" ASC NULLS LAST,
  "raiseHandTime" ASC NULLS LAST,
  "isDialIn" DESC NULLS FIRST,
  "hasDrawPermissionOnCurrentPage" DESC NULLS FIRST,
  "nameSortable" ASC NULLS LAST,
  "registeredAt" ASC NULLS LAST,
  "userId" ASC NULLS LAST
) WHERE "currentlyInMeeting" IS TRUE;
```

### Results (EXPLAIN ANALYZE, same workload)

* **Before (old index):** `Execution Time: 158.679 ms`

  * Plan shows **Bitmap Heap Scan** on `"user"` + **top-N heapsort**.
* **After (new index):** `Execution Time: 28.563 ms`

  * Plan uses **Index Scan** on `idx_v_user_meetingId_orderByColumns` and returns the first 50 rows directly (early stop), eliminating the sort and large heap visits.

Representative plan diffs:

* Old: `Bitmap Heap Scan` → `Sort (top-N heapsort)` → `Limit`
* New: `Index Scan using idx_v_user_meetingId_orderByColumns` → `Limit`

End-to-end for the whole query (6 `__subs` items) dropped from \~**158.7 ms** to \~**28.6 ms** (\~**5.6× faster**).


**Summary:** By making the index match the filter and the exact ordering, Postgres can satisfy `ORDER BY … LIMIT 50` directly from the index, removing sorting and cutting execution time from \~159 ms to \~29 ms on this query.
