### PR TITLE
fix (bbb-web): Increase default bbb-web LimitNOFILE to 4096

### DIFF
--- a/build/packages-template/bbb-web/bbb-web.service
+++ b/build/packages-template/bbb-web/bbb-web.service
@@ -19,8 +19,7 @@ RestartSec=60
 SuccessExitStatus=143
 TimeoutStopSec=5
 PermissionsStartOnly=true
-LimitNOFILE=1024
+LimitNOFILE=4096
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target
-


### PR DESCRIPTION
Setting `LimitNOFILE=4096` will be fine for servers meeting BigBlueButton’s minimum requirements, safely handling the necessary file descriptors without issue.

`4096` is also the value used for `akka-apps` (https://github.com/bigbluebutton/bigbluebutton/pull/22633) and others.

Closes: #23896

----

TODO: Check if this Docs sections is still necessary:
https://docs.bigbluebutton.org/support/troubleshooting/#too-many-open-files