### PR TITLE
fix: do not enforce muteOnStart on dial-in participants, make behavior configurable

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -55,6 +55,7 @@ trait SystemConfiguration {
   lazy val transparentListenOnlyThreshold = Try(config.getInt("voiceConf.transparentListenOnlyThreshold")).getOrElse(0)
   lazy val muteOnStartThreshold = Try(config.getInt("voiceConf.muteOnStartThreshold")).getOrElse(0)
   lazy val dialInEnforceGuestPolicy = Try(config.getBoolean("voiceConf.dialInEnforceGuestPolicy")).getOrElse(true)
+  lazy val dialInEnforceMuteOnStart = Try(config.getBoolean("voiceConf.dialInEnforceMuteOnStart")).getOrElse(false)
   lazy val floorEnabled = Try(config.getBoolean("voiceConf.floorControl.enabled")).getOrElse(false)
   lazy val minTalkingDuration = Try(config.getDuration(
     "voiceConf.floorControl.minTalkingDuration",

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -73,7 +73,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
         avatar = "",
         webcamBackground = "",
         color = userColor,
-        clientType = if (isDialInUser) "dial-in-user" else "",
+        clientType = if (isDialInUser) ClientType.DIAL_IN else "",
         userLeftFlag = UserLeftFlag(false, 0)
       )
       Users2x.add(liveMeeting.users2x, newUser)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -415,8 +415,10 @@ object VoiceApp extends SystemConfiguration {
     if (!isListenOnly) {
       enforceMuteOnStartThreshold(liveMeeting, outGW)
 
-      // if the meeting is muted tell freeswitch to mute the new person
-      if (MeetingStatus2x.isMeetingMuted(liveMeeting.status)) {
+      // If the meeting is muted tell freeswitch to mute the new person
+      // Dial-in users may skip this if dialInEnforceMuteOnStart=false (akka-apps config)
+      if (MeetingStatus2x.isMeetingMuted(liveMeeting.status)
+        && (dialInEnforceMuteOnStart || !intId.startsWith(IntIdPrefixType.DIAL_IN))) {
         val event = MsgBuilder.buildMuteUserInVoiceConfSysMsg(
           liveMeeting.props.meetingProp.intId,
           voiceConf,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -358,6 +358,14 @@ object VoiceApp extends SystemConfiguration {
     checkAndEjectOldDuplicateVoiceConfUser(intId, liveMeeting, outGW)
 
     val isListenOnly = if (callerIdName.startsWith("LISTENONLY")) true else false
+    val isDialInUser = if (intId.startsWith(IntIdPrefixType.DIAL_IN)) {
+      true
+    } else {
+      Users2x.findWithIntId(liveMeeting.users2x, intId) match {
+        case Some(u) => u.clientType == ClientType.DIAL_IN
+        case None    => true // If no user is found, we assume it's dial-in (i.e. voice-only)
+      }
+    }
 
     val voiceUserState = VoiceUserState(
       intId,
@@ -418,7 +426,7 @@ object VoiceApp extends SystemConfiguration {
       // If the meeting is muted tell freeswitch to mute the new person
       // Dial-in users may skip this if dialInEnforceMuteOnStart=false (akka-apps config)
       if (MeetingStatus2x.isMeetingMuted(liveMeeting.status)
-        && (dialInEnforceMuteOnStart || !intId.startsWith(IntIdPrefixType.DIAL_IN))) {
+        && (dialInEnforceMuteOnStart || !isDialInUser)) {
         val event = MsgBuilder.buildMuteUserInVoiceConfSysMsg(
           liveMeeting.props.meetingProp.intId,
           voiceConf,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -1,5 +1,5 @@
 package org.bigbluebutton.core.db
-import org.bigbluebutton.core.models.{RegisteredUser, UserLockSettings, VoiceUserState}
+import org.bigbluebutton.core.models.{ClientType, RegisteredUser, UserLockSettings, VoiceUserState}
 import slick.jdbc.PostgresProfile.api._
 
 case class UserNameColumnsDbModel(
@@ -198,7 +198,7 @@ object UserDAO {
                "joined",
                "registeredOn",
                true as "transferredFromParentMeeting",
-               'dial-in-user' as "clientType"
+               ${ClientType.DIAL_IN} as "clientType"
               from "user"
               where "userId" = ${userId}
               and "meetingId" = ${meetingIdFrom}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -474,6 +474,7 @@ object Roles {
 object ClientType {
   val FLASH = "FLASH"
   val HTML5 = "HTML5"
+  val DIAL_IN = "dial-in-user"
 }
 
 object SystemUser {

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -139,6 +139,9 @@ voiceConf {
   # Whether guest policy should be enforced on dial-in endpoints
   dialInEnforceGuestPolicy = true
 
+  # Whether muteOnStart should be enforced on dial-in endpoints at join time.
+  dialInEnforceMuteOnStart = false
+
   floorControl {
     # Enables akka-apps floor control based on its own VAD data (LiveKit only)
     enabled = true

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -681,7 +681,16 @@ If you want to have all users join muted, you can add an overwrite in `/etc/bigb
 muteOnStart=true
 ```
 
-After making them modification, restart your server with `sudo bbb-conf --restart` to apply the changes.
+Mute state is applied to all users joining the meeting, except telephone (dial-in) users.
+If desired, enforcement can be enabled for telephone users by setting the following property in `/etc/bigbluebutton/bbb-apps-akka.conf`:
+
+```properties
+voiceConf {
+  dialInEnforceMuteOnStart = true
+}
+```
+
+Restart your server with `sudo bbb-conf --restart` to apply the changes.
 
 #### Turn off "you are now muted"
 


### PR DESCRIPTION
### What does this PR do?

- [feat: optionally enforce muteOnStart on dial-in participants](https://github.com/bigbluebutton/bigbluebutton/pull/23925/commits/ddb927ecf146a37e1d71a490a637dcd74da564c8) 
  - The `muteOnStart` state is currently enforced on all participant types
(web or dial-in/SIP). Depending on the usage, it might no be desirable
to enforce it on dial-in endpoints due to:
    - Voice being their only mode of communication
    - The ability to unmute via DTMF tones not being clear enough to the
    end user
  - Introduce an akka-apps  config `voiceConf.dialInEnforceMuteOnStart` that
controls whether the meeting mute state is applied to dial-in at join time.
  - **Default behavior is now changed to *not enforcing mute state for
dial-in* on join (i.e.: false, always join unmuted)**. The rationale is that
dial-in users joining muted was never an explicit goal of anyone. It's just
an unplanned side-effect of setting muteOnStart=true by default.
- [docs: add reference to akka-apps#voiceConf.dialInEnforceMuteOnStart](https://github.com/bigbluebutton/bigbluebutton/pull/23925/commits/ea4fd9f41a7474794cd18120eabd6d417d5929bf)
- [fix(audio): unmute breakout audio transfers on join](https://github.com/bigbluebutton/bigbluebutton/pull/23925/commits/335791a591831ba05f2f07331e01f4b5ef51d731) 
  - Breakout room audio-only transfers are incorrectly muted on join.
These transfers should not be muted because the moderator has no
mute/unmute controls for the transfer channel. This happens when
`voiceConf.muteOnStartThreshold` is in effect.
  - Ensure breakout audio transfers are not muted on activation. This
is fixed by checking for `clientType=dial-in-user` in addition to
the `intId` prefix check. Also, refactor the `dial-in-user`
clientType into a constant.

### Closes Issue(s)

None

### More

Port of https://github.com/bigbluebutton/bigbluebutton/pull/23702 into 3.0.