### PR TITLE
fix: presence label margin

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/options-dropdown/styles.js
@@ -24,6 +24,11 @@ const AwayOption = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  & > span b {
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+  }
 `;
 
 const ToggleButtonWrapper = styled.div`


### PR DESCRIPTION
### What does this PR do?
Adjusts spacing for presence labels in the options dropdown

#### before
<img width="189" height="53" alt="Screenshot from 2025-10-15 16-35-09" src="https://github.com/user-attachments/assets/75b0fea2-5b4e-46f1-a0b4-7b8fdd26d825" />

#### after
<img width="189" height="53" alt="Screenshot from 2025-10-15 16-34-47" src="https://github.com/user-attachments/assets/cb7adc0f-615a-4a7f-87d2-a58299008b83" />