### PR TITLE
fix(recording): improve raw file resampling to address A/V sync issues (audio)

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -178,9 +178,9 @@ module BigBlueButton
 
               # Build track label
               track_label = "t#{i}_#{idx}"
-              line = "[#{input_index}]#{FFMPEG_AFORMAT},apad,asetpts=N"
-              line << ",atempo=#{speed}" if speed != 1.0
-              line << "[#{track_label}];"
+              line = "[#{input_index}]#{FFMPEG_AFORMAT},apad"
+              line << ",atempo=#{speed},atrim=start=#{ms_to_s(audio_data[:timestamp])}" if speed != 1.0
+              line << ",asetpts=N[#{track_label}];"
               filter_lines << line
               track_labels << "[#{track_label}]"
               input_index += 1

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -18,6 +18,7 @@
 # along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
 
 require_relative './media_utils'
+require 'fileutils'
 
 module BigBlueButton
   module EDL
@@ -305,26 +306,162 @@ module BigBlueButton
       # Returns a map of { original_filename => new_resampled_filename }.
       def self.resample_audio_files(original_filenames_to_resample, output_dir_basename)
         filename_update_map = {}
-        original_filenames_to_resample.each do |original_filename|
-          output_filename_base = File.basename(original_filename, '.*')
-          resampled_file_dir = File.dirname(output_dir_basename)
-          output_filename_ogg = File.join(resampled_file_dir, "#{output_filename_base}_resampled.#{WF_EXT}")
+        target_directory = File.dirname(output_dir_basename)
 
-          BigBlueButton.logger.info "Resampling #{original_filename} to #{output_filename_ogg}"
-          
-          resample_cmd = [*FFMPEG, '-i', original_filename,
-                          '-vn', '-acodec', FFMPEG_WF_CODEC, 
-                          '-af', 'aresample=async=1000', output_filename_ogg]
-          
-          exitstatus = BigBlueButton.exec_ret(*resample_cmd)
-          if exitstatus != 0
-            BigBlueButton.logger.error "ffmpeg resampling failed for #{original_filename} to #{output_filename_ogg}, exit code #{exitstatus}."
-            raise "ffmpeg resampling failed for #{original_filename}, exit code #{exitstatus}"
-          else
-            filename_update_map[original_filename] = output_filename_ogg
+        original_filenames_to_resample.each do |original_filename|
+          original_basename = File.basename(original_filename, '.*')
+          parts_dir = File.join(target_directory, "#{original_basename}_parts")
+          FileUtils.mkdir_p(parts_dir)
+
+          info = audio_info(original_filename)
+          if !info || !info[:duration]
+            BigBlueButton.logger.warn "Could not get duration for #{original_filename}. Skipping segmented resampling."
+            FileUtils.remove_entry_secure(parts_dir) if Dir.exist?(parts_dir)
+            next
           end
