### PR TITLE
ref(plugin): Refactor logic to reduce load on back-end

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2371,6 +2371,7 @@ CREATE UNLOGGED TABLE "pluginDataChannelEntry" (
 	"toRoles" varchar[], --MODERATOR, VIEWER, PRESENTER
 	"toUserIds" varchar[],
 	"createdAt" timestamp with time zone DEFAULT current_timestamp,
+	"updatedAt" timestamp with time zone DEFAULT current_timestamp,
 	"deletedAt" timestamp with time zone,
 	CONSTRAINT "pluginDataChannel_pkey" PRIMARY KEY ("meetingId","pluginName","channelName","entryId", "subChannelName"),
 	FOREIGN KEY ("meetingId", "createdBy") REFERENCES "user"("meetingId","userId") ON DELETE CASCADE
@@ -2382,7 +2383,7 @@ create index "idx_pluginDataChannelEntry_channelName" on "pluginDataChannelEntry
 create index "idx_pluginDataChannelEntry_roles" on "pluginDataChannelEntry"("meetingId", "toRoles", "toUserIds", "createdAt") where "deletedAt" is null;
 
 CREATE OR REPLACE VIEW "v_pluginDataChannelEntry" AS
-SELECT u."meetingId", u."userId", m."pluginName", m."channelName", m."subChannelName", m."entryId", m."payloadJson", m."createdBy", m."toRoles", m."createdAt"
+SELECT u."meetingId", u."userId", m."pluginName", m."channelName", m."subChannelName", m."entryId", m."payloadJson", m."createdBy", m."toRoles", m."createdAt", m."updatedAt"
 FROM "user" u
 JOIN "pluginDataChannelEntry" m ON m."meetingId" = u."meetingId"
 			AND ((m."toRoles" IS NULL AND m."toUserIds" IS NULL)

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pluginDataChannelEntry.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pluginDataChannelEntry.yaml
@@ -28,6 +28,7 @@ select_permissions:
         - entryId
         - payloadJson
         - createdBy
+        - updatedAt
         - toRoles
       filter:
         _and:

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/manager.tsx
@@ -6,6 +6,7 @@ import { DataChannelTypes } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-ch
 
 import { DataChannelItemManagerReader } from './reader-manager';
 import DataChannelItemManagerWriter from './writer-manager';
+import { DataChannelEntry } from '../types';
 
 export interface DataChannelItemManagerProps {
   identifier: string;
@@ -13,6 +14,7 @@ export interface DataChannelItemManagerProps {
   channelName: string;
   subChannelName: string;
   pluginApi: PluginSdk.PluginApi;
+  dataChannelEntries: DataChannelEntry[];
   dataChannelTypes: DataChannelTypes[];
 }
 
@@ -26,6 +28,7 @@ export const DataChannelItemManager: React.ElementType<DataChannelItemManagerPro
     pluginApi,
     dataChannelTypes,
     subChannelName,
+    dataChannelEntries,
   } = props;
 
   const dataChannelIdentifier = createChannelIdentifier(channelName, subChannelName, pluginName);
@@ -50,6 +53,7 @@ export const DataChannelItemManager: React.ElementType<DataChannelItemManagerPro
               channelName,
               dataChannelType: type,
               subChannelName,
+              dataChannelEntriesReceived: dataChannelEntries,
               dataChannelIdentifier,
             }}
           />

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/reader-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/reader-manager.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { DocumentNode } from 'graphql';
+// import { DocumentNode } from 'graphql';
 
 import {
   GraphqlResponseWrapper, HookEventWrapper, SubscribedEventDetails, UpdatedEventDetails,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import { DataChannelHooks, DataChannelTypes } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/enums';
 
-import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
 import { HookEvents } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
 import { DataChannelArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-channel/types';
-import { PLUGIN_DATA_CHANNEL_LATEST_ITEM, PLUGIN_DATA_CHANNEL_NEW_ITEMS, PLUGIN_DATA_CHANNEL_ALL_ITEMS } from '../subscriptions';
+import { DataChannelEntry } from '../types';
 
 export interface DataChannelItemManagerReaderProps {
   pluginName: string;
@@ -17,6 +16,7 @@ export interface DataChannelItemManagerReaderProps {
   subChannelName: string;
   dataChannelType: DataChannelTypes;
   dataChannelIdentifier: string;
+  dataChannelEntriesReceived: DataChannelEntry[];
 }
 
 export interface SubscriptionVariables {
@@ -25,6 +25,24 @@ export interface SubscriptionVariables {
   channelName: string;
   createdAt?: string;
 }
+
+const areListsDifferent = (
+  previousList: DataChannelEntry[], currentList: DataChannelEntry[],
+): boolean => currentList.length !== previousList.length || currentList.some((l2Entry) => {
+  const indexOfEntry = previousList.findIndex((l1Entry) => l1Entry.entryId === l2Entry.entryId);
+  if (indexOfEntry === -1) return true;
+  const l1Entry = previousList[indexOfEntry];
+  return l1Entry.updatedAt !== l2Entry.updatedAt;
+});
+
+const getDifference = (
+  previousList: DataChannelEntry[], currentList: DataChannelEntry[],
+): DataChannelEntry[] => currentList.filter((l2Entry) => {
+  const indexOfEntry = previousList.findIndex((l1Entry) => l1Entry.entryId === l2Entry.entryId);
+  if (indexOfEntry === -1) return true;
+  const l1Entry = previousList[indexOfEntry];
+  return l1Entry.updatedAt !== l2Entry.updatedAt;
+});
 
 export const DataChannelItemManagerReader: React.ElementType<DataChannelItemManagerReaderProps> = (
   props: DataChannelItemManagerReaderProps,
@@ -35,36 +53,61 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
     dataChannelType,
     subChannelName,
     dataChannelIdentifier,
+    dataChannelEntriesReceived,
   } = props;
   const [sendSignal, setSendSignal] = useState<boolean>(false);
-  const cursor = useRef(new Date());
-  let subscription: DocumentNode;
-  const variables: SubscriptionVariables = {
-    subChannelName,
-    pluginName,
-    channelName,
-  };
-  let usePatchedSubscription = true;
-  switch (dataChannelType) {
-    case DataChannelTypes.LATEST_ITEM:
-      subscription = PLUGIN_DATA_CHANNEL_LATEST_ITEM;
-      usePatchedSubscription = false;
-      break;
-    case DataChannelTypes.NEW_ITEMS:
-      subscription = PLUGIN_DATA_CHANNEL_NEW_ITEMS;
-      variables.createdAt = cursor.current.toISOString();
-      usePatchedSubscription = false;
-      break;
-    case DataChannelTypes.ALL_ITEMS:
-      subscription = PLUGIN_DATA_CHANNEL_ALL_ITEMS;
-      break;
-    default:
-      subscription = PLUGIN_DATA_CHANNEL_ALL_ITEMS;
-      break;
-  }
 
-  const dataResultFromSubscription = createUseSubscription<object>(subscription,
-    variables, usePatchedSubscription)((obj) => obj);
+  const [completeDataEntry, setCompleteDataEntry] = useState<DataChannelEntry[]>([]);
+
+  const [differenceData, setDifferenceData] = useState<DataChannelEntry[]>([]);
+
+  const startedAtTimestamp = useRef(new Date());
+
+  useEffect(() => {
+    const updateAllItems = () => {
+      const listsDifferent = areListsDifferent(completeDataEntry, dataChannelEntriesReceived);
+      if (listsDifferent) {
+        setCompleteDataEntry(dataChannelEntriesReceived);
+      }
+    };
+
+    const updateNewItems = () => {
+      const differenceList = getDifference(completeDataEntry, dataChannelEntriesReceived).filter(
+        (entry) => new Date(entry.createdAt) >= startedAtTimestamp.current,
+      );
+      const dataChannelWasReset = dataChannelEntriesReceived.length === 0
+        && completeDataEntry.length !== 0;
+      if (differenceList.length > 0 || dataChannelWasReset) {
+        setDifferenceData(differenceList);
+        setCompleteDataEntry(dataChannelEntriesReceived);
+      }
+    };
+
+    const updateLatestItem = () => {
+      const differenceList = getDifference(completeDataEntry, dataChannelEntriesReceived);
+      const dataChannelWasReset = dataChannelEntriesReceived.length === 0
+        && completeDataEntry.length !== 0;
+      if (differenceList.length > 0 || dataChannelWasReset) {
+        setDifferenceData(differenceList);
+        setCompleteDataEntry(dataChannelEntriesReceived);
+      }
+    };
+
+    switch (dataChannelType) {
+      case DataChannelTypes.LATEST_ITEM:
+        updateLatestItem();
+        break;
+      case DataChannelTypes.NEW_ITEMS:
+        updateNewItems();
+        break;
+      case DataChannelTypes.ALL_ITEMS:
+        updateAllItems();
+        break;
+      default:
+        updateAllItems();
+        break;
+    }
+  }, [dataChannelEntriesReceived]);
 
   useEffect(() => {
     const subscribeHandler: EventListener = (
@@ -91,10 +134,27 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
   }, []);
 
   useEffect(() => {
+    let dataToBeSent;
+    switch (dataChannelType) {
+      case DataChannelTypes.LATEST_ITEM:
+        dataToBeSent = differenceData;
+        break;
+      case DataChannelTypes.NEW_ITEMS:
+        dataToBeSent = differenceData;
+        break;
+      case DataChannelTypes.ALL_ITEMS:
+        dataToBeSent = completeDataEntry;
+        break;
+      default:
+        dataToBeSent = completeDataEntry;
+        break;
+    }
+
     const dataResult = {
-      data: dataResultFromSubscription.data,
-      loading: dataResultFromSubscription.loading,
+      data: dataToBeSent,
+      loading: !dataToBeSent,
     } as GraphqlResponseWrapper<object>;
+
     window.dispatchEvent(
       new CustomEvent<UpdatedEventDetails<
       GraphqlResponseWrapper<object>
@@ -111,7 +171,7 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
       },
     }),
     );
-  }, [dataResultFromSubscription, sendSignal]);
+  }, [sendSignal, completeDataEntry, differenceData]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/reader-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/reader-manager.tsx
@@ -56,11 +56,8 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
     dataChannelEntriesReceived,
   } = props;
   const [sendSignal, setSendSignal] = useState<boolean>(false);
