### PR TITLE
fix(html5): locked shared notes + small fixes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -60,7 +60,6 @@ const Input = styled(TextareaAutosize)<InputProps>`
   border: ${colorBorder};
   box-shadow: none;
   outline: none;
-  align-content: center;
 
   &::-webkit-scrollbar {
     width: 5px;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -87,8 +87,14 @@ const Chat: React.FC<ChatProps> = ({
         type: ACTIONS.SET_ID_CHAT_OPEN,
         value: PUBLIC_GROUP_CHAT_ID,
       });
-    } else {
+    } else if (filteredPrivateChats.length > 0) {
       setPrivateList(true);
+    } else {
+      // no private chat was started, go back to public chat
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: PUBLIC_GROUP_CHAT_ID,
+      });
     }
   };
 
@@ -167,7 +173,7 @@ const Chat: React.FC<ChatProps> = ({
     );
   };
 
-  const privateChatButtonLabel = isPrivateChat
+  const privateChatButtonLabel = isPrivateChat && !privateList
     ? intl.formatMessage(intlMessages.titlePrivateToUser, { participantName })
     : intl.formatMessage(intlMessages.titlePrivate);
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
@@ -15,6 +15,7 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
   label,
   hasNotification = false,
   isDisabled = false,
+  isLocked = false,
   accessKey,
   dataTest,
   id,
@@ -87,6 +88,7 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
         onKeyDown={handleKeyDown}
         $hasNotification={hasNotification}
         $disabled={isDisabled}
+        $locked={isLocked}
       >
         {children}
         <Icon iconName={iconName} />

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
@@ -88,6 +88,12 @@ export const ListItem = styled.div<ListItemProps>`
     background-color: ${colorGrayLightest};
   `}
 
+  ${({ $locked }) => $locked && `
+    cursor: normal;
+    border: none;
+    background-color: ${colorGrayLightest};
+  `}
+
   :disabled {
     border: none;
   }

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/types.ts
@@ -8,6 +8,7 @@ export interface SidebarNavigationButtonProps {
   label: string;
   hasNotification?: boolean;
   isDisabled?: boolean;
+  isLocked?: boolean;
   accessKey?: string;
   dataTest?: string;
   id?: string;
@@ -22,4 +23,5 @@ export interface ListItemProps {
   $active?: boolean;
   $hasNotification?: boolean;
   $disabled?: boolean;
+  $locked?: boolean;
 }

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState, memo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import Icon from '/imports/ui/components/common/icon/component';
 import NotesService from '/imports/ui/components/notes/service';
 import { notify } from '/imports/ui/services/notification';
-import Styled from './styles';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 import useHasUnreadNotes from '/imports/ui/components/notes/hooks/useHasUnreadNotes';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
@@ -77,7 +75,9 @@ const UserNotesListItemContainerGraphql: React.FC<BaseSidebarButtonProps> = (pro
   });
 
   const notesOpen = isOpened && !isPinned;
-  const label = intl.formatMessage(isPinned ? intlMessages.sharedNotesPinned : intlMessages.sharedNotes);
+  const label = disableNotes
+    ? `${intl.formatMessage(intlMessages.locked)} ${intl.formatMessage(intlMessages.byModerator)}`
+    : intl.formatMessage(isPinned ? intlMessages.sharedNotesPinned : intlMessages.sharedNotes);
   if (!isEnabled) return null;
   return (
     <SidebarNavigationButton
@@ -89,20 +89,9 @@ const UserNotesListItemContainerGraphql: React.FC<BaseSidebarButtonProps> = (pro
       ariaDescribedBy="lockedNotes"
       dataTest="sharedNotesSidebarButton"
       hasNotification={hasUnreadNotes}
-      isDisabled={disableNotes || isPinned}
-    >
-      {disableNotes
-        ? (
-          <Styled.NotesLock>
-            {/* @ts-ignore */}
-            <span id="lockedNotes">
-              <Icon iconName="lock" />
-              &nbsp;
-              {`${intl.formatMessage(intlMessages.locked)} ${intl.formatMessage(intlMessages.byModerator)}`}
-            </span>
-          </Styled.NotesLock>
-        ) : null}
-    </SidebarNavigationButton>
+      isDisabled={isPinned}
+      isLocked={disableNotes}
+    />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/component.tsx
@@ -139,7 +139,7 @@ const UserList: React.FC<UserListComponentProps> = () => {
   }, [layoutContextDispatch]);
 
   const title = hideUserList
-    ? intl.formatMessage(intlMessages.hideUserListTitle, { moderatorCount: count })
+    ? intl.formatMessage(intlMessages.hideUserListTitle, { userCount: count })
     : intl.formatMessage(intlMessages.usersTitle, { userCount: count });
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/component.tsx
@@ -57,7 +57,7 @@ const CrowdActionButtons: React.FC<CrowdActionButtonsProps> = () => {
     <>
       {lockViewersModal.isOpen && (
         <LockViewersContainer
-          onRequestClose={() => lockViewersModal.close}
+          onRequestClose={() => lockViewersModal.close()}
           isOpen={lockViewersModal.isOpen}
           setIsOpen={lockViewersModal.close}
         />

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1190,7 +1190,7 @@
     "app.lock-viewers.button.cancel": "Cancel",
     "app.lock-viewers.locked": "Locked",
     "app.lock-viewers.hideViewersCursor": "Seeing other participants' cursors on the whiteboard.",
-    "app.lock-viewers.hideAnnotationsLabel": "Seeing other participants' shared notes.",
+    "app.lock-viewers.hideAnnotationsLabel": "Seeing other participants' annotations on the whiteboard.",
     "app.guest-policy.ariaTitle": "Guest policy settings modal",
     "app.guest-policy.title": "Guest policy",
     "app.guest-policy.description": "Change session guest policy setting",

--- a/bigbluebutton-html5/public/locales/pt_BR.json
+++ b/bigbluebutton-html5/public/locales/pt_BR.json
@@ -160,7 +160,7 @@
     "app.userList.usersTitle": "Usuários ({userCount})",
     "app.userList.usersStaticTitle": "Lista de Usuários",
     "app.userList.profileTitle": "Perfil",
-    "app.userList.lockedUsersTitle": "Moderadores ({moderatorCount})",
+    "app.userList.lockedUsersTitle": "Moderadores ({userCount})",
     "app.userList.participantsTitle": "Participantes",
     "app.userList.learningDashboardLabel": "Painel Analítico de Aprendizagem",
     "app.userList.settingsTitle": "Configurações",


### PR DESCRIPTION
### What does this PR do?
- Remove wrong label and allow shared notes to be clicked and viewed when locked
- Adjust private chat button label when in private chat list
- Fix locked chat input text not showing correctly
- Fix locked user list title in english
- Fix wrong locale for hideAnnotationsLabel lock settings
- Fix lock settings modal not closing when clicking on x button or clicking outside of it

Some bugs to verify:
<img width="78" height="903" alt="image" src="https://github.com/user-attachments/assets/67f371dd-ea60-4a32-8862-291d3b478266" />
<img width="369" height="77" alt="image" src="https://github.com/user-attachments/assets/25fe250b-7cc6-4c9b-885c-7f4cf3ae9e93" />
<img width="384" height="214" alt="image" src="https://github.com/user-attachments/assets/cee79aa0-a5ce-441e-8604-32733f0c04fc" />

