### PR TITLE
fix(shared-notes): disable sidebar button when pinned

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
@@ -89,7 +89,7 @@ const UserNotesListItemContainerGraphql: React.FC<BaseSidebarButtonProps> = (pro
       ariaDescribedBy="lockedNotes"
       dataTest="sharedNotesSidebarButton"
       hasNotification={hasUnreadNotes}
-      isDisabled={disableNotes}
+      isDisabled={disableNotes || isPinned}
     >
       {disableNotes
         ? (


### PR DESCRIPTION
### What does this PR do?
Restores the expected behavior where the shared notes sidebar button is disabled while pinned. This regression was introduced in 6c7ff0ea4144491d8318dc89a5215c6c2cec0eae.
![shared_notes_fix](https://github.com/user-attachments/assets/d3840ffa-58a6-48aa-ab22-32cbc52f25b7)

### Closes Issue(s)
Closes #24302 