### PR TITLE
fix: client crash when plugins incorrectly supply icons to the media area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
@@ -221,27 +221,32 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
           )}
           {mediaAreaItems
             .filter((item) => item.allowed && item.type === MediaAreaItemType.OPTION)
-            .map((item) => (
-              <MediaButton
-                key={item.id}
-                dataTest={item.dataTest}
-                color="default"
-                text={item.label || ''}
-                icon={item?.icon && 'iconName' in item.icon ? (
-                  <Icon iconName={item.icon.iconName} />
-                ) : (
-                  <SvgIcon fontSize="large" sx={{ color: btnDefaultColor }}>
-                    {/* @ts-ignore */}
-                    {item.icon?.svgContent}
-                  </SvgIcon>
-                )}
-                tooltip={item.tooltip}
-                onClick={() => {
-                  if (item.onClick) item.onClick();
-                  handleClose();
-                }}
-              />
-            ))}
+            .map((item: MediaButtonPluginItem) => {
+              const icon = item?.icon;
+              const builtInIcon = icon && typeof icon === 'object' && !Array.isArray(icon) && 'iconName' in icon;
+
+              return (
+                <MediaButton
+                  key={item.id}
+                  dataTest={item.dataTest}
+                  color="default"
+                  text={item.label || ''}
+                  icon={builtInIcon ? (
+                    <Icon iconName={icon?.iconName || ''} />
+                  ) : (
+                    <SvgIcon fontSize="large" sx={{ color: btnDefaultColor }}>
+                      {/* @ts-ignore */}
+                      {icon?.svgContent}
+                    </SvgIcon>
+                  )}
+                  tooltip={item.tooltip}
+                  onClick={() => {
+                    if (item.onClick) item.onClick();
+                    handleClose();
+                  }}
+                />
+              );
+            })}
         </Styled.MediaGrid>
       );
     }


### PR DESCRIPTION
### What does this PR do?

- [fix: client crash when plugins incorrectly supply icons to the media area](https://github.com/bigbluebutton/bigbluebutton/commit/7ca120e6f5313f886a8de85cd7f09e6550c92146) 
  - The client may crash if a plugin incorrectly supplies icons to their
media area entries. This is caused by the icon format check (svg vs
built-in icon name) not doing proper type-checks to verify if the
input is indeed an object while trying to operate upon it as if it were.
  - Properly check if the supplied icon parameter is an object before
operating on it. If incorrectly supplied by a plugin, it'll now default
to an empty string (built in) or nullish (svg).

### Closes Issue(s)

None