### PR TITLE
fix: improve viewer's slide zooming on Safari

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1740,6 +1740,16 @@ const Whiteboard = React.memo((props) => {
         z: newZoom,
       };
       tlEditorRef.current.store.put([updatedCurrentCam]);
+
+      // Force GPU acceleration to improve viewer's slide zooming on Safari
+      if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+        const images = window.document.querySelectorAll('.tl-image');
+        if (images.length > 0) {
+          images.forEach(div => {
+            div.style.webkitTransform = 'translateZ(0)';
+          });
+        }
+      }
     }
   };
 
@@ -2210,3 +2220,4 @@ Whiteboard.propTypes = {
   isInfiniteWhiteboard: PropTypes.bool,
   whiteboardWriters: PropTypes.arrayOf(PropTypes.shape).isRequired,
 };
+


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This patch forces GPU acceleration to improve viewer's zooming on Safari.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23956 

### Motivation
inspired from https://blog.pixelfreestudio.com/cross-browser-debugging-solving-inconsistencies-in-safari-and-chrome/, for example.


### How to test
See #23956 

### More
I am not sure if it's a final fix. But it certainly improves.
I didn't test it on iOS (which I do not have), but the current implementation will do the same GPU push on iOS.