### PR TITLE
refactor(bbb-web): Improve Embedded PNG Limits

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/DocumentConversionServiceImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/DocumentConversionServiceImp.java
@@ -1,21 +1,21 @@
 /**
-* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
-* 
-* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
-*
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License as published by the Free Software
-* Foundation; either version 3.0 of the License, or (at your option) any later
-* version.
-* 
-* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
-* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public License along
-* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * <p>
+ * Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 package org.bigbluebutton.presentation;
 
@@ -23,6 +23,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.bigbluebutton.api2.IBbbWebApiGWApp;
 import org.bigbluebutton.presentation.imp.*;
 import org.bigbluebutton.presentation.messages.DocConversionRequestReceived;
@@ -36,190 +37,198 @@ import xyz.capybara.clamav.commands.scan.result.ScanResult;
 import static org.bigbluebutton.presentation.Util.deleteDirectoryFromFileHandlingErrors;
 
 public class DocumentConversionServiceImp implements DocumentConversionService {
-  private static final String CLAMAV_HOST = "localhost";
-  private static final Integer CLAMAV_PORT = 3310;
+    private static final String CLAMAV_HOST = "localhost";
+    private static final Integer CLAMAV_PORT = 3310;
 
-  private static Logger log = LoggerFactory.getLogger(DocumentConversionServiceImp.class);
+    private static Logger log = LoggerFactory.getLogger(DocumentConversionServiceImp.class);
 
-  private IBbbWebApiGWApp gw;
-  private OfficeToPdfConversionService officeToPdfConversionService;
-  private SlidesGenerationProgressNotifier notifier;
-  private long maxPageConversionTime = 60L;
+    private IBbbWebApiGWApp gw;
+    private OfficeToPdfConversionService officeToPdfConversionService;
+    private SlidesGenerationProgressNotifier notifier;
+    private long maxPageConversionTime = 60L;
+    private long embeddedPngBudget = 128 * 1024 * 1024;
 
-  private PresentationFileProcessor presentationFileProcessor;
+    private PresentationFileProcessor presentationFileProcessor;
 
-  public void processDocument(UploadedPresentation pres, boolean scanUploadedPresentationFiles) {
-    if (pres.isUploadFailed()) {
-      // We should send a message to the client in the future.
-      // ralam may 1, 2020
-      log.error("Presentation upload failed for meetingId={} presId={}", pres.getMeetingId(), pres.getId());
-      log.error("Presentation upload fail reasons {}", pres.getUploadFailReason());
-      return;
-    }
-
-    if (scanUploadedPresentationFiles) {
-      try {
-        ClamavClient client = new ClamavClient(CLAMAV_HOST, CLAMAV_PORT);
-        ScanResult result = client.scan(Path.of(pres.getUploadedFile().getAbsolutePath()));
-
-        if (result instanceof ScanResult.VirusFound) {
-          log.error("Presentation upload failed for meetingId={} presId={}", pres.getMeetingId(), pres.getId());
-          log.error("Presentation upload failed because a virus was detected in the uploaded file");
-          notifier.sendUploadFileVirus(pres);
-          Util.deleteDirectoryFromFileHandlingErrors(pres.getUploadedFile());
-          return;
+    public void processDocument(UploadedPresentation pres, boolean scanUploadedPresentationFiles) {
+        if (pres.isUploadFailed()) {
+            // We should send a message to the client in the future.
+            // ralam may 1, 2020
+            log.error("Presentation upload failed for meetingId={} presId={}", pres.getMeetingId(), pres.getId());
+            log.error("Presentation upload fail reasons {}", pres.getUploadFailReason());
+            return;
         }
-      } catch (Exception e) {
-        log.error("Failed to scan uploaded file for meetingId={} presID={}: {}", pres.getMeetingId(), pres.getId(), e.getMessage());
-        notifier.sendUploadFileScanFailed(pres);
-        Util.deleteDirectoryFromFileHandlingErrors(pres.getUploadedFile());
-        return;
-      }
+
+        if (scanUploadedPresentationFiles) {
+            try {
+                ClamavClient client = new ClamavClient(CLAMAV_HOST, CLAMAV_PORT);
+                ScanResult result = client.scan(Path.of(pres.getUploadedFile().getAbsolutePath()));
+
+                if (result instanceof ScanResult.VirusFound) {
+                    log.error("Presentation upload failed for meetingId={} presId={}", pres.getMeetingId(), pres.getId());
+                    log.error("Presentation upload failed because a virus was detected in the uploaded file");
+                    notifier.sendUploadFileVirus(pres);
+                    Util.deleteDirectoryFromFileHandlingErrors(pres.getUploadedFile());
+                    return;
+                }
+            } catch (Exception e) {
+                log.error("Failed to scan uploaded file for meetingId={} presID={}: {}", pres.getMeetingId(), pres.getId(), e.getMessage());
+                notifier.sendUploadFileScanFailed(pres);
+                Util.deleteDirectoryFromFileHandlingErrors(pres.getUploadedFile());
+                return;
+            }
+        }
+
+        sendDocConversionRequestReceived(pres);
+
+        processDocumentStart(pres);
     }
 
-    sendDocConversionRequestReceived(pres);
+    public void processDocumentStart(UploadedPresentation pres) {
+        pres.setMaxPageConversionTime(maxPageConversionTime);
+        pres.setEmbeddedPngBudget(embeddedPngBudget);
+        pres.setRemainingEmbeddedPngBudget(pres.getEmbeddedPngBudget());
 
-    processDocumentStart(pres);
-  }
+        SupportedDocumentFilter sdf = new SupportedDocumentFilter(gw);
+        if (sdf.isSupported(pres)) {
+            String fileType = pres.getFileType();
 
-  public void processDocumentStart(UploadedPresentation pres) {
-    pres.setMaxPageConversionTime(maxPageConversionTime);
-    SupportedDocumentFilter sdf = new SupportedDocumentFilter(gw);
-    if (sdf.isSupported(pres)) {
-      String fileType = pres.getFileType();
+            if (SupportedFileTypes.isOfficeFile(fileType)) {
+                pres = officeToPdfConversionService.convertOfficeToPdf(pres);
+                OfficeToPdfConversionSuccessFilter ocsf = new OfficeToPdfConversionSuccessFilter(gw);
+                if (ocsf.didConversionSucceed(pres)) {
+                    ocsf.sendProgress(pres);
+                    // Successfully converted to pdf. Call the process again, this time it
+                    // should be handled by
+                    // the PDF conversion service.
+                    processDocumentStart(pres);
+                } else {
+                    // Send notification that office to pdf conversion failed.
+                    // The cause should have been set by the previous step.
+                    // (ralam feb 15, 2020)
+                    ocsf.sendOfficeToPdfConversionFailed(pres);
+                }
+            } else if (SupportedFileTypes.isPdfFile(fileType)) {
+                presentationFileProcessor.process(pres);
+            } else if (SupportedFileTypes.isImageFile(fileType)) {
+                presentationFileProcessor.process(pres);
+            } else {
+                Map<String, Object> logData = new HashMap<String, Object>();
+                logData = new HashMap<String, Object>();
+                logData.put("podId", pres.getPodId());
+                logData.put("meetingId", pres.getMeetingId());
+                logData.put("presId", pres.getId());
+                logData.put("filename", pres.getName());
+                logData.put("current", pres.isCurrent());
+                logData.put("logCode", "supported_file_not_handled");
+                logData.put("message", "Supported file not handled.");
+                logData.put("removable", pres.isRemovable());
 
-      if (SupportedFileTypes.isOfficeFile(fileType)) {
-        pres = officeToPdfConversionService.convertOfficeToPdf(pres);
-        OfficeToPdfConversionSuccessFilter ocsf = new OfficeToPdfConversionSuccessFilter(gw);
-        if (ocsf.didConversionSucceed(pres)) {
-          ocsf.sendProgress(pres);
-          // Successfully converted to pdf. Call the process again, this time it
-          // should be handled by
-          // the PDF conversion service.
-          processDocumentStart(pres);
+                Gson gson = new Gson();
+                String logStr = gson.toJson(logData);
+                log.warn(" --analytics-- data={}", logStr);
+            }
+
         } else {
-          // Send notification that office to pdf conversion failed.
-          // The cause should have been set by the previous step.
-          // (ralam feb 15, 2020)
-          ocsf.sendOfficeToPdfConversionFailed(pres);
+            File presentationFile = pres.getUploadedFile();
+            deleteDirectoryFromFileHandlingErrors(presentationFile);
+
+            Map<String, Object> logData = new HashMap<String, Object>();
+            logData = new HashMap<String, Object>();
+            logData.put("podId", pres.getPodId());
+            logData.put("meetingId", pres.getMeetingId());
+            logData.put("presId", pres.getId());
+            logData.put("filename", pres.getName());
+            logData.put("current", pres.isCurrent());
+            logData.put("logCode", "unsupported_file_format");
+            logData.put("message", "Unsupported file format");
+
+            Gson gson = new Gson();
+            String logStr = gson.toJson(logData);
+            log.error(" --analytics-- data={}", logStr);
+
+            logData.clear();
+
+            logData.put("podId", pres.getPodId());
+            logData.put("meetingId", pres.getMeetingId());
+            logData.put("presId", pres.getId());
+            logData.put("filename", pres.getName());
+            logData.put("current", pres.isCurrent());
+            logData.put("logCode", "presentation_conversion_end");
+            logData.put("message", "End presentation conversion.");
+
+            logStr = gson.toJson(logData);
+            log.info(" --analytics-- data={}", logStr);
+
+            notifier.sendConversionCompletedMessage(pres);
         }
-      } else if (SupportedFileTypes.isPdfFile(fileType)) {
-        presentationFileProcessor.process(pres);
-      } else if (SupportedFileTypes.isImageFile(fileType)) {
-        presentationFileProcessor.process(pres);
-      } else {
-        Map<String, Object> logData = new HashMap<String, Object>();
-        logData = new HashMap<String, Object>();
-        logData.put("podId", pres.getPodId());
-        logData.put("meetingId", pres.getMeetingId());
-        logData.put("presId", pres.getId());
-        logData.put("filename", pres.getName());
-        logData.put("current", pres.isCurrent());
-        logData.put("logCode", "supported_file_not_handled");
-        logData.put("message", "Supported file not handled.");
-        logData.put("removable", pres.isRemovable());
-
-        Gson gson = new Gson();
-        String logStr = gson.toJson(logData);
-        log.warn(" --analytics-- data={}", logStr);
-      }
-
-    } else {
-      File presentationFile = pres.getUploadedFile();
-      deleteDirectoryFromFileHandlingErrors(presentationFile);
-
-      Map<String, Object> logData = new HashMap<String, Object>();
-      logData = new HashMap<String, Object>();
-      logData.put("podId", pres.getPodId());
-      logData.put("meetingId", pres.getMeetingId());
-      logData.put("presId", pres.getId());
-      logData.put("filename", pres.getName());
-      logData.put("current", pres.isCurrent());
-      logData.put("logCode", "unsupported_file_format");
-      logData.put("message", "Unsupported file format");
-
-      Gson gson = new Gson();
-      String logStr = gson.toJson(logData);
-      log.error(" --analytics-- data={}", logStr);
-
-      logData.clear();
-
-      logData.put("podId", pres.getPodId());
-      logData.put("meetingId", pres.getMeetingId());
-      logData.put("presId", pres.getId());
-      logData.put("filename", pres.getName());
-      logData.put("current", pres.isCurrent());
-      logData.put("logCode", "presentation_conversion_end");
-      logData.put("message", "End presentation conversion.");
-
-      logStr = gson.toJson(logData);
-      log.info(" --analytics-- data={}", logStr);
-
-      notifier.sendConversionCompletedMessage(pres);
     }
-  }
 
-  public void sendDocConversionFailedOnMimeType(UploadedPresentation pres, String fileMime,
-                                                String fileExtension) {
-    notifier.sendInvalidMimeTypeMessage(pres, fileMime, fileExtension);
-  }
+    public void sendDocConversionFailedOnMimeType(UploadedPresentation pres, String fileMime,
+                                                  String fileExtension) {
+        notifier.sendInvalidMimeTypeMessage(pres, fileMime, fileExtension);
+    }
 
-  private void sendDocConversionRequestReceived(UploadedPresentation pres) {
-      if (! pres.isConversionStarted()) {
-          Map<String, Object> logData = new HashMap<String, Object>();
+    private void sendDocConversionRequestReceived(UploadedPresentation pres) {
+        if (!pres.isConversionStarted()) {
+            Map<String, Object> logData = new HashMap<String, Object>();
 
-          logData.put("podId", pres.getPodId());
-          logData.put("meetingId", pres.getMeetingId());
-          logData.put("presId", pres.getId());
-          logData.put("filename", pres.getName());
-          logData.put("current", pres.isCurrent());
-          logData.put("authzToken", pres.getAuthzToken());
-          logData.put("logCode", "presentation_conversion_start");
-          logData.put("message", "Start presentation conversion.");
-          logData.put("isRemovable", pres.isRemovable());
+            logData.put("podId", pres.getPodId());
+            logData.put("meetingId", pres.getMeetingId());
+            logData.put("presId", pres.getId());
+            logData.put("filename", pres.getName());
+            logData.put("current", pres.isCurrent());
+            logData.put("authzToken", pres.getAuthzToken());
+            logData.put("logCode", "presentation_conversion_start");
+            logData.put("message", "Start presentation conversion.");
+            logData.put("isRemovable", pres.isRemovable());
 
-          Gson gson = new Gson();
-          String logStr = gson.toJson(logData);
-          log.info(" --analytics-- data={}", logStr);
+            Gson gson = new Gson();
+            String logStr = gson.toJson(logData);
+            log.info(" --analytics-- data={}", logStr);
 
-          pres.startConversion();
+            pres.startConversion();
 
-          DocConversionRequestReceived progress = new DocConversionRequestReceived(
-                  pres.getPodId(),
-                  pres.getMeetingId(),
-                  pres.getId(),
-                  pres.getTemporaryPresentationId(),
-                  pres.getName(),
-                  pres.getAuthzToken(),
-                  pres.isDownloadable(),
-                  pres.isRemovable(),
-                  pres.isCurrent()
-          );
-          notifier.sendDocConversionProgress(progress);
-      }
-  }
+            DocConversionRequestReceived progress = new DocConversionRequestReceived(
+                    pres.getPodId(),
+                    pres.getMeetingId(),
+                    pres.getId(),
+                    pres.getTemporaryPresentationId(),
+                    pres.getName(),
+                    pres.getAuthzToken(),
+                    pres.isDownloadable(),
+                    pres.isRemovable(),
+                    pres.isCurrent()
+            );
+            notifier.sendDocConversionProgress(progress);
+        }
+    }
 
-  public void setBbbWebApiGWApp(IBbbWebApiGWApp m) {
-    gw = m;
-  }
+    public void setBbbWebApiGWApp(IBbbWebApiGWApp m) {
+        gw = m;
+    }
 
-  public void setOfficeToPdfConversionService(OfficeToPdfConversionService s) {
-    officeToPdfConversionService = s;
-  }
+    public void setOfficeToPdfConversionService(OfficeToPdfConversionService s) {
+        officeToPdfConversionService = s;
+    }
 
-  public void setSlidesGenerationProgressNotifier(SlidesGenerationProgressNotifier notifier) {
-      this.notifier = notifier;
-  }
+    public void setSlidesGenerationProgressNotifier(SlidesGenerationProgressNotifier notifier) {
+        this.notifier = notifier;
+    }
 
-  public void setPresentationFileProcessor(PresentationFileProcessor presentationFileProcessor) {
-      this.presentationFileProcessor = presentationFileProcessor;
-  }
+    public void setPresentationFileProcessor(PresentationFileProcessor presentationFileProcessor) {
+        this.presentationFileProcessor = presentationFileProcessor;
+    }
 
-  public long getMaxPageConversionTime() {
-    return maxPageConversionTime;
-  }
+    public long getMaxPageConversionTime() {
+        return maxPageConversionTime;
+    }
 
-  public void setMaxPageConversionTime(long maxPageConversionTime) {
-    this.maxPageConversionTime = maxPageConversionTime;
-  }
+    public void setMaxPageConversionTime(long maxPageConversionTime) {
+        this.maxPageConversionTime = maxPageConversionTime;
+    }
+
+    public void setEmbeddedPngBudget(long embeddedPngBudget) {
+        this.embeddedPngBudget = embeddedPngBudget * 1024 * 1024;
+    }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/DocumentConversionServiceImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/DocumentConversionServiceImp.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import org.bigbluebutton.api2.IBbbWebApiGWApp;
 import org.bigbluebutton.presentation.imp.*;
 import org.bigbluebutton.presentation.messages.DocConversionRequestReceived;
-import org.bigbluebutton.presentation.messages.DocInvalidMimeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
@@ -46,7 +45,7 @@ public class DocumentConversionServiceImp implements DocumentConversionService {
     private OfficeToPdfConversionService officeToPdfConversionService;
     private SlidesGenerationProgressNotifier notifier;
     private long maxPageConversionTime = 60L;
-    private long embeddedPngBudget = 128 * 1024 * 1024;
+    private long embeddedPngBudget = 128;
 
     private PresentationFileProcessor presentationFileProcessor;
 
@@ -229,6 +228,6 @@ public class DocumentConversionServiceImp implements DocumentConversionService {
     }
 
     public void setEmbeddedPngBudget(long embeddedPngBudget) {
-        this.embeddedPngBudget = embeddedPngBudget * 1024 * 1024;
+        this.embeddedPngBudget = embeddedPngBudget;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -1,256 +1,285 @@
 /**
-* BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
-* 
-* Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
-*
-* This program is free software; you can redistribute it and/or modify it under the
-* terms of the GNU Lesser General Public License as published by the Free Software
-* Foundation; either version 3.0 of the License, or (at your option) any later
-* version.
-* 
-* BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
-* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-* PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public License along
-* with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
-*
-*/
+ * BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+ * <p>
+ * Copyright (c) 2012 BigBlueButton Inc. and by respective authors (see below).
+ * <p>
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3.0 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * BigBlueButton is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 package org.bigbluebutton.presentation;
 
 import java.io.File;
 import java.util.ArrayList;
