### PR TITLE
perf (gql-server): Create simplified views for current user joins

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -773,6 +773,10 @@ CREATE INDEX "idx_user_camera_meeting_contentType" ON "user_camera"("meetingId",
 CREATE OR REPLACE VIEW "v_user_camera" AS
 SELECT * FROM "user_camera";
 
+-- this view will be used specifically for the join with user_current
+CREATE OR REPLACE VIEW "v_user_current_camera" AS
+SELECT * FROM "user_camera";
+
 CREATE UNLOGGED TABLE "user_breakoutRoom" (
 	"meetingId" varchar(100),
     "userId" varchar(50),
@@ -787,6 +791,10 @@ CREATE UNLOGGED TABLE "user_breakoutRoom" (
 CREATE INDEX "idx_user_breakoutRoom_pk_reverse" ON "user_breakoutRoom"("userId", "meetingId");
 
 CREATE OR REPLACE VIEW "v_user_breakoutRoom" AS
+SELECT * FROM "user_breakoutRoom";
+
+-- this view will be used specifically for the join with user_current
+CREATE OR REPLACE VIEW "v_user_current_breakoutRoom" AS
 SELECT * FROM "user_breakoutRoom";
 
 CREATE UNLOGGED TABLE "user_connectionStatus" (

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -44,7 +44,7 @@ object_relationships:
           userId: userId
         insertion_order: null
         remote_table:
-          name: v_user_breakoutRoom
+          name: v_user_current_breakoutRoom
           schema: public
   - name: livekit
     using:
@@ -163,7 +163,7 @@ array_relationships:
           userId: userId
         insertion_order: null
         remote_table:
-          name: v_user_camera
+          name: v_user_current_camera
           schema: public
   - name: chats
     using:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current_breakoutRoom.yaml
@@ -1,0 +1,35 @@
+table:
+  name: v_user_current_breakoutRoom
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_current_breakoutRoom
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - breakoutRoomId
+        - currentlyInRoom
+        - isDefaultName
+        - sequence
+        - shortName
+        - userId
+      filter: {}
+      query_root_fields: []
+      subscription_root_fields: []
+    comment: ""
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - breakoutRoomId
+        - currentlyInRoom
+        - isDefaultName
+        - sequence
+        - shortName
+        - userId
+      filter: {}
+      query_root_fields: []
+      subscription_root_fields: []
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current_camera.yaml
@@ -1,0 +1,33 @@
+table:
+  name: v_user_current_camera
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: user_current_camera
+  custom_root_fields: {}
+select_permissions:
+  - role: bbb_client
+    permission:
+      columns:
+        - contentType
+        - hasAudio
+        - showAsContent
+        - streamId
+        - userId
+      filter: {}
+      query_root_fields: []
+      subscription_root_fields: []
+    comment: ""
+  - role: bbb_client_not_in_meeting
+    permission:
+      columns:
+        - contentType
+        - hasAudio
+        - showAsContent
+        - streamId
+        - userId
+      filter: {}
+      query_root_fields: []
+      subscription_root_fields: []
+    comment: ""

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/tables.yaml
@@ -59,6 +59,8 @@
 - "!include public_v_user_connectionStatusHistory.yaml"
 - "!include public_v_user_connectionStatusReport.yaml"
 - "!include public_v_user_current.yaml"
+- "!include public_v_user_current_breakoutRoom.yaml"
+- "!include public_v_user_current_camera.yaml"
 - "!include public_v_user_guest.yaml"
 - "!include public_v_user_livekit.yaml"
 - "!include public_v_user_lockSettings.yaml"


### PR DESCRIPTION
It introduced two new views: `v_user_current_camera` and `v_user_current_breakoutRoom`.
These are designed specifically for joins with `user_current`.

The motivation is performance: the existing views (`v_user_camera` and `v_user_breakoutRoom`) include multiple validations (such as lock settings) that aren’t needed when joining with `user_current`. Since the join itself already restricts results to the current user, those extra checks become redundant. By removing them in these new views, we reduce unnecessary overhead and improve query performance.

Additionally, these views are restricted so they cannot be queried directly; they can only be accessed through a join. This ensures they remain safe to use without the usual validations.