### PR TITLE
fix(layout): incorrectly setting `hasExternalVideo` to false

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -211,10 +211,6 @@ class ScreenshareComponent extends React.Component {
       });
     }
 
-    layoutContextDispatch({
-      type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-      value: Session.getItem('presentationLastState'),
-    });
     if (videoTagRef) {
       videoTagRef.removeEventListener('mousemove', this.handleMouseMovement);
     }


### PR DESCRIPTION
### What does this PR do?
Screenshare was still dispatching a layout context action to restore the presentation when the component unmounted. Since the presentation pile was introduced, this logic is now centralized there. The extra dispatch caused the wrong pile item (external video) to change state, leading to it being incorrectly displayed.

This commit removes the redundant restore action, leaving the presentation pile calculation to handle it properly.

### Closes Issue(s)
Closes #23908 
