### PR TITLE
fix(bbb-web): Change PNG Creation Execution Timeout to Seconds

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -48,7 +48,7 @@ public class PngCreatorImp implements PngCreator {
 	private String BLANK_PNG;
 	private int slideWidth = 800;
 	private int convTimeout = 7;
-	private long execTimeout = 10000;
+	private long execTimeout = 10;
 
 	private static final String TEMP_PNG_NAME = "temp-png";
 
@@ -148,7 +148,7 @@ public class PngCreatorImp implements PngCreator {
 
 		//System.out.println("********* CREATING PNGs " + COMMAND);
 
-		boolean done = new ExternalProcessExecutor().exec(COMMAND, execTimeout);
+		boolean done = new ExternalProcessExecutor().exec(COMMAND, TimeUnit.SECONDS.toMillis(execTimeout));
 
 		if (done) {
 			return true;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -154,7 +154,6 @@ officeToPdfMaxConcurrentConversions=4
 # Presentation upload and conversion timeouts in milliseconds
 #------------------------------------
 extractTimeoutInMs=10000
-pngCreationExecTimeoutInMs=10000
 thumbnailCreationExecTimeoutInMs=10000
 pdfPageDownscaleExecTimeoutInMs=10000
 officeDocumentValidationExecTimeoutInMs=25000
@@ -164,6 +163,7 @@ presDownloadReadTimeoutInMs=60000
 #------------------------------------
 # Presentation upload and conversion timeouts in seconds
 #------------------------------------
+pngCreationExecTimeout=10
 pngCreationConversionTimeout=7
 imageResizeWait=7
 officeDocumentValidationTimeout=20

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -95,7 +95,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="blankPng" value="${BLANK_PNG}"/>
         <property name="slideWidth" value="${pngSlideWidth}"/>
         <property name="convTimeout" value="${pngCreationConversionTimeout}"/>
-        <property name="execTimeout" value="${pngCreationExecTimeoutInMs}"/>
+        <property name="execTimeout" value="${pngCreationExecTimeout}"/>
     </bean>
 
     <bean id="textFileCreator" class="org.bigbluebutton.presentation.imp.TextFileCreatorImp">


### PR DESCRIPTION
### What does this PR do?

Changes the PNG creation execution timeout from 10,000 milliseconds to 10 seconds. The purpose of this is to align the timeout with the other timeouts used by the PNG creation service that are in seconds. A check is done that compares the PNG execution timeout (10,000 ms) against the `maxPageConversionTime` (60 seconds) and uses the smaller of the two. This check did not take into account the difference between milliseconds and seconds and always choose the `maxPageConversionTime` which was then implemented as a 60 millisecond timeout for PNG creation.


### Closes Issue(s)
Closes #24231


### How to test
1. Set `generatePngs=true` in `bigbluebutton.properties`
2. Restart BBB Web and upload a presentation.
