### PR TITLE
fix(html5): prevent local state mutation causing desync on modal close

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -114,21 +114,21 @@ class LockViewersComponent extends Component {
 
   toggleLockSettings(property) {
     const { lockSettingsProps } = this.state;
-
-    lockSettingsProps[property] = !lockSettingsProps[property];
+    const lockSettingsPropsLocal = { ...lockSettingsProps };
+    lockSettingsPropsLocal[property] = !lockSettingsPropsLocal[property];
 
     this.setState({
-      lockSettingsProps,
+      lockSettingsProps: lockSettingsPropsLocal,
     });
   }
 
   toggleUserProps(property) {
     const { usersProp } = this.state;
-
-    usersProp[property] = !usersProp[property];
+    const usersPropLocal = { ...usersProp };
+    usersPropLocal[property] = !usersPropLocal[property];
 
     this.setState({
-      usersProp,
+      usersProp: usersPropLocal,
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a local state synchronization issue in the **Lock Viewers** modal.
Previously, toggling any lock setting or user property directly mutated the component’s state object (`lockSettingsProps` or `usersProp`), causing React to miss state updates. As a result, the modal could reopen showing outdated toggle values after closing without applying changes.

The fix ensures immutability by creating shallow copies of these state objects before toggling properties. This guarantees proper re-rendering and consistent UI behavior when closing and reopening the modal.

### Closes Issue(s)
Closes [#24176](https://github.com/bigbluebutton/bigbluebutton/issues/24176)


### How to test

1. Join a meeting as a **moderator**.
2. Open the **Lock viewers** modal.
3. Toggle one or more lock settings (e.g., disable chat or webcam).
4. Close the modal **without clicking “Apply.”**
5. Reopen the **Lock viewers** modal.
6. ✅ **Expected behavior:** The toggles should reflect the actual saved (server-side) lock state, not the unapplied changes.


### More
[Screencast from 03-11-2025 11:04:45.webm](https://github.com/user-attachments/assets/babf2570-966c-491e-8b51-e17fd41bf277)
