### PR TITLE
fix: Leave button opens empty dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/component.jsx
@@ -157,11 +157,20 @@ class LeaveMeetingButton extends PureComponent {
       ismobile,
       isRTL,
       openLeaveMenu,
+      connected,
     } = this.props;
 
     const { isEndMeetingConfirmationModalOpen } = this.state;
 
     const customStyles = { top: '1rem' };
+
+    const actions = this.renderMenuItems();
+
+    if (actions.length === 0 && connected) {
+      return null;
+    }
+
+    const isDisabled = actions.length === 0 && !connected;
 
     return (
       <>
@@ -181,12 +190,14 @@ class LeaveMeetingButton extends PureComponent {
               color="danger"
               size="lg"
               hideLabel
+              disabled={isDisabled}
               // FIXME: Without onClick react proptypes keep warning
               // even after the DropdownTrigger inject an onClick handler
               onClick={() => null}
             />
           )}
-          actions={this.renderMenuItems()}
+          actions={actions}
+          disabled={isDisabled}
           opts={{
             id: 'app-leave-meeting-menu',
             keepMounted: true,


### PR DESCRIPTION
### What does this PR do?

Handles two additional states for the leave meeting button:

1. when there's no actions available due to settings (`public.app.allowLogout: false`) + user role (viewer): button is not displayed
<img width="191" height="120" alt="hidden-button" src="https://github.com/user-attachments/assets/eb8e895f-66c1-41b2-9837-38570c60503a" />

---

2. when there's no actions available due to a temporary network issue: button is disabled

https://github.com/user-attachments/assets/65814c18-528b-49cf-8c38-1aec6d05ca2d



### Closes Issue(s)
Closes #24474
