### PR TITLE
test: update "give and remove whiteboard access" test

### DIFF
--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -260,6 +260,8 @@ export const elements = {
   raisingHandToast: 'You have raised your hand',
   loweringHandToast: 'Your hand has been lowered',
   noActiveMicrophoneToast: 'No active microphone. Share your microphone to add audio to this recording.',
+  whiteboardAvailableToast: 'The whiteboard is now available',
+  whiteboardDisabledToast: 'The whiteboard access has been removed',
   // Icons
   unmuteIcon: `${baseBbbIcon}unmute`,
   listenOnlyIcon: `${baseBbbIcon}listen`,

--- a/bigbluebutton-tests/playwright/user/multiusers.ts
+++ b/bigbluebutton-tests/playwright/user/multiusers.ts
@@ -351,12 +351,43 @@ export class MultiUsers {
 
   async giveAndRemoveWhiteboardAccess() {
     await this.modPage.waitForSelector(e.whiteboard);
+
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage.wasRemoved(
+      e.wbToolbar,
+      'should not display the whiteboard toolbar for the attendee before being given access',
+    );
+
     await this.modPage.waitAndClick(e.userListItem);
     await this.modPage.waitAndClick(e.changeWhiteboardAccess);
-    await this.modPage.hasElement(e.multiUsersWhiteboardOff, 'should display the whiteboard off icon');
+    await this.modPage.hasElement(
+      e.multiUsersWhiteboardOff,
+      'should display the "turn multi-user whiteboard off" icon',
+    );
+
+    await this.userPage.hasElement(
+      e.wbToolbar,
+      'should display the whiteboard toolbar for the attendee after being given access',
+    );
+    await this.userPage.hasText(
+      e.smallToastMsg,
+      e.whiteboardAvailableToast,
+      `should have toast message "${e.whiteboardAvailableToast}" for the attendee after being given access`,
+    );
+
     await this.modPage.waitAndClick(e.userListItem);
     await this.modPage.waitAndClick(e.changeWhiteboardAccess);
-    await this.modPage.hasElement(e.multiUsersWhiteboardOn, 'should display the whiteboard on icon');
+    await this.modPage.hasElement(e.multiUsersWhiteboardOn, 'should display the "turn multi-user whiteboard on" icon');
+
+    await this.userPage.wasRemoved(
+      e.wbToolbar,
+      'should not display the whiteboard toolbar for the attendee after being removed access',
+    );
+    await this.userPage.hasText(
+      e.smallToastMsg,
+      e.whiteboardDisabledToast,
+      `should have toast message "${e.whiteboardDisabledToast}" for the attendee after being removed access`,
+    );
   }
 
   async disabledUsersJoinMuted() {


### PR DESCRIPTION
### What does this PR do?
  This PR enhances the "Give and remove whiteboard access" test to properly validate the new user-based whiteboard access control introduced in PR #24199. The test now verifies both moderator and attendee perspectives, including UI state changes and toast notifications when whiteboard access is granted or revoked.

#### Changes Made

  - Added validation to check that attendee initially does not have whiteboard toolbar access
  - Added verification that attendee receives whiteboard toolbar after being granted access by moderator
  - Added toast notification validation when whiteboard access is granted ("The whiteboard is now available")
  - Added verification that attendee loses whiteboard toolbar after access is revoked
  - Added toast notification validation when whiteboard access is removed ("The whiteboard access has been removed")
  - Added two new toast message selectors in elements.ts: whiteboardAvailableToast and whiteboardDisabledToast

###  How to Test

  1. Run playwright user tests with:
 ` npm run test user/user.spec.ts`
  1. Or run the specific test using the command:
  `npm run test:filter "Give and remove whiteboard access"`
  2. Confirm that the test passes and validates:
    - Attendee cannot access whiteboard toolbar initially
    - Moderator can grant whiteboard access to attendee
    - Attendee sees toolbar and toast notification after receiving access
    - Moderator can revoke whiteboard access from attendee
    - Attendee loses toolbar and sees toast notification after access removal



### Closes Issue(s)
Closes #24440 
