### PR TITLE
fix(client): recording modal duplicated on pause

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/recording/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/container.tsx
@@ -30,6 +30,7 @@ const RecordingContainer: React.FC<RecordingContainerProps> = (props) => {
   const connected = useReactiveVar(ConnectionStatus.getConnectedStatusVar());
   const {
     data: recordingData,
+    loading: recordingDataLoading,
   } = useDeduplicatedSubscription<GetRecordingResponse>(GET_MEETING_RECORDING_DATA);
 
   const {
@@ -53,7 +54,7 @@ const RecordingContainer: React.FC<RecordingContainerProps> = (props) => {
 
   const mayIRecord = Service.mayIRecord(amIModerator, allowStartStopRecording);
 
-  if (!mayIRecord) return null;
+  if (!mayIRecord || recordingDataLoading) return null;
 
   return (
     <>


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
Fixes recording modal appearing twice when trying to pause:
<img width="520" height="621" alt="image" src="https://github.com/user-attachments/assets/74c37e2e-438a-475a-8a6d-ca0f92c38676" />

### How to test
- Start meeting
- Start recording
- Try to pause recording
