### PR TITLE
feat(publish-reports): add action to publish Playwright reports to GitHub Pages

### DIFF
--- a/.github/actions/publish-playwright-report/action.yml
+++ b/.github/actions/publish-playwright-report/action.yml
@@ -24,22 +24,32 @@ runs:
         path: reports-repo
     - name: Publish report
       shell: bash
+      env:
+        REPORT_PATH: ${{ inputs.report-path }}
+        PR_NUMBER: ${{ inputs.pr-number }}
       run: |
         set -euo pipefail
-        if [ ! -d "${{ inputs.report-path }}" ]; then
-          echo "Report path not found: ${{ inputs.report-path }}"
+
+        # Validate PR_NUMBER is strictly numeric
+        if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+          echo "Invalid PR number: must be numeric"
           exit 1
         fi
-        dest_dir="reports-repo/pr-${{ inputs.pr-number }}"
+        if [ ! -d "$REPORT_PATH" ]; then
+          echo "Report path not found: $REPORT_PATH"
+          exit 1
+        fi
+
+        dest_dir="reports-repo/pr-$PR_NUMBER"
         rm -rf "$dest_dir"
         mkdir -p "$dest_dir"
-        rsync -a --delete "${{ inputs.report-path }}/" "$dest_dir/"
+        rsync -a --delete "$REPORT_PATH/" "$dest_dir/"
         touch reports-repo/.nojekyll
         git -C reports-repo config user.name "github-actions[bot]"
         git -C reports-repo config user.email "github-actions[bot]@users.noreply.github.com"
         if [ -n "$(git -C reports-repo status --porcelain)" ]; then
           git -C reports-repo add .
-          git -C reports-repo commit -m "Add Playwright report for PR #${{ inputs.pr-number }}"
+          git -C reports-repo commit -m "Add Playwright report for PR #$PR_NUMBER"
           git -C reports-repo push
         else
           echo "No changes to publish"

--- a/.github/actions/publish-playwright-report/action.yml
+++ b/.github/actions/publish-playwright-report/action.yml
@@ -1,0 +1,46 @@
+name: Publish Playwright report to external repo
+description: Publish a Playwright HTML report to a separate GitHub Pages repository
+inputs:
+  reports-repo:
+    description: GitHub repository (owner/name) that hosts Playwright reports
+    required: true
+  token:
+    description: Token with contents:write permission on the reports repo
+    required: true
+  pr-number:
+    description: Pull request number used for pr-<number> folder
+    required: true
+  report-path:
+    description: Local path to the Playwright HTML report directory
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Checkout reports repository
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.reports-repo }}
+        token: ${{ inputs.token }}
+        path: reports-repo
+    - name: Publish report
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -d "${{ inputs.report-path }}" ]; then
+          echo "Report path not found: ${{ inputs.report-path }}"
+          exit 1
+        fi
+        dest_dir="reports-repo/pr-${{ inputs.pr-number }}"
+        rm -rf "$dest_dir"
+        mkdir -p "$dest_dir"
+        rsync -a --delete "${{ inputs.report-path }}/" "$dest_dir/"
+        touch reports-repo/.nojekyll
+        git -C reports-repo config user.name "github-actions[bot]"
+        git -C reports-repo config user.email "github-actions[bot]@users.noreply.github.com"
+        if [ -n "$(git -C reports-repo status --porcelain)" ]; then
+          git -C reports-repo add .
+          git -C reports-repo commit -m "Add Playwright report for PR #${{ inputs.pr-number }}"
+          git -C reports-repo push
+        else
+          echo "No changes to publish"
+        fi

--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -101,28 +101,33 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const allArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-            });
-            const report = allArtifacts.find((artifact) => {
-              return artifact.name == "tests-report";
-            });
-            if (!report) {
+            try {
+              const allArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+              });
+              const report = allArtifacts.find((artifact) => {
+                return artifact.name == "tests-report";
+              });
+              if (!report) {
+                core.exportVariable('REPORT_ARTIFACT_FOUND', 'false');
+                console.log('No tests-report artifact found');
+                return;
+              }
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: report.id,
+                archive_format: 'zip',
+              });
+              const fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/tests-report.zip`, Buffer.from(download.data));
+              core.exportVariable('REPORT_ARTIFACT_FOUND', 'true');
+            } catch (error) {
+              console.log('Error fetching or downloading tests-report artifact:', error);
               core.exportVariable('REPORT_ARTIFACT_FOUND', 'false');
-              console.log('No tests-report artifact found');
-              return;
             }
-            const download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: report.id,
-              archive_format: 'zip',
-            });
-            const fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/tests-report.zip`, Buffer.from(download.data));
-            core.exportVariable('REPORT_ARTIFACT_FOUND', 'true');
       - name: Unzip tests report artifact
         if: ${{ env.REPORT_ARTIFACT_FOUND == 'true' }}
         run: unzip tests-report.zip -d tests-report

--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -42,23 +42,23 @@ jobs:
         with:
           script: |
             try {
-              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-                 owner: context.repo.owner,
-                 repo: context.repo.repo,
-                 run_id: context.payload.workflow_run.id,
+              let allArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
               });