-
   const [completeDataEntry, setCompleteDataEntry] = useState<DataChannelEntry[]>([]);
-
   const [differenceData, setDifferenceData] = useState<DataChannelEntry[]>([]);
-
   const startedAtTimestamp = useRef(new Date());
 
   useEffect(() => {
@@ -71,34 +68,24 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
       }
     };
 
-    const updateNewItems = () => {
-      const differenceList = getDifference(completeDataEntry, dataChannelEntriesReceived).filter(
-        (entry) => new Date(entry.createdAt) >= startedAtTimestamp.current,
-      );
-      const dataChannelWasReset = dataChannelEntriesReceived.length === 0
-        && completeDataEntry.length !== 0;
-      if (differenceList.length > 0 || dataChannelWasReset) {
-        setDifferenceData(differenceList);
-        setCompleteDataEntry(dataChannelEntriesReceived);
-      }
-    };
-
-    const updateLatestItem = () => {
+    const updateDifferenceItems = (afterSubscription: boolean) => {
       const differenceList = getDifference(completeDataEntry, dataChannelEntriesReceived);
-      const dataChannelWasReset = dataChannelEntriesReceived.length === 0
-        && completeDataEntry.length !== 0;
-      if (differenceList.length > 0 || dataChannelWasReset) {
-        setDifferenceData(differenceList);
+      const resultingDifference = (afterSubscription) ? differenceList.filter(
+        (entry) => new Date(entry.createdAt) >= startedAtTimestamp.current,
+      ) : differenceList;
+      const dataChannelWasReset = dataChannelEntriesReceived.length === 0 && completeDataEntry.length !== 0;
+      if (resultingDifference.length > 0 || dataChannelWasReset) {
+        setDifferenceData(resultingDifference);
         setCompleteDataEntry(dataChannelEntriesReceived);
       }
     };
 
     switch (dataChannelType) {
       case DataChannelTypes.LATEST_ITEM:
-        updateLatestItem();
+        updateDifferenceItems(false);
         break;
       case DataChannelTypes.NEW_ITEMS:
-        updateNewItems();
+        updateDifferenceItems(true);
         break;
       case DataChannelTypes.ALL_ITEMS:
         updateAllItems();

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/manager.tsx
@@ -16,7 +16,7 @@ const PluginDataChannelManager: React.ElementType<PluginDataChannelManagerProps>
   props: PluginDataChannelManagerProps,
 ) => {
   const {
-    pluginApi,
+    pluginApi, dataChannelEntries,
   } = props;
 
   const { pluginName: pluginNameInUse } = pluginApi;
@@ -103,6 +103,12 @@ const PluginDataChannelManager: React.ElementType<PluginDataChannelManagerProps>
           const identifier = createChannelIdentifier(
             channelName, subChannelName, pluginNameInUse,
           );
+          const filteredDataChannelEntries = dataChannelEntries?.filter((entry) => {
+            const currentIdentifier = createChannelIdentifier(
+              entry.channelName, entry.subChannelName, entry.pluginName,
+            );
+            return identifier === currentIdentifier;
+          });
           return (
             <DataChannelItemManager
               key={identifier}
@@ -111,6 +117,7 @@ const PluginDataChannelManager: React.ElementType<PluginDataChannelManagerProps>
                 pluginName: pluginNameInUse,
                 channelName,
                 subChannelName,
+                dataChannelEntries: filteredDataChannelEntries,
                 dataChannelTypes: mapOfDataChannelInformation.get(keyIdentifier)!.types,
                 pluginApi,
               }}

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/manager.tsx
@@ -103,7 +103,7 @@ const PluginDataChannelManager: React.ElementType<PluginDataChannelManagerProps>
           const identifier = createChannelIdentifier(
             channelName, subChannelName, pluginNameInUse,
           );
-          const filteredDataChannelEntries = dataChannelEntries?.filter((entry) => {
+          const filteredDataChannelEntries = dataChannelEntries.filter((entry) => {
             const currentIdentifier = createChannelIdentifier(
               entry.channelName, entry.subChannelName, entry.pluginName,
             );

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/subscriptions.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/subscriptions.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
 const PLUGIN_DATA_CHANNEL_SUBSCRIPTION = gql`
-  subscription FetchPluginDataChannelEntryNew {
+  subscription FetchPluginDataChannelEntry {
     pluginDataChannelEntry (
       order_by: {createdAt: desc}
     ) {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/subscriptions.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/subscriptions.ts
@@ -1,17 +1,12 @@
 import { gql } from '@apollo/client';
 
-const PLUGIN_DATA_CHANNEL_NEW_ITEMS = gql`
-  subscription FetchPluginDataChannelEntry($pluginName: String!,
-    $channelName: String! , $createdAt: timestamptz!, $subChannelName: String!){
-    pluginDataChannelEntry_stream(
-      cursor: {initial_value: {createdAt: $createdAt}}, batch_size: 100,
-      where: {
-        pluginName: { _eq: $pluginName }
-        channelName: { _eq: $channelName }
-        subChannelName: { _eq: $subChannelName }
-      }
+const PLUGIN_DATA_CHANNEL_SUBSCRIPTION = gql`
+  subscription FetchPluginDataChannelEntryNew {
+    pluginDataChannelEntry (
+      order_by: {createdAt: desc}
     ) {
       createdAt,
+      updatedAt,
       channelName,
       subChannelName,
       entryId,
@@ -23,53 +18,4 @@ const PLUGIN_DATA_CHANNEL_NEW_ITEMS = gql`
   }
 `;
 
-const PLUGIN_DATA_CHANNEL_ALL_ITEMS = gql`
-  subscription FetchPluginDataChannelEntry($pluginName: String!,
-    $channelName: String!, $subChannelName: String!
-  ){
-    pluginDataChannelEntry(
-      order_by: {createdAt: desc},
-      where: {
-        pluginName: { _eq: $pluginName }
-        channelName: { _eq: $channelName }
-        subChannelName: { _eq: $subChannelName }
-      }
-    ) {
-      createdAt,
-      channelName,
-      subChannelName,
-      entryId,
-      payloadJson,
-      createdBy,
-      pluginName,
-      toRoles,
-    }
-  }
-`;
-
-const PLUGIN_DATA_CHANNEL_LATEST_ITEM = gql`
-  subscription FetchPluginDataChannelEntry($pluginName: String!,
-    $channelName: String!, $subChannelName: String!
-  ){
-    pluginDataChannelEntry(
-      order_by: {createdAt: desc},
-      limit: 1,
-      where: {
-        pluginName: { _eq: $pluginName }
-        channelName: { _eq: $channelName }
-        subChannelName: { _eq: $subChannelName }
-      }
-    ) {
-      createdAt,
-      channelName,
-      subChannelName,
-      entryId,
-      payloadJson,
-      createdBy,
-      pluginName,
-      toRoles,
-    }
-  }
-`;
-
-export { PLUGIN_DATA_CHANNEL_LATEST_ITEM, PLUGIN_DATA_CHANNEL_NEW_ITEMS, PLUGIN_DATA_CHANNEL_ALL_ITEMS };
+export default PLUGIN_DATA_CHANNEL_SUBSCRIPTION;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/types.ts
@@ -23,5 +23,5 @@ export interface DataChannelEntry {
   createdBy: string;
   fromUserId: string;
   pluginName: string;
-  toRoles: string[];
+  toRoles?: string[];
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/types.ts
@@ -3,6 +3,7 @@ import { DataChannelTypes } from 'bigbluebutton-html-plugin-sdk/dist/cjs/data-ch
 
 export interface PluginDataChannelManagerProps {
   pluginApi: PluginSdk.PluginApi;
+  dataChannelEntries: DataChannelEntry[];
 }
 
 export interface MapInformation {
@@ -12,10 +13,15 @@ export interface MapInformation {
   types: DataChannelTypes[];
 }
 
-export interface SubscriptionResultFromGraphqlStream {
-  pluginDataChannelMessage_stream: object[]
-}
-
-export interface SubscriptionResultFromGraphql {
-  pluginDataChannelMessage: object[]
+export interface DataChannelEntry {
+  createdAt: string;
+  updatedAt: string;
+  channelName: string;
+  subChannelName: string;
+  entryId: string;
+  payloadJson: object;
+  createdBy: string;
+  fromUserId: string;
+  pluginName: string;
+  toRoles: string[];
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/utils.ts
@@ -1,0 +1,18 @@
+import { DataChannelEntry } from './types';
+
+const mapProjectedDataChannelEntries = (
+  receivedDataChannelEntries: Partial<DataChannelEntry>[] | undefined | null,
+): DataChannelEntry[] => receivedDataChannelEntries?.map((entry) => ({
+  createdAt: entry.createdAt!,
+  channelName: entry.channelName!,
+  subChannelName: entry.subChannelName!,
+  entryId: entry.entryId!,
+  payloadJson: entry.payloadJson!,
+  updatedAt: entry.updatedAt!,
+  fromUserId: entry.createdBy!,
+  createdBy: entry.createdBy!,
+  pluginName: entry.pluginName!,
+  toRoles: entry.toRoles!,
+})) || [];
+
+export default mapProjectedDataChannelEntries;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/utils.ts
@@ -12,7 +12,7 @@ const mapProjectedDataChannelEntries = (
   fromUserId: entry.createdBy!,
   createdBy: entry.createdBy!,
   pluginName: entry.pluginName!,
-  toRoles: entry.toRoles!,
+  toRoles: entry.toRoles ?? [],
 })) || [];
 
 export default mapProjectedDataChannelEntries;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/manager.tsx
@@ -20,6 +20,10 @@ import PluginDomElementManipulationManager from './dom-element-manipulation/mana
 import PluginServerCommandsHandler from './server-commands/handler';
 import PluginLearningAnalyticsDashboardManager from './learning-analytics-dashboard/manager';
 import PluginEventPersistenceManager from './event-persistence/manager';
+import { DataChannelEntry } from './data-channel/types';
+import createUseSubscription from '../../core/hooks/createUseSubscription';
+import PLUGIN_DATA_CHANNEL_SUBSCRIPTION from './data-channel/subscriptions';
+import mapProjectedDataChannelEntries from './data-channel/utils';
 
 const PluginsEngineManager = (props: PluginsEngineManagerProps) => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -88,6 +92,13 @@ const PluginsEngineManager = (props: PluginsEngineManagerProps) => {
   },
   [failedPlugins]);
 
+  const {
+    data: allEntriesFromDataChannel,
+  } = createUseSubscription<DataChannelEntry>(
+    PLUGIN_DATA_CHANNEL_SUBSCRIPTION,
+    {}, true,
+  )((obj) => obj);
+
   return (
     <>
       <PluginsEngineComponent
@@ -124,6 +135,7 @@ const PluginsEngineManager = (props: PluginsEngineManagerProps) => {
               <PluginDataChannelManager
                 {...{
                   pluginApi,
+                  dataChannelEntries: mapProjectedDataChannelEntries(allEntriesFromDataChannel),
                 }}
               />
               <ExtensibleAreaStateManager


### PR DESCRIPTION
### What does this PR do?

It moves filtering logic of data-channel over to the front-end to reduce load on the server side, this will directly reduce the number of subscriptions and computing from DB.

### Motivation

Increase performance in the server-side

### How to test

One can use a real-life example, such as pick-random-user and see if all the behaviours remain the same. Or test it with the `samples/sample-data-channel`.


### More

No changes into SDK are needed, nor in any plugin.
