### PR TITLE
fix(chat/notes): resolve persistent visual notifications in notes and chat hooks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/hooks/useHasUnreadChatMessages.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/hooks/useHasUnreadChatMessages.ts
@@ -14,8 +14,6 @@ interface UseUnreadChatMessagesProps {
 
 const useHasUnreadChatMessages = ({ isChatPanelOpened, skip = false }: UseUnreadChatMessagesProps) => {
   const [totalUnread, setTotalUnread] = useState(0);
-  const [isLatched, setIsLatched] = useState(false);
-  const [lastKnownTotal, setLastKnownTotal] = useState(0);
 
   const idChatOpen = layoutSelect((i: Layout) => i.idChatOpen);
 
@@ -34,33 +32,11 @@ const useHasUnreadChatMessages = ({ isChatPanelOpened, skip = false }: UseUnread
   );
 
   useEffect(() => {
-    if (skipSubscription || isLatched || !chats) return;
+    if (skipSubscription || !chats) return;
 
     const currentTotal = calculateTotalUnreadMessages(chats);
-
-    if (currentTotal > lastKnownTotal) {
-      setIsLatched(true);
-      setTotalUnread(currentTotal);
-    } else {
-      setLastKnownTotal(currentTotal);
-      setTotalUnread(currentTotal);
-    }
-  }, [chats, calculateTotalUnreadMessages, lastKnownTotal, isLatched, skipSubscription]);
-
-  const resetLatch = useCallback(() => {
-    if (!chats) return;
-
-    const currentTotal = calculateTotalUnreadMessages(chats);
-    setIsLatched(false);
     setTotalUnread(currentTotal);
-    setLastKnownTotal(currentTotal);
-  }, [chats, calculateTotalUnreadMessages]);
-
-  useEffect(() => {
-    if (skipSubscription && isLatched) {
-      resetLatch();
-    }
-  }, [skipSubscription, isLatched, resetLatch]);
+  }, [chats, calculateTotalUnreadMessages, skipSubscription]);
 
   const getActiveChat = useCallback((
     chats: Chat[] | null | undefined,
@@ -87,9 +63,8 @@ const useHasUnreadChatMessages = ({ isChatPanelOpened, skip = false }: UseUnread
       hasUnreadMessages: !isChatPanelOpened && totalUnread > 0,
       activeChat,
       chatIds,
-      resetLatch,
     };
-  }, [isChatPanelOpened, totalUnread, idChatOpen, getActiveChat, chats, resetLatch, chatIds]);
+  }, [isChatPanelOpened, totalUnread, idChatOpen, getActiveChat, chatIds]);
 };
 
 export default useHasUnreadChatMessages;

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -28,7 +28,6 @@ import {
   useIsScreenBroadcasting,
 } from '/imports/ui/components/screenshare/service';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
-import useNotesLastRead from './hooks/useNotesLastRead';
 import {
   Layout,
   SharedNotes,
@@ -90,7 +89,6 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
   } = props;
   const [shouldRenderNotes, setShouldRenderNotes] = useState(isVisible);
   const intl = useIntl();
-  const { markNotesAsRead } = useNotesLastRead();
 
   const isHidden = (isOnMediaArea && (sharedNotesOutput.width === 0 || sharedNotesOutput.height === 0))
     || (!isVisible && !ignoreDelayforUnmount);
@@ -100,15 +98,12 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     if (isVisible) {
       setShouldRenderNotes(true);
       clearTimeout(timeoutRef.current);
+    } else if (ignoreDelayforUnmount) {
+      setShouldRenderNotes(false);
     } else {
-      markNotesAsRead();
-      if (ignoreDelayforUnmount) {
+      timeoutRef.current = setTimeout(() => {
         setShouldRenderNotes(false);
-      } else {
-        timeoutRef.current = setTimeout(() => {
-          setShouldRenderNotes(false);
-        }, NOTES_UNMOUNT_DELAY());
-      }
+      }, NOTES_UNMOUNT_DELAY());
     }
     return () => clearTimeout(timeoutRef.current);
   }, [isVisible]);

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -187,6 +187,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
         isLocalChange={isLocalChange}
         isRTL={isRTL}
         amIPresenter={amIPresenter}
