### PR TITLE
fix (bbb-web): Handle unsupported Accept formats in `/create` requests after Grails 7 upgrade

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -115,6 +115,16 @@ class ApiController {
                   RESP_CODE_SUCCESS),
                   contentType: "text/xml")
         }
+        '*' {
+          render(text: responseBuilder.buildMeetingVersion(
+                  paramsProcessorUtil.getApiVersion(),
+                  paramsProcessorUtil.getBbbVersion(),
+                  paramsProcessorUtil.getGraphqlWebsocketUrl(),
+                  paramsProcessorUtil.getHtml5PluginSdkVersion(),
+                  paramsProcessorUtil.getGraphqlApiUrl(),
+                  RESP_CODE_SUCCESS),
+                  contentType: "text/xml")
+        }
       }
     }
   }
@@ -369,6 +379,10 @@ class ApiController {
               render(text: responseBuilder.buildError("Params required", "You must enter a valid password",
                       RESP_CODE_FAILED), contentType: "text/xml")
             }
+            '*' {
+              render(text: responseBuilder.buildError("Params required", "You must enter a valid password",
+                      RESP_CODE_FAILED), contentType: "text/xml")
+            }
           }
           return
         }
@@ -378,6 +392,10 @@ class ApiController {
         response.addHeader("Cache-Control", "no-cache")
         withFormat {
           xml {
+            render(text: responseBuilder.buildError("Params required", "You must send the 'role' parameter, since " +
+                    "this meeting doesn't have any password.", RESP_CODE_FAILED), contentType: "text/xml")
+          }
+         '*' {
             render(text: responseBuilder.buildError("Params required", "You must send the 'role' parameter, since " +
                     "this meeting doesn't have any password.", RESP_CODE_FAILED), contentType: "text/xml")
           }
@@ -391,6 +409,10 @@ class ApiController {
       response.addHeader("Cache-Control", "no-cache")
       withFormat {
         xml {
+          render(text: responseBuilder.buildError("Params required", "You must either send the valid role of the user, or " +
+                  "the password, sould the meeting has one.", RESP_CODE_FAILED), contentType: "text/xml")
+        }
+        '*' {
           render(text: responseBuilder.buildError("Params required", "You must either send the valid role of the user, or " +
                   "the password, sould the meeting has one.", RESP_CODE_FAILED), contentType: "text/xml")
         }
@@ -589,6 +611,9 @@ class ApiController {
         xml {
           render(text: responseBuilder.buildJoinMeeting(us, session[sessionToken], guestStatusVal, destUrl, msgKey, msgValue, RESP_CODE_SUCCESS), contentType: "text/xml")
         }
+        '*' {
+          render(text: responseBuilder.buildJoinMeeting(us, session[sessionToken], guestStatusVal, destUrl, msgKey, msgValue, RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
       }
     }
   }
@@ -715,6 +740,9 @@ class ApiController {
         xml {
           render(text: responseBuilder.buildJoinMeeting(us, session[sessionToken], guestStatusVal, destUrl, msgKey, msgValue, RESP_CODE_SUCCESS), contentType: "text/xml")
         }
+        '*' {
+          render(text: responseBuilder.buildJoinMeeting(us, session[sessionToken], guestStatusVal, destUrl, msgKey, msgValue, RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
       }
     }
   }
@@ -757,6 +785,11 @@ class ApiController {
       xml {
         render(contentType: "text/xml") {
           render(text: responseBuilder.buildIsMeetingRunning(isRunning, RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
+      }
+      '*' {
+        render(contentType: "text/xml") {
+            render(text: responseBuilder.buildIsMeetingRunning(isRunning, RESP_CODE_SUCCESS), contentType: "text/xml")
         }
       }
     }
@@ -802,6 +835,11 @@ class ApiController {
           render(text: responseBuilder.buildEndRunning("sentEndMeetingRequest", "A request to end the meeting was sent.  Please wait a few seconds, and then use the getMeetingInfo or isMeetingRunning API calls to verify that it was ended.", RESP_CODE_SUCCESS), contentType: "text/xml")
         }
       }
+      '*' {
+        render(contentType: "text/xml") {
+            render(text: responseBuilder.buildEndRunning("sentEndMeetingRequest", "A request to end the meeting was sent.  Please wait a few seconds, and then use the getMeetingInfo or isMeetingRunning API calls to verify that it was ended.", RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
+      }
     }
   }
 
@@ -827,6 +865,9 @@ class ApiController {
 
     withFormat {
       xml {
+        render(text: responseBuilder.buildGetMeetingInfoResponse(meeting, RESP_CODE_SUCCESS), contentType: "text/xml")
+      }
+      '*' {
         render(text: responseBuilder.buildGetMeetingInfoResponse(meeting, RESP_CODE_SUCCESS), contentType: "text/xml")
       }
     }
@@ -857,12 +898,18 @@ class ApiController {
         xml {
           render(text: responseBuilder.buildGetMeetingsResponse(mtgs, "noMeetings", "no meetings were found on this server", RESP_CODE_SUCCESS), contentType: "text/xml")
         }
+        '*' {
+          render(text: responseBuilder.buildGetMeetingsResponse(mtgs, "noMeetings", "no meetings were found on this server", RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
       }
     } else {
       response.addHeader("Cache-Control", "no-cache")
 
       withFormat {
         xml {
+          render(text: responseBuilder.buildGetMeetingsResponse(mtgs, null, null, RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
+        '*' {
           render(text: responseBuilder.buildGetMeetingsResponse(mtgs, null, null, RESP_CODE_SUCCESS), contentType: "text/xml")
         }
       }
@@ -894,6 +941,9 @@ class ApiController {
         xml {
           render(text: responseBuilder.buildGetSessionsResponse(sssns, "noSessions", "no sessions were found on this serverr", RESP_CODE_SUCCESS), contentType: "text/xml")
         }
+        '*' {
+          render(text: responseBuilder.buildGetSessionsResponse(sssns, "noSessions", "no sessions were found on this serverr", RESP_CODE_SUCCESS), contentType: "text/xml")
+        }
       }
     } else {
       response.addHeader("Cache-Control", "no-cache")
@@ -901,6 +951,11 @@ class ApiController {
         xml {
           render(contentType: "text/xml") {
             render(text: responseBuilder.buildGetSessionsResponse(sssns, null, null, RESP_CODE_SUCCESS), contentType: "text/xml")
+          }
+        }
+        '*' {
+          render(contentType: "text/xml") {
+              render(text: responseBuilder.buildGetSessionsResponse(sssns, null, null, RESP_CODE_SUCCESS), contentType: "text/xml")
           }
         }
       }
@@ -1045,6 +1100,10 @@ class ApiController {
         // No need to use the response builder here until we have a more complex response
         render(text: "<response><returncode>$RESP_CODE_SUCCESS</returncode></response>", contentType: "text/xml")
       }
+      '*' {
+        // No need to use the response builder here until we have a more complex response
+        render(text: "<response><returncode>$RESP_CODE_SUCCESS</returncode></response>", contentType: "text/xml")
+      }
     }
   }
 
@@ -1080,10 +1139,18 @@ class ApiController {
             render(text: responseBuilder.buildInsertDocumentResponse("Presentation is being uploaded", RESP_CODE_SUCCESS)
                     , contentType: "text/xml")
           }
+          '*' {
+            render(text: responseBuilder.buildInsertDocumentResponse("Presentation is being uploaded", RESP_CODE_SUCCESS)
+                    , contentType: "text/xml")
+          }
         }
       } else if (meetingService.isMeetingWithDisabledPresentation(meeting.getInternalId())) {
         withFormat {
           xml {
+            render(text: responseBuilder.buildInsertDocumentResponse("Presentation feature is disabled, ignoring.",
+                    RESP_CODE_FAILED), contentType: "text/xml")
+          }
+          '*' {
             render(text: responseBuilder.buildInsertDocumentResponse("Presentation feature is disabled, ignoring.",
                     RESP_CODE_FAILED), contentType: "text/xml")
           }
@@ -1093,6 +1160,11 @@ class ApiController {
       log.warn("Meeting with externalID ${externalMeetingId} doesn't exist.")
       withFormat {
         xml {
+          render(text: responseBuilder.buildInsertDocumentResponse(
+                  "Meeting with id [${externalMeetingId}] not found.", RESP_CODE_FAILED),
+                  contentType: "text/xml")
+        }
+        '*' {
           render(text: responseBuilder.buildInsertDocumentResponse(
                   "Meeting with id [${externalMeetingId}] not found.", RESP_CODE_FAILED),
                   contentType: "text/xml")
@@ -1133,6 +1205,10 @@ class ApiController {
     meetingService.sendChatMessage(meeting.internalId, userName, chatMessage);
     withFormat {
       xml {
+        render(text: responseBuilder.buildSendChatMessageResponse("Message successfully sent", RESP_CODE_SUCCESS)
+                , contentType: "text/xml")
+      }
+      '*' {
         render(text: responseBuilder.buildSendChatMessageResponse("Message successfully sent", RESP_CODE_SUCCESS)
                 , contentType: "text/xml")
       }
@@ -1760,6 +1836,9 @@ class ApiController {
         log.debug "Rendering as xml"
         render(text: responseBuilder.buildMeeting(meeting, msgKey, msg, RESP_CODE_SUCCESS), contentType: "text/xml")
       }
+      '*' {
+          render(text: responseBuilder.buildMeeting(meeting, msgKey, msg, RESP_CODE_SUCCESS), contentType: 'text/xml')
+      }
     }
   }
 
@@ -1917,6 +1996,9 @@ class ApiController {
           }
           render(contentType: "application/json", text: builder.toPrettyString())
         }
+        '*' {
+            render(text: responseBuilder.buildErrors(errorList.getErrors(), RESP_CODE_FAILED), contentType: "text/xml")
+        }
       }
     }
   }
@@ -1951,6 +2033,9 @@ class ApiController {
             message msg
           }
           render(contentType: "application/json", text: builder.toPrettyString())
+        }
+        '*' {
+          render(text: responseBuilder.buildError(key, msg, RESP_CODE_FAILED), contentType: "text/xml")
         }
       }
     }


### PR DESCRIPTION
* Fix an issue where requests to `/create` specifying `text/plain` in the `Accept` header caused `bbb-web` to throw an error due to unsupported format handling.

After upgrading to Grails 7, the framework began respecting the order of values in the `Accept` header. When a request included `Accept: application/json, text/plain, */*`, content negotiation could select a format (JSON or text) without a corresponding `withFormat` block, leading to no render being executed. Grails then attempted to locate `create` or `error` views, resulting in 500 errors.

Adding a `'*' { … }` fallback block to each `withFormat` ensures that unsupported formats are handled gracefully (rendering the XML response instead) and prevents errors regardless of the `Accept` header content.

---

**How we found it / How to reproduce:**
Playwright sends a request with the following header:

```bash
curl -s -X GET "https://bbb30.bbb.imdt.dev/bigbluebutton/api/create?$PARAMS&checksum=$CHECKSUM" \
  --header "Accept: application/json, text/plain, */*"
```

Return before this PR:
```html
<!doctype html>
<html lang="en">
<head><title>HTTP Status 500 – Internal Server Error</title>
<style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style>
</head>
<body><h1>HTTP Status 500 – Internal Server Error</h1></body>
</html>
```

Return after this PR:
```xml
<response>
<returncode>SUCCESS</returncode>
<meetingID>2025-11-07-13-09-20-571</meetingID>
<internalMeetingID>9d48d98fcac9e1b005e6549d22509a415b8a1e44-1762531760618</internalMeetingID>
<parentMeetingID>bbb-none</parentMeetingID>
<attendeePW>ap</attendeePW>
<moderatorPW>mp</moderatorPW>
<createTime>1762531760618</createTime>
<voiceBridge>0920572</voiceBridge>
<dialNumber>613-555-1234</dialNumber>
<createDate>Fri Nov 07 16:09:20 UTC 2025</createDate>
<hasUserJoined>false</hasUserJoined>
<duration>0</duration>
<hasBeenForciblyEnded>false</hasBeenForciblyEnded>
<messageKey></messageKey>
<message></message>
* Connection #0 to host bbb30.bbb.imdt.dev left intact
</response>
```