### PR TITLE
fix (bbb-web): Fix timeout units for `pdftotext` and `generateThumbnail` (seconds passed instead of milliseconds)

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -122,7 +122,7 @@ public class TextFileCreatorImp implements TextFileCreator {
         long execTimeout = this.execTimeout;
         long pageConversionTimeoutInMs = pres.getMaxPageConversionTime() * 1000;
         if (execTimeout > pageConversionTimeoutInMs) {
-        execTimeout = pageConversionTimeoutInMs;
+            execTimeout = pageConversionTimeoutInMs;
         }
 
         boolean done = new ExternalProcessExecutor().exec(COMMAND, execTimeout);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -119,10 +119,11 @@ public class TextFileCreatorImp implements TextFileCreator {
 
         //System.out.println(COMMAND);
 
-      long execTimeout = this.execTimeout;
-      if (execTimeout > pres.getMaxPageConversionTime()) {
-        execTimeout = pres.getMaxPageConversionTime();
-      }
+        long execTimeout = this.execTimeout;
+        long pageConversionTimeoutInMs = pres.getMaxPageConversionTime() * 1000;
+        if (execTimeout > pageConversionTimeoutInMs) {
+        execTimeout = pageConversionTimeoutInMs;
+        }
 
         boolean done = new ExternalProcessExecutor().exec(COMMAND, execTimeout);
         if (!done) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -99,8 +99,9 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
     //System.out.println(COMMAND);
 
     long execTimeout = this.execTimeout;
-    if (execTimeout > pres.getMaxPageConversionTime()) {
-      execTimeout = pres.getMaxPageConversionTime();
+    long pageConversionTimeoutInMs = pres.getMaxPageConversionTime() * 1000;
+    if (execTimeout > pageConversionTimeoutInMs) {
+      execTimeout = pageConversionTimeoutInMs;
     }
 
     boolean done = new ExternalProcessExecutor().exec(COMMAND, execTimeout);

--- a/bigbluebutton-tests/playwright/polling/polling.spec.js
+++ b/bigbluebutton-tests/playwright/polling/polling.spec.js
@@ -46,7 +46,7 @@ test.describe.parallel('Polling', { tag: '@ci' }, async () => {
     await polling.allowMultipleChoices();
   });
 
-  test('Smart slides questions', { tag: '@flaky' }, async () => {
+  test('Smart slides questions', async () => {
     await polling.smartSlidesQuestions();
   });
 


### PR DESCRIPTION
Fix an issue in the presentation conversion flow.
The code compares `thumbnailCreationExecTimeoutInMs` and `textFileCreationExecTimeoutInMs` (both in milliseconds) against `maxPageConversionTime` (in seconds).
Because of the unit mismatch, it always assumes `maxPageConversionTime` is smaller and uses it. However, the function expects the timeout in milliseconds, which means it effectively only had 60 ms to run, causing frequent failures.

<img width="350" src="https://github.com/user-attachments/assets/5ba09e7a-18e7-414a-bd6c-079170af1157" />
<img width="350" src="https://github.com/user-attachments/assets/7dc08a02-5ca4-469a-bf7c-e4502badb363" />

- Issue identified thanks to Automated Tests:

<img width="2598" height="1215" alt="image" src="https://github.com/user-attachments/assets/86665b5f-566c-4999-b976-5a5441becdf0" />

The problem exists in production but was not reported yet.


Related: #23328