### PR TITLE
perf (gql-server): Create a pre-populated field with total of unread messages for chat

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-messages/chat-list/chat-list-item/component.tsx
@@ -81,6 +81,13 @@ const ChatListItem = (props: ChatListItemProps) => {
         setUnreadMessagesToDisplay(chat.totalUnread);
       }
     }
+
+    return () => {
+      if (chatCountTimeoutRef.current) {
+        clearTimeout(chatCountTimeoutRef.current);
+        chatCountTimeoutRef.current = undefined;
+      }
+    };
   }, [chat.totalUnread, isCurrentChat, unreadMessagesToDisplay]);
 
   useEffect(() => {


### PR DESCRIPTION
Currently the most heavy query is the list of chats because it have to calculate the number of unread messages each time.
This PR will create a pre-populated field with this number always available.