### PR TITLE
fix(chat): adjust input spacing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -645,7 +645,6 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
             <Styled.Input
               id="message-input"
               ref={textAreaRef}
-              $showEmojiPicker={showEmojiPicker}
               placeholder={intl.formatMessage(messages.inputPlaceholder, { chatName: title })}
               aria-label={intl.formatMessage(messages.inputLabel, { chatName: title })}
               aria-invalid={hasErrors ? 'true' : 'false'}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -11,7 +11,6 @@ import {
 import {
   smPaddingX,
   xsPadding,
-  smPaddingY,
   borderRadius,
   borderSize,
 } from '/imports/ui/stylesheets/styled-components/general';
@@ -47,22 +46,20 @@ const Input = styled(TextareaAutosize)<InputProps>`
   flex: 1;
   background: #fff;
   background-clip: padding-box;
-  margin: ${xsPadding} 0 ${xsPadding} ${xsPadding};
+  margin: 0px;
+  border-radius: 0px;
   color: ${colorGrayLight};
   -webkit-appearance: none;
-  padding: calc(${smPaddingY} * 2.5) calc(${smPaddingX} * 1.25) calc(${smPaddingX} * 1.25) calc(${smPaddingY} * 2.5);
+  padding: 0px;
   resize: none;
   transition: color 0.3s ease, margin-right 0.3s ease;
-  border-radius: ${borderRadius};
   font-size: ${fontSizeBase};
   line-height: 1;
-  min-height: 2.5rem;
   overflow-y: auto;
   border: ${colorBorder};
   box-shadow: none;
   outline: none;
-
-  margin-right: ${({ $showEmojiPicker }) => ($showEmojiPicker ? '0' : '0.75rem')};
+  align-content: center;
 
   &::-webkit-scrollbar {
     width: 5px;
@@ -79,14 +76,6 @@ const Input = styled(TextareaAutosize)<InputProps>`
 
   &::-webkit-scrollbar-track {
     background: transparent;
-  }
-
-  [dir='ltr'] & {
-    border-radius: 0.75rem 0 0 0.75rem;
-  }
-
-  [dir='rtl'] & {
-    border-radius: 0 0.75rem 0.75rem 0;
   }
 
   &:focus {
@@ -195,6 +184,7 @@ const InputWrapper = styled.div`
   z-index: 0;
   border-radius: 0.75rem;
   border: 1px solid ${colorBorder};
+  gap: 3px;
 
   &:focus-within {
     box-shadow: 0 0 0 ${xsPadding} ${colorBorder};


### PR DESCRIPTION
### What does this PR do?
Adjusts the chat message input paddings to better fit in the chat panel without taking more space than necessary.

- Small SD Screen:
![new_chat_padding_small_screen](https://github.com/user-attachments/assets/ae56e587-79df-4375-9894-8ce8b4cfdc3d)

- Full HD Screen:
![new_chat_padding_normal_screen](https://github.com/user-attachments/assets/200fa42c-b847-479a-9c92-bac9f3cf6139)

- Full HD Screen with emoji picker enabled:
<img width="901" height="602" alt="Screenshot from 2025-12-10 18-57-43" src="https://github.com/user-attachments/assets/6d837049-5efe-443d-a795-81c7ac0a45b2" />

### More
Related: https://github.com/bigbluebutton/bigbluebutton/pull/24099
