### PR TITLE
fix: client crash due to incorrect toggle usage in notification settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
@@ -71,8 +71,6 @@ const Separator = styled.hr`
   opacity: 0.25;
 `;
 
-const FormElementCenter = styled(Styled.FormElementCenter)``;
-
 const BoldLabel = styled.label`
   color: ${colorGrayLabel};
   font-size: 1rem;
@@ -141,7 +139,6 @@ export default {
   Bounce1,
   Bounce2,
   Separator,
-  FormElementCenter,
   BoldLabel,
   PullContentRight,
   LocalesDropdownSelect,

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
@@ -199,29 +199,29 @@ class NotificationMenu extends BaseMenu {
                 </Styled.Label>
               </Styled.Col>
               <Styled.Col>
-                <Styled.FormElementCenter>
+                <Styled.FormElementRight>
                   {displaySettingsStatus(settings.muteUnmuteAudioAlerts)}
-                  <Toggle
-                    icons={false}
-                    defaultChecked={settings.muteUnmuteAudioAlerts}
+                  <SubMenusStyle.MaterialSwitch
+                    checked={settings.muteUnmuteAudioAlerts}
                     onChange={() => this.handleToggle('muteUnmuteAudioAlerts')}
-                    ariaLabel={`${intl.formatMessage(intlMessages.muteUnmuteLabel)} ${intl.formatMessage(intlMessages.audioAlertLabel)} - ${displaySettingsStatus(settings.muteUnmuteAudioAlerts, true)}`}
-                    showToggleLabel={showToggleLabel}
+                    inputProps={{
+                      'aria-label': `${intl.formatMessage(intlMessages.muteUnmuteLabel)} ${intl.formatMessage(intlMessages.audioAlertLabel)} - ${displaySettingsStatus(settings.muteUnmuteAudioAlerts, true)}`,
+                    }}
                   />
-                </Styled.FormElementCenter>
+                </Styled.FormElementRight>
               </Styled.Col>
               <Styled.Col>
-                <Styled.FormElementCenter>
+                <Styled.FormElementRight>
                   {displaySettingsStatus(false)}
-                  <Toggle
-                    icons={false}
-                    defaultChecked={false}
+                  <SubMenusStyle.MaterialSwitch
+                    checked={false}
                     onChange={() => { }}
                     disabled
-                    ariaLabel={`${intl.formatMessage(intlMessages.muteUnmuteLabel)} ${intl.formatMessage(intlMessages.pushAlertLabel)}`}
-                    showToggleLabel={showToggleLabel}
+                    inputProps={{
+                      'aria-label': `${intl.formatMessage(intlMessages.muteUnmuteLabel)} ${intl.formatMessage(intlMessages.pushAlertLabel)}`,
+                    }}
                   />
-                </Styled.FormElementCenter>
+                </Styled.FormElementRight>
               </Styled.Col>
             </Styled.Row>
           ) : null}

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/styles.js
@@ -15,8 +15,6 @@ const FormElement = styled(Styled.FormElement)``;
 
 const FormElementRight = styled(Styled.FormElementRight)``;
 
-const FormElementCenter = styled(Styled.FormElementCenter)``;
-
 const Label = styled(Styled.Label)``;
 
 const ColHeading = styled(Styled.Col)`
@@ -35,7 +33,6 @@ export default {
   Col,
   FormElement,
   FormElementRight,
-  FormElementCenter,
   Label,
   ColHeading,
 };

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.js
@@ -68,15 +68,6 @@ const FormElementRight = styled.div`
   align-items: center;
 `;
 
-const FormElementCenter = styled.div`
-  position: relative;
-  display: flex;
-  flex-grow: 1;
-  justify-content: center;
-  flex-flow: row;
-  align-items: center;
-`;
-
 const Label = styled.span`
   color: ${colorGrayLabel};
   font-size: 0.9rem;
@@ -158,7 +149,6 @@ export default {
   Col,
   FormElement,
   FormElementRight,
-  FormElementCenter,
   Label,
   Select,
   MaterialSwitch,


### PR DESCRIPTION
### What does this PR do?

- [fix: client crash due to incorrect toggle usage in notification settings](https://github.com/bigbluebutton/bigbluebutton/commit/4b3ff9b9233fa61fc33f75ea7240f221b9b0d818) 
  - Client is crashing when opening the notification settins panel in a
LiveKit-enabled meeting. This is caused by a 3.0 -> 3.1 merge
introducing the new "mute" notification option from 3.0 without
porting the toggle usage to 3.1's variant.
  - Fix the client crash by adjusting the mute notification setting to use
3.1's components. Additionally, remove the now unused FormElementCenter
style from the settings submenus.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/24128
