### PR TITLE
fix: Can't start a quiz with "true/false" or "yes/no/abstention" in languages other than english

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/poll/components/StartPollButton.tsx
+++ b/bigbluebutton-html5/imports/ui/components/poll/components/StartPollButton.tsx
@@ -53,7 +53,7 @@ const intlMessages = defineMessages({
 });
 
 interface StartPollButtonProps {
-  optList: Array<{val: string}>;
+  optList: Array<{val: string, key: string}>;
   question: string | string[];
   type: string | null;
   setError: (err: string) => void;
@@ -116,7 +116,7 @@ const StartPollButton: React.FC<StartPollButtonProps> = ({
     && optList.filter((o) => o.val.trim().length > 0).length < 1);
   const quizHasNoCorrectAnswer = (
     isQuiz
-    && !(optList[correctAnswer.index]?.val === correctAnswer.text));
+    && !(optList[correctAnswer.index]?.key === correctAnswer.text));
   return (
     <Styled.StartPollBtn
       data-test="startPoll"


### PR DESCRIPTION
### What does this PR do?

Adjusts quiz correct answer validation to work with any language

### Closes Issue(s)
Closes #24365

### How to test
1. join a meeting
2. change BigBlueButton client language to French (or any other language except english)
3. open the poll/quiz panel and select "Quiz"
4. set the response type as True/False and select a correct answer from the list
5. Start Quiz button should be active