### PR TITLE
fix(livekit): trigger forced room reconnection on fatal errors

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -21,7 +21,7 @@ import {
   filterSupportedConstraints,
   doGUM,
 } from '/imports/api/audio/client/bridge/service';
-import { liveKitRoom, getLKStats } from '/imports/ui/services/livekit';
+import { liveKitRoom, getLKStats, LK_FATAL_ERROR_EVENT } from '/imports/ui/services/livekit';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 
 const BRIDGE_NAME = 'livekit';
@@ -224,6 +224,11 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     const { source } = track;
 
     return source === Track.Source.Microphone;
+  }
+
+  private static isFatalPublishError(error: Error): boolean {
+    return error.name === 'ConnectionError'
+      && error.message?.includes('timed out');
   }
 
   private isLocalPublicationMuted(): boolean {
@@ -435,6 +440,26 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.liveKitRoom.localParticipant.off(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
     this.liveKitRoom.localParticipant.off(ParticipantEvent.LocalTrackPublished, this.handleLocalTrackPublished);
     this.liveKitRoom.localParticipant.off(ParticipantEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
+  }
+
+  private handleFatalPublishError(error: Error): void {
+    logger.error({
+      logCode: 'livekit_audio_fatal_publish_error_reconnect',
+      extraInfo: {
+        errorMessage: error?.message,
+        errorName: error?.name,
+        errorStack: error?.stack,
+        bridge: this.bridgeName,
+        role: this.role,
+        inputDeviceId: this.inputDeviceId,
+        streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
+      },
+    }, 'LiveKit: fatal audio publish error detected, triggering reconnection');
+
+    // Handled in /ui/components/livekit/component (BBBLiveKitRoom)
+    window.dispatchEvent(new CustomEvent(LK_FATAL_ERROR_EVENT, {
+      detail: { error, source: 'audio' },
+    }));
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -1227,6 +1252,11 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           streamData: MediaStreamUtils.getMediaStreamLogData(inputStream || this.originalStream),
         },
       }, 'LiveKit: failed to publish audio track');
