### PR TITLE
fix (bbb-web): systemd-run failures caused by accumulated failed transient units

### DIFF
--- a/bigbluebutton-web/run-in-systemd.sh
+++ b/bigbluebutton-web/run-in-systemd.sh
@@ -35,6 +35,7 @@ systemd-run --user --pipe --wait --quiet --same-dir                   \
   --property=MemoryMax="${BBB_PRESENTATION_CONVERSION_MEMORY_MAX}"    \
   --property=MemorySwapMax=0                                          \
   --property=UMask=0022                                               \
+  --property=CollectMode=inactive-or-failed                           \
   "$@"
 
 exit $?   # propagate the child’s exit status


### PR DESCRIPTION
`bbb-web` was experiencing multiple timeout errors due to a bug fixed in **#24065**.
All affected commands were being executed through `systemd-run --user`.
After many of these failures, no new commands could be started, even a simple `systemd-run --user echo test` failed with:

```
Failed to start transient service unit: Argument list too long
```

**Root Cause**

The issue occurred because the **user-level systemd manager became overloaded with failed transient units**.
Every time a process launched with `systemd-run --user` exited with a non-zero status or hit a timeout, systemd kept the unit marked as *failed*.
Over time, these accumulated, in this case, over **130,000 failed units**, pushing the user manager into a **degraded state**:

```
State: degraded
Failed: 130786 units
```

Once it reached that volume, systemd began to misbehave and produced misleading errors like “Argument list too long.”

**Fix**

Added a new property to `systemd-run --user`:

```
--property=CollectMode=inactive-or-failed
```

This option ensures that failed units are automatically unloaded, eliminating the need to manually reset their state.

<img width="1424" height="362" src="https://github.com/user-attachments/assets/97fbf6aa-e943-441c-836f-bcf05f3df0e9" />

https://www.freedesktop.org/software/systemd/man/latest/systemd-run.html

----

* Error "degraded status": *

```
● axxx233336.mybbb.server
    State: degraded
     Jobs: 0 queued
   Failed: 130786 units
    Since: Tue 2025-10-07 21:23:09 UTC; 5 days ago
   CGroup: /user.slice/user-998.slice/user@998.service
           ├─app.slice 
           │ └─dbus.service 
           │   └─15045 /usr/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
           └─init.scope 
             ├─1220 /lib/systemd/systemd --user
             └─1267 (sd-pam)
```


Related: #23007
