### PR TITLE
update(recording): add LayoutBroadcastedRecordEvent to events.xml

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/LayoutBroadcastedRecordEvent.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/record/events/LayoutBroadcastedRecordEvent.scala
@@ -1,0 +1,60 @@
+/**
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ *
+ * Copyright (c) 2017 BigBlueButton Inc. and by respective authors (see below).
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ *
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.bigbluebutton.core.record.events
+
+class LayoutBroadcastedRecordEvent extends AbstractParticipantRecordEvent {
+  import LayoutBroadcastedRecordEvent._
+
+  setEvent("LayoutBroadcastedEvent")
+
+  def setLayout(layout: String) {
+    eventMap.put(LAYOUT, layout)
+  }
+
+  def setPresentationIsOpen(isOpen: Boolean) {
+    eventMap.put(PRESENTATION_IS_OPEN, isOpen.toString)
+  }
+
+  def setIsResizing(isResizing: Boolean) {
+    eventMap.put(IS_RESIZING, isResizing.toString)
+  }
+
+  def setCameraPosition(cameraPosition: String) {
+    eventMap.put(CAMERA_POSITION, cameraPosition)
+  }
+
+  def setFocusedCamera(focusedCamera: String) {
+    eventMap.put(FOCUSED_CAMERA, focusedCamera)
+  }
+
+  def setPresentationVideoRate(presentationVideoRate: Double) {
+    eventMap.put(PRESENTATION_VIDEO_RATE, presentationVideoRate.toString)
+  }
+
+}
+
+object LayoutBroadcastedRecordEvent {
+  protected final val PRESENTATION_IS_OPEN = "presentationIsOpen"
+  protected final val LAYOUT = "layout"
+  protected final val IS_RESIZING = "isResizing"
+  protected final val CAMERA_POSITION = "cameraPosition"
+  protected final val FOCUSED_CAMERA = "focusedCamera"
+  protected final val PRESENTATION_VIDEO_RATE = "presentationVideoRate"
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -126,6 +126,7 @@ class RedisRecorderActor(
       case m: WebcamsOnlyForModeratorChangedEvtMsg  => handleWebcamsOnlyForModeratorChangedEvtMsg(m)
       case m: MeetingEndingEvtMsg                   => handleMeetingEndingEvtMsg(m)
       case m: MeetingCreatedEvtMsg                  => handleStarterConfigurations(m)
+      case m: BroadcastLayoutEvtMsg                 => handleBroadcastLayoutEvtMsg(m)
       case m: SetScreenshareAsContentEvtMsg         => handleSetScreenshareAsContent(m)
       case m: ScreenshareRtmpBroadcastStartedEvtMsg => handleScreenshareRtmpBroadcastStartedEvtMsg(m)
       case m: ScreenshareRtmpBroadcastStoppedEvtMsg => handleScreenshareRtmpBroadcastStoppedEvtMsg(m)
@@ -802,6 +803,17 @@ class RedisRecorderActor(
     val ev = new MeetingConfigurationEvent()
     ev.setWebcamsOnlyForModerator(msg.body.props.usersProp.webcamsOnlyForModerator)
     record(msg.body.props.meetingProp.intId, ev.toMap().asJava)
+  }
+
+  private def handleBroadcastLayoutEvtMsg(msg: BroadcastLayoutEvtMsg): Unit = {
+    val ev = new LayoutBroadcastedRecordEvent()
+    ev.setLayout(msg.body.layout)
+    ev.setPresentationIsOpen(msg.body.presentationIsOpen)
+    ev.setIsResizing(msg.body.isResizing)
+    ev.setCameraPosition(msg.body.cameraPosition)
+    ev.setFocusedCamera(msg.body.focusedCamera)
+    ev.setPresentationVideoRate(msg.body.presentationVideoRate)
+    record(msg.header.meetingId, ev.toMap().asJava)
   }
 
   private def handleSetScreenshareAsContent(msg: SetScreenshareAsContentEvtMsg): Unit = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -807,6 +807,7 @@ class RedisRecorderActor(
 
   private def handleBroadcastLayoutEvtMsg(msg: BroadcastLayoutEvtMsg): Unit = {
     val ev = new LayoutBroadcastedRecordEvent()
+    ev.setMeetingId(msg.header.meetingId)
     ev.setLayout(msg.body.layout)
     ev.setPresentationIsOpen(msg.body.presentationIsOpen)
     ev.setIsResizing(msg.body.isResizing)


### PR DESCRIPTION
### What does this PR do?
Adds the info about layout when presenter changes something with push layout enabled (BroadcastLayoutEvtMsg):

```
  <event timestamp="677408846" module="PARTICIPANT" eventname="LayoutBroadcastedEvent">
    <focusedCamera>none</focusedCamera>
    <presentationVideoRate>0.0</presentationVideoRate>
    <cameraPosition>contentTop</cameraPosition>
    <presentationIsOpen>false</presentationIsOpen>
    <layout>CUSTOM_LAYOUT</layout>
    <timestampUTC>1763562184363</timestampUTC>
    <date>2025-11-19T11:23:04.363-03</date>
    <isResizing>false</isResizing>
  </event>
  ```

### Motivation
No info in recording scripts about presentation global state during meeting.


### How to test

1. Start a meeting
2. Enable Update to everyone in layout settings
3. Minimize/resetore presentation
4. End meeting
5. Check generated events.xml file for the new event

