### PR TITLE
fix(bbb-web): Fallback to Using Blank Files if Page Downscaling Fails

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PngCreator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PngCreator.java
@@ -21,6 +21,6 @@ package org.bigbluebutton.presentation;
 import java.io.File;
 
 public interface PngCreator {
-	public boolean createPng(UploadedPresentation pres, int page, File pageFile);
+	public boolean createPng(UploadedPresentation pres, int page, File pageFile, boolean useBlank);
 	public void createBlank(UploadedPresentation pres, int page);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SvgImageCreator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/SvgImageCreator.java
@@ -28,6 +28,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeoutException;
 
 public interface SvgImageCreator {
-	public boolean createSvgImage(UploadedPresentation pres, int page) throws TimeoutException;
+	public boolean createSvgImage(UploadedPresentation pres, int page, boolean useBlank) throws TimeoutException;
 	public void createBlank(UploadedPresentation pres, int page);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/TextFileCreator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/TextFileCreator.java
@@ -22,6 +22,6 @@ package org.bigbluebutton.presentation;
 import org.bigbluebutton.presentation.imp.PageToConvert;
 
 public interface TextFileCreator {
-	public boolean createTextFile(UploadedPresentation pres, int page);
+	public boolean createTextFile(UploadedPresentation pres, int page, boolean useBlank);
 	public void createBlank(UploadedPresentation pres, int page);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ThumbnailCreator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ThumbnailCreator.java
@@ -24,6 +24,6 @@ import org.bigbluebutton.presentation.imp.PageToConvert;
 import java.io.File;
 
 public interface ThumbnailCreator {
-	public boolean createThumbnail(UploadedPresentation pres, int page, File pageFile);
+	public boolean createThumbnail(UploadedPresentation pres, int page, File pageFile, boolean useBlank);
 	public void createBlank(UploadedPresentation pres, int page);
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ImageSlidesGenerationService.java
@@ -77,13 +77,13 @@ public class ImageSlidesGenerationService {
 	private void createTextFiles(UploadedPresentation pres, int page) {
 		log.debug("Creating textfiles for accessibility.");
 		notifier.sendCreatingTextFilesUpdateMessage(pres);
-		textFileCreator.createTextFile(pres, page);
+		textFileCreator.createTextFile(pres, page, false);
 	}
 	
 	private void createThumbnails(UploadedPresentation pres, int page) {
 		log.debug("Creating thumbnails.");
 		notifier.sendCreatingThumbnailsUpdateMessage(pres);
-		thumbnailCreator.createThumbnail(pres, page, pres.getUploadedFile());
+		thumbnailCreator.createThumbnail(pres, page, pres.getUploadedFile(), false);
 	}
 	
 	private void createSvgImages(UploadedPresentation pres, int page) throws TimeoutException{
@@ -103,11 +103,11 @@ public class ImageSlidesGenerationService {
 		}
 
 		notifier.sendCreatingSvgImagesUpdateMessage(pres);
-		svgImageCreator.createSvgImage(pres, page);
+		svgImageCreator.createSvgImage(pres, page, false);
 	}
 	
    private void createPngImages(UploadedPresentation pres, int page) {
-        pngCreator.createPng(pres, page, pres.getUploadedFile());
+        pngCreator.createPng(pres, page, pres.getUploadedFile(), false);
    }
 
 	private void resizeImage(UploadedPresentation pres, String ratio) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PageToConvert.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PageToConvert.java
@@ -13,6 +13,7 @@ public class PageToConvert {
 
   private boolean svgImagesRequired=true;
   private boolean generatePngs;
+  private boolean useBlanks;
   private PageExtractor pageExtractor;
 
 
@@ -29,6 +30,7 @@ public class PageToConvert {
                        File pageFile,
                        boolean svgImagesRequired,
                        boolean generatePngs,
+                       boolean useBlanks,
                        TextFileCreator textFileCreator,
                        SvgImageCreator svgImageCreator,
                        ThumbnailCreator thumbnailCreator,
@@ -39,6 +41,7 @@ public class PageToConvert {
     this.pageFile = pageFile;
     this.svgImagesRequired = svgImagesRequired;
     this.generatePngs = generatePngs;
+    this.useBlanks = useBlanks;
     this.textFileCreator = textFileCreator;
     this.svgImageCreator = svgImageCreator;
     this.thumbnailCreator = thumbnailCreator;
@@ -74,14 +77,14 @@ public class PageToConvert {
 
   public boolean convert() {
     /* adding accessibility */
-    createThumbnails(pres, page, pageFile);
+    createThumbnails(pres, page, pageFile, useBlanks);
 
-    createTextFiles(pres, page);
+    createTextFiles(pres, page, useBlanks);
 
     // only create SVG images if the configuration requires it
     if (svgImagesRequired) {
       try{
-        createSvgImages(pres, page);
+        createSvgImages(pres, page, useBlanks);
       } catch (TimeoutException e) {
         messageErrorInConversion = e.getMessage();
       }
@@ -89,7 +92,7 @@ public class PageToConvert {
 
     // only create PNG images if the configuration requires it
     if (generatePngs) {
-      createPngImages(pres, page, pageFile);
+      createPngImages(pres, page, pageFile, useBlanks);
     }
 
     return true;
@@ -102,23 +105,23 @@ public class PageToConvert {
     if (generatePngs) pngCreator.createBlank(pres, page);
   }
 
-  private void createThumbnails(UploadedPresentation pres, int page, File pageFile) {
+  private void createThumbnails(UploadedPresentation pres, int page, File pageFile, boolean useBlank) {
     //notifier.sendCreatingThumbnailsUpdateMessage(pres);
-    thumbnailCreator.createThumbnail(pres, page, pageFile);
+    thumbnailCreator.createThumbnail(pres, page, pageFile, useBlank);
   }
 
-  private void createTextFiles(UploadedPresentation pres, int page) {
+  private void createTextFiles(UploadedPresentation pres, int page, boolean useBlank) {
     //notifier.sendCreatingTextFilesUpdateMessage(pres);
-    textFileCreator.createTextFile(pres, page);
+    textFileCreator.createTextFile(pres, page, useBlank);
   }
 
-  private void createSvgImages(UploadedPresentation pres, int page) throws TimeoutException {
+  private void createSvgImages(UploadedPresentation pres, int page, boolean useBlank) throws TimeoutException {
     //notifier.sendCreatingSvgImagesUpdateMessage(pres);
-    svgImageCreator.createSvgImage(pres, page);
+    svgImageCreator.createSvgImage(pres, page, useBlank);
   }
 
-  private void createPngImages(UploadedPresentation pres, int page, File pageFile) {
-    pngCreator.createPng(pres, page, pageFile);
+  private void createPngImages(UploadedPresentation pres, int page, File pageFile, boolean useBlank) {
+    pngCreator.createPng(pres, page, pageFile, useBlank);
   }
 
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfPageDownscaler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PdfPageDownscaler.java
@@ -13,8 +13,6 @@ public class PdfPageDownscaler {
                 + "/etc/bigbluebutton/nopdfmark.ps" + SPACE
                 + source.getAbsolutePath();
 
-        //System.out.println("DOWNSCALING " + COMMAND);
-
         return new ExternalProcessExecutor().exec(COMMAND, execTimeout);
     }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -52,12 +52,17 @@ public class PngCreatorImp implements PngCreator {
 
 	private static final String TEMP_PNG_NAME = "temp-png";
 
-	public boolean createPng(UploadedPresentation pres, int page, File pageFile) {
+	public boolean createPng(UploadedPresentation pres, int page, File pageFile, boolean useBlank) {
 		boolean success = false;
 		File pngDir = determinePngDirectory(pres.getUploadedFile());
 
 		if (!pngDir.exists())
 			pngDir.mkdir();
+
+        if (useBlank) {
+            createBlankPng(pngDir, page);
+            return success;
+        }
 
 		try {
 			long start = System.currentTimeMillis();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -61,7 +61,7 @@ public class PngCreatorImp implements PngCreator {
 
         if (useBlank) {
             createBlankPng(pngDir, page);
-            return success;
+            return true;
         }
 
 		try {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
@@ -194,12 +194,18 @@ public class PresentationFileProcessor {
         for (int page = 1; page <= pres.getNumberOfPages(); page++) {
             File pageFile = new File(presDir + "/page" + "-" + page + ".pdf");
 
+            boolean useBlanks = false;
             if(!pageFile.exists()) {
                 File extractedPageFile = extractPage(pres, page);
                 if (extractedPageFile.length() > maxBigPdfPageSize) {
                     File downscaledPageFile = downscalePage(pres, extractedPageFile, page);
-                    downscaledPageFile.renameTo(pageFile);
-                    extractedPageFile.delete();
+                    if (downscaledPageFile == null) {
+                        useBlanks = true;
+                        extractedPageFile.renameTo(pageFile);
+                    } else {
+                        downscaledPageFile.renameTo(pageFile);
+                        extractedPageFile.delete();
+                    }
                 } else {
                     extractedPageFile.renameTo(pageFile);
                 }
@@ -211,6 +217,7 @@ public class PresentationFileProcessor {
                     pageFile,
                     svgImagesRequired,
                     generatePngs,
+                    useBlanks,
                     textFileCreator,
                     svgImageCreator,
                     thumbnailCreator,
@@ -243,12 +250,13 @@ public class PresentationFileProcessor {
         String presDir = pres.getUploadedFile().getParent();
         File tempPage = new File(presDir + "/downscaled" + "-" + pageNum + ".pdf");
         PdfPageDownscaler downscaler = new PdfPageDownscaler();
-        downscaler.downscale(filePage, tempPage);
-        if (tempPage.exists()) {
+        boolean success = downscaler.downscale(filePage, tempPage);
+        if (tempPage.exists() && success) {
             return tempPage;
         }
 
-        return filePage;
+        log.warn("Failed to downscale [{}]", filePage);
+        return null;
     }
 
     private File extractPage(UploadedPresentation pres, int page) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -369,7 +369,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         long endConv = System.currentTimeMillis();
 
         long svgLength = destsvg.length();
-        if (svgLength > maxBigSvgSize) {
+        if (maxBigSvgSize > 0 && svgLength > maxBigSvgSize) {
             log.warn("Generated SVG [{}] is too large: {}; using blank SVG instead", destsvg, svgLength);
             return false;
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -41,12 +41,21 @@ public class SvgImageCreatorImp implements SvgImageCreator {
     private ImageResizer imageResizer;
     private ImageResolutionService imageResolutionService;
 
+    private long maxBigSvgSize;
+
     @Override
-    public boolean createSvgImage(UploadedPresentation pres, int page) throws TimeoutException{
+    public boolean createSvgImage(UploadedPresentation pres, int page, boolean useBlank) throws TimeoutException{
         boolean success = false;
         File svgImagesPresentationDir = determineSvgImagesDirectory(pres.getUploadedFile());
         if (!svgImagesPresentationDir.exists())
             svgImagesPresentationDir.mkdir();
+
+        File destSvg = new File(svgImagesPresentationDir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
+
+        if (useBlank) {
+            copyBlankSvg(destSvg);
+            return true;
+        }
 
         try {
             success = generateSvgImage(svgImagesPresentationDir, pres, page);
@@ -56,7 +65,6 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         }
 
         if (!success) {
-            File destSvg = new File(svgImagesPresentationDir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
             if (destSvg.exists()) {
                 destSvg.delete();
             }
@@ -360,7 +368,11 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
         long endConv = System.currentTimeMillis();
 
-        //System.out.println("******** CREATING SVG page " + page + " " + (endConv - startConv));
+        long svgLength = destsvg.length();
+        if (svgLength > maxBigSvgSize) {
+            log.warn("Generated SVG [{}] is too large: {}; using blank SVG instead", destsvg, svgLength);
+            return false;
+        }
 
         if (done) {
             return true;
@@ -501,5 +513,9 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     public void setImageResolutionService(ImageResolutionService imageResolutionService) {
         this.imageResolutionService = imageResolutionService;
+    }
+
+    public void setMaxBigSvgSize(long maxBigSvgSize) {
+        this.maxBigSvgSize = maxBigSvgSize;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -43,12 +43,16 @@ public class TextFileCreatorImp implements TextFileCreator {
   private long execTimeout = 60000;
 
   @Override
-  public boolean createTextFile(UploadedPresentation pres, int page) {
+  public boolean createTextFile(UploadedPresentation pres, int page, boolean useBlank) {
     boolean success = false;
     File textfilesDir = determineTextfilesDirectory(pres.getUploadedFile());
     if (!textfilesDir.exists())
       textfilesDir.mkdir();
 
+    if (useBlank) {
+        createBlankTextFile(textfilesDir, page);
+        return true;
+    }
 
     try {
       success = generateTextFile(textfilesDir, pres, page);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -52,12 +52,17 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
   private long execTimeout = 10000;
 
   @Override
-  public boolean createThumbnail(UploadedPresentation pres, int page, File pageFile) {
+  public boolean createThumbnail(UploadedPresentation pres, int page, File pageFile, boolean useBlank) {
     boolean success = false;
     File thumbsDir = determineThumbnailDirectory(pres.getUploadedFile());
 
     if (!thumbsDir.exists())
       thumbsDir.mkdir();
+
+    if (useBlank) {
+        createBlankThumbnail(thumbsDir, page);
+        return true;
+    }
 
     try {
       success = generateThumbnail(thumbsDir, pres, page, pageFile);

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -192,6 +192,9 @@ bigPdfSize=14000000
 # The maximum allowed page size for PDF files exceeding the 'pdfCheckSize' value, 2 MB by default
 maxBigPdfPageSize=2000000
 
+# The maximum allowed generated SVG size. 20MB by default.
+maxBigSvgSize=20000000
+
 # This functionality stores outputs such as SVGs, PNGs, and text generated from PDFs or document files uploaded as presentations.
 # The processed outputs are cached in an S3-based storage system, keyed by a hash of the presentation file.
 # When the same presentation is uploaded again, the system retrieves the cached outputs, avoiding redundant processing and improving performance.

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -115,6 +115,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="pngWidthRasterizedSlides" value="${pngWidthRasterizedSlides}"/>
         <property name="imageResizer" ref="imageResizer"/>
         <property name="imageResolutionService" ref="imageResolutionService"/>
+        <property name="maxBigSvgSize" value="${maxBigPdfPageSize}"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -116,7 +116,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="pngWidthRasterizedSlides" value="${pngWidthRasterizedSlides}"/>
         <property name="imageResizer" ref="imageResizer"/>
         <property name="imageResolutionService" ref="imageResolutionService"/>
-        <property name="maxBigSvgSize" value="${maxBigPdfPageSize}"/>
+        <property name="maxBigSvgSize" value="${maxBigSvgSize}"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>


### PR DESCRIPTION
### What does this PR do?

Refactors BBB presentation conversion to use blanks for textfiles, thumbnails, SVGs, and PNGs if a presentation page is too large and attempts to downscale the page fail.


### Closes Issue(s)
Closes #24143

### Motivation

Currently, if the size of a presentation page exceeds the configured limits an attempt will be made to downscale the page. If this downscaling fails, due to a timeout for example, the failure is ignored and conversion continues with the unaltered large page. This can cause problems in conversion, but if the conversion succeeds, the resulting SVG may then cause in the client.


### How to test
1. Upload a presentation that contains at least one large page (the presentation in #24143 is good).
2. Before the change the conversion is successful but when you try to view the large page (page 14 in that presentation) in the client you will notice a massive drop in performance.
3. After the change notice that a blank slide has been used in place of the previous problematic slide and there is no decrease is client performance.
