### PR TITLE
refactor (gql-middleware): Reject new mutations once the rate limit is reached, instead of delaying them

### DIFF
--- a/bbb-graphql-middleware/config/config.yml
+++ b/bbb-graphql-middleware/config/config.yml
@@ -10,7 +10,7 @@ server:
   max_connection_queries_per_minute: 200
   # Rate limit: maximum number of mutations each connection can send per minute.
   # A high number is recommended because the whiteboard cursor and annotations generate frequent mutations.
-  max_connection_mutations_per_minute: 900
+  max_connection_mutations_per_minute: 2000
   # Maximum number of concurrent subscriptions allowed per connection.
   max_connection_concurrent_subscriptions: 150
   # Maximum length of the query body.

--- a/bbb-graphql-middleware/internal/gql_actions/client.go
+++ b/bbb-graphql-middleware/internal/gql_actions/client.go
@@ -2,7 +2,6 @@ package gql_actions
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -57,7 +56,7 @@ RangeLoop:
 								browserConnection,
 								browserMessage.ID,
 								fmt.Sprintf(
-									"Mutation %s is not valid with length %d and the max allowed is %d",
+									"Mutation failed (%s): Length %d and the max allowed is %d",
 									browserMessage.Payload.OperationName,
 									mutationLength, config.GetConfig().Server.MaxMutationLength))
 							continue
@@ -65,12 +64,14 @@ RangeLoop:
 					}
 
 					// Rate limiter from config max_connection_mutations_per_minute
-					ctxRateLimiter, _ := context.WithTimeout(browserConnection.Context, 30*time.Second)
-					if err := browserConnection.FromBrowserToGqlActionsRateLimiter.Wait(ctxRateLimiter); err != nil {
+					if !browserConnection.FromBrowserToGqlActionsRateLimiter.Allow() {
 						sendErrorMessage(
 							browserConnection,
 							browserMessage.ID,
-							fmt.Sprintf("Rate limit exceeded: Maximum %d mutations per minute allowed. Please try again later.", config.GetConfig().Server.MaxConnectionMutationsPerMinute),
+							fmt.Sprintf("Mutation failed (%s): Rate limit exceeded - Maximum %d mutations per minute allowed",
+								browserMessage.Payload.OperationName,
+								config.GetConfig().Server.MaxConnectionMutationsPerMinute,
+							),
 						)
 
 						continue
@@ -83,11 +84,25 @@ RangeLoop:
 								// Add Prometheus Metrics
 								common.GqlMutationsCounter.With(prometheus.Labels{"operationName": browserMessage.Payload.OperationName}).Inc()
 							} else {
-								sendErrorMessage(browserConnection, browserMessage.ID, fmt.Sprintf("It was not able to send the request to Graphql Actions: %s", err.Error()))
+								sendErrorMessage(
+									browserConnection,
+									browserMessage.ID,
+									fmt.Sprintf("Mutation failed (%s): It was not able to send the request to Graphql Actions: %s",
+										browserMessage.Payload.OperationName,
+										err.Error(),
+									),
+								)
 								continue
 							}
 						} else {
-							sendErrorMessage(browserConnection, browserMessage.ID, fmt.Sprintf("It was not able to parse graphQL query: %s", err.Error()))
+							sendErrorMessage(
+								browserConnection,
+								browserMessage.ID,
+								fmt.Sprintf("Mutation failed (%s): It was not able to parse graphQL query: %s",
+									browserMessage.Payload.OperationName,
+									err.Error(),
+								),
+							)
 							continue
 						}
 					}

--- a/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/error-boundary/error-boundary-with-reload/component.jsx
@@ -91,6 +91,10 @@ const ErrorBoundaryWithReload = ({ children }) => {
       if (event.reason?.message?.toString().indexOf('Permission Denied') !== -1) {
         return;
       }
+      // Ignore errors caused by graphql Mutations (and is not related with Presentation)
+      if (event.reason?.message?.toString().indexOf('Mutation failed') !== -1 && event.reason?.message?.toString().indexOf('Presentation') === -1) {
+        return;
+      }
       // Ignore errors caused by missing permissions on browser
       if (event.reason?.name === 'NotAllowedError') {
         return;

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -79,7 +79,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   }
 
   if (networkError) {
-    const isMutation = networkError.message.includes('graphql actions request failed');
+    const isMutation = networkError.message.includes('Mutation failed');
     if (!isMutation) {
       connectionStatus.setSubscriptionFailed(true);
     }


### PR DESCRIPTION
When the client exceeds the mutation rate limit, the middleware currently delays processing new mutations. This behavior is undesirable because actions may be executed at unexpected times, and in the case of application RTT calculations, it can incorrectly trigger high-RTT alerts that are actually caused by rate-limit delays.

Proposed changes:

- Reject new mutations once the rate limit is reached, instead of delaying them.
- Increase the maximum allowed mutations per minute to 2,000 (still within safe bounds).
- Standardize the error prefix for mutation-related errors so clients can reliably detect them and suppress unnecessary warnings.
- Include the mutation name in the error message to make it easier to debug which mutation is causing the problem.

<img width="2131" height="706" alt="image" src="https://github.com/user-attachments/assets/d65dd905-0780-472a-9eb5-9e54f6c1722a" />
