### PR TITLE
fix(tldraw): remove unnecessary extra zoom call +

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1869,12 +1869,14 @@ const Whiteboard = React.memo((props) => {
     prevZoomValueRef.current = zoomValue;
   }, [zoomValue, pageChanged, tlEditorRef.current, isWheelZoomRef.current]);
 
+  const prevFitToWidth = usePrevious(fitToWidth);
+
   React.useEffect(() => {
-    if (isPresenter) {
+    if (prevFitToWidth !== undefined && prevFitToWidth !== fitToWidth && isPresenter) {
       zoomChanger(HUNDRED_PERCENT);
       zoomSlide(HUNDRED_PERCENT, HUNDRED_PERCENT, 0, 0);
     }
-  }, [fitToWidth]);
+  }, [fitToWidth, prevFitToWidth, isPresenter, zoomChanger, zoomSlide]);
 
   React.useEffect(() => {
     debouncedSetInitialZoom();

--- a/bigbluebutton-html5/imports/utils/slideCalcUtils.js
+++ b/bigbluebutton-html5/imports/utils/slideCalcUtils.js
@@ -13,12 +13,18 @@ export default class SlideCalcUtil {
    * Calculate the viewed region width
    */
   static calcViewedRegionWidth(vpw, cpw) {
-    const width = (vpw / cpw) * HUNDRED_PERCENT;
+    let width = (vpw / cpw) * HUNDRED_PERCENT;
+    if (Math.abs(width - HUNDRED_PERCENT) < 0.2) {
+      width = HUNDRED_PERCENT;
+    }
     return Math.max(MIN_PERCENT, width);
   }
 
   static calcViewedRegionHeight(vph, cph) {
-    const height = (vph / cph) * HUNDRED_PERCENT;
+    let height = (vph / cph) * HUNDRED_PERCENT;
+    if (Math.abs(height - HUNDRED_PERCENT) < 0.2) {
+      height = HUNDRED_PERCENT;
+    }
     return Math.max(MIN_PERCENT, height);
   }
 


### PR DESCRIPTION
### What does this PR do?

An extra zoom/pan change call was being sent to server every time presentation is mounted, so there were two calls, this removes one of them.

- Only reset camera when fitTwoWdith actually changes, it was being set on every presentation mount
- Round viewed region up to 100 percent when its too near (avoids 99.99... values)


This was found when trying to investigate https://github.com/bigbluebutton/bigbluebutton/issues/24314, not sure it fixes it.
