### PR TITLE
fix(emoji-rain): increase z-index to render above presentation area

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/emoji-rain/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/emoji-rain/component.jsx
@@ -113,7 +113,7 @@ const EmojiRain = ({ reactions }) => {
     left: 0,
     overflow: 'hidden',
     pointerEvents: 'none',
-    zIndex: 2,
+    zIndex: 6,
   };
 
   return <div ref={containerRef} style={containerStyle} data-test="emojiRain" />;


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Previously, the emoji rain container had a smaller size than the generic content container. Because of this, some plugins that occupy the presentation area could overlap the emoji rain.



### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
- Join a meeting where emoji reactions are enabled.
- Trigger the emoji rain (for example, by sending multiple emoji reactions).
- Enable or open any plugin that occupies the presentation area.
- Verify that the emoji rain is rendered correctly and is not overlapped by the plugin or any other content.