### PR TITLE
chore (gql-middleware): Introduce a config to dump queries to files (for debugging)

### DIFF
--- a/bbb-graphql-middleware/config/Config.go
+++ b/bbb-graphql-middleware/config/Config.go
@@ -59,6 +59,7 @@ type Config struct {
 	} `yaml:"session_vars_hook"`
 	LogLevel                         string `yaml:"log_level"`
 	PrometheusAdvancedMetricsEnabled bool   `yaml:"prometheus_advanced_metrics_enabled"`
+	DumpQueriesDir                   string `yaml:"dump_queries_dir"`
 }
 
 func GetConfig() *Config {

--- a/bbb-graphql-middleware/config/config.yml
+++ b/bbb-graphql-middleware/config/config.yml
@@ -41,3 +41,5 @@ session_vars_hook:
   url: http://127.0.0.1:8901/userInfo
 prometheus_advanced_metrics_enabled: false
 log_level: INFO
+# If set, all received queries will be dumped to the specified path, e.g /tmp/queries-dump
+dump_queries_dir:

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -24,6 +25,8 @@ var (
 	allowedSubscriptions []string
 	deniedSubscriptions  []string
 	jsonPatchDisabled    = config.GetConfig().Server.JsonPatchDisabled
+	dumpQueriesDir       = ""
+	dumpQueriesCounter   = make(map[string]int)
 )
 
 func init() {
@@ -33,6 +36,9 @@ func init() {
 
 	if config.GetConfig().Server.SubscriptionsDeniedList != "" {
 		deniedSubscriptions = strings.Split(config.GetConfig().Server.SubscriptionsDeniedList, ",")
+	}
+	if config.GetConfig().DumpQueriesDir != "" {
+		dumpQueriesDir = config.GetConfig().DumpQueriesDir
 	}
 }
 
@@ -231,9 +237,21 @@ RangeLoop:
 						Inc()
 
 					// Dump of all subscriptions for analysis purpose
-					// queryCounter++
-					// saveItToFile(fmt.Sprintf("%02d-%s-%s", queryCounter, string(messageType), browserMessage.Payload.OperationName), fromBrowserMessage)
-					// saveItToFile(fmt.Sprintf("%s-%s-%02s", string(messageType), operationName, queryId), fromBrowserMessage)
+					if dumpQueriesDir != "" {
+						if _, exists := dumpQueriesCounter[browserConnection.Id]; !exists {
+							dumpQueriesCounter[browserConnection.Id] = 1
+						} else {
+							dumpQueriesCounter[browserConnection.Id]++
+						}
+
+						if errSavingQueryDump := saveContentToFile(
+							fmt.Sprintf("/%s/%s", common.GetUniqueID(), browserConnection.Id),
+							fmt.Sprintf("%02d-%s-%s", dumpQueriesCounter[browserConnection.Id], string(messageType), browserMessage.Payload.OperationName),
+							fromBrowserMessage,
+						); errSavingQueryDump != nil {
+							hc.BrowserConn.Logger.Error(errSavingQueryDump)
+						}
+					}
 				}
 
 				if browserMessage.Type == "complete" {
@@ -283,26 +301,34 @@ RangeLoop:
 	}
 }
 
-//
-//var queryCounter = 0
-//
-//func saveItToFile(filename string, contentInBytes []byte) {
-//	filePath := fmt.Sprintf("/tmp/%s.txt", filename)
-//	//message, err := json.Marshal(contentInBytes)
-//
-//	fmt.Printf("Saving %s\n", filePath)
-//
-//	file, err := os.Create(filePath)
-//	if err != nil {
-//		panic(err)
-//	}
-//	defer file.Close()
-//
-//	_, err = file.Write(contentInBytes)
-//	if err != nil {
-//		panic(err)
-//	}
-//}
+func saveContentToFile(subDir string, filename string, contentInBytes []byte) error {
+	fileDir := fmt.Sprintf("%s/%s", dumpQueriesDir, subDir)
+	filePath := fmt.Sprintf("%s/%s.txt", fileDir, filename)
+
+	if _, err := os.Stat(fileDir); os.IsNotExist(err) {
+		// Create directory (and parents if needed)
+		err := os.MkdirAll(fileDir, 0o755)
+		if err != nil {
+			return fmt.Errorf("error creating directory: %v", err)
+		}
+		fmt.Println("Directory created:", fileDir)
+	} else if err != nil {
+		return fmt.Errorf("error checking directory: %v", err)
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("error creating query dump: %v", err)
+	}
+	defer file.Close()
+
+	_, err = file.Write(contentInBytes)
+	if err != nil {
+		return fmt.Errorf("error writing query dump: %v", err)
+	}
+
+	return nil
+}
 
 func calculateQueryDepth(query string) (int, error) {
 	src := source.NewSource(&source.Source{

--- a/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/writer/writer.go
@@ -22,11 +22,12 @@ import (
 )
 
 var (
-	allowedSubscriptions []string
-	deniedSubscriptions  []string
-	jsonPatchDisabled    = config.GetConfig().Server.JsonPatchDisabled
-	dumpQueriesDir       = ""
-	dumpQueriesCounter   = make(map[string]int)
+	allowedSubscriptions    []string
+	deniedSubscriptions     []string
+	jsonPatchDisabled       = config.GetConfig().Server.JsonPatchDisabled
+	dumpQueriesDir          = ""
+	dumpQueriesCounter      = make(map[string]int)
+	dumpQueriesCounterMutex sync.RWMutex
 )
 
 func init() {
@@ -238,15 +239,18 @@ RangeLoop:
 
 					// Dump of all subscriptions for analysis purpose
 					if dumpQueriesDir != "" {
+						dumpQueriesCounterMutex.Lock()
 						if _, exists := dumpQueriesCounter[browserConnection.Id]; !exists {
 							dumpQueriesCounter[browserConnection.Id] = 1
 						} else {
 							dumpQueriesCounter[browserConnection.Id]++
 						}
+						counterValue := dumpQueriesCounter[browserConnection.Id]
+						dumpQueriesCounterMutex.Unlock()
 
 						if errSavingQueryDump := saveContentToFile(
 							fmt.Sprintf("/%s/%s", common.GetUniqueID(), browserConnection.Id),
-							fmt.Sprintf("%02d-%s-%s", dumpQueriesCounter[browserConnection.Id], string(messageType), browserMessage.Payload.OperationName),
+							fmt.Sprintf("%02d-%s-%s", counterValue, string(messageType), strings.ReplaceAll(browserMessage.Payload.OperationName, "/", "_")),
 							fromBrowserMessage,
 						); errSavingQueryDump != nil {
 							hc.BrowserConn.Logger.Error(errSavingQueryDump)
@@ -311,7 +315,6 @@ func saveContentToFile(subDir string, filename string, contentInBytes []byte) er
 		if err != nil {
 			return fmt.Errorf("error creating directory: %v", err)
 		}
-		fmt.Println("Directory created:", fileDir)
 	} else if err != nil {
 		return fmt.Errorf("error checking directory: %v", err)
 	}


### PR DESCRIPTION
Add a new configuration option `dump_queries_dir` to the GraphQL Middleware.
When enabled, it saves every received query to a file at the path:
`/middlewareID/browserConnectionID/count+messageType+operationName.txt`.

<img width="1432" height="1472" alt="image" src="https://github.com/user-attachments/assets/47d8616b-f1fa-4252-b3ab-5b560778b904" />

This feature allows inspecting all queries executed by the browser and is especially useful for the stress-test client, which can use the queries to simulate real browser behavior to help reproduce and analyze database performance issues.