### PR TITLE
feat: Add prop `version` to plugins manifest to avoid browser caching

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -82,12 +82,14 @@ object PluginModel {
     plugin.manifest.content match {
       case Some(pluginScalaContent) =>
         val jsEntrypoint = pluginScalaContent.javascriptEntrypointUrl
-        if (!jsEntrypoint.startsWith("http://") && !jsEntrypoint.startsWith("https://")) {
-          val finalJavascriptEntrypointUrl = createFinalJavascriptEntrypointUrl(plugin, jsEntrypoint)
-          val newPluginManifestContent = pluginScalaContent.copy(javascriptEntrypointUrl = finalJavascriptEntrypointUrl)
-          val newPluginManifest = plugin.manifest.copy(content = Some(newPluginManifestContent))
-          return plugin.copy(manifest = newPluginManifest)
-        }
+        val jsEntrypointAbsoluteUrl =
+          if (!jsEntrypoint.startsWith("http://") && !jsEntrypoint.startsWith("https://"))
+            makeAbsoluteUrl(plugin, jsEntrypoint)
+          else jsEntrypoint
+        val finalJavascriptEntrypointUrl = createFinalJavascriptEntrypointUrl(plugin, jsEntrypointAbsoluteUrl)
+        val newPluginManifestContent = pluginScalaContent.copy(javascriptEntrypointUrl = finalJavascriptEntrypointUrl)
+        val newPluginManifest = plugin.manifest.copy(content = Some(newPluginManifestContent))
+        return plugin.copy(manifest = newPluginManifest)
     }
     plugin
   }
@@ -114,8 +116,7 @@ object PluginModel {
     val baseUrl = plugin.manifest.url.substring(0, plugin.manifest.url.lastIndexOf('/') + 1)
     baseUrl + relativeUrl
   }
