### PR TITLE
fix: Do not allow private chat in Breakouts if it the parent room had it locked

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -119,16 +119,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         liveMeeting.props.meetingProp.audioBridge,
         liveMeeting.props.meetingProp.cameraBridge,
         liveMeeting.props.meetingProp.screenShareBridge,
-        lockSettings.disableCam,
-        lockSettings.disableMic,
-        lockSettings.disablePrivChat,
-        lockSettings.disablePubChat,
-        lockSettings.disableNotes,
-        lockSettings.hideUserList,
-        lockSettings.lockOnJoin,
-        lockSettings.lockOnJoinConfigurable,
-        lockSettings.hideViewersCursor,
-        lockSettings.hideViewersAnnotation
+        lockSettings.disablePrivChat
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -1,13 +1,13 @@
 package org.bigbluebutton.core.apps.breakout
 
-import org.bigbluebutton.ClientSettings.{getConfigPropertyValueByPath, getConfigPropertyValueByPathAsIntOrElse}
+import org.bigbluebutton.ClientSettings.{ getConfigPropertyValueByPath, getConfigPropertyValueByPathAsIntOrElse }
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.apps.{BreakoutModel, PermissionCheck, RightsManagementTrait}
+import org.bigbluebutton.core.apps.{ BreakoutModel, PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.db.BreakoutRoomDAO
-import org.bigbluebutton.core.domain.{BreakoutRoom2x, MeetingState2x}
+import org.bigbluebutton.core.domain.{ BreakoutRoom2x, MeetingState2x }
 import org.bigbluebutton.core.models.PluginModel.getPlugins
-import org.bigbluebutton.core.models.{Plugin, PresentationInPod}
-import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
+import org.bigbluebutton.core.models.{ Plugin, PresentationInPod }
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.running.MeetingActor
 
 import java.util
@@ -20,7 +20,6 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleCreateBreakoutRoomsCmdMsg(msg: CreateBreakoutRoomsCmdMsg, state: MeetingState2x): MeetingState2x = {
-
 
     val minOfRooms = 1
     val maxOfRooms = getConfigPropertyValueByPathAsIntOrElse(liveMeeting.clientSettings, "public.app.breakouts.breakoutRoomLimit", 16)
@@ -36,7 +35,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId,
         reason, outGW, liveMeeting)
       state
-    } else if(msg.body.rooms.length > maxOfRooms || msg.body.rooms.length < minOfRooms) {
+    } else if (msg.body.rooms.length > maxOfRooms || msg.body.rooms.length < minOfRooms) {
       log.warning(
         "Attempt to create breakout rooms with invalid number of rooms (rooms: {}, max: {}, min: {}) in meeting {}",
         msg.body.rooms.size,
@@ -66,8 +65,8 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     val filteredPluginProp = liveMeeting.props.pluginProp.asScala
       .filter { case (key, _) =>
         getPlugins(liveMeeting.plugins).get(key).exists(_.manifest.content match {
-          case Some(pluginManifestContent) => pluginManifestContent.enabledForBreakoutRooms
-          case None => false
+          case Some(pluginManifestContent)   => pluginManifestContent.enabledForBreakoutRooms
+          case None                          => false
         })
       }
       .asJava
@@ -91,6 +90,10 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
     for (breakout <- rooms.values.toVector) {
 
       val roomSlides = if (breakout.allPages) -1 else presSlide;
+
+      // get lock settings from parent meeting
+      val lockSettings = org.bigbluebutton.core2.MeetingStatus2x.getPermissions(liveMeeting.status)
+
       val roomDetail = new BreakoutRoomDetail(
         breakout.id, breakout.name,
         liveMeeting.props.meetingProp.intId,
@@ -116,6 +119,16 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         liveMeeting.props.meetingProp.audioBridge,
         liveMeeting.props.meetingProp.cameraBridge,
         liveMeeting.props.meetingProp.screenShareBridge,
+        lockSettings.disableCam,
+        lockSettings.disableMic,
+        lockSettings.disablePrivChat,
+        lockSettings.disablePubChat,
+        lockSettings.disableNotes,
+        lockSettings.hideUserList,
+        lockSettings.lockOnJoin,
+        lockSettings.lockOnJoinConfigurable,
+        lockSettings.hideViewersCursor,
+        lockSettings.hideViewersAnnotation
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -63,6 +63,16 @@ case class BreakoutRoomDetail(
     audioBridge:             String,
     cameraBridge:            String,
     screenShareBridge:       String,
+    disableCam:              Boolean,
+    disableMic:              Boolean,
+    disablePrivChat:         Boolean,
+    disablePubChat:          Boolean,
+    disableNotes:            Boolean,
+    hideUserList:            Boolean,
+    lockOnJoin:              Boolean,
+    lockOnJoinConfigurable:  Boolean,
+    hideViewersCursor:       Boolean,
+    hideViewersAnnotation:   Boolean
 )
 
 /**

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -63,16 +63,7 @@ case class BreakoutRoomDetail(
     audioBridge:             String,
     cameraBridge:            String,
     screenShareBridge:       String,
-    disableCam:              Boolean,
-    disableMic:              Boolean,
-    disablePrivChat:         Boolean,
-    disablePubChat:          Boolean,
-    disableNotes:            Boolean,
-    hideUserList:            Boolean,
-    lockOnJoin:              Boolean,
-    lockOnJoinConfigurable:  Boolean,
-    hideViewersCursor:       Boolean,
-    hideViewersAnnotation:   Boolean
+    disablePrivChat:         Boolean
 )
 
 /**

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -856,17 +856,8 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
       params.put(ApiParams.DISABLED_FEATURES,String.join(",", message.disabledFeatures));
 
-      // Apply lock settings from parent meeting to breakout room
-      params.put(ApiParams.LOCK_SETTINGS_DISABLE_CAM, message.disableCam.toString());
-      params.put(ApiParams.LOCK_SETTINGS_DISABLE_MIC, message.disableMic.toString());
+      // Apply private chat lock settings from parent meeting to breakout room
       params.put(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT, message.disablePrivChat.toString());
-      params.put(ApiParams.LOCK_SETTINGS_DISABLE_PUBLIC_CHAT, message.disablePubChat.toString());
-      params.put(ApiParams.LOCK_SETTINGS_DISABLE_NOTES, message.disableNotes.toString());
-      params.put(ApiParams.LOCK_SETTINGS_HIDE_USER_LIST, message.hideUserList.toString());
-      params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN, message.lockOnJoin.toString());
-      params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE, message.lockOnJoinConfigurable.toString());
-      params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_CURSOR, message.hideViewersCursor.toString());
-      params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION, message.hideViewersAnnotation.toString());
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -856,6 +856,18 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
       params.put(ApiParams.DISABLED_FEATURES,String.join(",", message.disabledFeatures));
 
+      // Apply lock settings from parent meeting to breakout room
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_CAM, message.disableCam.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_MIC, message.disableMic.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT, message.disablePrivChat.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_PUBLIC_CHAT, message.disablePubChat.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_NOTES, message.disableNotes.toString());
+      params.put(ApiParams.LOCK_SETTINGS_HIDE_USER_LIST, message.hideUserList.toString());
+      params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN, message.lockOnJoin.toString());
+      params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE, message.lockOnJoinConfigurable.toString());
+      params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_CURSOR, message.hideViewersCursor.toString());
+      params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION, message.hideViewersAnnotation.toString());
+
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();
 
       String metaPrefix = "meta_";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -31,6 +31,16 @@ public class CreateBreakoutRoom implements IMessage {
     public final String audioBridge;
     public final String cameraBridge;
     public final String screenShareBridge;
+    public final Boolean disableCam;
+    public final Boolean disableMic;
+    public final Boolean disablePrivChat;
+    public final Boolean disablePubChat;
+    public final Boolean disableNotes;
+    public final Boolean hideUserList;
+    public final Boolean lockOnJoin;
+    public final Boolean lockOnJoinConfigurable;
+    public final Boolean hideViewersCursor;
+    public final Boolean hideViewersAnnotation;
 
     public CreateBreakoutRoom(String meetingId,
 															String parentMeetingId,
@@ -56,7 +66,17 @@ public class CreateBreakoutRoom implements IMessage {
                                                             ArrayList<String> disabledFeatures,
                                                             String audioBridge,
                                                             String cameraBridge,
-                                                            String screenShareBridge) {
+                                                            String screenShareBridge,
+                                                            Boolean disableCam,
+                                                            Boolean disableMic,
+                                                            Boolean disablePrivChat,
+                                                            Boolean disablePubChat,
+                                                            Boolean disableNotes,
+                                                            Boolean hideUserList,
+                                                            Boolean lockOnJoin,
+                                                            Boolean lockOnJoinConfigurable,
+                                                            Boolean hideViewersCursor,
+                                                            Boolean hideViewersAnnotation) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -82,5 +102,15 @@ public class CreateBreakoutRoom implements IMessage {
         this.audioBridge = audioBridge;
         this.cameraBridge = cameraBridge;
         this.screenShareBridge = screenShareBridge;
+        this.disableCam = disableCam;
+        this.disableMic = disableMic;
+        this.disablePrivChat = disablePrivChat;
+        this.disablePubChat = disablePubChat;
+        this.disableNotes = disableNotes;
+        this.hideUserList = hideUserList;
+        this.lockOnJoin = lockOnJoin;
+        this.lockOnJoinConfigurable = lockOnJoinConfigurable;
+        this.hideViewersCursor = hideViewersCursor;
+        this.hideViewersAnnotation = hideViewersAnnotation;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -31,16 +31,7 @@ public class CreateBreakoutRoom implements IMessage {
     public final String audioBridge;
     public final String cameraBridge;
     public final String screenShareBridge;
-    public final Boolean disableCam;
-    public final Boolean disableMic;
     public final Boolean disablePrivChat;
-    public final Boolean disablePubChat;
-    public final Boolean disableNotes;
-    public final Boolean hideUserList;
-    public final Boolean lockOnJoin;
-    public final Boolean lockOnJoinConfigurable;
-    public final Boolean hideViewersCursor;
-    public final Boolean hideViewersAnnotation;
 
     public CreateBreakoutRoom(String meetingId,
 															String parentMeetingId,
@@ -67,16 +58,7 @@ public class CreateBreakoutRoom implements IMessage {
                                                             String audioBridge,
                                                             String cameraBridge,
                                                             String screenShareBridge,
-                                                            Boolean disableCam,
-                                                            Boolean disableMic,
-                                                            Boolean disablePrivChat,
-                                                            Boolean disablePubChat,
-                                                            Boolean disableNotes,
-                                                            Boolean hideUserList,
-                                                            Boolean lockOnJoin,
-                                                            Boolean lockOnJoinConfigurable,
-                                                            Boolean hideViewersCursor,
-                                                            Boolean hideViewersAnnotation) {
+                                                            Boolean disablePrivChat) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -102,15 +84,6 @@ public class CreateBreakoutRoom implements IMessage {
         this.audioBridge = audioBridge;
         this.cameraBridge = cameraBridge;
         this.screenShareBridge = screenShareBridge;
-        this.disableCam = disableCam;
-        this.disableMic = disableMic;
         this.disablePrivChat = disablePrivChat;
-        this.disablePubChat = disablePubChat;
-        this.disableNotes = disableNotes;
-        this.hideUserList = hideUserList;
-        this.lockOnJoin = lockOnJoin;
-        this.lockOnJoinConfigurable = lockOnJoinConfigurable;
-        this.hideViewersCursor = hideViewersCursor;
-        this.hideViewersAnnotation = hideViewersAnnotation;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -132,6 +132,16 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.audioBridge,
       msg.body.room.cameraBridge,
       msg.body.room.screenShareBridge,
+      msg.body.room.disableCam,
+      msg.body.room.disableMic,
+      msg.body.room.disablePrivChat,
+      msg.body.room.disablePubChat,
+      msg.body.room.disableNotes,
+      msg.body.room.hideUserList,
+      msg.body.room.lockOnJoin,
+      msg.body.room.lockOnJoinConfigurable,
+      msg.body.room.hideViewersCursor,
+      msg.body.room.hideViewersAnnotation
     ))
   }
 

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -132,16 +132,7 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.audioBridge,
       msg.body.room.cameraBridge,
       msg.body.room.screenShareBridge,
-      msg.body.room.disableCam,
-      msg.body.room.disableMic,
-      msg.body.room.disablePrivChat,
-      msg.body.room.disablePubChat,
-      msg.body.room.disableNotes,
-      msg.body.room.hideUserList,
-      msg.body.room.lockOnJoin,
-      msg.body.room.lockOnJoinConfigurable,
-      msg.body.room.hideViewersCursor,
-      msg.body.room.hideViewersAnnotation
+      msg.body.room.disablePrivChat
     ))
   }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -407,6 +407,8 @@ const UserActions: React.FC<UserActionsProps> = ({
     {
       allowed: (() => {
         const preventSelfChat = user.userId !== currentUser.userId;
+        const isBreakoutPrivateChatLocked = isBreakout
+          && lockSettings?.disablePrivateChat;
         const moderatorOverride = currentUser.isModerator
           && allowedToChatPrivately;
         const regularUserCondition = (isPrivateChatEnabled
@@ -418,6 +420,7 @@ const UserActions: React.FC<UserActionsProps> = ({
 
         const isAllowed = preventSelfChat
           && (moderatorOverride || regularUserCondition || !currentUser.locked)
+          && !isBreakoutPrivateChatLocked
           && type === 'participant';
 
         return isAllowed;


### PR DESCRIPTION
### What does this PR do?

Makes breakout rooms inherit lock settings from parent meeting.

### Closes Issue(s)
Closes #24318

### How to test
1. Start a session
2. Join with 2 users
3. In the lock settings prohibit private chat
4. Create breakouts such that both users go in the same room
5. One of the user clicks on the other's name in the participants list