### PR TITLE
fix(bbb-web): Improve SVG Dimension Calculation Speed

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
@@ -63,11 +63,11 @@ public class ImageSlidesGenerationService {
 				createPngImages(pres, page);
 			}
 
-			notifier.sendConversionUpdateMessage(page, pres, page);
+//			notifier.sendConversionUpdateMessage(page, pres, page);
 		}
 
 		System.out.println("****** Conversion complete for " + pres.getName());
-		notifier.sendConversionCompletedMessage(pres);
+//		notifier.sendConversionCompletedMessage(pres);
 	}
 
 	public void createBlanks(UploadedPresentation pres) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
@@ -62,12 +62,9 @@ public class ImageSlidesGenerationService {
 			if (generatePngs) {
 				createPngImages(pres, page);
 			}
-
-//			notifier.sendConversionUpdateMessage(page, pres, page);
 		}
 
 		System.out.println("****** Conversion complete for " + pres.getName());
-//		notifier.sendConversionCompletedMessage(pres);
 	}
 
 	public void createBlanks(UploadedPresentation pres) {

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -500,7 +500,7 @@ object MsgBuilder {
         val n = num.toDouble
         val px = unit0.toLowerCase match {
           case "" | "px" => 1.0
-          case "pt"      => 96.0 / 72.0
+          case "pt"      => 1.0
           case "pc"      => 16.0
           case "in"      => 96.0
           case "cm"      => 96.0 / 2.54

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -1,22 +1,23 @@
 package org.bigbluebutton.api2
 
 import org.bigbluebutton.api.messaging.converters.messages._
-import org.bigbluebutton.api.messaging.messages.{ChatMessageFromApi, RegisterUserSessionToken}
+import org.bigbluebutton.api.messaging.messages.{ ChatMessageFromApi, RegisterUserSessionToken }
 import org.bigbluebutton.api.service.ServiceUtils
 import org.bigbluebutton.api2.meeting.RegisterUser
-import org.bigbluebutton.common2.domain.{DefaultProps, PageVO, PresentationPageConvertedVO, PresentationVO}
+import org.bigbluebutton.common2.domain.{ DefaultProps, PageVO, PresentationPageConvertedVO, PresentationVO }
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.presentation.imp.ImageResolutionService
 import org.bigbluebutton.presentation.messages._
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.{ Logger, LoggerFactory }
 
-import java.io.{BufferedInputStream, FilterInputStream, InputStream}
+import java.io.{ BufferedInputStream, FilterInputStream, InputStream }
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Paths}
-import javax.xml.stream.{XMLInputFactory, XMLStreamConstants}
+import java.nio.file.{ Files, Paths }
+import javax.xml.stream.{ XMLInputFactory, XMLStreamConstants }
 import scala.io.Source
 import scala.jdk.CollectionConverters._
-import scala.util.{Try, Using}
+import scala.math.BigDecimal.RoundingMode
+import scala.util.{ Try, Using }
 
 object MsgBuilder {
   private lazy val imageResolutionService: ImageResolutionService = new ImageResolutionService
@@ -107,20 +108,17 @@ object MsgBuilder {
     var width = 1440D
     var height = 1080D
     val pageAbsoluteSvgPath = presParentPath + "/svgs/slide" + page.toString + ".svg"
-    //    val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
-    //    if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
-    //      width = imageResolution.getWidth
-    //      height = imageResolution.getHeight
-    //    }
 
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
       case Some(d) =>
         logger.info("***** Dimensions found from probe *****")
+        println("***** Dimensions found from probe *****")
         width = d.width
         height = d.height
       case None =>
         logger.info("***** Falling back to image resolution service *****")
+        println("***** Falling back to image resolution service *****")
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth
@@ -451,7 +449,7 @@ object MsgBuilder {
 
   private final case class SvgDimensions(width: Double, height: Double)
 
-  private def readSvgDims(svgPath: String, maxBytes: Long = 10L * 1024 * 1024): Option[SvgDimensions] = {
+  private def readSvgDims(svgPath: String, maxBytes: Long = 10L * 1024 * 1024, scale: Int = 0): Option[SvgDimensions] = {
     val in = Files.newInputStream(Paths.get(svgPath))
     val bis = new BufferedInputStream(in)
     try {
@@ -476,7 +474,10 @@ object MsgBuilder {
               val hPx = hRaw.flatMap(parseCssLengthPx)
 
               (wPx, hPx) match {
-                case (Some(w), Some(h)) => return Some(SvgDimensions(w, h))
+                case (Some(w), Some(h)) =>
+                  val W = roundPx(w, scale)
+                  val H = roundPx(h, scale)
+                  return Some(SvgDimensions(W, H))
                 case _ =>
                   return None
               }
@@ -498,7 +499,7 @@ object MsgBuilder {
         val n = num.toDouble
         val px = unit0.toLowerCase match {
           case "" | "px" => 1.0
-          case "pt"      => 96.0 / 72.0
+          case "pt"      => 1.0
           case "pc"      => 16.0
           case "in"      => 96.0
           case "cm"      => 96.0 / 2.54
@@ -508,6 +509,14 @@ object MsgBuilder {
         }
         if (px.isNaN) None else Some(n * px)
       case _ => None
+    }
+  }
+
+  private def roundPx(d: Double, scale: Int): Double = {
+    if (java.lang.Double.isNaN(d) || java.lang.Double.isInfinite(d)) d
+    else {
+      val r = BigDecimal(d).setScale(scale, RoundingMode.HALF_UP).toDouble
+      if (r == -0.0d) 0.0d else r
     }
   }
 

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.api2
 
+import org.apache.commons.io.input.BoundedInputStream
 import org.bigbluebutton.api.messaging.converters.messages._
 import org.bigbluebutton.api.messaging.messages.{ ChatMessageFromApi, RegisterUserSessionToken }
 import org.bigbluebutton.api.service.ServiceUtils
@@ -8,10 +9,15 @@ import org.bigbluebutton.common2.domain.{ DefaultProps, PageVO, PresentationPage
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.presentation.imp.ImageResolutionService
 import org.bigbluebutton.presentation.messages._
+
+import java.io.{ BufferedInputStream, FilterInputStream, InputStream }
+import java.net.URL
 import scala.jdk.CollectionConverters._
 import scala.util.{ Try, Using }
 import scala.io.Source
 import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Paths }
+import javax.xml.stream.{ XMLInputFactory, XMLStreamConstants }
 
 object MsgBuilder {
   private lazy val imageResolutionService: ImageResolutionService = new ImageResolutionService
@@ -101,10 +107,23 @@ object MsgBuilder {
     var width = 1440D
     var height = 1080D
     val pageAbsoluteSvgPath = presParentPath + "/svgs/slide" + page.toString + ".svg"
-    val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
-    if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
-      width = imageResolution.getWidth
-      height = imageResolution.getHeight
+    //    val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
+    //    if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
+    //      width = imageResolution.getWidth
+    //      height = imageResolution.getHeight
+    //    }
+
+    val dims = readSvgDims(pageAbsoluteSvgPath)
+    dims match {
+      case Some(d) =>
+        width = d.width
+        height = d.height
+      case None =>
+        val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
+        if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
+          width = imageResolution.getWidth
+          height = imageResolution.getHeight
+        }
     }
 
     val content = Try {
@@ -428,4 +447,87 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, req)
   }
 
+  private final case class SvgDimensions(width: Double, height: Double)
+
+  private def readSvgDims(svgPath: String, maxBytes: Long = 10L * 1024 * 1024): Option[SvgDimensions] = {
+    val in = Files.newInputStream(Paths.get(svgPath))
+    val bis = new BufferedInputStream(in)
+    try {
+      val bounded = new BoundedInputStream(bis, if (maxBytes <= 0) Long.MaxValue else maxBytes)
+
+      val f = XMLInputFactory.newFactory()
+      f.setProperty(XMLInputFactory.SUPPORT_DTD, java.lang.Boolean.FALSE)
+      Try(f.setProperty("javax.xml.stream.isSupportingExternalEntities", java.lang.Boolean.FALSE))
+      Try(f.setProperty("javax.xml.stream.isCoalescing", java.lang.Boolean.FALSE))
+      Try(f.setProperty("javax.xml.stream.isNamespaceAware", java.lang.Boolean.TRUE))
+      Try(f.setXMLResolver((_, _, _, _) => null))
+
+      val r = f.createXMLStreamReader(bounded, StandardCharsets.UTF_8.name())
+      try {
+        while (r.hasNext) {
+          r.next() match {
+            case XMLStreamConstants.START_ELEMENT if r.getLocalName.equalsIgnoreCase("svg") =>
+              val wRaw = Option(r.getAttributeValue(null, "width"))
+              val hRaw = Option(r.getAttributeValue(null, "height"))
+
+              val wPx = wRaw.flatMap(parseCssLengthPx)
+              val hPx = hRaw.flatMap(parseCssLengthPx)
+
+              (wPx, hPx) match {
+                case (Some(w), Some(h)) => return Some(SvgDimensions(w, h))
+                case _ =>
+                  return None
+              }
+            case _ =>
+          }
+        }
+        None
+      } finally Try(r.close())
+    } finally Try(bis.close())
+  }
+
+  private def parseCssLengthPx(s: String): Option[Double] = {
+    if (s == null) return None
+    val t = s.trim
+    if (t.isEmpty || t.endsWith("%")) return None
+    val R = """^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s*([A-Za-z]*)\s*$""".r
+    t match {
+      case R(num, unit0) =>
+        val n = num.toDouble
+        val px = unit0.toLowerCase match {
+          case "" | "px" => 1.0
+          case "pt"      => 96.0 / 72.0
+          case "pc"      => 16.0
+          case "in"      => 96.0
+          case "cm"      => 96.0 / 2.54
+          case "mm"      => 96.0 / 25.4
+          case "q"       => 96.0 / 25.4 / 40.0
+          case _         => Double.NaN
+        }
+        if (px.isNaN) None else Some(n * px)
+      case _ => None
+    }
+  }
+
+  private final class BoundedInputStream(in: InputStream, max: Long) extends FilterInputStream(in) {
+    private var remaining = max
+
+    override def read(): Int =
+      if (remaining <= 0) -1
+      else {
+        val r = super.read();
+        if (r >= 0) remaining -= 1;
+        r
+      }
+
+    override def read(b: Array[Byte], off: Int, len: Int): Int = {
+      if (remaining <= 0) -1
+      else {
+        val want = Math.min(len.toLong, Math.max(0L, Math.min(Int.MaxValue.toLong, remaining))).toInt
+        val r = super.read(b, off, want)
+        if (r > 0) remaining -= r
+        r
+      }
+    }
+  }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -116,9 +116,11 @@ object MsgBuilder {
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
       case Some(d) =>
+        println("***** Dimensions found from probe *****")
         width = d.width
         height = d.height
       case None =>
+        println("***** Falling back to image resolution service *****")
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -112,11 +112,11 @@ object MsgBuilder {
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
       case Some(d) =>
-        logger.info("***** Dimensions found from probe *****")
+        println("***** Dimensions found from probe *****")
         width = d.width
         height = d.height
       case None =>
-        logger.info("***** Falling back to image resolution service *****")
+        println("***** Falling back to image resolution service *****")
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth
@@ -448,10 +448,10 @@ object MsgBuilder {
   private final case class SvgDimensions(width: Double, height: Double)
 
   private def readSvgDims(svgPath: String, maxBytes: Long = 10L * 1024 * 1024, scale: Int = 0): Option[SvgDimensions] = {
-    val in = Files.newInputStream(Paths.get(svgPath))
-    val bis = new BufferedInputStream(in)
-    try {
-      val bounded = new BoundedInputStream(bis, if (maxBytes <= 0) Long.MaxValue else maxBytes)
+    Using.Manager { use =>
+      val in = use(Files.newInputStream(Paths.get(svgPath)))
+      val bis = use(new BufferedInputStream(in))
+      val bounded = use(new BoundedInputStream(bis, if (maxBytes <= 0) Long.MaxValue else maxBytes))
 
       val f = XMLInputFactory.newFactory()
       f.setProperty(XMLInputFactory.SUPPORT_DTD, java.lang.Boolean.FALSE)
@@ -460,31 +460,34 @@ object MsgBuilder {
       Try(f.setProperty("javax.xml.stream.isNamespaceAware", java.lang.Boolean.TRUE))
       Try(f.setXMLResolver((_, _, _, _) => null))
 
-      val r = f.createXMLStreamReader(bounded, StandardCharsets.UTF_8.name())
-      try {
-        while (r.hasNext) {
-          r.next() match {
-            case XMLStreamConstants.START_ELEMENT if r.getLocalName.equalsIgnoreCase("svg") =>
-              val wRaw = Option(r.getAttributeValue(null, "width"))
-              val hRaw = Option(r.getAttributeValue(null, "height"))
+      val reader = {
+        val r0 = f.createXMLStreamReader(bounded, StandardCharsets.UTF_8.name())
+        use(new AutoCloseable { override def close(): Unit = r0.close() })
+        r0
+      }
 
-              val wPx = wRaw.flatMap(parseCssLengthPx)
-              val hPx = hRaw.flatMap(parseCssLengthPx)
+      while (reader.hasNext) {
+        reader.next() match {
+          case XMLStreamConstants.START_ELEMENT if reader.getLocalName.equalsIgnoreCase("svg") =>
+            val wRaw = Option(reader.getAttributeValue(null, "width"))
+            val hRaw = Option(reader.getAttributeValue(null, "height"))
 
-              (wPx, hPx) match {
-                case (Some(w), Some(h)) =>
-                  val W = roundPx(w, scale)
-                  val H = roundPx(h, scale)
-                  return Some(SvgDimensions(W, H))
-                case _ =>
-                  return None
-              }
-            case _ =>
-          }
+            val wPx = wRaw.flatMap(parseCssLengthPx)
+            val hPx = hRaw.flatMap(parseCssLengthPx)
+
+            (wPx, hPx) match {
+              case (Some(w), Some(h)) =>
+                val W = roundPx(w, scale)
+                val H = roundPx(h, scale)
+                return Some(SvgDimensions(W, H))
+              case _ =>
+                return None
+            }
+          case _ =>
         }
-        None
-      } finally Try(r.close())
-    } finally Try(bis.close())
+      }
+      None
+    }.toOption.flatten
   }
 
   private def parseCssLengthPx(s: String): Option[Double] = {

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -500,12 +500,12 @@ object MsgBuilder {
         val n = num.toDouble
         val px = unit0.toLowerCase match {
           case "" | "px" => 1.0
-          case "pt"      => 1.0
+          case "pt"      => 96.0 / 72.0
           case "pc"      => 16.0
           case "in"      => 96.0
           case "cm"      => 96.0 / 2.54
           case "mm"      => 96.0 / 25.4
-          case "q"       => 96.0 / 25.4 / 40.0
+          case "q"       => 96.0 / 25.4 / 4.0
           case _         => Double.NaN
         }
         if (px.isNaN) None else Some(n * px)

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -112,11 +112,11 @@ object MsgBuilder {
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
       case Some(d) =>
-        println("***** Dimensions found from probe *****")
+        logger.info("***** Dimensions found from probe *****")
         width = d.width
         height = d.height
       case None =>
-        println("***** Falling back to image resolution service *****")
+        logger.info("***** Falling back to image resolution service *****")
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -1,26 +1,26 @@
 package org.bigbluebutton.api2
 
-import org.apache.commons.io.input.BoundedInputStream
 import org.bigbluebutton.api.messaging.converters.messages._
-import org.bigbluebutton.api.messaging.messages.{ ChatMessageFromApi, RegisterUserSessionToken }
+import org.bigbluebutton.api.messaging.messages.{ChatMessageFromApi, RegisterUserSessionToken}
 import org.bigbluebutton.api.service.ServiceUtils
 import org.bigbluebutton.api2.meeting.RegisterUser
-import org.bigbluebutton.common2.domain.{ DefaultProps, PageVO, PresentationPageConvertedVO, PresentationVO }
+import org.bigbluebutton.common2.domain.{DefaultProps, PageVO, PresentationPageConvertedVO, PresentationVO}
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.presentation.imp.ImageResolutionService
 import org.bigbluebutton.presentation.messages._
+import org.slf4j.{Logger, LoggerFactory}
 
-import java.io.{ BufferedInputStream, FilterInputStream, InputStream }
-import java.net.URL
-import scala.jdk.CollectionConverters._
-import scala.util.{ Try, Using }
-import scala.io.Source
+import java.io.{BufferedInputStream, FilterInputStream, InputStream}
 import java.nio.charset.StandardCharsets
-import java.nio.file.{ Files, Paths }
-import javax.xml.stream.{ XMLInputFactory, XMLStreamConstants }
+import java.nio.file.{Files, Paths}
+import javax.xml.stream.{XMLInputFactory, XMLStreamConstants}
+import scala.io.Source
+import scala.jdk.CollectionConverters._
+import scala.util.{Try, Using}
 
 object MsgBuilder {
   private lazy val imageResolutionService: ImageResolutionService = new ImageResolutionService
+  private lazy val logger: Logger = LoggerFactory.getLogger("msg-builder")
 
   def buildDestroyMeetingSysCmdMsg(msg: DestroyMeetingMessage): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-web")
@@ -116,11 +116,11 @@ object MsgBuilder {
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
       case Some(d) =>
-        println("***** Dimensions found from probe *****")
+        logger.info("***** Dimensions found from probe *****")
         width = d.width
         height = d.height
       case None =>
-        println("***** Falling back to image resolution service *****")
+        logger.info("***** Falling back to image resolution service *****")
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -112,11 +112,12 @@ object MsgBuilder {
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
       case Some(d) =>
-        logger.info("***** Dimensions found from probe *****")
+        logger.info("Dimensions found from probe")
         width = d.width
         height = d.height
       case None =>
-        logger.info("***** Falling back to image resolution service *****")
+        logger.info("Falling back to image resolution service")
+
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -113,12 +113,10 @@ object MsgBuilder {
     dims match {
       case Some(d) =>
         logger.info("***** Dimensions found from probe *****")
-        println("***** Dimensions found from probe *****")
         width = d.width
         height = d.height
       case None =>
         logger.info("***** Falling back to image resolution service *****")
-        println("***** Falling back to image resolution service *****")
         val imageResolution = imageResolutionService.identifyImageResolution(pageAbsoluteSvgPath)
         if (imageResolution.getWidth != 0 && imageResolution.getHeight != 0) {
           width = imageResolution.getWidth

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -128,8 +128,6 @@ class ApiController {
     log.debug request.getParameterMap().toMapString()
     log.debug request.getQueryString()
 
-    log.info("***** THE CHANGES HAVE BEEN PICKED UP *****")
-
     String[] ap = request.getParameterMap().get("attendeePW")
     String attendeePW
     if(ap == null) log.info("No attendeePW provided")

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -128,6 +128,8 @@ class ApiController {
     log.debug request.getParameterMap().toMapString()
     log.debug request.getQueryString()
 
+    log.info("***** THE CHANGES HAVE BEEN PICKED UP *****")
+
     String[] ap = request.getParameterMap().get("attendeePW")
     String attendeePW
     if(ap == null) log.info("No attendeePW provided")


### PR DESCRIPTION

### What does this PR do?

Implements a new method for determining SVG dimensions by probing the content of the SVG for dimension properties. This approach avoids the OOM issue caused by the previous method from reading the entire SVG content into memory and is faster than the current method of initializing an external service to determine the dimensions of SVGs. The external service implementation for determining SVG dimensions has been kept as a fallback in cases where the probe cannot determine the SVG dimensions.

### Motivation

A new approach to determining SVG dimensions was implemented to avoid OOM issues causes by the previous implementation. The downside of this approach is that it can be quite slow which has led to a degradation of user experience for loading cached presentations. The approach introduced in this PR should avoid both of these issues.


### How to test

1. Create a meeting.
2. Upload and cache a large presentation.
3. Create a new meeting and load the previous presentation from the cache.

Do this before the changes in this PR and then after and track the time it takes for the presentation to load.
