### PR TITLE
Fix #23964: avoid printing on the standard output in cron jobs

### DIFF
--- a/bigbluebutton-config/cron.daily/bigbluebutton
+++ b/bigbluebutton-config/cron.daily/bigbluebutton
@@ -125,7 +125,7 @@ remove_raw_of_published_recordings
 #
 # Remove untagged and unnamed docker images, cleaning /var/lib/docker/overlay2
 #
-docker image prune -f
+docker image prune -f 2>&1 | logger
 
 #
 # Remove old *.afm and *.pfb files from /tmp directory (if any exist)


### PR DESCRIPTION
### What does this PR do?
Avoid printing on the standard output in cron jobs in order to prevent any mail to be sent to the root user of the server.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23964 #18254

### Motivation
This is a really quick fix to a really annoying issue.


### How to test
Check the issue #23964
