### PR TITLE
perf (gql-server): Pre-load `meetingStaticData` before first user join in the meeting

### DIFF
--- a/bbb-graphql-middleware/config/Config.go
+++ b/bbb-graphql-middleware/config/Config.go
@@ -46,7 +46,8 @@ type Config struct {
 		Password string `yaml:"password"`
 	} `yaml:"redis"`
 	Hasura struct {
-		Url string `yaml:"url"`
+		Url                          string `yaml:"url"`
+		MeetingStaticDataInternalUrl string `yaml:"meetingStaticDataInternalUrl"`
 	} `yaml:"hasura"`
 	GraphqlActions struct {
 		Url string `yaml:"url"`

--- a/bbb-graphql-middleware/config/config.yml
+++ b/bbb-graphql-middleware/config/config.yml
@@ -33,6 +33,7 @@ redis:
   password: ""
 hasura:
   url: ws://127.0.0.1:8185/v1/graphql
+  meetingStaticDataInternalUrl: https://127.0.0.1/api/rest/meetingStaticDataInternal
 graphql-actions:
   url: http://127.0.0.1:8093
 auth_hook:

--- a/bbb-graphql-middleware/internal/hasura/rest_client.go
+++ b/bbb-graphql-middleware/internal/hasura/rest_client.go
@@ -17,7 +17,7 @@ import (
 func PreLoadMeetingStaticDataCache(receivedMessage common.RedisMessage) {
 	secret := os.Getenv("HASURA_GRAPHQL_ADMIN_SECRET")
 	if secret == "" {
-		log.Println("Hasura admin password not found, skiping meetingStaticDataInternal cache")
+		log.Debug("Hasura admin password not found, skiping meetingStaticDataInternal cache")
 		return
 	}
 
@@ -63,7 +63,7 @@ func PreLoadMeetingStaticDataCache(receivedMessage common.RedisMessage) {
 		log.Errorf("Error doing request for meetingStaticDataInternal cache (%s): %v", targetURL, err)
 		return
 	} else {
-		log.Info("Cache meetingStaticDataInternal created successfully.", targetURL)
+		log.Infof("Cache meetingStaticDataInternal created successfully (%s).", targetURL)
 	}
 	defer resp.Body.Close()
 

--- a/bbb-graphql-middleware/internal/hasura/rest_client.go
+++ b/bbb-graphql-middleware/internal/hasura/rest_client.go
@@ -1,0 +1,77 @@
+package hasura
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"bbb-graphql-middleware/config"
+	"bbb-graphql-middleware/internal/common"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func PreLoadMeetingStaticDataCache(receivedMessage common.RedisMessage) {
+	secret := os.Getenv("HASURA_GRAPHQL_ADMIN_SECRET")
+	if secret == "" {
+		log.Println("Hasura admin password not found, skiping meetingStaticDataInternal cache")
+		return
+	}
+
+	props, ok := receivedMessage.Core.Body["props"].(map[string]any)
+	if !ok {
+		return
+	}
+	meetingProp, ok := props["meetingProp"].(map[string]any)
+	if !ok {
+		return
+	}
+	meetingId, ok := meetingProp["intId"].(string)
+	if !ok {
+		return
+	}
+
+	// wait for database inserts
+	time.Sleep(1500 * time.Millisecond)
+
+	targetURL := config.GetConfig().Hasura.MeetingStaticDataInternalUrl + "/" + meetingId
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		log.Errorf("Error creating request for meetingStaticDataInternal cache (%s): %v", targetURL, err)
+		return
+	}
+
+	// Hasura admin header
+	req.Header.Set("x-hasura-admin-secret", secret)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Errorf("Error doing request for meetingStaticDataInternal cache (%s): %v", targetURL, err)
+		return
+	} else {
+		log.Info("Cache meetingStaticDataInternal created successfully.", targetURL)
+	}
+	defer resp.Body.Close()
+
+	if log.IsLevelEnabled(log.DebugLevel) {
+		body, _ := io.ReadAll(resp.Body)
+		log.Debugf("Status (%s): %s", targetURL, resp.Status)
+		log.Debugf("Body (%s):%s", targetURL, string(body))
+	} else {
+		io.Copy(io.Discard, resp.Body)
+	}
+}

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -10,6 +10,7 @@ import (
 
 	"bbb-graphql-middleware/config"
 	"bbb-graphql-middleware/internal/common"
+	"bbb-graphql-middleware/internal/hasura"
 	streamingserver "bbb-graphql-middleware/internal/streaming_server"
 
 	"github.com/redis/go-redis/v9"
@@ -39,6 +40,7 @@ var allowedMessages = []string{
 	"ModifyWhiteboardAccessEvtMsg",
 	"UserLeftMeetingEvtMsg",
 	"MeetingEndedEvtMsg",
+	"MeetingCreatedEvtMsg",
 }
 
 func StartRedisListener() {
@@ -102,6 +104,9 @@ func StartRedisListener() {
 		if messageName == "SetCurrentPageEvtMsg" || messageName == "ModifyWhiteboardAccessEvtMsg" {
 			log.Debugf("Removing cursor positions for meeting: %s", receivedMessage.Core.Header.MeetingId)
 			go streamingserver.RemoveMeetingCursorsCache(receivedMessage.Core.Header.MeetingId)
+		}
+		if messageName == "MeetingCreatedEvtMsg" {
+			go hasura.PreLoadMeetingStaticDataCache(receivedMessage)
 		}
 		if messageName == "MeetingEndedEvtMsg" {
 			log.Debugf("Removing cursor positions for meeting: %s", receivedMessage.Core.Body["meetingId"].(string))

--- a/bbb-graphql-middleware/run-dev.sh
+++ b/bbb-graphql-middleware/run-dev.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+eval "$(sudo cat /etc/default/bbb-graphql-server-admin-pass | grep HASURA_GRAPHQL_ADMIN_SECRET | sed 's/^/export /')"
 sudo systemctl stop bbb-graphql-middleware
 go run cmd/bbb-graphql-middleware/main.go  --signal SIGTERM

--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -82,3 +82,69 @@
               }
             }
           }
+      - name: meetingStaticDataInternal
+        query: |
+          query meetingStaticData ($meetingId: String!) {
+            meeting(where: {meetingId:{_eq:$meetingId}}) {
+              meetingId
+              extId
+              name
+              disabledFeatures
+              isBreakout
+              endWhenNoModerator
+              endWhenNoModeratorDelayInMinutes
+              createdTime
+              maxPinnedCameras
+              meetingCameraCap
+              cameraBridge
+              screenShareBridge
+              audioBridge
+              loginUrl
+              logoutUrl
+              bannerColor
+              bannerText
+              customLogoUrl
+              customDarkLogoUrl
+              notifyRecordingIsOn
+              presentationUploadExternalDescription
+              presentationUploadExternalUrl
+              recordingPolicies {
+                allowStartStopRecording
+                autoStartRecording
+                record
+                keepEvents
+              }
+              usersPolicies {
+                allowModsToEjectCameras
+                allowModsToUnmuteUsers
+                authenticatedGuest
+                maxUserConcurrentAccesses
+                maxUsers
+                meetingLayout
+                moderatorsCanMuteAudio
+                moderatorsCanUnmuteAudio
+                userCameraCap
+              }
+              breakoutPolicies {
+                breakoutRooms
+                captureNotes
+                captureNotesFilename
+                captureSlides
+                captureSlidesFilename
+                freeJoin
+                parentId
+                privateChatEnabled
+                record
+                sequence
+              }
+              voiceSettings {
+                dialNumber
+                muteOnStart
+                voiceConf
+                telVoice
+              }
+              clientSettings {
+                clientSettingsJson
+              }
+            }
+          }

--- a/bbb-graphql-server/metadata/rest_endpoints.yaml
+++ b/bbb-graphql-server/metadata/rest_endpoints.yaml
@@ -20,6 +20,15 @@
   definition:
     query:
       collection_name: allowed-queries
+      query_name: meetingStaticDataInternal
+  methods:
+    - GET
+  name: meetingStaticDataInternal
+  url: meetingStaticDataInternal/:meetingId
+- comment: ""
+  definition:
+    query:
+      collection_name: allowed-queries
       query_name: userMetadata
   methods:
     - GET

--- a/build/packages-template/bbb-graphql-middleware/bbb-graphql-middleware.service
+++ b/build/packages-template/bbb-graphql-middleware/bbb-graphql-middleware.service
@@ -10,6 +10,7 @@ Type=simple
 User=bigbluebutton
 Group=bigbluebutton
 WorkingDirectory=/usr/bin
+EnvironmentFile=/etc/default/bbb-graphql-server-admin-pass
 ExecStart=/usr/bin/bbb-graphql-middleware
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/build/packages-template/bbb-graphql-middleware/graphql.nginx
+++ b/build/packages-template/bbb-graphql-middleware/graphql.nginx
@@ -34,13 +34,38 @@ location /api/rest/meetingStaticData {
     auth_request /bigbluebutton/connection/checkGraphqlAuthorization;
     auth_request_set $meeting_id $sent_http_meeting_id;
 
-    proxy_cache client_settings_cache;
-    proxy_cache_key "$uri|$meeting_id";
-    proxy_cache_use_stale updating;
-    proxy_cache_valid 24h;
-    proxy_cache_lock on;
-    add_header X-Cached $upstream_cache_status;
+    # cache
+    proxy_cache              client_settings_cache;
+    proxy_cache_key          "msd:$meeting_id";
+    proxy_cache_use_stale    updating;
+    proxy_cache_valid        24h;
+    proxy_cache_lock         on;
+    add_header X-Cached      $upstream_cache_status;
 
+    # proxy
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+    proxy_pass http://127.0.0.1:8185; #Hasura
+}
+
+# Endpoint to be called internally to warm up the meetingStaticData cache before the first user
+location ~ ^/api/rest/meetingStaticDataInternal/(?<meeting_id>[^/]+)$ {
+    allow 127.0.0.1;
+    allow ::1;
+    deny all;
+
+    # cache
+    proxy_cache              client_settings_cache;
+    proxy_cache_key          "msd:$meeting_id";
+    proxy_cache_use_stale    updating;
+    proxy_cache_valid        24h;
+    proxy_cache_lock         on;
+    proxy_cache_background_update on;
+    add_header X-Cached      $upstream_cache_status;
+
+    # proxy
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
It introduces a new endpoint `/api/rest/meetingStaticDataInternal/` that will be called by `bbb-graphql-middleware` as soon as it listen the message `MeetingCreatedEvtMsg`.

The new endpoint validates internal IP and it requires the header `x-hasura-admin-secret` to work.

### Motivation:

Sometimes the client get stuck on the request to `/api/rest/meetingStaticData`. So it will help if nginx already has the cache for this response. (to be tested)

### Fix:

<img width="3278" height="1642" alt="image" src="https://github.com/user-attachments/assets/828fc1d1-b9eb-4752-a33f-d7d73218f3e0" />