+        isVisible={isVisible}
       />
     </Styled.PanelContent>
   );

--- a/bigbluebutton-html5/imports/ui/components/notes/hooks/useHasUnreadNotes.ts
+++ b/bigbluebutton-html5/imports/ui/components/notes/hooks/useHasUnreadNotes.ts
@@ -1,5 +1,5 @@
 import {
-  useEffect, useMemo, useState, useCallback,
+  useMemo,
 } from 'react';
 import useNotesLastUpdatedAt from './useNotesLastUpdatedAt';
 import useNotesLastRead from './useNotesLastRead';
@@ -14,38 +14,20 @@ interface UseHasUnreadNotesProps {
 const useHasUnreadNotes = ({ isNotesPanelOpened, skip = false }: UseHasUnreadNotesProps) => {
   const NOTES_CONFIG = window.meetingClientSettings.public.notes;
   const { lastReadTimestamp } = useNotesLastRead();
-  const [hasChanges, setHasChanges] = useState(false);
-  const [isLatched, setIsLatched] = useState(false);
 
   const isSharedNotesPinned = layoutSelectInput((i: Input) => i.sharedNotes?.isPinned ?? false);
 
   // Skip subscription when notes panel is open or pinned to avoid unnecessary updates
   const skipSubscription = isNotesPanelOpened || isSharedNotesPinned || skip;
 
-  const lastUpdatedAtTimestamp = useNotesLastUpdatedAt(NOTES_CONFIG.id, { skip: skipSubscription || isLatched });
+  const lastUpdatedAtTimestamp = useNotesLastUpdatedAt(NOTES_CONFIG.id, { skip: skipSubscription });
 
-  useEffect(() => {
-    if (skipSubscription || isLatched || !lastUpdatedAtTimestamp) return;
+  const hasChanges = useMemo(() => {
+    if (!lastUpdatedAtTimestamp) return false;
+    return lastUpdatedAtTimestamp > lastReadTimestamp;
+  }, [lastUpdatedAtTimestamp, lastReadTimestamp]);
 
-    if (lastUpdatedAtTimestamp > lastReadTimestamp) {
-      setIsLatched(true);
-      setHasChanges(true);
-    }
-  }, [lastUpdatedAtTimestamp, lastReadTimestamp, isLatched, skipSubscription]);
-
-  // Reset latch when panel opens
-  const resetLatch = useCallback(() => {
-    setIsLatched(false);
-    setHasChanges(false);
-  }, []);
-
-  useEffect(() => {
-    if (skipSubscription && (isLatched || hasChanges)) {
-      resetLatch();
-    }
-  }, [skipSubscription, isLatched, hasChanges, resetLatch]);
-
-  return useMemo(() => {
+  const returnedValue = useMemo(() => {
     // There should be no unread notes if the notes panel is open
     if (isNotesPanelOpened) return false;
 
@@ -54,6 +36,7 @@ const useHasUnreadNotes = ({ isNotesPanelOpened, skip = false }: UseHasUnreadNot
 
     return hasChanges;
   }, [isNotesPanelOpened, isSharedNotesPinned, hasChanges]);
+  return returnedValue;
 };
 
 export default useHasUnreadNotes;

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
@@ -28,6 +28,7 @@ interface PadContainerGraphqlProps {
   isRTL: boolean;
   amIPresenter: boolean;
   isOnMediaArea?: boolean;
+  isVisible?: boolean;
 }
 
 interface PadGraphqlProps extends PadContainerGraphqlProps {
@@ -36,6 +37,7 @@ interface PadGraphqlProps extends PadContainerGraphqlProps {
   padId: string | undefined;
   amIPresenter: boolean;
   isOnMediaArea: boolean;
+  isVisible: boolean;
 }
 
 const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
@@ -49,6 +51,7 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
     padId,
     amIPresenter,
     isOnMediaArea,
+    isVisible,
     hasPermission,
   } = props;
   const [padURL, setPadURL] = useState<string | undefined>();
@@ -67,11 +70,11 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
   useEffect(() => {
     if (!hasSession || !padId) return () => {};
     return () => {
-      if (hasLoaded) {
+      if (hasLoaded && isVisible) {
         markNotesAsRead();
       }
     };
-  }, [hasSession, padId, hasLoaded]);
+  }, [hasSession, padId, hasLoaded, isVisible]);
 
   if (!hasPermission) {
     return <PadContent externalId={externalId} isOnMediaArea={isOnMediaArea} />;
@@ -109,6 +112,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
     isLocalChange,
     amIPresenter,
     isOnMediaArea = false,
+    isVisible = true,
   } = props;
 
   const { data: meeting } = useMeeting((m) => ({
@@ -142,6 +146,7 @@ const PadContainerGraphql: React.FC<PadContainerGraphqlProps> = (props) => {
       padId={session?.sharedNotes?.padId}
       amIPresenter={amIPresenter}
       isOnMediaArea={isOnMediaArea}
+      isVisible={isVisible}
       hasPermission={hasPermission}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/pads/pads-graphql/component.tsx
@@ -11,6 +11,7 @@ import Styled from './styles';
 import PadContent from './content/component';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import useNotesLastRead from '/imports/ui/components/notes/hooks/useNotesLastRead';
 
 const intlMessages = defineMessages({
   hint: {
@@ -51,7 +52,9 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
     hasPermission,
   } = props;
   const [padURL, setPadURL] = useState<string | undefined>();
+  const [hasLoaded, setHasLoaded] = useState<boolean>(false);
   const intl = useIntl();
+  const { markNotesAsRead } = useNotesLastRead();
 
   useEffect(() => {
     if (!padId) {
@@ -60,6 +63,15 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
     }
     setPadURL(Service.buildPadURL(padId, sessionIds));
   }, [isRTL, hasSession, intl.locale]);
+
+  useEffect(() => {
+    if (!hasSession || !padId) return () => {};
+    return () => {
+      if (hasLoaded) {
+        markNotesAsRead();
+      }
+    };
+  }, [hasSession, padId, hasLoaded]);
 
   if (!hasPermission) {
     return <PadContent externalId={externalId} isOnMediaArea={isOnMediaArea} />;
@@ -73,6 +85,10 @@ const PadGraphql: React.FC<PadGraphqlProps> = (props) => {
         aria-describedby="padEscapeHint"
         amIPresenter={amIPresenter}
         preventInteraction={isResizing && isLocalChange}
+        onLoad={() => {
+          setHasLoaded(true);
+          markNotesAsRead();
+        }}
       />
       <Styled.Hint
         id="padEscapeHint"

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/chat-list-item/component.tsx
@@ -51,10 +51,10 @@ const ChatListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
     }
   }, [idChatOpen, activeChat, layoutContextDispatch, PUBLIC_GROUP_CHAT_ID]);
 
-  const handleChatToggle = useCallback(() => {
+  const handleChatToggle = useCallback((willOpen: boolean) => {
     layoutContextDispatch({
       type: ACTIONS.SET_ID_CHAT_OPEN,
-      value: PUBLIC_GROUP_CHAT_ID,
+      value: willOpen ? PUBLIC_GROUP_CHAT_ID : undefined,
     });
   }, [layoutContextDispatch, PUBLIC_GROUP_CHAT_ID]);
 


### PR DESCRIPTION
### What does this PR do?
- For notes: markNotesAsRead was not executed when isVisible was true (always true while in notes panel, i.e. not pinned). Moved it inside the pad and linked to iframe load to improve the relationship between
iframe loading and marking as viewed.
- Both notes and chat hooks had issues recalculating when there were certain updates in the last read timestamp. The latch logic was wrong and prevented the hooks from recalculating internal states. Simplified the latch logic in both hooks using memo for reactive computation.

- Additionally, fixes an incorrectly open chat id logic

### Closes Issue(s)
Closes #24255