### PR TITLE
fix: Lock Settings should not be visible in breakout rooms

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -250,7 +250,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'muteAllExceptPresenter',
       },
       {
-        allow: true,
+        allow: !isBreakout,
         key: uuids.current[2],
         label: intl.formatMessage(intlMessages.lockViewersLabel),
         description: intl.formatMessage(intlMessages.lockViewersDesc),


### PR DESCRIPTION
### What does this PR do?

Adjusts the userlist dropdown to only display lock viewers option in the main room.

### Closes Issue(s)
Closes #24223

### How to test
1. join a meeting
2. create breakout rooms
3. join a breakout room
4. check if "lock viewers" appears in the "manage users" menu