+          original_total_duration_s = info[:duration] / 1000.0
+
+          output_filename_ogg = File.join(target_directory, "#{original_basename}_resampled.#{WF_EXT}")
+          BigBlueButton.logger.info "Segmented resampling for '#{original_filename}' (duration: #{original_total_duration_s}s). Output: '#{output_filename_ogg}'"
+
+          processing_segments = get_all_processing_segments(original_filename, MAX_AUDIO_GAP_FOR_RESAMPLE_MS, original_total_duration_s, 0.2)
+
+          if processing_segments.empty? || (processing_segments.length == 1 && processing_segments.first[:action] == :copy)
+             BigBlueButton.logger.info "No gaps requiring special handling found for '#{original_filename}'. Performing standard resampling."
+             resample_cmd = [*FFMPEG, '-i', original_filename,
+                             '-vn', '-acodec', FFMPEG_WF_CODEC, 
+                             '-af', 'aresample=async=1000', output_filename_ogg]
+             exitstatus = BigBlueButton.exec_ret(*resample_cmd)
+             if exitstatus != 0
+               BigBlueButton.logger.error "ffmpeg resampling failed for #{original_filename}, exit code #{exitstatus}."
+               raise "ffmpeg resampling failed for #{original_filename}, exit code #{exitstatus}"
+             else
+               filename_update_map[original_filename] = output_filename_ogg
+             end
+             FileUtils.remove_entry_secure(parts_dir) if Dir.exist?(parts_dir)
+             next
+          end
+
+          parts_to_concat = []
+          overall_success = true
+
+          processing_segments.each_with_index do |segment, index|
+            part_start_pts = segment[:start_pts]
+            part_end_pts = segment[:end_pts]
+            action = segment[:action]
+            part_duration = part_end_pts - part_start_pts
+
+            if part_duration <= 0.01
+              next
+            end
+
+            part_path = File.join(parts_dir, "#{original_basename}_part#{index + 1}.#{WF_EXT}")
+
+            if action == :recode
+              # Generate silence
+              cmd_part = [*FFMPEG, '-y', '-f', 'lavfi', '-i', 'aevalsrc=0', '-t', part_duration.to_s]
+              cmd_part += ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2']
+              BigBlueButton.logger.info "Creating Part ##{index + 1} (SILENCE from #{part_start_pts.round(3)}s to #{part_end_pts.round(3)}s) for '#{original_filename}'"
+            else # :copy
+              cmd_part = [*FFMPEG, '-y', '-ss', part_start_pts.to_s, '-i', original_filename, '-t', part_duration.to_s]
+              cmd_part += ['-vn', '-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-af', 'aresample=async=1000', '-avoid_negative_ts', 'make_zero']
+              BigBlueButton.logger.info "Creating Part ##{index + 1} (COPY from #{part_start_pts.round(3)}s) to #{part_end_pts.round(3)}s) for '#{original_filename}'"
+            end
+            cmd_part << part_path
+
+            exit_status_part = BigBlueButton.exec_ret(*cmd_part)
+            if exit_status_part == 0 && File.exist?(part_path)
+               parts_to_concat << part_path
+            else
+               if exit_status_part.nil?
+                 BigBlueButton.logger.error "ffmpeg process crashed or was killed for Part ##{index + 1} of #{original_filename}"
+               else
+                 BigBlueButton.logger.error "Failed to create Part ##{index + 1} for #{original_filename}, exit code #{exit_status_part}"
+               end
+               overall_success = false
+               break
+            end
+          end
+
+          if overall_success && parts_to_concat.any?
+             concat_list_path = File.join(parts_dir, "concat_list.txt")
+             File.open(concat_list_path, 'w') do |f|
+               parts_to_concat.each { |part_file| f.puts "file '#{File.absolute_path(part_file)}'" }
+             end
+             
+             cmd_concat = [*FFMPEG, '-y', '-f', 'concat', '-safe', '0', '-i', concat_list_path,
+                           '-c', 'copy', output_filename_ogg]
+             
+             exit_status_concat = BigBlueButton.exec_ret(*cmd_concat)
+             if exit_status_concat == 0 && File.exist?(output_filename_ogg)
+                filename_update_map[original_filename] = output_filename_ogg
+             else
+                BigBlueButton.logger.error "Concatenation failed for #{original_filename}"
+             end
+          else
+             BigBlueButton.logger.error "Segmented resampling failed for #{original_filename}"
+          end
+          
+          FileUtils.remove_entry_secure(parts_dir) if Dir.exist?(parts_dir)
         end
         filename_update_map
