### PR TITLE
Draft: Enable persistence for locksettings and shared notes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadContentSysMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadContentSysMsgHdlr.scala
@@ -35,5 +35,8 @@ trait PadContentSysMsgHdlr {
       }
       case _ =>
     }
+    if (Pads.isSharedNotes(liveMeeting, groupId = msg.body.groupId)) {
+      liveMeeting.sharedNotesHtml = msg.body.html
+    }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadCreateReqMsgHdlr.scala
@@ -14,7 +14,7 @@ trait PadCreateReqMsgHdlr {
       val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
       val envelope = BbbCoreEnvelope(PadCreateCmdMsg.NAME, routing)
       val header = BbbCoreHeaderWithMeetingId(PadCreateCmdMsg.NAME, liveMeeting.props.meetingProp.intId)
-      val body = PadCreateCmdMsgBody(groupId, name)
+      val body = PadCreateCmdMsgBody(groupId, name, liveMeeting.props.meetingProp.sharedNotesInitialContent)
       val event = PadCreateCmdMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadGroupCreatedEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadGroupCreatedEvtMsgHdlr.scala
@@ -14,7 +14,7 @@ trait PadGroupCreatedEvtMsgHdlr {
         Pads.setGroupId(liveMeeting.pads, msg.body.externalId, msg.body.groupId)
 
         //Group was created, now request to create the pad
-        PadslHdlrHelpers.broadcastPadCreateCmdMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.body.groupId, msg.body.externalId)
+        PadslHdlrHelpers.broadcastPadCreateCmdMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.body.groupId, msg.body.externalId, liveMeeting.props.meetingProp.sharedNotesInitialContent)
       }
       case _ =>
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadslHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/pads/PadslHdlrHelpers.scala
@@ -16,11 +16,11 @@ object PadslHdlrHelpers {
     outGW.send(msgEvent)
   }
 
