### PR TITLE
refactor (bbb-web): Read presentation txt content from local file instead of page URL

### DIFF
--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -8,10 +8,10 @@ import org.bigbluebutton.common2.domain.{ DefaultProps, PageVO, PresentationPage
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.presentation.imp.ImageResolutionService
 import org.bigbluebutton.presentation.messages._
-
-import java.net.URL
 import scala.jdk.CollectionConverters._
 import scala.util.{ Try, Using }
+import scala.io.Source
+import java.nio.charset.StandardCharsets
 
 object MsgBuilder {
   private lazy val imageResolutionService: ImageResolutionService = new ImageResolutionService
@@ -108,9 +108,10 @@ object MsgBuilder {
     }
 
     val content = Try {
-      val c = new URL(txtUrl).openConnection()
-      c.setConnectTimeout(5000); c.setReadTimeout(5000)
-      Using(scala.io.Source.fromInputStream(c.getInputStream, "UTF-8"))(_.mkString).get
+      val pageAbsoluteTxtPath = presParentPath + "/textfiles/slide-" + page.toString + ".txt"
+      Using(Source.fromFile(pageAbsoluteTxtPath, StandardCharsets.UTF_8.name())) { source =>
+        source.mkString
+      }.get
     }.getOrElse("")
 
     PresentationPageConvertedVO(

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -108,9 +108,17 @@ object MsgBuilder {
     }
 
     val content = Try {
+      val maxChars: Int = 1024 * 1024 // limit ~1 MB to avoid OOM
       val pageAbsoluteTxtPath = presParentPath + "/textfiles/slide-" + page.toString + ".txt"
       Using(Source.fromFile(pageAbsoluteTxtPath, StandardCharsets.UTF_8.name())) { source =>
-        source.mkString
+        val buffer = new StringBuilder
+        val iter = source.iter
+        var count = 0
+        while (iter.hasNext && count < maxChars) {
+          buffer.append(iter.next())
+          count += 1
+        }
+        buffer.toString()
       }.get
     }.getOrElse("")
 


### PR DESCRIPTION
Following #23963, the code now reads the SVG file from a local path instead of a URL.
This PR applies the same idea to text files: the function that previously read page text from a TXT URL has been updated to read from a local TXT path instead.

This approach is faster, avoids timeouts, and reduces potential risks.