### PR TITLE
refactor (ci): Avoid generating APT Cache for every new PR

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -378,7 +378,7 @@ jobs:
           sudo chmod 755 /var/cache/apt/archives /var/cache/apt/archives/partial 2>/dev/null || true
           find /var/cache/apt/archives -type f -name '*.deb' -print0 \
             | sort -z \
-            | xargs -0 -r sha256sum > apt-manifest-end.txt
+            | sha256sum > apt-manifest-end.txt
           echo "hash=$(sha256sum apt-manifest-end.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
       - name: APT CACHE - Upload new packages (if changed)
         if: success() && matrix.shard == 1

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -370,18 +370,19 @@ jobs:
           name: bbb-logs-${{ env.MATRIX_SHARD_UNDERSCORED }}
           path: ./bbb-logs.tar.gz
       - name: APT CACHE - Check for changes using packages hash
-        if: success() && matrix.shard == 1
+        if: success() && matrix.shard == 1 && github.event_name != 'pull_request'
         id: apt-manifest
         shell: bash
         run: |
           sudo chown -R "$USER:$USER" /var/cache/apt/archives || true
           sudo chmod 755 /var/cache/apt/archives /var/cache/apt/archives/partial 2>/dev/null || true
-          find /var/cache/apt/archives -type f -name '*.deb' -print0 \
-            | sort -z \
-            | sha256sum > apt-manifest-end.txt
-          echo "hash=$(sha256sum apt-manifest-end.txt | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          hash=$(find /var/cache/apt/archives -type f -name '*.deb' \
+                   | sort \
+                   | sha256sum \
+                   | cut -d' ' -f1)
+          echo "hash=$hash" >> $GITHUB_OUTPUT
       - name: APT CACHE - Upload new packages (if changed)
-        if: success() && matrix.shard == 1
+        if: success() && matrix.shard == 1 && github.event_name != 'pull_request'
         uses: actions/cache/save@v4
         with:
           path: /var/cache/apt/archives


### PR DESCRIPTION
GitHub caches are constantly hitting the limit:
<img width="1595" height="166" alt="image" src="https://github.com/user-attachments/assets/1c21ff0d-1eef-4484-a641-6af859365882" />

One reason is that APT package caches are now being generated, but since each PR can’t reuse the cache produced by another, it ends up duplicating them.
To reduce the problem, the cache will no longer be created for PRs. Instead, it will only be generated once a PR is merged, allowing future PRs to benefit from the shared cache.

<img width="2339" height="1865" alt="image" src="https://github.com/user-attachments/assets/f50c136d-48aa-45b2-b080-ccbbd7340bb4" />





- Other minor change: It will generate the hash based on the package names instead of based on packages content.