-              let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              let matchArtifact = allArtifacts.find((artifact) => {
                 return artifact.name == "pr-comment-data"
-              })[0];
+              });
               if (!matchArtifact) {
                 console.log('No artifact found');
                 return;
               }
               let download = await github.rest.actions.downloadArtifact({
-                 owner: context.repo.owner,
-                 repo: context.repo.repo,
-                 artifact_id: matchArtifact.id,
-                 archive_format: 'zip',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
               });
               let fs = require('fs');
               fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr-comment-data.zip`, Buffer.from(download.data));
@@ -90,10 +90,58 @@ jobs:
   publish-test-results:
     runs-on: ubuntu-latest
     needs: get-pr-data
-    if: ${{ needs.get-pr-data.outputs.pr-number && needs.get-pr-data.outputs.workflow-id }}
+    if: ${{ needs.get-pr-data.outputs.pr-number && needs.get-pr-data.outputs.workflow-id && github.event.workflow_run.status == 'completed' && github.event.workflow_run.conclusion != 'success' }}
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - name: Publish Test Results
-        run: echo "hello world"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Download tests report artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const allArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const report = allArtifacts.find((artifact) => {
+              return artifact.name == "tests-report";
+            });
+            if (!report) {
+              core.exportVariable('REPORT_ARTIFACT_FOUND', 'false');
+              console.log('No tests-report artifact found');
+              return;
+            }
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: report.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/tests-report.zip`, Buffer.from(download.data));
+            core.exportVariable('REPORT_ARTIFACT_FOUND', 'true');
+      - name: Unzip tests report artifact
+        if: ${{ env.REPORT_ARTIFACT_FOUND == 'true' }}
+        run: unzip tests-report.zip -d tests-report
+      - name: Normalize report directory
+        if: ${{ env.REPORT_ARTIFACT_FOUND == 'true' }}
+        run: |
+          if [ -d "tests-report/playwright-report" ]; then
+            echo "REPORT_PATH=tests-report/playwright-report" >> "$GITHUB_ENV"
+          else
+            echo "REPORT_PATH=tests-report" >> "$GITHUB_ENV"
+          fi
+      - name: Publish report to reports repository
+        if: ${{ env.REPORT_ARTIFACT_FOUND == 'true' }}
+        uses: ./.github/actions/publish-playwright-report
+        with:
+          reports-repo: ${{ github.repository_owner }}/bigbluebutton-ci-playwright-reports
+          token: ${{ secrets.PLAYWRIGHT_REPORTS_REPO_TOKEN }}
+          pr-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          report-path: ${{ env.REPORT_PATH }}
   comment-pr:
     runs-on: ubuntu-latest
     permissions:
@@ -145,4 +193,4 @@ jobs:
 
             ___
 
-            [Click here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }}) to check the action test reports (_to view the report locally, see the [docs](https://github.com/bigbluebutton/bigbluebutton/blob/v3.0.x-release/bigbluebutton-tests/playwright/README.md#check-test-results)_)
+            [Click here](https://bigbluebutton.github.io/bigbluebutton-ci-playwright-reports/pr-${{ needs.get-pr-data.outputs.pr-number }}/) to check the action test reports (_to view the report locally, see the [docs](https://github.com/${{ github.repository_owner }}/bigbluebutton/blob/v3.0.x-release/bigbluebutton-tests/playwright/README.md#check-test-results)_)

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -418,7 +418,7 @@ jobs:
             echo "SDK_URL=$SDK_DEP" >> $GITHUB_ENV
           else
             SDK_VERSION=$(jq -r '.packages["node_modules/bigbluebutton-html-plugin-sdk"]["version"]' package-lock.json)
-            echo "SDK_URL=https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/archive/refs/tags/v${SDK_VERSION}.tar.gz" >> $GITHUB_ENV
+            echo "SDK_URL=https://github.com/${{ github.repository_owner }}/bigbluebutton-html-plugin-sdk/archive/refs/tags/v${SDK_VERSION}.tar.gz" >> $GITHUB_ENV
           fi
       - name: Plugins SDK - Download bigbluebutton-html-plugin-sdk.tar.gz
         working-directory: bigbluebutton-tests

--- a/.github/workflows/playwright-reports-cleanup.yml
+++ b/.github/workflows/playwright-reports-cleanup.yml
@@ -1,0 +1,34 @@
+name: Cleanup Playwright reports
+on:
+  pull_request:
+    types:
+      - closed
+jobs:
+  cleanup-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout reports repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/bigbluebutton-ci-playwright-reports
+          token: ${{ secrets.PLAYWRIGHT_REPORTS_REPO_TOKEN }}
+          path: reports-repo
+      - name: Remove PR report
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr_dir="reports-repo/pr-${{ github.event.pull_request.number }}"
+          if [ ! -d "$pr_dir" ]; then
+            echo "No report directory for PR #${{ github.event.pull_request.number }}"
+            exit 0
+          fi
+          rm -rf "$pr_dir"
+          git -C reports-repo config user.name "github-actions[bot]"
+          git -C reports-repo config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ -n "$(git -C reports-repo status --porcelain)" ]; then
+            git -C reports-repo add .
+            git -C reports-repo commit -m "Remove Playwright report for PR #${{ github.event.pull_request.number }}"
+            git -C reports-repo push
+          else
+            echo "No changes to publish"
+          fi


### PR DESCRIPTION
### What does this PR do?
This pull request introduces a new GitHub Action for publishing Playwright HTML reports to an external repository and updates the test results publishing workflow to automate report uploads and improve artifact handling. The workflow now ensures test reports are published only when workflows fail and provides direct links to the published reports.

### Motivation
publishing test reports will ease debugging and provide a quick check on what's making a test fail in CI