### PR TITLE
test: Added step to check config quickPollConfirmationStep

### DIFF
--- a/bigbluebutton-tests/playwright/core/settings.js
+++ b/bigbluebutton-tests/playwright/core/settings.js
@@ -29,6 +29,7 @@ async function generateSettingsData(page) {
       // Polling
       pollEnabled: settingsData.poll?.enabled,
       pollChatMessage: settingsData.poll?.chatMessage,
+      quickPollConfirmationStep: settingsData.poll?.quickPollConfirmationStep,
       // Presentation
       originalPresentationDownloadable: settingsData.presentation?.allowDownloadOriginal,
       presentationWithAnnotationsDownloadable: settingsData.presentation?.allowDownloadWithAnnotations,

--- a/bigbluebutton-tests/playwright/polling/poll.js
+++ b/bigbluebutton-tests/playwright/polling/poll.js
@@ -35,10 +35,19 @@ class Polling extends MultiUsers {
   }
 
   async quickPoll() {
+    const { quickPollConfirmationStep } = getSettings();
     await util.uploadSPresentationForTestingPolls(this.modPage, e.questionSlideFileName);
 
     // The slide needs to be uploaded and converted, so wait a bit longer for this step
     await this.modPage.waitAndClick(e.quickPoll, ELEMENT_WAIT_LONGER_TIME);
+    if(!quickPollConfirmationStep) {
+      await this.modPage.hasElement(e.pollMenuButton, 'should display the poll menu button');
+
+      await this.userPage.hasElement(e.pollingContainer, 'should display the polling container for the attendee to answer it');
+
+      await this.modPage.waitAndClick(e.closePollingBtn);
+      return this.modPage.wasRemoved(e.closePollingBtn, 'should not display the close poll button after the poll closes');
+    }
     await this.modPage.waitAndClick(e.startPoll);
     await this.modPage.hasElement(e.pollMenuButton, 'should display the poll menu button');
 


### PR DESCRIPTION
### What does this PR do?
Added a step to check if the config public.poll.quickPollConfirmationStep is set to false, so the quick poll can start with one click.

[recording (43).webm](https://github.com/user-attachments/assets/5025cea4-2513-4b4d-9dbf-9751fe7f6072)

