### PR TITLE
tests: Replace `type` with `fill` for text input unrelated to keystrokes

### DIFF
--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -112,7 +112,7 @@ export class Create extends MultiUsers {
     await this.modPage.waitAndClick(e.createBreakoutRooms);
     await this.modPage.waitAndClick(e.randomlyAssign);
     // Change room's name
-    await this.modPage.type(e.roomNameInput1, 'Test');
+    await this.modPage.fill(e.roomNameInput1, 'Test');
     await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
     await this.modPage.hasText(e.roomName1Test, /Test/, 'should display the correct breakout room name');

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -112,10 +112,10 @@ export class Create extends MultiUsers {
     await this.modPage.waitAndClick(e.createBreakoutRooms);
     await this.modPage.waitAndClick(e.randomlyAssign);
     // Change room's name
-    await this.modPage.fill(e.roomNameInput1, 'Test');
+    await this.modPage.fill(e.roomNameInput1, 'TestRoom 1');
     await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
-    await this.modPage.hasText(e.roomName1Test, /Test/, 'should display the correct breakout room name');
+    await this.modPage.hasText(e.roomName1Test, /TestRoom 1/, 'should display the correct breakout room name');
   }
 
   async removeAndResetAssignments() {

--- a/bigbluebutton-tests/playwright/breakout/join.ts
+++ b/bigbluebutton-tests/playwright/breakout/join.ts
@@ -199,7 +199,7 @@ export class Join extends Create {
 
     await this.modPage.waitAndClick(e.breakoutRoomsItem);
     await this.modPage.hasElement(e.breakoutRemainingTime, 'should display the breakout room remaining time element');
-    await this.modPage.type(e.chatBox, 'Test message to all breakout rooms');
+    await this.modPage.fill(e.chatBox, 'Test message to all breakout rooms');
     await this.modPage.waitAndClick(e.sendButton);
     await breakoutUserPage.hasElement(e.chatUserMessageText, 'should have a test message on the public chat.');
 
@@ -208,7 +208,7 @@ export class Join extends Create {
       'should display a message from the moderator, html element will have data-message-type="breakoutRoomModeratorMsg"',
     );
 
-    await this.modPage.type(e.chatBox, 'Second Test message to all breakout rooms');
+    await this.modPage.fill(e.chatBox, 'Second Test message to all breakout rooms');
     await this.modPage.waitAndClick(e.sendButton);
     await breakoutUserPage.hasElement(e.chatUserMessageText, 'should have another test message on the public chat.');
 
@@ -400,7 +400,7 @@ export class Join extends Create {
       'should display the hide notes element when shared notes is opened',
     );
     const notesLocator = getNotesLocator(breakoutUserPage);
-    await notesLocator.type(e.message);
+    await notesLocator.pressSequentially(e.message);
     // making sure there's enough time for the typing to finish
     await breakoutUserPage.page.waitForTimeout(1000);
     // end breakout rooms

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -11,7 +11,7 @@ export class Chat extends MultiUsers {
     await openPublicChat(this.modPage);
     await this.modPage.hasElementCount(e.chatUserMessageText, 0, 'should have none message on the public chat');
 
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.userPage.hasElement(e.typingIndicator, 'should display the typing indicator element');
     await this.modPage.page.click(e.sendButton);
     await this.modPage.hasElementCount(e.chatUserMessageText, 1, 'should have on message on the public chat');
@@ -26,7 +26,7 @@ export class Chat extends MultiUsers {
     // prevent a race condition when running on a deployed server
     await this.modPage.page.waitForTimeout(500);
     // modPage send message
-    await this.modPage.type(e.chatBox, e.message1);
+    await this.modPage.fill(e.chatBox, e.message1);
     await this.modPage.waitAndClick(e.sendButton);
     await this.userPage.waitUntilHaveCountSelector(e.chatButton, 2);
     await this.userPage.waitAndClickElement(e.chatButton, 1);
@@ -42,7 +42,7 @@ export class Chat extends MultiUsers {
       'should display the message sent by the moderator for the attendee',
     );
     // userPage send message
-    await this.userPage.type(e.chatBox, e.message2);
+    await this.userPage.fill(e.chatBox, e.message2);
     await this.modPage.hasElement(
       e.typingIndicator,
       'should display the typing indicator for the moderator when user is typing a message',
@@ -66,7 +66,7 @@ export class Chat extends MultiUsers {
 
     const userMessageTextCount = await this.modPage.getSelectorCount(e.chatUserMessageText);
 
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(e.chatUserMessageText, 'should display a message sent by the moderator');
 
@@ -94,7 +94,7 @@ export class Chat extends MultiUsers {
       return;
     }
     // sending a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
 
     await this.modPage.waitAndClick(e.chatOptions);
@@ -118,7 +118,7 @@ export class Chat extends MultiUsers {
       return;
     }
 
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -156,7 +156,7 @@ export class Chat extends MultiUsers {
     );
 
     await this.modPage.page.fill(e.chatBox, e.uniqueCharacterMessage.repeat(maxMessageLength || 1000));
-    await this.modPage.type(e.chatBox, '123'); // it should has no effect
+    await this.modPage.fill(e.chatBox, '123'); // it should has no effect
     await this.modPage.hasElement(e.errorTypingIndicator, 'Should appear the warning message below the chat box');
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElementCount(
@@ -180,7 +180,7 @@ export class Chat extends MultiUsers {
   }
 
   async copyPastePublicMessage() {
-    await this.modPage.type(e.chatBox, 'test');
+    await this.modPage.fill(e.chatBox, 'test');
     await this.modPage.waitAndClick(e.sendButton);
     await checkLastMessageSent(this.modPage, /test/);
 
@@ -191,7 +191,7 @@ export class Chat extends MultiUsers {
     await this.modPage.press('Control+KeyC');
     await this.modPage.page.locator(e.chatBox).focus();
     await this.modPage.press('Control+KeyV');
-    await this.modPage.type(e.chatBox, '2');
+    await this.modPage.fill(e.chatBox, '2');
     await this.modPage.waitAndClick(e.sendButton);
 
     await checkLastMessageSent(this.modPage, /test2/);
@@ -271,7 +271,7 @@ export class Chat extends MultiUsers {
       chatMessageCount,
       'should not display any new messages on the private chat',
     );
-    await this.modPage.type(e.chatBox, e.message1);
+    await this.modPage.fill(e.chatBox, e.message1);
     await this.modPage.waitAndClick(e.sendButton);
     await this.userPage.waitUntilHaveCountSelector(e.chatButton, 2);
     await this.modPage.waitAndClick(e.closePrivateChat);
@@ -382,7 +382,7 @@ export class Chat extends MultiUsers {
 
     await this.modPage.hasElementCount(e.chatUserMessageText, 0, 'should not display any messages on the public chat');
 
-    await this.modPage.type(e.chatBox, e.autoConvertEmojiMessage);
+    await this.modPage.fill(e.chatBox, e.autoConvertEmojiMessage);
     await this.modPage.waitAndClick(e.sendButton);
 
     if (!autoConvertEmojiEnabled) {
@@ -399,7 +399,7 @@ export class Chat extends MultiUsers {
     const { autoConvertEmojiEnabled } = this.modPage.settings || {};
 
     await openPublicChat(this.modPage);
-    await this.modPage.type(e.chatBox, e.autoConvertEmojiMessage);
+    await this.modPage.fill(e.chatBox, e.autoConvertEmojiMessage);
     await this.modPage.waitAndClick(e.sendButton);
     if (!autoConvertEmojiEnabled) {
       await this.modPage.hasElement(e.chatBox, 'should display chat box on the public chat for the moderator');
@@ -426,7 +426,7 @@ export class Chat extends MultiUsers {
     const { autoConvertEmojiEnabled } = this.modPage.settings || {};
 
     await openPublicChat(this.modPage);
-    await this.modPage.type(e.chatBox, e.autoConvertEmojiMessage);
+    await this.modPage.fill(e.chatBox, e.autoConvertEmojiMessage);
     await this.modPage.waitAndClick(e.sendButton);
     if (!autoConvertEmojiEnabled) {
       await this.modPage.hasElement(e.chatBox, 'should display the chat box on the public chat');
@@ -461,7 +461,7 @@ export class Chat extends MultiUsers {
     // prevent a race condition when running on a deployed server
     await this.modPage.page.waitForTimeout(500);
     // modPage send message
-    await this.modPage.type(e.chatBox, e.autoConvertEmojiMessage);
+    await this.modPage.fill(e.chatBox, e.autoConvertEmojiMessage);
     await this.modPage.waitAndClick(e.sendButton);
     if (!autoConvertEmojiEnabled && !emojiPickerEnabled) {
       await this.modPage.hasElement(e.chatBox, 'should display the chat box on the private chat');
@@ -491,7 +491,7 @@ export class Chat extends MultiUsers {
     await checkLastMessageSent(this.modPage, e.convertedEmojiMessage);
     await checkLastMessageSent(this.userPage, e.convertedEmojiMessage);
     // userPage send message
-    await this.userPage.type(e.chatBox, e.autoConvertEmojiMessage);
+    await this.userPage.fill(e.chatBox, e.autoConvertEmojiMessage);
     await this.userPage.waitAndClick(e.sendButton);
     // check sent messages
     const lastMessageLocator = this.modPage.page.locator(e.chatUserMessageText).last();

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -191,7 +191,7 @@ export class Chat extends MultiUsers {
     await this.modPage.press('Control+KeyC');
     await this.modPage.page.locator(e.chatBox).focus();
     await this.modPage.press('Control+KeyV');
-    await this.modPage.fill(e.chatBox, '2');
+    await this.modPage.type(e.chatBox, '2');
     await this.modPage.waitAndClick(e.sendButton);
 
     await checkLastMessageSent(this.modPage, /test2/);

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -156,7 +156,7 @@ export class Chat extends MultiUsers {
     );
 
     await this.modPage.page.fill(e.chatBox, e.uniqueCharacterMessage.repeat(maxMessageLength || 1000));
-    await this.modPage.fill(e.chatBox, '123'); // it should has no effect
+    await this.modPage.type(e.chatBox, '123'); // it should has no effect
     await this.modPage.hasElement(e.errorTypingIndicator, 'Should appear the warning message below the chat box');
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElementCount(

--- a/bigbluebutton-tests/playwright/chat/messageActions.ts
+++ b/bigbluebutton-tests/playwright/chat/messageActions.ts
@@ -9,7 +9,7 @@ export class MessageActions extends Chat {
   async editMessageFromToolbarButton() {
     await openPublicChat(this.modPage);
     // send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -49,7 +49,7 @@ export class MessageActions extends Chat {
   async editMessageFromArrowUp() {
     await openPublicChat(this.modPage);
     // send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -93,7 +93,7 @@ export class MessageActions extends Chat {
   async ableToEditOwnMessage() {
     await openPublicChat(this.modPage);
     // mod send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -125,7 +125,7 @@ export class MessageActions extends Chat {
       'should display the edit message button when hovering the mod message',
     ).toBeVisible();
     // user send a message
-    await this.userPage.type(e.chatBox, e.testMessage);
+    await this.userPage.fill(e.chatBox, e.testMessage);
     await this.userPage.waitAndClick(e.sendButton);
     await this.userPage.hasElementCount(
       e.chatUserMessageText,
@@ -164,7 +164,7 @@ export class MessageActions extends Chat {
   async deleteOwnMessage() {
     await openPublicChat(this.modPage);
     // send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -212,7 +212,7 @@ export class MessageActions extends Chat {
   async deleteAnotherUserMessage() {
     await openPublicChat(this.userPage);
     // user send a message
-    await this.userPage.type(e.chatBox, e.message);
+    await this.userPage.fill(e.chatBox, e.message);
     await this.userPage.waitAndClick(e.sendButton);
     await this.userPage.hasElement(
       e.chatUserMessageText,
@@ -256,7 +256,7 @@ export class MessageActions extends Chat {
     ).not.toBeVisible();
     // join mod2 and send a message
     await this.initModPage2();
-    await this.modPage2.type(e.chatBox, e.message);
+    await this.modPage2.fill(e.chatBox, e.message);
     await this.modPage2.waitAndClick(e.sendButton);
     // check if mod2 message is deletable by mod1
     await this.modPage.hasElement(
@@ -311,7 +311,7 @@ export class MessageActions extends Chat {
     const breakoutModPage = await this.modPage.getLastTargetPage(this.context);
     await breakoutModPage.waitAndClick(e.closeModal);
     // mod send a message
-    await breakoutModPage.type(e.chatBox, e.message);
+    await breakoutModPage.fill(e.chatBox, e.message);
     await breakoutModPage.waitAndClick(e.sendButton);
     await breakoutModPage.hasElement(
       e.chatUserMessageText,
@@ -375,7 +375,7 @@ export class MessageActions extends Chat {
   async replyMessage() {
     await openPublicChat(this.modPage);
     // send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -420,7 +420,7 @@ export class MessageActions extends Chat {
   async cancelReplyMessage() {
     await openPublicChat(this.modPage);
     // send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -494,7 +494,7 @@ export class MessageActions extends Chat {
   async scrollToRepliedMessage() {
     await openPublicChat(this.modPage);
     // send first message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -504,7 +504,7 @@ export class MessageActions extends Chat {
     // send many messages
     const MESSAGES_COUNT = 20;
     for (let i = 1; i <= MESSAGES_COUNT; i += 1) {
-      await this.modPage.type(e.chatBox, `message ${i}`);
+      await this.modPage.fill(e.chatBox, `message ${i}`);
       await this.modPage.waitAndClick(e.sendButton);
       await this.modPage.hasElementCount(
         e.chatUserMessageText,
@@ -567,7 +567,7 @@ export class MessageActions extends Chat {
 
   async addRemoveReaction() {
     // send first message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -612,7 +612,7 @@ export class MessageActions extends Chat {
 
   async incrementDecrementReaction() {
     // send first message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -650,7 +650,7 @@ export class MessageActions extends Chat {
 
   async orderReactions() {
     // send first message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,

--- a/bigbluebutton-tests/playwright/errorLogs/errorLogs.ts
+++ b/bigbluebutton-tests/playwright/errorLogs/errorLogs.ts
@@ -52,7 +52,7 @@ export class ErrorLogs extends MultiUsers {
   async sendPublicChatMessage() {
     await openPublicChat(this.modPage);
     const testMessage = 'Test message from error monitoring test';
-    await this.modPage.type(e.chatBox, testMessage);
+    await this.modPage.fill(e.chatBox, testMessage);
     await this.modPage.waitAndClick(e.sendButton);
     // Verify message was sent
     await this.modPage.hasText(e.chatUserMessageText, testMessage, 'should display the sent message');

--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.ts
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.ts
@@ -29,7 +29,7 @@ export class LearningDashboard extends MultiUsers {
     await openPublicChat(this.modPage);
     await this.modPage.hasElementCount(e.chatUserMessageText, 0, 'should not have any messages yet');
 
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElementCount(e.chatUserMessageText, 1, 'should display the sent message');
     await this.dashboardPage.reloadPage();
@@ -62,7 +62,7 @@ export class LearningDashboard extends MultiUsers {
   async polls() {
     // True/False
     await openPoll(this.modPage);
-    await this.modPage.type(e.pollQuestionArea, 'True/False?');
+    await this.modPage.fill(e.pollQuestionArea, 'True/False?');
     await this.modPage.waitAndClick(e.pollTrueFalse);
     await this.modPage.waitAndClick(e.startPoll);
 
@@ -72,7 +72,7 @@ export class LearningDashboard extends MultiUsers {
 
     // ABCD
     await this.modPage.page.locator(e.pollQuestionArea).fill(' ');
-    await this.modPage.type(e.pollQuestionArea, 'ABCD?');
+    await this.modPage.fill(e.pollQuestionArea, 'ABCD?');
     await this.modPage.waitAndClick(e.pollLetterAlternatives);
     await this.modPage.waitAndClick(e.startPoll);
     await this.userPage.waitAndClick(e.pollAnswerOptionBtn);
@@ -81,7 +81,7 @@ export class LearningDashboard extends MultiUsers {
 
     // Yes/No/Abstention
     await this.modPage.page.locator(e.pollQuestionArea).fill(' ');
-    await this.modPage.type(e.pollQuestionArea, 'Yes/No/Abstention?');
+    await this.modPage.fill(e.pollQuestionArea, 'Yes/No/Abstention?');
     await this.modPage.waitAndClick(e.pollYesNoAbstentionBtn);
     await this.modPage.waitAndClick(e.startPoll);
     await this.userPage.waitAndClick(e.pollAnswerOptionBtn);
@@ -90,11 +90,11 @@ export class LearningDashboard extends MultiUsers {
 
     // User Response
     await this.modPage.page.locator(e.pollQuestionArea).fill(' ');
-    await this.modPage.type(e.pollQuestionArea, 'User response?');
+    await this.modPage.fill(e.pollQuestionArea, 'User response?');
     await this.modPage.waitAndClick(e.userResponseBtn);
     await this.modPage.waitAndClick(e.startPoll);
     await this.userPage.waitForSelector(e.pollingContainer);
-    await this.userPage.type(e.pollAnswerOptionInput, e.answerMessage);
+    await this.userPage.fill(e.pollAnswerOptionInput, e.answerMessage);
     await this.userPage.waitAndClick(e.pollSubmitAnswer);
     await this.modPage.hasText(e.userVoteLiveResult, e.answerMessage, 'should display the user vote live result');
     await this.modPage.waitAndClick(e.cancelPollBtn);

--- a/bigbluebutton-tests/playwright/notifications/util.ts
+++ b/bigbluebutton-tests/playwright/notifications/util.ts
@@ -32,7 +32,7 @@ export async function publicChatMessageToast(testPage: Page, testPage2: Page) {
   await testPage.waitAndClick(e.startPrivateChat);
   await testPage.waitForSelector(e.hidePrivateChat);
   // send a public message
-  await testPage2.type(e.chatBox, e.publicMessage1);
+  await testPage2.fill(e.chatBox, e.publicMessage1);
   await testPage2.waitAndClick(e.sendButton);
 }
 
@@ -43,7 +43,7 @@ export async function privateChatMessageToast(testPage: Page) {
   // wait for the private chat to be ready
   await testPage.waitUntilHaveCountSelector(e.chatButton, 2);
   // send a private message
-  await testPage.type(e.chatBox, e.message1);
+  await testPage.fill(e.chatBox, e.message1);
   await testPage.page.waitForTimeout(1000);
   await testPage.waitAndClick(e.sendButton);
 }

--- a/bigbluebutton-tests/playwright/options/options.ts
+++ b/bigbluebutton-tests/playwright/options/options.ts
@@ -64,7 +64,7 @@ export class Options extends MultiUsers {
   async darkMode() {
     await this.modPage.hasElement(e.whiteboard, 'should the whiteboard be display');
     // send chat message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(e.chatUserMessageText, 'should the chat message be displayed');
     // set all locators

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -97,6 +97,7 @@ export const constants = {
   customVirtualBackgroundDisabled: 'disabledFeatures=customVirtualBackgrounds',
   slideSnapshotDisabled: 'disabledFeatures=snapshotOfCurrentSlide',
   cameraAsContent: 'disabledFeatures=cameraAsContent',
+  infiniteWhiteboard: 'disabledFeatures=infiniteWhiteboard',
   // Disabled Features Exclude
   breakoutRoomsExclude: 'disabledFeatures=breakoutRooms,presentation,chat&disabledFeaturesExclude=breakoutRooms',
   speechRecognitionExclude:
@@ -123,6 +124,7 @@ export const constants = {
     'disabledFeatures=presentation,chat,customVirtualBackground&disabledFeaturesExclude=customVirtualBackground',
   slideSnapshotExclude: 'disabledFeatures=snapShotOfCurrentSlide,chat&disabledFeaturesExclude=snapShotOfCurrentSlide',
   cameraAsContentExclude: 'disabledFeatures=cameraAsContent,chat&disabledFeaturesExclude=cameraAsContent',
+  infiniteWhiteboardExclude: 'disabledFeatures=infiniteWhiteboard,chat&disabledFeaturesExclude=infiniteWhiteboard',
   // Shortcuts
   shortcuts: 'userdata-bbb_shortcuts=[$]',
   initialShortcuts: [

--- a/bigbluebutton-tests/playwright/parameters/customparameters.ts
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.ts
@@ -251,7 +251,7 @@ export class CustomParameters extends MultiUsers {
 
     await this.modPage.waitAndClick(e.actions);
     await this.modPage.waitAndClick(e.shareExternalVideoBtn);
-    await this.modPage.type(e.videoModalInput, e.youtubeLink);
+    await this.modPage.fill(e.videoModalInput, e.youtubeLink);
     await this.modPage.waitAndClick(e.startShareVideoBtn);
 
     const modFrame = await this.modPage.getYoutubeFrame();

--- a/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
+++ b/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
@@ -143,7 +143,7 @@ export class DisabledFeatures extends MultiUsers {
   async infiniteWhiteboard() {
     const { allowInfiniteWhiteboard } = this.modPage.settings || {};
 
-    if(allowInfiniteWhiteboard) {
+    if (allowInfiniteWhiteboard) {
       await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard');
       await this.modPage.wasRemoved(e.turnInfiniteWhiteboardOn, 'should not display the infinite whiteboard button');
     }
@@ -281,7 +281,7 @@ export class DisabledFeatures extends MultiUsers {
   async infiniteWhiteboardExclude() {
     const { allowInfiniteWhiteboard } = this.modPage.settings || {};
 
-    if(allowInfiniteWhiteboard) {
+    if (allowInfiniteWhiteboard) {
       await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard');
       await this.modPage.hasElement(e.turnInfiniteWhiteboardOn, 'should display the infinite whiteboard button');
     }

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -514,12 +514,12 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     test.describe.serial(() => {
       test('Infinite Whiteboard', async ({ browser, context, page }, testInfo) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { createParameter: c.infiniteWhiteboard, testInfo });
+        await disabledFeatures.initModPage(page, { createParameter: c.infiniteWhiteboard, testInfo });
         await disabledFeatures.infiniteWhiteboard();
       });
       test('Infinite Whiteboard (exclude)', async ({ browser, context, page }, testInfo) => {
         const disabledFeatures = new DisabledFeatures(browser, context);
-        await disabledFeatures.initModPage(page, true, { createParameter: c.infiniteWhiteboardExclude, testInfo });
+        await disabledFeatures.initModPage(page, { createParameter: c.infiniteWhiteboardExclude, testInfo });
         await disabledFeatures.infiniteWhiteboardExclude();
       });
     });

--- a/bigbluebutton-tests/playwright/polling/poll.ts
+++ b/bigbluebutton-tests/playwright/polling/poll.ts
@@ -72,7 +72,7 @@ export class Polling extends MultiUsers {
     await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard for the moderator');
     await util.openPoll(this.modPage);
 
-    await this.modPage.type(e.pollQuestionArea, e.pollQuestion);
+    await this.modPage.fill(e.pollQuestionArea, e.pollQuestion);
     await this.modPage.waitAndClick(e.userResponseBtn);
     await this.modPage.waitAndClick(e.startPoll);
 
@@ -80,7 +80,7 @@ export class Polling extends MultiUsers {
       e.pollingContainer,
       'should display the polling container for the user to answer it',
     );
-    await this.userPage.type(e.pollAnswerOptionInput, e.answerMessage);
+    await this.userPage.fill(e.pollAnswerOptionInput, e.answerMessage);
     await this.userPage.waitAndClick(e.pollSubmitAnswer);
 
     await this.modPage.hasText(e.userVoteLiveResult, e.answerMessage, 'should display the answer sent by the attendee');
@@ -204,11 +204,11 @@ export class Polling extends MultiUsers {
     await this.modPage.waitAndClick(e.polling);
     await this.modPage.waitAndClickElement(e.autoOptioningPollBtn);
 
-    await this.modPage.type(e.pollQuestionArea, 'Test');
+    await this.modPage.fill(e.pollQuestionArea, 'Test');
     await this.modPage.waitAndClick(e.addPollItem);
-    await this.modPage.type(e.pollOptionItem, 'test1');
+    await this.modPage.fill(e.pollOptionItem, 'test1');
     await this.modPage.waitAndClick(e.addPollItem);
-    await this.modPage.type(e.pollOptionItem2, 'test2');
+    await this.modPage.fill(e.pollOptionItem2, 'test2');
     await this.modPage.waitAndClick(e.startPoll);
 
     await this.userPage.hasElement(
@@ -232,15 +232,15 @@ export class Polling extends MultiUsers {
     await this.modPage.waitAndClick(e.polling);
     await this.modPage.waitAndClickElement(e.autoOptioningPollBtn);
 
-    await this.modPage.type(e.pollQuestionArea, 'Test');
+    await this.modPage.fill(e.pollQuestionArea, 'Test');
     await this.modPage.waitAndClickElement(e.allowMultiple);
 
     await this.modPage.waitAndClick(e.addPollItem);
     await this.modPage.hasElementDisabled(e.startPoll, 'should display the start poll button disabled');
 
-    await this.modPage.type(e.pollOptionItem1, 'test1');
+    await this.modPage.fill(e.pollOptionItem1, 'test1');
     await this.modPage.waitAndClick(e.addPollItem);
-    await this.modPage.type(e.pollOptionItem2, 'test2');
+    await this.modPage.fill(e.pollOptionItem2, 'test2');
     await this.modPage.waitAndClick(e.startPoll);
     await this.modPage.hasText(
       e.currentPollQuestion,
@@ -401,7 +401,7 @@ export class Polling extends MultiUsers {
       e.pollingContainer,
       'should display the polling container for the user to answer it',
     );
-    await this.userPage.type(e.pollAnswerOptionInput, e.answerMessage);
+    await this.userPage.fill(e.pollAnswerOptionInput, e.answerMessage);
     await this.userPage.waitAndClick(e.pollSubmitAnswer);
     await this.modPage.hasText(e.userVoteLiveResult, e.answerMessage, 'should display the answer sent by the attendee');
     await util.countingVotes(this.modPage, e.userVoteLiveResult, 1, 'All good!');

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -117,7 +117,7 @@ export class Presentation extends MultiUsers {
       e.closeModal,
       'should display the close modal button after the moderator opens the modal for sharing external video',
     );
-    await this.modPage.type(e.videoModalInput, e.youtubeLink);
+    await this.modPage.fill(e.videoModalInput, e.youtubeLink);
     await this.modPage.waitAndClick(e.startShareVideoBtn);
 
     const modFrame = await this.modPage.getYoutubeFrame();

--- a/bigbluebutton-tests/playwright/recording/recording.ts
+++ b/bigbluebutton-tests/playwright/recording/recording.ts
@@ -66,7 +66,7 @@ export class Recording extends MultiUsers {
 
     // send chat message
     await openPublicChat(this.modPage);
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElementCount(e.chatUserMessageText, 1, 'should have on message on the public chat');
 
@@ -76,7 +76,7 @@ export class Recording extends MultiUsers {
     // type on shared notes
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type(e.testMessage);
+    await notesLocator.pressSequentially(e.testMessage);
     await expect(notesLocator, 'should contain the typed text on shared notes').toContainText(e.testMessage, {
       timeout: ELEMENT_WAIT_TIME,
     });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -46,7 +46,7 @@ export class ScreenShare extends MultiUsers {
     await this.modPage.waitAndClick(e.actions);
     await this.modPage.waitAndClick(e.shareExternalVideoBtn);
     await this.modPage.waitForSelector(e.closeModal);
-    await this.modPage.type(e.videoModalInput, e.youtubeLink);
+    await this.modPage.fill(e.videoModalInput, e.youtubeLink);
     await this.modPage.waitAndClick(e.startShareVideoBtn);
 
     const modFrame = await this.modPage.getYoutubeFrame();

--- a/bigbluebutton-tests/playwright/sharednotes/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/sharednotes.ts
@@ -75,7 +75,7 @@ export class SharedNotes extends MultiUsers {
     }
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type(e.message);
+    await notesLocator.pressSequentially(e.message);
 
     await notesLocator.press('Control+Z');
     await expect(notesLocator, 'should not contain any text on the shared notes').toContainText('');
@@ -112,7 +112,7 @@ export class SharedNotes extends MultiUsers {
     }
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type(e.message);
+    await notesLocator.pressSequentially(e.message);
 
     const showMoreButtonLocator = getShowMoreButtonLocator(this.modPage);
     await showMoreButtonLocator.click({ timeout: ELEMENT_WAIT_TIME });
@@ -166,7 +166,7 @@ export class SharedNotes extends MultiUsers {
     }
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type('test');
+    await notesLocator.pressSequentially('test');
     await this.modPage.page.waitForTimeout(1000);
 
     await this.modPage.waitAndClick(e.notesOptions);
@@ -201,12 +201,12 @@ export class SharedNotes extends MultiUsers {
     }
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type(e.message);
+    await notesLocator.pressSequentially(e.message);
 
     await startSharedNotes(this.userPage);
     const notesLocatorUser = getNotesLocator(this.userPage);
     await notesLocatorUser.press('Delete');
-    await notesLocatorUser.type('J');
+    await notesLocatorUser.press('J');
 
     await expect(notesLocator, 'should the shared notes contain the text "Jello" for the moderator').toContainText(
       /Jello/,
@@ -233,7 +233,7 @@ export class SharedNotes extends MultiUsers {
     // type on shared notes as moderator
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type('Hello');
+    await notesLocator.pressSequentially('Hello');
     // lock shared notes
     await startSharedNotes(this.userPage);
 
@@ -272,7 +272,7 @@ export class SharedNotes extends MultiUsers {
     // type on shared notes as moderator
     await startSharedNotes(this.modPage);
     const notesLocator = getNotesLocator(this.modPage);
-    await notesLocator.type('Hello');
+    await notesLocator.pressSequentially('Hello');
     await this.modPage.page.waitForTimeout(1000); // avoid pinning notes before the text is fully applied
     // pin notes
     await this.modPage.waitAndClick(e.notesOptions);

--- a/bigbluebutton-tests/playwright/user/guestPolicy.ts
+++ b/bigbluebutton-tests/playwright/user/guestPolicy.ts
@@ -11,7 +11,7 @@ export class GuestPolicy extends MultiUsers {
     await this.modPage.hasElement(e.waitingUsersBtn, 'should display the waiting users button');
 
     await this.modPage.waitAndClick(e.waitingUsersBtn);
-    await this.modPage.type(e.waitingUsersLobbyMessage, 'test');
+    await this.modPage.fill(e.waitingUsersLobbyMessage, 'test');
     await this.modPage.waitAndClick(e.sendLobbyMessage);
     await this.modPage.hasText(e.lobbyMessage, /test/, 'should the lobby message contain the text "test"');
   }
@@ -82,7 +82,7 @@ export class GuestPolicy extends MultiUsers {
     await this.modPage.waitAndClick(e.waitingUsersBtn);
 
     await this.modPage.waitAndClick(e.privateMessageGuest);
-    await this.modPage.type(e.inputPrivateLobbyMessage, 'test');
+    await this.modPage.fill(e.inputPrivateLobbyMessage, 'test');
     await this.modPage.waitAndClick(e.sendPrivateLobbyMessage);
     await this.userPage.hasText(
       e.guestMessage,

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -118,7 +118,7 @@ export class LockViewers extends MultiUsers {
 
   async lockSendPublicChatMessages() {
     // mod send a message
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     await this.modPage.hasElement(
       e.chatUserMessageText,
@@ -149,7 +149,7 @@ export class LockViewers extends MultiUsers {
       e.sendButton,
       'should have the send button on the public chat disabled for the second attendee',
     );
-    await this.modPage.type(e.chatBox, e.message);
+    await this.modPage.fill(e.chatBox, e.message);
     await this.modPage.waitAndClick(e.sendButton);
     // unlock user2
     await this.modPage.waitAndClick(`${e.userListItem}>>nth=1`);
@@ -160,7 +160,7 @@ export class LockViewers extends MultiUsers {
       'should have the public chat enabled for the second attendee',
       ELEMENT_WAIT_LONGER_TIME,
     );
-    await this.userPage2.type(e.chatBox, e.message);
+    await this.userPage2.fill(e.chatBox, e.message);
     await this.modPage.hasElement(e.typingIndicator, 'should display the typing indicator element for the moderator');
     await this.userPage2.waitAndClick(e.sendButton);
     await this.userPage2.hasElementCount(
@@ -202,7 +202,7 @@ export class LockViewers extends MultiUsers {
       e.sendButton,
       'should have the send button on the private chat enabled for the first attendee',
     );
-    await this.userPage.type(e.chatBox, 'Test');
+    await this.userPage.fill(e.chatBox, 'Test');
     await this.userPage.waitAndClick(e.sendButton);
     // check message sent and toolbar
     await this.userPage.hasElement(
@@ -235,7 +235,7 @@ export class LockViewers extends MultiUsers {
     await this.userPage.waitAndClick(e.sharedNotes);
     await this.userPage.waitForSelector(e.hideNotesLabel);
     const sharedNotesLocator = getNotesLocator(this.userPage);
-    await sharedNotesLocator.type(e.message, { timeout: ELEMENT_WAIT_LONGER_TIME });
+    await sharedNotesLocator.pressSequentially(e.message, { timeout: ELEMENT_WAIT_LONGER_TIME });
     await expect(
       sharedNotesLocator,
       'should the shared notes contain the text "Hello World!" for the first attendee',


### PR DESCRIPTION
### What does this PR do?
This PR replaces the function `type` with `fill` to avoid unexpected failures recently seen on CI reports + updated the deprecated function to `pressSequentially`

### More
- added missing infinite whiteboard disable feature constant parameters