### PR TITLE
fix(user-list): broken pagination due to incorrect parent ref, +

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
@@ -45,6 +45,7 @@ const intlMessages = defineMessages({
 const UserList: React.FC<UserListComponentProps> = () => {
   const intl = useIntl();
   const layoutContextDispatch = layoutDispatch();
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
   const { data: currentUserData } = useCurrentUser((user) => ({
     isModerator: user.isModerator,
     locked: user?.locked ?? false,
@@ -90,9 +91,9 @@ const UserList: React.FC<UserListComponentProps> = () => {
 
   const renderScrollableSection = () => {
     return (
-      <Styled.ScrollableSection id="scroll-box">
+      <Styled.ScrollableSection id="scroll-box" ref={parentRef}>
         {renderGuestManagement()}
-        <UserListParticipants />
+        <UserListParticipants parentRef={parentRef} />
       </Styled.ScrollableSection>
     );
   };

--- a/bigbluebutton-html5/imports/ui/components/user-list/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-list/service.js
@@ -37,6 +37,8 @@ const CUSTOM_LOGO_URL_KEY = 'CustomLogoUrl';
 
 const CUSTOM_DARK_LOGO_URL_KEY = 'CustomDarkLogoUrl';
 
+const DEFAULT_USERS_PER_USER_LIST_PAGE = 50;
+
 export const setCustomLogoUrl = (path) => Storage.setItem(CUSTOM_LOGO_URL_KEY, path);
 
 export const setCustomDarkLogoUrl = (path) => Storage.setItem(CUSTOM_DARK_LOGO_URL_KEY, path);
@@ -483,6 +485,10 @@ export const onSaveUserNames = (intl, meetingName, users) => {
     meetingName,
   ).dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
 };
+
+export const getUsersPerUserListPage = () => window.meetingClientSettings?.public?.layout
+  ?.usersPerUserListPage
+  || DEFAULT_USERS_PER_USER_LIST_PAGE;
 
 export default {
   sortUsersByName,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
@@ -3,6 +3,7 @@ import { UI_DATA_LISTENER_SUBSCRIBED } from 'bigbluebutton-html-plugin-sdk/dist/
 import { UserListUiDataPayloads } from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-data/domain/user-list/types';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import { User } from '/imports/ui/Types/user';
+import { getUsersPerUserListPage } from '/imports/ui/components/user-list/service';
 import Styled from './styles';
 import {
   USER_AGGREGATE_COUNT_SUBSCRIPTION,
@@ -13,7 +14,6 @@ import UserListParticipantsPageContainer from './page/component';
 import IntersectionWatcher from './intersection-watcher/intersectionWatcher';
 import { setLocalUserList } from '/imports/ui/core/hooks/useLoadedUserList';
 import roveBuilder from '/imports/ui/core/utils/keyboardRove';
-import { USERS_PER_USER_LIST_PAGE } from '/imports/ui/components/user-list/user-list-participants/constants';
 
 interface UserListParticipantsProps {
   count: number;
@@ -28,6 +28,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
     [key: number]: User[];
   }>({});
   const selectedUserRef = React.useRef<HTMLElement | null>(null);
+  const usersPerUserListPage = getUsersPerUserListPage();
 
   useEffect(() => {
     const keys = Object.keys(visibleUsers);
@@ -80,7 +81,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   }, []);
   // --- End of plugin related code ---
 
-  const amountOfPages = Math.ceil(count / USERS_PER_USER_LIST_PAGE);
+  const amountOfPages = Math.ceil(count / usersPerUserListPage);
   return (
     (
       <Styled.UserListColumn
@@ -92,7 +93,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
           {
             Array.from({ length: amountOfPages }).map((_, i) => {
               const isLastItem = amountOfPages === (i + 1);
-              const restOfUsers = count % USERS_PER_USER_LIST_PAGE;
+              const restOfUsers = count % usersPerUserListPage;
               const key = i;
               return i === 0
                 ? (
@@ -100,7 +101,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                     key={key}
                     index={i}
                     isLastItem={isLastItem}
-                    restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
+                    restOfUsers={isLastItem ? restOfUsers : usersPerUserListPage}
                     setVisibleUsers={setVisibleUsers}
                   />
                 )
@@ -110,13 +111,13 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                     key={i}
                     ParentRef={parentRef}
                     isLastItem={isLastItem}
-                    restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
+                    restOfUsers={isLastItem ? restOfUsers : usersPerUserListPage}
                   >
                     <UserListParticipantsPageContainer
                       key={key}
                       index={i}
                       isLastItem={isLastItem}
-                      restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
+                      restOfUsers={isLastItem ? restOfUsers : usersPerUserListPage}
                       setVisibleUsers={setVisibleUsers}
                     />
                   </IntersectionWatcher>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
@@ -17,15 +17,16 @@ import { USERS_PER_USER_LIST_PAGE } from '/imports/ui/components/user-list/user-
 
 interface UserListParticipantsProps {
   count: number;
+  parentRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   count,
+  parentRef,
 }) => {
   const [visibleUsers, setVisibleUsers] = React.useState<{
     [key: number]: User[];
   }>({});
-  const userListRef = React.useRef<HTMLUListElement | null>(null);
   const selectedUserRef = React.useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -85,8 +86,9 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
       <Styled.UserListColumn
         onKeyDown={rove}
         tabIndex={0}
+        role="list"
       >
-        <Styled.VirtualizedList as="ul" ref={userListRef}>
+        <Styled.VirtualizedList as="ul">
           {
             Array.from({ length: amountOfPages }).map((_, i) => {
               const isLastItem = amountOfPages === (i + 1);
@@ -106,7 +108,7 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
                   <IntersectionWatcher
                     // eslint-disable-next-line react/no-array-index-key
                     key={i}
-                    ParentRef={userListRef}
+                    ParentRef={parentRef}
                     isLastItem={isLastItem}
                     restOfUsers={isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE}
                   >
@@ -127,18 +129,21 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   );
 };
 
-const UserListParticipantsContainer: React.FC = () => {
+interface UserListParticipantsContainerProps {
+  parentRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const UserListParticipantsContainer: React.FC<UserListParticipantsContainerProps> = ({ parentRef }) => {
   const {
     data: countData,
   } = useDeduplicatedSubscription<UsersCountSubscriptionResponse>(USER_AGGREGATE_COUNT_SUBSCRIPTION);
   const count = countData?.user_aggregate?.aggregate?.count || 0;
 
   return (
-    <>
-      <UserListParticipants
-        count={count ?? 0}
-      />
-    </>
+    <UserListParticipants
+      count={count ?? 0}
+      parentRef={parentRef}
+    />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/constants.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/constants.ts
@@ -1,3 +1,0 @@
-export const USERS_PER_USER_LIST_PAGE = 50;
-
-export default USERS_PER_USER_LIST_PAGE;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/intersection-watcher/intersectionWatcher.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/intersection-watcher/intersectionWatcher.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import useIntersectionObserver from '/imports/ui/hooks/useIntersectionObserver';
+import { getUsersPerUserListPage } from '/imports/ui/components/user-list/service';
 import SkeletonUserListItem from '../list-item/skeleton/component';
-import USERS_PER_USER_LIST_PAGE from '/imports/ui/components/user-list/user-list-participants/constants';
 
 const MOUNT_DELAY = 1000;
 
@@ -27,6 +27,7 @@ const IntersectionWatcher: React.FC<IntersectionWatcherProps> = ({
     childRefProxy,
     intersecting,
   } = useIntersectionObserver(ParentRef, childrenRef, 0);
+  const usersPerUserListPage = getUsersPerUserListPage();
 
   const handleIntersection = (bool: boolean) => {
     clearTimeout(setTimoutRef.current);
@@ -53,7 +54,7 @@ const IntersectionWatcher: React.FC<IntersectionWatcherProps> = ({
     <div ref={childRefProxy}>
       { renderPage ? children
         : (
-          Array.from({ length: isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE }).map((_, index) => (
+          Array.from({ length: isLastItem ? restOfUsers : usersPerUserListPage }).map((_, index) => (
             <SkeletonUserListItem key={`not-visible-item-${index + 1}`} enableAnimation={intersecting} />
           ))
         )}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/intersection-watcher/intersectionWatcher.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/intersection-watcher/intersectionWatcher.tsx
@@ -8,7 +8,7 @@ const MOUNT_DELAY = 1000;
 const UNMOUNT_DELAY = 20000;
 
 interface IntersectionWatcherProps {
-  ParentRef: React.MutableRefObject<HTMLUListElement | null>;
+  ParentRef: React.RefObject<HTMLDivElement | null>;
   children: React.ReactNode;
   isLastItem: boolean;
   restOfUsers: number;
@@ -49,17 +49,14 @@ const IntersectionWatcher: React.FC<IntersectionWatcherProps> = ({
     }
   }, [intersecting]);
 
-  if (renderPage) {
-    return children;
-  }
-
   return (
     <div ref={childRefProxy}>
-      {
-        Array.from({ length: isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE }).map((_, index) => (
-          <SkeletonUserListItem key={`not-visible-item-${index + 1}`} enableAnimation={intersecting} />
-        ))
-      }
+      { renderPage ? children
+        : (
+          Array.from({ length: isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE }).map((_, index) => (
+            <SkeletonUserListItem key={`not-visible-item-${index + 1}`} enableAnimation={intersecting} />
+          ))
+        )}
     </div>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
@@ -6,13 +6,13 @@ import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { CURRENT_PRESENTATION_PAGE_SUBSCRIPTION, CurrentPresentationPagesSubscriptionResponse } from '/imports/ui/components/whiteboard/queries';
 import { User } from '/imports/ui/Types/user';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
+import { getUsersPerUserListPage } from '/imports/ui/components/user-list/service';
 import Styled from '../styles';
 import ListItem from '../list-item/component';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import SkeletonUserListItem from '../list-item/skeleton/component';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
-import USERS_PER_USER_LIST_PAGE from '../constants';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { LockSettings, Meeting, UsersPolicies } from '/imports/ui/Types/meeting';
 import logger from '/imports/startup/client/logger';
@@ -88,8 +88,9 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   restOfUsers,
   setVisibleUsers,
 }) => {
-  const offset = index * USERS_PER_USER_LIST_PAGE;
-  const limit = useRef(USERS_PER_USER_LIST_PAGE);
+  const usersPerUserListPage = getUsersPerUserListPage();
+  const offset = index * usersPerUserListPage;
+  const limit = useRef(usersPerUserListPage);
 
   const {
     data: meeting,
@@ -184,7 +185,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   }, []);
 
   if (usersLoading || meetingLoading || !meeting || currentUserLoading || presentationLoading) {
-    return Array.from({ length: isLastItem ? restOfUsers : USERS_PER_USER_LIST_PAGE }).map((_, i) => (
+    return Array.from({ length: isLastItem ? restOfUsers : usersPerUserListPage }).map((_, i) => (
       <Styled.UserListItem key={`not-visible-item-${i + 1}`}>
         {/* eslint-disable-next-line */}
         <SkeletonUserListItem enableAnimation={true} />

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -830,6 +830,7 @@ public:
     showSessionDetailsOnJoin: true
     showScreenshareQuickSwapButton: false
     showLeaveSessionLabel: false
+    usersPerUserListPage: 50
   pads:
     url: ETHERPAD_HOST
   media:


### PR DESCRIPTION
### What does this PR do?

- [fix(user-list): broken pagination due to incorrect parent ref](https://github.com/bigbluebutton/bigbluebutton/commit/32edef17b914c6fc92a01023e10ad0298fb1b60b) 
  - User list pagination is broken due to two different issues:
    - In 3.1, the reference element for visibility changed from the
    virtualized user list div to the scrollable element, which now
    encapsulates all of the user list panel (including guest mgmt et
    al). The intersection watcher parent ref did not follow that change,
    which causes it to render all entries since the user list div is
    always "visible" to its parent element (the scrollable component)
    - A style fix inadvertently removed the container div for user
    list entries that are out of bounds. This causes their actual user
    list components to be rendered rather than their skeleton variants.
  - Fix user list pagination via:
    - Make the scrollable element the intersection watcher's parent ref
    - Re-introduce the skeleton container div in the intersection watcher
- [feat: make user list page size configurable](https://github.com/bigbluebutton/bigbluebutton/commit/caaed685b95c72985bc205579169ccc89877ebd9) 
  - Make the user list page size configurable. The goal is to experiment
with lower values as a temporary measure to improve client-side
performance.
  - See `public.layout.usersPerUserListPage` in bbb-html5's configuration.
  Default value of 50 is preserved.
  
### Closes Issue(s)

None