### PR TITLE
fix(html5): Error notification bar appears when presentation is removed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -93,7 +93,7 @@ const PresentationContainer = (props) => {
 
   useSubscription(ANNOTATION_HISTORY_STREAM, {
     variables: { pageId: currentPageId, updatedAt: lastUpdatedAt },
-    skip: !currentPresentationPage || !canStream,
+    skip: !currentPageId || !canStream,
     onData: ({ data: subscriptionData }) => {
       const annotationStream = subscriptionData.data?.pres_annotation_history_curr_stream || [];
       if (annotationStream.length > 0 && restoreOnUpdate && !presentationIsOpen) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -81,6 +81,7 @@ const WhiteboardContainer = (props) => {
   const flushScheduledRef = useRef(false);
 
   const fetchDeletableShapesRef = useRef();
+  const currentPresentationPageRef = useRef();
 
   // Aggregates the queues and updates state at once.
   const flushUpdates = useCallback(() => {
@@ -134,6 +135,7 @@ const WhiteboardContainer = (props) => {
   );
   const { pres_page_curr: presentationPageArray } = (presentationPageData || {});
   const newPresentationPage = presentationPageArray && presentationPageArray[0];
+  currentPresentationPageRef.current = newPresentationPage;
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -286,7 +288,7 @@ const WhiteboardContainer = (props) => {
 
   useEffect(() => {
     setTimeout(async () => {
-      if (!newPresentationPage?.pageId || !editor || !connectedStatus) return;
+      if (!currentPresentationPageRef.current?.pageId || !editor || !connectedStatus) return;
       try {
         const result = await refetchInitialPageAnnotations();
         const serverAnnotations = result?.data?.pres_annotation_curr || [];

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -71,7 +71,6 @@ const WhiteboardContainer = (props) => {
   const [shapes, setShapes] = useState([]);
   const [removedShapes, setRemovedShapes] = useState([]);
   const [isTabVisible, setIsTabVisible] = useState(document.visibilityState === 'visible');
-  const [currentPresentationPage, setCurrentPresentationPage] = useState(null);
 
   const { userLocks } = useLockContext();
 
@@ -134,8 +133,8 @@ const WhiteboardContainer = (props) => {
     CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
   );
   const { pres_page_curr: presentationPageArray } = (presentationPageData || {});
-  const newPresentationPage = presentationPageArray && presentationPageArray[0];
-  currentPresentationPageRef.current = newPresentationPage;
+  const currentPresentationPage = presentationPageArray && presentationPageArray[0];
+  currentPresentationPageRef.current = currentPresentationPage;
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -148,12 +147,6 @@ const WhiteboardContainer = (props) => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);
-
-  useEffect(() => {
-    if (newPresentationPage) {
-      setCurrentPresentationPage(newPresentationPage);
-    }
-  }, [newPresentationPage]);
 
   const curPageNum = currentPresentationPage?.num;
   const curPageId = currentPresentationPage?.pageId;
@@ -398,7 +391,7 @@ const WhiteboardContainer = (props) => {
   }, [annotationStreamData]);
 
   useEffect(() => {
-    if (!isTabVisible || !curPageId || !connectedStatus) return;
+    if (!isTabVisible || !curPageIdRef.current || !connectedStatus) return;
 
     setTimeout(() => {
       refetchInitialPageAnnotations();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -159,10 +159,7 @@ const WhiteboardContainer = (props) => {
   const curPageId = currentPresentationPage?.pageId;
   const isInfiniteWhiteboard = currentPresentationPage?.infiniteWhiteboard;
   const curPageIdRef = useRef();
-
-  React.useEffect(() => {
-    curPageIdRef.current = curPageId;
-  }, [curPageId]);
+  curPageIdRef.current = curPageId;
 
   const presentationId = currentPresentationPage?.presentationId;
 
@@ -212,14 +209,16 @@ const WhiteboardContainer = (props) => {
     return allowedShapeIds;
   }, [isModerator, isPresenter, hasWBAccess, shapes, currentUser?.userId]);
 
-  useEffect(() => {
-    fetchDeletableShapesRef.current = fetchDeletableShapes;
-  }, [fetchDeletableShapes]);
+  fetchDeletableShapesRef.current = fetchDeletableShapes;
 
   const removeShapes = (shapeIds) => {
     const deletableShapeIds = fetchDeletableShapesRef.current?.(shapeIds);
 
-    if (!Array.isArray(deletableShapeIds) || deletableShapeIds.length === 0) return;
+    if (
+      !Array.isArray(deletableShapeIds)
+      || deletableShapeIds.length === 0
+      || !curPageIdRef.current
+    ) return;
 
     presentationDeleteAnnotations({
       variables: {
@@ -248,6 +247,7 @@ const WhiteboardContainer = (props) => {
   }, 500);
 
   const submitAnnotations = async (newAnnotations) => {
+    if (!curPageIdRef.current) return false;
     const isAnnotationSent = await presentationSubmitAnnotations({
       variables: {
         pageId: curPageIdRef.current,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -286,7 +286,7 @@ const WhiteboardContainer = (props) => {
 
   useEffect(() => {
     setTimeout(async () => {
-      if (!curPageId || !editor || !connectedStatus) return;
+      if (!newPresentationPage?.pageId || !editor || !connectedStatus) return;
       try {
         const result = await refetchInitialPageAnnotations();
         const serverAnnotations = result?.data?.pres_annotation_curr || [];


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?

Avoids calling annotation resync code unnecessarily. That's because the `curPageId` is not properly updated when all presentations are removed. Calling `refetchInitialPageAnnotations` with `pageId` being `undefined` throws a query error which triggers the notification bar.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23991
