### PR TITLE
fix: Do not allow private chat in Breakouts if it the parent room had it locked

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1058,9 +1058,12 @@ create view "v_user_transcriptionError" as select * from "user_transcriptionErro
 
 
 create view "v_meeting" as
-select "meeting".*,  "user_ended"."name" as "endedByUserName"
+select "meeting".*,  "user_ended"."name" as "endedByUserName", "meeting_breakout"."parentId" as "parentMeetingId",
+       "parent_meeting_lockSettings"."disablePrivateChat" as "parentMeetingDisablePrivateChat"
 from "meeting"
 left join "user" "user_ended" on "user_ended"."meetingId" = "meeting"."meetingId" and "user_ended"."userId" = "meeting"."endedBy"
+left join "meeting_breakout" on "meeting_breakout"."meetingId" = "meeting"."meetingId"
+left join "meeting_lockSettings" "parent_meeting_lockSettings" on "parent_meeting_lockSettings"."meetingId" = "meeting_breakout"."parentId"
 ;
 
 create view "v_meeting_learningDashboard" as
@@ -2163,9 +2166,11 @@ SELECT bu."meetingId" as "userMeetingId", bu."userId", b."parentMeetingId", b."b
             b."shortName", b."startedAt", b."endedAt", b."durationInSeconds", b."sendInvitationToModerators",
             bu."assignedAt", bu."joinURL", bu."inviteDismissedAt",
             bu."isLastAssignedRoom", bu."isLastJoinedRoom", bu."isUserCurrentlyInRoom", bu."showInvitation",
-            bu."joinedAt" is not null as "hasJoined"
+            bu."joinedAt" is not null as "hasJoined",
+            pmls."disablePrivateChat" as "parentMeetingDisablePrivateChat"
     FROM "breakoutRoom_user" bu
     JOIN "breakoutRoom" b ON b."breakoutRoomId" = bu."breakoutRoomId" and b."endedAt" IS NULL
+    LEFT JOIN "meeting_lockSettings" pmls ON pmls."meetingId" = b."parentMeetingId"
     --JOIN  bu ON bu."meetingId" = u."meetingId" AND bu."userId" = u."userId" AND bu."breakoutRoomId" = b."breakoutRoomId"
     ;
 

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_breakoutRoom.yaml
@@ -46,6 +46,7 @@ select_permissions:
         - shortName
         - showInvitation
         - startedAt
+        - parentMeetingDisablePrivateChat
       filter:
         _and:
           - userMeetingId:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -185,6 +185,7 @@ select_permissions:
         - notifyRecordingIsOn
         - presentationUploadExternalDescription
         - presentationUploadExternalUrl
+        - parentMeetingDisablePrivateChat
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bigbluebutton-html5/imports/ui/Types/meeting.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meeting.ts
@@ -144,4 +144,5 @@ export interface Meeting {
   endWhenNoModeratorDelayInMinutes: number;
   loginUrl: string | null;
   groups: Array<groups>;
+  parentMeetingDisablePrivateChat: boolean;
 }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/raised-hands/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/raised-hands/component.tsx
@@ -45,6 +45,7 @@ interface RaisedHandsComponentProps {
     isBreakout: boolean;
     lockSettings: LockSettings;
     usersPolicies: UsersPolicies;
+    parentMeetingDisablePrivateChat: boolean;
   };
   pageId: string;
   currentUser: User;
@@ -94,6 +95,7 @@ const RaisedHandsComponent: React.FC<RaisedHandsComponentProps> = ({
         user={user as User}
         currentUser={currentUser}
         lockSettings={meeting.lockSettings}
+        parentMeetingDisablePrivateChat={meeting.parentMeetingDisablePrivateChat}
         usersPolicies={meeting.usersPolicies}
         pageId={pageId}
         userListDropdownItems={[]}
@@ -206,6 +208,7 @@ const RaisedHandsContainer: React.FC = () => {
     isBreakout: m.isBreakout,
     meetingId: m.meetingId,
     breakoutPolicies: m.breakoutPolicies,
+    parentMeetingDisablePrivateChat: m.parentMeetingDisablePrivateChat,
   }));
 
   const {
@@ -254,6 +257,7 @@ const RaisedHandsContainer: React.FC = () => {
         isBreakout: !!meeting.isBreakout,
         lockSettings: meeting.lockSettings as LockSettings ?? {},
         usersPolicies: (meeting.usersPolicies as UsersPolicies) ?? {},
+        parentMeetingDisablePrivateChat: meeting.parentMeetingDisablePrivateChat ?? false,
       }}
       currentUser={currentUser as User}
       hideUserList={hideUserList}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
