### PR TITLE
test: add test cases for external video

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -675,6 +675,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
               icon="close"
               size="sm"
               onClick={stopExternalVideoShare}
+              data-test="stopExternalVideoShare"
               label={intl.formatMessage(intlMessages.closeExternalVideoLabel)}
               hideLabel
               className={Styled.ExternalVideoCloseButton}

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -333,6 +333,7 @@ export const elements = {
   minimizePresentation: 'button[data-test="minimizePresentation"]',
   restorePresentation: 'button[data-test="restorePresentation"]',
   shareExternalVideoBtn: 'li[data-test="shareExternalVideo"]',
+  stopExternalVideoBtn: 'button[data-test="stopExternalVideoShare"]',
   videoModalInput: 'input[id="video-modal-input"]',
   startShareVideoBtn: 'button[data-test="startNewVideo"]',
   videoPlayer: 'div[data-test="videoPlayer"]',

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -23,15 +23,6 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.hideAndRestorePresentation();
   });
 
-  // https://docs.bigbluebutton.org/3.0/testing/release-testing/#start-youtube-video-sharing
-  test('Start external video', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
-    // requiring logged user to start external video on CI environment
-    linkIssue(21589);
-    const presentation = new Presentation(browser, context);
-    await presentation.initPages(page, testInfo);
-    await presentation.startExternalVideo();
-  });
-
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#fit-to-width-option
   test('Presentation fit to width', async ({ browser, context, page }, testInfo) => {
     const presentation = new Presentation(browser, context);
@@ -70,6 +61,50 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     const presentation = new Presentation(browser, context);
     await presentation.initPages(page, testInfo);
     await presentation.selectSlide();
+  });
+
+  test.describe.parallel('External Video', () => {
+    // https://docs.bigbluebutton.org/3.0/testing/release-testing/#start-youtube-video-sharing
+    test('Start external video', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
+      // requiring logged user to start external video on CI environment
+      linkIssue(21589);
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+    });
+
+    test('External video loads correctly after new user joins the meeting', async ({
+      browser,
+      context,
+      page,
+    }, testInfo) => {
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+      await presentation.initUserPage2(context, { testInfo });
+      await presentation.checkVideoAfterUserJoins();
+    });
+
+    test('Pause External video', async ({ browser, context, page }, testInfo) => {
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+      await presentation.pauseExternalVideo();
+    });
+
+    test('Change presenter while playing external video', async ({ browser, context, page }, testInfo) => {
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+      await presentation.changePresenterWhileVideoPlaying();
+    });
+
+    test('End External video', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+      await presentation.endExternalVideo();
+    });
   });
 
   test.describe.parallel('Manage', () => {

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -63,10 +63,10 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.selectSlide();
   });
 
