### PR TITLE
feat(html5): add showConnectionErrors to control shown error codes

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -106,6 +106,7 @@ export interface App {
   enableApolloDevTools: boolean
   terminateAndRetryConnection: number
   timeoutBeforeRedirectOnMeetingEnd: number | null
+  allowedConnectionErrors: number[]
 }
 
 export interface BbbTabletApp {

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -106,7 +106,7 @@ export interface App {
   enableApolloDevTools: boolean
   terminateAndRetryConnection: number
   timeoutBeforeRedirectOnMeetingEnd: number | null
-  allowedConnectionErrors: number[]
+  showConnectionErrors: number[]
 }
 
 export interface BbbTabletApp {

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -46,6 +46,12 @@ const NotificationsBarContainer = () => {
   const { hasNotification } = layoutSelectInput((i) => i.notificationsBar);
   const dispatch = layoutDispatch();
 
+  const allowedConnectionErrors = window.meetingClientSettings
+    .public.app.allowedConnectionErrors || [];
+  const checkIfAllowed = (status) => allowedConnectionErrors.includes(status)
+  // Allow all connection errors in development mode
+  || process.env.NODE_ENV === 'development';
+
   const { data: meeting } = useMeeting((m) => ({
     isBreakout: m.isBreakout,
     componentsFlags: m.componentsFlags,
@@ -67,15 +73,18 @@ const NotificationsBarContainer = () => {
         isCritical ? intlMessages.connectionCode3002 : intlMessages.connectionCode3001,
       );
 
+      const canShowTheMessage = checkIfAllowed(code);
+
       logger.warn({
         logCode: 'connection_disconnected',
         extraInfo: {
           errorCode: code,
           isCritical,
           connected,
+          messageShownForUser: canShowTheMessage,
         },
       }, `NotificationsBar: ${msg} (connected=${connected}, isCritical=${isCritical})`);
-
+      if (!canShowTheMessage) return null;
       return msg;
     }
 
@@ -84,47 +93,50 @@ const NotificationsBarContainer = () => {
       const msg = intl.formatMessage(
         isCritical ? intlMessages.connectionCode3004 : intlMessages.connectionCode3003,
       );
-
+      const canShowTheMessage = checkIfAllowed(code);
       logger.warn({
         logCode: 'connection_server_unresponsive',
         extraInfo: {
           errorCode: code,
           isCritical,
           serverIsResponding,
+          errorShownForUser: canShowTheMessage,
         },
       }, `NotificationsBar: ${msg} (serverIsResponding=${serverIsResponding}, isCritical=${isCritical})`);
-
+      if (!canShowTheMessage) return null;
       return msg;
     }
 
     if (connected && serverIsResponding && !pingIsComing && lastRttRequestSuccess) {
       const code = 3005;
       const msg = intl.formatMessage(intlMessages.connectionCode3005);
-
+      const canShowTheMessage = checkIfAllowed(code);
       logger.warn({
         logCode: 'connection_slow_data',
         extraInfo: {
           errorCode: code,
           pingIsComing,
           lastRttRequestSuccess,
+          errorShownForUser: canShowTheMessage,
         },
       }, `NotificationsBar: ${msg} (pingIsComing=${pingIsComing}, lastRttSuccess=${lastRttRequestSuccess})`);
-
+      if (!canShowTheMessage) return null;
       return msg;
     }
 
     if (connected && serverIsResponding && pingIsComing && subscriptionFailed) {
       const code = 3006;
       const msg = intl.formatMessage(intlMessages.connectionCode3006);
-
+      const canShowTheMessage = checkIfAllowed(code);
       logger.warn({
         logCode: 'connection_subscription_failed',
         extraInfo: {
           errorCode: code,
           subscriptionFailed,
+          errorShownForUser: canShowTheMessage,
         },
       }, `NotificationsBar: ${msg} (subscriptionFailed=${subscriptionFailed})`);
-
+      if (!canShowTheMessage) return null;
       return msg;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -46,9 +46,9 @@ const NotificationsBarContainer = () => {
   const { hasNotification } = layoutSelectInput((i) => i.notificationsBar);
   const dispatch = layoutDispatch();
 
-  const allowedConnectionErrors = window.meetingClientSettings
-    .public.app.allowedConnectionErrors || [];
-  const checkIfAllowed = (status) => allowedConnectionErrors.includes(status)
+  const showConnectionErrors = window.meetingClientSettings
+    .public.app.showConnectionErrors || [];
+  const checkIfAllowed = (status) => showConnectionErrors.includes(status)
   // Allow all connection errors in development mode
   || process.env.NODE_ENV === 'development';
 

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -212,7 +212,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       disableWebsocketFallback: true,
       maxMutationPayloadSize: 10485760, // 10MB
       timeoutBeforeRedirectOnMeetingEnd: 20000,
-      allowedConnectionErrors: [3001, 3002, 3003, 3004, 3005, 3006],
+      showConnectionErrors: [3001, 3002, 3003, 3004, 3005, 3006],
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -212,6 +212,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       disableWebsocketFallback: true,
       maxMutationPayloadSize: 10485760, // 10MB
       timeoutBeforeRedirectOnMeetingEnd: 20000,
+      allowedConnectionErrors: [3001, 3002, 3003, 3004, 3005, 3006],
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -311,7 +311,7 @@ public:
   #   - name: SamplePresentationToolbarPlugin
   #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js
   # Allowed errors to be shown on notifications bar
-    allowedConnectionErrors:
+    showConnectionErrors:
       # - 3001
       - 3002
       # - 3003

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -310,6 +310,14 @@ public:
   # plugins:
   #   - name: SamplePresentationToolbarPlugin
   #     url: https://<your-Host>/plugins/SamplePresentationToolbarPlugin.js
+  # Allowed errors to be shown on notifications bar
+    allowedConnectionErrors:
+      # - 3001
+      - 3002
+      # - 3003
+      - 3004
+      # - 3005
+      # - 3006
   externalVideoPlayer:
     enabled: true
   kurento:


### PR DESCRIPTION
### What does this PR do?
This PR introduces support for configurable connection error codes in the notifications bar.  
- Adds a new `showConnectionErrors` array to `meetingClientSettings`.  
- Updates `NotificationsBarContainer` so that error messages are only shown when their codes are explicitly allowed (or always in development mode).  
- Enhances logger outputs with metadata indicating whether a message was shown to the user.  
- Adds configuration support in `settings.yml` under `public.app.showConnectionErrors`.  

### Closes Issue(s)
N/A

### Motivation
Currently, all connection error codes trigger visible notifications, which can overwhelm users and reduce clarity. Allowing configurable error codes provides better control over which errors surface in the UI, aligning with specific deployment needs and reducing noise.  

### How to test
1. Change one subscription to fetch a non-existent field
2. Load the client
3. Open console, see the error log

### More:
<img width="1901" height="905" alt="image" src="https://github.com/user-attachments/assets/3af4596b-9ffe-4fc5-9735-100a34908fa3" />

