### PR TITLE
fix(html5): exclude worker.ts from ReactRefresh so hot reload can work

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -69,6 +69,7 @@ const config = {
     }),
     (isDev && hotReload) && new ReactRefreshWebpackPlugin({
       overlay: false,
+      exclude: /worker\.ts$/,
     }),
   ],
   resolve: {


### PR DESCRIPTION
### What does this PR do?
React refresh was broken after https://github.com/bigbluebutton/bigbluebutton/pull/24152, it don't work in the worker thread. Excluded the worker file so hot reload can work again.

### Motivation
Fast development testing in client.
