### PR TITLE
fix(bbb-web): Fix defaultHTML5ClientUrl trailing slash

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -367,7 +367,7 @@ bigbluebutton.web.logoutURL=default
 
 # The url of the BigBlueButton HTML5 client. Users will be redirected here when
 # successfully joining the meeting.
-defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client
+defaultHTML5ClientUrl=${bigbluebutton.web.serverURL}/html5client/
 
 # Graphql websocket url (it's necessary to change for cluster setup)
 # Using `serverURL` as default, so `https` will be automatically replaced by `wss`


### PR DESCRIPTION
### What does this PR do?
Adds missing trailing slash for the html5 client to prevent a redirect request on each join

### Motivation
Reduce client load time

Currently only to add "/" a network request is made
<img width="1509" height="616" alt="image" src="https://github.com/user-attachments/assets/2f447ede-2570-41b8-8247-7c8ae7d527a6" />

### How to test
- Watch browser requests to see only a single /html5client request when joining