### PR TITLE
build(livekit): remove logging.level: debug from after-install

### DIFF
--- a/build/packages-template/bbb-livekit/after-install.sh
+++ b/build/packages-template/bbb-livekit/after-install.sh
@@ -8,8 +8,6 @@ if [ ! -f /etc/bigbluebutton/livekit.yaml ]; then
 # This file will be merged with /usr/share/livekit-server/livekit.yaml
 # on startup. Settings specified here will take  precedence.
 
-logging:
-  level: debug
 keys:
   $API_KEY: $API_SECRET
 webhook:


### PR DESCRIPTION
### What does this PR do?

- [build(livekit): remove logging.level: debug from after-install](https://github.com/bigbluebutton/bigbluebutton/commit/0824b1f6e505dfcdfadbffe744d1436647204b3c) 
  - bbb-livekit's after-install script is explicitly setting up the
override config file with logging.level: debug. This is not
necessary.
  - Defer to the main config file which sets logging.level: info

### Closes Issue(s)

None