### PR TITLE
fix(livekit): stricter measures to prevent publish-unpublish loops, +

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -229,7 +229,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   private isLocalPublicationMuted(): boolean {
     const pubs = this.getLocalMicTrackPubs();
 
-    return pubs.length === 0 || pubs.every((pub) => pub.isMuted);
+    return pubs.every((pub) => pub.isMuted);
   }
 
   private isTrackPublishedWithStream(stream: MediaStream | null): boolean {
@@ -345,8 +345,9 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       this.clearUnpublishRequest();
 
       this.unpublishRequest = setTimeout(() => {
-        // TODO also check if still muted?
-        if (!this.hasMicrophoneTrack()) return;
+        // If the publication is unmuted, we don't need to unpublish anymore
+        // (this unpublish request is only set if the publication is muted)
+        if (!this.hasMicrophoneTrack() || !this.isLocalPublicationMuted()) return;
 
         this.unpublish();
         this.unpublishRequest = null;
@@ -1100,7 +1101,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     }).finally(() => {
       // Only clear pending if no newer publish has started
       if (this.publishGeneration === currentGeneration) this.isPublishPending = false;
-    }) as Promise<void>;
+    });
   }
 
   private unpublish(): Promise<void> {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -30,6 +30,7 @@ const PUBLISH_OP = 'publish';
 const UNPUBLISH_OP = 'unpublish';
 const IS_CHROME = browserInfo.isChrome;
 const ROOM_CONNECTION_TIMEOUT = 15000;
+const DEFAULT_UNPUBLISH_AFTER_MUTE_MS = 5000;
 
 interface JoinOptions {
   inputStream: MediaStream;
@@ -68,6 +69,17 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
   private clientSessionUUID: string = '0';
 
+  private unpublishRequest: ReturnType<typeof setTimeout> | null;
+
+  // Tracks whether a publish operation is pending
+  // Used for idempotency checks since LiveKit's actual state is not immediate
+  private isPublishPending: boolean;
+
+  // Generation counter for publish operations. Used to prevent stale finally()
+  // callbacks from incorrectly clearing isPublishPending when a newer publish
+  // has superseded them.
+  private publishGeneration: number;
+
   private static assembleTrackName(
     clientSessionId: string,
     deviceId: string | null | undefined,
@@ -100,6 +112,9 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.handleLocalTrackUnmuted = this.handleLocalTrackUnmuted.bind(this);
     this.handleLocalTrackPublished = this.handleLocalTrackPublished.bind(this);
     this.handleLocalTrackUnpublished = this.handleLocalTrackUnpublished.bind(this);
+    this.unpublishRequest = null;
+    this.isPublishPending = false;
+    this.publishGeneration = 0;
 
     this.observeLiveKitEvents();
   }
@@ -211,6 +226,33 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     return source === Track.Source.Microphone;
   }
 
+  private isLocalPublicationMuted(): boolean {
+    const pubs = this.getLocalMicTrackPubs();
+
+    return pubs.length === 0 || pubs.every((pub) => pub.isMuted);
+  }
+
+  private isTrackPublishedWithStream(stream: MediaStream | null): boolean {
+    if (!stream) return false;
+
+    const pubs = this.getLocalMicTrackPubs();
+
+    if (pubs.length === 0) return false;
+
+    return pubs.some((pub) => {
+      const pubStream = pub.track?.mediaStream;
+
+      return pubStream?.id === stream.id && pubStream?.active;
+    });
+  }
+
+  private clearUnpublishRequest(): void {
+    if (this.unpublishRequest) {
+      clearTimeout(this.unpublishRequest);
+      this.unpublishRequest = null;
+    }
+  }
+
   private handleTrackSubscribed(
     // @ts-ignore - unused for now
     track: RemoteTrack,
@@ -283,6 +325,9 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   private handleLocalTrackMuted(publication: TrackPublication): void {
     if (!LiveKitAudioBridge.isMicrophonePublication(publication)) return;
 
+    // @ts-ignore
+    const LIVEKIT_SETTINGS = window.meetingClientSettings.public.media?.livekit?.audio;
+    const unpublishAfterMuteMs = LIVEKIT_SETTINGS?.unpublishAfterMuteMs ?? DEFAULT_UNPUBLISH_AFTER_MUTE_MS;
     const { trackSid, isMuted, trackName } = publication;
 
     logger.info({
@@ -295,12 +340,26 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         isMuted,
       },
     }, `LiveKit: local audio track muted - ${trackSid}`);
+
+    if (LIVEKIT_SETTINGS?.unpublishOnMute && this.hasMicrophoneTrack()) {
+      this.clearUnpublishRequest();
+
+      this.unpublishRequest = setTimeout(() => {
+        // TODO also check if still muted?
+        if (!this.hasMicrophoneTrack()) return;
+
+        this.unpublish();
+        this.unpublishRequest = null;
+      }, unpublishAfterMuteMs);
+    }
   }
 
   private handleLocalTrackUnmuted(publication: TrackPublication): void {
     if (!LiveKitAudioBridge.isMicrophonePublication(publication)) return;
 
     const { trackSid, isMuted, trackName } = publication;
+
+    this.clearUnpublishRequest();
 
     logger.info({
       logCode: 'livekit_audio_local_track_unmuted',
@@ -432,23 +491,25 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     }, 'LiveKit: set audio input stream');
 
     if (hasCurrentPub) {
-      return this.publish(stream)
-        .catch((error) => {
-          logger.error({
-            logCode: 'livekit_audio_set_input_stream_error',
-            extraInfo: {
-              errorMessage: (error as Error).message,
-              errorName: (error as Error).name,
-              errorStack: (error as Error).stack,
-              bridge: this.bridgeName,
-              role: this.role,
-              inputDeviceId: this.inputDeviceId,
-              streamData: MediaStreamUtils.getMediaStreamLogData(stream),
-              originalStreamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
-            },
-          }, 'LiveKit: set audio input stream failed');
-          throw error;
-        });
+      // Force publish to supersede any pending publish with the new stream.
+      // This is intentional - when changing the input stream, we want the new
+      // one to take precedence over any ongoing publish.
+      return this.publish(stream, true).catch((error) => {
+        logger.error({
+          logCode: 'livekit_audio_set_input_stream_error',
+          extraInfo: {
+            errorMessage: (error as Error).message,
+            errorName: (error as Error).name,
+            errorStack: (error as Error).stack,
+            bridge: this.bridgeName,
+            role: this.role,
+            inputDeviceId: this.inputDeviceId,
+            streamData: MediaStreamUtils.getMediaStreamLogData(stream),
+            originalStreamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
+          },
+        }, 'LiveKit: set audio input stream failed');
+        throw error;
+      });
     }
 
     // No previous publication, so no need to publish yet - unmute will handle it
@@ -577,14 +638,16 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         backup();
 
         // We have a published track, but it's stream is inactive. Likely a dead
-        // stream. Restart the track.
-        if (this.publicationTrackStream && !this.publicationTrackStream.active) {
+        // stream or muted. Restart the track as switchActiveDevice will not work.
+        if ((this.publicationTrackStream && !this.publicationTrackStream.active)
+          || this.publicationTrack?.isMuted) {
           logger.warn({
             logCode: 'livekit_audio_live_change_input_device_inactive_stream',
             extraInfo: {
               bridge: this.bridgeName,
               role: this.role,
               deviceId,
+              muted: this.publicationTrack?.isMuted,
               streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
               originalStreamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
               publicationStreamData: MediaStreamUtils.getMediaStreamLogData(this.publicationTrackStream),
@@ -693,6 +756,9 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
   setSenderTrackEnabled(shouldEnable: boolean): void {
     const trackPubs = this.getLocalMicTrackPubs();
+    const isCurrentlyMuted = this.isLocalPublicationMuted();
+    const hasPublishedTrack = this.hasMicrophoneTrack();
+
     const handleMuteError = (error: Error) => {
       logger.error({
         logCode: 'livekit_audio_set_sender_track_error',
@@ -709,27 +775,54 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       }, `LiveKit: setSenderTrackEnabled failed - ${error.message}`);
     };
 
-    if (shouldEnable) {
-      const trackName = LiveKitAudioBridge.assembleTrackName(this.clientSessionId, this.inputDeviceId);
-      const currentPubs = trackPubs.filter((pub) => {
-        return LiveKitAudioBridge.publicationMatchesDevice(pub, this.inputDeviceId) && pub.isMuted;
-      });
+    logger.debug({
+      logCode: 'livekit_audio_set_sender_track_enabled',
+      extraInfo: {
+        shouldEnable,
+        bridge: this.bridgeName,
+        role: this.role,
+        isCurrentlyMuted,
+        hasPublishedTrack,
+        isPublishPending: this.isPublishPending,
+        inputDeviceId: this.inputDeviceId,
+        streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
+        originalStreamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
+      },
+    }, `LiveKit: setSenderTrackEnabled(${shouldEnable}) muted=${isCurrentlyMuted} published=${hasPublishedTrack}`);
 
-      // Track was not unpublished on previous mute toggle, so no need to publish again
-      // Just toggle mute.
-      if (currentPubs.length) {
-        currentPubs.forEach((pub) => pub.unmute());
-        logger.debug({
-          logCode: 'livekit_audio_track_unmute',
-          extraInfo: {
-            bridge: this.bridgeName,
-            role: this.role,
-            trackName,
-          },
-        }, `LiveKit: unmuting audio track - ${trackName}`);
-      } else if (trackPubs.length === 0) {
-        // Track was unpublished on previous mute toggle, so publish again
-        // If audio hasn't been shared yet, do nothing
+    if (shouldEnable) {
+      // If track is already published and unmuted, do nothing
+      if (hasPublishedTrack && !isCurrentlyMuted) return;
+
+      // Cancel any pending unpublish request since we're unmuting
+      this.clearUnpublishRequest();
+
+      const trackName = LiveKitAudioBridge.assembleTrackName(this.clientSessionId, this.inputDeviceId);
+      const currentPubs = trackPubs.filter(
+        (pub) => LiveKitAudioBridge.publicationMatchesDevice(pub, this.inputDeviceId),
+      );
+
+      // Track is published but muted - just unmute it
+      if (currentPubs.length > 0) {
+        const mutedPubs = currentPubs.filter((pub) => pub.isMuted);
+
+        if (mutedPubs.length > 0) {
+          mutedPubs.forEach((pub) => pub.unmute());
+          logger.debug({
+            logCode: 'livekit_audio_track_unmute',
+            extraInfo: {
+              bridge: this.bridgeName,
+              role: this.role,
+              trackName,
+              streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
+              originalStreamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
+              mutedPubs: mutedPubs.map((pub) => pub.trackName),
+            },
+          }, `LiveKit: unmuting audio track - ${trackName}`);
+        }
+      } else if (trackPubs.length === 0 && this.originalStream) {
+        // Track was unpublished on previous mute toggle, so publish again.
+        // Only publish if we have an original stream (audio was shared before).
         this.publish(this.originalStream).catch(handleMuteError);
         logger.debug({
           logCode: 'livekit_audio_track_unmute_publish',
@@ -746,19 +839,19 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
             bridge: this.bridgeName,
             role: this.role,
             trackName,
-            trackPubs,
+            hasPublishedTrack,
+            isCurrentlyMuted,
+            streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
+            originalStreamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
           },
-        }, 'LiveKit: audio track unmute no-op');
+        }, 'LiveKit: audio track unmute no-op - no matching pubs or no original stream');
       }
     } else {
-      // @ts-ignore
-      const LIVEKIT_SETTINGS = window.meetingClientSettings.public.media?.livekit?.audio;
+      if (isCurrentlyMuted || !hasPublishedTrack) return;
 
-      if (LIVEKIT_SETTINGS?.unpublishOnMute) {
-        this.unpublish();
-      } else {
-        this.liveKitRoom.localParticipant.setMicrophoneEnabled(false).catch(handleMuteError);
-      }
+      // Track is published and unmuted - mute it
+      // The handleLocalTrackMuted callback will handle the debounced unpublish
+      this.liveKitRoom.localParticipant.setMicrophoneEnabled(false).catch(handleMuteError);
     }
   }
 
@@ -955,8 +1048,46 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     }
   }
 
-  private publish(inputStream: MediaStream | null): Promise<void> {
-    return new Promise((resolve, reject) => {
+  private publish(inputStream: MediaStream | null, force = false): Promise<void> {
+    // If the stream is already published and active, skip
+    if (inputStream && this.isTrackPublishedWithStream(inputStream)) {
+      logger.debug({
+        logCode: 'livekit_audio_publish_idempotent_skip',
+        extraInfo: {
+          bridge: this.bridgeName,
+          role: this.role,
+          inputDeviceId: this.inputDeviceId,
+          streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
+        },
+      }, 'LiveKit: stream already published, skipping publish');
+
+      return Promise.resolve();
+    }
+
+    // If a publish is already pending and this isn't a forced supersede, skip.
+    // This prevents multiple publish operations from being queued when calls
+    // arrive faster than LiveKit can process them.
+    if (this.isPublishPending && !force) {
+      logger.debug({
+        logCode: 'livekit_audio_publish_pending_skip',
+        extraInfo: {
+          bridge: this.bridgeName,
+          role: this.role,
+          inputDeviceId: this.inputDeviceId,
+          streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
+        },
+      }, 'LiveKit: publish already pending, skipping');
+
+      return Promise.resolve();
+    }
+
+    // The counter  prevents stale finally() callbacks from incorrectly clearing
+    // isPublishPending when a newer publish has superseded them - prlanzarin
+    this.publishGeneration += 1;
+    const currentGeneration = this.publishGeneration;
+    this.isPublishPending = true;
+
+    return new Promise<void>((resolve, reject) => {
       // Discard trailing, unprocessed publish requests.
       this.flushPublishQueue(PUBLISH_OP);
       this.dispatchPublishOperation({
@@ -966,10 +1097,15 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         resolve,
         reject,
       });
-    });
+    }).finally(() => {
+      // Only clear pending if no newer publish has started
+      if (this.publishGeneration === currentGeneration) this.isPublishPending = false;
+    }) as Promise<void>;
   }
 
   private unpublish(): Promise<void> {
+    if (!this.hasMicrophoneTrack()) return Promise.resolve();
+
     return new Promise((resolve, reject) => {
       // Discard ALL trailing, unprocessed requests.
       this.flushPublishQueue();
@@ -982,6 +1118,22 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   }
 
   private async doPublish(inputStream: MediaStream | null): Promise<void> {
+    // If the stream is already published, skip the publish
+    // This prevents unnecessary unpublish/publish cycles when doPublish is called directly
+    if (inputStream && this.isTrackPublishedWithStream(inputStream)) {
+      logger.debug({
+        logCode: 'livekit_audio_do_publish_idempotent_skip',
+        extraInfo: {
+          bridge: this.bridgeName,
+          role: this.role,
+          inputDeviceId: this.inputDeviceId,
+          streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
+        },
+      }, 'LiveKit: stream already published, skipping doPublish');
+
+      return;
+    }
+
     try {
       if (this.hasMicrophoneTrack()) await this.doUnpublish();
     } catch (error) {
@@ -1248,6 +1400,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       })
       .finally(() => {
         this.originalStream = null;
+        this.isPublishPending = false;
         this.audioEnded();
       });
   }

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -648,6 +648,7 @@ export interface LiveKitScreenShareSettings {
 export interface LiveKitAudioSettings {
   publishOptions?: TrackPublishOptions
   unpublishOnMute?: boolean
+  unpublishAfterMuteMs?: number
 }
 
 export interface LiveKitSettings {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -121,9 +121,11 @@ const AudioModalContainer = (props) => {
       setIsOpen(false);
 
       // When using LiveKit, force joining audio when the modal is closed,
-      // but the user is not connected nor connecting to audio.
+      // but the user is not connected nor connecting to audio. This also means
+      // that the user will join muted as not clicking "Join Audio" signals
+      // that intention.
       if (usingLiveKit && !isConnected && !isConnecting) {
-        joinMic().catch((error) => handleJoinError(error, false));
+        joinMic({ muteOnStart: true }).catch((error) => handleJoinError(error, false));
       }
     };
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -104,8 +104,8 @@ const AudioModalContainer = (props) => {
     (options = {}) => joinMicrophone({
       skipEchoTest: options.skipEchoTest || joinFullAudioImmediately,
       muted: options.muteOnStart
-        || meeting?.voiceSettings?.muteOnStart
-        || storageMuteState,
+        ?? storageMuteState
+        ?? meeting?.voiceSettings?.muteOnStart,
     }),
     [skipCheck, skipCheckOnJoin, meeting, storageMuteState],
   );

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -220,7 +220,7 @@ const AudioContainer = (props) => {
     if (userSelectedMicrophone) {
       joinMicrophone({
         skipEchoTest: true,
-        muted: meeting?.voiceSettings?.muteOnStart || storageMuteState,
+        muted: storageMuteState ?? meeting?.voiceSettings?.muteOnStart,
       });
       return;
     }

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -678,6 +678,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
             forceStereo: false,
           },
           unpublishOnMute: false,
+          unpublishAfterMuteMs: 5000,
         },
         camera: {
           publishOptions: {


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): stricter measures to prevent publish-unpublish loops](https://github.com/bigbluebutton/bigbluebutton/commit/731e00c8cfe26a2ee38e30d4ef70ff4d946ea9b6) 
  - Our LK audio bridge is prone to publish-unpublish loops since some of
its primitives (setSenderTrackEnabled, liveChangeInputDevice,
updateAudioConstraints) are not idempotent - while audio-manager thinks
they are (because they should be). A sample of the issues this causes is
what commit https://github.com/bigbluebutton/bigbluebutton/commit/b3e0427858660ee8634b6e556c6fd20e91a52a5d mitigated.
  - Add a set of stricter measures to the LK audio bridge to nudge it closer
to actual idempotency:
    - Add publish skip checks based on whether the state outcome should be
    the same based on: input stream IDs, pending publish requests not
    pre-empted by the publish queue
    - Add publish generation counters so that subsequent requests do no
    trample over previous ones
    - Add a debounced-unpublish approach: tracks are now only unpublished
    Xs (configurable, default 5s) after the track has been muted. This
    serves a few goals:
      - Reducing unpublish noise on frequent mute/unmute cycles
      - Reducing the chance a unpublish-publish loop may happen
      - Reducing overhead for frequent mute/unmutes for an end user
        (same logic applied to transparent listen only hold/unhold
        debounces)
- [fix(livekit): honor session mute state](https://github.com/bigbluebutton/bigbluebutton/commit/a92532bc9348846e52a7a1df1a1969809ec06929) 
  - Two issues with honoring the session's previous mute state when
re-joining audio:
    - The || operator is incorrect and may incorrectly defer to secondary
    flags (e.g.: storage = false would defer to mute on start)
    - muteOnStart always overrides storage mute state
- [fix(livekit): always join muted when skipping the "Join Audio" action](https://github.com/bigbluebutton/bigbluebutton/commit/68d2ab58473d23464bb6ffa9926b1ecba67cbe88) 
  - When the audio settings modal is configured to show up on join, there
are two options when using LK:
    - Clicking "Join Audio": joins audio
    - Closing the modal (via `X` or clicking out of its boundaries):
    should also join audio, but muted - regardless of meeting or storage
    mute state. We interpret skipping "Join Audio" as signaling that
    intention.
  - The second step is currently broken - it'll defer to the storage or
meeting mute state instead.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/24289
Closes https://github.com/bigbluebutton/bigbluebutton/issues/24288

### Motivation

Ref https://github.com/bigbluebutton/bigbluebutton/issues/24013
