### PR TITLE
fix(bbb-web): thumbnail and text conversion fails due to timeouts

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.bigbluebutton.presentation.SupportedFileTypes;
 import org.bigbluebutton.presentation.TextFileCreator;
@@ -40,7 +41,7 @@ import com.google.gson.Gson;
 public class TextFileCreatorImp implements TextFileCreator {
   private static Logger log = LoggerFactory.getLogger(TextFileCreatorImp.class);
 
-  private long execTimeout = 60000;
+  private long execTimeout = 60;
 
   @Override
   public boolean createTextFile(UploadedPresentation pres, int page) {
@@ -125,7 +126,7 @@ public class TextFileCreatorImp implements TextFileCreator {
             execTimeout = pageConversionTimeoutInMs;
         }
 
-        boolean done = new ExternalProcessExecutor().exec(COMMAND, execTimeout);
+        boolean done = new ExternalProcessExecutor().exec(COMMAND, TimeUnit.SECONDS.toMillis(execTimeout));
         if (!done) {
           success = false;
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.bigbluebutton.presentation.SupportedFileTypes;
@@ -35,6 +36,7 @@ import org.bigbluebutton.presentation.ThumbnailCreator;
 import org.bigbluebutton.presentation.UploadedPresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 import com.google.gson.Gson;
 
@@ -49,7 +51,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
 
   private String BLANK_THUMBNAIL;
 
-  private long execTimeout = 10000;
+  private long execTimeout = 10;
 
   @Override
   public boolean createThumbnail(UploadedPresentation pres, int page, File pageFile) {
@@ -104,7 +106,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
       execTimeout = pageConversionTimeoutInMs;
     }
 
-    boolean done = new ExternalProcessExecutor().exec(COMMAND, execTimeout);
+    boolean done = new ExternalProcessExecutor().exec(COMMAND, TimeUnit.SECONDS.toMillis(execTimeout));
 
     if (done) {
       return true;

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -154,10 +154,8 @@ officeToPdfMaxConcurrentConversions=4
 # Presentation upload and conversion timeouts in milliseconds
 #------------------------------------
 extractTimeoutInMs=10000
-thumbnailCreationExecTimeoutInMs=10000
 pdfPageDownscaleExecTimeoutInMs=10000
 officeDocumentValidationExecTimeoutInMs=25000
-textFileCreationExecTimeoutInMs=60000
 presDownloadReadTimeoutInMs=60000
 
 #------------------------------------
@@ -170,6 +168,8 @@ officeDocumentValidationTimeout=20
 presOfficeConversionTimeout=60
 pdfPageCountWait=5
 detectImageDimensionsTimeout=20
+thumbnailCreationExecTimeout=10
+textFileCreationExecTimeout=60
 
 #----------------------------------------------------
 # Additional conversion of the presentation slides to PNG

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -88,7 +88,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     <bean id="thumbCreator" class="org.bigbluebutton.presentation.imp.ThumbnailCreatorImp">
         <property name="imageMagickDir" value="${imageMagickDir}"/>
         <property name="blankThumbnail" value="${BLANK_THUMBNAIL}"/>
-        <property name="execTimeout" value="${thumbnailCreationExecTimeoutInMs}"/>
+        <property name="execTimeout" value="${thumbnailCreationExecTimeout}"/>
     </bean>
 
     <bean id="pngCreator" class="org.bigbluebutton.presentation.imp.PngCreatorImp">
@@ -99,7 +99,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     </bean>
 
     <bean id="textFileCreator" class="org.bigbluebutton.presentation.imp.TextFileCreatorImp">
-        <property name="execTimeout" value="${textFileCreationExecTimeoutInMs}"/>
+        <property name="execTimeout" value="${textFileCreationExecTimeout}"/>
     </bean>
 
     <bean id="svgImageCreator" class="org.bigbluebutton.presentation.imp.SvgImageCreatorImp">

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -372,10 +372,12 @@ Added
 - `extractTimeoutInMs` added
 - `pngCreationExecTimeoutInMs` added, later (BBB 3.0.17) renamed to `pngCreationExecTimeout`
 - `pngCreationExecTimeout` added (used to be `pngCreationExecTimeoutInMs`)
-- `thumbnailCreationExecTimeoutInMs` added
+- `thumbnailCreationExecTimeoutInMs` added, later (BBB 3.0.17) renamed to `thumbnailCreationExecTimeout`
+- `thumbnailCreationExecTimeout` added (used to be `thumbnailCreationExecTimeoutInMs`)
 - `pdfPageDownscaleExecTimeoutInMs` added
 - `officeDocumentValidationExecTimeoutInMs` added
-- `textFileCreationExecTimeoutInMs` added
+- `textFileCreationExecTimeoutInMs` added, later (BBB 3.0.17) renamed to `textFileCreationExecTimeout`
+- `textFileCreationExecTimeout` added (used to be `textFileCreationExecTimeoutInMs`)
 - `presDownloadReadTimeoutInMs` added
 - `pngCreationConversionTimeout` added
 - `imageResizeWait` added


### PR DESCRIPTION
### What does this PR do?

- [fix(bbb-web): thumbnail and text conversion fails due to timeouts](https://github.com/bigbluebutton/bigbluebutton/commit/2c1da48b39d5a275fec4efd9535c8a46c185d88c) 
  - The thumbnail and text conversion implementations in bbb-web use the
incorrect timeout unit (ms rather than s) when fetching the base timeout
against the max presentation conversion one (which is seconds). This
causes both of them to fail intermittently.
  - Use the correct unit (s) for thumbnail creation and text file creation
timeouts. Their configurations changed name:
    - thumbnailCreationExecTimeoutMs -> thumbnailCreationExecTimeout
    - textFileCreationExecTimeoutMs -> textFileCreationExecTimeout

### Closes Issue(s)

None

### Motivation

Follow up to https://github.com/bigbluebutton/bigbluebutton/pull/24234
Follow up to https://github.com/bigbluebutton/bigbluebutton/issues/24231