### PR TITLE
Fix(html5): Old chat messages being notified when nofications are enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -208,8 +208,8 @@ const ChatAlertContainerGraphql: React.FC = () => {
   const { data: chatMessages } = useDeduplicatedSubscription<ChatMessageStreamResponse>(
     CHAT_MESSAGE_STREAM,
     {
+      skip: skipSubscriptions,
       variables: {
-        skip: skipSubscriptions,
         createdAt: cursor.current.toISOString(),
       },
     },


### PR DESCRIPTION

### What does this PR do?
- Prevents retroactive chat notifications when a user enables push or audio notifications in Settings.

- Fixes subscription control: moves `skip: skipSubscriptions` from the GraphQL `variables` object to the top‑level options of `useDeduplicatedSubscription`, so the subscription is actually skipped when intended.

### Closes Issue(s)
N/A

### Motivation
A bug caused notifications to fire for previously received (historical) messages immediately after enabling push or audio notifications. The subscription wasn’t being skipped because `skip` was placed inside `variables` instead of as a hook option.


### How to test
1. Open Client A (receiver) and Client B (sender) in the same meeting.
2. On Client A, ensure push/audio notifications are disabled. Open a chat thread that already has messages.
3. From Client B, send several messages while A still has notifications disabled.
4. On Client A, enable push/audio notifications in Settings.
 - ✅ Expected: No notifications for the earlier/historical messages.
5. From Client B, send a new message.
- ✅ Expected: Exactly one notification on Client A.
6. Toggle notifications off → on on Client A and repeat step 5.
- ✅ Expected: No retroactive alerts; only new messages notify.

### More
[Screencast from 02-10-2025 09:51:06.webm](https://github.com/user-attachments/assets/8d5b7a30-7ae1-4596-af23-9ce8e09cea69)