-  private def createFinalJavascriptEntrypointUrl(plugin: Plugin, relativeUrl: String): String = {
-    val jsEntrypointAbsoluteUrl = makeAbsoluteUrl(plugin, relativeUrl)
+  private def createFinalJavascriptEntrypointUrl(plugin: Plugin, jsEntrypointAbsoluteUrl: String): String = {
     val maybeVersion = for {
       manifest <- plugin.manifest.content
       version  <- manifest.pluginVersion
@@ -131,7 +132,7 @@ object PluginModel {
     }
 
     maybeVersion match {
-      case Some(version) => new URIBuilder(jsEntrypointAbsoluteUrl).addParameter("version", version).toString
+      case Some(version) => new URIBuilder(jsEntrypointAbsoluteUrl).setParameter("version", version).toString
       case None          => jsEntrypointAbsoluteUrl
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -39,6 +39,7 @@ case class PluginSettingSchema(
 
 case class PluginManifestContent(
     requiredSdkVersion:            String,
+    pluginVersion:                 Option[String]                       = None,
     name:                          String,
     javascriptEntrypointUrl:       String,
     enabledForBreakoutRooms:       Boolean                              = false,
@@ -81,8 +82,8 @@ object PluginModel {
       case Some(pluginScalaContent) =>
         val jsEntrypoint = pluginScalaContent.javascriptEntrypointUrl
         if (!jsEntrypoint.startsWith("http://") && !jsEntrypoint.startsWith("https://")) {
-          val absoluteJavascriptEntrypoint = makeAbsoluteUrl(plugin, jsEntrypoint)
-          val newPluginManifestContent = pluginScalaContent.copy(javascriptEntrypointUrl = absoluteJavascriptEntrypoint)
+          val finalJavascriptEntrypointUrl = createFinalJavascriptEntrypointUrl(plugin, jsEntrypoint)
+          val newPluginManifestContent = pluginScalaContent.copy(javascriptEntrypointUrl = finalJavascriptEntrypointUrl)
           val newPluginManifest = plugin.manifest.copy(content = Some(newPluginManifestContent))
           return plugin.copy(manifest = newPluginManifest)
         }
@@ -111,6 +112,21 @@ object PluginModel {
   private def makeAbsoluteUrl(plugin: Plugin, relativeUrl: String): String = {
     val baseUrl = plugin.manifest.url.substring(0, plugin.manifest.url.lastIndexOf('/') + 1)
     baseUrl + relativeUrl
+  }
+  private def createFinalJavascriptEntrypointUrl(plugin: Plugin, relativeUrl: String): String = {
+    val jsEntrypointAbsoluteUrl = makeAbsoluteUrl(plugin, relativeUrl)
+    val maybeVersion = for {
+      manifest <- plugin.manifest.content
+      version  <- manifest.pluginVersion
+    } yield {
+      if (Version.isValid(version)) version
+      else logger.warn("pluginVersion for [{}] is not valid, ignoring...", manifest.name)
+    }
+
+    maybeVersion match {
+      case Some(version) => s"$jsEntrypointAbsoluteUrl?version=$version"
+      case None          => jsEntrypointAbsoluteUrl
+    }
   }
   private def replaceAllRelativeUrls(plugin: Plugin): Plugin = {
     val pluginWithAbsoluteJsEntrypoint = replaceRelativeJavascriptEntrypoint(plugin)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -118,9 +118,15 @@ object PluginModel {
     val maybeVersion = for {
       manifest <- plugin.manifest.content
       version  <- manifest.pluginVersion
-    } yield {
-      if (Version.isValid(version)) version
-      else logger.warn("pluginVersion for [{}] is not valid, ignoring...", manifest.name)
+      if Version.isValid(version)
+    } yield version
+
+    plugin.manifest.content.foreach { manifest =>
+      manifest.pluginVersion.foreach { version =>
+          if (!Version.isValid(version)) {
+            logger.warn("pluginVersion for [{}] is not valid, ignoring...", manifest.name)
+          }
+        }
     }
 
     maybeVersion match {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -8,6 +8,7 @@ import org.bigbluebutton.ClientSettings.getPluginsFromConfig
 import org.bigbluebutton.core.db.PluginDAO
 import org.slf4j.{Logger, LoggerFactory}
 import com.github.zafarkhaja.semver.Version
+import org.apache.http.client.utils.URIBuilder
 import org.bigbluebutton.core.exceptions.PluginHtml5VersionValidationException
 
 import java.util
@@ -130,7 +131,7 @@ object PluginModel {
     }
 
     maybeVersion match {
-      case Some(version) => s"$jsEntrypointAbsoluteUrl?version=$version"
+      case Some(version) => new URIBuilder(jsEntrypointAbsoluteUrl).addParameter("version", version).toString
       case None          => jsEntrypointAbsoluteUrl
     }
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -40,7 +40,7 @@ case class PluginSettingSchema(
 
 case class PluginManifestContent(
     requiredSdkVersion:            String,
-    pluginVersion:                 Option[String]                       = None,
+    version:                       Option[String]                       = None,
     name:                          String,
     javascriptEntrypointUrl:       String,
     enabledForBreakoutRooms:       Boolean                              = false,
@@ -89,9 +89,8 @@ object PluginModel {
         val finalJavascriptEntrypointUrl = createFinalJavascriptEntrypointUrl(plugin, jsEntrypointAbsoluteUrl)
         val newPluginManifestContent = pluginScalaContent.copy(javascriptEntrypointUrl = finalJavascriptEntrypointUrl)
         val newPluginManifest = plugin.manifest.copy(content = Some(newPluginManifestContent))
-        return plugin.copy(manifest = newPluginManifest)
+        plugin.copy(manifest = newPluginManifest)
     }
-    plugin
   }
   private def replaceRelativeLocalesBaseUrl(plugin: Plugin): Plugin = {
     plugin.manifest.content match {
@@ -117,24 +116,17 @@ object PluginModel {
     baseUrl + relativeUrl
   }
   private def createFinalJavascriptEntrypointUrl(plugin: Plugin, jsEntrypointAbsoluteUrl: String): String = {
-    val maybeVersion = for {
+    (for {
       manifest <- plugin.manifest.content
-      version  <- manifest.pluginVersion
-      if Version.isValid(version)
-    } yield version
-
-    plugin.manifest.content.foreach { manifest =>
-      manifest.pluginVersion.foreach { version =>
-          if (!Version.isValid(version)) {
-            logger.warn("pluginVersion for [{}] is not valid, ignoring...", manifest.name)
-          }
-        }
-    }
-
-    maybeVersion match {
-      case Some(version) => new URIBuilder(jsEntrypointAbsoluteUrl).setParameter("version", version).toString
-      case None          => jsEntrypointAbsoluteUrl
-    }
+      version  <- manifest.version
+    } yield {
+      if (Version.isValid(version, false)) {
+        new URIBuilder(jsEntrypointAbsoluteUrl).setParameter("version", version).toString
+      } else {
+        logger.warn("Plugin version {} for [{}] is not valid, ignoring...", version, manifest.name)
+        jsEntrypointAbsoluteUrl
+      }
+    }).getOrElse(jsEntrypointAbsoluteUrl)
   }
   private def replaceAllRelativeUrls(plugin: Plugin): Plugin = {
     val pluginWithAbsoluteJsEntrypoint = replaceRelativeJavascriptEntrypoint(plugin)

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -178,12 +178,13 @@ In the future, support for additional placeholders may be added.
 
 ### Manifest Json
 
-Here is as complete `manifest.json` example with all possible configurations:
+Here is a complete `manifest.json` example with all possible configurations:
 
 ```json
 {
   "requiredSdkVersion": "~0.0.77",
   "name": "MyPlugin",
+  "pluginVersion": "0.0.8",
   "javascriptEntrypointUrl": "MyPlugin.js",
   "javascriptEntrypointIntegrity": "sha384-Bwsz2rxm...", // Optional
   "localesBaseUrl": "https://cdn.domain.com/my-plugin/", // Optional
@@ -221,9 +222,16 @@ Here is as complete `manifest.json` example with all possible configurations:
 
 To better understand remote-data-sources, please, refer to [this section](#external-data-resources)
 
+**pluginVersion:**
+The `pluginVersion` directive is used solely to prevent the browser from caching an outdated version of the plugin between deployments.
+
+When this field is defined in your manifest, the system automatically appends the version number as a query parameter to the `javascriptEntrypointUrl`. This doesn’t change the plugin’s behavior — it simply ensures that browsers treat each version as a new file and reload it instead of using a cached copy.
+
+For example, if your plugin version is `0.0.8`, the browser will load `MyPlugin.js?version=0.0.8`
+
 **settingsSchema:**
 
-The settingsSchema serves two main purposes:
+The `settingsSchema` serves two main purposes:
 
 1. **Validation:** Ensures that all required settings are provided for a plugin. If any required setting is missing, the plugin will not load.
 2. **Configuration Exposure:** Lists all available settings for the plugin, enabling external systems—such as a Learning Management System (LMS)—to present these settings to a meeting organizer. This allows the organizer to configure the plugin manually before the meeting begins.

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -184,7 +184,7 @@ Here is a complete `manifest.json` example with all possible configurations:
 {
   "requiredSdkVersion": "~0.0.77",
   "name": "MyPlugin",
-  "pluginVersion": "0.0.8", // Optional
+  "version": "0.0.8", // Optional
   "javascriptEntrypointUrl": "MyPlugin.js",
   "javascriptEntrypointIntegrity": "sha384-Bwsz2rxm...", // Optional
   "localesBaseUrl": "https://cdn.domain.com/my-plugin/", // Optional
@@ -222,12 +222,12 @@ Here is a complete `manifest.json` example with all possible configurations:
 
 To better understand remote-data-sources, please, refer to [this section](#external-data-resources)
 
-**pluginVersion:**
+**version:**
 
-Prevents browsers from caching old plugin files.
+This refers to the version of the plugin. It prevents browsers from caching old plugin files.
 When set, it appends the version to `javascriptEntrypointUrl`, forcing browsers to fetch the latest file.
 Example: 
-`pluginVersion=0.0.8`
+`version=0.0.8`
 `javascriptEntrypointUrl=MyPlugin.js`
 Browser will load: `MyPlugin.js?version=0.0.8`.
 
@@ -907,7 +907,7 @@ The data-channel name must be in the `manifest.json` along with all the permissi
     {
       "name": "channel-name",
       "pushPermission": ["moderator","presenter"],
-      "replaceOrDeletePermission": ["moderator", "sender"]
+      "replaceOrDeletePermission": ["moderator", "creator"]
     }
   ]
 }

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -184,7 +184,7 @@ Here is a complete `manifest.json` example with all possible configurations:
 {
   "requiredSdkVersion": "~0.0.77",
   "name": "MyPlugin",
-  "pluginVersion": "0.0.8",
+  "pluginVersion": "0.0.8", // Optional
   "javascriptEntrypointUrl": "MyPlugin.js",
   "javascriptEntrypointIntegrity": "sha384-Bwsz2rxm...", // Optional
   "localesBaseUrl": "https://cdn.domain.com/my-plugin/", // Optional
@@ -223,11 +223,13 @@ Here is a complete `manifest.json` example with all possible configurations:
 To better understand remote-data-sources, please, refer to [this section](#external-data-resources)
 
 **pluginVersion:**
-The `pluginVersion` directive is used solely to prevent the browser from caching an outdated version of the plugin between deployments.
 
-When this field is defined in your manifest, the system automatically appends the version number as a query parameter to the `javascriptEntrypointUrl`. This doesn’t change the plugin’s behavior — it simply ensures that browsers treat each version as a new file and reload it instead of using a cached copy.
-
-For example, if your plugin version is `0.0.8`, the browser will load `MyPlugin.js?version=0.0.8`
+Prevents browsers from caching old plugin files.
+When set, it appends the version to `javascriptEntrypointUrl`, forcing browsers to fetch the latest file.
+Example: 
+`pluginVersion=0.0.8`
+`javascriptEntrypointUrl=MyPlugin.js`
+Browser will load: `MyPlugin.js?version=0.0.8`.
 
 **settingsSchema:**
 


### PR DESCRIPTION
### What does this PR do?
This PR introduces support for the optional `version` directive in plugin manifests.  
When defined, the plugin version is automatically appended as a query parameter to the `javascriptEntrypointUrl` during plugin loading (e.g., `MyPlugin.js?version=0.0.8`).  

This change helps prevent browsers from caching outdated plugin scripts between deployments, ensuring that the latest version is always loaded without affecting plugin behavior.  

### Closes

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/224

### Motivation
Previously, when redeploying a plugin without changing its filename, browsers could continue serving a cached version of the JavaScript entry point. This often led to unexpected behavior or outdated logic being executed.  

By adding the `version` directive, we ensure that each deployment produces a unique URL, prompting browsers to fetch the updated file instead of using the cached one.

### How to test
1. Add a `version` field in your plugin’s manifest, for example:
   ```json
   {
     "version": "0.0.8"
   }
   ```
2. Deploy the plugin.
3. Open the browser’s developer tools and check the network tab — the plugin will now be loaded as:
   ```
   MyPlugin.js?version=0.0.8
   ```
4. Update the version number and redeploy.
5. Confirm that the new URL includes the updated version and that the browser fetches the new file (not cached).  

No additional configuration is required.

### More
- [x] Added/updated documentation (see `version` directive section in the plugin manifest docs)
