### PR TITLE
fix(html5): skip chat message subscriptions when alerts are disabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -215,19 +215,26 @@ const ChatAlertContainerGraphql: React.FC = () => {
     chatPushAlerts: boolean;
   };
 
+  const skipSubscriptions = !chatPushAlerts && !chatAudioAlerts;
+  const previousSkipSubscriptions = usePreviousValue(skipSubscriptions);
   const cursor = useRef(new Date());
+
+  if (previousSkipSubscriptions && !skipSubscriptions) {
+    cursor.current = new Date();
+  }
+
   const { data: publicMessages } = useDeduplicatedSubscription<PublicMessageStreamResponse>(
     CHAT_MESSAGE_PUBLIC_STREAM,
     {
       variables: { createdAt: cursor.current.toISOString() },
-      skip: !chatPushAlerts && !chatAudioAlerts,
+      skip: skipSubscriptions,
     },
   );
   const { data: privateMessages } = useDeduplicatedSubscription<PrivateMessageStreamResponse>(
     CHAT_MESSAGE_PRIVATE_STREAM,
     {
       variables: { createdAt: cursor.current.toISOString() },
-      skip: !chatPushAlerts && !chatAudioAlerts,
+      skip: skipSubscriptions,
     },
   );
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -207,16 +207,6 @@ const ChatAlertGraphql: React.FC<ChatAlertGraphqlProps> = (props) => {
 };
 
 const ChatAlertContainerGraphql: React.FC = () => {
-  const cursor = useRef(new Date());
-  const { data: publicMessages } = useDeduplicatedSubscription<PublicMessageStreamResponse>(
-    CHAT_MESSAGE_PUBLIC_STREAM,
-    { variables: { createdAt: cursor.current.toISOString() } },
-  );
-  const { data: privateMessages } = useDeduplicatedSubscription<PrivateMessageStreamResponse>(
-    CHAT_MESSAGE_PRIVATE_STREAM,
-    { variables: { createdAt: cursor.current.toISOString() } },
-  );
-
   const {
     chatAudioAlerts,
     chatPushAlerts,
@@ -224,6 +214,22 @@ const ChatAlertContainerGraphql: React.FC = () => {
     chatAudioAlerts: boolean;
     chatPushAlerts: boolean;
   };
+
+  const cursor = useRef(new Date());
+  const { data: publicMessages } = useDeduplicatedSubscription<PublicMessageStreamResponse>(
+    CHAT_MESSAGE_PUBLIC_STREAM,
+    {
+      variables: { createdAt: cursor.current.toISOString() },
+      skip: !chatPushAlerts && !chatAudioAlerts,
+    },
+  );
+  const { data: privateMessages } = useDeduplicatedSubscription<PrivateMessageStreamResponse>(
+    CHAT_MESSAGE_PRIVATE_STREAM,
+    {
+      variables: { createdAt: cursor.current.toISOString() },
+      skip: !chatPushAlerts && !chatAudioAlerts,
+    },
+  );
 
   const idChatOpen = layoutSelect((i: Layout) => i.idChatOpen);
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);


### PR DESCRIPTION
### What does this PR do?
This PR optimizes chat alert subscriptions by skipping GraphQL chat message streams when alerts are disabled.  
- Moves subscription logic inside `ChatAlertContainerGraphql`.  
- Adds `skip` conditions to `useDeduplicatedSubscription` for both public and private chat streams.  
- Prevents unnecessary data flow and processing when both `chatPushAlerts` and `chatAudioAlerts` are disabled.  

### Closes Issue(s)
N/A

### Motivation
Previously, chat message streams were always active, even when alerts were turned off. This caused redundant GraphQL traffic and unnecessary component updates. By introducing a `skip` condition, subscriptions are only created when alerts are enabled, reducing overhead and improving efficiency.  

### How to test
1. Join a meeting with chat enabled.  
2. Confirm the chat alert is disabled
3. Open devtools -> Network -> Socket
4. On graphql connection look by the subscription
