### PR TITLE
perf (gql-server): Shift notification streaming from Hasura to bbb-graphql-middleware

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
@@ -67,6 +67,7 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
           "Notification when a new presentation is set as current",
           Map("presentationName"->s"${pres.name}")
         )
+        bus.outGW.send(notifyEvent)
         NotificationDAO.insert(notifyEvent)
       }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPresentationPubMsgHdlr.scala
@@ -53,6 +53,7 @@ trait SetCurrentPresentationPubMsgHdlr extends RightsManagementTrait {
           "Notification when a new presentation is set as current",
           Map("presentationName" -> s"${pres.name}")
         )
+        bus.outGW.send(notifyEvent)
         NotificationDAO.insert(notifyEvent)
 
         val pods = state.presentationPodManager.addPod(updatedPod)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresentationDownloadablePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetPresentationDownloadablePubMsgHdlr.scala
@@ -65,6 +65,7 @@ trait SetPresentationDownloadablePubMsgHdlr extends RightsManagementTrait {
             "Notification when the download of the presentation has been enabled",
             Map("presentationName" -> s"${pres.name}")
           )
+          bus.outGW.send(notifyEvent)
           NotificationDAO.insert(notifyEvent)
         }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/NotificationDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/NotificationDAO.scala
@@ -34,37 +34,39 @@ class NotificationDbTableDef(tag: Tag) extends Table[NotificationDbModel](tag, N
 object NotificationDAO {
   def insert(notification: BbbCommonEnvCoreMsg) = {
 
-    val (meetingId, notificationType, icon, messageId, messageDescription, messageValues, role, userId) = notification.core match {
-      case event: NotifyAllInMeetingEvtMsg =>
-        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, None, None)
-      case event: NotifyRoleInMeetingEvtMsg =>
-        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, Some(event.body.role), None)
-      case event: NotifyUserInMeetingEvtMsg =>
-        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, None, Some(event.body.userId))
-      case _ =>
-        ("","", "", "", "", Map(""->""), None, None)
-    }
+    // Stop inserting notification into the database as it will be streamed by the Middleware
 
-    if (notificationType != "") {
-      DatabaseConnection.enqueue(
-        TableQuery[NotificationDbTableDef].forceInsert(
-          NotificationDbModel(
-            meetingId,
-            notificationType,
-            icon,
-            messageId,
-            messageDescription,
-            JsonUtils.mapToJson(messageValues),
-            role,
-            userMeetingId = userId match {
-              case Some(u) => Some(meetingId)
-              case _ => None
-            },
-            userId,
-            createdAt = new java.sql.Timestamp(System.currentTimeMillis())
-          )
-        )
-      )
-    }
+//    val (meetingId, notificationType, icon, messageId, messageDescription, messageValues, role, userId) = notification.core match {
+//      case event: NotifyAllInMeetingEvtMsg =>
+//        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, None, None)
+//      case event: NotifyRoleInMeetingEvtMsg =>
+//        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, Some(event.body.role), None)
+//      case event: NotifyUserInMeetingEvtMsg =>
+//        (event.body.meetingId, event.body.notificationType, event.body.icon, event.body.messageId, event.body.messageDescription, event.body.messageValues, None, Some(event.body.userId))
+//      case _ =>
+//        ("","", "", "", "", Map(""->""), None, None)
+//    }
+//
+//    if (notificationType != "") {
+//      DatabaseConnection.enqueue(
+//        TableQuery[NotificationDbTableDef].forceInsert(
+//          NotificationDbModel(
+//            meetingId,
+//            notificationType,
+//            icon,
+//            messageId,
+//            messageDescription,
+//            JsonUtils.mapToJson(messageValues),
+//            role,
+//            userMeetingId = userId match {
+//              case Some(u) => Some(meetingId)
+//              case _ => None
+//            },
+//            userId,
+//            createdAt = new java.sql.Timestamp(System.currentTimeMillis())
+//          )
+//        )
+//      )
+//    }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -139,13 +139,13 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
         msgSender.send("from-akka-apps-frontend-redis-channel", json)
 
       case NotifyAllInMeetingEvtMsg.NAME =>
