### PR TITLE
fix(plugins-sdk): compare generic content items by their id

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/generic-content/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/utils.ts
@@ -1,8 +1,10 @@
-import { difference } from 'ramda';
+import { differenceWith } from 'ramda';
 
-const getDifferenceBetweenLists = <T>(previousState: T[], currentState: T[]): T[][] => {
-  const added = difference(currentState, previousState);
-  const removed = difference(previousState, currentState);
+const cmp = (x: { id: string; }, y: { id: string; }) => x.id === y.id;
+
+const getDifferenceBetweenLists = <T extends { id: string; }>(previousState: T[], currentState: T[]): T[][] => {
+  const added = differenceWith(cmp, currentState, previousState);
+  const removed = differenceWith(cmp, previousState, currentState);
   return [added, removed];
 };
 


### PR DESCRIPTION
### What does this PR do?


Currently, the diff function is comparing all the object to decide when to add/remove new generic content items, this has problems when the same generic content (same id) is set by a plugin, causing it to be added and removed wrongly.

This fixes it by comparing the items by their id to decide when to add/remove.

### Motivation
Fixes generic content disappearing from presentation area when added with same id.


### How to test
- Call `setGenericContentItems` to add a `GenericContentMainArea` in a plugin. 
- Call it again passing the id of the same item generated.

Presentation area should show the content, currently it is disappearing.