### PR TITLE
tests(fix): Increase sleep duration for presentation minimize and add checks for zoom buttons

### DIFF
--- a/bigbluebutton-tests/playwright/parameters/customparameters.js
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.js
@@ -294,9 +294,17 @@ class CustomParameters extends MultiUsers {
       await this.userPage.waitAndClick(e.minimizePresentation);
     }
     await this.userPage.wasRemoved(e.whiteboard, 'should remove the whiteboard element for the attendee when minimized');
-    await sleep(1000);  // first minimize of presentation takes longer to be fully applied
+    await sleep(2000);  // first minimize of presentation takes longer to be fully applied
     // zoom in
     await this.modPage.waitAndClick(e.zoomInButton);
+    await expect(
+      this.modPage.page.locator(e.resetZoomButton),
+      'should enable the reset zoom button after zooming in'
+    ).not.toBeDisabled();
+    await expect(
+      this.modPage.page.locator(e.zoomOutButton),
+      'should enable the zoom out button after zooming in'
+    ).not.toBeDisabled();
     await this.userPage.hasElement(e.whiteboard, 'should restore presentation when zooming in the slide');
     await this.userPage.hasElement(e.minimizePresentation, 'should display the minimize presentation button when the presentation is restored');
     await this.userPage.waitAndClick(e.minimizePresentation);


### PR DESCRIPTION
### What does this PR do?
This PR adds new button assertions when zooming in on the presentation and also increases the time between the first presentation minimize and mod actions that will restore the user's presentation.

This is intended to avoid recent CI failures on the test `Custom Parameters › Presentation › Force restore presentation on new events`, which I was able to reproduce locally very few times, not consistently

<img width="1216" height="499" alt="image" src="https://github.com/user-attachments/assets/00163140-9961-44ca-9a6c-b28fb859ebfb" />