-        msgSender.send("from-akka-apps-frontend-redis-channel", json)
+        msgSender.send(fromAkkaAppsRedisChannel, json)
 
       case NotifyUserInMeetingEvtMsg.NAME =>
-        msgSender.send("from-akka-apps-frontend-redis-channel", json)
+        msgSender.send(fromAkkaAppsRedisChannel, json)
 
       case NotifyRoleInMeetingEvtMsg.NAME =>
-        msgSender.send("from-akka-apps-frontend-redis-channel", json)
+        msgSender.send(fromAkkaAppsRedisChannel, json)
 
       case _ =>
         msgSender.send(fromAkkaAppsRedisChannel, json)

--- a/bbb-graphql-middleware/config/Config.go
+++ b/bbb-graphql-middleware/config/Config.go
@@ -119,3 +119,8 @@ var AllowedSubscriptionsForNotInMeetingUsers = []string{
 	"userCurrentSubscription",
 	"Patched_userCurrentSubscription",
 }
+
+var StreamingSubscriptionsManagedByMiddleware = []string{
+	"getCursorCoordinatesStream",
+	"getNotificationStream",
+}

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -247,6 +247,9 @@ RangeLoop:
 					if browserConnection.ActiveStreamings["getCursorCoordinatesStream"] == browserMessage.ID {
 						delete(browserConnection.ActiveStreamings, "getCursorCoordinatesStream")
 					}
+					if browserConnection.ActiveStreamings["getNotificationStream"] == browserMessage.ID {
+						delete(browserConnection.ActiveStreamings, "getNotificationStream")
+					}
 					browserConnection.ActiveStreamingsMutex.Unlock()
 				}
 

