### PR TITLE
fix(breakout-room): fix cancel button and time display alignment issues

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/components/timeRemaining.tsx
@@ -101,7 +101,6 @@ const TimeRemaingPanel: React.FC<TimeRemainingPanelProps> = ({
 
   return (
     <Styled.DurationContainer
-      centeredText={!showChangeTimeForm}
       ref={durationContainerRef}
     >
       <BreakoutRemainingTime

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/styles.ts
@@ -182,15 +182,8 @@ const BreakoutScrollableList = styled(ScrollboxVertical)`
   background: none;
 `;
 
-type DurationContainerProps = {
-  centeredText: boolean;
-};
-
-const DurationContainer = styled.div<DurationContainerProps>`
-  ${({ centeredText }) => centeredText && `
-    text-align: center;
-  `}
-
+const DurationContainer = styled.div`
+  text-align: center;
   border-radius: ${borderRadius};
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -679,7 +679,14 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         </Styled.Content>
         <Styled.PanelSeparator />
         <Styled.ActionButtonContainer>
-          <Styled.FooterButton onClick={() => setIsOpen(false)}>
+          <Styled.FooterButton onClick={() => {
+            if (isUpdate) {
+              setUpdateUsersWhileRunning(false);
+            } else {
+              setIsOpen(false);
+            }
+          }}
+          >
             {intl.formatMessage(intlMessages.cancelLabel)}
           </Styled.FooterButton>
           <Styled.FooterButton


### PR DESCRIPTION
### What does this PR do?
- Fix cancel button in update users modal not properly closing the modal state.
- Keep time remaining display centered when duration form is shown.



### Closes Issue(s)
Closes None

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->


### More
[Screencast from 05-01-2026 15:59:33.webm](https://github.com/user-attachments/assets/2a083946-0a2e-4e17-8783-abea46c8d9b9)

<img width="387" height="269" alt="Screenshot from 2026-01-05 16-05-16" src="https://github.com/user-attachments/assets/9afdb6f2-37fa-469e-a6d8-9b71107e266a" />
