### PR TITLE
fix: whiteboard access toggle in userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -240,7 +240,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     try {
       // Fetch the writers data
       const { data } = await getWriters();
-      const currentWriters: Writer[] = data?.user || [];
+      const currentWriters: Writer[] = data?.user_whiteboardWriteAccess || [];
 
       // Determine if the user has access
       const { userId, whiteboardWriteAccess } = user;


### PR DESCRIPTION
### What does this PR do?

Fix issue with whiteboard access toggle in the userlist affecting all users due to an invalid property

### How to test
1. join a meeting with multiple users
2. use the option "give/remove whiteboard access"
3. check if only the selected user is affected