### PR TITLE
Revert "conf: Hide nginx version in bigbluebutton.nginx"

### DIFF
--- a/build/packages-template/bbb-html5/bigbluebutton.nginx
+++ b/build/packages-template/bbb-html5/bigbluebutton.nginx
@@ -1,5 +1,4 @@
 server {
-    server_tokens off;
     listen   80;
     listen [::]:80;
     server_name  192.168.0.103;


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#24104

Reverting for now as it's causing too much confusion on BBB updates (and at this point of the cycle (3.0.17) it's a very common use case) 