### PR TITLE
fix(bbb-web): Fallback to Rasterization if SVG has Mask Tags

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/SvgConversionHandler.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/handlers/SvgConversionHandler.java
@@ -18,6 +18,9 @@ public class SvgConversionHandler extends AbstractCommandHandler {
     private static String USE_TAG_OUTPUT = "<use";
     private static String USE_TAG_PATTERN = "\\d+\\s" + USE_TAG_OUTPUT;
 
+    private static String MASK_TAG_OUTPUT = "<mask";
+    private static String MASK_TAG_PATTERN = "\\d+\\s" + MASK_TAG_OUTPUT;
+
     private final String id;
 
     public SvgConversionHandler(String id) {
@@ -78,6 +81,26 @@ public class SvgConversionHandler extends AbstractCommandHandler {
                 return Integer.parseInt(m.group(0).replace(USE_TAG_OUTPUT, "").trim());
             } catch (Exception e) {
                 log.error("Exception counting the number of use tags", e);
+                return 0;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     *
+     * @return The number of <mask/> tags in the generated SVG.
+     */
+    public int numberOfMaskTags() {
+        if (stdoutContains(MASK_TAG_OUTPUT)) {
+            try {
+                String out = stdoutBuilder.toString();
+                Pattern r = Pattern.compile(MASK_TAG_PATTERN);
+                Matcher m = r.matcher(out);
+                m.find();
+                return Integer.parseInt(m.group(0).replace(MASK_TAG_OUTPUT, "").trim());
+            } catch (Exception e) {
+                log.error("Exception counting the number of mask tags", e);
                 return 0;
             }
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -214,10 +214,16 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
         }
 
+        // Masks with color filters (common in scanned PDFs from pdftocairo) often
+        // render incorrectly in browsers, causing blank/dark overlays on slides.
+        // Any presence of masks should trigger rasterization for reliable rendering.
+        boolean hasMasks = pHandler.numberOfMaskTags() > 0;
+
         if (destsvg.length() == 0 ||
                 pHandler.numberOfImageTags() > imageTagThreshold ||
                 pHandler.numberOfPaths() > pathsThreshold ||
                 pHandler.numberOfUseTags() > useTagThreshold ||
+                hasMasks ||
                 rasterizeCurrSlide) {
 
             // We need t delete the destination file as we are starting a
@@ -238,8 +244,10 @@ public class SvgImageCreatorImp implements SvgImageCreator {
                 logData.put("fileExists", destsvg.exists());
                 logData.put("numberOfImages", pHandler.numberOfImageTags());
                 logData.put("numberOfPaths", pHandler.numberOfPaths());
+                logData.put("numberOfMasks", pHandler.numberOfMaskTags());
+                logData.put("hasMasks", hasMasks);
                 logData.put("logCode", "potential_problem_with_svg");
-                logData.put("message", "Potential problem with generated SVG");
+                logData.put("message", "Potential problem with generated SVG, triggering rasterization fallback");
                 Gson gson = new Gson();
                 String logStr = gson.toJson(logData);
 
@@ -395,7 +403,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
         rawCommand  += " -q -f " + String.valueOf(page) + " -l " + String.valueOf(page) + " " + source + " " + destFile;
         if (analyze) {
-            rawCommand += " && grep -oE '<image|<path|<use' "+destFile+" | sort | uniq -c ";
+            rawCommand += " && grep -oE '<image|<path|<use|<mask' "+destFile+" | sort | uniq -c ";
         }
 
         return new NuProcessBuilder(Arrays.asList("/usr/share/bbb-web/run-in-systemd.sh", timeout + "s", "/bin/sh", "-c", rawCommand));


### PR DESCRIPTION
### What does this PR do?

Detects whether a generated SVG from a PDF page during document conversion contains any `mask` tags. If the SVG contains `mask` tags the conversion falls back to rasterizing the page by converting it to a PNG and then embedding the PNG in an SVG.

### Motivation

Some uploaded PDFs, particularly ones that come from scans, contain `mask` tags which may be improperly rendered causing large portions of the page to be blank after conversion to SVG.


### How to test
1. Create a meeting in BBB without this change and upload a scanner PDF that does not render properly. Notice the missing portions of the page.
2. Create a meeting in BBB after this change and upload the same PDF. Notice that the PDF renders properly.
