### PR TITLE
fix(livekit): frozen cams on reconn, camera bridge improvements

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -1,7 +1,13 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import {
   type LocalTrack,
+  type RemoteParticipant,
   type RemoteTrack,
   type RemoteTrackPublication,
   type LocalTrackPublication,
@@ -71,7 +77,7 @@ interface LiveKitCameraBridgeProps {
   overflowCount: number;
 }
 
-interface StreamRefs {
+interface LiveKitCameraBridgeRefs {
   connectingStreams: Record<string, boolean>;
   remoteTracks: Record<string, RemoteTrack<Track.Kind>>;
   localTracks: Record<string, LocalTrack<Track.Kind>>;
@@ -109,10 +115,11 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       RoomEvent.TrackSubscribed, RoomEvent.TrackUnsubscribed,
       RoomEvent.TrackSubscriptionStatusChanged, RoomEvent.TrackSubscriptionPermissionChanged,
       RoomEvent.TrackSubscriptionFailed,
+      RoomEvent.ConnectionStateChanged,
     ],
   });
   const [meetingSettings] = useMeetingSettings();
-  const streamRefs = useRef<StreamRefs>({
+  const bridgeRefs = useRef<LiveKitCameraBridgeRefs>({
     remoteTracks: {},
     localTracks: {},
     connectingStreams: {},
@@ -121,6 +128,10 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     publications: new Map(),
     subscriptions: new Map(),
   });
+  // This is a hacky way to break circular deps between some effects and callbacks - prlanzarin
+  const streamsRef = useRef(streams);
+  streamsRef.current = streams;
+
   const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription || false;
 
   const handleStreamFailure = useCallback((error: Error, stream: string, isLocal: boolean) => {
@@ -144,13 +155,15 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       stopStream(stream, false);
       if (errorLocale) VideoService.notify(intl.formatMessage(errorLocale));
     } else {
-      const stillExists = streams.some((item) => item.type === VIDEO_TYPES.STREAM && item.stream === stream);
+      const stillExists = streamsRef.current.some(
+        (item) => item.type === VIDEO_TYPES.STREAM && item.stream === stream,
+      );
       stopStream(stream, stillExists);
     }
-  }, [intl, streams]);
+  }, [intl]);
 
   const handleLocalStreamInactive = useCallback((stream: string) => {
-    const track = streamRefs.current.localTracks[stream];
+    const track = bridgeRefs.current.localTracks[stream];
     const isLocal = VideoService.isLocalStream(stream);
 
     if (track == null || !isLocal) return;
@@ -179,7 +192,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     stream: string,
     publication: RemoteTrackPublication,
   ) => {
-    const track = streamRefs.current.remoteTracks[stream];
+    const track = bridgeRefs.current.remoteTracks[stream];
 
     if (track) track.detach();
     if (publication?.isSubscribed && withSelectiveSubscription) {
@@ -188,8 +201,8 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   };
 
   const destroyStream = (stream: string) => {
-    const localStream = streamRefs.current.localVideoStreams[stream];
-    const publication = streamRefs.current.publications.get(stream);
+    const localStream = bridgeRefs.current.localVideoStreams[stream];
+    const publication = bridgeRefs.current.publications.get(stream);
     const isLocal = VideoService.isLocalStream(stream);
 
     if (localStream) {
@@ -201,7 +214,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     }
 
     if (isLocal) {
-      const track = streamRefs.current.localTracks[stream];
+      const track = bridgeRefs.current.localTracks[stream];
       const { videoTrackPublications } = liveKitRoom.localParticipant;
 
       if (!videoTrackPublications || !track) return;
@@ -231,25 +244,25 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
                 },
               }, `LiveKit: failed to unpublish track: ${error.message}`);
             }).finally(() => {
-              streamRefs.current.publications.delete(publication.trackName);
+              bridgeRefs.current.publications.delete(publication.trackName);
             });
         }
       });
