### PR TITLE
fix (bbb-web): Rework SVG dimension parsing using ImageMagick identify

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -41,9 +41,9 @@ public class ImageResolutionService {
     public ImageResolution identifyImageResolution(String presentationFileAbsolutePath) {
 
         NuProcessBuilder imageResolution = new NuProcessBuilder(
-                Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", String.valueOf(wait),
+        NuProcessBuilder imageResolution = new NuProcessBuilder(
+                Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", wait + "s",
                         "identify", "-format","%w %h", presentationFileAbsolutePath));
-
         ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler("imgresolution-" + presentationFileAbsolutePath);
         imageResolution.setProcessListener(imgResHandler);
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 public class ImageResolutionService {
     private static Logger log = LoggerFactory.getLogger(ImageResolutionService.class);
 
-    private int wait = 5;
+    private int wait = 20;
 
     public ImageResolution identifyImageResolution(File presentationFile) {
         return identifyImageResolution(presentationFile.getAbsolutePath());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -41,7 +41,6 @@ public class ImageResolutionService {
     public ImageResolution identifyImageResolution(String presentationFileAbsolutePath) {
 
         NuProcessBuilder imageResolution = new NuProcessBuilder(
-        NuProcessBuilder imageResolution = new NuProcessBuilder(
                 Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", wait + "s",
                         "identify", "-format","%w %h", presentationFileAbsolutePath));
         ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler("imgresolution-" + presentationFileAbsolutePath);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -49,9 +49,14 @@ public class ImageResolutionService {
 
         NuProcess process = imageResolution.start();
         try {
-            process.waitFor(wait + 1, TimeUnit.SECONDS);
+            int returnCode = process.waitFor(wait + 1, TimeUnit.SECONDS);
+            if (returnCode == Integer.MIN_VALUE) {
+                log.warn("Timeout ({}s) identifying image resolution for {}", wait + 1, presentationFileAbsolutePath);
+                process.destroy(true);
+            }
         } catch (InterruptedException e) {
-            log.error("InterruptedException while identifying image resolution {}", presentationFileAbsolutePath, e);
+            Thread.currentThread().interrupt();
+            log.error("Interrupted while identifying image resolution {}", presentationFileAbsolutePath, e);
         }
 
         return new ImageResolution(imgResHandler.getWidth(), imgResHandler.getHeight());

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageResolutionService.java
@@ -30,30 +30,34 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 public class ImageResolutionService {
-  private static Logger log = LoggerFactory.getLogger(ImageResolutionService.class);
+    private static Logger log = LoggerFactory.getLogger(ImageResolutionService.class);
 
-  private int wait = 5;
+    private int wait = 5;
 
-  public ImageResolution identifyImageResolution(File presentationFile) {
-
-    NuProcessBuilder imageResolution = new NuProcessBuilder(
-        Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", String.valueOf(wait),
-                "identify", "-format","%w %h", presentationFile.getAbsolutePath()));
-
-    ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler("imgresolution-" + presentationFile.getName());
-    imageResolution.setProcessListener(imgResHandler);
-
-    NuProcess process = imageResolution.start();
-    try {
-      process.waitFor(wait + 1, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      log.error("InterruptedException while identifying image resolution {}", presentationFile.getName(), e);
+    public ImageResolution identifyImageResolution(File presentationFile) {
+        return identifyImageResolution(presentationFile.getAbsolutePath());
     }
 
-    return new ImageResolution(imgResHandler.getWidth(), imgResHandler.getHeight());
-  }
+    public ImageResolution identifyImageResolution(String presentationFileAbsolutePath) {
 
-  public void setWait(int wait) {
+        NuProcessBuilder imageResolution = new NuProcessBuilder(
+                Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", String.valueOf(wait),
+                        "identify", "-format","%w %h", presentationFileAbsolutePath));
+
+        ImageResolutionServiceHandler imgResHandler = new ImageResolutionServiceHandler("imgresolution-" + presentationFileAbsolutePath);
+        imageResolution.setProcessListener(imgResHandler);
+
+        NuProcess process = imageResolution.start();
+        try {
+            process.waitFor(wait + 1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.error("InterruptedException while identifying image resolution {}", presentationFileAbsolutePath, e);
+        }
+
+        return new ImageResolution(imgResHandler.getWidth(), imgResHandler.getHeight());
+    }
+
+    public void setWait(int wait) {
     this.wait = wait;
   }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
@@ -37,6 +37,7 @@ public class ImageSlidesGenerationService {
 	private TextFileCreator textFileCreator;
 	private PngCreator pngCreator;
 	private ImageResizer imageResizer;
+	private ImageResolutionService imageResolutionService;
 	private long maxImageWidth = 2048;
 	private long maxImageHeight = 1536;
 	private boolean svgImagesRequired=true;
@@ -92,8 +93,7 @@ public class ImageSlidesGenerationService {
 		log.debug("Creating SVG images.");
 
 		try {
-			ImageResolutionService imgResService = new ImageResolutionService();
-			ImageResolution imageResolution = imgResService.identifyImageResolution(pres.getUploadedFile());
+			ImageResolution imageResolution = imageResolutionService.identifyImageResolution(pres.getUploadedFile());
 
 			log.debug("Identified image {} width={} and height={}", pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
 
@@ -148,6 +148,10 @@ public class ImageSlidesGenerationService {
 	public void setImageResizer(ImageResizer imageResizer) {
 	    this.imageResizer = imageResizer;
 	}
+
+    public void setImageResolutionService(ImageResolutionService imageResolutionService) {
+        this.imageResolutionService = imageResolutionService;
+    }
 	
 	public void setMaxImageWidth(long maxImageWidth) {
 	    this.maxImageWidth = maxImageWidth;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SlidesGenerationProgressNotifier.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SlidesGenerationProgressNotifier.java
@@ -115,6 +115,7 @@ public class SlidesGenerationProgressNotifier {
             pres.getNumberOfPages(),
             slidesCompleted,
             generateBasePresUrl(pres),
+            pres.getUploadedFile().getParent(),
             pageGenerated,
             (pageGenerated == 1));
     messagingService.sendDocConversionMsg(progress);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -39,6 +39,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 	private String BLANK_SVG;
     private int maxNumberOfAttempts = 3;
     private ImageResizer imageResizer;
+    private ImageResolutionService imageResolutionService;
 
     @Override
     public boolean createSvgImage(UploadedPresentation pres, int page) throws TimeoutException{
@@ -298,8 +299,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                         int width = 500;
                         int height = 500;
 
-                        ImageResolutionService imgResService = new ImageResolutionService();
-                        ImageResolution imageResolution = imgResService.identifyImageResolution(tempPng);
+                        ImageResolution imageResolution = imageResolutionService.identifyImageResolution(tempPng);
                         log.debug("Identified page {} image {} width={} and height={}", page, pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
 
                         if (imageResolution.getWidth() != 0 && imageResolution.getHeight() != 0) {
@@ -310,7 +310,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                         if(imageResolution.getWidth() > MAX_SVG_WIDTH || imageResolution.getHeight() > MAX_SVG_HEIGHT) {
                             log.info("The image exceeds max dimension allowed, it will be resized.");
                             imageResizer.resize(tempPng, MAX_SVG_WIDTH + "x" + MAX_SVG_HEIGHT);
-                            imageResolution = imgResService.identifyImageResolution(tempPng);
+                            imageResolution = imageResolutionService.identifyImageResolution(tempPng);
                             width = imageResolution.getWidth();
                             height = imageResolution.getHeight();
                         }
@@ -497,5 +497,9 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     public void setImageResizer(ImageResizer imageResizer) {
         this.imageResizer = imageResizer;
+    }
+
+    public void setImageResolutionService(ImageResolutionService imageResolutionService) {
+        this.imageResolutionService = imageResolutionService;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/DocPageGeneratedProgress.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/DocPageGeneratedProgress.java
@@ -14,6 +14,7 @@ public class DocPageGeneratedProgress implements IDocConversionMsg {
   public final Integer numPages;
   public final Integer pagesCompleted;
   public final String presBaseUrl;
+  public final String presParentPath;
   public final Boolean current;
   public final Integer page;
 
@@ -30,6 +31,7 @@ public class DocPageGeneratedProgress implements IDocConversionMsg {
                                   Integer numPages,
                                   Integer pagesCompleted,
                                   String presBaseUrl,
+                                  String presParentPath,
                                   Integer page,
                                   Boolean current) {
     this.podId = podId;
@@ -45,6 +47,7 @@ public class DocPageGeneratedProgress implements IDocConversionMsg {
     this.numPages = numPages;
     this.pagesCompleted = pagesCompleted;
     this.presBaseUrl = presBaseUrl;
+    this.presParentPath = presParentPath;
     this.page = page;
     this.current = current;
   }

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -166,6 +166,7 @@ imageResizeWait=7
 officeDocumentValidationTimeout=20
 presOfficeConversionTimeout=60
 pdfPageCountWait=5
+detectImageDimensionsTimeout=20
 
 #----------------------------------------------------
 # Additional conversion of the presentation slides to PNG

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -77,6 +77,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="wait" value="${imageResizeWait}"/>
     </bean>
 
+    <bean id="imageResolutionService" class="org.bigbluebutton.presentation.imp.ImageResolutionService">
+        <property name="wait" value="${detectImageDimensionsTimeout}"/>
+    </bean>
+
     <bean id="pageCounterService" class="org.bigbluebutton.presentation.imp.PageCounterService">
         <property name="pageCounter" ref="pageCounter"/>
     </bean>
@@ -110,6 +114,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="forceRasterizeSlides" value="${forceRasterizeSlides}"/>
         <property name="pngWidthRasterizedSlides" value="${pngWidthRasterizedSlides}"/>
         <property name="imageResizer" ref="imageResizer"/>
+        <property name="imageResolutionService" ref="imageResolutionService"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>
@@ -147,6 +152,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="textFileCreator" ref="textFileCreator"/>
         <property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>
         <property name="imageResizer" ref="imageResizer"/>
+        <property name="imageResolutionService" ref="imageResolutionService"/>
         <property name="maxImageWidth" value="${maxImageWidth}"/>
         <property name="maxImageHeight" value="${maxImageHeight}"/>
         <property name="generatePngs" value="${generatePngs}"/>

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -21,7 +21,7 @@ We have done significant work to adopt the newly released version 2 of tl;draw. 
 
 When transparentListenOnly is enabled on the server (enabled by default starting with BigBlueButton 3.0.0-rc.1), users can now switch seamlessly between Listen Only and Microphone modes without needing to rejoin audio.
 
-To further improve the user experience, you can disable listenOnlyMode (`public.app.listenOnlyMode` in `/etc/bigbluebutton/bbb-html5.yml` or `userdata-bbb_listen_only_mode`). 
+To further improve the user experience, you can disable listenOnlyMode (`public.app.listenOnlyMode` in `/etc/bigbluebutton/bbb-html5.yml` or `userdata-bbb_listen_only_mode`).
 This removes the need to choose between Microphone or Listen Only mode when joining audio in a session. Instead, you are taken directly to the audio configuration screen.
 
 ![audio controls when joining audio](/img/30/30-ui-join-audio.png)
@@ -68,7 +68,7 @@ A contribution from community member Jan Kessler, the direct Leave Meeting butto
 
 ![leave the meeting red button](/img/30/30-leave-meeting.png)
 
-Viewers can leave the meeting by using this new red button, previously hidden near the Setting menu. For moderators, the button includes the option to end the meeting as well. 
+Viewers can leave the meeting by using this new red button, previously hidden near the Setting menu. For moderators, the button includes the option to end the meeting as well.
 
 #### Better looking polling results
 
@@ -105,7 +105,7 @@ To enable see `public.app.defaultSettings.application.pushToTalkEnabled` https:/
 
 We have made significant changes to the architecture of BigBlueButton and have introduced support to plugins -- optional custom modules included in the client which allow expanding the capabilities of BigBlueButton. A data channel is provided to allow for data exchange between clients. See the [HTML5 Plugin SDK](https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk) for examples and more information.
 
-At the moment of writing this documentation, the official list of plugins includes: 
+At the moment of writing this documentation, the official list of plugins includes:
 - [Select Random User](https://github.com/bigbluebutton/plugin-pick-random-user)
 - [Share a link](https://github.com/bigbluebutton/plugin-generic-link-share)
 - [H5P plugin for BigBlueButton](https://github.com/bigbluebutton/plugin-h5p)
@@ -376,6 +376,7 @@ Added
 - `officeDocumentValidationTimeout` added
 - `presOfficeConversionTimeout` added
 - `pdfPageCountWait` added
+- `detectImageDimensionsTimeout` added
 - `presentationConversionCacheEnabled` added
 - `presentationConversionCacheS3AccessKeyId` added
 - `presentationConversionCacheS3AccessKeySecret` added
@@ -403,7 +404,7 @@ In BigBlueButton 2.6.18/2.7.8 POST requests are no longer allowed for the `join`
 
 #### Changes in document formats we support
 
-We improved the documentation for which types of files we support when uploading presentations. Support for `.odi` and `.odc` was dropped. Support for `.svg`, `.odg` and `.webp` was officially added even though animated webp's are no longer animated after the image processing. 
+We improved the documentation for which types of files we support when uploading presentations. Support for `.odi` and `.odc` was dropped. Support for `.svg`, `.odg` and `.webp` was officially added even though animated webp's are no longer animated after the image processing.
 
 #### We mirror the webcam preview by default now
 


### PR DESCRIPTION
As noted by @paultrudel in #23933, the current method for obtaining SVG dimensions can lead to OOM issues.
The proposed fix in that PR introduces a restriction, "limits the size of SVGs that can be read to 10 MB".

This PR takes a different approach: it reuses the same sandboxed command (using `ImageMagick identify`) already employed for other images to read SVG dimensions as well. In my tests, this method worked reliably and showed promising results.