### PR TITLE
fix(recording): add presentation minimized events + screenshare as content fixes

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1339,6 +1339,15 @@ module BigBlueButton
       return false
     end
 
+    # Get a list of times when the "screenshare as content" flag is changed
+    #
+    # The returned times account for recording start/stop events, and have timestamps relative to the start of the
+    # recording.
+    #
+    # @param events [Nokogiri::XML::Document] The parsed events.xml document
+    # @param start_time [Integer] The recording segment start timestamp (ms)
+    # @param end_time [Integer] The recording segment end timestamp (ms)
+    # @return [Array<Hash>] An array of events, each with a timestamp and the screenshareAsContent flag
     def self.get_screenshare_as_content_events(events, start_time, end_time)
       BigBlueButton.logger.info('Getting Screenshare as Content Events')
 
@@ -1352,7 +1361,6 @@ module BigBlueButton
       record = events.at_xpath('/recording/event[@eventname="RecordStatusEvent"]').nil?
 
       screenshare_content_events = []
-      last_screenshare_as_content = nil
 
       events.xpath('/recording/event').each do |event|
         timestamp = event[:timestamp].to_i - initial_timestamp
@@ -1360,29 +1368,50 @@ module BigBlueButton
 
         case [event[:module], event[:eventname]]
         when %w[PARTICIPANT SetScreenshareAsContentEvent]
-          last_screenshare_as_content = event.at_xpath('screenshareAsContent')&.text == "true"
-          next if timestamp < start_time || !record
+          screenshare_as_content = event.at_xpath('screenshareAsContent')&.content == 'true'
 
-          screenshareAsContent = event.at_xpath('screenshareAsContent')&.text == "true"
+          # Don't emit events during unrecorded sections of the meeting. An event will be emitted when recording resumes
+          next unless timestamp >= start_time && record
+          # Don't emit an event if the previous event has the same state
+          next if screenshare_content_events.dig(-1, :screenshareAsContent) == screenshare_as_content
 
           screenshare_content_events << {
             timestamp: timestamp - offset,
-            screenshareAsContent: screenshareAsContent,
+            screenshareAsContent: screenshare_as_content,
           }
         when %w[PARTICIPANT RecordStatusEvent]
-          is_recording = event.at_xpath('status').content == 'true'
-          next if timestamp < start_time
-
-          if is_recording && !record # Recording resumed
+          record = event.at_xpath('status').content == 'true'
+          if record
+            # Recording resumed; update offset to account for the timestamp jump
             offset += timestamp - last_stop_timestamp
+
+            # Don't emit an event if it's prior to the segment start time
+            next unless timestamp >= start_time
+            # Don't emit an event if the previous event has the same state
+            next if screenshare_content_events.dig(-1, :screenshareAsContent) == screenshare_as_content
+
             screenshare_content_events << {
               timestamp: timestamp - offset,
-              screenshareAsContent: last_screenshare_as_content,
-            } if !last_screenshare_as_content.nil?
-          elsif !is_recording && record # Recording paused
+              screenshareAsContent: screenshare_as_content,
+            }
+          else
+            # Recording paused
             last_stop_timestamp = timestamp
           end
-          record = is_recording
+        else
+          # Handle the case of start_time being inside a recording segment - need to add an event corresponding to
+          # whatever the state happened to be when start_time was reached
+
+          # Don't emit an event during unrecorded sections of the meeting, or if one has already been emitted.
+          next unless timestamp >= start_time && record && screenshare_content_events.empty?
+
+          # Don't emit an event if we haven't seen a SetScreenshareAsContentEvent yet
+          next if screenshare_as_content.nil?
+
+          screenshare_content_events << {
+            timestamp: 0,
+            screenshareAsContent: screenshare_as_content,
+          }
         end
       end
       screenshare_content_events

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1339,20 +1339,53 @@ module BigBlueButton
       return false
     end
 