+      end
+
+      def self.get_all_processing_segments(filename, max_gap_ms, audio_total_duration_s, margin_s = 0.0)
+        pts_times = BigBlueButton::EDL::MediaUtils.get_packet_pts_times(filename, 'a')
+        return [{ start_pts: 0.0, end_pts: audio_total_duration_s, action: :copy }] if pts_times.nil? || pts_times.empty?
+
+        max_gap_seconds = max_gap_ms / 1000.0
+        recode_intervals = []
+
+        previous_pts = pts_times.first
+        pts_times.each do |current_pts|
+          if current_pts > previous_pts
+            gap = current_pts - previous_pts
+            if gap > max_gap_seconds
+              gap_start = [previous_pts - margin_s, 0.0].max
+              gap_end = current_pts + margin_s
+              recode_intervals << { start: gap_start, end: gap_end }
+            end
+          end
+          previous_pts = current_pts
+        end
+
+        recode_intervals.sort_by! { |r| r[:start] }
+        merged_recode_intervals = []
+        recode_intervals.each do |current_interval|
+          if merged_recode_intervals.empty?
+            merged_recode_intervals << current_interval
+          else
+            last_interval = merged_recode_intervals.last
+            if current_interval[:start] <= last_interval[:end] + 0.01
+              last_interval[:end] = [last_interval[:end], current_interval[:end]].max
+            else
+              merged_recode_intervals << current_interval
+            end
+          end
+        end
+
+        segments = []
+        last_processed_pts = 0.0
+        
+        merged_recode_intervals.each do |interval|
+          if interval[:start] > last_processed_pts + 0.01
+            segments << { start_pts: last_processed_pts, end_pts: interval[:start], action: :copy }
+          end
+          segments << { start_pts: interval[:start], end_pts: interval[:end], action: :recode }
+          last_processed_pts = interval[:end]
+        end
+
+        if last_processed_pts < audio_total_duration_s - 0.01
+          segments << { start_pts: last_processed_pts, end_pts: audio_total_duration_s, action: :copy }
+        end
+        
+        if segments.empty?
+           segments << { start_pts: 0.0, end_pts: audio_total_duration_s, action: :copy }
+        end
+
+        segments
       end
 
       def self.audio_info(filename)

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -324,7 +324,7 @@ module BigBlueButton
           output_filename_ogg = File.join(target_directory, "#{original_basename}_resampled.#{WF_EXT}")
           BigBlueButton.logger.info "Segmented resampling for '#{original_filename}' (duration: #{original_total_duration_s}s). Output: '#{output_filename_ogg}'"
 
-          processing_segments = get_all_processing_segments(original_filename, MAX_AUDIO_GAP_FOR_RESAMPLE_MS, original_total_duration_s, 0.01)
+          processing_segments = get_all_processing_segments(original_filename, 1_000, original_total_duration_s, 0.05)
 
           if processing_segments.empty? || (processing_segments.length == 1 && processing_segments.first[:action] == :copy)
              BigBlueButton.logger.info "No gaps requiring special handling found for '#{original_filename}'. Performing standard resampling."

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
 
+require_relative './media_utils'
+
 module BigBlueButton
   module EDL
     module Audio
@@ -25,6 +27,7 @@ module BigBlueButton
       FFMPEG_WF_CODEC = 'libvorbis'
       FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'
+      MAX_AUDIO_GAP_FOR_RESAMPLE_MS = 60_000 # 1 minute
 
       def self.dump(edl)
         BigBlueButton.logger.debug "EDL Dump:"
@@ -115,37 +118,56 @@ module BigBlueButton
 
         # Get a list of unique audio files that are still valid after corruption check
         # These are the files that need to be resampled.
-        valid_original_filenames = audioinfo.keys.dup 
+        valid_original_filenames = audioinfo.keys.dup
         if valid_original_filenames.any?
-          BigBlueButton.logger.info "Resampling audio files with aresample=async=1000"
-          filename_update_map = resample_audio_files(valid_original_filenames, output_basename)
+          BigBlueButton.logger.info "Checking audio files for large PTS gaps."
+          audio_files_to_resample = []
+          valid_original_filenames.each do |audio_filename|
+            gap_details = BigBlueButton::EDL::MediaUtils.has_large_pts_gaps?(audio_filename, MAX_AUDIO_GAP_FOR_RESAMPLE_MS, 'a')
+            if gap_details
+              BigBlueButton.logger.info "Audio file '#{File.basename(audio_filename)}' identified with large PTS gap between #{gap_details[0].round(3)}s and #{gap_details[1].round(3)}s. Marking for resampling."
+              audio_files_to_resample << audio_filename
+            else
+              BigBlueButton.logger.debug "No large PTS gaps found in '#{File.basename(audio_filename)}'."
+            end
+          end
 
-          # Update EDL to point to new .ogg files
-          if filename_update_map.any?
-            BigBlueButton.logger.info "Updating EDL with resampled audio filenames"
-            edl.each do |entry|
-              if entry[:audios]
-                entry[:audios].each do |a|
-                  if filename_update_map.key?(a[:filename])
-                    a[:filename] = filename_update_map[a[:filename]]
+          if audio_files_to_resample.any?
+            BigBlueButton.logger.info "Resampling #{audio_files_to_resample.length} audio file(s) with aresample=async=1000 due to large PTS gaps."
+            filename_update_map = resample_audio_files(audio_files_to_resample, output_basename)
+
+            # Update EDL to point to new .ogg files
+            if filename_update_map.any?
+              BigBlueButton.logger.info "Updating EDL with resampled audio filenames"
+              edl.each do |entry|
+                if entry[:audios]
+                  entry[:audios].each do |a|
+                    if filename_update_map.key?(a[:filename])
+                      a[:filename] = filename_update_map[a[:filename]]
+                    end
                   end
                 end
               end
