### PR TITLE
fix: guarantee deafen is executed for dial-in users in lobby

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -582,7 +582,16 @@ object VoiceApp extends SystemConfiguration {
     )
     outGW.send(muteEvent)
 
-    deafenUserInVoiceConf(liveMeeting, outGW, intId, !enabled)
+    // Directly deafen the user here as guest lobby policies mean an user
+    // might not be fully registered yet.
+    val deafEvent = MsgBuilder.buildDeafUserInVoiceConfSysMsg(
+      liveMeeting.props.meetingProp.intId,
+      liveMeeting.props.voiceProp.voiceConf,
+      intId,
+      voiceUserId,
+      !enabled
+    )
+    outGW.send(deafEvent)
   }
 
   def removeToggleListenOnlyTask(userId: String): Unit = {
@@ -796,6 +805,10 @@ object VoiceApp extends SystemConfiguration {
     }
   }
 
+  /*
+   * Deafens a web conference user in the voice conference.
+   * Does not apply to voice-only users (e.g.: dial-in)
+   */
   def deafenUserInVoiceConf(
     liveMeeting: LiveMeeting,
     outGW:       OutMsgRouter,


### PR DESCRIPTION
### What does this PR do?

- [fix: guarantee deafen is executed for dial-in users in lobby](https://github.com/bigbluebutton/bigbluebutton/commit/25153d1bb79ce408d342be0df9dc0e9431d77915) 
  - The deafen command is not always executed for dial-in users when
they're in the guest lobby. The centralized deafen method looks for a
valid VoiceUser via its internal user ID to execute deafen, but there
might not be a valid intId registered yet for voice-only users at that
point in time.
  - Guarantee deafen is always executed for dial-in users when applicable by
splitting deafen into a web user version (looks for valid voice user)
and dial-in version (executes the deafen command directly).

### Closes Issue(s)

None