### PR TITLE
fix: LiveKit token update fails on database

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserLivekitDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserLivekitDAO.scala
@@ -10,8 +10,8 @@ case class UserLivekitDbModel(
 )
 
 class UserLivekitDbTableDef(tag: Tag) extends Table[UserLivekitDbModel](tag, "user_livekit") {
-  val meetingId = column[String]("meetingId")
-  val userId = column[String]("userId")
+  val meetingId = column[String]("meetingId", O.PrimaryKey)
+  val userId = column[String]("userId", O.PrimaryKey)
   val livekitToken = column[String]("livekitToken")
 
   override def * : ProvenShape[UserLivekitDbModel] = (
@@ -24,7 +24,7 @@ class UserLivekitDbTableDef(tag: Tag) extends Table[UserLivekitDbModel](tag, "us
 object UserLivekitDAO {
   def insert(meetingId: String, userId: String, livekitToken: String) = {
     DatabaseConnection.enqueue(
-      TableQuery[UserLivekitDbTableDef].forceInsert(
+      TableQuery[UserLivekitDbTableDef].insertOrUpdate(
         UserLivekitDbModel(
           meetingId = meetingId,
           userId = userId,


### PR DESCRIPTION
### What does this PR do?

- [fix: LiveKit token update fails on database](https://github.com/bigbluebutton/bigbluebutton/commit/acd1a18a845be002591ce3d92093a435add54e0d) 
  - When a new LK token is generated for an existing session, its insertion
in the database is failing due to the usage of forceInsert. This is not
the expected behavior - the token should be updated.
While the behavior is mostly benign as token re-generation does not yet
play a significant role, this might bork unrelated batched DB ops and
should be fixed.
  - Fix the issue by using insertOrUpdate so that LK tokens are properly
updated.


### Closes Issue(s)

None