### PR TITLE
build: Add dependency on libmagickcore-extra (bbb-web)

### DIFF
--- a/build/packages-template/bbb-web/opts-jammy.sh
+++ b/build/packages-template/bbb-web/opts-jammy.sh
@@ -2,4 +2,4 @@
 
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d zip,unzip,imagemagick,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-17-jdk,file,potrace"
+OPTS="$OPTS -t deb -d zip,unzip,imagemagick,libmagickcore-extra,redis-server,xpdf-utils,bbb-libreoffice-docker,psmisc,fonts-crosextra-carlito,fonts-crosextra-caladea,fonts-noto,openjdk-17-jdk,file,potrace"


### PR DESCRIPTION
Seems for some servers libmagickcore-6.q16-6-extra is not auto installed and slides do not get properly converted https://github.com/bigbluebutton/bigbluebutton/issues/23726 Here I am trying to add the dependency to the -extra package in a more flexible way (not only for -6.q16-6)

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Seems for some servers libmagickcore-6.q16-6-extra is not auto installed and slides do not get properly converted https://github.com/bigbluebutton/bigbluebutton/issues/23726 Here I am trying to add the dependency to the -extra package in a more flexible way (not only for -6.q16-6)


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23726

### Motivation
<!-- What inspired you to submit this pull request? -->
Some Ubuntu 22.04 servers seem to not have package `libmagickcore-6.q16-6-extra`, causing right-hand-side of slides to not be visible. The servers I have access to all have both `imagemagick` and this library.

### More

```
$ apt show libmagickcore-6.q16-6-extra | grep Provides

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Provides: libmagickcore-6.q16-1-extra, libmagickcore-6.q16-2-extra, libmagickcore-6.q16-3-extra, libmagickcore-6.q16-4-extra, libmagickcore-6.q16-5-extra, libmagickcore-extra
```

However,

```
#  apt install libmagickcore-extra
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package libmagickcore-extra is a virtual package provided by:
  libmagickcore-6.q16hdri-6-extra 8:6.9.11.60+dfsg-1.3ubuntu0.22.04.5
  libmagickcore-6.q16-6-extra 8:6.9.11.60+dfsg-1.3ubuntu0.22.04.5
You should explicitly select one to install.

E: Package 'libmagickcore-extra' has no installation candidate
```

So I am not 100% confident if I can keep this flexible.