### PR TITLE
fix: Poll Custom input don't work with .txt file

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/components/DragAndDrop.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/DragAndDrop.tsx
@@ -3,14 +3,13 @@ import Styled from '../styles';
 
 interface DragAndDropPros {
   MAX_INPUT_CHARS: number;
-  handlePollValuesText: (value: string) => void;
+  handleTextareaChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   [key: string]: unknown;
 }
 
 const DragAndDrop = React.forwardRef<HTMLTextAreaElement, DragAndDropPros>((props, ref) => {
-  const { MAX_INPUT_CHARS, handlePollValuesText } = props;
+  const { MAX_INPUT_CHARS, handleTextareaChange } = props;
   const [drag, setDrag] = useState(false);
-  const [pollValueText, setPollValueText] = useState('');
   const dropRef = useRef<HTMLTextAreaElement | null>(null);
   const dragCounter = useRef(0);
 
@@ -61,12 +60,6 @@ const DragAndDrop = React.forwardRef<HTMLTextAreaElement, DragAndDropPros>((prop
     };
   }, []);
 
-  const setPollValues = () => {
-    if (pollValueText) {
-      handlePollValuesText(pollValueText);
-    }
-  };
-
   const setPollValuesFromFile = (file: File) => {
     const reader = new FileReader();
     reader.onload = async (e) => {
@@ -74,7 +67,6 @@ const DragAndDrop = React.forwardRef<HTMLTextAreaElement, DragAndDropPros>((prop
       if (!result) return;
       const text = typeof result === 'string' ? result : String(result);
       setPollText(text);
-      setPollValues();
     };
     reader.readAsText(file);
   };
@@ -84,7 +76,7 @@ const DragAndDrop = React.forwardRef<HTMLTextAreaElement, DragAndDropPros>((prop
     const text = arr.map((line) => (
       line.length > MAX_INPUT_CHARS ? line.substring(0, MAX_INPUT_CHARS) : line
     )).join('\n');
-    setPollValueText(text);
+    handleTextareaChange({ target: { value: text } } as React.ChangeEvent<HTMLTextAreaElement>);
   };
 
   const getCleanProps = () => {

--- a/bigbluebutton-html5/imports/ui/components/poll/components/PollQuestionArea.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/PollQuestionArea.tsx
@@ -82,6 +82,7 @@ const PollQuestionArea: React.FC<PollQuestionAreaProps> = ({
         placeholder={intl.formatMessage(customInput ? questionsAndOptionsPlaceholder
           : questionPlaceholder)}
         {...{ MAX_INPUT_CHARS }}
+        handleTextareaChange={handleTextareaChange}
         as={customInput ? DraggableTextArea : 'textarea'}
         ref={textareaRef}
       />

--- a/bigbluebutton-tests/playwright/polling/polling.spec.js
+++ b/bigbluebutton-tests/playwright/polling/polling.spec.js
@@ -46,7 +46,7 @@ test.describe.parallel('Polling', { tag: '@ci' }, async () => {
     await polling.allowMultipleChoices();
   });
 
-  test('Smart slides questions', async () => {
+  test('Smart slides questions', { tag: '@flaky' }, async () => {
     await polling.smartSlidesQuestions();
   });
 


### PR DESCRIPTION
### What does this PR do?

Adjusts poll drag and drop feature to work with the new poll/quiz

### Closes Issue(s)
Closes #24076

### How to test
1. Open poll (or quizz)
2. Set "Custom input"
3. Drag N drop a .txt file