### PR TITLE
fix: Raise hand notification not working for second moderator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/component.tsx
@@ -60,14 +60,14 @@ const RaiseHandNotifier: React.FC<RaiseHandNotifierProps> = ({
       return;
     }
 
+    const isAllowed = isModerator || isPresenter;
     const previousUserIdsSet = new Set(previousUserIdsRef.current);
     const newRaisedHandUsers = raiseHandUsers.filter(
       (user) => !previousUserIdsSet.has(user.userId),
-    ).filter((user) => isPresenter && user.userId !== currentUserId);
+    ).filter((user) => isAllowed && user.userId !== currentUserId);
     const hasNewRaisedHand = newRaisedHandUsers.length > 0;
-    const isAllowed = isModerator || isPresenter;
 
-    if (hasNewRaisedHand && isAllowed) {
+    if (hasNewRaisedHand) {
       if (raiseHandAudioAlert) {
         AudioService.playAlertSound(getRaiseHandSoundUrl());
       }
@@ -79,7 +79,6 @@ const RaiseHandNotifier: React.FC<RaiseHandNotifierProps> = ({
           .map((user) => user.name)
           .filter((name): name is string => !!name && name.length > 0);
         const message = buildRaisedHandMessage(names);
-
         if (message) {
           notify(message, 'info', 'hand');
         }


### PR DESCRIPTION
### What does this PR do?

Changes raise hand notification logic to show raise hand notifications to moderators, not just the presenter

### Closes Issue(s)
Closes #24436

### How to test
1. Join a meeting as moderator A
2. join as a second moderator B
3. As A: raise hand
4. B should receive a popup and audio notification that someone raised hand.
5. Raise hand as B. A receives a popup and audio notification.