### PR TITLE
Ref(html5): Re-introduce raise hand audio notification and full user options for raised hand users list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -46,6 +46,7 @@ import { notify } from '/imports/ui/services/notification';
 import VoiceActivityAdapter from '../../core/adapters/voice-activity';
 import LayoutObserver from '../layout/observer';
 import BBBLiveKitRoomContainer from '/imports/ui/components/livekit/component';
+import RaiseHandNotifier from '/imports/ui/components/raisehand-notifier/container';
 
 const intlMessages = defineMessages({
   userListLabel: {
@@ -114,6 +115,7 @@ const propTypes = {
   darkTheme: PropTypes.bool.isRequired,
   hideNotificationToasts: PropTypes.bool.isRequired,
   isBreakout: PropTypes.bool.isRequired,
+  isRaiseHandEnabled: PropTypes.bool.isRequired,
   meetingId: PropTypes.string.isRequired,
   meetingName: PropTypes.string.isRequired,
 };
@@ -333,6 +335,7 @@ class App extends Component {
       hideNotificationToasts,
       isNotificationEnabled,
       isNonMediaLayout,
+      isRaiseHandEnabled,
     } = this.props;
 
     const {
@@ -409,6 +412,7 @@ class App extends Component {
             !hideNotificationToasts
             && isNotificationEnabled) && <ToastContainer rtl /> }
           <ChatAlertContainerGraphql />
+          {isRaiseHandEnabled && <RaiseHandNotifier />}
           <ManyWebcamsNotifier />
           <PollingContainer />
           <WakeLockContainer />

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
@@ -63,7 +63,7 @@ const RaiseHandNotifier: React.FC<RaiseHandNotifierProps> = ({
     const previousUserIdsSet = new Set(previousUserIdsRef.current);
     const newRaisedHandUsers = raiseHandUsers.filter(
       (user) => !previousUserIdsSet.has(user.userId),
-    );
+    ).filter((user) => isPresenter && user.userId !== currentUserId);
     const hasNewRaisedHand = newRaisedHandUsers.length > 0;
     const isAllowed = isModerator || isPresenter;
 

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import AudioService from '/imports/ui/components/audio/service';
+
+type RaiseHandNotifierProps = {
+  raiseHandUsers: Array<{ userId: string }>;
+  raiseHandAudioAlert: boolean;
+  isModerator: boolean;
+  isPresenter: boolean;
+};
+
+const getRaiseHandSoundUrl = () => {
+  const { cdn, basename } = window.meetingClientSettings.public.app;
+  return `${cdn + basename}/resources/sounds/bbb-handRaise.mp3`;
+};
+
+const RaiseHandNotifier: React.FC<RaiseHandNotifierProps> = ({
+  raiseHandUsers,
+  raiseHandAudioAlert,
+  isModerator,
+  isPresenter,
+}) => {
+  const previousUserIdsRef = React.useRef<string[] | null>(null);
+
+  React.useEffect(() => {
+    const currentUserIds = raiseHandUsers.map((user) => user.userId);
+
+    if (previousUserIdsRef.current === null) {
+      previousUserIdsRef.current = currentUserIds;
+      return;
+    }
+
+    const isAllowed = raiseHandAudioAlert && (isModerator || isPresenter);
+
+    if (isAllowed) {
+      const previousUserIdsSet = new Set(previousUserIdsRef.current);
+      const hasNewRaisedHand = currentUserIds.some((id) => !previousUserIdsSet.has(id));
+
+      if (hasNewRaisedHand) {
+        AudioService.playAlertSound(getRaiseHandSoundUrl());
+      }
+    }
+
+    previousUserIdsRef.current = currentUserIds;
+  }, [raiseHandUsers, raiseHandAudioAlert, isModerator, isPresenter]);
+
+  return null;
+};
+
+export default RaiseHandNotifier;

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
@@ -1,27 +1,58 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import AudioService from '/imports/ui/components/audio/service';
+import { notify } from '/imports/ui/services/notification';
+import { RaisedHandUser } from '/imports/ui/core/graphql/queries/users';
 
 type RaiseHandNotifierProps = {
-  raiseHandUsers: Array<{ userId: string }>;
+  raiseHandUsers: RaisedHandUser[];
   raiseHandAudioAlert: boolean;
+  raiseHandPushAlert: boolean;
   isModerator: boolean;
   isPresenter: boolean;
+  currentUserId: string;
 };
 
-const getRaiseHandSoundUrl = () => {
-  const { cdn, basename } = window.meetingClientSettings.public.app;
-  return `${cdn + basename}/resources/sounds/bbb-handRaise.mp3`;
-};
+const intlMessages = defineMessages({
+  raisedHandSingle: {
+    id: 'app.statusNotifier.raisedHandDescOneUser',
+    description: 'Label for a single user with raised hand',
+  },
+  raisedHandMultiple: {
+    id: 'app.statusNotifier.raisedHandDesc',
+    description: 'Label for multiple users with raised hand',
+  },
+});
 
 const RaiseHandNotifier: React.FC<RaiseHandNotifierProps> = ({
   raiseHandUsers,
   raiseHandAudioAlert,
+  raiseHandPushAlert,
   isModerator,
   isPresenter,
+  currentUserId,
 }) => {
-  const previousUserIdsRef = React.useRef<string[] | null>(null);
+  const intl = useIntl();
+  const previousUserIdsRef = useRef<string[] | null>(null);
 
-  React.useEffect(() => {
+  const getRaiseHandSoundUrl = () => {
+    const { cdn, basename } = window.meetingClientSettings.public.app;
+    return `${cdn + basename}/resources/sounds/bbb-handRaise.mp3`;
+  };
+
+  const buildRaisedHandMessage = (names: string[]) => {
+    if (names.length === 0) return null;
+
+    const formattedNames = names.join(', ');
+
+    if (names.length === 1) {
+      return intl.formatMessage(intlMessages.raisedHandSingle, { userNames: formattedNames });
+    }
+
+    return intl.formatMessage(intlMessages.raisedHandMultiple, { userNames: formattedNames });
+  };
+
+  useEffect(() => {
     const currentUserIds = raiseHandUsers.map((user) => user.userId);
 
     if (previousUserIdsRef.current === null) {
@@ -29,19 +60,41 @@ const RaiseHandNotifier: React.FC<RaiseHandNotifierProps> = ({
       return;
     }
 
-    const isAllowed = raiseHandAudioAlert && (isModerator || isPresenter);
+    const previousUserIdsSet = new Set(previousUserIdsRef.current);
+    const newRaisedHandUsers = raiseHandUsers.filter(
+      (user) => !previousUserIdsSet.has(user.userId),
+    );
+    const hasNewRaisedHand = newRaisedHandUsers.length > 0;
+    const isAllowed = isModerator || isPresenter;
 
-    if (isAllowed) {
-      const previousUserIdsSet = new Set(previousUserIdsRef.current);
-      const hasNewRaisedHand = currentUserIds.some((id) => !previousUserIdsSet.has(id));
-
-      if (hasNewRaisedHand) {
+    if (hasNewRaisedHand && isAllowed) {
+      if (raiseHandAudioAlert) {
         AudioService.playAlertSound(getRaiseHandSoundUrl());
+      }
+
+      if (raiseHandPushAlert) {
+        const nonCurrentUser = newRaisedHandUsers
+          .filter((user) => user.userId !== currentUserId);
+        const names = nonCurrentUser
+          .map((user) => user.name)
+          .filter((name): name is string => !!name && name.length > 0);
+        const message = buildRaisedHandMessage(names);
+
+        if (message) {
+          notify(message, 'info', 'hand');
+        }
       }
     }
 
     previousUserIdsRef.current = currentUserIds;
-  }, [raiseHandUsers, raiseHandAudioAlert, isModerator, isPresenter]);
+  }, [
+    intl,
+    isModerator,
+    isPresenter,
+    raiseHandAudioAlert,
+    raiseHandPushAlert,
+    raiseHandUsers,
+  ]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/container.tsx
@@ -13,6 +13,7 @@ const RaiseHandNotifierContainer: React.FC = () => {
   const { data: currentUser } = useCurrentUser((user: Partial<User>) => ({
     isModerator: user?.isModerator ?? false,
     presenter: user?.presenter ?? false,
+    userId: user?.userId ?? '',
   }));
 
   const {
@@ -29,15 +30,17 @@ const RaiseHandNotifierContainer: React.FC = () => {
     }, 'Error on requesting raise hand data');
   }
   // @ts-ignore
-  const { raiseHandAudioAlerts } = useSettings(SETTINGS.APPLICATION);
+  const { raiseHandAudioAlerts, raiseHandPushAlerts } = useSettings(SETTINGS.APPLICATION);
   if (!currentUser) return null;
 
   return (
     <RaiseHandNotifier
       raiseHandUsers={raiseHandUsers}
       raiseHandAudioAlert={!!raiseHandAudioAlerts}
+      raiseHandPushAlert={!!raiseHandPushAlerts}
       isModerator={!!currentUser.isModerator}
       isPresenter={!!currentUser.presenter}
+      currentUserId={currentUser.userId ?? ''}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/container.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import logger from '/imports/startup/client/logger';
+import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import { RAISED_HAND_USERS, RaisedHandUsersSubscriptionResponse } from '/imports/ui/core/graphql/queries/users';
+import RaiseHandNotifier from './component';
+import useSettings from '/imports/ui/services/settings/hooks/useSettings';
+import { SETTINGS } from '/imports/ui/services/settings/enums';
+import { User } from '/imports/ui/Types/user';
+import connectionStatus from '../../core/graphql/singletons/connectionStatus';
+
+const RaiseHandNotifierContainer: React.FC = () => {
+  const { data: currentUser } = useCurrentUser((user: Partial<User>) => ({
+    isModerator: user?.isModerator ?? false,
+    presenter: user?.presenter ?? false,
+  }));
+
+  const {
+    data: usersData,
+    error: usersError,
+  } = useDeduplicatedSubscription<RaisedHandUsersSubscriptionResponse>(RAISED_HAND_USERS);
+  const raiseHandUsers = usersData?.user ?? [];
+
+  if (usersError) {
+    connectionStatus.setSubscriptionFailed(true);
+    logger.error({
+      logCode: 'raisehand_notifier_container_subscription_error',
+      extraInfo: { usersError },
+    }, 'Error on requesting raise hand data');
+  }
+  // @ts-ignore
+  const { raiseHandAudioAlerts } = useSettings(SETTINGS.APPLICATION);
+  if (!currentUser) return null;
+
+  return (
+    <RaiseHandNotifier
+      raiseHandUsers={raiseHandUsers}
+      raiseHandAudioAlert={!!raiseHandAudioAlerts}
+      isModerator={!!currentUser.isModerator}
+      isPresenter={!!currentUser.presenter}
+    />
+  );
+};
+
+export default RaiseHandNotifierContainer;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/raised-hands/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/raised-hands/component.tsx
@@ -4,7 +4,7 @@ import { useMutation } from '@apollo/client';
 import logger from '/imports/startup/client/logger';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Styled from './styles';
-import { RAISED_HAND_USERS } from '/imports/ui/core/graphql/queries/users';
+import { RAISED_HAND_USERS, RaisedHandUser, RaisedHandUsersSubscriptionResponse } from '/imports/ui/core/graphql/queries/users';
 import { SET_RAISE_HAND } from '/imports/ui/core/graphql/mutations/userMutations';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import UserListStyles from '../user-participants/user-list-participants/list-item/styles';
@@ -36,26 +36,6 @@ const intlMessages = defineMessages({
   },
 
 });
-
-type RaisedHandUser = {
-  userId: string;
-  name: string;
-  color?: string;
-  presenter?: boolean;
-  isModerator?: boolean;
-  raiseHand?: boolean;
-  whiteboardWriteAccess?: boolean;
-  userAvatarFiltered?: string;
-  avatarContent?: React.ReactNode;
-  voiceUser?: {
-    joined: boolean;
-    talking: boolean;
-    muted: boolean;
-    listenOnly: boolean;
-    listenOnlyInputDevice: boolean;
-    deafened: boolean;
-  };
-};
 
 interface RaisedHandsComponentProps {
   raisedHands: RaisedHandUser[];
@@ -120,7 +100,6 @@ const RaisedHandsComponent: React.FC<RaisedHandsComponentProps> = ({
         open={user.userId === openUserAction}
         setOpenUserAction={setOpenUserAction}
         isBreakout={meeting.isBreakout}
-        type="raised-hand"
       >
         <UserListStyles.UserItemContents id={`raised-hand-index-${index}`} tabIndex={-1} role="listitem">
           <UserListStyles.Avatar
@@ -204,7 +183,7 @@ const RaisedHandsContainer: React.FC = () => {
   const {
     data: usersData,
     error: usersError,
-  } = useDeduplicatedSubscription<{ user: RaisedHandUser[] }>(RAISED_HAND_USERS);
+  } = useDeduplicatedSubscription<RaisedHandUsersSubscriptionResponse>(RAISED_HAND_USERS);
   const raisedHands: RaisedHandUser[] = usersData?.user ?? [];
 
   const [setRaiseHand] = useMutation(SET_RAISE_HAND);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -157,7 +157,7 @@ const messages = defineMessages({
     description: 'Confirmation message for removing a user from the meeting',
   },
   lowerUserHand: {
-    id: 'app.statusNotifier.lowerHandDescOneUser',
+    id: 'app.actionsBar.reactions.lowUserHand',
     description: 'Label for lowering a user raised hand',
   },
 });

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client';
+import type { User } from '/imports/ui/Types/user';
 
 export interface UsersCountSubscriptionResponse {
   user_aggregate: {
@@ -94,6 +95,23 @@ export const GET_USER_NAMES = gql`
     }
   }
 `;
+
+export type RaisedHandUser = Pick<
+User,
+| 'userId'
+| 'name'
+| 'color'
+| 'presenter'
+| 'isModerator'
+| 'raiseHand'
+| 'whiteboardWriteAccess'
+> & {
+  raiseHandTime?: string;
+};
+
+export interface RaisedHandUsersSubscriptionResponse {
+  user: RaisedHandUser[];
+}
 
 export const RAISED_HAND_USERS = gql`
 subscription RaisedHandUsers {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1377,7 +1377,7 @@ class AudioManager {
 
     if (outputDeviceId && typeof audioAlert.setSinkId === 'function') {
       return audioAlert
-        .setSinkId(outputDeviceId)
+        .setSinkId(outputDeviceId || 'default')
         .then(() => AudioManager.playAudioElement(audioAlert));
     }
 

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -714,6 +714,7 @@
     "app.actionsBar.reactions.removeReactionLabel": "Remove reaction",
     "app.actionsBar.reactions.raiseHand": "Raise your hand",
     "app.actionsBar.reactions.lowHand": "Lower your hand",
+    "app.actionsBar.reactions.lowUserHand": "Lower user's hand",
     "app.actionsBar.reactions.autoCloseReactionsBarLabel": "Auto close the reactions bar",
     "app.actionsBar.reactions.away": "away",
     "app.actionsBar.reactions.available": "available",


### PR DESCRIPTION
### What does this PR do?
- Reintroduces a lightweight raise-hand notifier that restores the audible alert when hands go up, even if the user list is closed.
- Adds a simple toast (“{users} raised their hand”) that respects the notification toggles, filters out presenter self-raises, and shares the existing notification infrastructure.
- Consolidates typing for the raised-hand subscription so all consumers rely on the same response shape.

### Closes Issue(s)
Closes #24175

### How to test
1. Join a BBB session as a moderator/presenter.
2. In Settings → Notifications, toggle “audible notification” and “popup notification” for raised hands; verify sounds/toasts only fire when their respective toggle is ON.
3. Have a participant raise their hand while the user list is closed; ensure you still hear/see the notifications.
4. Have the presenter raise their own hand; confirm no “Presenter raised hand” toast appears.
5. Repeat with popup disabled to confirm only the sound plays, and vice versa.

### More
- Raised hand user list dropdown
<img width="489" height="447" alt="image" src="https://github.com/user-attachments/assets/899e41df-f54d-4629-b9e2-be1b9b06a70e" />

Simple notification 
<img width="374" height="131" alt="image" src="https://github.com/user-attachments/assets/99bf2011-f417-43cb-91d9-9c8682ba989d" />

