### PR TITLE
fix(shared-notes): bypass unmount delay when pinned on grid layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -130,16 +130,6 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
   };
 
   const {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    display,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isPinned,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    browserHeight,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    browserWidth,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    tabOrder,
     ...cssProps
   } = sharedNotesOutput;
 
@@ -248,7 +238,8 @@ const NotesContainerGraphql: React.FC<NotesContainerGraphqlProps> = (props) => {
       layoutContextDispatch={layoutContextDispatch}
       isResizing={isResizing}
       isLocalChange={isLocalChange}
-      ignoreDelayforUnmount={sidebarContentToIgnoreDelay.includes(sidebarContent.sidebarContentPanel)}
+      ignoreDelayforUnmount={sidebarContentToIgnoreDelay.includes(sidebarContent.sidebarContentPanel)
+        || (isOnMediaArea && !!isGridLayout)}
       sharedNotesOutput={sharedNotesOutput}
       amIPresenter={amIPresenter}
       isRTL={isRTL}


### PR DESCRIPTION
### What does this PR do?
Bypasses the unmount delay to correcly folow the sidebar content panel state when the shared notes is pinned and the layout is set to grid.

![pinned_shared_notes_grid_layout_1](https://github.com/user-attachments/assets/8d072e9b-1259-481f-9620-31f5f8b15ae8)


### Closes Issue(s)
Closes #24308 

