### PR TITLE
feat(plugin): private chat messages commands

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/chat/create-private-chat/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/chat/create-private-chat/manager.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { CreatePrivateChatCommandArguments } from 'bigbluebutton-html-plugin-sdk/dist/cjs/server-commands/chat/types';
+import { useMutation } from '@apollo/client';
+import {
+  ChatCommandsEnum,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/server-commands/chat/enum';
+import { CHAT_CREATE_WITH_USER } from '/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/mutations';
+
+const PluginCreatePrivateChatServerCommandsManager = () => {
+  const [chatCreateWithUser] = useMutation(CHAT_CREATE_WITH_USER);
+
+  const handleCreatePrivateChat = ((
+    event: CustomEvent<CreatePrivateChatCommandArguments>,
+  ) => {
+    const { userId } = event.detail;
+    chatCreateWithUser({
+      variables: {
+        userId,
+      },
+    });
+  }) as EventListener;
+
+  useEffect(() => {
+    window.addEventListener(ChatCommandsEnum.CREATE_PRIVATE_CHAT, handleCreatePrivateChat);
+
+    return () => {
+      window.removeEventListener(ChatCommandsEnum.CREATE_PRIVATE_CHAT, handleCreatePrivateChat);
+    };
+  }, []);
+
+  return null;
+};
+
+export default PluginCreatePrivateChatServerCommandsManager;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/handler.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import PluginSaveCaptionServerCommandsManager from './caption/save/manager';
 import PluginAddLocaleCaptionServerCommandsManager from './caption/add-locale/manager';
 import PluginSendMessageChatServerCommandsManager from './chat/send-message/manager';
+import PluginCreatePrivateChatServerCommandsManager from './chat/create-private-chat/manager';
 
 const PluginServerCommandsHandler = () => (
   <>
     <PluginSaveCaptionServerCommandsManager />
     <PluginAddLocaleCaptionServerCommandsManager />
     <PluginSendMessageChatServerCommandsManager />
+    <PluginCreatePrivateChatServerCommandsManager />
   </>
 );
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/chat/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/chat/handler.tsx
@@ -3,32 +3,17 @@ import {
   ChatFormCommandsEnum,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/form/enums';
 import {
-  ChatUiCommandsEnum,
-} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/enums';
-import {
-  OpenPrivateChatCommandArguments,
-} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/types';
+  OpenChatFormCommandArguments,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/form/types';
 import { layoutDispatch } from '../../../layout/context';
 import { PANELS, ACTIONS } from '../../../layout/enums';
 
 const PluginChatUiCommandsHandler = () => {
   const layoutContextDispatch = layoutDispatch();
+  const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
 
-  const handleChatFormsOpen = () => {
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-      value: true,
-    });
-    layoutContextDispatch({
-      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
-      value: PANELS.CHAT,
-    });
-  };
-
-  const handleOpenPrivateChat = ((event: CustomEvent<OpenPrivateChatCommandArguments>) => {
-    const { chatId } = event.detail;
-
-    // Open the sidebar with chat panel
+  const handleChatFormsOpen = ((event: CustomEvent<OpenChatFormCommandArguments>) => {
+    const { chatId } = event?.detail || { chatId: null };
     layoutContextDispatch({
       type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
       value: true,
@@ -38,20 +23,25 @@ const PluginChatUiCommandsHandler = () => {
       value: PANELS.CHAT,
     });
 
-    // Set the specific chat to open
-    layoutContextDispatch({
-      type: ACTIONS.SET_ID_CHAT_OPEN,
-      value: chatId,
-    });
+    if (chatId !== null) {
+      // Set the specific chat to open
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: chatId,
+      });
+    } else {
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: PUBLIC_CHAT_ID,
+      });
+    }
   }) as EventListener;
 
   useEffect(() => {
     window.addEventListener(ChatFormCommandsEnum.OPEN, handleChatFormsOpen);
-    window.addEventListener(ChatUiCommandsEnum.OPEN_PRIVATE_CHAT, handleOpenPrivateChat);
 
     return () => {
       window.removeEventListener(ChatFormCommandsEnum.OPEN, handleChatFormsOpen);
-      window.removeEventListener(ChatUiCommandsEnum.OPEN_PRIVATE_CHAT, handleOpenPrivateChat);
     };
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/chat/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/chat/handler.tsx
@@ -2,6 +2,12 @@ import { useEffect } from 'react';
 import {
   ChatFormCommandsEnum,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/form/enums';
+import {
+  ChatUiCommandsEnum,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/enums';
+import {
+  OpenPrivateChatCommandArguments,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/chat/types';
 import { layoutDispatch } from '../../../layout/context';
 import { PANELS, ACTIONS } from '../../../layout/enums';
 
@@ -19,13 +25,36 @@ const PluginChatUiCommandsHandler = () => {
     });
   };
 
+  const handleOpenPrivateChat = ((event: CustomEvent<OpenPrivateChatCommandArguments>) => {
+    const { chatId } = event.detail;
+
+    // Open the sidebar with chat panel
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: true,
+    });
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: PANELS.CHAT,
+    });
+
+    // Set the specific chat to open
+    layoutContextDispatch({
+      type: ACTIONS.SET_ID_CHAT_OPEN,
+      value: chatId,
+    });
+  }) as EventListener;
+
   useEffect(() => {
     window.addEventListener(ChatFormCommandsEnum.OPEN, handleChatFormsOpen);
+    window.addEventListener(ChatUiCommandsEnum.OPEN_PRIVATE_CHAT, handleOpenPrivateChat);
 
     return () => {
-      window.addEventListener(ChatFormCommandsEnum.OPEN, handleChatFormsOpen);
+      window.removeEventListener(ChatFormCommandsEnum.OPEN, handleChatFormsOpen);
+      window.removeEventListener(ChatUiCommandsEnum.OPEN_PRIVATE_CHAT, handleOpenPrivateChat);
     };
   }, []);