+
 import org.apache.commons.io.FilenameUtils;
 
 public final class UploadedPresentation {
-  private final String podId;
-  private final String meetingId;
-  private final String id;
-  private final String temporaryPresentationId;
-  private final String name;
-  private final boolean uploadFailed;
-  private final ArrayList<String> uploadFailReason;
-  private File uploadedFile;
-  private String uploadedFileHash;
-  private String fileType = "unknown";
-  private int numberOfPages = 0;
-  private String conversionStatus;
-  private String filenameConverted;
-  private final String baseUrl;
-  private boolean isDownloadable = false;
-  private boolean isRemovable = true;
-  private boolean current = false;
-  private String authzToken;
-  private boolean conversionStarted = false;
-  private long maxPageConversionTime;
+    private final String podId;
+    private final String meetingId;
+    private final String id;
+    private final String temporaryPresentationId;
+    private final String name;
+    private final boolean uploadFailed;
+    private final ArrayList<String> uploadFailReason;
+    private File uploadedFile;
+    private String uploadedFileHash;
+    private String fileType = "unknown";
+    private int numberOfPages = 0;
+    private String conversionStatus;
+    private String filenameConverted;
+    private final String baseUrl;
+    private boolean isDownloadable = false;
+    private boolean isRemovable = true;
+    private boolean current = false;
+    private String authzToken;
+    private boolean conversionStarted = false;
+    private long maxPageConversionTime;
+    private long embeddedPngBudget = 128 * 1024 * 1024;
+    private long remainingEmbeddedPngBudget = 128 * 1024 * 1024;
 
-  private boolean defaultPresentation;
+    private boolean defaultPresentation;
 
-  public UploadedPresentation(String podId,
-                              String meetingId,
-                              String id,
-                              String temporaryPresentationId,
-                              String name,
-                              String baseUrl,
-                              Boolean current,
-                              String authzToken,
-                              Boolean uploadFailed,
-                              ArrayList<String> uploadFailReason,
-                              Boolean defaultPresentation) {
-    this.podId = podId;
-    this.meetingId = meetingId;
-    this.id = id;
-    this.temporaryPresentationId = temporaryPresentationId;
-    this.name = name;
-    this.baseUrl = baseUrl;
-    this.isDownloadable = false;
-    this.current = current;
-    this.authzToken = authzToken;
-    this.uploadFailed = uploadFailed;
-    this.uploadFailReason = uploadFailReason;
-    this.defaultPresentation = defaultPresentation;
-  }
-
-  public UploadedPresentation(String podId,
-                              String meetingId,
-                              String id,
-                              String temporaryPresentationId,
-                              String name,
-                              String baseUrl,
-                              Boolean current,
-                              String authzToken,
-                              Boolean uploadFailed,
-                              ArrayList<String> uploadFailReason) {
-    this(podId, meetingId, id, temporaryPresentationId, name, baseUrl,
-            current, authzToken, uploadFailed, uploadFailReason, false);
-  }
-
-  public UploadedPresentation(String podId,
-                              String meetingId,
-                              String id,
-                              String name,
-                              String baseUrl,
-                              Boolean current,
-                              String authzToken,
-                              Boolean uploadFailed,
-                              ArrayList<String> uploadFailReason) {
-    this(podId, meetingId, id, "", name, baseUrl,
-            current, authzToken, uploadFailed, uploadFailReason, false);
-  }
-
-  public UploadedPresentation(String podId,
-                              String meetingId,
-                              String id,
-                              String name,
-                              String baseUrl,
-                              Boolean current,
-                              String authzToken,
-                              Boolean uploadFailed,
-                              ArrayList<String> uploadFailReason,
-                              Boolean defaultPresentation) {
-    this(podId, meetingId, id, "", name, baseUrl,
-            current, authzToken, uploadFailed, uploadFailReason, defaultPresentation);
-  }
-
-  public File getUploadedFile() {
-    return uploadedFile;
-  }
-
-  public void setUploadedFile(File uploadedFile) {
-    this.uploadedFile = uploadedFile;
-  }
-
-  public String getUploadedFileHash() {
-    return uploadedFileHash;
-  }
-
-  public void setUploadedFileHash(String uploadedFileHash) {
-    this.uploadedFileHash = uploadedFileHash;
-  }
-
-  public String getMeetingId() {
-    return meetingId;
-  }
-
-  public String getPodId() {
-    return podId;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public String getTemporaryPresentationId() {
-    return temporaryPresentationId;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public String getBaseUrl() {
-    return baseUrl;
-  }
-
-  public String getFileType() {
-    return fileType;
-  }
-
-  public void setFileType(String fileType) {
-    this.fileType = fileType;
-  }
-
-  public int getNumberOfPages() {
-    return numberOfPages;
-  }
-
-  public void setNumberOfPages(int numberOfPages) {
-    this.numberOfPages = numberOfPages;
-  }
-
-  public String getConversionStatus() {
-    return conversionStatus;
-  }
-
-  public void setConversionStatus(String conversionStatus) {
-    this.conversionStatus = conversionStatus;
-  }
-
-  public boolean isDownloadable() {
-    return isDownloadable;
-  }
-
-  public void setDownloadable() {
-    this.isDownloadable = true;
-  }
-
-  public boolean isRemovable() {
-    return isRemovable;
-  }
-
-  public void setRemovable(boolean removable) {
-    isRemovable = removable;
-  }
-
-  public boolean isCurrent() {
-    return current;
-  }
-
-  public void setCurrent(Boolean value) {
-    this.current = value;
-  }
-
-  public String getAuthzToken() {
-    return authzToken;
-  }
-
-  public void startConversion() {
-    conversionStarted = true;
-  }
-
-  public boolean isConversionStarted() {
-    return conversionStarted;
-  }
-
-  public boolean isUploadFailed() {
-    return uploadFailed;
-  }
-
-  public ArrayList<String> getUploadFailReason() {
-    return uploadFailReason;
-  }
-
-  public boolean isDefaultPresentation() {
-    return defaultPresentation;
-  }
-
-  public String getFilenameConverted() {
-    if (filenameConverted != null) {
-      return filenameConverted;
-    } else {
-      return "";
+    public UploadedPresentation(String podId,
+                                String meetingId,
+                                String id,
+                                String temporaryPresentationId,
+                                String name,
+                                String baseUrl,
+                                Boolean current,
+                                String authzToken,
+                                Boolean uploadFailed,
+                                ArrayList<String> uploadFailReason,
+                                Boolean defaultPresentation) {
+        this.podId = podId;
+        this.meetingId = meetingId;
+        this.id = id;
+        this.temporaryPresentationId = temporaryPresentationId;
+        this.name = name;
+        this.baseUrl = baseUrl;
+        this.isDownloadable = false;
+        this.current = current;
+        this.authzToken = authzToken;
+        this.uploadFailed = uploadFailed;
+        this.uploadFailReason = uploadFailReason;
+        this.defaultPresentation = defaultPresentation;
     }
-  }
 
-  public void generateFilenameConverted(String newExtension) {
-    String nameWithoutExtension = FilenameUtils.removeExtension(name);
-    this.filenameConverted = nameWithoutExtension.concat("." + newExtension);
-  }
-
-  public long getMaxPageConversionTime() {
-    return maxPageConversionTime;
-  }
-
-  public void setMaxPageConversionTime(long maxPageConversionTime) {
-    if (maxPageConversionTime <= 0) maxPageConversionTime = 30L;
-    this.maxPageConversionTime = maxPageConversionTime;
-  }
-
-  public long getMaxTotalConversionTime() {
-    if (numberOfPages == 0) {
-      return maxPageConversionTime;
+    public UploadedPresentation(String podId,
+                                String meetingId,
+                                String id,
+                                String temporaryPresentationId,
+                                String name,
+                                String baseUrl,
+                                Boolean current,
+                                String authzToken,
+                                Boolean uploadFailed,
+                                ArrayList<String> uploadFailReason) {
+        this(podId, meetingId, id, temporaryPresentationId, name, baseUrl,
+                current, authzToken, uploadFailed, uploadFailReason, false);
     }
-    return maxPageConversionTime * numberOfPages;
-  }
+
+    public UploadedPresentation(String podId,
+                                String meetingId,
+                                String id,
+                                String name,
+                                String baseUrl,
+                                Boolean current,
+                                String authzToken,
+                                Boolean uploadFailed,
+                                ArrayList<String> uploadFailReason) {
+        this(podId, meetingId, id, "", name, baseUrl,
+                current, authzToken, uploadFailed, uploadFailReason, false);
+    }
+
+    public UploadedPresentation(String podId,
+                                String meetingId,
+                                String id,
+                                String name,
+                                String baseUrl,
+                                Boolean current,
+                                String authzToken,
+                                Boolean uploadFailed,
+                                ArrayList<String> uploadFailReason,
+                                Boolean defaultPresentation) {
+        this(podId, meetingId, id, "", name, baseUrl,
+                current, authzToken, uploadFailed, uploadFailReason, defaultPresentation);
+    }
+
+    public File getUploadedFile() {
+        return uploadedFile;
+    }
+
+    public void setUploadedFile(File uploadedFile) {
+        this.uploadedFile = uploadedFile;
+    }
+
+    public String getUploadedFileHash() {
+        return uploadedFileHash;
+    }
+
+    public void setUploadedFileHash(String uploadedFileHash) {
+        this.uploadedFileHash = uploadedFileHash;
+    }
+
+    public String getMeetingId() {
+        return meetingId;
+    }
+
+    public String getPodId() {
+        return podId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getTemporaryPresentationId() {
+        return temporaryPresentationId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public String getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(String fileType) {
+        this.fileType = fileType;
+    }
+
+    public int getNumberOfPages() {
+        return numberOfPages;
+    }
+
+    public void setNumberOfPages(int numberOfPages) {
+        this.numberOfPages = numberOfPages;
+    }
+
+    public String getConversionStatus() {
+        return conversionStatus;
+    }
+
+    public void setConversionStatus(String conversionStatus) {
+        this.conversionStatus = conversionStatus;
+    }
+
+    public boolean isDownloadable() {
+        return isDownloadable;
+    }
+
+    public void setDownloadable() {
+        this.isDownloadable = true;
+    }
+
+    public boolean isRemovable() {
+        return isRemovable;
+    }
+
+    public void setRemovable(boolean removable) {
+        isRemovable = removable;
+    }
+
+    public boolean isCurrent() {
+        return current;
+    }
+
+    public void setCurrent(Boolean value) {
+        this.current = value;
+    }
+
+    public String getAuthzToken() {
+        return authzToken;
+    }
+
+    public void startConversion() {
+        conversionStarted = true;
+    }
+
+    public boolean isConversionStarted() {
+        return conversionStarted;
+    }
+
+    public boolean isUploadFailed() {
+        return uploadFailed;
+    }
+
+    public ArrayList<String> getUploadFailReason() {
+        return uploadFailReason;
+    }
+
+    public boolean isDefaultPresentation() {
+        return defaultPresentation;
+    }
+
+    public String getFilenameConverted() {
+        if (filenameConverted != null) {
+            return filenameConverted;
+        } else {
+            return "";
+        }
+    }
+
+    public void generateFilenameConverted(String newExtension) {
+        String nameWithoutExtension = FilenameUtils.removeExtension(name);
+        this.filenameConverted = nameWithoutExtension.concat("." + newExtension);
+    }
+
+    public long getMaxPageConversionTime() {
+        return maxPageConversionTime;
+    }
+
+    public void setMaxPageConversionTime(long maxPageConversionTime) {
+        if (maxPageConversionTime <= 0) maxPageConversionTime = 30L;
+        this.maxPageConversionTime = maxPageConversionTime;
+    }
+
+    public long getMaxTotalConversionTime() {
+        if (numberOfPages == 0) {
+            return maxPageConversionTime;
+        }
+        return maxPageConversionTime * numberOfPages;
+    }
+
+    public long getEmbeddedPngBudget() {
+        return embeddedPngBudget;
+    }
+
+    public void setEmbeddedPngBudget(long embeddedPngBudget) {
+        if (embeddedPngBudget <= 0) {
+            embeddedPngBudget = Long.MAX_VALUE;
+        }
+        this.embeddedPngBudget = embeddedPngBudget * 1024 * 1024;
+    }
+
+    public long getRemainingEmbeddedPngBudget() {
+        return remainingEmbeddedPngBudget;
+    }
+
+    public void setRemainingEmbeddedPngBudget(long remainingEmbeddedPngBudget) {
+        this.remainingEmbeddedPngBudget = remainingEmbeddedPngBudget;
+    }
+
+    public void alterRemainingEmbeddedPngBudget(long amount) {
+        remainingEmbeddedPngBudget = remainingEmbeddedPngBudget - amount;
+        if (remainingEmbeddedPngBudget < 0) {
+            remainingEmbeddedPngBudget = 0;
+        }
+    }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -21,8 +21,10 @@ package org.bigbluebutton.presentation;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.io.FilenameUtils;
+import scala.xml.Atom;
 
 public final class UploadedPresentation {
     private final String podId;
@@ -46,7 +48,7 @@ public final class UploadedPresentation {
     private boolean conversionStarted = false;
     private long maxPageConversionTime;
     private long embeddedPngBudget = 128 * 1024 * 1024;
-    private long remainingEmbeddedPngBudget = 128 * 1024 * 1024;
+    private AtomicLong remainingEmbeddedPngBudget = new AtomicLong(embeddedPngBudget);
 
     private boolean defaultPresentation;
 
@@ -263,23 +265,21 @@ public final class UploadedPresentation {
 
     public void setEmbeddedPngBudget(long embeddedPngBudget) {
         if (embeddedPngBudget <= 0) {
-            embeddedPngBudget = Long.MAX_VALUE;
+            this.embeddedPngBudget = Long.MAX_VALUE;
+        } else {
+            this.embeddedPngBudget = embeddedPngBudget * 1024 * 1024;
         }
-        this.embeddedPngBudget = embeddedPngBudget * 1024 * 1024;
     }
 
-    public long getRemainingEmbeddedPngBudget() {
+    public AtomicLong getRemainingEmbeddedPngBudget() {
         return remainingEmbeddedPngBudget;
     }
 
     public void setRemainingEmbeddedPngBudget(long remainingEmbeddedPngBudget) {
-        this.remainingEmbeddedPngBudget = remainingEmbeddedPngBudget;
+        this.remainingEmbeddedPngBudget = new AtomicLong(remainingEmbeddedPngBudget);
     }
 
     public void alterRemainingEmbeddedPngBudget(long amount) {
-        remainingEmbeddedPngBudget = remainingEmbeddedPngBudget - amount;
-        if (remainingEmbeddedPngBudget < 0) {
-            remainingEmbeddedPngBudget = 0;
-        }
+        remainingEmbeddedPngBudget = new AtomicLong(remainingEmbeddedPngBudget.addAndGet(amount * -1));
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -271,15 +271,29 @@ public final class UploadedPresentation {
         }
     }
 
-    public AtomicLong getRemainingEmbeddedPngBudget() {
-        return remainingEmbeddedPngBudget;
+    public long getRemainingEmbeddedPngBudget() {
+        return remainingEmbeddedPngBudget.get();
     }
 
     public void setRemainingEmbeddedPngBudget(long remainingEmbeddedPngBudget) {
         this.remainingEmbeddedPngBudget = new AtomicLong(remainingEmbeddedPngBudget);
     }
 
-    public void alterRemainingEmbeddedPngBudget(long amount) {
-        remainingEmbeddedPngBudget = new AtomicLong(remainingEmbeddedPngBudget.addAndGet(amount * -1));
+    public boolean tryConsumeRemainingEmbeddedPngBudget(long amount) {
+        if (amount <= 0) {
+            return true;
+        }
+
+        while (true) {
+            long current = remainingEmbeddedPngBudget.get();
+            if (current < amount) {
+                return false;
+            }
+
+            long updated = current - amount;
+            if (remainingEmbeddedPngBudget.compareAndSet(current, updated)) {
+                return true;
+            }
+        }
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -265,6 +265,9 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                 Gson gson = new Gson();
                 String logStr = gson.toJson(logData);
                 log.error(" --analytics-- data={}", logStr, ioException);
+
+                copyBlankSvg(destsvg);
+                return false;
             }
 
             // Step 1: Convert a PDF page to PNG using a raw pdftocairo

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -37,7 +37,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
     private int svgResolutionPpi = 300;
     private boolean forceRasterizeSlides = false;
     private int pngWidthRasterizedSlides = 2048;
-    private int maxEmbeddedPngSize = 4 * 1024 * 1024;
+    private long maxEmbeddedPngSize = 8 * 1024 * 1024;
 	private String BLANK_SVG;
     private int maxNumberOfAttempts = 3;
     private ImageResizer imageResizer;
@@ -313,7 +313,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
                     if (base64Size > maxEmbeddedPngSize) {
                         log.error("Encoded PNG is too large for the browser - size: {}, limit: {}", base64Size, maxEmbeddedPngSize);
-                    } else if (pres.getRemainingEmbeddedPngBudget() < base64Size) {
+                    } else if (pres.getRemainingEmbeddedPngBudget().get() < base64Size) {
                         log.error("Encoded PNG size exceeds the remaining embedded PNG budget - size: {}, remaining: {}", base64Size, pres.getRemainingEmbeddedPngBudget());
                     } else {
                         String svg = createSvgWithEmbeddedPng(base64encodedPng, width, height);
@@ -508,10 +508,11 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         this.imageResolutionService = imageResolutionService;
     }
 
-    public void setMaxEmbeddedPngSize(int maxEmbeddedPngSize) {
+    public void setMaxEmbeddedPngSize(long maxEmbeddedPngSize) {
         if (maxEmbeddedPngSize <= 0) {
-            maxEmbeddedPngSize = Integer.MAX_VALUE;
+            this.maxEmbeddedPngSize = Long.MAX_VALUE;
+        } else {
+            this.maxEmbeddedPngSize = maxEmbeddedPngSize * 1024 * 1024;
         }
-        this.maxEmbeddedPngSize = maxEmbeddedPngSize * 1024 * 1024;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -37,6 +37,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
     private int svgResolutionPpi = 300;
     private boolean forceRasterizeSlides = false;
     private int pngWidthRasterizedSlides = 2048;
+    private int maxEmbeddedPngSize = 4 * 1024 * 1024;
 	private String BLANK_SVG;
     private int maxNumberOfAttempts = 3;
     private ImageResizer imageResizer;
@@ -254,7 +255,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             } catch (IOException ioException) {
                 // We should never fall into this if the server is correctly
                 // configured
-                Map<String, Object> logData = new HashMap<String, Object>();
+                Map<String, Object> logData;
                 logData = new HashMap<String, Object>();
                 logData.put("meetingId", pres.getMeetingId());
                 logData.put("presId", pres.getId());
@@ -287,39 +288,39 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
             if(tempPng.length() > 0) {
                 try  {
+                    int width = 500;
+                    int height = 500;
+
+                    ImageResolution imageResolution = imageResolutionService.identifyImageResolution(tempPng);
+                    log.debug("Identified page {} image {} width={} and height={}", page, pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
+
+                    if (imageResolution.getWidth() != 0 && imageResolution.getHeight() != 0) {
+                        width = imageResolution.getWidth();
+                        height = imageResolution.getHeight();
+                    }
+
+                    if(imageResolution.getWidth() > MAX_SVG_WIDTH || imageResolution.getHeight() > MAX_SVG_HEIGHT) {
+                        log.info("The image exceeds max dimension allowed, it will be resized.");
+                        imageResizer.resize(tempPng, MAX_SVG_WIDTH + "x" + MAX_SVG_HEIGHT);
+                        imageResolution = imageResolutionService.identifyImageResolution(tempPng);
+                        width = imageResolution.getWidth();
+                        height = imageResolution.getHeight();
+                    }
+
                     byte[] pngData = readFileToByteArray(tempPng);
                     String base64encodedPng = Base64.getEncoder().encodeToString(pngData);
                     int base64Size = base64encodedPng.getBytes(StandardCharsets.UTF_8).length;
 
-                    // Maximum base64 encoded PNG size to embed in the SVG (currently 4MB)
-                    int browserLimit = 2 * 2 * 1024 * 1024;
-
-                    if (base64Size > browserLimit) {
-                        log.error("Encoded PNG is too large for the browser");
+                    if (base64Size > maxEmbeddedPngSize) {
+                        log.error("Encoded PNG is too large for the browser - size: {}, limit: {}", base64Size, maxEmbeddedPngSize);
+                    } else if (pres.getRemainingEmbeddedPngBudget() < base64Size) {
+                        log.error("Encoded PNG size exceeds the remaining embedded PNG budget - size: {}, remaining: {}", base64Size, pres.getRemainingEmbeddedPngBudget());
                     } else {
-                        int width = 500;
-                        int height = 500;
-
-                        ImageResolution imageResolution = imageResolutionService.identifyImageResolution(tempPng);
-                        log.debug("Identified page {} image {} width={} and height={}", page, pres.getName(), imageResolution.getWidth(), imageResolution.getHeight());
-
-                        if (imageResolution.getWidth() != 0 && imageResolution.getHeight() != 0) {
-                            width = imageResolution.getWidth();
-                            height = imageResolution.getHeight();
-                        }
-
-                        if(imageResolution.getWidth() > MAX_SVG_WIDTH || imageResolution.getHeight() > MAX_SVG_HEIGHT) {
-                            log.info("The image exceeds max dimension allowed, it will be resized.");
-                            imageResizer.resize(tempPng, MAX_SVG_WIDTH + "x" + MAX_SVG_HEIGHT);
-                            imageResolution = imageResolutionService.identifyImageResolution(tempPng);
-                            width = imageResolution.getWidth();
-                            height = imageResolution.getHeight();
-                        }
-
                         String svg = createSvgWithEmbeddedPng(base64encodedPng, width, height);
                         try (FileWriter writer = new FileWriter(destsvg)) {
                             writer.write(svg);
                         }
+                        pres.alterRemainingEmbeddedPngBudget(base64Size);
                     }
                 } catch (IOException e) {
                     log.error("Error during conversion from PNG to SVG: {}", e.getMessage());
@@ -505,5 +506,12 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     public void setImageResolutionService(ImageResolutionService imageResolutionService) {
         this.imageResolutionService = imageResolutionService;
+    }
+
+    public void setMaxEmbeddedPngSize(int maxEmbeddedPngSize) {
+        if (maxEmbeddedPngSize <= 0) {
+            maxEmbeddedPngSize = Integer.MAX_VALUE;
+        }
+        this.maxEmbeddedPngSize = maxEmbeddedPngSize * 1024 * 1024;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -248,7 +248,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
 
 
-            File tempPng = null;
+            File tempPng;
             String basePresentationame = UUID.randomUUID().toString();
             try {
                 tempPng = File.createTempFile(basePresentationame + "-" + page, ".png");
@@ -316,14 +316,13 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
                     if (base64Size > maxEmbeddedPngSize) {
                         log.error("Encoded PNG is too large for the browser - size: {}, limit: {}", base64Size, maxEmbeddedPngSize);
-                    } else if (pres.getRemainingEmbeddedPngBudget().get() < base64Size) {
+                    } else if (!pres.tryConsumeRemainingEmbeddedPngBudget(base64Size)) {
                         log.error("Encoded PNG size exceeds the remaining embedded PNG budget - size: {}, remaining: {}", base64Size, pres.getRemainingEmbeddedPngBudget());
                     } else {
                         String svg = createSvgWithEmbeddedPng(base64encodedPng, width, height);
                         try (FileWriter writer = new FileWriter(destsvg)) {
                             writer.write(svg);
                         }
-                        pres.alterRemainingEmbeddedPngBudget(base64Size);
                     }
                 } catch (IOException e) {
                     log.error("Error during conversion from PNG to SVG: {}", e.getMessage());

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -139,6 +139,13 @@ forceRasterizeSlides=false
 #------------------------------------
 pngWidthRasterizedSlides=2048
 
+# Maximum file size allowed for PNGs that will be embedded in an SVG in MB (default 8 MB).
+# A value of 0 indicates no limit.
+maxEmbeddedPngSize=8
+
+# Maximum allowable sum of all embedded PNGs in SVGs in MB (default 128 MB).
+# A value of 0 indicates no limit.
+embeddedPngBudget = 128
 
 #------------------------------------
 # Timeout(secs) to wait for conversion script execution

--- a/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/doc-conversion.xml
@@ -40,6 +40,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="presentationFileProcessor" ref="presentationFileProcessor"/>
         <property name="slidesGenerationProgressNotifier" ref="slidesGenerationProgressNotifier"/>
         <property name="maxPageConversionTime" value="${maxPageConversionTime}"/>
+        <property name="embeddedPngBudget" value="${embeddedPngBudget}"/>
     </bean>
 
     <bean id="officeDocumentValidator" class="org.bigbluebutton.presentation.imp.OfficeDocumentValidator2">
@@ -116,6 +117,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="pngWidthRasterizedSlides" value="${pngWidthRasterizedSlides}"/>
         <property name="imageResizer" ref="imageResizer"/>
         <property name="imageResolutionService" ref="imageResolutionService"/>
+        <property name="maxEmbeddedPngSize" value="${maxEmbeddedPngSize}"/>
     </bean>
 
     <bean id="generatedSlidesInfoHelper" class="org.bigbluebutton.presentation.GeneratedSlidesInfoHelperImp"/>


### PR DESCRIPTION
### What does this PR do?

Improves the fallback to embedded PNGs for SVG generation to reduce the number of slides that fallback to using a blank SVG. PNG downscaling is now applied prior to validating the size of the generated PNG to allow a wider range of images to pass validation. The cap on the maximum size of generated PNGs for embedding has been raised from 4 MB to 8 MB. To prevent additional stress on the client that may result from raising this cap a presentation wide embedded PNG size budget has been introduced, with a default of 128 MB,  to restrict the number of large PNGs that can be embedded in slide SVGs.

### Motivation

Some users have mentioned that a large number of their slides in uploaded presentations are using blanks and it would be ideal to reduce this number to provide a better user experience.


### How to test

1. Upload a presentation that has some slides replaced by blanks prior to these changes.
2. Upload the same presentation after these changes and check if those same slides are still using blanks.
