### PR TITLE
refactor (gql-middleware) Increase `max_connection_concurrent_subscriptions` to `150`

### DIFF
--- a/bbb-graphql-middleware/config/config.yml
+++ b/bbb-graphql-middleware/config/config.yml
@@ -12,7 +12,7 @@ server:
   # A high number is recommended because the whiteboard cursor and annotations generate frequent mutations.
   max_connection_mutations_per_minute: 900
   # Maximum number of concurrent subscriptions allowed per connection.
-  max_connection_concurrent_subscriptions: 100
+  max_connection_concurrent_subscriptions: 150
   # Maximum length of the query body.
   max_query_length: 5000
   # Maximum query depth when querying relationships.


### PR DESCRIPTION
When we initially set `100` as the default for `max_connection_concurrent_subscriptions`, it seemed like a safe limit.
However, we’ve seen cases where clients hit this threshold when opening multiple features and plugins.
This PR slightly increases the limit to `150` to prevent errors in such situations.