### PR TITLE
(test): refac methods in Page class

### DIFF
--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -254,7 +254,7 @@ class Page {
 
   async wasRemoved(selector, description, timeout = ELEMENT_WAIT_TIME) {
     const locator = this.getLocator(selector);
-    await expect(locator, description).toBeHidden({ timeout });
+    await expect(locator, description).not.toBeVisible({ timeout });
   }
 
   async hasElement(selector, description, timeout = ELEMENT_WAIT_TIME) {

--- a/bigbluebutton-tests/playwright/core/page.js
+++ b/bigbluebutton-tests/playwright/core/page.js
@@ -257,11 +257,6 @@ class Page {
     await expect(locator, description).toBeHidden({ timeout });
   }
 
-  async wasNthElementRemoved(selector, count, timeout = ELEMENT_WAIT_TIME) {
-    const locator = this.getLocator(':nth-match(' + selector + ',' + count + ')');
-    await expect(locator).toBeHidden({ timeout });
-  }
-
   async hasElement(selector, description, timeout = ELEMENT_WAIT_TIME) {
     const locator = this.getLocator(selector);
     await expect(locator, description).toBeVisible({ timeout });


### PR DESCRIPTION

### What does this PR do?
This PR changes the page method wasRemoved assertion to use `not.visible()` instead of `toBeHidden()`.
With this assertion playwright checks if the element exists in the DOM and if it is visible.


#### Changes made
- changed method `wasRemoved()` 
- removed unused method `wasNthElementRemoved()`


### Closes Issue(s)
Closes #24090 


### How to test
1. run full suite: `npm run test` or `npx playwright test` 
2. ensure the tests are passing