--- a/bbb-graphql-middleware/internal/streaming_server/notificationStream.go
+++ b/bbb-graphql-middleware/internal/streaming_server/notificationStream.go
@@ -1,0 +1,117 @@
+package streamingserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"bbb-graphql-middleware/internal/common"
+)
+
+func HandleNotifyAllInMeetingEvtMsg(receivedMessage common.RedisMessage, browserConnectionsMutex *sync.RWMutex, browserConnections map[string]*common.BrowserConnection) {
+	jsonDataNext, _ := createGraphqlMessage(receivedMessage, false)
+
+	browserConnectionsToSendCursor := make([]*common.BrowserConnection, 0)
+	browserConnectionsMutex.RLock()
+	for _, bc := range browserConnections {
+		if bc.MeetingId == receivedMessage.Core.Header.MeetingId {
+			browserConnectionsToSendCursor = append(browserConnectionsToSendCursor, bc)
+		}
+	}
+	browserConnectionsMutex.RUnlock()
+
+	for _, bc := range browserConnectionsToSendCursor {
+		bc.ActiveStreamingsMutex.RLock()
+		queryId, existsCursorStream := bc.ActiveStreamings["getNotificationStream"]
+		bc.ActiveStreamingsMutex.RUnlock()
+		if existsCursorStream {
+			payload := bytes.Replace(jsonDataNext, QueryIdPlaceholderInBytes, []byte(queryId), 1)
+			bc.FromHasuraToBrowserChannel.TrySend(payload)
+		}
+	}
+}
+
+func HandleNotifyUserInMeetingEvtMsg(receivedMessage common.RedisMessage, browserConnectionsMutex *sync.RWMutex, browserConnections map[string]*common.BrowserConnection) {
+	userId := receivedMessage.Core.Body["userId"].(string)
+	jsonDataNext, _ := createGraphqlMessage(receivedMessage, true)
+
+	browserConnectionsToSendCursor := make([]*common.BrowserConnection, 0)
+	browserConnectionsMutex.RLock()
+	for _, bc := range browserConnections {
+		if bc.MeetingId == receivedMessage.Core.Header.MeetingId && bc.UserId == userId {
+			browserConnectionsToSendCursor = append(browserConnectionsToSendCursor, bc)
+		}
+	}
+	browserConnectionsMutex.RUnlock()
+
+	for _, bc := range browserConnectionsToSendCursor {
+		bc.ActiveStreamingsMutex.RLock()
+		queryId, existsCursorStream := bc.ActiveStreamings["getNotificationStream"]
+		bc.ActiveStreamingsMutex.RUnlock()
+		if existsCursorStream {
+			payload := bytes.Replace(jsonDataNext, QueryIdPlaceholderInBytes, []byte(queryId), 1)
+			bc.FromHasuraToBrowserChannel.TrySend(payload)
+		}
+	}
+}
+
+func HandleNotifyRoleInMeetingEvtMsg(receivedMessage common.RedisMessage, browserConnectionsMutex *sync.RWMutex, browserConnections map[string]*common.BrowserConnection) {
+	role := receivedMessage.Core.Body["role"].(string)
+	jsonDataNext, _ := createGraphqlMessage(receivedMessage, false)
+
+	browserConnectionsToSendCursor := make([]*common.BrowserConnection, 0)
+	browserConnectionsMutex.RLock()
+	for _, bc := range browserConnections {
+		if bc.MeetingId == receivedMessage.Core.Header.MeetingId {
+			if role == "moderator" && bc.BBBWebSessionVariables["x-hasura-moderatorinmeeting"] == receivedMessage.Core.Header.MeetingId {
+				browserConnectionsToSendCursor = append(browserConnectionsToSendCursor, bc)
+			} else if role == "presenter" && bc.BBBWebSessionVariables["x-hasura-presenterinmeeting"] == receivedMessage.Core.Header.MeetingId {
+				browserConnectionsToSendCursor = append(browserConnectionsToSendCursor, bc)
+			}
+		}
+	}
+	browserConnectionsMutex.RUnlock()
+
+	for _, bc := range browserConnectionsToSendCursor {
+		bc.ActiveStreamingsMutex.RLock()
+		queryId, existsCursorStream := bc.ActiveStreamings["getNotificationStream"]
+		bc.ActiveStreamingsMutex.RUnlock()
+		if existsCursorStream {
+			payload := bytes.Replace(jsonDataNext, QueryIdPlaceholderInBytes, []byte(queryId), 1)
+			bc.FromHasuraToBrowserChannel.TrySend(payload)
+		}
+	}
+}
+
+func createGraphqlMessage(receivedMessage common.RedisMessage, isSingleUserNotification bool) ([]byte, error) {
+	notificationType := receivedMessage.Core.Body["notificationType"].(string)
+	icon := receivedMessage.Core.Body["icon"].(string)
+	messageId := receivedMessage.Core.Body["messageId"].(string)
+	messageValues := receivedMessage.Core.Body["messageValues"]
+	now := time.Now().UTC()
+
+	item := map[string]any{
+		"notificationType":         notificationType,
+		"icon":                     icon,
+		"messageId":                messageId,
+		"messageValues":            messageValues,
+		"isSingleUserNotification": isSingleUserNotification,
+		"createdAt":                now.Format("2006-01-02T15:04:05.000Z"),
+		"__typename":               "notification",
+	}
+
+	browserResponseData := map[string]any{
+		"id":   QueryIdPlaceholder,
+		"type": "next",
+		"payload": map[string]any{
+			"data": map[string]any{
+				"notification_stream": []any{
+					item,
+				},
+			},
+		},
+	}
+
+	return json.Marshal(browserResponseData)
+}

--- a/bbb-graphql-middleware/internal/websrv/reader/reader.go
+++ b/bbb-graphql-middleware/internal/websrv/reader/reader.go
@@ -78,7 +78,8 @@ func BrowserConnectionReader(
 				browserConnection.FromBrowserToGqlActionsChannel.SendWait(browserConnection.Context, message)
 				continue
 			}
