### PR TITLE
Fix(html5): Normalize correct answer to match options in QuickPollDropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -126,9 +126,13 @@ const QuickPollDropdown = (props) => {
   // Join lines into a single question string
   const question = [questionLines.join(' ').trim()];
 
-  const correctAnswer = lines.map(line => line.trimStart()).find((line) => line.endsWith(QUICK_POLL_CORRECT_ANSWER_SUFFIX)
+  const correctAnswer = lines
+    .map((line) => line.trimStart()).find((line) => line.endsWith(QUICK_POLL_CORRECT_ANSWER_SUFFIX)
   && !question.includes(line))?.slice(0, -QUICK_POLL_CORRECT_ANSWER_SUFFIX.length);
 
+  const normalizedCorrectAnswer = correctAnswer
+    ? correctAnswer.replace(/^[a-zA-Z0-9][.)]\s+/, '').trim()
+    : correctAnswer;
   // Check explicitly if options exist or if the question ends with '?'
   const hasExplicitQuestionMark = basicQuestionPattern.test(question);
 
@@ -406,8 +410,8 @@ const QuickPollDropdown = (props) => {
                 letterAnswers,
                 pollQuestion,
                 pollData?.multiResp,
-                correctAnswer?.length > 0,
-                correctAnswer,
+                normalizedCorrectAnswer?.length > 0,
+                normalizedCorrectAnswer,
               );
             }, CANCELED_POLL_DELAY);
           }}
@@ -468,8 +472,8 @@ const QuickPollDropdown = (props) => {
               answers,
               pollQuestion,
               multiResponse,
-              correctAnswer?.length > 0,
-              correctAnswer,
+              normalizedCorrectAnswer?.length > 0,
+              normalizedCorrectAnswer,
             );
           } else {
             startPoll(
@@ -478,8 +482,8 @@ const QuickPollDropdown = (props) => {
               (optionGroupsWithLabels[0] || []),
               pollQuestion,
               multiResponse,
-              correctAnswer?.length > 0,
-              correctAnswer,
+              normalizedCorrectAnswer?.length > 0,
+              normalizedCorrectAnswer,
             );
           }
         }, CANCELED_POLL_DELAY);

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/quick-poll-dropdown/component.jsx
@@ -130,9 +130,6 @@ const QuickPollDropdown = (props) => {
     .map((line) => line.trimStart()).find((line) => line.endsWith(QUICK_POLL_CORRECT_ANSWER_SUFFIX)
   && !question.includes(line))?.slice(0, -QUICK_POLL_CORRECT_ANSWER_SUFFIX.length);
 
-  const normalizedCorrectAnswer = correctAnswer
-    ? correctAnswer.replace(/^[a-zA-Z0-9][.)]\s+/, '').trim()
-    : correctAnswer;
   // Check explicitly if options exist or if the question ends with '?'
   const hasExplicitQuestionMark = basicQuestionPattern.test(question);
 
@@ -184,6 +181,9 @@ const QuickPollDropdown = (props) => {
       return `\r${labelChar}.`;
     });
   }
