### PR TITLE
Test CI Automated Tests with http2 disabled

### DIFF
--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -157,7 +157,7 @@ runs:
         sudo -i <<'EOF'
         set -e
         cd /root/
-        wget -nv https://raw.githubusercontent.com/bigbluebutton/bbb-install/v3.0.x-release/bbb-install.sh -O bbb-install.sh
+        wget -nv https://raw.githubusercontent.com/gustavotrott/bbb-install/refs/heads/http2-disabled/bbb-install.sh -O bbb-install.sh
         sed -i "s|> /etc/apt/sources.list.d/bigbluebutton.list||g" bbb-install.sh
         chmod +x bbb-install.sh
 


### PR DESCRIPTION
Run tests with a bbb-install script that disabled http2.