### PR TITLE
fix(screenshare): incorrect placeholder locale

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/screenshare/component.jsx
@@ -152,14 +152,13 @@ const ScreenshareButton = ({
     const toastType = getToastType(errorCode);
 
     if (localizedError) {
-      notify(intl.formatMessage(localizedError, { 0: errorCode }), toastType, 'desktop', { ...helpInfo });
+      notify(intl.formatMessage(localizedError, { errorCode }), toastType, 'desktop', { ...helpInfo });
       logger.error({
         logCode: 'screenshare_failed',
         extraInfo: { errorCode, errorMessage },
       }, `Screenshare failed: ${errorMessage} (code=${errorCode})`);
     }
 
-    console.log('opa');
     screenshareHasEnded();
   };
 


### PR DESCRIPTION
### What does this PR do?
Fixes an incorrect placeholder locale for `errorCode`. Additionaly removes a left over `console.log`.


### Closes Issue(s)
Closes none