### PR TITLE
chore (nginx/html5): Improve tracking for `/rtt-check` request

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectionAliveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectionAliveReqMsgHdlr.scala
@@ -14,7 +14,7 @@ trait UserConnectionAliveReqMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleUserConnectionAliveReqMsg(msg: UserConnectionAliveReqMsg): Unit = {
-    log.info("handleUserConnectionAliveReqMsg: networkRttInMs={} userId={}", msg.body.networkRttInMs, msg.body.userId)
+    log.info("handleUserConnectionAliveReqMsg: networkRttInMs={} userId={} serverRequestId={}", msg.body.networkRttInMs, msg.body.userId, msg.body.serverRequestId)
 
     val traceLog = {
       if (msg.body.traceLog != "") {
@@ -39,6 +39,7 @@ trait UserConnectionAliveReqMsgHdlr extends RightsManagementTrait {
         user.intId,
         msg.body.sessionToken,
         msg.body.clientSessionUUID,
+        msg.body.serverRequestId,
         msg.body.networkRttInMs,
         msg.body.applicationRttInMs,
         traceLog,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -253,7 +253,15 @@ case class ClearedAllUsersReactionEvtMsgBody()
  */
 object UserConnectionAliveReqMsg { val NAME = "UserConnectionAliveReqMsg" }
 case class UserConnectionAliveReqMsg(header: BbbClientMsgHeader, body: UserConnectionAliveReqMsgBody) extends StandardMsg
-case class UserConnectionAliveReqMsgBody(userId: String, sessionToken: String, clientSessionUUID: String, networkRttInMs: Double, applicationRttInMs: Double, traceLog: String)
+case class UserConnectionAliveReqMsgBody(
+    userId:             String,
+    sessionToken:       String,
+    serverRequestId:    String,
+    clientSessionUUID:  String,
+    networkRttInMs:     Double,
+    applicationRttInMs: Double,
+    traceLog:           String
+)
 
 /**
  * Sent from client to update clientSettings.

--- a/bbb-graphql-actions/src/actions/userSetConnectionAlive.ts
+++ b/bbb-graphql-actions/src/actions/userSetConnectionAlive.ts
@@ -4,6 +4,7 @@ import {throwErrorIfInvalidInput} from "../imports/validation";
 export default function buildRedisMessage(sessionVariables: Record<string, unknown>, input: Record<string, unknown>): RedisMessage {
   throwErrorIfInvalidInput(input,
       [
+        {name: 'serverRequestId', type: 'string', required: true},
         {name: 'clientSessionUUID', type: 'string', required: true},
         {name: 'networkRttInMs', type: 'number', required: true},
         {name: 'applicationRttInMs', type: 'number', required: false},
@@ -35,6 +36,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
   const body = {
     userId: routing.userId,
     sessionToken: sessionToken,
+    serverRequestId: input.serverRequestId,
     clientSessionUUID: input.clientSessionUUID,
     networkRttInMs: input.networkRttInMs,
     applicationRttInMs: input.applicationRttInMs ?? 0,

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -808,6 +808,7 @@ CREATE UNLOGGED TABLE "user_connectionStatus" (
     "lastEntriesCap" integer,
     "connectionAliveAtMaxIntervalMs" numeric,
     "connectionAliveAt" timestamp with time zone,
+    "serverRequestId" text,
     "networkRttInMs" numeric,
     "applicationRttInMs" numeric, --presenter only
     "traceLog" varchar(500), --presenter only

--- a/bigbluebutton-html5/imports/api/bbb-web-api/index.ts
+++ b/bigbluebutton-html5/imports/api/bbb-web-api/index.ts
@@ -34,6 +34,7 @@ class BBBWebApi {
         'Content-Type': 'application/json',
       },
       signal,
+      credentials: 'omit',
     });
 
     const body: IndexResponse = await response.json();

--- a/bigbluebutton-html5/imports/ui/components/connection-status/mutations.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/mutations.jsx
@@ -1,8 +1,9 @@
 import { gql } from '@apollo/client';
 
 export const UPDATE_CONNECTION_ALIVE_AT = gql`
-  mutation UpdateConnectionAliveAt($clientSessionUUID: String!, $networkRttInMs: Float!, $applicationRttInMs: Float, $traceLog: String) {
+  mutation UpdateConnectionAliveAt($serverRequestId: String!, $clientSessionUUID: String!, $networkRttInMs: Float!, $applicationRttInMs: Float, $traceLog: String) {
     userSetConnectionAlive(
+      serverRequestId: $serverRequestId
       clientSessionUUID: $clientSessionUUID
       networkRttInMs: $networkRttInMs
       applicationRttInMs: $applicationRttInMs

--- a/bigbluebutton-web/bbb-web.nginx
+++ b/bigbluebutton-web/bbb-web.nginx
@@ -165,6 +165,8 @@
             add_header Pragma "no-cache";
             add_header Expires "0";
             add_header X-Server-Epoch-Msec $msec;
+            add_header X-Request-Id $request_id;
+
             # this Header is required for cluster setups as the ping check is a
             # CORS request. No cookies are required so we can just allow anyone
             # to use this endpoint.


### PR DESCRIPTION
Improve tracking for `/rtt-check` request:

Now the client send the following params:
`session`: the `clientSessionUUID` that is unique per tab
`user`: `userId`
`meeting`: `meetingId`

The server return the header `x-request-id` that is a unique id created by nginx for each request.

<img width="1493" height="1007" alt="image" src="https://github.com/user-attachments/assets/23180f5f-052a-4aa3-9fde-e2c5bee2277f" />

Now it will be possible to track the `serverRequestId` at redis msg `UserConnectionAliveReqMsg` and Akka-apps logs:

<img width="1938" height="371" alt="image" src="https://github.com/user-attachments/assets/014449d8-35db-42a6-a86a-3a2f33dc2e55" />
