### PR TITLE
Fix(html5): moderators were unable to unlock users via the Raised Hand list.

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -97,6 +97,7 @@ User,
 | 'isModerator'
 | 'raiseHand'
 | 'whiteboardWriteAccess'
+| 'locked'
 > & {
   raiseHandTime?: string;
 };
@@ -122,5 +123,6 @@ subscription RaisedHandUsers {
     raiseHand
     raiseHandTime
     whiteboardWriteAccess
+    locked
   }
 }`;


### PR DESCRIPTION
### What does this PR do?
The problem occurred because the Raised Hand users query did not include the locked status property, preventing the unlock action from working correctly. This change adds the missing property to ensure moderators can unlock users as expected.


### Closes Issue(s)
Closes #24478

### How to test
- Join a Mod and a Viewer
- Apply any lock settings as mod
- Raised hand as viewer
- Try to unlock user as Mod


### More
<img width="497" height="458" alt="image" src="https://github.com/user-attachments/assets/08711158-a2d6-4070-9d9c-2e61c40053d2" />
