### PR TITLE
fix: hide learning dashboad button from side navigation if it is disa…

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/learning-dashboard-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/learning-dashboard-list-item/component.tsx
@@ -3,6 +3,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import LearningDashboardService from '/imports/ui/components/learning-dashboard/service';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
+import { useIsLearningDashboardEnabled } from '../../../services/features';
 
 const intlMessages = defineMessages({
   learningDashboardLabel: {
@@ -17,6 +18,9 @@ const LearningDashboardListItem = () => {
     learningDashboardAccessToken: meeting.learningDashboardAccessToken,
     isBreakout: meeting?.isBreakout,
   }));
+  const isLearningDashboardEnabled = useIsLearningDashboardEnabled();
+
+  if (!isLearningDashboardEnabled) return null;
 
   const openLearningDashboardPanel = useCallback(() => {
     LearningDashboardService.openLearningDashboardUrl(intl.locale, meetingInfo?.learningDashboardAccessToken);


### PR DESCRIPTION
This pr solve the issue of learning dashboad button displaing on side bar even it is disabled by including it in "disabledFeatures" param of create API