### PR TITLE
build(bbb-webrtc-sfu): v2.21.0

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.20.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.21.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

* [build(bbb-webrtc-sfu): v2.21.0](https://github.com/bigbluebutton/bigbluebutton/commit/fdaf4b5d46ad82f0f075815c1fff04157c68c2ac) 
  * feat(livekit): add agent conn state and event metrics
  * feat: add docker matrix build to support arm64
  * fix(livekit): add conn retry logic for RTC state sync agents
  * fix(livekit): BBB state sync stalls on idle rooms
  * fix(mediasoup): incorrect media direction causes tab sharing + audio to fail
  * build: add environment variable to disable file logging
  * build: remove QEMU setup from publish Docker workflow
  * build(deps): livekit-server-sdk@2.14.0
  * build(deps): @livekit/rtc-node@0.13.20
  * build(deps): pino@10.1.0
  * build(deps): pino-pretty@13.1.2
  * build(deps): bump actions/checkout from 4 to 5

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/24310

### Motivation

Important note: this version fixes an issue with tab sharing + audio failing in Chrome +143