### PR TITLE
fix (html5): Show chat message notification from html version of the message (instead of markdown)

### DIFF
--- a/bbb-graphql-middleware/internal/streaming_server/chatMessageStream.go
+++ b/bbb-graphql-middleware/internal/streaming_server/chatMessageStream.go
@@ -52,6 +52,7 @@ func createChatMesssageGraphqlMessage(receivedMessage common.RedisMessage) ([]by
 		return nil, fmt.Errorf("it was not able to read msg in GroupChatMessageBroadcastEvtMsg")
 	}
 	message := messageProps["message"].(string)
+	messageAsHtml := messageProps["messageAsHtml"].(string)
 	messageId := messageProps["id"].(string)
 	messageMetadata := messageProps["metadata"]
 	messageType := messageProps["messageType"].(string)
@@ -68,6 +69,7 @@ func createChatMesssageGraphqlMessage(receivedMessage common.RedisMessage) ([]by
 	item := map[string]any{
 		"chatId":          chatId,
 		"message":         message,
+		"messageAsHtml":   messageAsHtml,
 		"messageId":       messageId,
 		"messageMetadata": messageMetadata,
 		"messageType":     messageType,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/component.tsx
@@ -129,7 +129,7 @@ const ChatAlertGraphql: React.FC<ChatAlertGraphqlProps> = (props) => {
       return intl.formatMessage(intlMessages.publicChatClear);
     }
 
-    return unescapeHtml(stripTags(msg.message));
+    return unescapeHtml(stripTags(msg.messageAsHtml));
   };
 
   const createMessage = (msg: Message) => (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/alert/queries.ts
@@ -4,6 +4,7 @@ export interface Message {
   messageType: string;
   chatId: string;
   message: string;
+  messageAsHtml: string;
   messageId: string;
   createdAt: string;
   messageMetadata: string | null;
@@ -26,6 +27,7 @@ export const CHAT_MESSAGE_STREAM = gql`
       chatId
       createdAt
       message
+      messageAsHtml
       messageId
       messageMetadata
       messageType


### PR DESCRIPTION
Currently, chat message notifications display the raw Markdown syntax.
It should instead use the HTML version of the message, which appears correctly without the markdown characters.

<table>
<tr>
<td>
Before:
<img width="700" height="279" alt="notification-before" src="https://github.com/user-attachments/assets/3058d310-9077-4aaa-a2d9-388081331cff" />

</td>
<td>
After:
<img width="695" height="255" alt="notification-after" src="https://github.com/user-attachments/assets/54f52475-c0de-4e59-985f-49e4f99c1a30" />

</td>