### PR TITLE
feat(apps-gallery): adds isNew ribbon for app in the gallery

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
@@ -1,6 +1,7 @@
 import React, { memo, ReactNode } from 'react';
 import Icon from '/imports/ui/components/common/icon/component';
 import { layoutDispatch } from '/imports/ui/components/layout/context';
+import { defineMessages, useIntl } from 'react-intl';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import Styled from '../styles';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
@@ -10,6 +11,7 @@ interface AppItemProps {
   name: string;
   icon: string;
   isPinned: boolean;
+  isNew?: boolean;
   onClick?: (() => void) | undefined;
   pinnedAppsLength: number;
   maxPinned: number;
@@ -19,11 +21,19 @@ interface AppItemProps {
   children?: ReactNode;
 }
 
+const intlMessages = defineMessages({
+  newAppLabel: {
+    id: 'app.appsGallery.newAppLabel',
+    description: 'Label for inidicate new apps in gallery panel title',
+  },
+});
+
 const AppItem: React.FC<AppItemProps> = ({
   appKey,
   name,
   icon,
   isPinned,
+  isNew = false,
   onClick,
   pinnedAppsLength,
   maxPinned,
@@ -33,6 +43,7 @@ const AppItem: React.FC<AppItemProps> = ({
   children = null,
 }) => {
   const layoutContextDispatch = layoutDispatch();
+  const intl = useIntl();
 
   const togglePinApp = (event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -75,6 +86,7 @@ const AppItem: React.FC<AppItemProps> = ({
           onClick={() => {}}
         />
         <Styled.AppTitle>{name}</Styled.AppTitle>
+        {isNew && <Styled.NewLabel>{intl.formatMessage(intlMessages.newAppLabel)}</Styled.NewLabel>}
         {children}
       </Styled.ClickableArea>
       <TooltipContainer title={isPinned ? unpinTooltip : pinTooltip}>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -8,6 +8,7 @@ import Styled from './styles';
 import TooManyPinnedAppsModal from './modal/component';
 import AppItem from './app-item/component';
 import ExternalAppItem from './external-app-item/component';
+import { isPluginNew } from './service';
 
 const intlMessages = defineMessages({
   appsGalleryTitle: {
@@ -46,7 +47,14 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
 
   const renderedPinnedApps = useMemo(() => (
     pinnedApps.map((pinnedAppKey) => {
-      const { name, icon } = registeredApps[pinnedAppKey];
+      const {
+        name,
+        icon,
+        pluginName,
+      } = registeredApps[pinnedAppKey];
+
+      const isNew = isPluginNew(pluginName);
+
       // type guard
       const { onClick } = registeredApps[pinnedAppKey] as InjectedAppGalleryItem;
       const isPluginInjectedApp = pinnedAppKey.startsWith(PANELS.GENERIC_CONTENT_SIDEKICK);
@@ -58,6 +66,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           name={name}
           icon={icon}
           isPinned
+          isNew={isNew}
           onClick={onClick}
           pinnedAppsLength={pinnedApps.length}
           maxPinned={MAX_PINNED_APPS_GALLERY}
@@ -73,7 +82,14 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
     Object.keys(registeredApps)
       .filter((registeredObjectKey) => !pinnedApps.includes(registeredObjectKey))
       .map((unpinnedAppKey) => {
-        const { name, icon } = registeredApps[unpinnedAppKey];
+        const {
+          name,
+          icon,
+          pluginName,
+        } = registeredApps[unpinnedAppKey];
+
+        const isNew = isPluginNew(pluginName);
+
         // type guard
         const { onClick } = registeredApps[unpinnedAppKey] as InjectedAppGalleryItem;
         const isPluginInjectedApp = unpinnedAppKey.startsWith(PANELS.GENERIC_CONTENT_SIDEKICK);
@@ -85,6 +101,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
             name={name}
             icon={icon}
             isPinned={false}
+            isNew={isNew}
             onClick={onClick}
             pinnedAppsLength={pinnedApps.length}
             maxPinned={MAX_PINNED_APPS_GALLERY}

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/external-app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/external-app-item/component.tsx
@@ -5,7 +5,11 @@ import React, {
   useMemo,
 } from 'react';
 import { SidekickAreaOptionsEnum } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/options/enums';
-import { RemoveGenericContentSidekickAreaBadgeCommandArguments, RenameGenericContentSidekickAreaCommandArguments, SetGenericContentSidekickAreaBadgeCommandArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/options/types';
+import {
+  RemoveGenericContentSidekickAreaBadgeCommandArguments,
+  RenameGenericContentSidekickAreaCommandArguments,
+  SetGenericContentSidekickAreaBadgeCommandArguments,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/options/types';
 import AppItem from '/imports/ui/components/apps-gallery/app-item/component';
 import { PANELS } from '/imports/ui/components/layout/enums';
 import Styled from './styles';
@@ -21,6 +25,7 @@ interface ExternalAppItemProps {
   setError: (v: boolean) => void;
   pinTooltip: string;
   unpinTooltip: string;
+  isNew?: boolean;
 }
 
 const ExternalAppItem: React.FC<ExternalAppItemProps> = ({
@@ -34,10 +39,14 @@ const ExternalAppItem: React.FC<ExternalAppItemProps> = ({
   setError,
   pinTooltip,
   unpinTooltip,
+  isNew = false,
 }) => {
   const [nameReplacement, setNameReplacement] = useState<string>(name);
   const [badgeContent, setBadgeContent] = useState<string | null>(null);
-  const extractedId = useMemo(() => (appKey.replace(PANELS.GENERIC_CONTENT_SIDEKICK, '')), [appKey]);
+  const extractedId = useMemo(
+    () => appKey.replace(PANELS.GENERIC_CONTENT_SIDEKICK, ''),
+    [appKey],
+  );
 
   const handleGenericContentSetBadge = ((ev: CustomEvent<SetGenericContentSidekickAreaBadgeCommandArguments>) => {
     const {
@@ -110,6 +119,7 @@ const ExternalAppItem: React.FC<ExternalAppItemProps> = ({
       setError={setError}
       pinTooltip={pinTooltip}
       unpinTooltip={unpinTooltip}
+      isNew={isNew}
     >
       {badgeContent && (
         <Styled.BadgeCircle>{badgeContent}</Styled.BadgeCircle>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/service.ts
@@ -1,0 +1,40 @@
+export type PluginSettingsMap = Record<string, boolean>;
+
+interface PluginSettings {
+  isNew?: boolean;
+  [key: string]: unknown;
+}
+
+interface PluginConfig {
+  name: string;
+  settings?: PluginSettings;
+}
+
+type PublicSettingsWithPlugins = {
+  plugins?: PluginConfig[];
+};
+
+/**
+ * Utility function that returns the plugins array from the settings.
+ */
+const getPluginsFromSettings = (): PluginConfig[] => {
+  const publicSettings = window.meetingClientSettings?.public as PublicSettingsWithPlugins;
+  return publicSettings?.plugins || [];
+};
+
+/**
+ * Checks if a plugin is marked as "isNew" in the settings.
+ * @param {string} pluginName The name of the plugin to check.
+ * @returns {boolean} True if it is new, false otherwise.
+ */
+export const isPluginNew = (pluginName?: string): boolean => {
+  if (!pluginName) return false;
+
+  const plugins = getPluginsFromSettings();
+
+  const found = plugins.find((p) => p.name === pluginName);
+
+  const result = found?.settings?.isNew === true;
+
+  return result;
+};

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -8,7 +8,7 @@ import {
   colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import Button from '/imports/ui/components/common/button/component';
-import { titlesFontWeight, headingsFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
+import { titlesFontWeight, headingsFontWeight, fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 import {
   $2xlPadding,
   lgPadding,
@@ -74,7 +74,7 @@ const RegisteredAppContent = styled.div`
 const OpenButton = styled(Button)<{$pinned: boolean}>`
   padding: ${$2xlPadding};
   border-radius: ${appsButtonsBorderRadius} 0px 0px ${appsButtonsBorderRadius};
-  
+
   ${({ $pinned }) => ($pinned ? `
     background-color: ${colorPrimary};
     color: ${colorWhite};
@@ -92,7 +92,7 @@ const ClickableArea = styled.div`
   display: flex;
   flex-direction: row;
   flex-grow: 1;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   gap: ${lgPadding};
   cursor: pointer;
@@ -134,6 +134,16 @@ const BoldText = styled.span`
   font-weight: ${titlesFontWeight};
 `;
 
+const NewLabel = styled.span`
+  background-color: ${colorPrimary};
+  color: ${colorWhite};
+  padding: 0.1rem 0.75rem;
+  border-radius: 10px;
+  font-size: ${fontSizeBase};
+  text-transform: uppercase;
+  flex-shrink: 1;
+`;
+
 export default {
   HeaderContainer,
   PanelContent,
@@ -148,4 +158,5 @@ export default {
   ClickableArea,
   DescWrapper,
   BoldText,
+  NewLabel,
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -405,6 +405,8 @@ const reducer = (state, action) => {
         icon,
         contentFunction = undefined,
         onClick = undefined,
+        uuid,
+        pluginName,
       } = action.value;
       const { sidebarNavigation } = state.input;
       const { registeredApps = {}, pinnedApps = [] } = sidebarNavigation;
@@ -414,6 +416,8 @@ const reducer = (state, action) => {
         [id]: {
           name,
           icon,
+          uuid,
+          pluginName,
           ...(contentFunction && { contentFunction }),
           ...(onClick && { onClick }),
         },

--- a/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
@@ -196,6 +196,8 @@ interface SidebarContentHorizontalResizer {
 interface Widget {
     name: string;
     icon: string;
+    uuid?: string;
+    pluginName?: string;
 }
 
 export interface NativeWidget extends Widget {}

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/apps-gallery/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/apps-gallery/manager.tsx
@@ -60,6 +60,8 @@ const AppsGalleryPluginStateContainer = ((
           name: agi.name,
           icon: agi.icon,
           onClick: agi.onClick,
+          uuid,
+          pluginName: pluginApi.pluginName,
         },
       });
     });

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
@@ -103,6 +103,8 @@ const GenericContentPluginStateContainer = ((
           name: genericContentItem.name,
           icon: genericContentItem.buttonIcon,
           contentFunction: genericContentItem.contentFunction,
+          uuid,
+          pluginName: pluginApi.pluginName,
         },
       });
     });

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -134,6 +134,7 @@
     "app.appsGallery.maxpinnedAppsContinue": " in the sidebar.",
     "app.appsGallery.pinTooltip": "Pin app",
     "app.appsGallery.unpinTooltip": "Unpin app",
+    "app.appsGallery.newAppLabel": "New",
     "app.appsGallery.modal.title": "Oops!",
     "app.appsGallery.modal.subtitle": "You already have {0} pinned apps in the sidebar.",
     "app.appsGallery.modal.description": "To pin a new app, you must unpin another first.",

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -478,6 +478,17 @@ plugin {
 
 - Using this information, the client fetches the plugin’s JavaScript bundle from the plugin storage server and loads it into the React component tree.
 
+### Apps Gallery
+
+The Apps Gallery is the central UI panel where users can discover and interact with the plugins and tools available during a meeting. It is designed as an extensible dashboard that allows developers to register their own applications to appear alongside BigBlueButton's native tools.
+
+The gallery renders two main groups of applications:
+
+* **Pinned Apps:** Applications that the user has chosen to keep visible on the sidebar for quick access.
+* **Unpinned Apps:** The list of all other registered applications that are not currently pinned.
+
+Based on the provided files, the core logic resides in `ui/components/apps-gallery/component.tsx`, which maps the `registeredApps` and `pinnedApps` from the layout context to render them in the correct UI sections. The container for this component is `ui/components/apps-gallery/container.tsx`.
+
 ### Developing the `bigbluebutton-html-plugin-sdk`
 
 This guide explains how to contribute to the [`bigbluebutton-html-plugin-sdk`](https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk), including adding new features or fixing existing issues. It also covers how to integrate those changes with the BigBlueButton client when necessary.
@@ -743,8 +754,27 @@ That being said, here are the extensible areas we have so far:
 - Generic Content (main, sidekick)
 - User Camera Helper (button)
 - Screenshare Helper (button)
+- Apps Gallery (item, "New" badge)
 
 Mind that no plugin will interfere into another's extensible area. So feel free to set whatever you need into a certain plugin with no worries.
+
+#### Apps Gallery "New" Badge
+
+This feature allows administrators to highlight new or featured plugins by displaying a "New" badge next to them in the Apps Gallery.
+
+To enable this badge for a specific plugin, add the `isNew: true` flag to its configuration within the `settings.yml` file.
+
+**Example (`settings.yml`):**
+
+```yml
+public:
+  plugins:
+    - name: my-plugin-name
+      settings:
+        isNew: true
+```
+
+When the client loads, the item for "my-plugin-name" will automatically display the "New" badge in the Apps Gallery.
 
 ### Auxiliary functions:
 
@@ -985,7 +1015,7 @@ As seen for the `useUiData`, the return type is well defined by the enum chosen 
   - volume:
     - set: this function will set the external video volume to a certain number between 0 and 1 (that is 0% and);
 - layout:
-  - changeEnforcedLayout: (deprecated) Changes the enforced layout 
+  - changeEnforcedLayout: (deprecated) Changes the enforced layout
   - setEnforcedLayout: Sets the enforced layout
 - navBar:
   - setDisplayNavBar: Sets the displayNavBar to true (show it) or false (hide it).


### PR DESCRIPTION
### What does this PR do?
This PR introduces a "New" badge for items in the Apps Gallery. This allows admins to highlight new or featured plugins by setting an isNew: true flag in settings.yml.

### How to Test
In your settings.yml, add the settings key with isNew: true to any plugin.

```
 name: my-plugin-name
  settings:
    isNew: true
```

- Run the client and join a meeting.
- Open the Apps Gallery from the action bar.
- Expected Result: The item for "my-plugin-name" should display a "New" badge, while others should not.


### Closes Issue(s)
Closes None

### More
<img width="391" height="337" alt="Screenshot from 2025-09-30 14-45-14" src="https://github.com/user-attachments/assets/2d01f308-5c55-4435-a4f7-0053111b6840" />
<img width="391" height="337" alt="Screenshot from 2025-09-30 14-45-28" src="https://github.com/user-attachments/assets/056140ae-5324-4fe8-b5f4-8ad2b67551ce" />

