### PR TITLE
fix(audio): edge cases with permission reset and input device rollbacks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -10,7 +10,6 @@ import { User } from '/imports/ui/Types/user';
 import { defineMessages, useIntl } from 'react-intl';
 import {
   handleLeaveAudio,
-  liveChangeInputDevice,
   liveChangeOutputDevice,
   notify,
   toggleMuteMicrophone,
@@ -119,28 +118,8 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   const { enabled: muteAlertEnabled } = MUTE_ALERT_CONFIG;
 
   const updateRemovedDevices = useCallback((
-    audioInputDevices: MediaDeviceInfo[],
     audioOutputDevices: MediaDeviceInfo[],
   ) => {
-    if (inputDeviceId
-      && (inputDeviceId !== DEFAULT_DEVICE)
-      && !audioInputDevices.find((d) => d.deviceId === inputDeviceId)) {
-      const fallbackInputDevice = audioInputDevices[0];
-
-      if (fallbackInputDevice?.deviceId) {
-        logger.warn({
-          logCode: 'audio_input_live_selector',
-          extraInfo: {
-            fallbackDeviceId: fallbackInputDevice?.deviceId,
-            fallbackDeviceLabel: fallbackInputDevice?.label,
-          },
-        }, 'Current input device was removed. Fallback to default device');
-        liveChangeInputDevice(fallbackInputDevice.deviceId).catch(() => {
-          notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
-        });
-      }
-    }
-
     if (outputDeviceId
       && (outputDeviceId !== DEFAULT_DEVICE)
       && !audioOutputDevices.find((d) => d.deviceId === outputDeviceId)) {
@@ -172,7 +151,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
         updateInputDevices(audioInputDevices as InputDeviceInfo[]);
         updateOutputDevices(audioOutputDevices);
 
-        if (inAudio) updateRemovedDevices(audioInputDevices, audioOutputDevices);
+        if (inAudio) updateRemovedDevices(audioOutputDevices);
       })
       .catch((error) => {
         logger.warn({

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -75,6 +75,10 @@ const intlMessages = defineMessages({
     id: 'app.audioNotificaion.reconnectingAsListenOnly',
     description: 'ice negotiation error message',
   },
+  deviceChangeFailed: {
+    id: 'app.audioNotification.deviceChangeFailed',
+    description: 'Device change failed',
+  },
 });
 
 let didMountAutoJoin = false;
@@ -99,6 +103,7 @@ const messages = {
     INVALID_TARGET: intlMessages.invalidTarget,
     MEDIA_ERROR: intlMessages.mediaError,
     WEBRTC_NOT_SUPPORTED: intlMessages.BrowserNotSupported,
+    DEVICE_CHANGE_FAILED: intlMessages.deviceChangeFailed,
     ...webRtcError,
   },
 };


### PR DESCRIPTION
### What does this PR do?

There are a few edge cases with the existing handling for microphone permission resets and rollback procedures:
  - The input device selector may become "orphaned"; i.e.: no input device selected when losing a previously set device
  - LiveKit: the rollback procedure does not account for a possible inactivation of the backup stream; i.e.: renders a silent stream
  - LiveKit: gUM permission reset may render a silent stream
  - LiveKit: an unnecessary publish-unpublish loop may occur when losing an active input device
  - Duplicate "rollback" procedures in audio-manager and the input stream selector component may cause an inconsistent input device state

Fix the above edge cases via the following changes:
  - Remove the input stream selector component's device rollback procedure. It's function is the same as audio-manager's handleMediaStreamInactive, but it does not account for media stream inactivations.
  - Guarantee that the correct input device and stream is set when audio-manager's input device change routine fails
  - LiveKit: add a final rollback attempt when recovering from device failures - it fetches a new stream via a crude gUM call
  - LiveKit: change publication comparison to look for the underlying deviceId instead of the track name. The track name is not a reliable field to fetch the target track as the underlying deviceId might change without the trackName changing - causes perpetually muted tracks in some scenarios.
  - LiveKit: account for inactive tracks when changing the input device for an active publication. When inactive, the track is now restarted with the desired deviceId. Without this, the track would be "silent" as switchActiveDevice does not restore it.

### Closes Issue(s)

None