### PR TITLE
[3.0] Adds the test upload multiple presentation on ci

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -87,7 +87,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#uploading-multiple-presentations-automated
-    test('Upload multiple presentations', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
+    test('Upload multiple presentations', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, testInfo);
       await presentation.uploadMultiplePresentationsTest();

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -110,7 +110,6 @@ export async function uploadMultiplePresentations(
     e.presentationUploadProgressToast,
     'should display a toast presentation upload progress after confirming the presentation to be uploaded',
   );
-
   try {
     await testPage.hasNElements(
       e.processingPresentationItem,

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -110,16 +110,25 @@ export async function uploadMultiplePresentations(
     e.presentationUploadProgressToast,
     'should display a toast presentation upload progress after confirming the presentation to be uploaded',
   );
-  await testPage.hasNElements(
-    e.processingPresentationItem,
-    fileNames.length,
-    'should display the presentation status info element with converting label after confirmation to upload the new file',
-  );
-  await testPage.hasNElements(
+
+  try {
+    await testPage.hasNElements(
+      e.processingPresentationItem,
+      fileNames.length,
+      'should display the presentation status info element with converting label after confirmation to upload the new file',
+    );
+
+    await testPage.hasNElements(
     e.uploadDoneIcon,
     fileNames.length,
-    'should display the upload done icon after all presentations are successfully uploaded',
-  );
+    'should display the upload done icon after all presentations are successfully uploaded',);
+    } catch {
+    await testPage.hasNElements(
+      e.uploadDoneIcon,
+      fileNames.length,
+      'should display the upload done icon after all presentations are successfully uploaded',
+    );
+  }
   await hasCurrentPresentationToastElement(testPage, { timeout: uploadTimeout });
 }
 


### PR DESCRIPTION

### What does this PR do?
Updates the test "Upload multiple presentations" so it can run on CI again.

Sometimes, the upload is too fast, and the processing file notification does not appear. To address this, I added a try/catch block to check if the processing file notification appears. If it does not, the test checks the uploaded presentation icon.