### PR TITLE
Fix(html5): External video modal no longer opens unexpectedly on presenter change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/actions-dropdown/component.jsx
@@ -399,7 +399,10 @@ class ActionsDropdown extends PureComponent {
             open,
             close,
           }) => {
-            this.setExternalVideoModalIsOpen = isOpen ? close : open;
+            this.setExternalVideoModalIsOpen = (value) => {
+              if (value) open();
+              else close();
+            };
             return isOpen && (
               <ExternalVideoModal
                 onRequestClose={close}
@@ -420,7 +423,10 @@ class ActionsDropdown extends PureComponent {
             open,
             close,
           }) => {
-            this.setLayoutModalIsOpen = isOpen ? close : open;
+            this.setLayoutModalIsOpen = (value) => {
+              if (value) open();
+              else close();
+            };
             return isOpen && (
               <LayoutModalContainer
                 onRequestClose={close}
@@ -441,7 +447,10 @@ class ActionsDropdown extends PureComponent {
             open,
             close,
           }) => {
-            this.setCameraAsContentModalIsOpen = isOpen ? close : open;
+            this.setCameraAsContentModalIsOpen = (value) => {
+              if (value) open();
+              else close();
+            };
             return isOpen && (
               <VideoPreviewContainer
                 cameraAsContent


### PR DESCRIPTION
### What does this PR do?
changes the `setExternalVideoModalIsOpen` to consider the value received via parameter instead of be based on the state.


### Closes Issue(s)
Closes #24098

### How to test
- Join UserA and UserB
- With UserA being presenter, promote userB to presenter
- No trace of external video modal should appear


### More
[Screencast from 15-10-2025 18:02:06.webm](https://github.com/user-attachments/assets/a5312aa2-66e2-420a-a430-e129ffae6fd1)