-			if bytes.Contains(message, []byte("\"query\":\"subscription getCursorCoordinatesStream")) {
+			if bytes.Contains(message, []byte("\"query\":\"subscription getCursorCoordinatesStream")) ||
+				bytes.Contains(message, []byte("\"query\":\"subscription getNotificationStream")) {
 				go streamingserver.ReadNewStreamingSubscription(browserConnection, message)
 				continue
 			}

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -32,6 +32,9 @@ var allowedMessages = []string{
 	"CheckGraphqlMiddlewareAlivePingSysMsg",
 	"SendCursorPositionEvtMsg",
 	"SetCurrentPageEvtMsg",
+	"NotifyAllInMeetingEvtMsg",
+	"NotifyUserInMeetingEvtMsg",
+	"NotifyRoleInMeetingEvtMsg",
 	"ModifyWhiteboardAccessEvtMsg",
 	"UserLeftMeetingEvtMsg",
 	"MeetingEndedEvtMsg",
@@ -110,6 +113,30 @@ func StartRedisListener() {
 
 		if messageName == "SendCursorPositionEvtMsg" {
 			go streamingserver.HandleSendCursorPositionEvtMsg(
+				receivedMessage,
+				BrowserConnectionsMutex,
+				BrowserConnections,
+			)
+		}
+
+		if messageName == "NotifyAllInMeetingEvtMsg" {
+			go streamingserver.HandleNotifyAllInMeetingEvtMsg(
+				receivedMessage,
+				BrowserConnectionsMutex,
+				BrowserConnections,
+			)
+		}
+
+		if messageName == "NotifyUserInMeetingEvtMsg" {
+			go streamingserver.HandleNotifyUserInMeetingEvtMsg(
+				receivedMessage,
+				BrowserConnectionsMutex,
+				BrowserConnections,
+			)
+		}
+
+		if messageName == "NotifyRoleInMeetingEvtMsg" {
+			go streamingserver.HandleNotifyRoleInMeetingEvtMsg(
 				receivedMessage,
 				BrowserConnectionsMutex,
 				BrowserConnections,

--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -12,7 +12,6 @@ import {
 } from './service';
 import Styled from './styles';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
-import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 
 const Notifications: React.FC = () => {
   const [registeredAt, setRegisteredAt] = React.useState<string>(new Date().toISOString());
@@ -37,34 +36,10 @@ const Notifications: React.FC = () => {
     isModerator: u.isModerator,
   }));
 
-  const Settings = getSettingsSingletonInstance();
-  const {
-    userJoinPushAlerts,
-    userJoinAudioAlerts,
-    userLeavePushAlerts,
-    userLeaveAudioAlerts,
-    guestWaitingPushAlerts,
-    guestWaitingAudioAlerts,
-  } = Settings.application;
-
-  const excludedMessageIds = [];
-
-  if (!userJoinPushAlerts && !userJoinAudioAlerts) {
-    excludedMessageIds.push('app.notification.userJoinPushAlert');
-  }
-
-  if (!userLeavePushAlerts && !userLeaveAudioAlerts) {
-    excludedMessageIds.push('app.notification.userLeavePushAlert');
-  }
-
-  if (!guestWaitingPushAlerts && !guestWaitingAudioAlerts) {
-    excludedMessageIds.push('app.userList.guest.pendingGuestAlert');
-  }
-
   const {
     data: notificationsStream,
   } = useDeduplicatedSubscription<NotificationResponse>(getNotificationsStream, {
-    variables: { initialCursor: '2024-04-18', excludedMessageIds },
+    variables: { initialCursor: '2000-01-01' },
   });
 
   const notifier = (notification: Notification) => {

--- a/bigbluebutton-html5/imports/ui/components/notifications/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/queries.ts
@@ -15,6 +15,7 @@ export interface NotificationResponse {
   notification_stream: Notification[];
 }
 
+// This subscription is handled by bbb-graphql-middleware and its content should not be modified
 export const getNotificationsStream = gql`
   subscription getNotificationStream($initialCursor: timestamptz!) {
     notification_stream(

--- a/bigbluebutton-html5/imports/ui/components/notifications/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/queries.ts
@@ -16,14 +16,10 @@ export interface NotificationResponse {
 }
 
 export const getNotificationsStream = gql`
-  subscription getNotificationStream(
-    $initialCursor: timestamptz!,
-    $excludedMessageIds: [String!]!
-  ){
+  subscription getNotificationStream($initialCursor: timestamptz!) {
     notification_stream(
       batch_size: 10,
-      cursor: {initial_value: {createdAt: $initialCursor}},
-      where: {messageId: {_nin: $excludedMessageIds}}
+      cursor: {initial_value: {createdAt: $initialCursor}}
     ) {
       notificationType
       icon


### PR DESCRIPTION
Following #23768

Graphql-middleware will intercept `getNotificationStream` and handle the notifications instead forwarding it to Hasura.