-  def broadcastPadCreateCmdMsg(outGW: OutMsgRouter, meetingId: String, groupId: String, name: String): Unit = {
+  def broadcastPadCreateCmdMsg(outGW: OutMsgRouter, meetingId: String, groupId: String, name: String, initialHtmlContent: String): Unit = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(PadCreateCmdMsg.NAME, routing)
     val header = BbbCoreHeaderWithMeetingId(PadCreateCmdMsg.NAME, meetingId)
-    val body = PadCreateCmdMsgBody(groupId, name)
+    val body = PadCreateCmdMsgBody(groupId, name, initialHtmlContent)
     val event = PadCreateCmdMsg(header, body)
     val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
@@ -6,7 +6,7 @@ case class SharedNotesRevDbModel(
     meetingId:        String,
     sharedNotesExtId: String,
     rev:              Int,
-    userId:           String,
+    userId:           Option[String],
     changeset:        String,
     start:            Option[Int],
     end:              Option[Int],
@@ -18,7 +18,7 @@ class SharedNotesRevDbTableDef(tag: Tag) extends Table[SharedNotesRevDbModel](ta
   val meetingId = column[String]("meetingId", O.PrimaryKey)
   val sharedNotesExtId = column[String]("sharedNotesExtId", O.PrimaryKey)
   val rev = column[Int]("rev", O.PrimaryKey)
-  val userId = column[String]("userId")
+  val userId = column[Option[String]]("userId")
   val changeset = column[String]("changeset")
   val start = column[Option[Int]]("start")
   val end = column[Option[Int]]("end")
@@ -35,7 +35,10 @@ object SharedNotesRevDAO {
           meetingId = meetingId,
           sharedNotesExtId = sharedNotesExtId,
           rev = revId,
-          userId = userId,
+          userId = userId match {
+            case ""         => None
+            case id: String => Some(id)
+          },
           changeset = changeset,
           start = None,
           end = None,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Pads.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Pads.scala
@@ -28,6 +28,18 @@ object Pads {
     }
   }
 
+  def isSharedNotes(liveMeeting: LiveMeeting, groupId: String): Boolean = {
+    getGroupById(liveMeeting.pads, groupId) match {
+      case Some(group) => {
+        group.model match {
+          case "notes" => true
+          case _       => false
+        }
+      }
+      case _ => false
+    }
+  }
+
   def hasGroup(pads: Pads, externalId: String): Boolean = pads.groups.contains(externalId)
 
   def addGroup(pads: Pads, externalId: String, model: String, name: String, userId: String): Unit = pads.addGroup(externalId, model, name, userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.net.http.HttpRequest.BodyPublishers
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.nio.charset.StandardCharsets
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 trait HandlerHelpers extends SystemConfiguration {
@@ -199,16 +200,16 @@ trait HandlerHelpers extends SystemConfiguration {
       val gson: Gson = new Gson()
       val lockSettingsJson: String = gson.toJson(getPermissions(liveMeeting.status))
       val log = LoggerFactory.getLogger(this.getClass)
-      log.info("collectPersistentState: Meeting lock settings: {}", lockSettingsJson)
-      log.info("collectPersistentState: Meeting shared notes: {}", liveMeeting.sharedNotesHtml)
       val baos = new ByteArrayOutputStream
       val zos = new ZipOutputStream(baos)
       zos.putNextEntry(new ZipEntry("locksettings.json"))
-      zos.write(lockSettingsJson.getBytes("utf-8"))
+      zos.write(lockSettingsJson.getBytes(StandardCharsets.UTF_8))
       zos.closeEntry()
-      zos.putNextEntry(new ZipEntry("shared_notes.html"))
-      zos.write(liveMeeting.sharedNotesHtml.getBytes("utf-8"))
-      zos.closeEntry()
+      if (liveMeeting.sharedNotesHtml != null) {
+        zos.putNextEntry(new ZipEntry("shared_notes.html"))
+        zos.write(liveMeeting.sharedNotesHtml.getBytes(StandardCharsets.UTF_8))
+        zos.closeEntry()
+      }
       zos.close()
       baos.toByteArray
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -1,18 +1,28 @@
 package org.bigbluebutton.core.running
 
+import com.google.gson.Gson
+import org.apache.commons.lang3.StringUtils
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
-import org.bigbluebutton.core.api.{ BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg, EndBreakoutRoomInternalMsg }
+import org.bigbluebutton.core.api.{BreakoutRoomEndedInternalMsg, DestroyMeetingInternalMsg, EndBreakoutRoomInternalMsg}
 import org.bigbluebutton.core.apps.groupchats.GroupChatApp
 import org.bigbluebutton.core.apps.users.UsersApp
 import org.bigbluebutton.core.apps.voice.VoiceApp
-import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
-import org.bigbluebutton.core.db.{ BreakoutRoomUserDAO, MeetingDAO, MeetingRecordingDAO, NotificationDAO, UserBreakoutRoomDAO }
-import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }
+import org.bigbluebutton.core.bus.{BigBlueButtonEvent, InternalEventBus}
+import org.bigbluebutton.core.db.{MeetingDAO, MeetingRecordingDAO, NotificationDAO, UserBreakoutRoomDAO}
+import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models._
-import org.bigbluebutton.core2.MeetingStatus2x
-import org.bigbluebutton.core2.message.senders.{ MsgBuilder, UserJoinedMeetingEvtMsgBuilder }
 import org.bigbluebutton.core.util.TimeUtil
+import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core2.MeetingStatus2x.getPermissions
+import org.bigbluebutton.core2.message.senders.{MsgBuilder, UserJoinedMeetingEvtMsgBuilder}
+import org.slf4j.LoggerFactory
+
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.util.zip.{ZipEntry, ZipOutputStream}
 
 trait HandlerHelpers extends SystemConfiguration {
 
@@ -184,6 +194,41 @@ trait HandlerHelpers extends SystemConfiguration {
     outGW.send(endingEvent)
 
     MeetingStatus2x.meetingHasEnded(liveMeeting.status)
+
+    def collectPersistentState(): Array[Byte] = {
+      val gson: Gson = new Gson()
+      val lockSettingsJson: String = gson.toJson(getPermissions(liveMeeting.status))
+      val log = LoggerFactory.getLogger(this.getClass)
+      log.info("collectPersistentState: Meeting lock settings: {}", lockSettingsJson)
+      log.info("collectPersistentState: Meeting shared notes: {}", liveMeeting.sharedNotesHtml)
+      val baos = new ByteArrayOutputStream
+      val zos = new ZipOutputStream(baos)
+      zos.putNextEntry(new ZipEntry("locksettings.json"))
+      zos.write(lockSettingsJson.getBytes("utf-8"))
+      zos.closeEntry()
+      zos.putNextEntry(new ZipEntry("shared_notes.html"))
+      zos.write(liveMeeting.sharedNotesHtml.getBytes("utf-8"))
+      zos.closeEntry()
+      zos.close()
+      baos.toByteArray
+    }
+
+    def uploadPersistentState(url: String, zipBytes: Array[Byte]): Unit = {
+      val client = HttpClient.newHttpClient()
+      val request = HttpRequest.newBuilder()
+        .uri(URI.create(url))
+        .PUT(BodyPublishers.ofByteArray(zipBytes))
+        .header("Content-Type", "application/octet-stream")
+        .build()
+      val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+      val log = LoggerFactory.getLogger(this.getClass)
+      log.info("Uploaded ZIP: status={}", response.statusCode())
+    }
+
+    if (!StringUtils.isEmpty(liveMeeting.props.meetingProp.persistentStateUrl)) {
+      val zipBytes = collectPersistentState()
+      uploadPersistentState(liveMeeting.props.meetingProp.persistentStateUrl, zipBytes)
+    }
 
     def buildMeetingEndedEvtMsg(meetingId: String): BbbCommonEnvCoreMsg = {
       val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -27,4 +27,5 @@ class LiveMeeting(
     val guestsWaiting:       GuestsWaiting,
     val clientSettings:      Map[String, Object],
     val plugins:             PluginModel,
+    var sharedNotesHtml:     String,
 )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
@@ -44,7 +44,7 @@ class RunningMeeting(val props: DefaultProps, outGW: OutMessageGateway,
   // easy to test.
   private val liveMeeting = new LiveMeeting(props, meetingStatux2x, deskshareModel, audioCaptions, timerModel,
     chatModel, externalVideoModel, layouts, pads, registeredUsers, polls2x, wbModel, presModel,
-    webcams, voiceUsers, users2x, guestsWaiting, clientSettings, plugins)
+    webcams, voiceUsers, users2x, guestsWaiting, clientSettings, plugins, "")
 
   GuestsWaiting.setGuestPolicy(
     liveMeeting.props.meetingProp.intId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/meeting/EndMeetingSysCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/meeting/EndMeetingSysCmdMsgHdlr.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.core2.message.handlers.meeting
 
+import com.google.gson.Gson
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.InternalEventBus
 import org.bigbluebutton.core.domain.{ MeetingEndReason, MeetingState2x }

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -109,7 +109,7 @@ trait AppsTestFixtures {
     val polls2x = new Polls
     val guestsWaiting = new GuestsWaiting
     val deskshareModel = new ScreenshareModel
-    val SharedNotesHtml = ""
+    val sharedNotesHtml = ""
 
     // We extract the meeting handlers into this class so it is
     // easy to test.

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/AppsTestFixtures.scala
@@ -109,10 +109,11 @@ trait AppsTestFixtures {
     val polls2x = new Polls
     val guestsWaiting = new GuestsWaiting
     val deskshareModel = new ScreenshareModel
+    val SharedNotesHtml = ""
 
     // We extract the meeting handlers into this class so it is
     // easy to test.
     new LiveMeeting(defaultProps, meetingStatux2x, deskshareModel, chatModel, layouts,
-      registeredUsers, polls2x, wbModel, presModel, webcams, voiceUsers, users2x, guestsWaiting)
+      registeredUsers, polls2x, wbModel, presModel, webcams, voiceUsers, users2x, guestsWaiting, sharedNotesHtml)
   }
 }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -22,6 +22,8 @@ case class MeetingProp(
     notifyRecordingIsOn:                    Boolean,
     presentationUploadExternalDescription:  String,
     presentationUploadExternalUrl:          String,
+    persistentStateUrl:                     String,
+    sharedNotesInitialContent:              String,
 )
 
 case class BreakoutProps(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PadsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PadsMsgs.scala
@@ -27,7 +27,7 @@ case class PadCreateReqMsgBody(externalId: String, name: String)
 // apps -> pads
 object PadCreateCmdMsg { val NAME = "PadCreateCmdMsg" }
 case class PadCreateCmdMsg(header: BbbCoreHeaderWithMeetingId, body: PadCreateCmdMsgBody) extends BbbCoreMsg
-case class PadCreateCmdMsgBody(groupId: String, name: String)
+case class PadCreateCmdMsgBody(groupId: String, name: String, initialHtmlContent: String)
 
 // pads -> apps
 object PadCreatedEvtMsg { val NAME = "PadCreatedEvtMsg" }
@@ -82,7 +82,7 @@ case class PadUpdatedEvtMsgBody(externalId: String, padId: String, userId: Strin
 // pads -> apps
 object PadContentSysMsg { val NAME = "PadContentSysMsg" }
 case class PadContentSysMsg(header: BbbCoreHeaderWithMeetingId, body: PadContentSysMsgBody) extends PadStandardMsg
-case class PadContentSysMsgBody(groupId: String, padId: String, rev: String, start: Int, end: Int, text: String)
+case class PadContentSysMsgBody(groupId: String, padId: String, rev: String, html: String, start: Int, end: Int, text: String)
 
 // apps -> client
 object PadContentEvtMsg { val NAME = "PadContentEvtMsg" }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -117,6 +117,8 @@ public class ApiParams {
 
     public static final String MAX_NUM_PAGES = "maxNumPages";
 
+    public static final String PERSISTENT_STATE_URL = "persistentStateUrl";
+
     private ApiParams() {
         throw new IllegalStateException("ApiParams is a utility class. Instantiation is forbidden.");
     }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LockSettingsStateFormat.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LockSettingsStateFormat.java
@@ -1,0 +1,15 @@
+package org.bigbluebutton.api;
+
+public class LockSettingsStateFormat {
+    public Boolean disableCam = false;
+    public Boolean disableMic = false;
+    public Boolean disablePrivChat = false;
+    public Boolean disablePubChat = false;
+    public Boolean disableNotes = false;
+    public Boolean hideUserList = false;
+    public Boolean lockOnJoin = false;
+    public Boolean lockOnJoinConfigurable = false;
+    public Boolean hideViewersCursor = false;
+    public Boolean hideViewersAnnotation = false;
+    public Boolean webcamsOnlyForModerator = false;
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -613,7 +613,7 @@ public class MeetingService implements MessageListener {
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams, m.lockSettingsParams, m.getLoginUrl(), m.getLogoutUrl(), m.getCustomLogoURL(), m.getCustomDarkLogoURL(),
             m.getBannerText(), m.getBannerColor(), m.getGroups(), m.getDisabledFeatures(), m.getNotifyRecordingIsOn(),
-            m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(), m.getPersistenStateUrl(), m.getSharedNotesInitialContent(),  m.getPlugins(),
+            m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(), m.getPersistentStateUrl(), m.getSharedNotesInitialContent(),  m.getPlugins(),
             m.getHtml5PluginSdkVersion(), m.getOverrideClientSettings());
   }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -613,7 +613,7 @@ public class MeetingService implements MessageListener {
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams, m.lockSettingsParams, m.getLoginUrl(), m.getLogoutUrl(), m.getCustomLogoURL(), m.getCustomDarkLogoURL(),
             m.getBannerText(), m.getBannerColor(), m.getGroups(), m.getDisabledFeatures(), m.getNotifyRecordingIsOn(),
-            m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(), m.getPlugins(),
+            m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(), m.getPersistenStateUrl(), m.getSharedNotesInitialContent(),  m.getPlugins(),
             m.getHtml5PluginSdkVersion(), m.getOverrideClientSettings());
   }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import com.google.gson.*;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.io.FileUtils;
 import org.bigbluebutton.api.domain.*;
 import org.bigbluebutton.api.util.PluginUtils;
 import org.jsoup.Jsoup;
@@ -579,21 +580,38 @@ public class ParamsProcessorUtil {
         return null;
     }
 
-    private void downloadAndExtractState(String stateURL, Path destDir) {
+    private boolean downloadAndExtractState(String stateURL, Path destDir) {
+        HttpURLConnection httpConn = null;
         try {
             log.debug("extracting state file to " + destDir.getFileName());
             URL url = new URL(stateURL);
-            HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+            // At minimum, restrict to https
+            if (!"https".equalsIgnoreCase(url.getProtocol())) {
+                log.warn("Refusing to download persistent state over non-HTTPS URL");
+                return false;
+            }
+            httpConn = (HttpURLConnection) url.openConnection();
+            httpConn.setInstanceFollowRedirects(false);
+            httpConn.setConnectTimeout(5000);
+            httpConn.setReadTimeout(5000);
             int responseCode = httpConn.getResponseCode();
 
             if (responseCode == HttpURLConnection.HTTP_OK) {
                 try (InputStream inputStream = httpConn.getInputStream();
-                    ZipInputStream zipIn = new ZipInputStream(inputStream)) {
+                     ZipInputStream zipIn = new ZipInputStream(inputStream)) {
 
                     ZipEntry entry;
+                    long extractedBytes = 0L;
+                    // allow 10 maxsize presentations + 2 MB for shared notes, annotations ect.
+                    final long maxExtractBytes = maxPresentationFileUpload * 10 + 2L * 1024 * 1024;
                     while ((entry = zipIn.getNextEntry()) != null) {
                         // Construct the file path to unzip to
-                        Path entryPath = destDir.resolve(entry.getName());
+                        Path entryPath = destDir.resolve(entry.getName()).normalize();
+                        if (!entryPath.startsWith(destDir)) {
+                            log.warn("Skipping suspicious ZIP entry path: {}", entry.getName());
+                            zipIn.closeEntry();
+                            continue;
+                        }
 
                         // If it's a directory, create it
                         if (entry.isDirectory()) {
@@ -602,33 +620,40 @@ public class ParamsProcessorUtil {
                         } else {
                             // If it's a file, extract it
                             log.debug("extracting file " + entryPath.getFileName());
-                            extractFile(zipIn, entryPath);
+                            extractedBytes += extractFile(zipIn, entryPath, maxExtractBytes - extractedBytes);
+                            if (extractedBytes > maxExtractBytes) {
+                                log.warn("Aborting ZIP extract: exceeding max extracted bytes");
+                                return false;
+                            }
                         }
 
                         zipIn.closeEntry();
                     }
                     log.debug("extracted state file to " + destDir.getFileName());
                 } catch (IOException e) {
-                    e.printStackTrace();
-                    log.error("failed to extract zip file");
-                    //throw new IOException("Error extracting ZIP file");
-                }       
+                    log.error("failed to extract zip file", e);
+                    return false;
+                }
             } else {
                 log.info("No file to download. Server replied HTTP code: " + responseCode);
+                return false;
             }
-            httpConn.disconnect();
-            
         } catch (MalformedURLException e) {
-            e.printStackTrace();
             log.warn("malformed URL for statefile");
+            return false;
         } catch (IOException e) {
-            e.printStackTrace();
-            log.error("IO Exception while downloading state file");
+            log.error("IO Exception while downloading state file", e);
+            return false;
+        } finally {
+            if (httpConn != null) {
+                httpConn.disconnect();
+            }
         }
+        return true;
     }
 
     // Helper method to extract files from the ZIP stream
-    private static void extractFile(ZipInputStream zipIn, Path filePath) throws IOException {
+    private static long extractFile(ZipInputStream zipIn, Path filePath, long remainingBudgetBytes) throws IOException {
         // Create parent directories if they do not exist
         Files.createDirectories(filePath.getParent());
 
@@ -636,9 +661,15 @@ public class ParamsProcessorUtil {
         try (BufferedOutputStream bos = new BufferedOutputStream(Files.newOutputStream(filePath))) {
             byte[] bytesIn = new byte[4096];
             int read;
+            long written =0L;
             while ((read = zipIn.read(bytesIn)) != -1) {
+                if (written + read > remainingBudgetBytes) {
+                    throw new IOException("ZIP entry exceeds remaining extraction budget");
+                }
                 bos.write(bytesIn, 0, read);
+                written += read;
             }
+            return written;
         }
     }
 
@@ -1010,14 +1041,26 @@ public class ParamsProcessorUtil {
         String initialSharedNotesContent = "";
         if (!StringUtils.isEmpty(params.get(ApiParams.PERSISTENT_STATE_URL))) {
             persistentStateUrl = params.get(ApiParams.PERSISTENT_STATE_URL);
+            Path tempDir = null;
             try {
-                Path tempDir = Files.createTempDirectory(Paths.get(System.getProperty("java.io.tmpdir")), "bbb_downloaded_state_");
-                downloadAndExtractState(persistentStateUrl, tempDir);
-                savedLockSettingsState = parsePersistedLockSettings(tempDir);
-                initialSharedNotesContent = loadSharedNotesInitialContent(tempDir);
-                webcamsOnlyForMod = savedLockSettingsState.webcamsOnlyForModerator;
+                tempDir = Files.createTempDirectory(Paths.get(System.getProperty("java.io.tmpdir")), "bbb_downloaded_state_");
+                if (downloadAndExtractState(persistentStateUrl, tempDir)) {
+                    savedLockSettingsState = parsePersistedLockSettings(tempDir);
+                    initialSharedNotesContent = loadSharedNotesInitialContent(tempDir);
+                    if (savedLockSettingsState != null) {
+                        webcamsOnlyForMod = savedLockSettingsState.webcamsOnlyForModerator;
+                    }
+                }
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Error handling downloaded persistence zip file", e);
+            } finally {
+                if (tempDir != null) {
+                    try {
+                        FileUtils.deleteDirectory(tempDir.toFile());
+                    } catch (IOException e) {
+                        log.error("Error deleting temporary directory", e);
+                    }
+                }
             }
         }
         LockSettingsParams lockSettingsParams = processLockSettingsParams(params, savedLockSettingsState);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -19,17 +19,23 @@
 
 package org.bigbluebutton.api;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.zip.*;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.bigbluebutton.api.domain.*;
 import org.bigbluebutton.api.util.PluginUtils;
 import org.jsoup.Jsoup;
@@ -350,11 +356,17 @@ public class ParamsProcessorUtil {
 			return new BreakoutRoomsParams(breakoutRoomsRecord, breakoutRoomsPrivateChatEnabled, breakoutRoomsCaptureNotes, breakoutRoomsCaptureSlides, breakoutRoomsCaptureNotesFilename, breakoutRoomsCaptureSlidesFilename);
 		}
 
-		private LockSettingsParams processLockSettingsParams(Map<String, String> params) {
+		private LockSettingsParams processLockSettingsParams(Map<String, String> params, LockSettingsStateFormat savedState) {
 			Boolean lockSettingsDisableCam = defaultLockSettingsDisableCam;
+            log.debug("processing lock settings parameters");
+            Gson gson = new Gson();
+            log.debug("state format is " + gson.toJson(savedState));
 			String lockSettingsDisableCamParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_CAM);
 			if (!StringUtils.isEmpty(lockSettingsDisableCamParam)) {
 				lockSettingsDisableCam = Boolean.parseBoolean(lockSettingsDisableCamParam);
+			}
+			if (savedState != null) {
+				lockSettingsDisableCam = savedState.disableCam;
 			}
 
 			Boolean lockSettingsDisableMic = defaultLockSettingsDisableMic;
@@ -362,17 +374,26 @@ public class ParamsProcessorUtil {
 			if (!StringUtils.isEmpty(lockSettingsDisableMicParam)) {
 				lockSettingsDisableMic = Boolean.parseBoolean(lockSettingsDisableMicParam);
 			}
+			if (savedState != null) {
+				lockSettingsDisableMic = savedState.disableMic;
+			}
 
 			Boolean lockSettingsDisablePrivateChat = defaultLockSettingsDisablePrivateChat;
 			String lockSettingsDisablePrivateChatParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT);
 			if (!StringUtils.isEmpty(lockSettingsDisablePrivateChatParam)) {
 				lockSettingsDisablePrivateChat = Boolean.parseBoolean(lockSettingsDisablePrivateChatParam);
 			}
+			if (savedState != null) {
+				lockSettingsDisablePrivateChat = savedState.disablePrivChat;
+			}
 
 			Boolean lockSettingsDisablePublicChat = defaultLockSettingsDisablePublicChat;
 			String lockSettingsDisablePublicChatParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_PUBLIC_CHAT);
 			if (!StringUtils.isEmpty(lockSettingsDisablePublicChatParam)) {
 				lockSettingsDisablePublicChat = Boolean.parseBoolean(lockSettingsDisablePublicChatParam);
+			}
+			if (savedState != null) {
+				lockSettingsDisablePublicChat = savedState.disablePubChat;
 			}
 
 			Boolean lockSettingsDisableNotes = defaultLockSettingsDisableNotes;
@@ -387,11 +408,17 @@ public class ParamsProcessorUtil {
 					lockSettingsDisableNotes = Boolean.parseBoolean(lockSettingsDisableNotesParam);
 				}
 			}
+			if (savedState != null) {
+				lockSettingsDisableNotes = savedState.disableNotes;
+			}
 
 			Boolean lockSettingsHideUserList = defaultLockSettingsHideUserList;
 			String lockSettingsHideUserListParam = params.get(ApiParams.LOCK_SETTINGS_HIDE_USER_LIST);
 			if (!StringUtils.isEmpty(lockSettingsHideUserListParam)) {
 				lockSettingsHideUserList = Boolean.parseBoolean(lockSettingsHideUserListParam);
+			}
+			if (savedState != null) {
+				lockSettingsHideUserList = savedState.hideUserList;
 			}
 
 			Boolean lockSettingsLockOnJoin = defaultLockSettingsLockOnJoin;
@@ -399,11 +426,17 @@ public class ParamsProcessorUtil {
 			if (!StringUtils.isEmpty(lockSettingsLockOnJoinParam)) {
 				lockSettingsLockOnJoin = Boolean.parseBoolean(lockSettingsLockOnJoinParam);
 			}
+			if (savedState != null) {
+				lockSettingsLockOnJoin = savedState.lockOnJoin;
+			}
 
 			Boolean lockSettingsLockOnJoinConfigurable = defaultLockSettingsLockOnJoinConfigurable;
 			String lockSettingsLockOnJoinConfigurableParam = params.get(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE);
 			if (!StringUtils.isEmpty(lockSettingsLockOnJoinConfigurableParam)) {
 				lockSettingsLockOnJoinConfigurable = Boolean.parseBoolean(lockSettingsLockOnJoinConfigurableParam);
+			}
+			if (savedState != null) {
+				lockSettingsLockOnJoinConfigurable = savedState.lockOnJoinConfigurable;
 			}
 
 			Boolean lockSettingsHideViewersCursor = defaultLockSettingsHideViewersCursor;
@@ -411,11 +444,17 @@ public class ParamsProcessorUtil {
 			if (!StringUtils.isEmpty(lockSettingsHideViewersCursorParam)) {
                 lockSettingsHideViewersCursor = Boolean.parseBoolean(lockSettingsHideViewersCursorParam);
 			}
+			if (savedState != null) {
+				lockSettingsHideViewersCursor = savedState.hideViewersCursor;
+			}
 
             Boolean lockSettingsHideViewersAnnotation = defaultLockSettingsHideViewersAnnotation;
 			String lockSettingsHideViewersAnnotationParam = params.get(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION);
 			if (!StringUtils.isEmpty(lockSettingsHideViewersAnnotationParam)) {
                 lockSettingsHideViewersAnnotation = Boolean.parseBoolean(lockSettingsHideViewersAnnotationParam);
+			}
+			if (savedState != null) {
+				lockSettingsHideViewersAnnotation = savedState.hideViewersAnnotation;
 			}
 
 			return new LockSettingsParams(lockSettingsDisableCam,
@@ -538,6 +577,107 @@ public class ParamsProcessorUtil {
             log.error("Unexpected error while processing pluginManifestsFetchUrl [{}]", urlStr, e);
         }
         return null;
+    }
+
+    private void downloadAndExtractState(String stateURL, Path destDir) {
+        try {
+            log.debug("extracting state file to " + destDir.getFileName());
+            URL url = new URL(stateURL);
+            HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+            int responseCode = httpConn.getResponseCode();
+
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                try (InputStream inputStream = httpConn.getInputStream();
+                    ZipInputStream zipIn = new ZipInputStream(inputStream)) {
+
+                    ZipEntry entry;
+                    while ((entry = zipIn.getNextEntry()) != null) {
+                        // Construct the file path to unzip to
+                        Path entryPath = destDir.resolve(entry.getName());
+
+                        // If it's a directory, create it
+                        if (entry.isDirectory()) {
+                            log.debug("create directories " + entryPath.getFileName());
+                            Files.createDirectories(entryPath);
+                        } else {
+                            // If it's a file, extract it
+                            log.debug("extracting file " + entryPath.getFileName());
+                            extractFile(zipIn, entryPath);
+                        }
+
+                        zipIn.closeEntry();
+                    }
+                    log.debug("extracted state file to " + destDir.getFileName());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    log.error("failed to extract zip file");
+                    //throw new IOException("Error extracting ZIP file");
+                }       
+            } else {
+                log.info("No file to download. Server replied HTTP code: " + responseCode);
+            }
+            httpConn.disconnect();
+            
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            log.warn("malformed URL for statefile");
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.error("IO Exception while downloading state file");
+        }
+    }
+
+    // Helper method to extract files from the ZIP stream
+    private static void extractFile(ZipInputStream zipIn, Path filePath) throws IOException {
+        // Create parent directories if they do not exist
+        Files.createDirectories(filePath.getParent());
+
+        // Write the content of the zip entry to the file
+        try (BufferedOutputStream bos = new BufferedOutputStream(Files.newOutputStream(filePath))) {
+            byte[] bytesIn = new byte[4096];
+            int read;
+            while ((read = zipIn.read(bytesIn)) != -1) {
+                bos.write(bytesIn, 0, read);
+            }
+        }
+    }
+
+    private static LockSettingsStateFormat parsePersistedLockSettings(Path stateDir) {
+        Map<String, Boolean> settings = new HashMap<>();
+        Path jsonPath = stateDir.resolve("locksettings.json");
+        if (Files.exists(jsonPath)) {
+            try {
+                String message = Files.readString(jsonPath);
+                /*JsonObject obj = JsonParser.parseString(message).getAsJsonObject();
+                if (obj.has("disableCam")) {
+                    settings.put(ApiParams.LOCK_SETTINGS_DISABLE_CAM, obj.get("disableCam").getAsBoolean());
+                }*/
+                Gson gson = new Gson();
+                LockSettingsStateFormat lockSettingsState = gson.fromJson(message, LockSettingsStateFormat.class);
+                return lockSettingsState;
+            } catch (IOException e) {
+                e.printStackTrace();
+                log.error("parsePersistedLockSettings failed");
+            }
+        } else {
+            log.info("no locksettings.json found in persistence zip file");
+        }
+        return null;
+    }
+
+    public String loadSharedNotesInitialContent(Path stateDir) {
+        Path sharedNotesPath = stateDir.resolve("shared_notes.html");
+        try {
+            if (Files.exists(sharedNotesPath)) {
+                return Files.readString(sharedNotesPath);
+            } else {
+                log.info("no shared notes in persistence zip file found");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            log.error("error loading shared notes from persistence zip file");
+        }
+        return "";
     }
 
     public Meeting processCreateParams(Map<String, String> params) {
@@ -864,7 +1004,25 @@ public class ParamsProcessorUtil {
         }
 
         BreakoutRoomsParams breakoutParams = processBreakoutRoomsParams(params);
-        LockSettingsParams lockSettingsParams = processLockSettingsParams(params);
+
+        LockSettingsStateFormat savedLockSettingsState = null;
+        String persistentStateUrl = "";
+        String initialSharedNotesContent = "";
+        if (!StringUtils.isEmpty(params.get(ApiParams.PERSISTENT_STATE_URL))) {
+            persistentStateUrl = params.get(ApiParams.PERSISTENT_STATE_URL);
+            try {
+                Path tempDir = Files.createTempDirectory(Paths.get(System.getProperty("java.io.tmpdir")), "bbb_downloaded_state_");
+                downloadAndExtractState(persistentStateUrl, tempDir);
+                savedLockSettingsState = parsePersistedLockSettings(tempDir);
+                initialSharedNotesContent = loadSharedNotesInitialContent(tempDir);
+                webcamsOnlyForMod = savedLockSettingsState.webcamsOnlyForModerator;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        LockSettingsParams lockSettingsParams = processLockSettingsParams(params, savedLockSettingsState);
+        Gson gson = new Gson();
+        log.debug("lockSettingsParams = " + gson.toJson(lockSettingsParams));
 
         // Collect metadata for this meeting that the third-party app wants to
         // store if meeting is recorded.
@@ -953,6 +1111,8 @@ public class ParamsProcessorUtil {
                 .withNotifyRecordingIsOn(notifyRecordingIsOn)
                 .withPresentationUploadExternalDescription(presentationUploadExternalDescription)
                 .withPresentationUploadExternalUrl(presentationUploadExternalUrl)
+                .withPersistentStateUrl(persistentStateUrl)
+                .withInitialSharedNotesContent(initialSharedNotesContent)
                 .build();
 
         if (!StringUtils.isEmpty(params.get(ApiParams.MODERATOR_ONLY_MESSAGE))) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -134,6 +134,9 @@ public class Meeting {
 
 	private int maxNumPages;
 
+	private String persistentStateUrl = "";
+    private String sharedNotesInitialContent = "";
+
     public Meeting(Meeting.Builder builder) {
         name = builder.name;
         extMeetingId = builder.externalId;
@@ -175,6 +178,8 @@ public class Meeting {
         userCameraCap = builder.userCameraCap;
         maxPinnedCameras = builder.maxPinnedCameras;
         duration = builder.duration;
+		persistentStateUrl = builder.persistentStateUrl;
+        sharedNotesInitialContent = builder.sharedNotesInitialContent;
         webVoice = builder.webVoice;
         telVoice = builder.telVoice;
         welcomeMsgTemplate = builder.welcomeMsgTemplate;
@@ -967,8 +972,19 @@ public class Meeting {
 	public void setMaxNumPages(int maxNumPages) { this.maxNumPages = maxNumPages; }
 	public int getMaxNumPages() { return maxNumPages; }
 
+	public void setPersistentStateUrl(String persistentStateUrl) { this.persistentStateUrl = persistentStateUrl; }
+	public String getPersistenStateUrl() { return this.persistentStateUrl; }
+
     public Map<String, String> getPluginMetadataParametersMap() {
         return pluginMetadataParametersMap;
+    }
+
+    public String getSharedNotesInitialContent() {
+        return sharedNotesInitialContent;
+    }
+
+    public void setSharedNotesInitialContent(String sharedNotesInitialContent) {
+        this.sharedNotesInitialContent = sharedNotesInitialContent;
     }
 
     /***
@@ -1033,6 +1049,8 @@ public class Meeting {
 		private Boolean endWhenNoModerator;
 		private Integer endWhenNoModeratorDelayInMinutes;
 		private ArrayList<Group> groups;
+		private String persistentStateUrl;
+        private String sharedNotesInitialContent;
 
     	public Builder(String externalId, String internalId, long createTime) {
     		this.externalId = externalId;
@@ -1054,6 +1072,16 @@ public class Meeting {
     		maxUsers = n;
     		return this;
     	}
+
+		public Builder withPersistentStateUrl(String persistentStateUrl) {
+			this.persistentStateUrl = persistentStateUrl;
+			return this;
+		}
+
+        public Builder withInitialSharedNotesContent(String initialSharedNotesContent) {
+            this.sharedNotesInitialContent = initialSharedNotesContent;
+            return this;
+        }
 
     	public Builder withRecording(boolean record) {
     		this.record = record;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -973,7 +973,7 @@ public class Meeting {
 	public int getMaxNumPages() { return maxNumPages; }
 
 	public void setPersistentStateUrl(String persistentStateUrl) { this.persistentStateUrl = persistentStateUrl; }
-	public String getPersistenStateUrl() { return this.persistentStateUrl; }
+	public String getPersistentStateUrl() { return this.persistentStateUrl; }
 
     public Map<String, String> getPluginMetadataParametersMap() {
         return pluginMetadataParametersMap;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/converters/messages/CreateMeetingMessage.java
@@ -31,6 +31,7 @@ public class CreateMeetingMessage {
 	public final Boolean notifyRecordingIsOn;
 	public final String presentationUploadExternalDescription;
 	public final String presentationUploadExternalUrl;
+	public final String persistentStateUrl;
 	public final Long createTime;
 	public final String createDate;
 	public final Map<String, String> metadata;
@@ -49,6 +50,7 @@ public class CreateMeetingMessage {
 						Boolean notifyRecordingIsOn,
 						String presentationUploadExternalDescription,
 						String presentationUploadExternalUrl,
+						String persistentStateUrl,
 						Long createTime, String createDate, Map<String, String> metadata) {
 		this.id = id;
 		this.externalId = externalId;
@@ -73,6 +75,7 @@ public class CreateMeetingMessage {
 		this.notifyRecordingIsOn = notifyRecordingIsOn;
 		this.presentationUploadExternalDescription = presentationUploadExternalDescription;
 		this.presentationUploadExternalUrl = presentationUploadExternalUrl;
+		this.persistentStateUrl = persistentStateUrl;
 		this.createTime = createTime;
 		this.createDate = createDate;
 		this.metadata = metadata;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -72,6 +72,8 @@ public interface IBbbWebApiGWApp {
                      Boolean notifyRecordingIsOn,
                      String presentationUploadExternalDescription,
                      String presentationUploadExternalUrl,
+                     String persistentStateUrl,
+                     String sharedNotesInitialContent,
                      Map<String, Object> plugins,
                      String html5PluginSdkVersion,
                      String overrideClientSettings);

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -171,6 +171,8 @@ class BbbWebApiGWApp(
                     notifyRecordingIsOn:                    java.lang.Boolean,
                     presentationUploadExternalDescription:  String,
                     presentationUploadExternalUrl:          String,
+                    persistentStateUrl:                     String,
+                    sharedNotesInitialContent:              String,
                     plugins:                                util.Map[String, AnyRef],
                     html5PluginSdkVersion:                   String,
                     overrideClientSettings:                 String): Unit = {
@@ -190,7 +192,9 @@ class BbbWebApiGWApp(
       disabledFeaturesAsVector,
       notifyRecordingIsOn,
       presentationUploadExternalDescription,
-      presentationUploadExternalUrl
+      presentationUploadExternalUrl,
+      persistentStateUrl,
+      sharedNotesInitialContent,
     )
 
     val durationProps = DurationProps(


### PR DESCRIPTION
This request adds an `create` API parameter `persistentStateUrl`. If this parameter is passed, then BBB will GET this URL and parse the content to restore locksettings and shared notes.

When the meeting ends BBB will PUT state back to this URL.

### What does this PR do?

Implements parts of #24374 (lock settings, shared notes). It adds a new `create` API Parameter `persistentStateUrl`. Depends on https://github.com/bigbluebutton/bbb-pads/pull/84


### Motivation

implement persistent meetings

### How to test

Create a URL endpoint where BBB can store and fetch its state from. Pass this URL as parameter to the create API call. A draft implementation for the PILOS frontend is implemented in https://github.com/THM-Health/PILOS/compare/persistent-meeting-state This is available as docker image `pilos/pilos:dev-persistent-meeting-state`.

### More

There is still a known issue that I do not know how to get it right: the shared notes throttle sending update messages to BBB. So if someone terminates a session while the update is throttled, BBB won't notice the updated content and some old content is persisted.

API documentation needs to be updated as well.