### PR TITLE
fix: drop areas appearing when presentation is removed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -711,7 +711,7 @@ const CustomLayout = (props) => {
         left: cameraDockBounds.left,
         right: cameraDockBounds.right,
         tabOrder: 4,
-        isDraggable: !isMobile && !isTablet && presentationInput.isOpen,
+        isDraggable: !isMobile && !isTablet && isMediaOpen,
         resizableEdge: {
           top:
           isMediaOpen

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
@@ -711,7 +711,7 @@ const UnifiedLayout = (props) => {
         left: cameraDockBounds.left,
         right: cameraDockBounds.right,
         tabOrder: 4,
-        isDraggable: !isMobile && !isTablet && presentationInput.isOpen,
+        isDraggable: !isMobile && !isTablet && isMediaOpen,
         resizableEdge: {
           top:
           isMediaOpen


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where camera dock drop areas would appear when the presentation was removed, even though no media was actually open. 

The camera dock should only be draggable when media (presentation, screenshare, or external video) is actually present.

### How to test
1. Start a meeting and share webcam
2. Upload a presentation - verify camera dock is draggable
3. Remove the presentation - verify drop areas disappear
4. Share screen - verify camera dock becomes draggable again
5. Stop screenshare - verify drop areas disappear
6. Test with external video to ensure same behavior