### PR TITLE
fix(timer): sync timer display with meeting timer count

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -842,7 +842,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
 
 const TimerPanelContaier: React.FC = () => {
   const [timerActivate] = useMutation(TIMER_ACTIVATE);
-  const { data: timerData } = useTimer(true);
+  const { data: timerData } = useTimer();
   const { data: currentUser } = useCurrentUser();
 
   const amIModerator = !!currentUser?.isModerator;

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/component.tsx
@@ -644,7 +644,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
                       type="number"
                       readOnly={running}
                       disabled={running}
-                      value={String(localHours).padStart(2, '0')}
+                      value={String(running ? hours : localHours).padStart(2, '0')}
                       max={MAX_HOURS}
                       min="0"
                       step="1"
@@ -691,7 +691,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
                       type="number"
                       readOnly={running}
                       disabled={running}
-                      value={String(localMinutes).padStart(2, '0')}
+                      value={String(running ? minutes : localMinutes).padStart(2, '0')}
                       max="59"
                       min="0"
                       step="1"
@@ -738,7 +738,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
                       type="number"
                       readOnly={running}
                       disabled={running}
-                      value={String(localSeconds).padStart(2, '0')}
+                      value={String(running ? seconds : localSeconds).padStart(2, '0')}
                       max="59"
                       min="0"
                       step="1"
@@ -842,7 +842,7 @@ const TimerPanel: React.FC<TimerPanelProps> = ({
 
 const TimerPanelContaier: React.FC = () => {
   const [timerActivate] = useMutation(TIMER_ACTIVATE);
-  const { data: timerData } = useTimer();
+  const { data: timerData } = useTimer(true);
   const { data: currentUser } = useCurrentUser();
 
   const amIModerator = !!currentUser?.isModerator;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Fixes the timer panel to display real-time countdown values synchronized with the meeting timer.

- Changed `useTimer()` to `useTimer(true)` to enable real-time sync via TimerSingleton
- Updated input fields to show real-time values when running, editable values when stopped

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
1. Join a meeting as a moderator
2. Open the timer panel and set a time (e.g., 5 minutes)
3. Click "Start"
4. **Verify:** Timer panel inputs count down in real-time and match the navbar timer indicator
5. Click "Stop" and "Start" again to confirm sync is maintained



