### PR TITLE
fix(presentation): dispatch close when there is no presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -18,7 +18,7 @@ import {
   layoutSelectOutput,
   layoutDispatch,
 } from '../layout/context';
-import { DEVICE_TYPE } from '../layout/enums';
+import { DEVICE_TYPE, ACTIONS } from '/imports/ui/components/layout/enums';
 import MediaService from '../media/service';
 import {
   CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
@@ -46,7 +46,10 @@ const PresentationContainer = ({
   const layoutContextDispatch = layoutDispatch();
   const { selectedLayout } = useSettings(SETTINGS.LAYOUT);
 
-  const { data: presentationPageData } = useDeduplicatedSubscription(
+  const {
+    data: presentationPageData,
+    loading: loadingPresentationPageData,
+  } = useDeduplicatedSubscription(
     CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
   );
 
@@ -54,6 +57,19 @@ const PresentationContainer = ({
   const currentPresentationPage = presentationPageArray?.[0];
   const slideSvgUrl = currentPresentationPage?.svgUrl;
   const currentPageId = currentPresentationPage?.pageId;
+
+  useEffect(() => {
+    // close presentation if there isn't any
+    // case when the presentation has been manually removed in the media area drop up
+    // or when defaultUploadedPresentation is null in bigbluebutton.properties
+    if (loadingPresentationPageData) return;
+    if (!currentPageId) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: false,
+      });
+    }
+  }, [currentPageId, loadingPresentationPageData]);
 
   const { data: whiteboardWritersData } = useDeduplicatedSubscription(
     CURRENT_PAGE_WRITERS_SUBSCRIPTION,


### PR DESCRIPTION
### What does this PR do?
When the default presentation is set to `null` in the `bigbluebutton.properties` file, the presentation element is still rendered as an invisible layer over other interface elements. This affects all layouts, but is especially problematic in the videoFocus layout, where it makes most of the interface unclickable.

The issue was caused by an inconsistency in the presentation state within the layout context, which was not being updated to `display: false` when no presentation was available.

Adds a simple check in the presentation container component to update the presentation state to closed when there is no presentation. 

### Closes Issue(s)
Closes #24455