### PR TITLE
fix(chat): wrap text input placeholder

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -675,6 +675,7 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
               onCut={(e) => { e.stopPropagation(); }}
               onCopy={(e) => { e.stopPropagation(); }}
               async
+              $hasContent={message.length > 0}
             />
             {ENABLE_EMOJI_PICKER ? (
               <Tooltip title={<span style={{ fontSize: '0.9rem' }}>{intl.formatMessage(messages.emojiButtonLabel)}</span>} arrow>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -24,7 +24,7 @@ interface FormProps {
 }
 
 interface InputProps {
-  $showEmojiPicker?: boolean;
+  $hasContent?: boolean;
 }
 
 const Form = styled.form<FormProps>`
@@ -55,7 +55,8 @@ const Input = styled(TextareaAutosize)<InputProps>`
   transition: color 0.3s ease, margin-right 0.3s ease;
   font-size: ${fontSizeBase};
   line-height: 1;
-  overflow-y: auto;
+  overflow-y: ${({ $hasContent }) => ($hasContent ? 'auto' : 'hidden')};
+  white-space: ${({ $hasContent }) => ($hasContent ? 'normal' : 'nowrap')};
   border: ${colorBorder};
   box-shadow: none;
   outline: none;


### PR DESCRIPTION
### What does this PR do?
Adds `overflow: hidden` and `white-space: nowrap` when the chat input is empty, preventing the placeholder from becoming misaligned when the chat panel is too narrow.

**Before:**
<img width="298" height="109" alt="image" src="https://github.com/user-attachments/assets/b8a18f76-8f6d-4fdf-986c-9698debcdba3" />


**After:**
![chat-placeholder](https://github.com/user-attachments/assets/cac5685f-27c0-4a5a-80ff-8ffc996aa9dc)