+              dump(edl)
             end
-            dump(edl)
-          end
           
-          # Update audioinfo with the new resampled files
-          BigBlueButton.logger.info "Updating audio information for resampled files"
-          #new_audioinfo = {}
-          filename_update_map.each_value do |new_filename|
-            info = audio_info(new_filename)
-            if !info[:audio] || !info[:duration]
-              BigBlueButton.logger.warn "Resampled audio file #{new_filename} is corrupt or invalid. This should not happen."
-              raise "Resampled audio file #{new_filename} is corrupt or invalid after resampling."
-            else
-              audioinfo[new_filename] = info
+            # Update audioinfo with the new resampled files
+            BigBlueButton.logger.info "Updating audio information for resampled files"
+            filename_update_map.each_value do |new_filename|
+              # Remove original file info if it was resampled, to avoid using stale data
+              original_file_key = filename_update_map.key(new_filename)
+              audioinfo.delete(original_file_key) if original_file_key
+              
+              info = audio_info(new_filename)
+              if !info[:audio] || !info[:duration]
+                BigBlueButton.logger.warn "Resampled audio file #{new_filename} is corrupt or invalid. This should not happen."
+                raise "Resampled audio file #{new_filename} is corrupt or invalid after resampling."
+              else
+                audioinfo[new_filename] = info
+              end
             end
+          else
+            BigBlueButton.logger.info "No audio files required resampling based on PTS gap analysis."
           end
         end
 
@@ -281,9 +303,9 @@ module BigBlueButton
 
       # Resamples a list of audio files to OGG Vorbis into the output_basename directory.
       # Returns a map of { original_filename => new_resampled_filename }.
-      def self.resample_audio_files(original_filenames, output_dir_basename)
+      def self.resample_audio_files(original_filenames_to_resample, output_dir_basename)
         filename_update_map = {}
-        original_filenames.each do |original_filename|
+        original_filenames_to_resample.each do |original_filename|
           output_filename_base = File.basename(original_filename, '.*')
           resampled_file_dir = File.dirname(output_dir_basename)
           output_filename_ogg = File.join(resampled_file_dir, "#{output_filename_base}_resampled.#{WF_EXT}")

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -121,6 +121,7 @@ module BigBlueButton
           f.write("ffconcat version 1.0\n") 
           segment_files.each do |segment|
             f.write("file #{segment[:file]}\n") 
+            f.write("duration #{ms_to_s(segment[:duration])}\n") 
           end
         end
 
@@ -177,9 +178,9 @@ module BigBlueButton
 
               # Build track label
               track_label = "t#{i}_#{idx}"
-              line = "[#{input_index}]#{FFMPEG_AFORMAT},apad"
-              line << ",atempo=#{speed},atrim=start=#{ms_to_s(audio_data[:timestamp])}" if speed != 1.0
-              line << ",asetpts=N[#{track_label}];"
+              line = "[#{input_index}]#{FFMPEG_AFORMAT},apad,asetpts=N"
+              line << ",atempo=#{speed}" if speed != 1.0
+              line << "[#{track_label}];"
               filter_lines << line
               track_labels << "[#{track_label}]"
               input_index += 1

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -324,7 +324,7 @@ module BigBlueButton
           output_filename_ogg = File.join(target_directory, "#{original_basename}_resampled.#{WF_EXT}")
           BigBlueButton.logger.info "Segmented resampling for '#{original_filename}' (duration: #{original_total_duration_s}s). Output: '#{output_filename_ogg}'"
 