-    def self.get_screenshare_as_content_events(events)
-      BigBlueButton.logger.info("Extracting SetScreenshareAsContentEvent")
+    def self.get_screenshare_as_content_events(events, start_time, end_time)
+      BigBlueButton.logger.info('Getting Screenshare as Content Events')
+
+      initial_timestamp = first_event_timestamp(events)
+      start_time -= initial_timestamp
+      end_time -= initial_timestamp
+
+      last_stop_timestamp = start_time
+      offset = start_time
+      # Recordings without status events are assumed to have been recorded from the beginning
+      record = events.at_xpath('/recording/event[@eventname="RecordStatusEvent"]').nil?
 
       screenshare_content_events = []
+      last_screenshare_as_content = nil
 
-      events.xpath("/recording/event[@eventname='SetScreenshareAsContentEvent']").each do |event|
-        screenshare_content_events << {
-          timestamp: event['timestamp'].to_i,
-          timestampUTC: event.at_xpath('timestampUTC')&.text.to_i,
-          date: event.at_xpath('date')&.text,
-          screenshareAsContent: event.at_xpath('screenshareAsContent')&.text == "true"
-        }
+      events.xpath('/recording/event').each do |event|
+        timestamp = event[:timestamp].to_i - initial_timestamp
+        break if timestamp >= end_time
+
+        case [event[:module], event[:eventname]]
+        when %w[PARTICIPANT SetScreenshareAsContentEvent]
+          last_screenshare_as_content = event.at_xpath('screenshareAsContent')&.text == "true"
+          next if timestamp < start_time || !record
+
+          screenshareAsContent = event.at_xpath('screenshareAsContent')&.text == "true"
+
+          screenshare_content_events << {
+            timestamp: timestamp - offset,
+            screenshareAsContent: screenshareAsContent,
+          }
+        when %w[PARTICIPANT RecordStatusEvent]
+          is_recording = event.at_xpath('status').content == 'true'
+          next if timestamp < start_time
+
+          if is_recording && !record # Recording resumed
+            offset += timestamp - last_stop_timestamp
+            screenshare_content_events << {
+              timestamp: timestamp - offset,
+              screenshareAsContent: last_screenshare_as_content,
+            } if !last_screenshare_as_content.nil?
+          elsif !is_recording && record # Recording paused
+            last_stop_timestamp = timestamp
+          end
+          record = is_recording
+        end
       end
-      screenshare_content_events.sort_by! { |event| event[:timestamp] }
+      screenshare_content_events
     end
   end
 end

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1352,8 +1352,7 @@ module BigBlueButton
           screenshareAsContent: event.at_xpath('screenshareAsContent')&.text == "true"
         }
       end
-
-      screenshare_content_events
+      screenshare_content_events.sort_by! { |event| event[:timestamp] }
     end
   end
 end

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1353,12 +1353,12 @@ module BigBlueButton
       layout_edl = BigBlueButton::Events.create_layout_edl(events)
       layout_edl = BigBlueButton::Events.edl_match_recording_marks_video(layout_edl, events, start_time, end_time)
 
-      layout_edl.each_with_object([]) do |entry, events|
+      layout_edl.each_with_object([]) do |entry, layout_events|
         next unless entry[:conditions] &&
                     !entry[:conditions][:screenshare_as_content].nil? &&
                     !entry[:conditions][:presentation_is_open].nil?
 
