### PR TITLE
Fix(html5): enable client read of X-Server-Epoch-Msec on cluster for proper time sync

### DIFF
--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -169,6 +169,7 @@
             # CORS request. No cookies are required so we can just allow anyone
             # to use this endpoint.
             add_header 'Access-Control-Allow-Origin' '*';
+            add_header Access-Control-Expose-Headers X-Server-Epoch-Msec;
             return 200 "";
         }
 


### PR DESCRIPTION
### What does this PR do?
- Fixes the CORS exposure of the `X-Server-Epoch-Msec` header in the `/bigbluebutton/rtt-check` endpoint so that browser JS can read it.  
- Restores client-side time synchronization for breakout rooms by ensuring the epoch timestamp header is exposed to scripts.

### Closes Issue(s)
Closes bigbluebutton/bigbluebutton#23943

### Motivation
In some cases, clients saw wildly incorrect timers (e.g. “488484… hours”) for breakout rooms. The root cause is that `X-Server-Epoch-Msec`—used for synchronizing time in the client—was being sent by nginx but **not exposed via CORS**, so `response.headers.get(...)` returned `null` (or zero). This PR corrects that by updating nginx configuration to properly expose the header, enabling JS to retrieve it and sync timers correctly.

### How to test
Should running a cluster!
1. Deploy the updated nginx config (or apply locally).  
2. Launch a session with breakout rooms enabled.  
3. Create a breakout room with a custom timer (e.g. 20 minutes).  
4. In the browser console, run:
   ```js
   fetch("/bigbluebutton/rtt-check")
     .then(r => console.log(r.headers.get("X-Server-Epoch-Msec")));
     
Expect a valid epoch value, not null or 0.
5. Verify the breakout room timer UI now displays correctly (counting down rather than showing absurd values).
6. Test across multiple browsers and from different origins to validate the CORS header works as expected.

More:


[Screencast from 24-09-2025 09:15:27.webm](https://github.com/user-attachments/assets/c5a2449c-d604-4b55-acba-7556d9cdefeb)
