### PR TITLE
Fix(html5): talking indicator being covered by webcam

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
@@ -348,7 +348,7 @@ const UnifiedLayout = (props) => {
         );
       }
 
-      cameraDockBounds.top = navBarHeight - bannerAreaHeight();
+      cameraDockBounds.top = navBarHeight + bannerAreaHeight();
       cameraDockBounds.left = mediaAreaBounds.left;
       cameraDockBounds.right = isRTL ? sidebarSize : null;
       cameraDockBounds.minWidth = mediaAreaBounds.width;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
@@ -348,7 +348,7 @@ const UnifiedLayout = (props) => {
         );
       }
 
-      cameraDockBounds.top = navBarHeight;
+      cameraDockBounds.top = navBarHeight - bannerAreaHeight();
       cameraDockBounds.left = mediaAreaBounds.left;
       cameraDockBounds.right = isRTL ? sidebarSize : null;
       cameraDockBounds.minWidth = mediaAreaBounds.width;


### PR DESCRIPTION
### What does this PR do?
This PR fixes the bug of talking indicator being convered by the webcam  it was happening because the unified layout was not considering the notification bar on their calculation adding it fixed the issue.

### Closes Issue(s)
Closes #24448 

### How to test
There's two way to reproduce one it's creating a room with a limited time or creating a breakout 
I was able to reproduce it using the chrome dev tool mobile setting it to "iphone 14 pro max"
1. Create a meeting with the parameter `duaration=15`
2. Join the meeting with a user
3. share a webcam
4. join audio
5. start talking


### More
<img width="548.1" height="686" alt="image" src="https://github.com/user-attachments/assets/daeab08f-c0cb-4cf0-8e59-7213354e9331" />

