### PR TITLE
fix: add null safety check for breakout room join

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -279,7 +279,7 @@ const BreakoutJoinConfirmationContainer: React.FC = () => {
   if (currentUser?.isModerator
       && !currentMeeting?.breakoutRoomsCommonProperties?.sendInvitationToModerators) return null;
 
-  if (!breakoutData || breakoutData.breakoutRoom.length === 0) return null;
+  if (!breakoutData || (breakoutData.breakoutRoom?.length ?? 0) === 0) return null;
 
   return (
     <BreakoutJoinConfirmation


### PR DESCRIPTION
### What does this PR do?

Add null safety check for `breakoutData.breakoutRoom` to prevent potential runtime errors

`TypeError: Cannot read properties of undefined (reading 'length')
    at BreakoutJoinConfirmationContainer`

### Motivation

While breakoutData is checked for nullish values, the breakoutRoom property itself could potentially be null or undefined. 

Directly accessing .length on a nullish value would cause a runtime error. This change ensures the code safely handles cases where breakoutRoom might not be defined.

### How to test
Verify breakout room join confirmation dialog still appears when invitations are sent
