### PR TITLE
bbb-web: Improve diagnostics, unit name in run-in-systemd.sh

### DIFF
--- a/bigbluebutton-web/run-in-systemd.sh
+++ b/bigbluebutton-web/run-in-systemd.sh
@@ -18,11 +18,18 @@ fi
 
 timeout_secs="$1"; shift
 
+if [[ -z ${XDG_RUNTIME_DIR-} ]] || [[ ! -d $XDG_RUNTIME_DIR ]]; then
+  echo "XDG_RUNTIME_DIR is not available, check user session manager" >&2
+  exit 1
+fi
+
 : "${BBB_PRESENTATION_DIR:=/var/bigbluebutton/}"
 : "${BBB_PRESENTATION_CONVERSION_MEMORY_HIGH:=512M}"
 : "${BBB_PRESENTATION_CONVERSION_MEMORY_MAX:=640M}"
 
 systemd-run --user --pipe --wait --quiet --same-dir                   \
+  --unit=bbb-web-run-in-systemd-$$                                    \
+  --description="bbb-web run-in-systemd $*"                           \
   --property=RuntimeMaxSec="${timeout_secs}"                          \
   --property=ProtectSystem=strict                                     \
   --property=ProtectHome=yes                                          \


### PR DESCRIPTION
A few issues have been found which cause presentation processing to stop working. To improve diagnostics for these issues, I've made the following changes to the run-in-systemd.sh script.

* Check if XDG_RUNTIME_DIR is set and present, and log a diagnostic message if it is missing.
* Set the unit name to a value which makes it clear that the process is associated with bbb-web. (Use the pid of the run-in-systemd.sh script to make the unit name unique.)
* Set the unit description to a value which mentions bbb-web and run-in-systemd. This description is printed in the logs when systemd starts the unit, so it helps explain where the command came from.

This does not fix any of the underlying problems. It should be applied in *addition* to https://github.com/bigbluebutton/bigbluebutton/pull/24088 which does fix a conversion problem.