### PR TITLE
fix: When locked settings for shared notes are applied, links in shared notes don't open in new window

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/content/component.tsx
@@ -18,6 +18,7 @@ const PadContent: React.FC<PadContentProps> = ({
   const contentSplit = content.split('<body>');
   const contentStyle = `
   <body>
+  <base target="_blank">
   <style type="text/css">
     body {
       ${Styled.contentText}


### PR DESCRIPTION
### What does this PR do?

Makes locked shared notes links open in new tab.

### Closes Issue(s)
Closes #24067

### How to test
1. Start a new meeting and join a moderator.  
2. Apply lock settings for viewers to lock editing of shared notes
3. Type https://google.com/ in shared notes
4. Join as a viewer
5. Open shared notes
6. Click on google link