### PR TITLE
translations: lt_LT: add missing substitution in usersTitle

### DIFF
--- a/bigbluebutton-html5/public/locales/lt_LT.json
+++ b/bigbluebutton-html5/public/locales/lt_LT.json
@@ -48,7 +48,7 @@
     "app.user.activityCheck": "Vartotojo aktyvumo patikra",
     "app.user.activityCheck.label": "Patikrina ar vartotojas vis dar yra susitikime ({responseDelay})",
     "app.user.activityCheck.check": "Patikrinti",
-    "app.userList.usersTitle": "Vartotojai",
+    "app.userList.usersTitle": "Vartotojai ({userCount})",
     "app.userList.participantsTitle": "Dalyviai",
     "app.userList.messagesTitle": "Žinutės",
     "app.userList.notesTitle": "Užrašai",


### PR DESCRIPTION
Teachers keep asking me why the "online user" counter has disappeared after upgrade to 3.0. It is present in the `en` translation but for some reason missing from `lt_LT`. For now I am manually re-adding it through `apply-config.sh`.