-          processing_segments = get_all_processing_segments(original_filename, MAX_AUDIO_GAP_FOR_RESAMPLE_MS, original_total_duration_s, 0.2)
+          processing_segments = get_all_processing_segments(original_filename, MAX_AUDIO_GAP_FOR_RESAMPLE_MS, original_total_duration_s, 0.01)
 
           if processing_segments.empty? || (processing_segments.length == 1 && processing_segments.first[:action] == :copy)
              BigBlueButton.logger.info "No gaps requiring special handling found for '#{original_filename}'. Performing standard resampling."
@@ -355,16 +355,17 @@ module BigBlueButton
               next
             end
 
-            part_path = File.join(parts_dir, "#{original_basename}_part#{index + 1}.#{WF_EXT}")
+            part_path = File.join(parts_dir, "#{original_basename}_part#{index + 1}.wav")
 
             if action == :recode
               # Generate silence
               cmd_part = [*FFMPEG, '-y', '-f', 'lavfi', '-i', 'aevalsrc=0', '-t', part_duration.to_s]
-              cmd_part += ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2']
+              cmd_part += ['-c:a', 'pcm_s16le', '-ar', '48000']
               BigBlueButton.logger.info "Creating Part ##{index + 1} (SILENCE from #{part_start_pts.round(3)}s to #{part_end_pts.round(3)}s) for '#{original_filename}'"
             else # :copy
-              cmd_part = [*FFMPEG, '-y', '-ss', part_start_pts.to_s, '-i', original_filename, '-t', part_duration.to_s]
-              cmd_part += ['-vn', '-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-af', 'aresample=async=1000', '-avoid_negative_ts', 'make_zero']
+              cmd_part = [*FFMPEG, '-y', '-ss', part_start_pts.to_s, '-i', original_filename]
+              cmd_part += ['-vn', '-c:a', 'pcm_s16le', '-ar', '48000']
+              cmd_part += ['-af', "atrim=duration=#{part_duration}"]
               BigBlueButton.logger.info "Creating Part ##{index + 1} (COPY from #{part_start_pts.round(3)}s) to #{part_end_pts.round(3)}s) for '#{original_filename}'"
             end
             cmd_part << part_path
@@ -390,7 +391,7 @@ module BigBlueButton
              end
              
              cmd_concat = [*FFMPEG, '-y', '-f', 'concat', '-safe', '0', '-i', concat_list_path,
-                           '-c', 'copy', output_filename_ogg]
+                           '-vn', *FFMPEG_WF_ARGS, output_filename_ogg]
              
              exit_status_concat = BigBlueButton.exec_ret(*cmd_concat)
              if exit_status_concat == 0 && File.exist?(output_filename_ogg)

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -188,7 +188,6 @@ module BigBlueButton
           f.write("ffconcat version 1.0\n") 
           segment_files.each do |segment|
             f.write("file #{segment[:file]}\n") 
-            f.write("duration #{ms_to_s(segment[:duration])}\n") 
           end
         end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -99,10 +99,54 @@ module BigBlueButton
           BigBlueButton.logger.info "Removing corrupt audio files from EDL"
           edl.each do |event|
             if event[:audios]
-              event[:audios].reject! { |a| corrupt_audios.include?(a[:filename]) }
+              # Remove references to corrupt files from audioinfo as well
+              event[:audios].reject! do |a|
+                if corrupt_audios.include?(a[:filename])
+                  audioinfo.delete(a[:filename])
+                  true
+                else
+                  false
+                end
+              end
             end
           end
           dump(edl)
+        end
+
+        # Get a list of unique audio files that are still valid after corruption check
+        # These are the files that need to be resampled.
+        valid_original_filenames = audioinfo.keys.dup 
+        if valid_original_filenames.any?
+          BigBlueButton.logger.info "Resampling audio files with aresample=async=1000"
+          filename_update_map = resample_audio_files(valid_original_filenames, output_basename)
+
+          # Update EDL to point to new .ogg files
+          if filename_update_map.any?
+            BigBlueButton.logger.info "Updating EDL with resampled audio filenames"
+            edl.each do |entry|
+              if entry[:audios]
+                entry[:audios].each do |a|
+                  if filename_update_map.key?(a[:filename])
+                    a[:filename] = filename_update_map[a[:filename]]
+                  end
+                end
+              end
+            end
+            dump(edl)
+          end
+          
+          # Update audioinfo with the new resampled files
+          BigBlueButton.logger.info "Updating audio information for resampled files"
+          #new_audioinfo = {}
+          filename_update_map.each_value do |new_filename|
+            info = audio_info(new_filename)
+            if !info[:audio] || !info[:duration]
+              BigBlueButton.logger.warn "Resampled audio file #{new_filename} is corrupt or invalid. This should not happen."
+              raise "Resampled audio file #{new_filename} is corrupt or invalid after resampling."
+            else
+              audioinfo[new_filename] = info
+            end
+          end
         end
 
         segment_files = []