-      delete streamRefs.current.localTracks[stream];
-      delete streamRefs.current.localVideoStreams[stream];
+      delete bridgeRefs.current.localTracks[stream];
+      delete bridgeRefs.current.localVideoStreams[stream];
     } else if (publication) {
       unsubscribeFromRemotePub(stream, publication as RemoteTrackPublication);
     }
   };
 
   const attachLiveKitStream = (stream: string) => {
-    const videoElement = streamRefs.current.videoTags[stream];
+    const videoElement = bridgeRefs.current.videoTags[stream];
     const isLocal = VideoService.isLocalStream(stream);
 
     if (!videoElement) return;
 
     if (isLocal) {
-      const localStream = streamRefs.current.localVideoStreams[stream];
+      const localStream = bridgeRefs.current.localVideoStreams[stream];
 
       if (localStream) {
         videoElement.pause();
@@ -258,7 +271,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
         notifyStreamStateChange(stream, 'completed');
       }
     } else {
-      const track = streamRefs.current.remoteTracks[stream];
+      const track = bridgeRefs.current.remoteTracks[stream];
 
       if (track?.attach) {
         track.attach(videoElement);
@@ -268,7 +281,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   };
 
   const subscribeToRemotePub = (stream: string) => {
-    const publication = streamRefs.current.publications.get(stream) as RemoteTrackPublication;
+    const publication = bridgeRefs.current.publications.get(stream) as RemoteTrackPublication;
 
     // If a publication is not present yet, it will be added when we receive
     // the publish event from the server and this function will be called again
@@ -286,7 +299,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   };
 
   const startStream = useCallback(async (stream: string, isLocal: boolean) => {
-    if (streamRefs.current.localTracks[stream] || streamRefs.current.connectingStreams[stream]) return;
+    if (bridgeRefs.current.localTracks[stream] || bridgeRefs.current.connectingStreams[stream]) return;
 
     const LIVEKIT_SETTINGS = meetingSettings.public.media.livekit?.camera;
     const source = Track.Source.Camera;
@@ -305,11 +318,11 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       return;
     }
 
-    streamRefs.current.connectingStreams[stream] = true;
+    bridgeRefs.current.connectingStreams[stream] = true;
 
     try {
       const localBBBStream = VideoService.getPreloadedStream();
-      streamRefs.current.localVideoStreams[stream] = localBBBStream;
+      bridgeRefs.current.localVideoStreams[stream] = localBBBStream;
       const { mediaStream } = localBBBStream;
       const publishers: Promise<LocalTrackPublication>[] = mediaStream
         .getTracks()
@@ -338,7 +351,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
         throw new Error('Failed to publish track: publication or track is missing');
       }
 
-      streamRefs.current.localTracks[stream] = publication.track;
+      bridgeRefs.current.localTracks[stream] = publication.track;
       localBBBStream.on('streamSwapped', ({ newStream }: { oldStream: MediaStream, newStream: MediaStream }) => {
         if (newStream) replaceVideoTracks(stream, newStream);
       });
@@ -351,7 +364,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     } catch (error) {
       handleStreamFailure(error as Error, stream, isLocal);
     } finally {
-      streamRefs.current.connectingStreams[stream] = false;
+      bridgeRefs.current.connectingStreams[stream] = false;
     }
   }, [handleLocalStreamInactive, handleStreamFailure, playStart]);
 
@@ -363,11 +376,11 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
 
     if (!lkIsCameraSource(track)) return;
 
-    streamRefs.current.subscriptions.set(trackSid, { track, publication });
+    bridgeRefs.current.subscriptions.set(trackSid, { track, publication });
 
     if (track?.kind === 'video' && publication) {
       const stream = publication.trackName;
-      streamRefs.current.remoteTracks[stream] = track;
+      bridgeRefs.current.remoteTracks[stream] = track;
       attachLiveKitStream(stream);
       logger.debug({
         logCode: 'livekit_camera_subscribed',
@@ -388,7 +401,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
 
     if (!lkIsCameraSource(track)) return;
 
-    streamRefs.current.subscriptions.delete(trackSid);
+    bridgeRefs.current.subscriptions.delete(trackSid);
     const stream = publication?.trackName;
 
     logger.debug({
@@ -400,35 +413,67 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       },
     }, `LiveKit: camera unsubscribed - ${trackSid}`);
 
-    delete streamRefs.current.remoteTracks[stream];
+    delete bridgeRefs.current.remoteTracks[stream];
   };
 
   const handleTrackPublished = useCallback((publication: RemoteTrackPublication) => {
     const { trackName } = publication;
 
-    if (!lkIsCameraSource(publication) || streamRefs.current.publications.has(trackName)) return;
+    if (!lkIsCameraSource(publication) || bridgeRefs.current.publications.has(trackName)) return;
 
-    streamRefs.current.publications.set(trackName, publication);
-    if (publication.track) streamRefs.current.remoteTracks[trackName] = publication.track;
+    bridgeRefs.current.publications.set(trackName, publication);
+
+    if (publication.track) bridgeRefs.current.remoteTracks[trackName] = publication.track;
 
     const isLocal = VideoService.isLocalStream(trackName);
     // If the track is remote, should be subscribed to and is not already,
     // subscribe to it
     if (!isLocal
       && !publication.isSubscribed
-      && streams.some((item) => item.type === VIDEO_TYPES.STREAM && item.stream === trackName)) {
+      && streamsRef.current.some(
+        (item) => item.type === VIDEO_TYPES.STREAM && item.stream === trackName,
+      )) {
       subscribeToRemotePub(trackName);
     }
-  }, [streams]);
+  }, []);
 
   const handleTrackUnpublished = (publication: RemoteTrackPublication) => {
     const { trackSid, trackName } = publication;
 
     if (!lkIsCameraSource(publication)) return;
 
-    streamRefs.current.publications.delete(trackName);
-    streamRefs.current.subscriptions.delete(trackSid);
+    bridgeRefs.current.publications.delete(trackName);
+    bridgeRefs.current.subscriptions.delete(trackSid);
   };
