### PR TITLE
fix (bbb-web): Fix SVG tag count checks and add rasterization based on `<use>` threshold

### DIFF
--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -1,7 +1,6 @@
 package org.bigbluebutton.build
 
-import sbt._
-import Keys._
+import sbt.*
 
 object Dependencies {
 

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -1,6 +1,7 @@
 package org.bigbluebutton.build
 
-import sbt.*
+import sbt._
+import Keys._
 
 object Dependencies {
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/SvgConversionHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/SvgConversionHandler.java
@@ -77,7 +77,7 @@ public class SvgConversionHandler extends AbstractCommandHandler {
                 m.find();
                 return Integer.parseInt(m.group(0).replace(USE_TAG_OUTPUT, "").trim());
             } catch (Exception e) {
-                log.error("Exception counting the number of image tags", e);
+                log.error("Exception counting the number of use tags", e);
                 return 0;
             }
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/SvgConversionHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/SvgConversionHandler.java
@@ -10,9 +10,13 @@ public class SvgConversionHandler extends AbstractCommandHandler {
     private static Logger log = LoggerFactory.getLogger(SvgConversionHandler.class);
 
     private static String PATH_OUTPUT = "<path";
-    private static String IMAGE_TAG_OUTPUT = "<image";
     private static String PATH_PATTERN = "\\d+\\s" + PATH_OUTPUT;
+
+    private static String IMAGE_TAG_OUTPUT = "<image";
     private static String IMAGE_TAG_PATTERN = "\\d+\\s" + IMAGE_TAG_OUTPUT;
+
+    private static String USE_TAG_OUTPUT = "<use";
+    private static String USE_TAG_PATTERN = "\\d+\\s" + USE_TAG_OUTPUT;
 
     private final String id;
 
@@ -52,6 +56,26 @@ public class SvgConversionHandler extends AbstractCommandHandler {
                 Matcher m = r.matcher(out);
                 m.find();
                 return Integer.parseInt(m.group(0).replace(IMAGE_TAG_OUTPUT, "").trim());
+            } catch (Exception e) {
+                log.error("Exception counting the number of image tags", e);
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     *
+     * @return The number of <use/> tags in the generated SVG.
+     */
+    public int numberOfUseTags() {
+        if (stdoutContains(USE_TAG_OUTPUT)) {
+            try {
+                String out = stdoutBuilder.toString();
+                Pattern r = Pattern.compile(USE_TAG_PATTERN);
+                Matcher m = r.matcher(out);
+                m.find();
+                return Integer.parseInt(m.group(0).replace(USE_TAG_OUTPUT, "").trim());
             } catch (Exception e) {
                 log.error("Exception counting the number of image tags", e);
                 return 0;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -30,6 +30,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     private SlidesGenerationProgressNotifier notifier;
     private long imageTagThreshold;
+    private long useTagThreshold;
     private long pathsThreshold;
     private int convPdfToSvgTimeout = 60;
     private int pdfFontsTimeout = 3;
@@ -213,10 +214,10 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
         }
 
-
         if (destsvg.length() == 0 ||
                 pHandler.numberOfImageTags() > imageTagThreshold ||
                 pHandler.numberOfPaths() > pathsThreshold ||
+                pHandler.numberOfUseTags() > useTagThreshold ||
                 rasterizeCurrSlide) {
 
             // We need t delete the destination file as we are starting a
@@ -394,8 +395,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
         rawCommand  += " -q -f " + String.valueOf(page) + " -l " + String.valueOf(page) + " " + source + " " + destFile;
         if (analyze) {
-            rawCommand += " && cat " + destFile;
-            rawCommand += " | egrep 'data:image/png;base64|<path' | sed 's/  / /g' | cut -d' ' -f 1 | sort | uniq -cw 2";
+            rawCommand += " && grep -oE '<image|<path|<use' "+destFile+" | sort | uniq -c ";
         }
 
         return new NuProcessBuilder(Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", timeout + "s", "/bin/sh", "-c", rawCommand));
@@ -468,6 +468,10 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     public void setImageTagThreshold(long threshold) {
         imageTagThreshold = threshold;
+    }
+
+    public void setUseTagThreshold(long threshold) {
+        useTagThreshold = threshold;
     }
 
     public void setPathsThreshold(long threshold) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -71,6 +71,9 @@ placementsThreshold=800
 # Maximum allowed number of bitmap images in generated svg, if exceeded the conversion will fallback to full BMP (default 800)
 imageTagThreshold=800
 
+# Maximum allowed number of <use> tags in generated svg, if exceeded the conversion will fallback to full BMP (default 10k)
+useTagThreshold=10000
+
 #------------------------------------
 # Number of threads in the pool to do the presentation conversion.
 #------------------------------------

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -105,6 +105,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <bean id="svgImageCreator" class="org.bigbluebutton.presentation.imp.SvgImageCreatorImp">
     	<property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>
         <property name="imageTagThreshold" value="${imageTagThreshold}"/>
+        <property name="useTagThreshold" value="${useTagThreshold}"/>
         <property name="pathsThreshold" value="${placementsThreshold}"/>
         <property name="blankSvg" value="${BLANK_SVG}"/>
         <property name="convPdfToSvgTimeout" value="${svgConversionTimeout}"/>


### PR DESCRIPTION
* Fixed the command that counts the number of `<path />` elements in the SVG.
* Added a function to count `<use />` elements and rasterize the SVG when their count exceeds 10k (default).
* Introduced a new configuration option `useTagThreshold=10000` to customize this limit.

Closes #24143

---

The reported PPTX produced an SVG containing **267,036 `<use>`** elements and **2,533 `<path>`** elements.
It should have been rasterized since the `<path>` limit is 800, but the command responsible for that check was malfunctioning.

After testing multiple SVGs, none exceeded 3k `<use>` elements, so a 10k threshold remains a safe default.