### PR TITLE
fix(html5): make user list actions icons bigger

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-item-toolbar/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-item-toolbar/styles.ts
@@ -18,7 +18,6 @@ const ToolbarItem = styled.div<{ disabled?: boolean, hasText?: boolean }>`
   cursor: pointer;
   color: ${({ hasText }) => (hasText ? colorPrimary : colorGrayIcons)};
 
-  font-size: 0.8rem;
   line-height: 1;
 
   ${({ disabled }) => disabled && `


### PR DESCRIPTION
### What does this PR do?
Return icons in user list back to normal.
This was reduced by mistake in a recent merge.



