### PR TITLE
fix(timer): correct title locale

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/timer/constants.ts
+++ b/bigbluebutton-html5/imports/ui/components/timer/constants.ts
@@ -3,8 +3,8 @@ import { PANELS } from '/imports/ui/components/layout/enums';
 export const TIMER_APP_KEY = PANELS.TIMER;
 export const TIMER_ICON = 'time';
 export const TIMER_LABEL = {
-  id: 'app.userList.timerTitle',
-  description: 'Title for the time',
+  id: 'app.timer.title',
+  description: 'Title for the timer app',
 };
 
 export default {

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -156,7 +156,6 @@
     "app.userList.messagesTitle": "Messages",
     "app.userList.notesTitle": "Notes",
     "app.userList.notesListItem.unreadContent": "New content is available in the shared notes section",
-    "app.userList.timerTitle": "Time",
     "app.userList.captionsTitle": "Captions",
     "app.userList.presenter": "Presenter",
     "app.userList.you": "You",


### PR DESCRIPTION
### What does this PR do?
Replaces the old and incorrect locale by the new locale for the timer feature. Additionally, removes the old locale that was not being used anymore.

### Closes Issue(s)
Closes #24052 