### PR TITLE
fix(userlist): fix how the breakout room number is displayed in the userlist

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
@@ -91,7 +91,7 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
         <Icon iconName="rooms" />
         &nbsp;
         {subjectUser.lastBreakoutRoom?.shortName
-          ? intl.formatMessage(intlMessages.breakoutRoom, { 0: subjectUser.lastBreakoutRoom?.sequence })
+          ? intl.formatMessage(intlMessages.breakoutRoom, { roomNumber: subjectUser.lastBreakoutRoom?.sequence })
           : subjectUser.lastBreakoutRoom?.shortName}
       </span>,
     );


### PR DESCRIPTION
…ser list

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Fix user list placeholder to correctly display the breakout room number each user is in.




### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Create a call with more than 2 participants if possible.
Create breakout rooms and join them with their respective users.
In the main call room, check how the room number is being displayed.

Expected:
Room 1

Unexpected:
Room {roomNumber}