@@ -234,6 +278,32 @@ module BigBlueButton
       end
 
       # The methods below should be considered private
+
+      # Resamples a list of audio files to OGG Vorbis into the output_basename directory.
+      # Returns a map of { original_filename => new_resampled_filename }.
+      def self.resample_audio_files(original_filenames, output_dir_basename)
+        filename_update_map = {}
+        original_filenames.each do |original_filename|
+          output_filename_base = File.basename(original_filename, '.*')
+          resampled_file_dir = File.dirname(output_dir_basename)
+          output_filename_ogg = File.join(resampled_file_dir, "#{output_filename_base}_resampled.#{WF_EXT}")
+
+          BigBlueButton.logger.info "Resampling #{original_filename} to #{output_filename_ogg}"
+          
+          resample_cmd = [*FFMPEG, '-i', original_filename,
+                          '-vn', '-acodec', FFMPEG_WF_CODEC, 
+                          '-af', 'aresample=async=1000', output_filename_ogg]
+          
+          exitstatus = BigBlueButton.exec_ret(*resample_cmd)
+          if exitstatus != 0
+            BigBlueButton.logger.error "ffmpeg resampling failed for #{original_filename} to #{output_filename_ogg}, exit code #{exitstatus}."
+            raise "ffmpeg resampling failed for #{original_filename}, exit code #{exitstatus}"
+          else
+            filename_update_map[original_filename] = output_filename_ogg
+          end
+        end
+        filename_update_map
+      end
 
       def self.audio_info(filename)
         IO.popen([*FFPROBE, filename]) do |probe|

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -1,0 +1,91 @@
+# encoding: UTF-8
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2024 BigBlueButton Inc. and by respective authors.
+#
+# BigBlueButton is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'json'
+require 'shellwords'
+
+module BigBlueButton
+  module EDL
+    module MediaUtils
+      # Gets all packet PTS times from a media file for a specific stream type.
+      # stream_type should be 'a' for audio, 'v' for video.
+      # Returns an array of PTS times (float) or nil on error / no data.
+      def self.get_packet_pts_times(filename, stream_type)
+        ffprobe_cmd = [
+          *FFPROBE, '-v', 'error', '-select_streams', "#{stream_type}:0",
+          '-show_entries', 'packet=pts_time', '-of', 'csv=p=0', filename
+        ]
+        BigBlueButton.logger.debug "Getting #{stream_type == 'a' ? 'audio' : 'video'} packet PTS times for '#{File.basename(filename)}': #{Shellwords.join(ffprobe_cmd)}"
+        
+        pts_times = []
+        begin
+          status = IO.popen(ffprobe_cmd) do |io|
+            io.each_line do |line|
+              line.strip!
+              next if line.empty? || line == "N/A" # Skip empty lines or "N/A"
+              begin
+                pts_times << Float(line)
+              rescue ArgumentError
+                BigBlueButton.logger.warn "Could not parse PTS value '#{line}' as float for '#{File.basename(filename)}' (#{stream_type} stream). Skipping line."
+              end
+            end
+            $? # Process status
+          end
+
+          if status.nil? || !status.success?
+            BigBlueButton.logger.warn "ffprobe command for PTS times on '#{File.basename(filename)}' (#{stream_type} stream) exited with status #{status&.exitstatus}."
+            return nil
+          end
+          
+          return pts_times.empty? ? nil : pts_times.sort.uniq
+        rescue StandardError => e
+          BigBlueButton.logger.error "Error getting PTS times from '#{File.basename(filename)}' (#{stream_type} stream): #{e.message}"
+          nil
+        end
+      end
+
+      # Check if a media file has PTS (Presentation Timestamp) gaps larger than max_gap_ms
+      # for the specified stream_type ('a' or 'v').
+      # Returns [previous_pts, current_pts] of the first large gap, or nil if no large gaps.
+      def self.has_large_pts_gaps?(filename, max_gap_ms, stream_type)
+        max_gap_seconds = max_gap_ms / 1000.0
+        
+        pts_times = get_packet_pts_times(filename, stream_type)
+        return nil if pts_times.nil? || pts_times.length < 2
+
+        stream_name = stream_type == 'a' ? 'audio' : 'video'
+        BigBlueButton.logger.debug "Checking for #{stream_name} PTS gaps in '#{File.basename(filename)}' (max_gap: #{max_gap_seconds.round(3)}s, total packets: #{pts_times.length})"
+
+        previous_pts = pts_times.first
+        (1...pts_times.length).each do |i|
+          current_pts = pts_times[i]
+          gap = current_pts - previous_pts
+          if gap > max_gap_seconds
+            BigBlueButton.logger.info "Large #{stream_name} PTS gap (#{gap.round(3)}s > #{max_gap_seconds.round(3)}s) detected in '#{File.basename(filename)}' between PTS #{previous_pts.round(3)} and #{current_pts.round(3)}."
+            return [previous_pts, current_pts] # Return PTS boundaries of the gap
+          end
+          previous_pts = current_pts
+        end
+        
+        BigBlueButton.logger.debug "No large #{stream_name} PTS gaps detected in '#{File.basename(filename)}'."
+        nil # No large gaps found
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

