### PR TITLE
fix(bbb-web/akka): Error while loading plugins

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Plugins.scala
@@ -8,8 +8,10 @@ import org.bigbluebutton.ClientSettings.getPluginsFromConfig
 import org.bigbluebutton.core.db.PluginDAO
 import org.slf4j.{Logger, LoggerFactory}
 import com.github.zafarkhaja.semver.Version
+import org.apache.commons.codec.digest.DigestUtils
 import org.apache.http.client.utils.URIBuilder
 import org.bigbluebutton.core.exceptions.PluginHtml5VersionValidationException
+import org.bigbluebutton.core.util.RandomStringGenerator
 
 import java.util
 
@@ -321,9 +323,14 @@ object PluginModel {
     validatePluginsBeforeCreateModel(instance, clientSettings)
   }
 
+  private def generateUnidentifiedPluginName(pluginmanifestUrl: String): String = {
+    "unidentified-plugin" + "-" + DigestUtils.sha1Hex(pluginmanifestUrl)
+  }
+
   def persistPluginsForClient(meetingId: String, instance: PluginModel): Unit = {
     instance.plugins.foreach { case (pluginNameRaw, plugin) =>
-      val pluginName = if (plugin.manifest.url == pluginNameRaw) "unidentified-plugin" else pluginNameRaw
+      val pluginName = if (plugin.manifest.url == pluginNameRaw) generateUnidentifiedPluginName(plugin.manifest.url) else pluginNameRaw
+
       plugin.manifest.content match {
         case Some(pluginManifestContent) =>
           PluginDAO.insert(meetingId, pluginName, pluginManifestContent.javascriptEntrypointUrl,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/RedirectFollowerService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/RedirectFollowerService.java
@@ -1,0 +1,70 @@
+package org.bigbluebutton.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class RedirectFollowerService {
+    private static final Logger log = LoggerFactory.getLogger(RedirectFollowerService.class);
+    private static final int MAX_REDIRECTS = 5;
+
+    public String followRedirect(
+            String meetingId, String redirectUrl,
+            int redirectCount, String origUrl,
+            RedirectValidator redirectValidator,
+            int downloadReadTimeoutInMs
+    ) {
+        if (redirectCount > MAX_REDIRECTS) {
+            log.error("Max redirect reached for meeting=[{}] with url=[{}]",
+                    meetingId, origUrl);
+            return null;
+        }
+
+        if(!redirectValidator.isRedirectValid(redirectUrl)) return null;
+
+        URL attemptUrl;
+        try {
+            attemptUrl = new URL(redirectUrl);
+        } catch (MalformedURLException e) {
+            log.error("Malformed url=[{}] for meeting=[{}]", redirectUrl, meetingId, e);
+            return null;
+        }
+
+        HttpURLConnection conn;
+        try {
+            conn = (HttpURLConnection) attemptUrl.openConnection();
+            conn.setReadTimeout(downloadReadTimeoutInMs);
+            conn.addRequestProperty("Accept-Language", "en-US,en;q=0.8");
+            conn.addRequestProperty("User-Agent", "Mozilla");
+            conn.setInstanceFollowRedirects(false);
+
+            // normally, 3xx is redirect
+            int status = conn.getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                if (status == HttpURLConnection.HTTP_MOVED_TEMP
+                        || status == HttpURLConnection.HTTP_MOVED_PERM
+                        || status == HttpURLConnection.HTTP_SEE_OTHER) {
+                    String newUrl = conn.getHeaderField("Location");
+                    return followRedirect(
+                            meetingId, newUrl, redirectCount + 1,
+                            origUrl, redirectValidator, downloadReadTimeoutInMs
+                    );
+                } else {
+                    log.error(
+                            "Invalid HTTP response=[{}] for url=[{}] with meeting[{}]",
+                            status, redirectUrl, meetingId);
+                    return null;
+                }
+            } else {
+                return redirectUrl;
+            }
+        } catch (IOException e) {
+            log.error("IOException for url=[{}] with meeting[{}]", redirectUrl, meetingId, e);
+            return null;
+        }
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/RedirectValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/RedirectValidator.java
@@ -1,0 +1,5 @@
+package org.bigbluebutton.api.service;
+
+public interface RedirectValidator {
+    boolean isRedirectValid(String redirectURL);
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/PluginRedirectValidatorService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/PluginRedirectValidatorService.java
@@ -1,0 +1,43 @@
+package org.bigbluebutton.api.service.impl;
+
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.bigbluebutton.api.service.RedirectValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+public class PluginRedirectValidatorService implements RedirectValidator {
+    private static final Logger log = LoggerFactory.getLogger(PluginRedirectValidatorService.class);
+    public boolean isRedirectValid(String redirectUrl) {
+        log.info("Validating redirect URL [{}]", redirectUrl);
+        URL url;
+
+        try {
+            url = new URL(redirectUrl);
+        } catch(MalformedURLException e) {
+            log.error("Malformed URL [{}]", redirectUrl);
+            return false;
+        }
+
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(url.getHost());
+            InetAddressValidator validator = InetAddressValidator.getInstance();
+
+            for(InetAddress address: addresses) {
+                if(!validator.isValid(address.getHostAddress())) {
+                    log.error("Invalid address [{}]", address.getHostAddress());
+                    return false;
+                }
+            }
+        } catch(UnknownHostException e) {
+            log.error("Unknown host [{}]", url.getHost());
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/PresRedirectValidator.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/PresRedirectValidator.java
@@ -1,0 +1,90 @@
+package org.bigbluebutton.api.service.impl;
+
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.bigbluebutton.api.service.RedirectValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.List;
+
+public class PresRedirectValidator implements RedirectValidator {
+    private List<String> insertDocumentSupportedProtocols;
+    private List<String> insertDocumentBlockedHosts;
+    private String defaultUploadedPresentation;
+    private static final Logger log = LoggerFactory.getLogger(PresRedirectValidator.class);
+
+    public boolean isRedirectValid(String redirectUrl) {
+        log.info("Validating redirect URL [{}]", redirectUrl);
+        URL url;
+
+        try {
+            url = new URL(redirectUrl);
+            String protocol = url.getProtocol();
+            String host = url.getHost();
+
+            if(insertDocumentSupportedProtocols.stream().noneMatch(p -> p.equalsIgnoreCase(protocol))) {
+                if(insertDocumentSupportedProtocols.size() == 1 && insertDocumentSupportedProtocols.get(0).equalsIgnoreCase("all")) {
+                    log.warn("Warning: All protocols are supported for presentation download. It is recommended to only allow HTTPS.");
+                } else {
+                    log.error("Invalid protocol [{}]", protocol);
+                    return false;
+                }
+            }
+
+            if(insertDocumentBlockedHosts.stream().anyMatch(h -> h.equalsIgnoreCase(host))) {
+                log.error("Attempted to download from blocked host [{}]", host);
+                return false;
+            }
+        } catch(MalformedURLException e) {
+            log.error("Malformed URL [{}]", redirectUrl);
+            return false;
+        }
+
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(url.getHost());
+            InetAddressValidator validator = InetAddressValidator.getInstance();
+
+            boolean localhostBlocked = insertDocumentBlockedHosts.stream().anyMatch(h -> h.equalsIgnoreCase("localhost"));
+
+            for(InetAddress address: addresses) {
+                if(!validator.isValid(address.getHostAddress())) {
+                    log.error("Invalid address [{}]", address.getHostAddress());
+                    return false;
+                }
+
+                if(localhostBlocked && !redirectUrl.equalsIgnoreCase(defaultUploadedPresentation)) {
+                    if(address.isAnyLocalAddress()) {
+                        log.error("Address [{}] is a local address", address.getHostAddress());
+                        return false;
+                    }
+
+                    if(address.isLoopbackAddress()) {
+                        log.error("Address [{}] is a loopback address", address.getHostAddress());
+                        return false;
+                    }
+                }
+            }
+        } catch(UnknownHostException e) {
+            log.error("Unknown host [{}]", url.getHost());
+            return false;
+        }
+
+        return true;
+    }
+
+    public void setInsertDocumentSupportedProtocols(List<String> insertDocumentSupportedProtocols) {
+        this.insertDocumentSupportedProtocols = insertDocumentSupportedProtocols;
+    }
+
+    public void setInsertDocumentBlockedHosts(List<String> insertDocumentBlockedHosts) {
+        this.insertDocumentBlockedHosts = insertDocumentBlockedHosts;
+    }
+
+    public void setDefaultUploadedPresentation(String defaultUploadedPresentation) {
+        this.defaultUploadedPresentation = defaultUploadedPresentation;
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/util/PluginUtils.java
@@ -6,6 +6,8 @@ import org.bigbluebutton.api.ParamsProcessorUtil;
 import org.bigbluebutton.api.domain.PluginManifest;
 import org.bigbluebutton.api.exception.PluginMalformedParametersException;
 import org.bigbluebutton.api.exception.PluginMetadataException;
+import org.bigbluebutton.api.service.impl.PluginRedirectValidatorService;
+import org.bigbluebutton.api.service.RedirectFollowerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.github.zafarkhaja.semver.Version;
@@ -25,6 +27,8 @@ public class PluginUtils {
     private static final Pattern METADATA_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{([\\w-]+)(?::([^}]*))?\\}");
     private static String bbbVersion;
     private String html5PluginSdkVersion;
+    private RedirectFollowerService redirectFollower;
+    private PluginRedirectValidatorService pluginRedirectValidator;
 
     private String getMainVersion(String version) {
         Version parsedVersion = Version.parse(version);
@@ -39,12 +43,26 @@ public class PluginUtils {
                 .replace(MEETING_ID, meetingId);
     }
 
+    private String extractFinalPluginManifestUrl(String rawManifestUrl, String meetingId) {
+        String manifestUrlBeforeRedirections = replaceAllPlaceholdersInManifestUrls(rawManifestUrl, meetingId);
+        String finalUrl = redirectFollower.followRedirect(
+                meetingId, manifestUrlBeforeRedirections, 0, manifestUrlBeforeRedirections,
+                pluginRedirectValidator, 6000
+        );
+        if (finalUrl != null) {
+            return finalUrl;
+        } else {
+            log.error("Raw manifest URL [{}] failed when following redirects", manifestUrlBeforeRedirections);
+            return manifestUrlBeforeRedirections;
+        }
+    }
+
     public PluginManifest createPluginManifestFromJson(JsonElement pluginManifestJson, String meetingId) {
         if (pluginManifestJson.isJsonObject()) {
             JsonObject pluginManifestJsonObj = pluginManifestJson.getAsJsonObject();
             if (pluginManifestJsonObj.has("url")) {
                 String barePluginManifestUrl = pluginManifestJsonObj.get("url").getAsString();
-                String url = replaceAllPlaceholdersInManifestUrls(barePluginManifestUrl, meetingId);
+                String url = extractFinalPluginManifestUrl(barePluginManifestUrl, meetingId);
                 PluginManifest newPlugin = new PluginManifest(url);
                 if (pluginManifestJsonObj.has("checksum")) {
                     newPlugin.setChecksum(pluginManifestJsonObj.get("checksum").getAsString());
@@ -170,5 +188,13 @@ public class PluginUtils {
 
     public static void setBbbVersion(String bbbVersion) {
         PluginUtils.bbbVersion = bbbVersion;
+    }
+
+    public void setRedirectFollower(RedirectFollowerService redirectFollower) {
+        this.redirectFollower = redirectFollower;
+    }
+
+    public void setPluginRedirectValidator(PluginRedirectValidatorService pluginRedirectValidator) {
+        this.pluginRedirectValidator = pluginRedirectValidator;
     }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
@@ -3,10 +3,7 @@ package org.bigbluebutton.presentation;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.net.*;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -23,8 +20,9 @@ import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.nio.client.methods.HttpAsyncMethods;
 import org.apache.http.nio.client.methods.ZeroCopyConsumer;
-import org.apache.commons.validator.routines.InetAddressValidator;
 import org.bigbluebutton.api.Util;
+import org.bigbluebutton.api.service.RedirectFollowerService;
+import org.bigbluebutton.api.service.impl.PresRedirectValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,16 +30,14 @@ public class PresentationUrlDownloadService {
     private static Logger log = LoggerFactory
             .getLogger(PresentationUrlDownloadService.class);
 
-    private static final int MAX_REDIRECTS = 5;
     private PageExtractor pageExtractor;
     private DocumentConversionService documentConversionService;
     private String presentationBaseURL;
     private String presentationDir;
     private String BLANK_PRESENTATION;
-    private String defaultUploadedPresentation;
-    private List<String> insertDocumentSupportedProtocols;
-    private List<String> insertDocumentBlockedHosts;
-    private int presDownloadReadTimeoutInMs = 60000;
+    private RedirectFollowerService redirectFollower;
+    private PresRedirectValidator presRedirectValidator;
+    private int presDownloadReadTimeoutInMs;
 
     private ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(3);
 
@@ -173,120 +169,14 @@ public class PresentationUrlDownloadService {
           scanUploadedPresentationFiles);
     }
 
-    private String followRedirect(String meetingId, String redirectUrl,
-            int redirectCount, String origUrl) {
 
-        if (redirectCount > MAX_REDIRECTS) {
-            log.error("Max redirect reached for meeting=[{}] with url=[{}]",
-                    meetingId, origUrl);
-            return null;
-        }
-
-        if(!isValidRedirectUrl(redirectUrl)) return null;
-
-        URL presUrl;
-        try {
-            presUrl = new URL(redirectUrl);
-        } catch (MalformedURLException e) {
-            log.error("Malformed url=[{}] for meeting=[{}]", redirectUrl, meetingId, e);
-            return null;
-        }
-
-        HttpURLConnection conn;
-        try {
-            conn = (HttpURLConnection) presUrl.openConnection();
-            conn.setReadTimeout(presDownloadReadTimeoutInMs);
-            conn.addRequestProperty("Accept-Language", "en-US,en;q=0.8");
-            conn.addRequestProperty("User-Agent", "Mozilla");
-            conn.setInstanceFollowRedirects(false);
-
-            // normally, 3xx is redirect
-            int status = conn.getResponseCode();
-            if (status != HttpURLConnection.HTTP_OK) {
-                if (status == HttpURLConnection.HTTP_MOVED_TEMP
-                        || status == HttpURLConnection.HTTP_MOVED_PERM
-                        || status == HttpURLConnection.HTTP_SEE_OTHER) {
-                    String newUrl = conn.getHeaderField("Location");
-                    return followRedirect(meetingId, newUrl, redirectCount + 1,
-                            origUrl);
-                } else {
-                    log.error(
-                            "Invalid HTTP response=[{}] for url=[{}] with meeting[{}]",
-                            status, redirectUrl, meetingId);
-                    return null;
-                }
-            } else {
-                return redirectUrl;
-            }
-        } catch (IOException e) {
-            log.error("IOException for url=[{}] with meeting[{}]", redirectUrl, meetingId, e);
-            return null;
-        }
-    }
-
-    private boolean isValidRedirectUrl(String redirectUrl) {
-        log.info("Validating redirect URL [{}]", redirectUrl);
-        URL url;
-
-        try {
-            url = new URL(redirectUrl);
-            String protocol = url.getProtocol();
-            String host = url.getHost();
-
-            if(insertDocumentSupportedProtocols.stream().noneMatch(p -> p.equalsIgnoreCase(protocol))) {
-                if(insertDocumentSupportedProtocols.size() == 1 && insertDocumentSupportedProtocols.get(0).equalsIgnoreCase("all")) {
-                    log.warn("Warning: All protocols are supported for presentation download. It is recommended to only allow HTTPS.");
-                } else {
-                    log.error("Invalid protocol [{}]", protocol);
-                    return false;
-                }
-            }
-
-            if(insertDocumentBlockedHosts.stream().anyMatch(h -> h.equalsIgnoreCase(host))) {
-                log.error("Attempted to download from blocked host [{}]", host);
-                return false;
-            }
-        } catch(MalformedURLException e) {
-            log.error("Malformed URL [{}]", redirectUrl);
-            return false;
-        }
-
-        try {
-            InetAddress[] addresses = InetAddress.getAllByName(url.getHost());
-            InetAddressValidator validator = InetAddressValidator.getInstance();
-
-            boolean localhostBlocked = insertDocumentBlockedHosts.stream().anyMatch(h -> h.equalsIgnoreCase("localhost"));
-
-            for(InetAddress address: addresses) {
-                if(!validator.isValid(address.getHostAddress())) {
-                    log.error("Invalid address [{}]", address.getHostAddress());
-                    return false;
-                }
-
-                if(localhostBlocked && !redirectUrl.equalsIgnoreCase(defaultUploadedPresentation)) {
-                    if(address.isAnyLocalAddress()) {
-                        log.error("Address [{}] is a local address", address.getHostAddress());
-                        return false;
-                    }
-
-                    if(address.isLoopbackAddress()) {
-                        log.error("Address [{}] is a loopback address", address.getHostAddress());
-                        return false;
-                    }
-                }
-            }
-        } catch(UnknownHostException e) {
-            log.error("Unknown host [{}]", url.getHost());
-            return false;
-        }
-
-        return true;
-    }
 
     public boolean savePresentation(final String meetingId,
             final String filename, final String urlString) {
 
-        String finalUrl = followRedirect(meetingId, urlString, 0, urlString);
+        String finalUrl = redirectFollower.followRedirect(
+                meetingId, urlString, 0, urlString, presRedirectValidator, presDownloadReadTimeoutInMs
+        );
 
         if (finalUrl == null) return false;
         if(!finalUrl.equals(urlString)) {
@@ -361,16 +251,12 @@ public class PresentationUrlDownloadService {
         this.BLANK_PRESENTATION = blankPresentation;
     }
 
-    public void setDefaultUploadedPresentation(String defaultUploadedPresentation) {
-        this.defaultUploadedPresentation = defaultUploadedPresentation;
+    public void setRedirectFollower(RedirectFollowerService redirectFollower) {
+        this.redirectFollower = redirectFollower;
     }
 
-    public void setInsertDocumentSupportedProtocols(String insertDocumentSupportedProtocols) {
-        this.insertDocumentSupportedProtocols = new ArrayList<>(Arrays.asList(insertDocumentSupportedProtocols.split(",")));
-    }
-
-    public void setInsertDocumentBlockedHosts(String insertDocumentBlockedHosts) {
-        this.insertDocumentBlockedHosts = new ArrayList<>(Arrays.asList(insertDocumentBlockedHosts.split(",")));
+    public void setPresRedirectValidator(PresRedirectValidator presRedirectValidator) {
+        this.presRedirectValidator = presRedirectValidator;
     }
 
     public void setPresDownloadReadTimeoutInMs(int presDownloadReadTimeoutInMs) {

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -82,12 +82,26 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="recordingServiceGW" ref="recordingServiceGW"/>
     </bean>
 
+    <bean id="redirectFollower" class="org.bigbluebutton.api.service.RedirectFollowerService">
+    </bean>
+
+    <bean id="pluginRedirectValidator" class="org.bigbluebutton.api.service.impl.PluginRedirectValidatorService">
+    </bean>
+
     <bean id="pluginUtils" class="org.bigbluebutton.api.util.PluginUtils">
         <property name="html5PluginSdkVersion" value="${html5PluginSdkVersion}"/>
+        <property name="redirectFollower" ref="redirectFollower"/>
+        <property name="pluginRedirectValidator" ref="pluginRedirectValidator"/>
     </bean>
 
     <bean id="recordingServiceGW" class="org.bigbluebutton.api2.util.RecMetaXmlHelper">
         <constructor-arg index="0" ref="bbbWebApiGWApp"/>
+    </bean>
+
+    <bean id="presRedirectValidator" class="org.bigbluebutton.api.service.impl.PresRedirectValidator">
+        <property name="defaultUploadedPresentation" value="${beans.presentationService.defaultUploadedPresentation}"/>
+        <property name="insertDocumentSupportedProtocols" value="${insertDocumentSupportedProtocols}" />
+        <property name="insertDocumentBlockedHosts" value="${insertDocumentBlockedHosts}" />
     </bean>
 
     <bean id="presDownloadService" class="org.bigbluebutton.presentation.PresentationUrlDownloadService"
@@ -97,10 +111,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="pageExtractor" ref="pageExtractor"/>
         <property name="documentConversionService" ref="documentConversionService"/>
         <property name="blankPresentation" value="${BLANK_PRESENTATION}"/>
-        <property name="defaultUploadedPresentation" value="${beans.presentationService.defaultUploadedPresentation}"/>
-        <property name="insertDocumentSupportedProtocols" value="${insertDocumentSupportedProtocols}" />
-        <property name="insertDocumentBlockedHosts" value="${insertDocumentBlockedHosts}" />
+        <property name="redirectFollower" ref="redirectFollower" />
         <property name="presDownloadReadTimeoutInMs" value="${presDownloadReadTimeoutInMs}" />
+        <property name="presRedirectValidator" ref="presRedirectValidator" />
     </bean>
 
     <bean id="xmlService" class="org.bigbluebutton.api.service.impl.XmlServiceImpl"/>


### PR DESCRIPTION
### What does this PR do?

Fixes 2 issues:
- When there are errors in which the pluginName is not identifiable, akka tries to save 2 plugins with the same pluginName "unidentified-plugin" which throws an error, since `pluginName` field must be unique;
- A pluginManifest URL that has redirect in it was not loading correctly;

### Motivation

We were getting some strange scenarios where multiple plugins were defined in bbb-web.properties, in our case 11, and only 8 were identified in the client console logs (this isn't correct because even if there are errors in back-end loading, we are supposed to show them in the client for a better debugging experience).

### How to test

I suggest using one plugin that does not work (returns a 404, for example), and one with a simple redirect (for instance: instead of writting https, write http only):

- https://ae42.live30.imdt.com.br/plugins/bbb30/latest/live-transcription-plugin/manifest.json
- http://bigbluebutton.nyc3.digitaloceanspaces.com/plugins/bbb30/latest/plugin-chat-mention/dist/manifest.json


### More

From the technical view, the solution was:
- Concatenate a sha1 of the pluginManifestUrl to the string `unidentified-plugin` so that this name will be unique and the URL will be hidden from the end user, still, because of the hashing;
- Copy the redirect following flow that we use for the presentation (making it a bit more generic to embrace this new scenario with plugins);
