### PR TITLE
test: Upload multiple presentations to flaky

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.js
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.js
@@ -88,7 +88,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#uploading-multiple-presentations-automated
-    test('Upload multiple presentations', async ({ browser, context, page }, testInfo) => {
+    test('Upload multiple presentations', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, testInfo);
       await presentation.uploadMultiplePresentationsTest();


### PR DESCRIPTION
### What does this PR do?
Changes the test "Upload Multiple Presentations" to be flaky, the upload is too fast, and the processing file notification is not appearing. This only happens on automated tests; manual tests are ok.