@@ -31,6 +31,7 @@ interface UsersListParticipantsPage {
     isBreakout: boolean;
     lockSettings: Meeting['lockSettings'];
     usersPolicies: UsersPolicies;
+    parentMeetingDisablePrivateChat: boolean
   };
   currentUser: Partial<User>;
   pageId: string;
@@ -66,6 +67,7 @@ const UsersListParticipantsPage: React.FC<UsersListParticipantsPage> = ({
                 user={user}
                 currentUser={currentUser as User}
                 lockSettings={meeting.lockSettings}
+                parentMeetingDisablePrivateChat={meeting.parentMeetingDisablePrivateChat}
                 usersPolicies={meeting.usersPolicies}
                 pageId={pageId}
                 userListDropdownItems={userListDropdownItems}
@@ -102,6 +104,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
     isBreakout: m.isBreakout,
     meetingId: m.meetingId,
     breakoutPolicies: m.breakoutPolicies,
+    parentMeetingDisablePrivateChat: m.parentMeetingDisablePrivateChat,
   }));
 
   useEffect(() => () => {
@@ -215,6 +218,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
         isBreakout: !!meeting.isBreakout,
         lockSettings: meeting.lockSettings as LockSettings ?? {},
         usersPolicies: (meeting.usersPolicies as UsersPolicies) ?? {},
+        parentMeetingDisablePrivateChat: meeting.parentMeetingDisablePrivateChat ?? false,
       }}
       currentUser={currentUser ?? {}}
       pageId={pageId ?? ''}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -56,6 +56,7 @@ interface UserActionsProps {
   open: boolean;
   setOpenUserAction: React.Dispatch<React.SetStateAction<string | null>>;
   type?: 'raised-hand' | 'participant';
+  parentMeetingDisablePrivateChat: boolean;
 }
 
 interface DropdownItem {
@@ -220,6 +221,7 @@ const UserActions: React.FC<UserActionsProps> = ({
   lockSettings,
   usersPolicies,
   isBreakout,
+  parentMeetingDisablePrivateChat,
   children,
   pageId = '',
   userListDropdownItems,
@@ -407,6 +409,9 @@ const UserActions: React.FC<UserActionsProps> = ({
     {
       allowed: (() => {
         const preventSelfChat = user.userId !== currentUser.userId;
+        const isParentMeetingPrivateChatDisabled = isBreakout
+          && parentMeetingDisablePrivateChat;
+
         const moderatorOverride = currentUser.isModerator
           && allowedToChatPrivately;
         const regularUserCondition = (isPrivateChatEnabled
@@ -418,6 +423,7 @@ const UserActions: React.FC<UserActionsProps> = ({
 
         const isAllowed = preventSelfChat
           && (moderatorOverride || regularUserCondition || !currentUser.locked)
+          && !isParentMeetingPrivateChatDisabled
           && type === 'participant';
 
         return isAllowed;

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
@@ -19,6 +19,8 @@ const MEETING_SUBSCRIPTION = gql`
           lockOnJoinConfigurable
         }
 
+        parentMeetingDisablePrivateChat
+
         learningDashboard {
           learningDashboardAccessToken
         }


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where users inside breakout rooms were still able to initiate private chats, even when private chat was locked in the parent room.

### Closes Issue(s)
Closes #24318

### How to test
1. Start a session
2. Join with 2 users
3. In the lock settings prohibit private chat
4. Create breakouts such that both users go in the same room
5. One of the user clicks on the other's name in the participants list