### PR TITLE
fix: Multi user whiteboard number of participants can be incorrect

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -188,7 +188,7 @@ export const CURRENT_PAGE_WRITERS_QUERY = gql`
 export const CURRENT_PAGE_WRITERS_SUBSCRIPTION = gql`
   subscription currentPageWritersSubscription {
     pres_page_writers(
-      where: { isCurrentPage: {_eq: true} },
+      where: { isCurrentPage: {_eq: true}, user: { currentlyInMeeting: { _eq: true } } },
       order_by: { userId: asc }
     ) {
       userId


### PR DESCRIPTION
### What does this PR do?

Adjusts page writers subscription to ignore users who are not in the meeting when counting for the multi-user whiteboard.

### Closes Issue(s)
Closes #23976

### How to test
1. join a meeting with 3 users (moderator A, viewer B, viewer C)
2. enable multi-user whiteboard
3. in moderator A tab, check multi-user counter under the whiteboard (it should be `3`)
4. viewer B leaves the meeting
5. check again the multi-user counter - the number should be changed from `3` to `2`