### PR TITLE
fix (bbb-web): Fix duplicate Grails SNAPSHOT jars by removing Asset Pipeline runtime dep

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -52,9 +52,6 @@ repositories {
 }
 
 dependencies {
-  // Asset‑Pipeline runtime (aligns with 5.x plugin)
-  runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:5.0.9"
-
   // Spring Boot managed libs – version comes from `springVersion` property
   implementation "org.springframework.boot:spring-boot:${springVersion}"
   implementation "org.springframework.boot:spring-boot-autoconfigure:${springVersion}"
@@ -72,8 +69,6 @@ dependencies {
 
   implementation "org.apache.grails:grails-views-gson"
   implementation "org.apache.grails:grails-cache"
-
-  runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:5.0.6"
 
 //  implementation "org.grails.plugins:external-config:1.2.2"
 //  implementation "org.yaml:snakeyaml:1.33"


### PR DESCRIPTION
Fix error when loading `bbb-web` service: `java.lang.NoSuchFieldError: GRAILS_HOME`

---

- What changed:
  - Removed the runtime dependency on the Asset Pipeline Grails runtime:
    - `runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:5.0.9"`
    - `runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:5.0.6"`

- Motivation:
  - Those runtime artifacts import a SNAPSHOT Grails BOM (`org.apache.grails:grails-bom:7.0.0-SNAPSHOT`) via their POM, which pulls the entire `org.grails:*:7.0.0-SNAPSHOT` tree.
  - This caused duplicate jars (e.g., both `grails-web-common-7.0.0.jar` and `grails-web-common-7.0.0-SNAPSHOT.jar`) to be packaged into the WAR and deployed to `/usr/share/bbb-web/WEB-INF/lib`.

- Why this resolves the issue:
  - The build only needs the Asset Pipeline Gradle plugin (already present via `buildscript`/`apply plugin`) to compile and package assets; the Grails runtime module is not required at runtime when assets are precompiled.
  - By removing the runtime dependency, the build no longer imports the SNAPSHOT BOM, so the `org.grails:*:7.0.0-SNAPSHOT` artifacts are not brought in, eliminating the `-SNAPSHOT.jar` duplicates in the final WAR.