### PR TITLE
Fix(html5): tldraw capturing link edit input events

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -595,7 +595,7 @@ const Whiteboard = React.memo((props) => {
       return;
     }
     // ignore if the edit link dialog is open
-    if (document.querySelector('h2.tlui-dialog__header__title')?.textContent === 'Edit link') {
+    if (event.target.tagName === 'INPUT') {
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
Reimplements keydown handling for edit inputs to rely on the target element’s tag name instead of using the tldraw-specific CSS class.


### Closes Issue(s)
Closes #24180

### How to test
- Join a meeting 
- change the language
- create a shape 
- edit a link
- try the letter g, t, r


### More
[Screencast from 04-11-2025 11:53:36.webm](https://github.com/user-attachments/assets/3e6d31f6-ab55-43da-8c45-dfb2573f1db4)