+
   return null;
 };
 

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -30,7 +30,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.94",
+        "bigbluebutton-html-plugin-sdk": "0.0.95",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -5974,9 +5974,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.94",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.94.tgz",
-      "integrity": "sha512-sBTrpD03CdQ11CH6L1OA7gDe6vBqJ1RxHkNY68pNwhlB7pdrVwdhW++YzGLCTyBcih+TCetupAZ/dixM1a7IdQ==",
+      "version": "0.0.95",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.95.tgz",
+      "integrity": "sha512-b4Uq2Vqpe+YWuC1Ofq5USCR3/IjOFLOGO8sbDAipr4RijOBdjQe4y5RwKoi3vIItlqTSTKxR5+rc7VBjvoNOAQ==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -57,7 +57,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.94",
+    "bigbluebutton-html-plugin-sdk": "0.0.95",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -548,4 +548,4 @@ pluginManifests=
 # List the parameters without including the 'userdata-' prefix
 getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools
 
-html5PluginSdkVersion=0.0.94
+html5PluginSdkVersion=0.0.95

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -991,7 +991,7 @@ As seen for the `useUiData`, the return type is well defined by the enum chosen 
   - setSelfViewDisable: Sets the self-view camera disabled/enabled for specific camera.
 - chat:
   - form:
-    - open: this function will open the sidebar chat panel automatically;
+    - open: this function will open the sidebar chat panel automatically. Optionally accepts `{chatId: string}` to open a specific chat;
     - fill: this function will fill the form input field of the chat passed in the argument as `{text: string}`
 - conference:
   - setSpeakerLevel: this function will set the speaker volume level(audio output) of the conference to a certain number between 0 and 1;
@@ -1030,9 +1030,11 @@ So the idea is that we have a `uiCommands` object and at a point, there will be 
 `serverCommands` object: It contains all the possible commands available to the developer to interact with the BBB core server, see the ones implemented down below:
 
   - chat:
-    - sendPublicChatMessage: This function sends a message to the public chat on behalf of the currently logged-in user.
-    - sendCustomPublicMessage: This function sends a text message to the public chat, optionally including custom metadata.
+    - sendChatMessage: This function sends a message to a specific chat by chatId on behalf of the currently logged-in user
+    - sendPublicChatMessage: This function sends a message to the public chat on behalf of the currently logged-in user
+    - sendCustomPublicMessage: This function sends a text message to the public chat, optionally including custom metadata
       > **Note**: The custom messages sent by plugins are not automatically rendered by the client. To display these messages, a plugin must handle the rendering using `useLoadedChatMessages` and `useChatMessageDomElements`.
+    - createPrivateChat: This function creates a private chat with a specific user
 
   - caption:
     - save: this function saves the given text, locale and caption type


### PR DESCRIPTION
### What does this PR do?

This pull request adds private chat support for BigBlueButton plugins, enabling plugins to programmatically create private chats and interact with them through new server commands and UI commands.

**Changes made:**

1. **Server Commands - Chat**:
   - Added `sendChatMessage()` - Send messages to specific chats by chatId
   - Added `createPrivateChat()` - Create private chats with specific users

2. **UI Commands - Chat Form**:
   - Enhanced `open()` - Now accepts optional chatId parameter to open specific chats

3. **Updated Sample Plugin**:
   - Updated `sample-ui-commands-plugin` to demonstrate the new private chat features
   - Shows complete workflow: create private chat, open it, and fill the form

4. **Documentation**:
   - Updated `docs/plugins.md` with new private chat commands

### Motivation

This PR extends the plugin SDK to support private chat operations, enabling use cases such as:

- Automated private messaging between users
- Custom chat routing logic
- Enhanced collaboration features
- Private notification systems

### More

Closely related to: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/239

- [x] Added/updated documentation
- Sample plugin demonstrates complete private chat workflow
- Backward compatible - all existing commands maintain their original behavior
- New commands follow existing SDK patterns and conventions

See demo video ahead:

https://github.com/user-attachments/assets/a94a8bb6-7ee1-42c9-ae03-60edaf37352f

