### PR TITLE
fix(livekit): mitigate audio publish timeouts from overlapping calls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -38,6 +38,7 @@ const AudioModalContainer = (props) => {
   }));
   const usingLiveKit = meeting?.audioBridge === 'livekit';
   const getEchoTest = useStorageKey('getEchoTest', 'session');
+  const storageMuteState = useStorageKey(Service.getStorageMuteStateKey(), 'session');
 
   const away = currentUserData?.away;
   const isModerator = currentUserData?.isModerator;
@@ -102,9 +103,11 @@ const AudioModalContainer = (props) => {
   const joinMic = useCallback(
     (options = {}) => joinMicrophone({
       skipEchoTest: options.skipEchoTest || joinFullAudioImmediately,
-      muted: options.muteOnStart || meeting?.voiceSettings?.muteOnStart,
+      muted: options.muteOnStart
+        || meeting?.voiceSettings?.muteOnStart
+        || storageMuteState,
     }),
-    [skipCheck, skipCheckOnJoin, meeting],
+    [skipCheck, skipCheckOnJoin, meeting, storageMuteState],
   );
   const close = useCallback(() => {
     const handleJoinError = (error, listenOnly) => {

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -124,6 +124,7 @@ const AudioContainer = (props) => {
   const toggleVoice = useToggleVoice();
   const userSelectedMicrophone = !!useStorageKey(CLIENT_DID_USER_SELECT_MICROPHONE_KEY, 'session');
   const userSelectedListenOnly = !!useStorageKey(CLIENT_DID_USER_SELECT_LISTEN_ONLY_KEY, 'session');
+  const storageMuteState = useStorageKey(Service.getStorageMuteStateKey(), 'session');
   const { microphoneConstraints } = useSettings(SETTINGS.APPLICATION);
 
   const meetingIsBreakout = useMeetingIsBreakout();
@@ -204,12 +205,20 @@ const AudioContainer = (props) => {
     if (Service.isConnected()) return;
 
     if (userSelectedMicrophone) {
-      joinMicrophone({ skipEchoTest: true, muted: meeting?.voiceSettings?.muteOnStart });
+      joinMicrophone({
+        skipEchoTest: true,
+        muted: meeting?.voiceSettings?.muteOnStart || storageMuteState,
+      });
       return;
     }
 
     if (userSelectedListenOnly) joinListenOnly();
-  }, [userSelectedMicrophone, userSelectedListenOnly, meeting?.voiceSettings?.muteOnStart]);
+  }, [
+    userSelectedMicrophone,
+    userSelectedListenOnly,
+    meeting?.voiceSettings?.muteOnStart,
+    storageMuteState,
+  ]);
 
   useEffect(() => {
     // Data is not loaded yet.

--- a/bigbluebutton-html5/imports/ui/components/audio/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/service.js
@@ -34,30 +34,30 @@ export const didUserSelectListenOnly = () => (
   !!Storage.getItem(CLIENT_DID_USER_SELECT_LISTEN_ONLY_KEY)
 );
 
-const recoverMicState = (toggleVoice) => {
+const getStorageMuteStateKey = () => {
   const meetingStaticStore = meetingStaticData.getMeetingData();
-  const recover = (storageKey) => {
-    const muted = Storage.getItem(storageKey);
-
-    if ((muted === undefined) || (muted === null) || AudioManager.inputDeviceId === 'listen-only') {
-      return;
-    }
-
-    logger.debug({
-      logCode: 'audio_recover_mic_state',
-    }, `Audio recover previous mic state: muted = ${muted}`);
-    toggleVoice(Auth.userID, muted);
-  };
-
   const isBreakout = meetingStaticStore?.isBreakout;
   const parentId = meetingStaticStore?.breakoutPolicies?.parentId;
-
   const meetingId = isBreakout && parentId
     ? parentId
     : Auth.meetingID;
-  const storageKey = `${MUTED_KEY}_${meetingId}`;
 
-  recover(storageKey);
+  return `${MUTED_KEY}_${meetingId}`;
+};
+
+const getStorageMuteState = () => Storage.getItem(getStorageMuteStateKey());
+
+const recoverMicState = (toggleVoice) => {
+  const muted = getStorageMuteState();
+
+  if ((muted === undefined) || (muted === null) || AudioManager.inputDeviceId === 'listen-only') {
+    return;
+  }
+
+  logger.debug({
+    logCode: 'audio_recover_mic_state',
+  }, `Audio recover previous mic state: muted = ${muted}`);
+  toggleVoice(Auth.userID, muted);
 };
 
 const audioEventHandler = (toggleVoice) => (event) => {
@@ -235,7 +235,6 @@ export default {
   handleAllowAutoplay: () => AudioManager.handleAllowAutoplay(),
   playAlertSound: (url) => AudioManager.playAlertSound(url),
   updateAudioConstraints: (constraints) => AudioManager.updateAudioConstraints(constraints),
-  recoverMicState,
   setBreakoutAudioTransferStatus: (status) => AudioManager
     .setBreakoutAudioTransferStatus(status),
   getBreakoutAudioTransferStatus: () => AudioManager
@@ -251,4 +250,6 @@ export default {
   didUserSelectListenOnly,
   setUserSelectedMicrophone,
   setUserSelectedListenOnly,
+  getStorageMuteStateKey,
+  getStorageMuteState,
 };

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/service.ts
@@ -39,7 +39,9 @@ const logUserCouldNotRejoinAudio = () => {
 
 export const rejoinAudio = () => {
   if (didUserSelectMicrophone()) {
-    AudioManager.joinMicrophone({ muted: true }).catch(() => {
+    const storageMuteState = AudioService.getStorageMuteState();
+
+    AudioManager.joinMicrophone({ muted: storageMuteState ?? true }).catch(() => {
       logUserCouldNotRejoinAudio();
     });
   } else if (didUserSelectListenOnly()) {


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): mitigate audio publish timeouts from overlapping calls](https://github.com/bigbluebutton/bigbluebutton/pull/24046/commits/866c8f8e99bb9df50eef94ce4b08090571ad0080)
  - LiveKit has an issue where overlapping publish calls for the same
track type cause an inconsistent server state. This leads to all
subsequent publish calls (of the target track type) timing out due
to a race condition in the offer/answer process with cancelled calls.
  - End users experience automatic audio muting when the timeout occurs.
The only way to remediate this inconsistent state is by re-creating
the participant's LK connection.
This issue is most often hit in meetings with muteOnStart=false or
when participants reconnect as with an unmuted state reconciled from 
storage.
  - Introduce a publish/unpublish processing queue in the LK audio
bridge to prevent overlapping publish calls. Serialize requests,
and skip overlapping ones whenever possible. This greatly reduces
the occurrence of the timeouts, based on field trial deployments of this
patch.
- [fix(audio): prevent spurious mute toggles on state recovery](https://github.com/bigbluebutton/bigbluebutton/pull/24046/commits/68c15011eef20db884eaff6828525feb2ea63286)
  - Adjust audio-manager join calls to account for the storage mute
state when defining the initial "muted" flag. This prevents the
spurious mute toggles in the LiveKit bridge. The original decoupled
recovery procedure is kept in place for SFU/FS bridges that do not
yet honor the initial mute state.

### Closes Issue(s)

Partially https://github.com/bigbluebutton/bigbluebutton/issues/24013
