### PR TITLE
fix: missing default value for camera position

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -257,7 +257,7 @@ const PushLayoutEngine = (props) => {
         || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
         layoutContextDispatch({
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
-          value: meetingLayoutCameraPosition,
+          value: meetingLayoutCameraPosition || DEFAULT_VALUES.cameraPosition,
         });
       }
     };


### PR DESCRIPTION
### What does this PR do?

Adjusts push layout engine to include missing value for default camera position

### How to test
1. join a meeting with 2 users (A,B)
2. share webcam with user A
3. share your screen with user A
4. check if screenshare is displayed for user B 