### PR TITLE
fix(bbb-export-annotations): Rendering fixes

### DIFF
--- a/bbb-export-annotations/shapes/Geo.js
+++ b/bbb-export-annotations/shapes/Geo.js
@@ -23,7 +23,7 @@ export class Geo extends Shape {
     this.geo = this.props?.geo;
     this.verticalAlign = this.props?.verticalAlign;
     this.labelColor = this.props?.labelColor;
-    this.padding = this.padding || Shape.determineFontSize(this.size)/2;
+    this.padding = this.padding || 16;
   }
 
   /**

--- a/bbb-export-annotations/shapes/Geo.js
+++ b/bbb-export-annotations/shapes/Geo.js
@@ -23,7 +23,7 @@ export class Geo extends Shape {
     this.geo = this.props?.geo;
     this.verticalAlign = this.props?.verticalAlign;
     this.labelColor = this.props?.labelColor;
-    this.padding = this.padding || 16;
+    this.padding = this.props?.padding ?? 16;
   }
 
   /**

--- a/bbb-export-annotations/shapes/Highlight.js
+++ b/bbb-export-annotations/shapes/Highlight.js
@@ -1,4 +1,5 @@
 import {Draw} from './Draw.js';
+import {Shape, ColorTypes} from './Shape.js';
 
 /**
  * Represents a Highlight shape, extending the functionality of the Draw class.
@@ -16,7 +17,7 @@ export class Highlight extends Draw {
     super(highlight);
 
     this.fill = 'none';
-    this.shapeColor = '#fedd00';
+    this.shapeColor = Shape.colorToHex(this.color, ColorTypes.HighlightColor);
     this.thickness = this.thickness * 7;
     this.isClosed = false;
   }

--- a/bbb-export-annotations/shapes/Shape.js
+++ b/bbb-export-annotations/shapes/Shape.js
@@ -12,6 +12,7 @@ import fs from 'fs';
  * @property {'fill'} FillColor - Solid fill color inside the shape.
  * @property {'semi'} SemiFillColor - Semi fill shape color.
  * @property {'sticky'} StickyColor - Color for sticky notes.
+ * @property {'highlight'} HighlightColor - Color for highlight drawings.
  */
 export class Shape {
   /**
@@ -164,6 +165,21 @@ export class Shape {
       'red': '#D61A25',
     };
 
+    const highlightMap = {
+      'black': '#fddd00',
+      'blue': '#10acff',
+      'green': '#00ffc8',
+      'grey': '#cbe7f1',
+      'light-blue': '#00f4ff',
+      'light-green': '#65f641',
+      'light-red': '#ff7fa3',
+      'light-violet': '#ff88ff',
+      'orange': '#ffa500',
+      'red': '#ff636e',
+      'violet': '#c77cff',
+      'yellow': '#fddd00',
+    };
+
     const fillMap = {
       'black': '#E2E2E2',
       'grey': '#E7EAEC',
@@ -203,6 +219,7 @@ export class Shape {
       fill: fillMap,
       semi: semiFillMap,
       sticky: stickyMap,
+      highlight: highlightMap,
     };
 
     return colors[colorType][color] || '#0d0d0d';
@@ -559,4 +576,5 @@ export const ColorTypes = Object.freeze({
   FillColor: 'fill',
   SemiFillColor: 'semi',
   StickyColor: 'sticky',
+  HighlightColor: 'highlight',
 });

--- a/bbb-export-annotations/shapes/Shape.js
+++ b/bbb-export-annotations/shapes/Shape.js
@@ -393,6 +393,20 @@ export class Shape {
   }
 
   /**
+     * Gets the smallest character width of a given text string using
+     * font metrics.
+    * @param {string} text - The text to measure.
+    * @param {opentype.Font} font - The loaded font object.
+    * @param {number} fontSize - The size of the font.
+    * @return {number} The width of the smallest character.
+    */
+  getSmallestCharWidth(text, font, fontSize) {
+    const widths = text.split('')
+        .map((char) => this.measureTextWidth(char, font, fontSize));
+    return Math.min(...widths);
+  }
+
+  /**
    * Wraps text to fit within a specified width and height.
    * @param {string} text - The text to wrap.
    * @param {number} width - The width of the bounding box.
@@ -428,13 +442,12 @@ export class Shape {
     const parsedFont = opentype.parse(decompressedArrayBuffer);
     const fontSize = Shape.determineFontSize(this.size, this.type);
 
-    width -= this.padding * 2;
-
     // In order to avoid bad line breaks due to rendering mismatch between
     // environments (browser and CairoSVG) we add some spacing for safety.
-    // Such spacing needs to be less than half the average character width
-    // to not mess up original line breaks.
-    width += fontSize * 0.5;
+    width += (this.getSmallestCharWidth(text, parsedFont, fontSize) - 1);
+
+    // Subtract inline padding
+    width -= (this.padding * 2);
 
     const _wrapText = (token, availableWidth) => {
       let prefix = '';

--- a/bbb-export-annotations/shapes/Shape.js
+++ b/bbb-export-annotations/shapes/Shape.js
@@ -32,6 +32,7 @@ export class Shape {
     rotation,
     opacity,
     props,
+    type,
   }) {
     this.id = id;
     this.x = x;
@@ -39,6 +40,7 @@ export class Shape {
     this.rotation = rotation;
     this.opacity = opacity;
     this.props = props;
+    this.type = type;
 
     this.size = this.props?.size;
     this.color = this.props?.color;
@@ -267,17 +269,31 @@ export class Shape {
    * Get the font size in pixels.
    *
    * @param {string} size - The size of the font ('s', 'm', 'l', 'xl').
+   * @param {string} [type='default'] The type of the shape
    * @return {number} - The corresponding font size, in pixels.
   */
-  static determineFontSize(size) {
-    const fontSizes = {
+  static determineFontSize(size, type = 'default') {
+    const textFontSizes = {
       's': 18,
       'm': 24,
       'l': 36,
       'xl': 44,
     };
 
-    return fontSizes[size] || 18;
+    const geoFontSizes = {
+      's': 18,
+      'm': 22,
+      'l': 26,
+      'xl': 32,
+    };
+
+    const fontSizeTypes = {
+      'geo': geoFontSizes,
+      'text': textFontSizes,
+      'default': textFontSizes,
+    };
+
+    return fontSizeTypes[type]?.[size] || 18;
   }
 
   /**
@@ -385,19 +401,21 @@ export class Shape {
 
     const decompressedBuffer = await wawoff2.decompress(arrayBuffer);
 
-    const decompresseArrayBuffer = decompressedBuffer.buffer.slice(
+    const decompressedArrayBuffer = decompressedBuffer.buffer.slice(
         decompressedBuffer.byteOffset,
         decompressedBuffer.byteOffset + decompressedBuffer.byteLength);
 
     // Parse the font using the ArrayBuffer
-    const parsedFont = opentype.parse(decompresseArrayBuffer);
-    const fontSize = Shape.determineFontSize(this.size);
+    const parsedFont = opentype.parse(decompressedArrayBuffer);
+    const fontSize = Shape.determineFontSize(this.size, this.type);
+
+    width -= this.padding * 2;
 
     // In order to avoid bad line breaks due to rendering mismatch between
     // environments (browser and CairoSVG) we add some spacing for safety.
-    // Such spacing needs to be less than 2 characters width wide
+    // Such spacing needs to be less than half the average character width
     // to not mess up original line breaks.
-    width += fontSize * 1.35;
+    width += fontSize * 0.5;
 
     const _wrapText = (token, availableWidth) => {
       let prefix = '';
@@ -476,7 +494,7 @@ export class Shape {
     const width = this.w;
     const height = this.h + this.growY;
 
-    const lineHeight = Shape.determineFontSize(this.size);
+    const lineHeight = Shape.determineFontSize(this.size, this.type);
     const fontFamily = Shape.determineFontFromFamily(this.props?.font);
     const x = Shape.alignHorizontally(this.align, width, this.padding);
     const y = Shape.alignVertically(

--- a/bbb-export-annotations/shapes/Shape.js
+++ b/bbb-export-annotations/shapes/Shape.js
@@ -49,6 +49,7 @@ export class Shape {
     this.fill = this.props?.fill;
     this.text = this.props?.text;
     this.padding = this.props?.padding ?? 0;
+    this.scale = this.props?.scale ?? 1;
 
     // Derived SVG properties
     this.thickness = Shape.getStrokeWidth(this.size);
@@ -133,7 +134,8 @@ export class Shape {
     const translate = `translate(${x} ${y})`;
     const transformOrigin = 'transform-origin: center';
     const rotate = `rotate(${rotation})`;
-    const transform = `${translate}; ${transformOrigin}; ${rotate}`;
+    const scale = `scale(${this.scale})`;
+    const transform = `${translate}; ${transformOrigin}; ${rotate}; ${scale}`;
 
     return transform;
   }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

- Fixes text wraping in geometric shapes.
- Fixes highlight colors.
- Fixes shape scaling.

#### Highlight colors

(Without fix - all yellow)
<img width="1446" height="810" alt="Screenshot from 2025-10-06 17-39-15" src="https://github.com/user-attachments/assets/ed6027bb-b9f3-429b-b3b3-59bdd8bf65c4" />

(With fix - proper colors)
<img width="1446" height="810" alt="Screenshot from 2025-10-06 17-39-24" src="https://github.com/user-attachments/assets/be12f5dc-cef1-4376-829b-be31e836e927" />

---

#### Text wraping in geometric shapes

(Without fix)
<img width="1446" height="810" alt="Screenshot from 2025-10-06 17-37-22" src="https://github.com/user-attachments/assets/bc54c346-ee3b-471b-977b-c5ea8247b5e0" />

(With fix)
<img width="1446" height="810" alt="Screenshot from 2025-10-06 17-37-35" src="https://github.com/user-attachments/assets/ad5b3d14-6e40-4b09-b79b-8f7554390e1f" />

---

#### Shape scaling

(Without fix)
<img width="1446" height="810" alt="Screenshot from 2025-10-06 17-41-14" src="https://github.com/user-attachments/assets/21b8a3f8-9a00-46ec-bac0-a8403b8a035e" />

(With fix)
<img width="1446" height="810" alt="Screenshot from 2025-10-06 17-41-21" src="https://github.com/user-attachments/assets/becb057c-be50-4530-808a-88cb4ef1a35b" />

---

Whiteboard in the session:

[Screencast from 2025-10-06 17-43-24.webm](https://github.com/user-attachments/assets/ca1215e3-2e5b-48d2-8e41-f019b1f0b411)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes none