### PR TITLE
fix(audio): stop exitAudio on modal close during livekit negotiation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
@@ -27,7 +27,7 @@ export const joinMicrophone = (options = {}) => {
   });
 
   return call.then(() => {
-    document.dispatchEvent(new Event("CLOSE_MODAL_AUDIO"));
+    document.dispatchEvent(new Event('CLOSE_MODAL_AUDIO'));
   }).catch((error) => {
     throw error;
   });
@@ -43,7 +43,7 @@ export const joinListenOnly = () => {
     // prop transitions to a state where it was handled OR the user opts
     // to close the modal.
     if (!Service.autoplayBlocked()) {
-      document.dispatchEvent(new Event("CLOSE_MODAL_AUDIO"));
+      document.dispatchEvent(new Event('CLOSE_MODAL_AUDIO'));
     }
   }).catch((error) => {
     throw error;
@@ -64,6 +64,9 @@ export const closeModal = (callback) => {
   if (Service.isConnecting()) {
     if (!ALLOW_AUDIO_JOIN_CANCEL) return;
 
+    // The LiveKit audio join flow succeeds or fails independently.
+    // There's no option to cancel it.
+    // Avoid calling forceExitAudio to prevent an extraneous exit sound.
     if (!Service.isUsingLiveKit()) {
       Service.forceExitAudio();
     }

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/service.js
@@ -58,12 +58,15 @@ export const leaveEchoTest = () => {
 };
 
 export const closeModal = (callback) => {
+  // eslint-disable-next-line max-len
   const ALLOW_AUDIO_JOIN_CANCEL = window.meetingClientSettings.public.media.audio.allowAudioJoinCancel;
 
   if (Service.isConnecting()) {
     if (!ALLOW_AUDIO_JOIN_CANCEL) return;
 
-    Service.forceExitAudio();
+    if (!Service.isUsingLiveKit()) {
+      Service.forceExitAudio();
+    }
   }
 
   callback();

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -134,6 +134,10 @@ class AudioManager {
     checkMediaDevicesTarget();
   }
 
+  isUsingLiveKit() {
+    return this.bridge?.bridgeName === 'livekit';
+  }
+
   onBeforeUnload() {
     const CONFIRMATION_ON_LEAVE = window.meetingClientSettings.public.app.askForConfirmationOnLeave;
     if (!CONFIRMATION_ON_LEAVE) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
This PR fixes the emission of exitAudio when the user closes the negotiation modal, which only occurs when the audio bridge in use is LiveKit




### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
In custom parameters, set: userdata-bbb_skip_check_audio=false
Start a call using the LiveKit audio bridge
During modal negotiation, click multiple times outside of the modal to close it.
#### Expected
exitAudio should not be executed

