### PR TITLE
chore: package build image with newer go 1.25.1 and node 22.19.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: bigbluebutton/bbb-build:v3.0.x-release--2025-03-12-163403
+  image: bigbluebutton/bbb-build:v3.0.x-release--2025-09-16-174734
 
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of


### PR DESCRIPTION
https://github.com/bigbluebutton/bbb-docker-build-packages/compare/a1b7062cf41920074d59f62f1bebbf3b6f34540b...antobinary-patch-1

<img width="2345" height="1382" alt="image" src="https://github.com/user-attachments/assets/87b4bd1f-da66-4a79-8458-6f53767a073c" />
