### PR TITLE
fix(whiteboard): Clear tldraw history when clearing annotations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -573,7 +573,7 @@ const PresentationMenu = (props) => {
             }
             return '';
           })?.filter((s) => s?.length > 0));
-          tldrawAPI?.history.clear();
+          tldrawAPI?.history?.clear?.();
           setIsClearModalOpen(false);
         }}
         priority="0"

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -573,6 +573,7 @@ const PresentationMenu = (props) => {
             }
             return '';
           })?.filter((s) => s?.length > 0));
+          tldrawAPI?.history.clear();
           setIsClearModalOpen(false);
         }}
         priority="0"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

Clears all the tldraw history when clearing annotations. This prevents the history from growing indefinitely.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Partially closes #23886

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Draw a few shapes on the whiteboard.
2. On the presentation menu, select 'Clear annotations'.
3. You must not be able to restore the shapes by undoing the last command.