### PR TITLE
Fix(akka, html5): Prevent upload error notifications when converting breakout rooms with no changes

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -44,6 +44,8 @@ class WhiteboardModel extends SystemConfiguration {
     }).toMap
 
   def addAnnotations(wbId: String, meetingId: String, userId: String, annotations: Array[AnnotationVO], isPresenter: Boolean, isModerator: Boolean): Array[AnnotationVO] = {
+    println("=== wbId:", wbId)
+
     val wb = getWhiteboard(wbId)
 
     var annotationsAdded = Array[AnnotationVO]()

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/WhiteboardModel.scala
@@ -44,7 +44,6 @@ class WhiteboardModel extends SystemConfiguration {
     }).toMap
 
   def addAnnotations(wbId: String, meetingId: String, userId: String, annotations: Array[AnnotationVO], isPresenter: Boolean, isModerator: Boolean): Array[AnnotationVO] = {
-    println("=== wbId:", wbId)
 
     val wb = getWhiteboard(wbId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
@@ -46,7 +46,6 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
         theMeetingHasNoChanges = false
       }
     })
-    println("=== theMeetingHasNoChanges:", theMeetingHasNoChanges)
     if (theMeetingHasNoChanges) {
       val notifyEvent = MsgBuilder.buildNotifyRoleInMeetingEvtMsg(
         Roles.PRESENTER_ROLE,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
@@ -19,7 +19,7 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
   val eventBus: InternalEventBus
 
   def handleEndBreakoutRoomInternalMsg(msg: EndBreakoutRoomInternalMsg, state: MeetingState2x): Unit = {
-    var theMeetingHasNoChanges = true
+    var noContentToImportFromRoom = liveMeeting.props.breakoutProps.captureSlides || liveMeeting.props.breakoutProps.captureNotes
 
     if (liveMeeting.props.breakoutProps.captureSlides) {
       val allPods = state.presentationPodManager.getAllPresentationPodsInMeeting()
@@ -36,23 +36,23 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
         val filename = liveMeeting.props.breakoutProps.captureSlidesFilename
         val captureSlidesEvent = BigBlueButtonEvent(msg.breakoutId, CapturePresentationReqInternalMsg("system", msg.parentId, filename))
         eventBus.publish(captureSlidesEvent)
-        theMeetingHasNoChanges = false
+        noContentToImportFromRoom = false
       }
     }
 
     Pads.getGroup(liveMeeting.pads, "notes").foreach(group => {
       if (liveMeeting.props.breakoutProps.captureNotes && group.rev > 0) {
         handleCaptureNotes(msg)
-        theMeetingHasNoChanges = false
+        noContentToImportFromRoom = false
       }
     })
-    if (theMeetingHasNoChanges) {
+    if (noContentToImportFromRoom) {
       val notifyEvent = MsgBuilder.buildNotifyRoleInMeetingEvtMsg(
-        Roles.PRESENTER_ROLE,
+        Roles.MODERATOR_ROLE,
         msg.parentId,
         "info",
         "rooms",
-        "app.toast.breakoutHadNoChanges",
+        "app.toast.breakoutContentUnchangedNotConverted",
         "Message informing that breakout room had no changes to capture.",
         Map()
       )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
@@ -4,11 +4,12 @@ import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg,
 import org.bigbluebutton.core.api.{ CapturePresentationReqInternalMsg, EndBreakoutRoomInternalMsg }
 import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
 import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
-import org.bigbluebutton.core.db.PresPresentationDAO
-import org.bigbluebutton.core.models.{ Pads, PresentationInPod, PresentationPage, PresentationPod }
+import org.bigbluebutton.core.db.{ NotificationDAO, PresPresentationDAO }
+import org.bigbluebutton.core.models.{ Pads, PresentationInPod, PresentationPage, PresentationPod, Roles }
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.PresentationInPod.getCurrentPage
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
   this: BaseMeetingActor =>
@@ -18,7 +19,8 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
   val eventBus: InternalEventBus
 
   def handleEndBreakoutRoomInternalMsg(msg: EndBreakoutRoomInternalMsg, state: MeetingState2x): Unit = {
-    println("=== Handling EndBreakoutRoomInternalMsg for breakoutId=" + msg.breakoutId + ", parentId=" + msg.parentId)
+    var theMeetingHasNoChanges = true
+
     if (liveMeeting.props.breakoutProps.captureSlides) {
       val allPods = state.presentationPodManager.getAllPresentationPodsInMeeting()
 
@@ -32,21 +34,31 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
 
       if (hasAnnotations) {
         val filename = liveMeeting.props.breakoutProps.captureSlidesFilename
-        println(s"=== captureSlides: triggering capture with filename=${filename}")
         val captureSlidesEvent = BigBlueButtonEvent(msg.breakoutId, CapturePresentationReqInternalMsg("system", msg.parentId, filename))
         eventBus.publish(captureSlidesEvent)
-      } else {
-        println(s"=== captureSlides: skipping capture - no annotations found in any presentation")
+        theMeetingHasNoChanges = false
       }
     }
 
     Pads.getGroup(liveMeeting.pads, "notes").foreach(group => {
-      println("=== group:", group)
-
       if (liveMeeting.props.breakoutProps.captureNotes && group.rev > 0) {
         handleCaptureNotes(msg)
+        theMeetingHasNoChanges = false
       }
     })
+    println("=== theMeetingHasNoChanges:", theMeetingHasNoChanges)
+    if (theMeetingHasNoChanges) {
+      val notifyEvent = MsgBuilder.buildNotifyRoleInMeetingEvtMsg(
+        Roles.PRESENTER_ROLE,
+        msg.parentId,
+        "info",
+        "rooms",
+        "app.toast.breakoutHadNoChanges",
+        "Message informing that breakout room had no changes to capture.",
+        Map()
+      )
+      outGW.send(notifyEvent)
+    }
 
     log.info("Breakout room {} ended by parent meeting {}.", msg.breakoutId, msg.parentId)
     sendEndMeetingDueToExpiry(msg.reason, eventBus, outGW, liveMeeting, "system")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/EndBreakoutRoomInternalMsgHdlr.scala
@@ -4,9 +4,11 @@ import org.bigbluebutton.common2.msgs.{ BbbClientMsgHeader, BbbCommonEnvCoreMsg,
 import org.bigbluebutton.core.api.{ CapturePresentationReqInternalMsg, EndBreakoutRoomInternalMsg }
 import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
 import org.bigbluebutton.core.bus.{ BigBlueButtonEvent, InternalEventBus }
-import org.bigbluebutton.core.db.{ PresPresentationDAO }
+import org.bigbluebutton.core.db.PresPresentationDAO
 import org.bigbluebutton.core.models.{ Pads, PresentationInPod, PresentationPage, PresentationPod }
 import org.bigbluebutton.core.running.{ BaseMeetingActor, HandlerHelpers, LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core.domain.MeetingState2x
+import org.bigbluebutton.core.models.PresentationInPod.getCurrentPage
 
 trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
   this: BaseMeetingActor =>
@@ -15,16 +17,36 @@ trait EndBreakoutRoomInternalMsgHdlr extends HandlerHelpers {
   val outGW: OutMsgRouter
   val eventBus: InternalEventBus
 
-  def handleEndBreakoutRoomInternalMsg(msg: EndBreakoutRoomInternalMsg): Unit = {
+  def handleEndBreakoutRoomInternalMsg(msg: EndBreakoutRoomInternalMsg, state: MeetingState2x): Unit = {
+    println("=== Handling EndBreakoutRoomInternalMsg for breakoutId=" + msg.breakoutId + ", parentId=" + msg.parentId)
     if (liveMeeting.props.breakoutProps.captureSlides) {
-      val filename = liveMeeting.props.breakoutProps.captureSlidesFilename
-      val captureSlidesEvent = BigBlueButtonEvent(msg.breakoutId, CapturePresentationReqInternalMsg("system", msg.parentId, filename))
-      eventBus.publish(captureSlidesEvent)
+      val allPods = state.presentationPodManager.getAllPresentationPodsInMeeting()
+
+      val hasAnnotations = allPods.exists { pod =>
+        pod.presentations.values.exists { pres =>
+          pres.pages.values.exists { page =>
+            liveMeeting.wbModel.getWhiteboard(page.id).annotationsMap.nonEmpty
+          }
+        }
+      }
+
+      if (hasAnnotations) {
+        val filename = liveMeeting.props.breakoutProps.captureSlidesFilename
+        println(s"=== captureSlides: triggering capture with filename=${filename}")
+        val captureSlidesEvent = BigBlueButtonEvent(msg.breakoutId, CapturePresentationReqInternalMsg("system", msg.parentId, filename))
+        eventBus.publish(captureSlidesEvent)
+      } else {
+        println(s"=== captureSlides: skipping capture - no annotations found in any presentation")
+      }
     }
 
-    if (liveMeeting.props.breakoutProps.captureNotes) {
-      handleCaptureNotes(msg)
-    }
+    Pads.getGroup(liveMeeting.pads, "notes").foreach(group => {
+      println("=== group:", group)
+
+      if (liveMeeting.props.breakoutProps.captureNotes && group.rev > 0) {
+        handleCaptureNotes(msg)
+      }
+    })
 
     log.info("Breakout room {} ended by parent meeting {}.", msg.breakoutId, msg.parentId)
     sendEndMeetingDueToExpiry(msg.reason, eventBus, outGW, liveMeeting, "system")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -307,7 +307,7 @@ class MeetingActor(
     case msg: BreakoutRoomCreatedInternalMsg       => state = handleBreakoutRoomCreatedInternalMsg(msg, state)
     case msg: SendBreakoutUsersAuditInternalMsg    => handleSendBreakoutUsersUpdateInternalMsg(msg)
     case msg: BreakoutRoomUsersUpdateInternalMsg   => state = handleBreakoutRoomUsersUpdateInternalMsg(msg, state)
-    case msg: EndBreakoutRoomInternalMsg           => handleEndBreakoutRoomInternalMsg(msg)
+    case msg: EndBreakoutRoomInternalMsg           => handleEndBreakoutRoomInternalMsg(msg, state)
     case msg: UpdateBreakoutRoomTimeInternalMsg    => state = handleUpdateBreakoutRoomTimeInternalMsgHdlr(msg, state)
     case msg: EjectUserFromBreakoutInternalMsg     => handleEjectUserFromBreakoutInternalMsgHdlr(msg)
     case msg: BreakoutRoomEndedInternalMsg         => state = handleBreakoutRoomEndedInternalMsg(msg, state)

--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -27,7 +27,7 @@ const Notifications: React.FC = () => {
         'app.notification.userJoinPushAlert': userJoinPushAlert,
         'app.notification.userLeavePushAlert': userLeavePushAlert,
         'app.layoutUpdate.label': layoutUpdate,
-        'app.toast.breakoutHadNoChanges': breakoutHadNoChanges,
+        'app.toast.breakoutContentUnchangedNotConverted': breakoutHadNoChanges,
       });
 
   const {

--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -5,6 +5,7 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import { notify } from '../../services/notification';
 import {
   NotifyPublishedPoll,
+  breakoutHadNoChanges,
   layoutUpdate,
   pendingGuestAlert,
   userJoinPushAlert,
@@ -26,6 +27,7 @@ const Notifications: React.FC = () => {
         'app.notification.userJoinPushAlert': userJoinPushAlert,
         'app.notification.userLeavePushAlert': userLeavePushAlert,
         'app.layoutUpdate.label': layoutUpdate,
+        'app.toast.breakoutHadNoChanges': breakoutHadNoChanges,
       });
 
   const {

--- a/bigbluebutton-html5/imports/ui/components/notifications/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/service.ts
@@ -7,6 +7,8 @@ const GUEST_WAITING_BELL_THROTTLE_TIME = 10000;
 
 const lastLayoutUpdateNotification = makeVar(new Date().getTime());
 
+const lastBreakoutHadNoChangesNotification = makeVar(new Date().getTime());
+
 export const NotifyPublishedPoll = (
   notification: Notification,
   notifier: (notification: Notification) => void,
@@ -117,10 +119,24 @@ export const layoutUpdate = (
   notifier(notification);
 };
 
+export const breakoutHadNoChanges = (
+  notification: Notification,
+  notifier: (notification: Notification) => void,
+) => {
+  const last = new Date(lastBreakoutHadNoChangesNotification()).getTime();
+  const now = new Date().getTime();
+  if (now - last < 1000) {
+    return;
+  }
+  lastBreakoutHadNoChangesNotification(now);
+  notifier(notification);
+};
+
 export default {
   NotifyPublishedPoll,
   pendingGuestAlert,
   userJoinPushAlert,
   userLeavePushAlert,
   layoutUpdate,
+  breakoutHadNoChanges,
 };

--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -18,6 +18,7 @@ export function notify(message, type = 'default', icon, options, content, small)
   };
 
   const { id: lastToastId, ...lastToastProps } = lastToast;
+
   const toastProps = {
     message,
     type,
@@ -26,7 +27,8 @@ export function notify(message, type = 'default', icon, options, content, small)
     small,
   };
 
-  if (!toast.isActive(lastToast.id) || !isEqual(lastToastProps, toastProps)) {
+  if (!toast.isActive(lastToast.id) || !isEqual(JSON.stringify(lastToastProps),
+    JSON.stringify(toastProps))) {
     if (options?.helpLink != null && options?.helpLabel != null) {
       const id = toast(
         <div role="alert">

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1003,6 +1003,7 @@
     "app.userList.guest.feedbackMessage": "Action applied: ",
     "app.user-info.title": "Directory Lookup",
     "app.toast.breakoutRoomEnded": "The breakout room ended.  Please rejoin in the audio.",
+    "app.toast.breakoutHadNoChanges": "One or more breakout rooms had no changes to be converted.",
     "app.toast.chat.public": "New Public Chat message",
     "app.toast.chat.private": "New Private Chat message",
     "app.toast.chat.system": "System",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1003,7 +1003,7 @@
     "app.userList.guest.feedbackMessage": "Action applied: ",
     "app.user-info.title": "Directory Lookup",
     "app.toast.breakoutRoomEnded": "The breakout room ended.  Please rejoin in the audio.",
-    "app.toast.breakoutHadNoChanges": "One or more breakout rooms had no changes to be converted.",
+    "app.toast.breakoutContentUnchangedNotConverted": "One or more breakout rooms had no whiteboard/shared notes updates, so they weren't converted to slides.",
     "app.toast.chat.public": "New Public Chat message",
     "app.toast.chat.private": "New Private Chat message",
     "app.toast.chat.system": "System",


### PR DESCRIPTION
### What does this PR do?
When a breakout room is configured to capture slides or notes, but participants do not interact with them during the meeting, no files are generated for conversion. However, the server was still attempting to publish this non-existent content, resulting in upload error notifications.

This PR adds conditional checks to each conversion handler so that publishing only occurs when there is actual content to process. If no changes were made during the meeting, the system now sends a simple notification to the presenter informing them that the meeting did not generate any content.


### Closes Issue(s)
Closes #24395

### How to test
1. Join with ModA
2. Create a Breakout Room
3. Join a Breakout Room
4. End all Breakouts


### More
Before:

[before.webm](https://github.com/user-attachments/assets/a575f372-bcf2-40ae-9b51-dcf2b8fae9a4)


After:

[after.webm](https://github.com/user-attachments/assets/72a6d263-6ab1-49f7-9a23-c17bdc13369c)

