### PR TITLE
fix(notes): incorrect CSS property types

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -125,8 +125,20 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
   };
 
   const {
-    ...cssProps
+    height,
+    width,
+    top,
+    left,
+    zIndex,
   } = sharedNotesOutput;
+
+  const cssProps = {
+    height,
+    width,
+    top,
+    left,
+    zIndex,
+  };
 
   return shouldRenderNotes && (
     <Styled.PanelContent


### PR DESCRIPTION
### What does this PR do?
Corrects the CSS properties passed to the shared-notes panel, which were broken in https://github.com/bigbluebutton/bigbluebutton/commit/e5d3370f4d65c4470c1872044051377daccffed9 and have since included invalid CSS properties.

This typescript compiler error is causing the CI tests to fail on v3.1.x-release.