This is the **audio** variant of #24490.

Raw audio and/or video files with significant PTS gaps may cause noticeable A/V desynchronization or just overall desync compared to the original wall-clock time of raw files.

For audio, the issue is more prominent in LiveKit where recordings are muxed without encoding - whereas FreeSWITCH encodes + muxes recordings which allows for PTS gaps to be filled with silence at _capture time_.

While we do have some resampling code in record-and-playback, it is not sufficient to address large enough gaps. Current behavior either compresses gaps and rewrites PTS to be monotonically increasing (causes overall desync) or do not do any resampling at all (cameras, A/V desync).

This pull request introduces various changes to the resampling of raw **audio** files in record-and-playback so that the aforementioned issues are addressed:
- [refactor(recording): add shared media_utils EDL module](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/7fe365762c2250ffbdfd4ba2a13f68e1d687836c)
Add a shared media_utils module to record-and-playback that provides
re-usable utils in EDL processing for all sources (A/V).
- [refactor(recording): move audio segment processing to separate function](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/1442832a040887c878572d01910160b200359736)
- [fix(recording): correctly apply atempo from beginning of file](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/d52e60f1e09720a88d138d5aa72884323ef0aec3)
- [fix(recording): resample audio files before processing](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/28584fa8577c22e8126dc30f999a110a6291124b)
  - Resample all files present in the final edl to help fix desyncs when file has large pts gaps.
- [refactor(recording): only resample audio tracks with gaps >= 60s](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/bcf869b6cd6e4ad3a534410ade6378649c2c2544)
  - Only resample individual audio tracks if their gaps are larger than 60s.
    For gaps smaller than that, the mixing process seems to handle PTS gaps
properly.
- [fix(recording): add segmented audio resampling](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/ccb532068a06c9572c5c9034d24e4dcb479d3efc)
  - Audio resample can lead to high ffmpeg memory usage when audio file has large pts gaps, change the resample to re-encode the gappy parts as silence (like it is done por video):
    - idenfity each gap > MAX_AUDIO_GAP_FOR_RESAMPLE_MS
    - break the file into multiple parts, copying the good parts and generating silence for the gappy parts
    - concatenate all the parts to create the new resampled file
- [fix(recording): use WAV instead of ogg as intermediate segment to avoid timestamp issues](https://github.com/bigbluebutton/bigbluebutton/pull/24481/changes/c572d4e13ecda5b58cbeaa7267db35bb42605dfb)
  - Process segments into intermediate WAV (PCM) files instead of OGG to avoid `libvorbis` timestamp issues and audio repetition artifacts.
  - Use `atrim` for frame-accurate cutting
  - Concatenate wav parts and encode them to ogg in one go. This ensures a clean, continuous output stream with fresh timestamps generated by the encoder.
  
### Closes Issue(s)

None