### PR TITLE
fix(layout/plugin): Fix blue screen when updating generic content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/generic-content/generic-main-content/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/generic-main-content/container.tsx
@@ -46,22 +46,22 @@ const GenericContentMainAreaContainer: React.FC<GenericContentMainAreaContainerP
     );
     if (genericContentItemsAdded.length > 0 || genericContentItemsRemoved.length > 0) {
       previousPluginGenericContainerContents.current = [...genericContainerContentExtensibleArea];
-      genericContentItemsAdded.forEach((g) => {
-        layoutContextDispatch({
-          type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
-          value: {
-            content: PRESENTATION_AREA.GENERIC_CONTENT,
-            open: true,
-            genericContentId: g.id,
-          },
-        });
-      });
       genericContentItemsRemoved.forEach((g) => {
         layoutContextDispatch({
           type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
           value: {
             content: PRESENTATION_AREA.GENERIC_CONTENT,
             open: false,
+            genericContentId: g.id,
+          },
+        });
+      });
+      genericContentItemsAdded.forEach((g) => {
+        layoutContextDispatch({
+          type: ACTIONS.SET_PILE_CONTENT_FOR_PRESENTATION_AREA,
+          value: {
+            content: PRESENTATION_AREA.GENERIC_CONTENT,
+            open: true,
             genericContentId: g.id,
           },
         });

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useReducer, useRef } from 'react';
 import { createContext, useContextSelector } from 'use-context-selector';
 import PropTypes from 'prop-types';
-import { clone, equals } from 'ramda';
+import { clone } from 'ramda';
+import { presentationContentHasChanges } from './utils';
 import {
   ACTIONS, PRESENTATION_AREA, PANELS, LAYOUT_TYPE,
 } from '/imports/ui/components/layout/enums';
@@ -1393,10 +1394,13 @@ const updatePresentationAreaContent = (
   const {
     presentationAreaContentActions: currentPresentationAreaContentActions,
   } = layoutContextState;
-  if (!equals(
-    currentPresentationAreaContentActions.map((action) => action.value.content),
-    previousPresentationAreaContentActions.current.map((action) => action.value.content),
-  ) || layoutType !== previousLayoutType) {
+  const hasPresentationContentChanged = presentationContentHasChanges(
+    currentPresentationAreaContentActions,
+    previousPresentationAreaContentActions.current,
+    layoutType,
+    previousLayoutType,
+  );
+  if (hasPresentationContentChanged) {
     const CHAT_CONFIG = window.meetingClientSettings.public.chat;
     const PUBLIC_CHAT_ID = CHAT_CONFIG.public_id;
 

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -1,8 +1,10 @@
+import { equals } from 'ramda';
 import {
   DEVICE_TYPE,
   LAYOUT_ELEMENTS,
   LAYOUT_TYPE,
   SYNC,
+  PRESENTATION_AREA,
 } from './enums';
 
 const phoneUpperBoundary = 600;
@@ -33,6 +35,23 @@ export default device;
 export {
   isMobile, isTablet, isTabletPortrait, isTabletLandscape, isDesktop,
 };
+
+const hasGenericContentChanged = (current, previous) => !equals(
+  current.filter((action) => action?.value?.content === PRESENTATION_AREA.GENERIC_CONTENT)
+    .map((action) => action.value.genericContentId),
+  previous.filter((action) => action?.value?.content === PRESENTATION_AREA.GENERIC_CONTENT)
+    .map((action) => action.value.genericContentId),
+);
+
+export const presentationContentHasChanges = (
+  current,
+  previous,
+  currentLayoutType,
+  previousLayoutType,
+) => !equals(
+  current.map((action) => action.value.content),
+  previous.map((action) => action.value.content),
+) || currentLayoutType !== previousLayoutType || hasGenericContentChanged(current, previous);
 
 // Array for select component to select different layout
 const suportedLayouts = [


### PR DESCRIPTION
### What does this PR do?

Previously, generic content was not updating correctly (meaning that changing one content to another would cause a blue screen to open in the main content area).

### Motivation

This issue has been spotted in the plugin-generic-link-share at first.

### How to test

Use the Generic link share to test this PR, and follow the steps in the demo video so as to reproduce the bug and then see that it doesn't happen anymore.

### More

Previously, this was the behaviour:

https://github.com/user-attachments/assets/3149201e-f6ef-46f7-b512-0d8712cfabe4

And this is the behaviour after the fix:

https://github.com/user-attachments/assets/e030f6e7-c863-49bd-91e8-b5e4d37101e9


