### PR TITLE
Fix(html5): chat counter stale due race condition on mark message as read

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   KeyboardEventHandler,
 } from 'react';
-import { makeVar, useMutation } from '@apollo/client';
+import { makeVar, useMutation, useReactiveVar } from '@apollo/client';
 import { defineMessages, useIntl } from 'react-intl';
 import useChat from '/imports/ui/core/hooks/useChat';
 import useIntersectionObserver from '/imports/ui/hooks/useIntersectionObserver';
@@ -67,7 +67,7 @@ interface ChatListProps {
         lastSeenAt: string,
       },
     }
-  ) => void;
+  ) => Promise<unknown>;
 }
 
 const isElement = (el: unknown): el is HTMLElement => {
@@ -102,19 +102,24 @@ const setLastSender = (lastSenderPerPage: Map<number, string>) => {
 };
 
 const lastSeenQueue = makeVar<{ [key: string]: Set<number> }>({});
-const setter = makeVar<{ [key: string]:(lastSeenTime: string) => void }>({});
 const lastSeenAtVar = makeVar<{ [key: string]: number }>({});
+const pendingLastSeenAtVar = makeVar<{ [key: string]: number }>({});
 const chatIdVar = makeVar<string>('');
 
 const dispatchLastSeen = () => setTimeout(() => {
   const lastSeenQueueValue = lastSeenQueue();
-  if (lastSeenQueueValue[chatIdVar()]) {
-    const lastTimeQueue = Array.from(lastSeenQueueValue[chatIdVar()]);
+  const activeChatId = chatIdVar();
+  if (lastSeenQueueValue[activeChatId]) {
+    const lastTimeQueue = Array.from(lastSeenQueueValue[activeChatId]);
     const lastSeenTime = Math.max(...lastTimeQueue);
     const lastSeenAtVarValue = lastSeenAtVar();
-    if (lastSeenTime > (lastSeenAtVarValue[chatIdVar()] ?? 0)) {
-      lastSeenAtVar({ ...lastSeenAtVar(), [chatIdVar()]: lastSeenTime });
-      setter()[chatIdVar()](new Date(lastSeenTime).toISOString());
+    const pendingLastSeenAtVarValue = pendingLastSeenAtVar();
+    if (
+      lastSeenTime > (lastSeenAtVarValue[activeChatId] ?? 0)
+      && lastSeenTime > (pendingLastSeenAtVarValue[activeChatId] ?? 0)
+    ) {
+      pendingLastSeenAtVar({ ...pendingLastSeenAtVarValue, [activeChatId]: lastSeenTime });
+      lastSeenQueue({ ...lastSeenQueueValue, [activeChatId]: new Set([lastSeenTime]) });
     }
   }
 }, 500);
@@ -210,6 +215,7 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   const [lockLoadingNewPages, setLockLoadingNewPages] = useState(true);
   const [isScrollingDisabled, setIsScrollingDisabled] = useState(false);
   const allPagesLoaded = loadingPages.size === 0;
+  const pendingLastSeenAtByChat = useReactiveVar(pendingLastSeenAtVar);
   const {
     childRefProxy: endSentinelRefProxy,
     intersecting: isEndSentinelVisible,
@@ -318,24 +324,56 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   }, [isStartSentinelVisible]);
 
   useEffect(() => {
-    setter({
-      ...setter(),
-      [chatId]: setLastMessageCreatedAt,
-    });
     chatIdVar(chatId);
     setLastMessageCreatedAt('');
   }, [chatId]);
 
   useEffect(() => {
-    if (lastMessageCreatedAt !== '') {
-      setMessageAsSeenMutation({
-        variables: {
+    const lastSeenTime = new Date(lastMessageCreatedAt).getTime();
+    if (!Number.isFinite(lastSeenTime) || lastMessageCreatedAt === '') return;
+
+    setMessageAsSeenMutation({
+      variables: {
+        chatId,
+        lastSeenAt: lastMessageCreatedAt,
+      },
+    }).then(() => {
+      // Use callback to confirm we have no connection issues before updating the last seen time
+      const lastSeenAtVarValue = lastSeenAtVar();
+      if (lastSeenTime > (lastSeenAtVarValue[chatId] ?? 0)) {
+        lastSeenAtVar({ ...lastSeenAtVarValue, [chatId]: lastSeenTime });
+      }
+
+      const pending = pendingLastSeenAtVar();
+      if ((pending[chatId] ?? 0) <= lastSeenTime) {
+        const pendingKeys = Object.keys(pending);
+        const pendingOtherKeys = pendingKeys.filter((key) => key !== chatId);
+        const rest = pendingOtherKeys.reduce((acc, key) => {
+          acc[key] = pending[key];
+          return acc;
+        }, {} as { [key: string]: number });
+        pendingLastSeenAtVar(rest);
+      }
+    }).catch((e) => {
+      logger.error({
+        logCode: 'chat_set_last_seen_error',
+        extraInfo: {
+          errorName: e?.name,
+          errorMessage: e?.message,
           chatId,
-          lastSeenAt: lastMessageCreatedAt,
         },
-      });
-    }
-  }, [lastMessageCreatedAt]);
+      }, `Setting chat last seen failed: ${e?.message}`);
+    });
+  }, [lastMessageCreatedAt, chatId, setMessageAsSeenMutation]);
+
+  useEffect(() => {
+    const pendingLastSeenAt = pendingLastSeenAtByChat[chatId];
+    if (!pendingLastSeenAt) return;
+    if (pendingLastSeenAt <= (lastSeenAtVar()[chatId] ?? 0)) return;
+    if (pendingLastSeenAt <= new Date(lastMessageCreatedAt || 0).getTime()) return;
+
+    setLastMessageCreatedAt(new Date(pendingLastSeenAt).toISOString());
+  }, [pendingLastSeenAtByChat, chatId, lastMessageCreatedAt]);
 
   useEffect(() => {
     const handler = (e: Event) => {


### PR DESCRIPTION
### What does this PR do?
The chat counter had a race condition where if a user close the chat at the same point a new message arrives it caused to a notification to be staled, I've added a pending per chat and also a better handler for this state.


### Closes Issue(s)
Closes #24392

### How to test
1. Join a meeting with two users.
2. User 1 sends a chat message.
3. User 2 closes the chat exactly as a new message arrives.
4. User 2 reopens the chat.


### More
[Screencast from 08-01-2026 11:40:23.webm](https://github.com/user-attachments/assets/795938c0-990f-41d9-9fb2-df1a77b49dad)

