### PR TITLE
[3.1] fix(chat): audio alerts playing when panel is opened

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -89,8 +89,9 @@ const ChatAlertGraphql: React.FC<ChatAlertGraphqlProps> = (props) => {
     && !!chatUnreadMessages
     && chatUnreadMessages.length > 0;
   const shouldPlayAudioAlert = useCallback(
-    (m: Message) => m.senderId !== Auth.userID && !history.current.has(m.messageId),
-    [history.current],
+    (m: Message) => m.senderId !== Auth.userID
+      && m.chatId !== idChatOpen && !history.current.has(m.messageId),
+    [history.current, idChatOpen],
   );
 
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;


### PR DESCRIPTION
### What does this PR do?
Adds a check to the audio alert playing logic, to check whether the new message is from a chat that is already opened - if so, the sound is not played.

### Closes Issue(s)
Closes #24241

### How to test
See issue