### PR TITLE
fix(whiteboard): highlight tool colors

### DIFF
--- a/bbb-playback.placeholder.sh
+++ b/bbb-playback.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v5.4.0 --depth 1 https://github.com/bigbluebutton/bbb-playback bbb-playback
+git clone --branch v5.4.2 --depth 1 https://github.com/bigbluebutton/bbb-playback bbb-playback

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -38,11 +38,13 @@ import {
 import { useMouseEvents, useCursor } from './hooks';
 import {
   notifyShapeNumberExceeded, getCustomEditorAssetUrls, getCustomAssetUrls,
-  debouncedUpdateShapes, sanitizeShape,
+  debouncedUpdateShapes, sanitizeShape, setupColorThemePaletteOverrides,
 } from './service';
 import NoopTool from './custom-tools/noop-tool/component';
 import DeleteSelectedItemsTool from './custom-tools/delete-selected-items/component';
 import SessionStorage from '/imports/ui/services/storage/session';
+
+setupColorThemePaletteOverrides();
 
 const CAMERA_TYPE = 'camera';
 const colorStyles = [

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -1,6 +1,7 @@
 import Auth from '/imports/ui/services/auth';
 import PollService from '/imports/ui/components/poll/service';
 import { defineMessages } from 'react-intl';
+import { DefaultColorThemePalette } from '@bigbluebutton/tldraw';
 import { notify } from '/imports/ui/services/notification';
 import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { debounce } from '/imports/utils/debounce';
@@ -408,6 +409,33 @@ const debouncedUpdateShapes = debounce((
   }
 }, 175);
 
+const setupColorThemePaletteOverrides = () => {
+  // Override the default color theme to use our custom palette with more vibrant yellow highlights
+  DefaultColorThemePalette.lightMode.black.highlight = {
+    srgb: '#FFFF00',
+    p3: 'color(display-p3 1 1 0)',
+  };
+  DefaultColorThemePalette.darkMode.black.highlight = {
+    srgb: '#FFFF00',
+    p3: 'color(display-p3 1 1 0)',
+  };
+  // Override the default yellow color to be a more vibrant yellow
+  DefaultColorThemePalette.lightMode.yellow = {
+    solid: '#FFFF00',
+    highlight: {
+      srgb: '#FFFF00',
+      p3: 'color(display-p3 1 1 0)',
+    },
+  };
+  DefaultColorThemePalette.darkMode.yellow = {
+    solid: '#FFFF00',
+    highlight: {
+      srgb: '#FFFF00',
+      p3: 'color(display-p3 1 1 0)',
+    },
+  };
+};
+
 export {
   initDefaultPages,
   sendAnnotation,
@@ -420,4 +448,5 @@ export {
   getCustomAssetUrls,
   debouncedUpdateShapes,
   sanitizeShape,
+  setupColorThemePaletteOverrides,
 };

--- a/record-and-playback/core/scripts/bigbluebutton.yml
+++ b/record-and-playback/core/scripts/bigbluebutton.yml
@@ -1,4 +1,4 @@
-bbb_version: '3.0.9'
+bbb_version: '3.0.17'
 raw_audio_src: /var/freeswitch/meetings
 mediasoup_video_src: /var/mediasoup/recordings
 mediasoup_screenshare_src: /var/mediasoup/screenshare


### PR DESCRIPTION
### What does this PR do?

- [feat(whiteboard): make default yellow color more vibrant](https://github.com/bigbluebutton/bigbluebutton/pull/24165/commits/9a20f9b0a8e204c2d7a23b595b9494fff3e2b3cf)
  Updates the default yellow color from #FFFF00 to a more vibrant shade, improving visual distinction from the orange color and enhancing overall visibility in drawings and highlights.

<img width="2551" height="1295" alt="Screenshot from 2025-11-07 19-23-03" src="https://github.com/user-attachments/assets/17138433-a6f7-404e-8218-cb1ba50d3103" />


### Closes Issue(s)
Closes #none

### More

The playback will still display the old yellow color, which will be adjusted in a separate PR:
<img width="2551" height="1295" alt="Screenshot from 2025-11-07 19-28-32" src="https://github.com/user-attachments/assets/ffc0e836-09d3-4194-b431-645502f5b2df" />
