### PR TITLE
fix(livekit): SIP calls aren't accepted w/o published audio tracks

### DIFF
--- a/build/packages-template/bbb-livekit/build.sh
+++ b/build/packages-template/bbb-livekit/build.sh
@@ -81,6 +81,17 @@ if [ -z "$SIP_DIR" ]; then
     exit 1
 fi
 
+# Apply livekit-sip patches if any. All patches end in "_sip.patch" and are in
+# the same directory as this script.
+for patch in "$BUILDDIR"/*_sip.patch; do
+    if [ -f "$patch" ]; then
+        echo "Applying patch: $patch"
+        pushd "$SIP_DIR" > /dev/null
+        git apply "$patch"
+        popd > /dev/null
+    fi
+done
+
 pushd "$SIP_DIR" > /dev/null
 
 if [ "$TARGETPLATFORM" = "linux/arm64" ]; then

--- a/build/packages-template/bbb-livekit/livekit-sip.yaml
+++ b/build/packages-template/bbb-livekit/livekit-sip.yaml
@@ -8,3 +8,4 @@ sip_port: 5062
 sip_port_listen: 5062
 redis:
   address: localhost:6379
+no_pin_wait_for_subscribe: false

--- a/build/packages-template/bbb-livekit/no-pin-sub_sip.patch
+++ b/build/packages-template/bbb-livekit/no-pin-sub_sip.patch
@@ -1,0 +1,38 @@
+diff --git a/pkg/config/config.go b/pkg/config/config.go
+index 8e2dc35..536fa59 100644
+--- a/pkg/config/config.go
++++ b/pkg/config/config.go
+@@ -69,6 +69,7 @@ type Config struct {
+ 	SIPPortListen      int                 `yaml:"sip_port_listen"` // SIP signaling port to listen on
+ 	SIPHostname        string              `yaml:"sip_hostname"`
+ 	SIPRingingInterval time.Duration       `yaml:"sip_ringing_interval"` // from 1 sec up to 60 (default '1s')
++	NoPinWaitForSubscribe bool                `yaml:"no_pin_wait_for_subscribe"`
+ 	TLS                *TLSConfig          `yaml:"tls"`
+ 	RTPPort            rtcconfig.PortRange `yaml:"rtp_port"`
+ 	Logging            logger.Config       `yaml:"logging"`
+@@ -117,6 +118,7 @@ func NewConfig(confString string) (*Config, error) {
+ 		ApiSecret:   os.Getenv("LIVEKIT_API_SECRET"),
+ 		WsUrl:       os.Getenv("LIVEKIT_WS_URL"),
+ 		ServiceName: "sip",
++		NoPinWaitForSubscribe: true,
+ 	}
+ 	if confString != "" {
+ 		if err := yaml.Unmarshal([]byte(confString), conf); err != nil {
+diff --git a/pkg/sip/inbound.go b/pkg/sip/inbound.go
+index abaf8ff..b791904 100644
+--- a/pkg/sip/inbound.go
++++ b/pkg/sip/inbound.go
+@@ -917,8 +917,11 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
+ 		c.log().Infow("Waiting for track subscription(s)")
+ 		// For dispatches without pin, we first wait for LK participant to become available,
+ 		// and also for at least one track subscription. In the meantime we keep ringing.
+-		if ok, err := c.waitSubscribe(ctx, disp.RingingTimeout); !ok {
+-			return err // already sent a response. Could be success if caller hung up
++
++		if c.s.conf.NoPinWaitForSubscribe {
++			if ok, err := c.waitSubscribe(ctx, disp.RingingTimeout); !ok {
++				return err // already sent a response. Could be success if caller hung up
++			}
+ 		}
+ 		if ok, err := acceptCall(answerData); !ok {
+ 			return err // already sent a response. Could be success if caller hung up


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): SIP calls aren't accepted w/o published audio tracks](https://github.com/bigbluebutton/bigbluebutton/pull/24270/commits/014ae1d58e3d8825e9b7767b07b5fe81a41e420f)
  - When livekit/sip dispatch rules do not require a PIN for inbound SIP
calls, they're only fully established once at least one audio
subscription in a room succeeds. In our use case, where PIN prompting
and IVR is currently done by an external gateway, this is not desirable
as it may lead to a deafened-muted scenario when calling into a meeting
with all-muted users.
  - Add a patch to livekit/sip that introduces a new configuration option:
`no_pin_wait_for_subscribe`. In our case, it's set to false - so calls
will be established regardless of whether there's published audio tracks
in a room.
  - The goal is to later make this into a dispatch rule option and submit it
to upstream LiveKit.

### Closes Issue(s)

Partially https://github.com/bigbluebutton/bigbluebutton/issues/24262
