### PR TITLE
fix(audio): broken mute toggle when using LiveKit

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -717,18 +717,24 @@ class AudioManager {
   }
 
   onVoiceUserChanges(fields = {}) {
+    let newMuteState;
+
     // when user leaves voice conf, set muted = false
     // as the user might have been transfered to a breakout room
     if (fields.leftVoiceConf !== undefined && fields.leftVoiceConf) {
-      this.isMuted = false;
+      newMuteState = false;
     } else if (fields.muted !== undefined && fields.muted !== this.isMuted) {
-      this.isMuted = fields.muted;
+      newMuteState = fields.muted;
     }
 
-    if (this.isMuted) {
-      this.mute();
-    } else {
-      this.unmute();
+    if (newMuteState !== undefined && newMuteState !== this.isMuted) {
+      this.isMuted = newMuteState;
+
+      if (this.isMuted) {
+        this.mute();
+      } else {
+        this.unmute();
+      }
     }
 
     if (fields.talking !== undefined && fields.talking !== this.isTalking) {


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): broken mute toggle when using LiveKit](https://github.com/bigbluebutton/bigbluebutton/commit/b3e0427858660ee8634b6e556c6fd20e91a52a5d) 
  - A recent change altered AudioManager's audio state observer to call
mute/unmute state on every audio state update - regardless of whether
the local mute state actually changes. Since the mute/unmute actions of
the LiveKit audio bridge are not fully idempotent yet, this may cause
audio tracks to be published and unpublished in sequence, mistakengly,
due to trailing (un)mute calls sent in a short timespan.
This breaks the mute toggle when using LiveKit - i.e.: unresponsive or
flipping mute states incorrectly.
  - Guarantee that AudioManager's audio state observer only triggers
mute/unmute when its muted state actually changes. This fixes the
"catalyst" for the above problem.
  - The LK audio bridge should still have an idempotent mute/unmute API
(setSenderTrackEnabled) - this issue wouldn't have happened if that was
the case. That will be addressed in subsequent commits.

### Closes Issue(s)

None