### PR TITLE
Fix automation queries to correctly identify the 'bot' flag

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -233,7 +233,6 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
   const { data: currentUser } = useCurrentUser((u) => {
     return {
       isModerator: u.isModerator,
-      bot: u.bot,
       lastBreakoutRoom: u.lastBreakoutRoom,
       presenter: u.presenter,
       breakoutRoomsSummary: u.breakoutRoomsSummary,

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -237,6 +237,7 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
       lastBreakoutRoom: u.lastBreakoutRoom,
       presenter: u.presenter,
       breakoutRoomsSummary: u.breakoutRoomsSummary,
+      bot: u.bot,
     };
   });
 
@@ -259,6 +260,8 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
   } = useDeduplicatedSubscription<GetBreakoutDataResponse>(getBreakoutData, { skip: !hasInvitationToShow });
 
   if (!hasInvitationToShow) return null;
+
+  if (currentUser?.bot) return null;
 
   if (currentUser?.isModerator
       && !currentMeeting?.breakoutRoomsCommonProperties?.sendInvitationToModerators) return null;

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/currentUserSubscription.ts
@@ -29,6 +29,7 @@ subscription userCurrentSubscription {
     locked
     loggedOut
     mobile
+    bot
     name
     nameSortable
     pinned

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -41,6 +41,7 @@ subscription UserListSubscription($offset: Int!, $limit: Int!) {
     authed
     mobile
     guest
+    bot
     clientType
     disconnected
     loggedOut


### PR DESCRIPTION
Automation users are not invited into breakout rooms and also show a specific label in the user area. Both of those features were broken probably due to merges with the 3.0 branch and this PR fixes them.