### PR TITLE
build(bbb-webrtc-recorder): v0.13.1

### DIFF
--- a/bbb-webrtc-recorder.placeholder.sh
+++ b/bbb-webrtc-recorder.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v0.13.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder
+git clone --branch v0.13.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-recorder bbb-webrtc-recorder


### PR DESCRIPTION

### What does this PR do?

* [build(bbb-webrtc-recorder): v0.13.1](https://github.com/bigbluebutton/bigbluebutton/commit/41c81a0c2fde0e1480db01204d635cc10cf34adc) 
  * fix: panic when stopping a mediasoup adapter recording
  * fix: unnecessary init of LK adapter fields when using mediasoup
  * build(docker): bump golang from 1.24 to 1.25

### Closes Issue(s)

None