### PR TITLE
fix: webcamsOnlyForModerator broken

### DIFF
--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -58,7 +58,6 @@
                 moderatorsCanMuteAudio
                 moderatorsCanUnmuteAudio
                 userCameraCap
-                webcamsOnlyForModerator
               }
               breakoutPolicies {
                 breakoutRooms

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
@@ -38,6 +38,7 @@ const MEETING_SUBSCRIPTION = gql`
         usersPolicies {
           guestPolicy
           guestLobbyMessage
+          webcamsOnlyForModerator
         }
         layout {
           cameraDockAspectRatio


### PR DESCRIPTION
### What does this PR do?

Adjusts meeting subscription so changes to webcamsOnlyForModerator are reflected on client

### Closes Issue(s)
Closes #23901

### How to test
A)

1. Create meeting with minimal API parameters
2. Join with 1 moderator, 2 attendees
3. Have 1 attendee share camera
4. Observe second attendee does see camera
5. Toggle "See other viewers webcams" to OFF and save
6. Open Lock settings again and see setting is still displayed as ON
7. Observe second attendee doesn't see camera anymore
8. Open Lock settings and just hit save
9. Observe second attendee does see camera again

B)

1. Create meeting with webcamsOnlyForModerator=True
2. Repeat steps 2-9 from A), but observe attendees will never see others webcams