### PR TITLE
Fix(graphql-server): Change type of some breakout name related fields to text

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -63,8 +63,8 @@ create unlogged table "meeting_breakoutRoomProps" (
     "privateChatEnabled"    boolean,
     "captureNotes"          boolean,
     "captureSlides"         boolean,
-    "captureNotesFilename"  varchar(100),
-    "captureSlidesFilename" varchar(100)
+    "captureNotesFilename"  text,
+    "captureSlidesFilename" text
 );
 create view "v_meeting_breakoutPolicies" as select * from "meeting_breakoutRoomProps";
 
@@ -1866,8 +1866,8 @@ CREATE UNLOGGED TABLE "breakoutRoom" (
 	"meetingId"                 varchar(100) REFERENCES "meeting"("meetingId") ON DELETE CASCADE,
 	"breakoutRoomExternalId"    varchar(100),
 	"sequence"                  numeric,
-	"name"                      varchar(100),
-	"shortName"                 varchar(100),
+	"name"                      text,
+	"shortName"                 text,
 	"isDefaultName"             bool,
 	"freeJoin"                  bool,
 	"createdAt"                 timestamp with time zone,


### PR DESCRIPTION
### What does this PR do?
Some fields related to breakout room names were limited to 100 characters, which caused silent failures. Akka allowed these values to be created, but they were later rejected by the database due to the length constraint. This change updates those fields to use the TEXT type, preventing the mismatch and avoiding hidden runtime errors.

### Closes Issue(s)
Closes #24384 

### How to test
1. Join a meeting
2. Try to create a breakout room with name greater than 100 characters.


### More
[Screencast from 16-01-2026 17:13:20.webm](https://github.com/user-attachments/assets/a3e852ac-b4ca-4e58-8104-9ef9d1f164af)


