### PR TITLE
fix(plugins/data-channel): Fix multiple connections not receiving data from data-channel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/reader-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/channel-manager/reader-manager.tsx
@@ -55,11 +55,14 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
     dataChannelIdentifier,
     dataChannelEntriesReceived,
   } = props;
-  const [sendSignal, setSendSignal] = useState<boolean>(false);
+  const [totalCount, setTotalCount] = useState<number>(0);
   const [completeDataEntry, setCompleteDataEntry] = useState<DataChannelEntry[]>([]);
   const [differenceData, setDifferenceData] = useState<DataChannelEntry[]>([]);
   const startedAtTimestamp = useRef(new Date());
 
+  const updateTotalCount = () => {
+    setTotalCount((counter) => counter + 1);
+  };
   useEffect(() => {
     const updateAllItems = () => {
       const listsDifferent = areListsDifferent(completeDataEntry, dataChannelEntriesReceived);
@@ -109,7 +112,7 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
             && hookArguments.channelName === channelName
             && dataChannelTypeFromEvent === dataChannelType
           ) {
-            setSendSignal((signal) => !signal);
+            updateTotalCount();
           }
         }
       }) as EventListener;
@@ -158,7 +161,7 @@ export const DataChannelItemManagerReader: React.ElementType<DataChannelItemMana
       },
     }),
     );
-  }, [sendSignal, completeDataEntry, differenceData]);
+  }, [totalCount, completeDataEntry, differenceData]);
 
   return null;
 };


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where multiple connections to the same data-channel (and subchannel) would not receive data.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/236 and https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/237

### Motivation

This will not only fix the issue mentioned above, but it will make data-channels work a lot smoother. See refactor in [plugin-typed-captions](https://github.com/bigbluebutton/plugin-typed-captions/pull/23).

### How to test

One can use the `plugin-typed-captions` with this PR: https://github.com/bigbluebutton/plugin-typed-captions/pull/23 and follow the instructions:

- Open the actions button dropdown;
- Click to start new typed-captions;
- Choose a language for the caption and start it;
- Then refresh the browser and open the action-button dropdown;

The correct behaviour is to show an option to remove the current typed caption, but without this PR, that's not the case, because the manager that controls this behaviour did not receive data from the data-channel and therefore doesn't know about it. 

### More

This problem happened because when a new connection came in, the manager in HTML5 would not trigger the update due to its internal logic.

The https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/237 is not really an issue. Further investigation showed that this problem is specific to the `plugin-typed-captions` and will be fixed in the PR mentioned.
