### PR TITLE
Option to create only one breakout room

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -22,7 +22,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
   def handleCreateBreakoutRoomsCmdMsg(msg: CreateBreakoutRoomsCmdMsg, state: MeetingState2x): MeetingState2x = {
 
 
-    val minOfRooms = 2
+    val minOfRooms = 1
     val maxOfRooms = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomLimit", 16)
 
     if (liveMeeting.props.meetingProp.disabledFeatures.contains("breakoutRooms")) {

--- a/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
@@ -18,8 +18,8 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   )
 
     const breakoutRooms = input['rooms'] as Array<Record<string, unknown>>;
-    if(breakoutRooms.length < 2) {
-        throw new ValidationError('It is required to set two or more rooms', 400);
+    if(breakoutRooms.length < 1) {
+        throw new ValidationError('It is required to set at least one room', 400);
     }
 
   throwErrorIfInvalidInput(breakoutRooms[0],

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -35,8 +35,9 @@ import { notify } from '/imports/ui/services/notification';
 import useTimeSync from '/imports/ui/core/local-states/useTimeSync';
 import { getRemainingMeetingTime, isNewTimeValid } from '/imports/ui/core/utils/calculateRemaingTime';
 
-const MIN_BREAKOUT_ROOMS = 2;
+const MIN_BREAKOUT_ROOMS = 1;
 const MIN_BREAKOUT_TIME = 5;
+const DEFAULT_BREAKOUT_ROOMS = 2;
 const DEFAULT_BREAKOUT_TIME = 15;
 const CURRENT_SLIDE_PREFIX = 'current-';
 
@@ -240,7 +241,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   const { isMobile } = deviceInfo;
   const intl = useIntl();
 
-  const initialNumberOfRooms = runningRooms.length > 0 ? runningRooms.length : MIN_BREAKOUT_ROOMS;
+  const initialNumberOfRooms = runningRooms.length > 0 ? runningRooms.length : DEFAULT_BREAKOUT_ROOMS;
 
   const isImportPresentationWithAnnotationsEnabled = useIsImportPresentationWithAnnotationsFromBreakoutRoomsEnabled();
   const isImportSharedNotesEnabled = useIsImportSharedNotesFromBreakoutRoomsEnabled();


### PR DESCRIPTION
### What does this PR do?

Reduces minimum number of breakout rooms that can be created from 2 to 1, while keeping the default number as 2

### Closes Issue(s)
Closes #24016
