### PR TITLE
fix: chat alert styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -50,12 +50,12 @@ export function notify(message, type = 'default', icon, options, content, small)
       toast.update(
         lastToast.id,
         {
-          render: <div role="alert"><Toast {...toastProps} /></div>,
+          render: <Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>,
           autoClose: options.autoClose,
         },
       );
     } else {
-      const id = toast(<div role="alert"><Toast {...toastProps} /></div>, settings);
+      const id = toast(<Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>, settings);
 
       lastToast = { id, ...toastProps };
 

--- a/bigbluebutton-html5/imports/ui/services/notification/styles.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
-import { 
+import {
   toastMargin,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
@@ -16,4 +16,8 @@ const HelpLinkButton = styled(Button)`
   
 `;
 
-export default { HelpLinkButton };
+const ToastWrapper = styled.div`
+  width: 100%;
+`;
+
+export default { HelpLinkButton, ToastWrapper };


### PR DESCRIPTION
### What does this PR do?

Fix chat notification styles: ensure toast uses full available width, even for short messages (currently noticeable by the misaligned line under "New Public Chat message").

#### before

<img width="338" height="122" alt="chat-before" src="https://github.com/user-attachments/assets/36645f36-841b-40ca-8484-4cae68124a42" />

#### after

<img width="338" height="122" alt="chat-after" src="https://github.com/user-attachments/assets/22d1e40e-a244-4df6-a6c8-e8f24935dc16" />

### How to test
1. join a meeting with 2 users (A,B)
2. user A enables chat push alerts
3. user A closes public chat
4. user B sends a message in the public chat
5. check chat notification styles