### PR TITLE
Try to make linting more useful in BBB 3.1 and update libraries

### DIFF
--- a/bigbluebutton-html5/.eslintignore
+++ b/bigbluebutton-html5/.eslintignore
@@ -1,2 +1,0 @@
-Gruntfile.js
-public/compatibility/*

--- a/bigbluebutton-html5/.eslintrc.js
+++ b/bigbluebutton-html5/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   ignorePatterns: ['public/compatibility/*', 'Gruntfile.js', '**/sdpUtils.js', '**/utils/*.js'],
   rules: {
 
+    'eol-last': 0,
     'object-shorthand': 0,
     'prefer-rest-params': 0,
     'implicit-arrow-linebreak': 0,

--- a/bigbluebutton-html5/.eslintrc.js
+++ b/bigbluebutton-html5/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020,
   },
-  plugins: ['react', 'jsx-a11y', 'import'],
+  plugins: ['react', 'react-hooks', 'jsx-a11y', 'import'],
   env: {
     es6: true,
     node: true,
@@ -11,17 +11,62 @@ module.exports = {
     meteor: true,
     jasmine: true,
   },
+  ignorePatterns: ['public/compatibility/*', 'Gruntfile.js', '**/sdpUtils.js', '**/utils/*.js'],
   rules: {
+
+    'object-shorthand': 0,
+    'prefer-rest-params': 0,
+    'implicit-arrow-linebreak': 0,
+    'nonblock-statement-body-position': 0,
+    'curly': 0,
+    'func-call-spacing': 0,
+    'padded-blocks': 0,
+    'quote-props': 0,
     'no-underscore-dangle': 0,
+    'indent': 0,
+    'space-before-function-paren': 0,
+    'operator-linebreak': 0,
+    'no-multiple-empty-lines': 0,
+    'func-names': 0,
+    'camelcase': 0,
+    'linebreak-style': 0,
+    'quotes': 0,
+    'semi': 0,
+    'comma-dangle': 0,
+    'keyword-spacing': 0,
+    'space-in-parens': 0,
+    'no-mixed-operators': 0,
+    'object-curly-spacing': 0,
+    'array-bracket-spacing': 0,
+    'object-curly-newline': 0,
+    'template-curly-spacing': 0,
+    'arrow-parens': 0,
+    'max-len': 0,
+    'arrow-spacing': 0,
+    'no-spaced-func': 0,
+    'no-multi-spaces': 0,
+    'arrow-body-style': 0,
+    'prefer-arrow-callback': 0,
+    'space-before-blocks': 0,
+    'block-spacing': 0,
+    'comma-spacing': 0,
+
     'import/extensions': [2, 'never'],
     'import/no-absolute-path': 0,
     'import/no-unresolved': 0,
     'import/no-extraneous-dependencies': 1,
+
     'react/prop-types': 1,
+
     'jsx-a11y/no-access-key': 0,
     'react/jsx-props-no-spreading': 'off',
+
     'max-classes-per-file': ['error', 2],
     'react/require-default-props': 0,
+
+    // Core hooks rules
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
   globals: {
     browser: 'writable',
@@ -29,7 +74,7 @@ module.exports = {
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
-      extends: ['airbnb', 'eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+      extends: ['airbnb', 'eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:security/recommended-legacy'],
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint'],
       rules: {

--- a/bigbluebutton-html5/imports/ui/components/common/switch/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/switch/styles.js
@@ -121,7 +121,9 @@ const ToggleTrackX = styled.div`
 const ToggleThumb = styled.div`
   position: absolute;
   top: 1px;
-  left: ${({ isRTL }) => isRTL ? '2.6rem' : '1px'};
+  left: ${({ isRTL }) => {
+    return isRTL ? '2.6rem' : '1px'
+  }};
   width: 1.35rem;
   height: 1.35rem;
   border-radius: 50%;
@@ -134,7 +136,9 @@ const ToggleThumb = styled.div`
   `}
 
   ${({ checked }) => checked && css`
-    left: ${({ isRTL }) => isRTL ? '1px' : '2.1rem' };
+    left: ${({ isRTL }) => {
+      return isRTL ? '1px' : '2.1rem'
+    }};
     box-shadow: -2px 0px 10px -1px rgba(0,0,0,0.4);
   `}
 

--- a/bigbluebutton-html5/imports/ui/components/dropdown/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/styles.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
-import { fontSizeLarge } from '/imports/ui/stylesheets/styled-components/typography';
-import { lineHeightComputed } from '/imports/ui/stylesheets/styled-components/typography';
+import { fontSizeLarge, lineHeightComputed } from '/imports/ui/stylesheets/styled-components/typography';
 import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 

--- a/bigbluebutton-html5/imports/ui/components/presentation/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/styles.js
@@ -4,7 +4,6 @@ import {
   toastIconSide,
   smPaddingX,
   smPaddingY,
-  contentSidebarMarginToMedia,
   lgBorderRadius,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {

--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -6,7 +6,9 @@ export const isKeepPushingLayoutEnabled = () => window.meetingClientSettings.pub
 
 export const updateSettings = (obj, msgDescriptor, mutation) => {
   const Settings = getSettingsSingletonInstance();
-  Object.keys(obj).forEach(k => (Settings[k] = obj[k]));
+  Object.keys(obj).forEach(k => {
+    Settings[k] = obj[k];
+  });
   Settings.save(mutation);
 
   if (msgDescriptor) {

--- a/bigbluebutton-html5/imports/ui/components/video-preview/service.js
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/service.js
@@ -27,7 +27,7 @@ const getCameraAsContentProfile = () => {
   // Unfiltered, includes hidden profiles
   const CAMERA_PROFILES = window.meetingClientSettings.public.kurento.cameraProfiles || [];
 
-  return CAMERA_PROFILES.find((profile) => profile.id == CAMERA_AS_CONTENT_PROFILE_ID)
+  return CAMERA_PROFILES.find((profile) => profile.id === CAMERA_AS_CONTENT_PROFILE_ID)
     || CAMERA_PROFILES.find((profile) => profile.default);
 };
 
@@ -41,6 +41,19 @@ const getCameraProfile = (id) => {
 // Easier to keep track of them. Easier to centralize their referencing.
 // Easier to shuffle them around.
 const VIDEO_STREAM_STORAGE = new Map();
+
+const getStream = (deviceId) => VIDEO_STREAM_STORAGE.get(deviceId);
+
+const hasStream = (deviceId) => VIDEO_STREAM_STORAGE.has(deviceId);
+
+const deleteStream = (deviceId) => {
+  const stream = getStream(deviceId);
+  if (stream == null) return false;
+  MediaStreamUtils.stopMediaStreamTracks(stream);
+  return VIDEO_STREAM_STORAGE.delete(deviceId);
+};
+
+const clearStreams = () => VIDEO_STREAM_STORAGE.clear();
 
 const storeStream = (deviceId, stream) => {
   if (!stream) return false;
@@ -63,19 +76,6 @@ const storeStream = (deviceId, stream) => {
 
   return true;
 };
-
-const getStream = (deviceId) => VIDEO_STREAM_STORAGE.get(deviceId);
-
-const hasStream = (deviceId) => VIDEO_STREAM_STORAGE.has(deviceId);
-
-const deleteStream = (deviceId) => {
-  const stream = getStream(deviceId);
-  if (stream == null) return false;
-  MediaStreamUtils.stopMediaStreamTracks(stream);
-  return VIDEO_STREAM_STORAGE.delete(deviceId);
-};
-
-const clearStreams = () => VIDEO_STREAM_STORAGE.clear();
 
 const promiseTimeout = (ms, promise) => {
   const timeout = new Promise((resolve, reject) => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -192,10 +192,7 @@ export const useDisableCam = () => {
   return meeting?.lockSettings ? meeting?.lockSettings.disableCam : false;
 };
 
-const getCountData = () => {
-  const { data: countData } = useDeduplicatedSubscription<UsersCountSubscriptionResponse>(
-    USER_AGGREGATE_COUNT_SUBSCRIPTION,
-  );
+const getCountData = (countData) => {
   return countData?.user_aggregate?.aggregate?.count || 0;
 };
 
@@ -204,7 +201,10 @@ export const usePageSizeDictionary = () => {
     desktopPageSizes: DESKTOP_PAGE_SIZES,
     mobilePageSizes: MOBILE_PAGE_SIZES,
   } = window.meetingClientSettings.public.kurento.pagination;
-  const userCount = getCountData();
+  const { data: countData } = useDeduplicatedSubscription<UsersCountSubscriptionResponse>(
+    USER_AGGREGATE_COUNT_SUBSCRIPTION,
+  );
+  const userCount = getCountData(countData);
 
   const PAGINATION_THRESHOLDS_CONF = window.meetingClientSettings.public.kurento.paginationThresholds;
   const PAGINATION_THRESHOLDS_ENABLED = PAGINATION_THRESHOLDS_CONF.enabled;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -192,7 +192,10 @@ export const useDisableCam = () => {
   return meeting?.lockSettings ? meeting?.lockSettings.disableCam : false;
 };
 
-const getCountData = (countData) => {
+const useCountData = () => {
+  const { data: countData } = useDeduplicatedSubscription<UsersCountSubscriptionResponse>(
+    USER_AGGREGATE_COUNT_SUBSCRIPTION,
+  );
   return countData?.user_aggregate?.aggregate?.count || 0;
 };
 
@@ -201,10 +204,7 @@ export const usePageSizeDictionary = () => {
     desktopPageSizes: DESKTOP_PAGE_SIZES,
     mobilePageSizes: MOBILE_PAGE_SIZES,
   } = window.meetingClientSettings.public.kurento.pagination;
-  const { data: countData } = useDeduplicatedSubscription<UsersCountSubscriptionResponse>(
-    USER_AGGREGATE_COUNT_SUBSCRIPTION,
-  );
-  const userCount = getCountData(countData);
+  const userCount = useCountData();
 
   const PAGINATION_THRESHOLDS_CONF = window.meetingClientSettings.public.kurento.paginationThresholds;
   const PAGINATION_THRESHOLDS_ENABLED = PAGINATION_THRESHOLDS_CONF.enabled;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
@@ -1,7 +1,7 @@
 // useMeeting.ts
 import { useMemo } from 'react';
 import { mergeDeepRight, isEmpty } from 'ramda';
-import useCreateUseSubscription from './createUseSubscription';
+import createUseSubscription from './createUseSubscription';
 import MEETING_SUBSCRIPTION from '../graphql/queries/meetingSubscription';
 import { Meeting } from '../../Types/meeting';
 import MeetingStaticDataStore from '/imports/ui/core/singletons/meetingStaticData';
@@ -30,6 +30,13 @@ type Combined = Prettify<
 // (We stay shallow for the public type.)
 type DistributePartial<T> = T extends object ? Partial<T> : T;
 type Loose<T> = { [K in keyof T]?: DistributePartial<T[K]> };
+
+// subscription remains on Meeting
+const useMeetingSubscription = createUseSubscription<Meeting>(
+  MEETING_SUBSCRIPTION,
+  {},
+  true,
+);
 
 function isNilOrEmptyObject(v: unknown) {
   return v == null || (typeof v === 'object' && v !== null && isEmpty(v as object));
@@ -61,13 +68,6 @@ function safeProject<
 export function useMeeting<T extends Loose<Combined> = Partial<Combined>>(
   fn?: (c: Partial<Combined>) => T,
 ) {
-  // subscription remains on Meeting
-  const useMeetingSubscription = useCreateUseSubscription<Meeting>(
-    MEETING_SUBSCRIPTION,
-    {},
-    true,
-  );
-
   const response = useMeetingSubscription();
 
   const data = useMemo<T | undefined>(() => {

--- a/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useMeeting.ts
@@ -31,13 +31,6 @@ type Combined = Prettify<
 type DistributePartial<T> = T extends object ? Partial<T> : T;
 type Loose<T> = { [K in keyof T]?: DistributePartial<T[K]> };
 
-// subscription remains on Meeting
-const useMeetingSubscription = useCreateUseSubscription<Meeting>(
-  MEETING_SUBSCRIPTION,
-  {},
-  true,
-);
-
 function isNilOrEmptyObject(v: unknown) {
   return v == null || (typeof v === 'object' && v !== null && isEmpty(v as object));
 }
@@ -68,6 +61,13 @@ function safeProject<
 export function useMeeting<T extends Loose<Combined> = Partial<Combined>>(
   fn?: (c: Partial<Combined>) => T,
 ) {
+  // subscription remains on Meeting
+  const useMeetingSubscription = useCreateUseSubscription<Meeting>(
+    MEETING_SUBSCRIPTION,
+    {},
+    true,
+  );
+
   const response = useMeetingSubscription();
 
   const data = useMemo<T | undefined>(() => {

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -1,5 +1,5 @@
 /* eslint prefer-promise-reject-errors: 0 */