+
+      if (LiveKitAudioBridge.isFatalPublishError(error as Error)) {
+        this.handleFatalPublishError(error as Error);
+      }
+
       throw error;
     }
   }

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -656,6 +656,7 @@ export interface LiveKitSettings {
   selectiveSubscription?: boolean
   logLevel?: LogLevel
   roomOptions?: Partial<InternalRoomOptions>
+  reconnectOnFatalFailures?: boolean
   audio?: LiveKitAudioSettings
   camera?: LiveKitCameraSettings
   screenshare?: LiveKitScreenShareSettings

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import {
   LiveKitRoom,
@@ -19,6 +21,7 @@ import {
   type InternalRoomOptions,
   type RoomConnectOptions,
 } from 'livekit-client';
+import { defineMessages, useIntl } from 'react-intl';
 import Auth from '/imports/ui/services/auth';
 import AudioManager from '/imports/ui/services/audio-manager';
 import logger from '/imports/startup/client/logger';
@@ -27,6 +30,7 @@ import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import {
   liveKitRoom,
+  LK_FATAL_ERROR_EVENT,
 } from '/imports/ui/services/livekit';
 import {
   USER_SET_DEAFENED,
@@ -34,9 +38,11 @@ import {
 } from '/imports/ui/components/livekit/mutations';
 import { useIceServers } from '/imports/ui/components/livekit/hooks';
 import LKAutoplayModalContainer from '/imports/ui/components/livekit/autoplay-modal/container';
+import { ForcedReconnectionError } from '/imports/ui/components/livekit/errors';
 import connectionStatus, { MetricStatus } from '/imports/ui/core/graphql/singletons/connectionStatus';
 import SelectiveSubscription from '/imports/ui/components/livekit/selective-subscription/component';
 import { useSpeakerLevel } from '/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service';
+import { notify } from '/imports/ui/services/notification';
 
 interface BBBLiveKitRoomProps {
   url?: string;
@@ -47,6 +53,7 @@ interface BBBLiveKitRoomProps {
   usingAudio: boolean;
   usingScreenShare: boolean;
   withSelectiveSubscription: boolean;
+  reconnectOnFatalFailures?: boolean;
 }
 
 interface ObserverProps {
@@ -56,6 +63,13 @@ interface ObserverProps {
 }
 
 const MAX_CONN_ATTEMPTS = 10;
+
+const intlMessages = defineMessages({
+  mediaReconnecting: {
+    id: 'app.media.mediaReconnecting',
+    description: 'Media reconnection in progress toast message',
+  },
+});
 
 const LiveKitObserver = ({
   room,
@@ -160,6 +174,7 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   usingAudio,
   usingScreenShare,
   withSelectiveSubscription,
+  reconnectOnFatalFailures = false,
 }) => {
   const [connAttempts, setConnAttempts] = useState(0);
   const [connError, setConnError] = useState<Error | null>(null);
@@ -168,6 +183,8 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   const isClientConnected = useReactiveVar(connectionStatus.getConnectedStatusVar());
   const { iceServers, isLoading: iceServersLoading } = useIceServers(bbbSessionToken);
   const speakerLevel = useSpeakerLevel();
+  const intl = useIntl();
+  const isReconnectingRef = useRef(false);
 
   const onDisconnected = useCallback((reason?: DisconnectReason) => {
     logger.warn({
@@ -195,7 +212,7 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       },
     }, `LiveKit room error: ${error.message}`);
     setConnError(error);
-    setConnAttempts(connAttempts + 1);
+    setConnAttempts((prev) => prev + 1);
   }, [isClientConnected, url, iceServers, connAttempts]);
 
   const onConnected = useCallback(() => {
@@ -222,7 +239,8 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       return;
     }
 
-    if (!(connError instanceof ConnectionError)) {
+    if (!(connError instanceof ConnectionError)
+      && !(connError instanceof ForcedReconnectionError)) {
       logger.warn({
         logCode: 'livekit_room_skip_retry',
         extraInfo: {
@@ -323,6 +341,69 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
     };
   }, []);
 
+  // Handle fatal errors emitted from other parts of the app to trigger
+  // a reconnection. This is used as a mitigation mechanism for certain
+  // LiveKit-originated issues that we can only address via a full reconnect.
+  const handleFatalError = useCallback((event: CustomEvent) => {
+    const { error, source } = event.detail;
+
+    logger.error({
+      logCode: 'livekit_fatal_error_reconnect',
+      extraInfo: {
+        errorMessage: error?.message,
+        errorName: error?.name,
+        errorStack: error?.stack,
+        source,
+        reconnectOnFatalFailures,
+      },
+    }, `LiveKit: fatal error detected - ${error?.message}, reconnect=${reconnectOnFatalFailures}`);
+
+    if (!reconnectOnFatalFailures) return;
+
+    if (isReconnectingRef.current || connAttempts >= MAX_CONN_ATTEMPTS) {
+      logger.debug({
+        logCode: 'livekit_fatal_error_reconnect_skipped',
+        extraInfo: {
+          errorMessage: error?.message,
+          errorName: error?.name,
+          errorStack: error?.stack,
+          source,
+          inProgress: isReconnectingRef.current,
+          maxAttempts: connAttempts >= MAX_CONN_ATTEMPTS,
+        },
+      }, 'LiveKit: skipping fatal error reconnect');
+      return;
+    }
+
+    notify(intl.formatMessage(intlMessages.mediaReconnecting), 'warning', 'warning');
+    isReconnectingRef.current = true;
+    liveKitRoom.disconnect().then(() => {
+      const fatalError = new ForcedReconnectionError('Fatal error recovery');
+      setConnError(fatalError);
+      setConnAttempts((prev) => prev + 1);
+    }).catch((disconnectError: Error) => {
+      logger.error({
+        logCode: 'livekit_fatal_error_disconnect_failed',
+        extraInfo: {
+          errorMessage: disconnectError?.message,
+          errorName: disconnectError?.name,
+          errorStack: disconnectError?.stack,
+          source,
+        },
+      }, 'LiveKit: failed to disconnect during fatal error recovery');
+    }).finally(() => {
+      isReconnectingRef.current = false;
+    });
+  }, [intl, reconnectOnFatalFailures, connAttempts]);
+
+  useEffect(() => {
+    window.addEventListener(LK_FATAL_ERROR_EVENT, handleFatalError as EventListener);
+
+    return () => {
+      window.removeEventListener(LK_FATAL_ERROR_EVENT, handleFatalError as EventListener);
+    };
+  }, [handleFatalError]);
+
   // Screen share requires audio playback as well (Chrome supports it)
   const withAudioPlayback = usingAudio || usingScreenShare;
 
@@ -369,6 +450,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
     dynacast: true,
     stopLocalTrackOnUnpublish: false,
   };
+  const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? false;
   const { data: bridges } = useMeeting((m) => ({
     cameraBridge: m.cameraBridge,
     screenShareBridge: m.screenShareBridge,
@@ -390,6 +472,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
       usingAudio={bridges?.audioBridge === 'livekit'}
       usingScreenShare={bridges?.screenShareBridge === 'livekit'}
       withSelectiveSubscription={withSelectiveSubscription}
+      reconnectOnFatalFailures={reconnectOnFatalFailures}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/livekit/errors.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/errors.ts
@@ -1,0 +1,14 @@
+export class ForcedReconnectionError extends Error {
+  readonly name = 'ForcedReconnectionError';
+
+  constructor(message: string = 'Forced reconnection due to fatal error') {
+    super(message);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ForcedReconnectionError);
+    }
+  }
+}
+
+export default {
+  ForcedReconnectionError,
+};

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -665,6 +665,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         url: `wss://${window.location.hostname}/livekit`,
         selectiveSubscription: false,
         logLevel: LogLevel.warn,
+        reconnectOnFatalFailures: false,
         roomOptions: {
           adaptiveStream: true,
           dynacast: true,

--- a/bigbluebutton-html5/imports/ui/services/livekit/index.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/index.ts
@@ -7,6 +7,8 @@ import {
 } from 'livekit-client';
 import logger from '/imports/startup/client/logger';
 
+export const LK_FATAL_ERROR_EVENT = 'liveKitFatalError';
+
 export const liveKitRoom: Room = new Room();
 
 export const getLKStats = async (): Promise<Map<string, unknown>> => {
@@ -63,6 +65,7 @@ export const lkToggleMuteCameras = (mute: boolean): void => {
 };
 
 export default {
+  LK_FATAL_ERROR_EVENT,
   getLKStats,
   lkIsCameraSource,
   liveKitRoom,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -955,6 +955,9 @@ public:
       # when set to true and in effect (conditional to client behavior).
       selectiveSubscription: true
       logLevel: 3
+      # reconnectOnFatalFailures: whether to trigger LK room reconnections when
+      # fatal errors occur (e.g.: unrecoverable publish timeouts). Default is false.
+      reconnectOnFatalFailures: false
       roomOptions:
         adaptiveStream: true
         dynacast: true

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -225,6 +225,7 @@
     "app.media.cameraAsContent.endDueToDataSaving": "Present camera stopped due to data savings",
     "app.media.cameraAsContent.autoplayBlockedDesc": "We need your permission to show you the presenter's camera.",
     "app.media.cameraAsContent.autoplayAllowLabel": "View present camera",
+    "app.media.mediaReconnecting": "Connection issue detected. Restoring your audio and video...",
     "app.screenshare.presenterLoadingLabel": "Your screenshare is loading",
     "app.screenshare.viewerLoadingLabel": "The presenter's screen is loading",
     "app.screenshare.presenterSharingLabel": "You are now sharing your screen",


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): trigger forced room reconnection on fatal errors](https://github.com/bigbluebutton/bigbluebutton/commit/bee54a0b013983377a34653dfd8847ab83d18a71) 
  - There are known scenarios that currently can only be "addressed" via
full LiveKit room reconnections. One of those is a race condition when
publishing tracks - mainly audio - that causes all subsequent publish
attempts to time out. While this is a media server issue, it should be
mitigated on our side until fixed.
  - A few mitigations have already been added to the client for the above
scenario (timeouts). While they've reduced the error occurrence to
0.5%-0.7%~ of total sessions, it can still happen. A fail-safe that
forces a reconnect is necessary for the remaining cases.
  - Add a mechanism that can trigger LiveKit room reconnects on demand via
custom browser events. When a reconnect is desired, the breakpoint
should fire a 'livekitFatalError'-named event with the error and a
source identifier as payload.
This is generic enough so that we can add or remove scenarios to it as
needed. The first use case is the above time out edge case.
  - This forced reconnect can be enabled via settings.yml's
`public.media.livekit.reconnectOnFatalFailures`. This is FALSE by
default for now while it undergoes further testing.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/24013 (alongside other referenced PRs)