### PR TITLE
[3.0 recording] fix: external video recording not shown after screenshare

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -891,7 +891,16 @@ module BigBlueButton
         s = { :timestamp => event['timestamp'].to_i }
         external_videos_events << s
       end
-      external_videos_events.sort_by {|a| a[:timestamp]}
+      sorted = external_videos_events.sort_by {|a| a[:timestamp]}
+      paired = []
+      sorted.each_with_index do |event, i|
+        if event.key?(:external_video_url)
+          paired << event
+          nxt = sorted[i+1]
+          paired << nxt if nxt && !nxt.key?(:external_video_url)
+        end
+      end
+      paired
     end
 
     # Get events when the moderator wants the recording to start or stop


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Make a pair of external-video-start and external-video-stop events and remove unnecessary external-video-stop events.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23986 

### Motivation
From BBB3.0 or earlier, external-video-stop event is recorded whenever a screen share event happens. This brings unnecessary external-video-stop events and breaks the recording logic.
Another solution would be stopping to add external-video-stop event when it's not paired with external-video-start event (graphql issue?).
