### PR TITLE
refactor: move pinned notes notification to backend

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadsApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadsApp2x.scala
@@ -2,8 +2,9 @@ package org.bigbluebutton.core.apps.pads
 
 import org.apache.pekko.actor.ActorContext
 import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg, BbbCoreEnvelope, PadPinnedEvtMsg, PadPinnedEvtMsgBody }
-import org.bigbluebutton.core.db.SharedNotesDAO
+import org.bigbluebutton.core.db.{ NotificationDAO, SharedNotesDAO }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 object PadsApp2x {
   def setPinned(outGW: OutMsgRouter, liveMeeting: LiveMeeting, sharedNotesExtId: String, pinned: Boolean): Unit = {
@@ -21,6 +22,20 @@ object PadsApp2x {
 
     SharedNotesDAO.updatePinned(liveMeeting.props.meetingProp.intId, sharedNotesExtId, pinned)
     broadcastEvent(sharedNotesExtId, pinned)
+
+    // Send notification to all users when notes are pinned
+    if (pinned) {
+      val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+        liveMeeting.props.meetingProp.intId,
+        "info",
+        "copy",
+        "app.notes.pinnedNotification",
+        "Notification text for pinned shared notes",
+        Map()
+      )
+      outGW.send(notifyEvent)
+      NotificationDAO.insert(notifyEvent)
+    }
   }
 }
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-list-content/user-notes/component.tsx
@@ -4,7 +4,6 @@ import Icon from '/imports/ui/components/common/icon/component';
 import NotesService from '/imports/ui/components/notes/service';
 import lockContextContainer from '/imports/ui/components/lock-viewers/context/container';
 import { PANELS } from '/imports/ui/components/layout/enums';
-import { notify } from '/imports/ui/services/notification';
 import { layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
 import Styled from './styles';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
@@ -79,7 +78,6 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
     toggleNotesPanel,
   } = props;
   const [unread, setUnread] = useState(false);
-  const [pinWasNotified, setPinWasNotified] = useState(false);
   const intl = useIntl();
   const prevSidebarContentPanel = usePreviousValue(sidebarContentPanel);
   const prevIsPinned = usePreviousValue(isPinned);
@@ -87,11 +85,6 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
   useEffect(() => {
     setUnread(hasUnreadNotes);
   }, []);
-
-  if (isPinned && !pinWasNotified) {
-    notify(intl.formatMessage(intlMessages.pinnedNotification), 'info', 'copy', { pauseOnFocusLoss: false });
-    setPinWasNotified(true);
-  }
 
   const notesOpen = sidebarContentPanel === PANELS.SHARED_NOTES && !isPinned;
   const notesClosed = (prevSidebarContentPanel === PANELS.SHARED_NOTES
@@ -106,9 +99,6 @@ const UserNotesGraphql: React.FC<UserNotesGraphqlProps> = (props) => {
   }
   if (unread && !hasUnreadNotes) {
     setUnread(false);
-  }
-  if (prevIsPinned && !isPinned && pinWasNotified) {
-    setPinWasNotified(false);
   }
 
   const renderNotes = () => {


### PR DESCRIPTION
### What does this PR do?

Moves the shared notes pinned notification from the front-end to the back-end, ensuring it only triggers once when notes are actually pinned rather than every time the sidebar is reopened.

### Motivation

Previously, the notification was triggered in the user notes component whenever it mounted and notes were pinned. This caused the notification to reappear every time users closed and reopened the sidebar, creating duplicate notifications. 

By moving the notification logic to the backend, the notification is now sent as a broadcast event to all meeting participants exactly once when the pin action occurs, following the project's notification pattern.


### How to test
1. Join a meeting as a presenter and another user
2. Open shared notes and add some content
3. Pin the shared notes to the whiteboard. Expected: Both users see the notification "The Shared Notes are now pinned in the whiteboard"
4. Close and reopen the sidebar multiple times. Expected: The notification does NOT appear again when reopening the sidebar
5. Unpin and re-pin the notes. Expected: The notification appears again for the new pin action