-  test.describe.parallel('External Video', () => {
+  // All external video tests (youtube) require logged user to start external video on CI environment
+  test.describe.parallel('External Video', { tag: '@flaky' }, () => {
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#start-youtube-video-sharing
-    test('Start external video', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
-      // requiring logged user to start external video on CI environment
+    test('Start external video', async ({ browser, context, page }, testInfo) => {
       linkIssue(21589);
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, testInfo);
@@ -99,7 +99,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
       await presentation.changePresenterWhileVideoPlaying();
     });
 
-    test('End External video', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
+    test('End External video', async ({ browser, context, page }, testInfo) => {
       const presentation = new Presentation(browser, context);
       await presentation.initPages(page, testInfo);
       await presentation.startExternalVideo();

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -175,6 +175,7 @@ export class Presentation extends MultiUsers {
     await this.userPage.closeAllToastNotifications();
 
     const userFrame = await this.userPage.getYoutubeFrame();
+    if (!userFrame) throw Error('Failed to get video frame element');
 
     await userFrame.hasElement('video', 'should display the element frame for the video that is being shared');
     await this.modPage.wasRemoved(

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -1,6 +1,12 @@
 import { expect } from '@playwright/test';
 
-import { CI, ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, UPLOAD_PDF_WAIT_TIME } from '../core/constants';
+import {
+  CI,
+  ELEMENT_WAIT_EXTRA_LONG_TIME,
+  ELEMENT_WAIT_LONGER_TIME,
+  ELEMENT_WAIT_TIME,
+  UPLOAD_PDF_WAIT_TIME,
+} from '../core/constants';
 import { elements as e } from '../core/elements';
 import { checkNotificationText } from '../notifications/util';
 import { MultiUsers } from '../user/multiusers';
@@ -121,7 +127,9 @@ export class Presentation extends MultiUsers {
     await this.modPage.waitAndClick(e.startShareVideoBtn);
 
     const modFrame = await this.modPage.getYoutubeFrame();
+    if (!modFrame) throw Error('Failed to get video frame element for moderator');
     const userFrame = await this.userPage.getYoutubeFrame();
+    if (!userFrame) throw Error('Failed to get video frame element for attendee');
 
     await modFrame.hasElement(
       'video',
@@ -131,6 +139,58 @@ export class Presentation extends MultiUsers {
       'video',
       'should display the element frame for the video that is being shared for the attendee',
     );
+  }
+
+  async checkVideoAfterUserJoins() {
+    await this.modPage.page.waitForTimeout(ELEMENT_WAIT_LONGER_TIME);
+
+    const user2Frame = await this.userPage2.getYoutubeFrame();
+    if (!user2Frame) throw Error('Failed to get video frame element for attendee 2');
+    await user2Frame.hasElement(
+      'video',
+      'should display the element frame for the video that is being shared for the attendee',
+    );
+  }
+
+  async pauseExternalVideo() {
+    const modFrame = await this.modPage.getYoutubeFrame();
+    if (!modFrame) throw Error('Failed to get video frame element');
+
+    await modFrame.hasElement('video', 'should display the video element before pausing');
+
+    const playButton = modFrame.frame.locator('.ytp-play-button');
+    await playButton.waitFor({ state: 'visible', timeout: 5000 });
+
+    await expect(playButton).toHaveAttribute('data-title-no-tooltip', 'Pause');
+
+    await playButton.click();
+    await this.modPage.page.waitForTimeout(ELEMENT_WAIT_TIME);
+
+    await expect(playButton).toHaveAttribute('data-title-no-tooltip', 'Play');
+  }
+
+  async changePresenterWhileVideoPlaying() {
+    await this.modPage.waitAndClick(e.userListItem);
+    await this.modPage.waitAndClick(e.makePresenter);
+    await this.userPage.closeAllToastNotifications();
+
+    const userFrame = await this.userPage.getYoutubeFrame();
+
+    await userFrame.hasElement('video', 'should display the element frame for the video that is being shared');
+    await this.modPage.wasRemoved(
+      e.stopExternalVideoBtn,
+      'should remove the stop external video button from the moderator when presenter change',
+    );
+
+    await this.userPage.hasElement(
+      e.stopExternalVideoBtn,
+      'should display the stop external video button for the new presenter',
+    );
+  }
+
+  async endExternalVideo() {
+    await this.modPage.waitAndClick(e.stopExternalVideoBtn);
+    await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard after stopping the external video');
   }
 
   async uploadSinglePresentationTest() {


### PR DESCRIPTION
### What does this PR do?
This PR adds test coverage for external video (YouTube) functionality in BigBlueButton, including video playback controls, pause validation, presenter change scenarios, and video termination. The tests validate that external video sharing works correctly across different user roles and that video state is properly synchronized between moderator and attendees.

#### Changes Made
- Added `pauseExternalVideo()` test method that validates video pause functionality by checking the YouTube player's native `data-title-no-tooltip` attribute on the play/pause button
- Added `changePresenterWhileVideoPlaying()` test method that validates presenter change during active external video playback and verifies control button visibility changes
- Added `endExternalVideo()` test method that validates stopping external video sharing and returning to whiteboard view
- Added `stopExternalVideoBtn` selector to `elements.ts` 
- Enhanced `startExternalVideo()` and `checkVideoAfterUserJoins()` methods with better error handling using explicit null checks
- Created three new test cases in `presentation.spec.ts`:
  - "Pause External video" - validates video pause state
  - "Change presenter while playing external video" - validates presenter handoff
  - "End External video" - validates video termination (marked as @flaky)

### Closes Issue(s)

Closes #24457


### How to test
1. Run playwright presentation tests with:
   ```bash
   npm run test:filter "External Video"
   ```
   or run specific external video tests using:
   ```bash
   npm run test:filter "Pause External video"
   npm run test:filter "Change presenter while playing external video"
   npm run test:filter "End External video"
   ```
2. Confirm that the external video tests pass and UI behaves as expected:
   - Video should pause when clicked and button tooltip should change to "Play"
   - When presenter changes, video should remain playing and controls should transfer to new presenter
   - When video is stopped, whiteboard should be displayed again
