### PR TITLE
fix: Virtual background image upload fails when userdata-bbb_hide_notifications is set to true

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/file-reader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/file-reader/component.jsx
@@ -48,7 +48,7 @@ const withFileReader = (
   mimeTypesAllowed,
   maxFileSize,
 ) => (props) => {
-  const { intl } = props;
+  const { intl, hideNotificationToasts } = props;
   const toastId = useRef(null);
 
   const parseFilename = (filename = '') => {
@@ -101,6 +101,11 @@ const withFileReader = (
   };
 
   const renderToast = (text = '', status = STATUS.DONE, callback) => {
+    if (hideNotificationToasts) {
+      if (typeof callback === 'function') callback();
+      return;
+    }
+
     if (toastId.current) {
       toast.dismiss(toastId.current);
     }
@@ -130,21 +135,25 @@ const withFileReader = (
     const sizeInKB = size / 1024;
 
     if (sizeInKB > maxFileSize) {
-      notify(
-        intl.formatMessage(
-          intlMessages.maximumSizeExceeded,
-          { maxFileSize: (maxFileSize / 1000).toFixed(0) },
-        ),
-        'error',
-      );
+      if (!hideNotificationToasts) {
+        notify(
+          intl.formatMessage(
+            intlMessages.maximumSizeExceeded,
+            { maxFileSize: (maxFileSize / 1000).toFixed(0) },
+          ),
+          'error',
+        );
+      }
       return onError(new Error('Maximum file size exceeded.'));
     }
 
     if (!mimeTypesAllowed.includes(type)) {
-      notify(
-        intl.formatMessage(intlMessages.typeNotAllowed),
-        'error',
-      );
+      if (!hideNotificationToasts) {
+        notify(
+          intl.formatMessage(intlMessages.typeNotAllowed),
+          'error',
+        );
+      }
       return onError(new Error('File type not allowed.'));
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -1176,7 +1176,7 @@ class VideoPreview extends Component {
   }
 
   renderVirtualBgSelector() {
-    const { isCustomVirtualBackgroundsEnabled } = this.props;
+    const { isCustomVirtualBackgroundsEnabled, hideNotificationToasts } = this.props;
     const { isStartSharingDisabled, webcamDeviceId } = this.state;
     const initialVirtualBgState = this.currentVideoStream ? {
       type: this.currentVideoStream.virtualBgType,
@@ -1187,7 +1187,7 @@ class VideoPreview extends Component {
     const {
       showThumbnails: SHOW_THUMBNAILS = true,
     } = window.meetingClientSettings.public.virtualBackgrounds;
-    
+
     return (
       <VirtualBgSelector
         handleVirtualBgSelected={this.handleVirtualBgSelected}
@@ -1195,6 +1195,7 @@ class VideoPreview extends Component {
         showThumbnails={SHOW_THUMBNAILS}
         initialVirtualBgState={initialVirtualBgState}
         isCustomVirtualBackgroundsEnabled={isCustomVirtualBackgroundsEnabled}
+        hideNotificationToasts={hideNotificationToasts}
       />
     );
   }

--- a/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
@@ -16,6 +16,8 @@ import { useStorageKey } from '../../services/storage/hooks';
 import { useIsCustomVirtualBackgroundsEnabled, useIsVirtualBackgroundsEnabled } from '../../services/features';
 import { SET_AWAY } from '../user-list/user-list-content/user-participants/user-list-participants/user-actions/mutations';
 import useCurrentUser from '../../core/hooks/useCurrentUser';
+import { layoutSelectInput } from '../layout/context';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 const VideoPreviewContainer = (props) => {
   const {
@@ -40,6 +42,9 @@ const VideoPreviewContainer = (props) => {
   const { data: currentUser } = useCurrentUser((u) => ({
     away: u.away,
   }));
+  const { hideNotificationToasts } = layoutSelectInput((i) => i.notificationsBar);
+  const hideNotifications = hideNotificationToasts
+    || getFromUserSettings('bbb_hide_notifications', false);
   const stopSharing = (deviceId) => {
     callbackToClose();
     setIsOpen(false);
@@ -110,6 +115,7 @@ const VideoPreviewContainer = (props) => {
         isCustomVirtualBackgroundsEnabled,
         setAway,
         isAway: currentUser?.away ?? false,
+        hideNotificationToasts: hideNotifications,
         ...props,
       }}
     />

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
@@ -7,7 +7,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { layoutSelect, layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
 import VideoListItem from './component';
 import { VideoItem } from '/imports/ui/components/video-provider/types';
-import { Layout } from '/imports/ui/components/layout/layoutTypes';
+import { Layout, Input } from '/imports/ui/components/layout/layoutTypes';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
@@ -94,7 +94,7 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
     ? raisedHands.findIndex((user) => user.userId === userId) + 1
     : 0;
 
-  const { hideNotificationToasts } = layoutSelectInput((i) => i.notificationsBar);
+  const { hideNotificationToasts } = layoutSelectInput((i: Input) => i.notificationsBar);
   const hideNotifications = hideNotificationToasts
     || getFromUserSettings('bbb_hide_notifications', false);
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
@@ -4,7 +4,7 @@ import { UpdatedDataForUserCameraDomElement } from 'bigbluebutton-html-plugin-sd
 
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
-import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
+import { layoutSelect, layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
 import VideoListItem from './component';
 import { VideoItem } from '/imports/ui/components/video-provider/types';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
@@ -17,6 +17,7 @@ import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
 import { UserCameraHelperAreas } from '../../../plugins-engine/extensible-areas/components/user-camera-helper/types';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { RAISED_HAND_USERS } from '/imports/ui/core/graphql/queries/users';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 
 interface VideoListItemContainerProps {
   numOfStreams: number;
@@ -93,6 +94,10 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
     ? raisedHands.findIndex((user) => user.userId === userId) + 1
     : 0;
 
+  const { hideNotificationToasts } = layoutSelectInput((i) => i.notificationsBar);
+  const hideNotifications = hideNotificationToasts
+    || getFromUserSettings('bbb_hide_notifications', false);
+
   return (
     <VideoListItem
       {...{
@@ -117,6 +122,7 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
       stream={stream}
       voiceUser={voiceUser}
       raisedHandPosition={raisedHandIndex}
+      hideNotificationToasts={hideNotifications}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?

Adjusts file reader to work if notifications are disabled.

### Closes Issue(s)
Closes #24356

### How to test
1. Create a bigbluebutton meeting and join user with `userdata-bbb_hide_notifications=true`
2. Open the webcam settings and select “Virtual Background”.
3. Try uploading an image.
4. The virtual background image should upload successfully.