+
+  const syncLiveKitRefs = useCallback((clearRefs = true) => {
+    if (clearRefs) {
+      bridgeRefs.current.publications.clear();
+      bridgeRefs.current.subscriptions.clear();
+    }
+
+    liveKitRoom.remoteParticipants.forEach((participant: RemoteParticipant) => {
+      participant.trackPublications.forEach((publication: RemoteTrackPublication) => {
+        if (lkIsCameraSource(publication)) {
+          handleTrackPublished(publication);
+
+          if (publication.isSubscribed && publication.track) {
+            handleTrackSubscribed(publication.track, publication);
+          }
+        }
+      });
+    });
+  }, [handleTrackPublished]);
+
+  useEffect(() => {
+    if (connectionState === ConnectionState.Connected) {
+      // On reconnection, clear refs to start fresh as old refs
+      // might be stale and won't work for subscriptions anymore
+      const isReconnection = bridgeRefs.current.publications.size > 0
+        || bridgeRefs.current.subscriptions.size > 0;
+      syncLiveKitRefs(isReconnection);
+    }
+  }, [connectionState, syncLiveKitRefs]);
 
   useEffect(() => {
     liveKitRoom.on(RoomEvent.TrackPublished, handleTrackPublished);
@@ -443,33 +488,23 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     liveKitRoom.on(RoomEvent.TrackUnpublished, handleTrackUnpublished);
     liveKitRoom.on(RoomEvent.TrackSubscribed, handleTrackSubscribed);
     liveKitRoom.on(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed);
-    liveKitRoom.remoteParticipants.forEach((participant) => {
-      participant.trackPublications.forEach((publication) => {
-        if (lkIsCameraSource(publication)) {
-          handleTrackPublished(publication);
-
-          if (publication.isSubscribed && publication.track) {
-            handleTrackSubscribed(publication.track, publication);
-          }
-        }
-      });
-    });
 
     return () => {
+      window.removeEventListener('beforeunload', exitVideo);
       liveKitRoom.off(RoomEvent.TrackUnpublished, handleTrackUnpublished);
       liveKitRoom.off(RoomEvent.TrackSubscribed, handleTrackSubscribed);
       liveKitRoom.off(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed);
-      window.removeEventListener('beforeunload', exitVideo);
+
       VideoService.updatePeerDictionaryReference({});
       exitVideo();
-      Object.keys(streamRefs.current.localTracks).forEach((stream) => {
+      Object.keys(bridgeRefs.current.localTracks).forEach((stream) => {
         stopStream(stream, false);
       });
-      Object.keys(streamRefs.current.remoteTracks).forEach((stream) => {
+      Object.keys(bridgeRefs.current.remoteTracks).forEach((stream) => {
         stopStream(stream, false);
       });
-      streamRefs.current.publications.clear();
-      streamRefs.current.subscriptions.clear();
+      bridgeRefs.current.publications.clear();
+      bridgeRefs.current.subscriptions.clear();
     };
   }, []);
 
@@ -484,19 +519,24 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     streamsToDisconnect.forEach(destroyStream);
   };
 
-  const debouncedConnectStreams = useCallback(
-    debounce(
-      connectStreams,
+  // We're using a ref to avoid recreating the debounced function on every render
+  // If that were the case, we'd lose the timer reference for the debounce and
+  // it wouldn't work as expected (ie.: no debounce) - prlanzarin
+  const connectStreamsRef = useRef(connectStreams);
+  connectStreamsRef.current = connectStreams;
+  const debouncedConnectStreams = useMemo(
+    () => debounce(
+      (streamsToConnect: string[]) => connectStreamsRef.current(streamsToConnect),
       VideoService.getPageChangeDebounceTime(),
       { leading: false, trailing: true },
     ),
-    [connectStreams],
+    [],
   );
 
   const updateStreams = useCallback((streamsList: VideoItem[], shouldDebounce = false) => {
     const connectedStreamIds = [
-      ...Object.keys(streamRefs.current.localTracks),
-      ...Object.keys(streamRefs.current.remoteTracks),
+      ...Object.keys(bridgeRefs.current.localTracks),
+      ...Object.keys(bridgeRefs.current.remoteTracks),
     ];
     const [
       streamsToConnect,
@@ -513,8 +553,8 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   }, [connectStreams, debouncedConnectStreams]);
 
   const replaceVideoTracks = (streamId: string, mediaStream: MediaStream) => {
-    const track = streamRefs.current.localTracks[streamId];
-    const videoElement = streamRefs.current.videoTags[streamId];
+    const track = bridgeRefs.current.localTracks[streamId];
+    const videoElement = bridgeRefs.current.videoTags[streamId];
 
     if (track && track.replaceTrack && videoElement) {
       const newTracks = mediaStream.getVideoTracks();
@@ -534,19 +574,21 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     }
   };
 
-  const createVideoTag = (stream: string, video: HTMLVideoElement) => {
+  // Downstream prop - useCallback to make it stable
+  const createVideoTag = useCallback((stream: string, video: HTMLVideoElement) => {
     const isLocal = VideoService.isLocalStream(stream);
     const track = isLocal
-      ? streamRefs.current.localTracks[stream]
-      : streamRefs.current.remoteTracks[stream];
+      ? bridgeRefs.current.localTracks[stream]
+      : bridgeRefs.current.remoteTracks[stream];
 
-    streamRefs.current.videoTags[stream] = video;
+    bridgeRefs.current.videoTags[stream] = video;
 
     if (track) attachLiveKitStream(stream);
-  };
+  }, []);
 
-  const destroyVideoTag = (stream: string) => {
-    const videoElement = streamRefs.current.videoTags[stream];
+  // Downstream prop - useCallback to make it stable
+  const destroyVideoTag = useCallback((stream: string) => {
+    const videoElement = bridgeRefs.current.videoTags[stream];
 
     if (videoElement == null) return;
 
@@ -555,8 +597,8 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       videoElement.srcObject = null;
     }
 
-    delete streamRefs.current.videoTags[stream];
-  };
+    delete bridgeRefs.current.videoTags[stream];
+  }, []);
 
   const startVirtualBackgroundByDrop = useCallback(async (
     stream: string,
@@ -565,7 +607,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     data: string,
   ) => {
     try {
-      const bbbVideoStream = streamRefs.current.localVideoStreams[stream];
+      const bbbVideoStream = bridgeRefs.current.localVideoStreams[stream];
       await VideoService.startVirtualBackground(bbbVideoStream, backgroundType, name, data);
     } catch (error) {
       const errorLocale = intlClientErrors.virtualBgGenericError;
@@ -587,6 +629,8 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     streams,
     currentVideoPageIndex,
     updateStreams,
+    // cameraTracks is used to trigger a re-render when the camera tracks change,
+    // even if not used explicitly. Not ideal, but it works (_for now_) - prlanzarin
     cameraTracks,
     overflowCount,
   ]);


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): frozen cams on reconn, camera bridge improvements](https://github.com/bigbluebutton/bigbluebutton/commit/be9d05c12cb7080e5422ade739e6bdeaa72d639b) 
  - LK's camera bridge streams may freeze in specific LK reconnection
scenarios. This is triggered by the bridge's usage of LK room events +
local React refs to track publications and subscriptions.
With reconnects, those refs become stale and, even though the remote
references are still present, they don't work anymore for subsequen
setSubscribed calls.
  - Add sync routine for the refs when LiveKit's connection state becomes
healthy, fixing the aforementioned freezes.
  - Additionally, do a general review pass of the camera bridge:
    - Fix the debounced stream connection method: it's ineffective due to
    being re-created on every render, which loses the debounce timer
    reference. Make the debounce method stable so that pagination
    subscriptions have their frequency constrained.
    - Fix circular dependencies between effects, callbacks and
    component properties to shave off some unecessary re-renders
    - Stabilize helper functions that are passed as props to children

### Closes Issue(s)

None