### PR TITLE
Import Toggle component in notification settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
+import Toggle from '/imports/ui/components/common/switch/component';
 import AudioManager from '/imports/ui/services/audio-manager';
 import BaseMenu from '../base/component';
 import SubMenusStyle from '../styles';


### PR DESCRIPTION
When setting up LiveKit, we need to import Toggle.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Add missing Toggle components.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #24128


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

- Ensure the app is configured to use the 'livekit' bridge.
- The app crashes when triggering the notification from the modal that is opened via the Settings screen.
- Before the fix, this would cause a crash.

