### PR TITLE
fix(captions): Unsupported captions should show warning instead of empty space

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
@@ -164,7 +164,7 @@ const AudioCaptionsSelectContainer: React.FC<AudioCaptionsContainerProps> = ({
     }),
   );
   const isEnabled = useIsAudioTranscriptionEnabled();
-  if (!currentUser || !isEnabled || !voices) return null;
+  if (!currentUser || !isEnabled) return null;
 
   return (
     <AudioCaptionsSelect


### PR DESCRIPTION
Fixes https://github.com/bigbluebutton/bigbluebutton/issues/23779

This problem happened because if we check for the language list before rendering the component we'll end up with an empty component (like shown in the issue) instead of rendering the component where it'll correctly detect we don't have support for transcription and render the error message.