### PR TITLE
Fix crash when hiding navbar via userdata or layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -166,7 +166,9 @@ class NavBar extends Component {
       meetingId,
     } = this.props;
     const ShownId = getStorageSingletonInstance().getItem('alreadyShowSessionDetailsOnJoin');
-    this.setModalIsOpen(showSessionDetailsOnJoin && ShownId !== meetingId);
+    if (this.setModalIsOpen) { // when hiding navbar this might be undefined and crash
+      this.setModalIsOpen(showSessionDetailsOnJoin && ShownId !== meetingId);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
When joining with with userdata-bbb_change_layout=MEDIA_ONLY or userdata-bbb_hide_navbar=true this line would crash because a function was not defined.