-        events << {
+        layout_events << {
           timestamp: entry[:timestamp],
           screenshareAsContent: entry[:conditions][:screenshare_as_content],
           presentationIsOpen: entry[:conditions][:presentation_is_open]

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1339,115 +1339,31 @@ module BigBlueButton
       return false
     end
 
-    # Generic function to get a list of times when a specific state changes
+    # Get a list of layout events (screenshare as content and presentation open)
     #
-    # The returned times account for recording start/stop events, and have timestamps relative to the start of the
-    # recording.
+    # The returned events account for recording start/stop events and have timestamps relative to the start of the
+    # recording. Only changes in state are included.
     #
     # @param events [Nokogiri::XML::Document] The parsed events.xml document
     # @param start_time [Integer] The recording segment start timestamp (ms)
     # @param end_time [Integer] The recording segment end timestamp (ms)
-    # @param target_module [String] The module name of the event to track
-    # @param target_eventname [String] The event name to track
-    # @param compare_keys [Array<Symbol>] Optional list of keys to compare for state changes. If nil, all keys are compared.
-    # @return [Array<Hash>] An array of events, each with a timestamp and the extracted state
-    def self.get_events(events, start_time, end_time, target_module, target_eventname, compare_keys = nil)
-      BigBlueButton.logger.info("Getting #{target_eventname} Events")
+    # @return [Array<Hash>] An array of events, each with a timestamp and the changed layout state keys
+    #   (:screenshareAsContent, :presentationIsOpen)
+    def self.get_layout_events(events, start_time, end_time)
+      layout_edl = BigBlueButton::Events.create_layout_edl(events)
+      layout_edl = BigBlueButton::Events.edl_match_recording_marks_video(layout_edl, events, start_time, end_time)
 
-      initial_timestamp = first_event_timestamp(events)
-      start_time -= initial_timestamp
-      end_time -= initial_timestamp
+      layout_edl.each_with_object([]) do |entry, events|
+        next unless entry[:conditions] &&
+                    !entry[:conditions][:screenshare_as_content].nil? &&
+                    !entry[:conditions][:presentation_is_open].nil?
 
-      last_stop_timestamp = start_time
-      offset = start_time
-      # Recordings without status events are assumed to have been recorded from the beginning
-      record = events.at_xpath('/recording/event[@eventname="RecordStatusEvent"]').nil?
-
-      extracted_events = []
-      current_state = nil
-
-      events.xpath('/recording/event').each do |event|
-        timestamp = event[:timestamp].to_i - initial_timestamp
-        break if timestamp >= end_time
-
-        case [event[:module], event[:eventname]]
-        when [target_module, target_eventname]
-          current_state = yield(event)
-
-          # Don't emit events during unrecorded sections of the meeting. An event will be emitted when recording resumes
-          next unless timestamp >= start_time && record
-          
-          # Don't emit an event if the previous event has the same state
-          if extracted_events.last
-            last_event = extracted_events.last.reject { |k| k == :timestamp }
-            if compare_keys
-              next if last_event.select { |k, _| compare_keys.include?(k) } == current_state.select { |k, _| compare_keys.include?(k) }
-            else
-              next if last_event == current_state
-            end
-          end
-
-          extracted_events << current_state.merge(timestamp: timestamp - offset)
-
-        when %w[PARTICIPANT RecordStatusEvent]
-          record = event.at_xpath('status').content == 'true'
-          # Don't update timestamps until we're past the segment start time
-          next unless timestamp >= start_time
-
-          if record
-            # Recording resumed; update offset to account for the timestamp jump
-            offset += timestamp - last_stop_timestamp
-
-            # Don't emit an event if the previous event has the same state
-            next if current_state.nil?
-            if extracted_events.last
-              last_event = extracted_events.last.reject { |k| k == :timestamp }
-              if compare_keys
-                next if last_event.select { |k, _| compare_keys.include?(k) } == current_state.select { |k, _| compare_keys.include?(k) }
-              else
-                next if last_event == current_state
-              end
-            end
-
-            extracted_events << current_state.merge(timestamp: timestamp - offset)
-          else
-            # Recording paused
-            last_stop_timestamp = timestamp
-          end
-        else
-          # Handle the case of start_time being inside a recording segment - need to add an event corresponding to
-          # whatever the state happened to be when start_time was reached
-
-          # Don't emit an event during unrecorded sections of the meeting, or if one has already been emitted.
-          next unless timestamp >= start_time && record && extracted_events.empty?
-
-          # Don't emit an event if we haven't seen the target event yet
-          next if current_state.nil?
-
-          extracted_events << current_state.merge(timestamp: 0)
-        end
-      end
-      extracted_events
-    end
-
-    def self.get_screenshare_as_content_events(events, start_time, end_time)
-      get_events(events, start_time, end_time, 'PARTICIPANT', 'SetScreenshareAsContentEvent', [:screenshareAsContent]) do |event|
-        {
-          screenshareAsContent: event.at_xpath('screenshareAsContent')&.content == "true"
+        events << {
+          timestamp: entry[:timestamp],
+          screenshareAsContent: entry[:conditions][:screenshare_as_content],
+          presentationIsOpen: entry[:conditions][:presentation_is_open]
         }
-      end
-    end
 
-    def self.get_layout_broadcasted_events(events, start_time, end_time)
-      get_events(events, start_time, end_time, 'PARTICIPANT', 'LayoutBroadcastedEvent', [:presentationIsOpen]) do |event|
-        {
-          focusedCamera: event.at_xpath('focusedCamera')&.content,
-          presentationVideoRate: event.at_xpath('presentationVideoRate')&.content.to_f,
-          cameraPosition: event.at_xpath('cameraPosition')&.content,
-          layout: event.at_xpath('layout')&.content,
-          presentationIsOpen: event.at_xpath('presentationIsOpen')&.content == "true",
-          isResizing: event.at_xpath('isResizing')&.content == "true"
-        }
       end
     end
   end

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1339,7 +1339,7 @@ module BigBlueButton
       return false
     end
 
-    # Get a list of times when the "screenshare as content" flag is changed
+    # Generic function to get a list of times when a specific state changes
     #
     # The returned times account for recording start/stop events, and have timestamps relative to the start of the
     # recording.
@@ -1347,9 +1347,12 @@ module BigBlueButton
     # @param events [Nokogiri::XML::Document] The parsed events.xml document
     # @param start_time [Integer] The recording segment start timestamp (ms)
     # @param end_time [Integer] The recording segment end timestamp (ms)
-    # @return [Array<Hash>] An array of events, each with a timestamp and the screenshareAsContent flag
-    def self.get_screenshare_as_content_events(events, start_time, end_time)
-      BigBlueButton.logger.info('Getting Screenshare as Content Events')
+    # @param target_module [String] The module name of the event to track
+    # @param target_eventname [String] The event name to track
+    # @param compare_keys [Array<Symbol>] Optional list of keys to compare for state changes. If nil, all keys are compared.
+    # @return [Array<Hash>] An array of events, each with a timestamp and the extracted state
+    def self.get_events(events, start_time, end_time, target_module, target_eventname, compare_keys = nil)
+      BigBlueButton.logger.info("Getting #{target_eventname} Events")
 
       initial_timestamp = first_event_timestamp(events)
       start_time -= initial_timestamp
@@ -1360,25 +1363,32 @@ module BigBlueButton
       # Recordings without status events are assumed to have been recorded from the beginning
       record = events.at_xpath('/recording/event[@eventname="RecordStatusEvent"]').nil?
 
-      screenshare_content_events = []
+      extracted_events = []
+      current_state = nil
 
       events.xpath('/recording/event').each do |event|
         timestamp = event[:timestamp].to_i - initial_timestamp
         break if timestamp >= end_time
 
         case [event[:module], event[:eventname]]
-        when %w[PARTICIPANT SetScreenshareAsContentEvent]
-          screenshare_as_content = event.at_xpath('screenshareAsContent')&.content == 'true'
+        when [target_module, target_eventname]
+          current_state = yield(event)
 
           # Don't emit events during unrecorded sections of the meeting. An event will be emitted when recording resumes
           next unless timestamp >= start_time && record
+          
           # Don't emit an event if the previous event has the same state
-          next if screenshare_content_events.dig(-1, :screenshareAsContent) == screenshare_as_content
+          if extracted_events.last
+            last_event = extracted_events.last.reject { |k| k == :timestamp }
+            if compare_keys
+              next if last_event.select { |k, _| compare_keys.include?(k) } == current_state.select { |k, _| compare_keys.include?(k) }
+            else
+              next if last_event == current_state
+            end
+          end
 
-          screenshare_content_events << {
-            timestamp: timestamp - offset,
-            screenshareAsContent: screenshare_as_content,
-          }
+          extracted_events << current_state.merge(timestamp: timestamp - offset)
+
         when %w[PARTICIPANT RecordStatusEvent]
           record = event.at_xpath('status').content == 'true'
           # Don't update timestamps until we're past the segment start time
@@ -1389,12 +1399,17 @@ module BigBlueButton
             offset += timestamp - last_stop_timestamp
 
             # Don't emit an event if the previous event has the same state
-            next if screenshare_content_events.dig(-1, :screenshareAsContent) == screenshare_as_content
+            next if current_state.nil?
+            if extracted_events.last
+              last_event = extracted_events.last.reject { |k| k == :timestamp }
+              if compare_keys
+                next if last_event.select { |k, _| compare_keys.include?(k) } == current_state.select { |k, _| compare_keys.include?(k) }
+              else
+                next if last_event == current_state
+              end
+            end
 
-            screenshare_content_events << {
-              timestamp: timestamp - offset,
-              screenshareAsContent: screenshare_as_content,
-            }
+            extracted_events << current_state.merge(timestamp: timestamp - offset)
           else
             # Recording paused
             last_stop_timestamp = timestamp
@@ -1404,18 +1419,36 @@ module BigBlueButton
           # whatever the state happened to be when start_time was reached
 
           # Don't emit an event during unrecorded sections of the meeting, or if one has already been emitted.
-          next unless timestamp >= start_time && record && screenshare_content_events.empty?
+          next unless timestamp >= start_time && record && extracted_events.empty?
 
-          # Don't emit an event if we haven't seen a SetScreenshareAsContentEvent yet
-          next if screenshare_as_content.nil?
+          # Don't emit an event if we haven't seen the target event yet
+          next if current_state.nil?
 
-          screenshare_content_events << {
-            timestamp: 0,
-            screenshareAsContent: screenshare_as_content,
-          }
+          extracted_events << current_state.merge(timestamp: 0)
         end
       end
-      screenshare_content_events
+      extracted_events
+    end
+
+    def self.get_screenshare_as_content_events(events, start_time, end_time)
+      get_events(events, start_time, end_time, 'PARTICIPANT', 'SetScreenshareAsContentEvent', [:screenshareAsContent]) do |event|
+        {
+          screenshareAsContent: event.at_xpath('screenshareAsContent')&.content == "true"
+        }
+      end
+    end
+
+    def self.get_layout_broadcasted_events(events, start_time, end_time)
+      get_events(events, start_time, end_time, 'PARTICIPANT', 'LayoutBroadcastedEvent', [:presentationIsOpen]) do |event|
+        {
+          focusedCamera: event.at_xpath('focusedCamera')&.content,
+          presentationVideoRate: event.at_xpath('presentationVideoRate')&.content.to_f,
+          cameraPosition: event.at_xpath('cameraPosition')&.content,
+          layout: event.at_xpath('layout')&.content,
+          presentationIsOpen: event.at_xpath('presentationIsOpen')&.content == "true",
+          isResizing: event.at_xpath('isResizing')&.content == "true"
+        }
+      end
     end
   end
 end

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -1381,12 +1381,13 @@ module BigBlueButton
           }
         when %w[PARTICIPANT RecordStatusEvent]
           record = event.at_xpath('status').content == 'true'
+          # Don't update timestamps until we're past the segment start time
+          next unless timestamp >= start_time
+
           if record
             # Recording resumed; update offset to account for the timestamp jump
             offset += timestamp - last_stop_timestamp
 
-            # Don't emit an event if it's prior to the segment start time
-            next unless timestamp >= start_time
             # Don't emit an event if the previous event has the same state
             next if screenshare_content_events.dig(-1, :screenshareAsContent) == screenshare_as_content
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -946,6 +946,17 @@ def process_presentation(package_dir)
         slide_changed = true
       end
 
+    when 'SetScreenshareAsContentEvent'
+      if @presentation_props['include_deskshare']
+        screenshareAsContent = event.at_xpath('screenshareAsContent')&.text == "true"
+        if !screenshareAsContent
+          deskshare = false
+          slide_changed = true
+        else
+          deskshare = slide_changed = true
+        end
+      end
+
     when 'AddShapeEvent', 'ModifyTextEvent'
       events_parse_shape(shapes, event, current_presentation, current_slide, timestamp)
 
@@ -1308,15 +1319,27 @@ def process_swap_events(events)
   @layout_swap_xml.instruct!
 
   @layout_swap_xml.recording('id' => 'layout_swap_events') do
-    swap_events.each do |event|
-      @layout_swap_xml.event(
-        timestamp: (translate_timestamp(event[:timestamp].to_f) / 1000).round(1),
-        show_screenshare: event[:screenshareAsContent],
-      )
+    @rec_events.each do |re|
+      # consider the last swap event before the current recording start
+      last_event_before_start = swap_events.select { |e| e[:timestamp].to_i < re[:start_timestamp] }.last
+      if last_event_before_start && last_event_before_start[:timestamp].to_i < re[:stop_timestamp]
+        @layout_swap_xml.event(
+          timestamp: (translate_timestamp(last_event_before_start[:timestamp].to_f) / 1000).round(1),
+          show_screenshare: last_event_before_start[:screenshareAsContent],
+        )
+      end
+
+      swap_events.each do |event|
+        timestamp = event[:timestamp].to_i
+        next unless (timestamp >= re[:start_timestamp]) && (timestamp <= re[:stop_timestamp])
+
+        @layout_swap_xml.event(
+          timestamp: (translate_timestamp(event[:timestamp].to_f) / 1000).round(1),
+          show_screenshare: event[:screenshareAsContent],
+        )
+      end
     end
   end
-
-
 end
 
 @shapes_svg_filename = 'shapes.svg'

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1311,18 +1311,27 @@ def copy_media_files_helper(media, media_files, package_dir)
   end
 end
 
-def process_swap_events(events)
-  BigBlueButton.logger.info("Processing screenshare as content events")
+def process_layout_events(events)
+  BigBlueButton.logger.info("Processing screenshare as content and layout events")
   swap_events = BigBlueButton::Events.get_screenshare_as_content_events(events, @meeting_start.to_i, @meeting_end.to_i)
+  layout_events = BigBlueButton::Events.get_layout_broadcasted_events(events, @meeting_start.to_i, @meeting_end.to_i)
   @layout_swap_xml = Builder::XmlMarkup.new(indent: 2)
   @layout_swap_xml.instruct!
 
   @layout_swap_xml.recording('id' => 'layout_swap_events') do
-    swap_events.each do |event|
-      @layout_swap_xml.event(
-        timestamp: (event[:timestamp].to_f / 1000.0).round(1),
-        show_screenshare: event[:screenshareAsContent],
-      )
+    # Merge and sort events chronologically
+    all_events = (swap_events + layout_events).sort_by { |e| e[:timestamp] }
+
+    all_events.each do |event|
+      attributes = { timestamp: (event[:timestamp].to_f / 1000.0).round(1) }
+
+      if event.key?(:screenshareAsContent)
+        attributes[:show_screenshare] = event[:screenshareAsContent]
+      elsif event.key?(:presentationIsOpen)
+        attributes[:show_presentation] = event[:presentationIsOpen]
+      end
+
+      @layout_swap_xml.event(attributes)
     end
   end
 end
@@ -1492,7 +1501,7 @@ begin
 
         process_deskshare_events(@doc)
 
-        process_swap_events(@doc)
+        process_layout_events(@doc)
 
         process_poll_events(@doc, package_dir)
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1312,24 +1312,16 @@ def copy_media_files_helper(media, media_files, package_dir)
 end
 
 def process_layout_events(events)
-  BigBlueButton.logger.info("Processing screenshare as content and layout events")
-  swap_events = BigBlueButton::Events.get_screenshare_as_content_events(events, @meeting_start.to_i, @meeting_end.to_i)
-  layout_events = BigBlueButton::Events.get_layout_broadcasted_events(events, @meeting_start.to_i, @meeting_end.to_i)
+  BigBlueButton.logger.info("Processing layout events")
+  layout_events = BigBlueButton::Events.get_layout_events(events, @meeting_start.to_i, @meeting_end.to_i)
   @layout_swap_xml = Builder::XmlMarkup.new(indent: 2)
   @layout_swap_xml.instruct!
 
   @layout_swap_xml.recording('id' => 'layout_swap_events') do
-    # Merge and sort events chronologically
-    all_events = (swap_events + layout_events).sort_by { |e| e[:timestamp] }
-
-    all_events.each do |event|
+    layout_events.each do |event|
       attributes = { timestamp: (event[:timestamp].to_f / 1000.0).round(1) }
-
-      if event.key?(:screenshareAsContent)
-        attributes[:show_screenshare] = event[:screenshareAsContent]
-      elsif event.key?(:presentationIsOpen)
-        attributes[:show_presentation] = event[:presentationIsOpen]
-      end
+      attributes[:show_screenshare] = event[:screenshareAsContent] unless event[:screenshareAsContent].nil?
+      attributes[:show_presentation] = event[:presentationIsOpen] unless event[:presentationIsOpen].nil?
 
       @layout_swap_xml.event(attributes)
     end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -947,14 +947,13 @@ def process_presentation(package_dir)
       end
 
     when 'SetScreenshareAsContentEvent'
-      if @presentation_props['include_deskshare']
-        screenshareAsContent = event.at_xpath('screenshareAsContent')&.text == "true"
-        if !screenshareAsContent
-          deskshare = false
-          slide_changed = true
-        else
-          deskshare = slide_changed = true
-        end
+      next unless @presentation_props['include_deskshare']
+      screenshare_as_content = event.at_xpath('screenshareAsContent')&.text == "true"
+      if screenshare_as_content
+        deskshare = slide_changed = true
+      else
+        deskshare = false
+        slide_changed = true
       end
 
     when 'AddShapeEvent', 'ModifyTextEvent'
@@ -1314,30 +1313,16 @@ end
 
 def process_swap_events(events)
   BigBlueButton.logger.info("Processing screenshare as content events")
-  swap_events = BigBlueButton::Events.get_screenshare_as_content_events(events)
+  swap_events = BigBlueButton::Events.get_screenshare_as_content_events(events, @meeting_start.to_i, @meeting_end.to_i)
   @layout_swap_xml = Builder::XmlMarkup.new(indent: 2)
   @layout_swap_xml.instruct!
 
   @layout_swap_xml.recording('id' => 'layout_swap_events') do
-    @rec_events.each do |re|
-      # consider the last swap event before the current recording start
-      last_event_before_start = swap_events.select { |e| e[:timestamp].to_i < re[:start_timestamp] }.last
-      if last_event_before_start && last_event_before_start[:timestamp].to_i < re[:stop_timestamp]
-        @layout_swap_xml.event(
-          timestamp: (translate_timestamp(last_event_before_start[:timestamp].to_f) / 1000).round(1),
-          show_screenshare: last_event_before_start[:screenshareAsContent],
-        )
-      end
-
-      swap_events.each do |event|
-        timestamp = event[:timestamp].to_i
-        next unless (timestamp >= re[:start_timestamp]) && (timestamp <= re[:stop_timestamp])
-
-        @layout_swap_xml.event(
-          timestamp: (translate_timestamp(event[:timestamp].to_f) / 1000).round(1),
-          show_screenshare: event[:screenshareAsContent],
-        )
-      end
+    swap_events.each do |event|
+      @layout_swap_xml.event(
+        timestamp: (event[:timestamp].to_f / 1000.0).round(1),
+        show_screenshare: event[:screenshareAsContent],
+      )
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?

- Include the info when presentation is minimized by presenter with push layout to layout.xml so it can be used in playback:
```
<?xml version="1.0" encoding="UTF-8"?>
<recording id="layout_swap_events">
  <event timestamp="0.0" show_screenshare="false" show_presentation="true"/>
  <event timestamp="10.8" show_screenshare="true" show_presentation="true"/>
  <event timestamp="22.5" show_screenshare="false" show_presentation="true"/>
  <event timestamp="30.4" show_screenshare="true" show_presentation="true"/>
  <event timestamp="43.0" show_screenshare="true" show_presentation="false"/>
  <event timestamp="45.6" show_screenshare="true" show_presentation="true"/>
  <event timestamp="47.1" show_screenshare="true" show_presentation="false"/>
  <event timestamp="48.5" show_screenshare="true" show_presentation="true"/>
</recording>
```
- Only consider swap/layout events inside recordings.
- Move logic to extract events to events.rb so it can be reused by other formats
- Add slides swaps to shapes.svg when quick swap occur so playback can show the slides and thumbnails when screenshare is on for the entire recording.
  - In this case, previously only the screenshare was shown.
  
To be used with https://github.com/bigbluebutton/bbb-playback/pull/331
