### PR TITLE
fix(nav-bar): changed leave button label in breakout rooms

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -23,6 +23,14 @@ const intlMessages = defineMessages({
     id: 'app.navBar.optionsDropdown.leaveSessionDesc',
     description: 'Describes leave session option',
   },
+  returnToMainRoomLabel: {
+    id: 'app.navBar.optionsDropdown.returnToMainRoomLabel',
+    description: 'Go back to the main room label',
+  },
+  returnToMainRoomDesc: {
+    id: 'app.navBar.optionsDropdown.returnToMainRoomDesc',
+    description: 'Describes option to return to the main room',
+  },
   endMeetingLabel: {
     id: 'app.navBar.optionsDropdown.endMeetingForAllLabel',
     description: 'End meeting button label',
@@ -91,16 +99,18 @@ class LeaveMeetingButton extends PureComponent {
     this.menuItems = [];
 
     if (allowLogoutSetting && connected) {
-      this.menuItems.push(
-        {
-          key: 'list-item-logout',
-          dataTest: 'directLogoutButton',
-          icon: 'logout',
-          label: intl.formatMessage(intlMessages.leaveSessionLabel),
-          description: intl.formatMessage(intlMessages.leaveSessionDesc),
-          onClick: () => this.leaveSession(),
-        },
-      );
+      this.menuItems.push({
+        key: isBreakoutRoom ? 'list-item-return-main-room' : 'list-item-logout',
+        dataTest: isBreakoutRoom ? 'returnToMainRoomButton' : 'directLogoutButton',
+        icon: isBreakoutRoom ? 'undo' : 'logout',
+        label: intl.formatMessage(isBreakoutRoom
+          ? intlMessages.returnToMainRoomLabel
+          : intlMessages.leaveSessionLabel),
+        description: intl.formatMessage(isBreakoutRoom
+          ? intlMessages.returnToMainRoomDesc
+          : intlMessages.leaveSessionDesc),
+        onClick: () => this.leaveSession(),
+      });
     }
 
     if (allowedToEndMeeting && connected) {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -520,6 +520,8 @@
     "app.navBar.optionsDropdown.helpDesc": "Links user to video tutorials (opens new tab)",
     "app.navBar.optionsDropdown.endMeetingDesc": "Terminates the current session",
     "app.navBar.optionsDropdown.endMeetingLabel": "End session",
+    "app.navBar.optionsDropdown.returnToMainRoomLabel": "Return to main room",
+    "app.navBar.optionsDropdown.returnToMainRoomDesc": "Returns to the main room session",
     "app.navBar.optionsDropdown.endMeetingForAllLabel": "End session for all",
     "app.navBar.optionsDropdown.presenceLabel": "I'm",
     "app.sidebarNavigation.toggle.btnLabel": "Navigation sidebar toggle",


### PR DESCRIPTION
### What does this PR do?
After discussion with the design team, we decided to just change the break room exit button label for now.


### Closes Issue(s)
Closes None

