### PR TITLE
fix(livekit): audio input switch fails while unmuted (Windows), +

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -110,7 +110,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.info({
       logCode: 'livekit_audio_org_stream_set',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         role: this.role,
         validStream: !!stream,
         streamData,
@@ -170,7 +170,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.debug({
       logCode: 'livekit_audio_subscribed',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         trackSid,
         trackName,
         role: this.role,
@@ -188,7 +188,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.debug({
       logCode: 'livekit_audio_unsubscribed',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         trackSid,
         trackName,
         role: this.role,
@@ -200,7 +200,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.error({
       logCode: 'livekit_audio_subscription_failed',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         trackSid,
         role: this.role,
       },
@@ -218,7 +218,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.debug({
       logCode: 'livekit_audio_subscription_status_changed',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         trackSid,
         trackName,
         role: this.role,
@@ -235,7 +235,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.info({
       logCode: 'livekit_audio_local_track_muted',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         role: this.role,
         trackSid,
         trackName,
@@ -252,7 +252,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.info({
       logCode: 'livekit_audio_local_track_unmuted',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         role: this.role,
         trackSid,
         trackName,
@@ -269,7 +269,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.info({
       logCode: 'livekit_audio_published',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         role: this.role,
         trackSid,
         trackName,
@@ -287,7 +287,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     logger.info({
       logCode: 'livekit_audio_unpublished',
       extraInfo: {
-        bridgeName: this.bridgeName,
+        bridge: this.bridgeName,
         role: this.role,
         trackSid,
         trackName,
@@ -364,7 +364,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
               errorMessage: (error as Error).message,
               errorName: (error as Error).name,
               errorStack: (error as Error).stack,
-              bridgeName: this.bridgeName,
+              bridge: this.bridgeName,
               role: this.role,
               inputDeviceId: this.inputDeviceId,
               streamData: MediaStreamUtils.getMediaStreamLogData(stream),
@@ -407,7 +407,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.warn({
           logCode: 'livekit_audio_switch_pub_stream_missing',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             deviceId,
             streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
@@ -454,7 +454,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           logger.error({
             logCode: 'audio_changeinputdevice_rollback_failure',
             extraInfo: {
-              bridgeName: this.bridgeName,
+              bridge: this.bridgeName,
               deviceId,
               errorName: rollbackError.name,
               errorMessage: rollbackError.message,
@@ -482,7 +482,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           errorMessage: error.message,
           errorName: error.name,
           errorStack: error.stack,
-          bridgeName: this.bridgeName,
+          bridge: this.bridgeName,
           role: this.role,
           enabled: shouldEnable,
           inputDeviceId: this.inputDeviceId,
@@ -502,7 +502,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.debug({
           logCode: 'livekit_audio_track_unmute',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             trackName,
           },
@@ -514,7 +514,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.debug({
           logCode: 'livekit_audio_track_unmute_publish',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             trackName,
           },
@@ -523,7 +523,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.debug({
           logCode: 'livekit_audio_track_unmute_noop',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             trackName,
             trackPubs,
@@ -559,7 +559,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       logger.debug({
         logCode: 'livekit_audio_change_output_device',
         extraInfo: {
-          bridgeName: this.bridgeName,
+          bridge: this.bridgeName,
           role: this.role,
           deviceId,
           activeDevices,
@@ -572,7 +572,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           errorMessage: (error as Error).message,
           errorName: (error as Error).name,
           errorStack: (error as Error).stack,
-          bridgeName: this.bridgeName,
+          bridge: this.bridgeName,
           role: this.role,
           deviceId,
         },
@@ -611,7 +611,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.warn({
           logCode: 'livekit_audio_publish_inactive_stream',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             inputDeviceId: this.inputDeviceId,
             streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
@@ -625,7 +625,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.debug({
           logCode: 'livekit_audio_publish_with_stream',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             inputDeviceId: this.inputDeviceId,
             streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
@@ -646,7 +646,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.debug({
           logCode: 'livekit_audio_publish_without_stream',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             inputDeviceId: this.inputDeviceId,
             streamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
@@ -662,7 +662,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           errorMessage: (error as Error).message,
           errorName: (error as Error).name,
           errorStack: (error as Error).stack,
-          bridgeName: this.bridgeName,
+          bridge: this.bridgeName,
           role: this.role,
           inputDeviceId: this.inputDeviceId,
           streamData: MediaStreamUtils.getMediaStreamLogData(inputStream || this.originalStream),
@@ -693,7 +693,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.debug({
           logCode: 'livekit_audio_unpublish',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
             unpublishedTracks,
           },
@@ -706,7 +706,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
             errorMessage: (error as Error).message,
             errorName: (error as Error).name,
             errorStack: (error as Error).stack,
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
           },
         }, 'LiveKit: failed to unpublish audio track');
@@ -767,7 +767,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           errorMessage: (error as Error).message,
           errorName: (error as Error).name,
           errorStack: (error as Error).stack,
-          bridgeName: this.bridgeName,
+          bridge: this.bridgeName,
           role: this.role,
           inputDeviceId: this.inputDeviceId,
           streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
@@ -807,7 +807,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           errorMessage: (error as Error).message,
           errorName: (error as Error).name,
           errorStack: (error as Error).stack,
-          bridgeName: this.bridgeName,
+          bridge: this.bridgeName,
           role: this.role,
         },
       }, 'LiveKit: update audio constraints failed');
@@ -821,7 +821,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         logger.info({
           logCode: 'livekit_audio_exit',
           extraInfo: {
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
           },
         }, 'LiveKit: audio exited');
@@ -834,7 +834,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
             errorMessage: (error as Error).message,
             errorName: (error as Error).name,
             errorStack: (error as Error).stack,
-            bridgeName: this.bridgeName,
+            bridge: this.bridgeName,
             role: this.role,
           },
         }, 'LiveKit: exit audio failed');

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -166,8 +166,10 @@ class AudioManager {
       logger.warn({
         logCode: 'audiomanager_permission_tracking_failed',
         extraInfo: {
+          bridge: this.bridgeName,
           errorName: error.name,
           errorMessage: error.message,
+          errorStack: error?.stack,
         },
       }, `Failed to track microphone permission status: ${error.message}`);
     };
@@ -180,6 +182,7 @@ class AudioManager {
             logger.debug({
               logCode: 'audiomanager_permission_status_changed',
               extraInfo: {
+                bridge: this.bridgeName,
                 newStatus: status.state,
               },
             }, `Microphone permission status changed: ${status.state}`);
@@ -201,16 +204,16 @@ class AudioManager {
           this.outputDeviceId = cachedId;
         })
         .catch((error) => {
-          logger.warn(
-            {
-              logCode: 'audiomanager_output_device_storage_failed',
-              extraInfo: {
-                deviceId: cachedId,
-                errorMessage: error.message,
-              },
+          logger.warn({
+            logCode: 'audiomanager_output_device_storage_failed',
+            extraInfo: {
+              bridge: this.bridgeName,
+              deviceId: cachedId,
+              errorMessage: error.message,
+              errorName: error.name,
+              errorStack: error?.stack,
             },
-            `Failed to apply output audio device from storage: ${error.message}`
-          );
+          }, `Failed to apply output audio device from storage: ${error.message}`);
         });
     }
   }
@@ -300,8 +303,10 @@ class AudioManager {
       logger.warn({
         logCode: 'audiomanager_enumerate_devices_failed',
         extraInfo: {
+          bridge: this.bridgeName,
           errorName: error.name,
           errorMessage: error.message,
+          errorStack: error?.stack,
         },
       }, `Audio manager: error enumerating devices - {${error.name}: ${error.message}}`);
 
@@ -557,6 +562,18 @@ class AudioManager {
   async joinAudio(callOptions, callStateCallback) {
     window.addEventListener('audioPlayFailed', this.handlePlayElementFailed);
 
+    logger.info({
+      logCode: 'audio_joining',
+      extraInfo: {
+        bridge: this.bridgeName,
+        inputDeviceId: this.inputDeviceId,
+        inputDevices: this.inputDevicesJSON,
+        outputDeviceId: this.outputDeviceId,
+        outputDevices: this.outputDevicesJSON,
+        isListenOnly: this.isListenOnly,
+      },
+    }, 'Joining audio');
+
     const enumDevicesIfNecessary = () => {
       // If we don't have I/O devices yet (e.g.: skipCheck/Echo), enumerate
       if (!this.inputDevices?.length || !this.outputDevices?.length) {
@@ -605,6 +622,7 @@ class AudioManager {
         logCode: 'audio_join_failure',
         extraInfo: {
           secondsToAudioFailure,
+          bridge: this.bridgeName,
           errorName: error.name,
           errorMessage: error.message,
           errorStack: error?.stack,
@@ -640,7 +658,7 @@ class AudioManager {
 
     logger.info({
       logCode: 'audiomanager_join_listenonly',
-      extraInfo: { logType: 'user_action' },
+      extraInfo: { logType: 'user_action', bridge: this.bridgeName },
     }, 'user requested to connect to audio conference as listen only');
 
     // If the bridge supports transparent listen-only, we set the placeholder
@@ -764,8 +782,10 @@ class AudioManager {
       logger.warn({
         logCode: 'audiomanager_device_enforce_failed',
         extraInfo: {
+          bridge: this.bridgeName,
           errorName: error.name,
           errorMessage: error.message,
+          errorStack: error?.stack,
           inputDeviceId: this.inputDeviceId,
           outputDeviceId: this.outputDeviceId,
         },
@@ -780,6 +800,7 @@ class AudioManager {
         logCode: 'audio_joined',
         extraInfo: {
           secondsToActivateAudio,
+          bridge: this.bridgeName,
           inputDeviceId: this.inputDeviceId,
           inputDevices: this.inputDevicesJSON,
           outputDeviceId: this.outputDeviceId,
@@ -866,6 +887,7 @@ class AudioManager {
         logger.info({
           logCode: 'audio_ended',
           extraInfo: {
+            bridge: this.bridgeName,
             inputDeviceId: this.inputDeviceId,
             inputDevices: this.inputDevicesJSON,
             outputDeviceId: this.outputDeviceId,
@@ -951,6 +973,7 @@ class AudioManager {
     logger.warn({
       logCode: 'audiomanager_stream_inactive',
       extraInfo: {
+        bridge: this.bridgeName,
         currentStreamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
         streamData: MediaStreamUtils.getMediaStreamLogData(stream),
       },
@@ -965,8 +988,10 @@ class AudioManager {
           logger.error({
             logCode: 'audiomanager_stream_inactive_device_reset_failed',
             extraInfo: {
+              bridge: this.bridgeName,
               errorName: error.name,
               errorMessage: error.message,
+              errorStack: error?.stack,
             },
           }, `Failed to reset input device after stream became inactive: ${error.message}`);
         });
@@ -1015,8 +1040,10 @@ class AudioManager {
       logger.error({
         logCode: 'audiomanager_stream_termination_tracking_failed',
         extraInfo: {
+          bridge: this.bridgeName,
           errorName: error.name,
           errorMessage: error.message,
+          errorStack: error?.stack,
         },
       }, `Failed to track stream termination - {${error.name}: ${error.message}}`);
     }
@@ -1030,6 +1057,7 @@ class AudioManager {
     logger.debug({
       logCode: 'audiomanager_input_device_change',
       extraInfo: {
+        bridge: this.bridgeName,
         deviceId: currentDeviceId,
         newDeviceId: deviceId || 'none',
       },
@@ -1063,8 +1091,10 @@ class AudioManager {
         logger.error({
           logCode: 'audiomanager_input_live_device_change_failure',
           extraInfo: {
+            bridge: this.bridgeName,
             errorName: error.name,
             errorMessage: error.message,
+            errorStack: error?.stack,
             deviceId: currentDeviceId,
             newDeviceId: deviceId,
             inputDevices: this.inputDevicesJSON,
@@ -1098,6 +1128,7 @@ class AudioManager {
         logger.debug({
           logCode: 'audiomanager_output_device_change',
           extraInfo: {
+            bridge: this.bridgeName,
             deviceId: currentDeviceId,
             newDeviceId: deviceId,
           },
@@ -1113,8 +1144,10 @@ class AudioManager {
         logger.error({
           logCode: 'audiomanager_output_device_change_failure',
           extraInfo: {
+            bridge: this.bridgeName,
             errorName: error.name,
             errorMessage: error.message,
+            errorStack: error?.stack,
             deviceId: currentDeviceId,
             newDeviceId: targetDeviceId,
             outputDevices: this.outputDevicesJSON,
@@ -1141,6 +1174,10 @@ class AudioManager {
 
   get bridge() {
     return this.isListenOnly ? this.listenOnlyBridge : this.fullAudioBridge;
+  }
+
+  get bridgeName() {
+    return this.bridge?.bridgeName;
   }
 
   set inputStream(stream) {
@@ -1283,6 +1320,9 @@ class AudioManager {
       // disrupting the join flow.
       logger.info({
         logCode: 'audiomanager_autoplay_prompt',
+        extraInfo: {
+          bridge: this.bridgeName,
+        },
       }, 'Prompting user for action to play listen only media');
       this.callStateCallback({
         status: AUTOPLAY_BLOCKED,


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): audio input switch fails while unmuted (Windows)](https://github.com/bigbluebutton/bigbluebutton/commit/19083e1774b3966a60d5ff9058f801b1a225290f) 
  - Audio input switching is failing while unmuted in Windows-based
environments + Chromium-based browsers.
  Windows-based envs, for some reason, just plainly ignore deviceIds
in non-exact constraints - at least in the way we're using it. That 
causes the device switch to be a no-op to the end user. [...]
- [refactor(audio): add bridge to all applicable audio-manager logs](https://github.com/bigbluebutton/bigbluebutton/commit/caed3c33f28f2a332f06dcbb84a4869eaef839c4) 
  - It is useful to segment client logs based on the audio bridge being
used when doing A/B-like testing between LiveKit and bbb-webrtc-sfu.
Unfortunately, not all audio-manager logs (which are the most important
ones) carry the bridge being used, which makes this somewhat difficult [...]
- [refactor(livekit): standardize bridge extraInfo field in audio bridge](https://github.com/bigbluebutton/bigbluebutton/commit/672318321dbeea5c2213cccabf213a49f452e259) 
  - The LiveKit audio bridge uses `bridgeName` as the key to identify the
bridge in its extraInfo logger paylods. This deviates from audio-manager
and sfu-audio-bridge (both use `bridge`).

### Closes Issue(s)

None