-import { makeVar, useReactiveVar } from '@apollo/client';
+import { makeVar } from '@apollo/client';
 import Storage from '/imports/ui/services/storage/session';
 import Session from '/imports/ui/services/storage/in-memory';
 
@@ -115,10 +115,6 @@ class Auth {
 
   set loggedIn(value) {
     this._loggedIn(value);
-  }
-
-  useLoggedIn() {
-    return useReactiveVar(this._loggedIn);
   }
 
   get credentials() {

--- a/bigbluebutton-html5/imports/ui/services/notification/styles.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/styles.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Button from '/imports/ui/components/common/button/component';
-import { 
+import {
   toastMargin,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -113,6 +113,7 @@
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "^4.4.0",
+        "eslint-plugin-security": "^3.0.1",
         "file-loader": "6.2.0",
         "html-webpack-plugin": "5.6.0",
         "husky": "^1.3.1",
@@ -8899,6 +8900,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
+      "integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -14804,6 +14821,16 @@
         "@babel/runtime": "^7.8.4"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -15193,6 +15220,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -191,13 +191,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -487,18 +488,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -529,13 +530,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
-      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -545,6 +546,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
       "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.7",
@@ -557,12 +559,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.28.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2053,14 +2055,14 @@
       "license": "MIT"
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2085,14 +2087,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2489,9 +2490,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2709,9 +2710,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6056,6 +6057,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -6639,9 +6641,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6884,6 +6886,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -6898,6 +6901,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -7101,6 +7105,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -7110,6 +7115,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -7419,9 +7425,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8698,9 +8704,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8776,9 +8782,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8846,9 +8852,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9006,9 +9012,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9300,9 +9306,9 @@
       }
     },
     "node_modules/execa/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10054,9 +10060,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16589,15 +16595,6 @@
         "@popperjs/core": "^2.9.0"
       }
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -17263,9 +17260,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "version": "13.15.20",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.20.tgz",
+      "integrity": "sha512-KxPOq3V2LmfQPP4eqf3Mq/zrT0Dqp2Vmx2Bn285LwVahLc+CsxOM0crBHczm8ijlcjZ0Q5Xd6LW3z3odTPnlrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -140,6 +140,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
+    "eslint-plugin-security": "^3.0.1",
     "file-loader": "6.2.0",
     "html-webpack-plugin": "5.6.0",
     "husky": "^1.3.1",


### PR DESCRIPTION
This PR tries to make eslint detect useful things apart from code formatting. I've added linters for common react errors and security issues.

* Running 'npm run eslint' will show aprox. 100 errors with different severities and close to 700 warnings now.
* The second commit fixes some security issues with 'npm audit fix'
* The last commit fixes a few of the easy linter errors.