+  const normalizedCorrectAnswer = correctAnswer && (hasYN || hasTF)
+    ? correctAnswer.replace(/^[a-zA-Z0-9][.)]\s+/, '').trim()
+    : correctAnswer;
 
   const optionGroupsWithLabels = [];
   optionsPoll.reduce((acc, currentValue) => {

--- a/bigbluebutton-html5/imports/ui/components/poll/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/component.tsx
@@ -305,13 +305,13 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
           : pollType,
       );
       setIsQuiz(isQuiz);
-      setCorrectAnswer({
-        text: correctAnswer ?? '',
-        index: answers.indexOf(correctAnswer) ?? -1,
-      });
       if (answers.length) {
         // @ts-ignore
         setOptList(answers.map((answer) => ({ key: pollTypesKeys[answer] ?? answer, val: answer })));
+        setCorrectAnswer({
+          text: correctAnswer ?? '',
+          index: answers.indexOf(correctAnswer) ?? -1,
+        });
         return;
       }
 
@@ -331,7 +331,7 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
 
       switch (pollType) {
         case pollTypes.TrueFalse: {
-          setOptList([
+          const pattern = [
             {
               key: pollTypesKeys.true,
               val: intl.formatMessage(intlMessages.true),
@@ -340,11 +340,16 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
               key: pollTypesKeys.false,
               val: intl.formatMessage(intlMessages.false),
             },
-          ]);
+          ];
+          setCorrectAnswer({
+            text: correctAnswer ?? '',
+            index: pattern.findIndex((o) => o.val === correctAnswer) ?? -1,
+          });
+          setOptList(pattern);
           break;
         }
         case pollTypes.YesNo: {
-          setOptList([
+          const pattern = [
             {
               key: pollTypesKeys.yes,
               val: intl.formatMessage(intlMessages.yes),
@@ -353,11 +358,16 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
               key: pollTypesKeys.no,
               val: intl.formatMessage(intlMessages.no),
             },
-          ]);
+          ];
+          setCorrectAnswer({
+            text: correctAnswer ?? '',
+            index: pattern.findIndex((o) => o.val === correctAnswer) ?? -1,
+          });
+          setOptList(pattern);
           break;
         }
         case pollTypes.YesNoAbstention: {
-          setOptList([
+          const pattern = [
             {
               key: pollTypesKeys.yes,
               val: intl.formatMessage(intlMessages.yes),
@@ -370,7 +380,12 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
               key: pollTypesKeys.abstention,
               val: intl.formatMessage(intlMessages.abstention),
             },
-          ]);
+          ];
+          setCorrectAnswer({
+            text: correctAnswer ?? '',
+            index: pattern.findIndex((o) => o.val === correctAnswer) ?? -1,
+          });
+          setOptList(pattern);
           break;
         }
         default: {
@@ -450,7 +465,12 @@ const PollCreationPanel: React.FC<PollCreationPanelProps> = ({
       setType(type);
       setWarning(warning);
       setIsQuiz(isQuiz);
-      setCorrectAnswer(correctAnswer);
+      setCorrectAnswer({
+        text: correctAnswer.text,
+        index: correctAnswer.index === -1
+          ? optList.findIndex((o) => o.val === correctAnswer.text)
+          : correctAnswer.index,
+      });
     }
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/poll/components/ResponseArea.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/ResponseArea.tsx
@@ -164,7 +164,7 @@ const ResponseArea: React.FC<ResponseAreaProps> = ({
           setIsPolling={setIsPolling}
           key="startPollButton"
           isQuiz={isQuiz}
-          correctAnswerText={correctAnswer.text}
+          correctAnswer={correctAnswer}
         />
       </Styled.ResponseArea>
     );

--- a/bigbluebutton-html5/imports/ui/components/poll/components/StartPollButton.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/StartPollButton.tsx
@@ -61,7 +61,10 @@ interface StartPollButtonProps {
   secretPoll: boolean;
   multipleResponse: boolean;
   isQuiz: boolean;
-  correctAnswerText: string;
+  correctAnswer: {
+    text: string;
+    index: number;
+  };
 }
 
 const StartPollButton: React.FC<StartPollButtonProps> = ({
@@ -73,7 +76,7 @@ const StartPollButton: React.FC<StartPollButtonProps> = ({
   secretPoll,
   multipleResponse,
   isQuiz = false,
-  correctAnswerText = '',
+  correctAnswer = { text: '', index: -1 },
 }) => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_CHAT_KEY = CHAT_CONFIG.public_id;
@@ -90,7 +93,7 @@ const StartPollButton: React.FC<StartPollButtonProps> = ({
     question: string | string[],
     multipleResponse: boolean,
     isQuiz: boolean = false,
-    correctAnswerText: string = '',
+    correctAnswerText: string,
     answers: (string | null)[] = [],
   ) => {
     const pollId = PUBLIC_CHAT_KEY;
@@ -102,16 +105,18 @@ const StartPollButton: React.FC<StartPollButtonProps> = ({
         secretPoll,
         question,
         multipleResponse,
-        quiz: isQuiz,
+        quiz: isQuiz && correctAnswerText.trim().length > 0,
         answers,
-        correctAnswer: correctAnswerText,
+        correctAnswer: isQuiz ? correctAnswerText : null,
       },
     });
   };
 
   const hasNotMinOptions = (type !== pollTypes.Response
     && optList.filter((o) => o.val.trim().length > 0).length < 1);
-  const quizHasNoCorrectAnswer = (isQuiz && correctAnswerText.trim().length === 0);
+  const quizHasNoCorrectAnswer = (
+    isQuiz
+    && !(optList[correctAnswer.index]?.val === correctAnswer.text));
   return (
     <Styled.StartPollBtn
       data-test="startPoll"
@@ -161,7 +166,7 @@ const StartPollButton: React.FC<StartPollButtonProps> = ({
               question,
               multipleResponse,
               isQuiz,
-              correctAnswerText,
+              correctAnswer.text,
               verifiedOptions?.filter(Boolean),
             );
           } else {
@@ -171,7 +176,7 @@ const StartPollButton: React.FC<StartPollButtonProps> = ({
               question,
               multipleResponse,
               isQuiz,
-              correctAnswerText,
+              correctAnswer.text,
             );
           }
         }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the issue where the correct answer in the quick poll dropdown was not properly aligning with the options due to the mismatch of prefixes. The correct answer was returned with its letter prefix (e.g., `b. no`), while the options list was stripped of the prefix (e.g., `no`). The code now normalizes the correct answer to match the format of the options.

* Normalized the correct answer to remove the letter prefix.
* Updated the poll handling in `QuickPollDropdown` to use the normalized correct answer.
* Fixed the issue of incorrect handling of the correct answer in `PollCreationPanel` and `StartPollButton`.

### Closes Issue(s)

Closes #23988
Closes #23989

### Motivation

The motivation for this change came from the issues reported regarding the mismatch between the correct answer and the options in the quick poll dropdown. Ensuring the correct answer aligns with the option values is crucial for the proper functioning of the poll feature.

### How to test

* Create a poll with options like `a) yes`, `b) no`, and mark `b) no` as the correct answer.
* Ensure that the correct answer is processed and displayed as `no` without the letter prefix.
* Test other poll types to ensure the functionality remains consistent across them.
* Validate that the options in the dropdown correctly match the correct answer and other options.

### More

[Screencast from 03-10-2025 12:37:10.webm](https://github.com/user-attachments/assets/724bd916-2690-4135-8d6c-ecb3f7fe0658)

