### PR TITLE
fix(html5): pinned shared notes and dropdown icon wrong position in rtl

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/button/styles.ts
@@ -22,6 +22,11 @@ const ClosedCaptionToggleButton = styled(Button)`
 
 const SpanButtonWrapper = styled.span`
   position: relative;
+  span {
+    i {
+      width: 98% !important;
+    }
+  }
 `;
 
 const TranscriptionToggle = styled(Toggle)`

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/styles.ts
@@ -91,7 +91,7 @@ export const DangerColor = {
 export const AudioDropdown = styled(ButtonEmoji)`
   span {
     i {
-      width: 10px !important;
+      width: 98% !important;
       bottom: 1px;
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
@@ -162,6 +162,7 @@ export interface SharedNotes {
     width: number;
     display?: boolean;
     left?: number;
+    right?: number;
     tabOrder?: number;
     top?: number;
     zIndex?: number;

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -130,6 +130,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     width,
     top,
     left,
+    right,
     zIndex,
   } = sharedNotesOutput;
 
@@ -138,6 +139,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     width,
     top,
     left,
+    right,
     zIndex,
   };
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/component.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useEffect, useState } from 'react';
 import { FetchResult } from '@apollo/client';
-import ButtonEmoji from '/imports/ui/components/common/button/button-emoji/ButtonEmoji';
 import { IntlShape, defineMessages, injectIntl } from 'react-intl';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { debounce } from '/imports/utils/debounce';
@@ -210,7 +209,7 @@ const JoinVideoButton: React.FC<JoinVideoButtonProps> = ({
       <BBBMenu
         customStyles={!isMobile ? customStyles : null}
         trigger={(
-          <ButtonEmoji
+          <Styled.VideoDropdown
             emoji="device_list_selector"
             data-test="videoDropdownMenu"
             hideLabel

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-button/styles.ts
@@ -1,9 +1,20 @@
 import styled from 'styled-components';
+import ButtonEmoji from '/imports/ui/components/common/button/button-emoji/ButtonEmoji';
 
 const OffsetBottom = styled.div`
   position: relative;
 `;
 
+// @ts-ignore - as button comes from JS, we can't provide its props
+export const VideoDropdown = styled(ButtonEmoji)`
+  span {
+    i {
+      width: 98% !important;
+    }
+  }
+`;
+
 export default {
   OffsetBottom,
+  VideoDropdown,
 };


### PR DESCRIPTION
### What does this PR do?
Fixes the position of pinned shared notes and audio/video dropdown icons in rtl languages.

Before:
<img width="282" height="52" alt="image" src="https://github.com/user-attachments/assets/bdf5b517-ecbf-45e9-b534-e0ea27a07e5f" />
<img width="1798" height="913" alt="image" src="https://github.com/user-attachments/assets/3e288941-f7d5-4590-8502-31e53dffd53d" />

After:
<img width="1920" height="941" alt="image" src="https://github.com/user-attachments/assets/00898a3b-866e-4f40-a07c-2473d5f016fc" />



### How to test
- Pin shared notes on whiteboard and join with audio and video
- Change language to rtl
- See if the position of shared notes and dropdown icons are correct


