### PR TITLE
fix(plugin/data-channel): Fix data-channel interface type

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/types.ts
@@ -21,7 +21,6 @@ export interface DataChannelEntry {
   entryId: string;
   payloadJson: object;
   createdBy: string;
-  fromUserId: string;
   pluginName: string;
   toRoles?: string[];
 }

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-channel/utils.ts
@@ -9,7 +9,6 @@ export const mapProjectedDataChannelEntries = (
   entryId: entry.entryId!,
   payloadJson: entry.payloadJson!,
   updatedAt: entry.updatedAt!,
-  fromUserId: entry.createdBy!,
   createdBy: entry.createdBy!,
   pluginName: entry.pluginName!,
   toRoles: entry.toRoles ?? [],


### PR DESCRIPTION
### What does this PR do?

It syncs up data-channel type with what's returned from server, by removing `fromUserId` and maintaining only `createdBy`. 

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/193

### How to test

To test this, one can run the `samples/sample-data-channel-plugin` and check the return of the data-channel hooks.

### More

https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/234
