### PR TITLE
fix: unified layout updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/presentation-options/component.jsx
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Button from '/imports/ui/components/common/button/component';
 import Session from '/imports/ui/services/storage/in-memory';
-import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { ACTIONS, PANELS, LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import {
-  layoutSelectInput,
+  layoutSelectInput, layoutSelect,
 } from '/imports/ui/components/layout/context';
-import { useStorageKey } from '/imports/ui/services/storage/hooks';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -67,7 +66,8 @@ const PresentationOptionsContainer = ({
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const isChatOpen = sidebarContent.sidebarContentPanel === PANELS.CHAT;
   const PUBLIC_CHAT_ID = window.meetingClientSettings.public.chat.public_group_id;
-  const isGridLayout = useStorageKey('isGridEnabled');
+  const layoutType = layoutSelect((i) => i.layoutType);
+  const isVideoFocusLayout = layoutType === LAYOUT_TYPE.VIDEO_FOCUS;
   return (
     <Button
       icon={`${buttonType}${!presentationIsOpen ? '_off' : ''}`}
@@ -80,7 +80,7 @@ const PresentationOptionsContainer = ({
       circle
       size="lg"
       onClick={() => {
-        if (!isChatOpen && isGridLayout && !presentationIsOpen) {
+        if (!isChatOpen && isVideoFocusLayout && !presentationIsOpen) {
           layoutContextDispatch({
             type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
             value: PANELS.CHAT,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/component.tsx
@@ -40,11 +40,13 @@ const OverflowTile: React.FC<OverflowTileProps> = ({ overflowCount }) => {
     });
   };
 
+  const displayCount = Math.min(overflowCount, 3);
+
   return (
     <Styled.OverflowTileContainer data-test="overflowTile" isClickable={!isUserListPanelOpen} onClick={() => handleOpenUserList()}>
       <Styled.OverflowTileContent>
-        <Styled.AvatarsContainer>
-          {Array.from({ length: 3 }, (_, index) => (
+        <Styled.AvatarsContainer $count={displayCount}>
+          {Array.from({ length: displayCount }, (_, index) => (
             <Styled.AvatarWrapper key={index} $index={index}>
               <Styled.Avatar $color="#4a148c">
                 <Styled.AvatarInitials>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/styles.ts
@@ -48,13 +48,17 @@ const OverflowTileContent = styled.div`
   gap: 0.75rem;
 `;
 
-const AvatarsContainer = styled.div`
+const AvatarsContainer = styled.div<{ $count: number }>`
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 60px;
-  width: 120px;
+  width: ${({ $count }) => {
+    if ($count === 1) return '50px';
+    if ($count === 2) return '78px';
+    return '106px';
+  }};
 `;
 
 const AvatarWrapper = styled.div<{ $index: number }>`


### PR DESCRIPTION
### What does this PR do?

This pull request is a follow up to #24250 and introduces two improvements related to user interface consistency and behavior across layouts:
- match number of avatars in special tile with overflow count (up to 3): if less than 3 users are in overflow tile, it will now display the same number of avatars
- fix sidebar content opening when presentation is restored (Unified Layout): sidebar content opening condition has been adjusted to only happen in grid layout
