### PR TITLE
feat(livekit): option to use LiveKit as the client's audio state source

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -639,6 +639,7 @@ export interface LiveKitAudioSettings {
   publishOptions?: TrackPublishOptions
   unpublishOnMute?: boolean
   unpublishAfterMuteMs?: number
+  useLiveKitAudioState?: boolean
 }
 
 export interface LiveKitSettings {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
@@ -51,13 +51,19 @@ export const muteLoadingState: ReactiveVar<boolean> = makeVar(false);
 export const useIsMuteLoading = () => useReactiveVar(muteLoadingState);
 
 const toggleMute = (
-  muted: boolean,
+  isMuted: boolean,
   toggleVoice: (userId: string, muted: boolean) => void,
   actionType = 'user_action',
 ) => {
   const meetingStaticStore = meetingStaticData.getMeetingData();
+  const newMutedState = !isMuted;
   const toggle = (storageKey: string) => {
-    if (muted) {
+    // If we are using LiveKit audio state, we allow calling the mute/unmute
+    // actions directly on the AudioManager instance.
+    const shouldRunLocalMute = AudioManager.shouldUseLiveKitAudioState()
+      && newMutedState !== AudioManager.isMuted;
+
+    if (isMuted) {
       if (AudioManager.inputDeviceId === 'listen-only') {
         // User is in duplex audio, passive-sendrecv, but has no input device set
         // Unmuting should not be allowed at all
@@ -68,15 +74,21 @@ const toggleMute = (
         logCode: 'audiomanager_unmute_audio',
         extraInfo: { logType: actionType },
       }, 'microphone unmuted');
-      Storage.setItem(storageKey, false);
-      toggleVoice(Auth.userID as string, false);
+      Storage.setItem(storageKey, newMutedState);
+
+      if (shouldRunLocalMute) AudioManager.unmute();
+
+      toggleVoice(Auth.userID as string, newMutedState);
     } else {
       logger.info({
         logCode: 'audiomanager_mute_audio',
         extraInfo: { logType: actionType },
       }, 'microphone muted');
-      Storage.setItem(storageKey, true);
-      toggleVoice(Auth.userID as string, true);
+      Storage.setItem(storageKey, newMutedState);
+
+      if (shouldRunLocalMute) AudioManager.mute();
+
+      toggleVoice(Auth.userID as string, newMutedState);
     }
   };
 

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -15,6 +15,7 @@ import {
 
 import Service from './service';
 import AudioModalContainer from './audio-modal/container';
+import useAudioManagerStateSync from './hooks/useAudioManagerStateSync';
 import useToggleVoice from './audio-graphql/hooks/useToggleVoice';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
@@ -219,6 +220,9 @@ const AudioContainer = (props) => {
 
   const { data: unmutedUsers } = useWhoIsUnmuted();
   const currentUserMuted = currentUser?.userId && !unmutedUsers[currentUser.userId];
+
+  // Sync AudioManager muted/talking states when using LiveKit audio state.
+  useAudioManagerStateSync();
 
   const joinAudio = useCallback(() => {
     if (Service.isConnected()) return;

--- a/bigbluebutton-html5/imports/ui/components/audio/hooks/useAudioManagerStateSync.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/hooks/useAudioManagerStateSync.ts
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+import { useReactiveVar } from '@apollo/client';
+import useWhoIsUnmuted from '/imports/ui/core/hooks/useWhoIsUnmuted';
+import useWhoIsTalking from '/imports/ui/core/hooks/useWhoIsTalking';
+import useShouldUseLiveKitAudioState from '/imports/ui/core/hooks/livekit/useShouldUseLiveKitAudioState';
+import AudioManager from '/imports/ui/services/audio-manager';
+import Auth from '/imports/ui/services/auth';
+
+/**
+ * Hook that synchronizes AudioManager's isMuted and isTalking states
+ * based on state provided by the useWhoIsUnmuted and useWhoIsTalking hooks.
+ *
+ * This is a no-op when public.media.livekit.audio.useLiveKitAudioState is false.
+ */
+const useAudioManagerStateSync = () => {
+  const { data: unmutedUsers, loading: unmutedLoading } = useWhoIsUnmuted();
+  const { data: talkingUsers, loading: talkingLoading } = useWhoIsTalking();
+  const shouldUseLiveKitAudioState = useShouldUseLiveKitAudioState();
+  const currentUserId = Auth.userID as string;
+  /* eslint no-underscore-dangle: 0 */
+  // @ts-ignore - AudioManager is untyped
+  const currentMuteState = useReactiveVar(AudioManager._isMuted.value) as boolean;
+  // @ts-ignore - AudioManager is untyped
+  const currentTalkingState = useReactiveVar(AudioManager._isTalking.value) as boolean;
+
+  // Synchronize mute state
+  useEffect(() => {
+    if (!shouldUseLiveKitAudioState || unmutedLoading || !currentUserId) return;
+
+    const newMuteState = !unmutedUsers[currentUserId];
+
+    if (currentMuteState !== newMuteState) {
+      AudioManager.isMuted = newMuteState;
+
+      if (newMuteState) {
+        AudioManager.mute();
+      } else {
+        AudioManager.unmute();
+      }
+    }
+  }, [
+    currentUserId,
+    unmutedUsers,
+    unmutedLoading,
+    currentMuteState,
+    shouldUseLiveKitAudioState,
+  ]);
+
+  // Synchronize talking state
+  useEffect(() => {
+    if (!shouldUseLiveKitAudioState || talkingLoading || !currentUserId) return;
+
+    const isTalking = talkingUsers[currentUserId];
+    // Respect mute state: if muted, talking should be false
+    const newTalkingState = isTalking && !currentMuteState;
+
+    // Only update if the desired talking state differs from the current one.
+    if (currentTalkingState !== newTalkingState) {
+      AudioManager.isTalking = newTalkingState;
+    }
+  }, [
+    currentUserId,
+    talkingUsers,
+    talkingLoading,
+    currentMuteState,
+    currentTalkingState,
+    shouldUseLiveKitAudioState,
+  ]);
+
+  // Ensure talking is false when muted
+  useEffect(() => {
+    if (!shouldUseLiveKitAudioState) return;
+
+    if (currentMuteState && currentTalkingState) {
+      AudioManager.isTalking = false;
+    }
+  }, [currentMuteState, currentTalkingState, shouldUseLiveKitAudioState]);
+};
+
+export default useAudioManagerStateSync;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -9,6 +9,7 @@ import useToggleVoice from '../../../audio/audio-graphql/hooks/useToggleVoice';
 import { setTalkingIndicatorList } from '/imports/ui/core/hooks/useTalkingIndicator';
 import useTalkingUsers from '/imports/ui/core/hooks/useTalkingUsers';
 import { partition } from '/imports/utils/array-utils';
+import { VoiceUserMetadata } from '/imports/ui/core/hooks/types';
 
 const TALKING_INDICATORS_MAX = 8;
 
@@ -43,7 +44,7 @@ interface TalkingIndicatorProps {
   talkingUsers: {
     talking: boolean;
     muted: boolean;
-    user: { color: string; speechLocale?: string; name: string };
+    user: VoiceUserMetadata;
     userId: string;
   }[];
   moreThanMaxIndicators: boolean;
@@ -138,7 +139,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
           icon={icon}
           size="lg"
           style={
-            isMuteActionAvailable
+            (isMuteActionAvailable && color)
               ? {
                 backgroundColor: color,
                 border: `solid 2px ${color}`,

--- a/bigbluebutton-html5/imports/ui/core/adapters/voice-activity.tsx
+++ b/bigbluebutton-html5/imports/ui/core/adapters/voice-activity.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import useVoiceActivity from '/imports/ui/core/hooks/useVoiceActivity';
+import useShouldUseLiveKitAudioState from '/imports/ui/core/hooks/livekit/useShouldUseLiveKitAudioState';
 import {
   setWhoIsUnmutedLoading,
   useWhoIsUnmutedConsumersCount,
@@ -19,6 +20,7 @@ import {
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 
 const VoiceActivityAdapter = () => {
+  const shouldUseLiveKitAudioState = useShouldUseLiveKitAudioState();
   const whoIsUnmutedConsumersCount = useWhoIsUnmutedConsumersCount();
   const whoIsTalkingConsumersCount = useWhoIsTalkingConsumersCount();
   const talkingUserConsumersCount = useTalkingUserConsumersCount();
@@ -43,12 +45,16 @@ const VoiceActivityAdapter = () => {
   }, [voiceActivityLoading]);
 
   useEffect(() => {
-    if (!connected) {
+    // Only clear updates on disconnection when using BBB/GraphQL audio state.
+    // LiveKit state should be resilient to GraphQL disconnections on certain
+    // occasions. Complete absence of data from either sources is treated in
+    // the LK hooks.
+    if (!connected && !shouldUseLiveKitAudioState) {
       dispatchWhoIsUnmutedUpdate(undefined);
       dispatchWhoIsTalkingUpdate(undefined);
       dispatchTalkingUserUpdate(undefined);
     }
-  }, [connected]);
+  }, [connected, shouldUseLiveKitAudioState]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/core/hooks/constants.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Timeout in milliseconds before removing a user from the talking indicator
+ * after they stop talking.
+ */
+export const TALKING_INDICATOR_TIMEOUT = 6000;
+
+export default {
+  TALKING_INDICATOR_TIMEOUT,
+};

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useShouldUseLiveKitAudioState.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useShouldUseLiveKitAudioState.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import useMeeting from '../useMeeting';
+import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
+
+const useShouldUseLiveKitAudioState = () => {
+  const { data: meeting } = useMeeting((m) => ({
+    audioBridge: m.audioBridge,
+  }));
+  const [meetingSettings] = useMeetingSettings();
+  const isLiveKitAudioBridge = meeting?.audioBridge === 'livekit';
+  const useLiveKitAudioState = meetingSettings.public.media?.livekit?.audio?.useLiveKitAudioState ?? false;
+
+  return useMemo(() => useLiveKitAudioState && isLiveKitAudioBridge, [
+    useLiveKitAudioState,
+    isLiveKitAudioBridge,
+  ]);
+};
+
+export default useShouldUseLiveKitAudioState;

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useSubscribedAudioUsers.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useSubscribedAudioUsers.ts
@@ -1,0 +1,49 @@
+import { useMemo, useRef } from 'react';
+import { isEqual } from 'radash';
+import { useTracks } from '@livekit/components-react';
+import { RoomEvent, Track } from 'livekit-client';
+import { liveKitRoom } from '/imports/ui/services/livekit';
+import useShouldUseLiveKitAudioState from './useShouldUseLiveKitAudioState';
+
+const BASELINE_DATA: Record<string, boolean> = Object.freeze({});
+
+/**
+ * Hook that returns a Map of userId -> boolean for participants whose
+ * audio tracks the client is subscribed to in LiveKit.
+ * Absence of a userId in the map means not subscribed.
+ *
+ */
+const useSubscribedAudioUsers = (): Record<string, boolean> => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const subscribedUsersRef = useRef<Record<string, boolean>>({});
+  const microphoneTracks = useTracks([Track.Source.Microphone], {
+    room: liveKitRoom,
+    onlySubscribed: true,
+    updateOnlyOn: [
+      RoomEvent.TrackSubscribed,
+      RoomEvent.TrackUnsubscribed,
+      RoomEvent.TrackPublished,
+      RoomEvent.TrackUnpublished,
+    ],
+  });
+
+  return useMemo(() => {
+    if (!shouldUseLiveKit) return BASELINE_DATA;
+
+    const subscribedUsers: Record<string, boolean> = {};
+    microphoneTracks.forEach((trackRef) => {
+      const userId = trackRef.participant.identity;
+      subscribedUsers[userId] = true;
+    });
+
+    if (isEqual(subscribedUsers, subscribedUsersRef.current)) {
+      return subscribedUsersRef.current;
+    }
+
+    subscribedUsersRef.current = subscribedUsers;
+
+    return subscribedUsers;
+  }, [shouldUseLiveKit, microphoneTracks]);
+};
+
+export default useSubscribedAudioUsers;

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
@@ -120,7 +120,6 @@ const createUseTalkingUsersLiveKit = () => {
           // Use BBB fallback for unsubscribed participants
           // LiveKit only emits speaking events for subscribed tracks of remote participants.
           const bbbTalking = bbbTalkingUsers[userId]?.talking ?? false;
-          console.debug('Livekit fallback for unsubscribed participant', userId, bbbTalking);
 
           if (bbbTalking) {
             newTalkingState[userId] = true;
@@ -133,7 +132,13 @@ const createUseTalkingUsersLiveKit = () => {
       if (!isEqual(currentTalkingState, newTalkingState)) {
         currentTalkingStateVar(newTalkingState);
       }
-    }, [remoteParticipants, localParticipant, subscribedAudioUsers, bbbTalkingUsers]);
+    }, [
+      remoteParticipants,
+      localParticipant,
+      subscribedAudioUsers,
+      bbbTalkingUsers,
+      shouldUseLiveKit,
+    ]);
 
     useEffect(() => {
       if (!shouldUseLiveKit) return;

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
@@ -31,7 +31,6 @@ const createUseTalkingUsersLiveKit = () => {
   const userMetadataVar = makeVar<Record<string, {
     name: string;
     speechLocale?: string;
-    role: string;
   }>>({});
 
   const setTalkingUserLoading = (loading: boolean) => loadingVar(loading);
@@ -45,7 +44,7 @@ const createUseTalkingUsersLiveKit = () => {
     if (!data) return;
 
     // Extract user metadata from voiceActivity data
-    const newUserMetadata: Record<string, { name: string; speechLocale?: string, role: string }> = {
+    const newUserMetadata: Record<string, { name: string; speechLocale?: string }> = {
       ...userMetadataVar(),
     };
 
@@ -54,7 +53,6 @@ const createUseTalkingUsersLiveKit = () => {
       newUserMetadata[userId] = {
         name: user.name,
         speechLocale: user?.speechLocale,
-        role: user.role,
       };
     });
 
@@ -187,7 +185,6 @@ const createUseTalkingUsersLiveKit = () => {
           userMetadata = {
             name: participant.name ?? participant.identity,
             speechLocale: undefined,
-            role: window.meetingClientSettings.public.user.role_viewer,
           };
         }
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
@@ -14,7 +14,7 @@ import useShouldUseLiveKitAudioState from './useShouldUseLiveKitAudioState';
 import useSubscribedAudioUsers from './useSubscribedAudioUsers';
 import useTalkingUsersGraphql from '../useTalkingUsersGraphql';
 import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/voiceActivity';
-import { VoiceItem, TalkingUsersHookResult } from '../types';
+import { VoiceItem, TalkingUsersHookResult, VoiceUserMetadata } from '../types';
 import { TALKING_INDICATOR_TIMEOUT } from '../constants';
 
 const BASELINE_DATA: TalkingUsersHookResult = Object.freeze({
@@ -28,10 +28,7 @@ const createUseTalkingUsersLiveKit = () => {
   const loadingVar = makeVar(true);
   const currentTalkingStateVar = makeVar<Record<string, boolean>>({});
   // User metadata from voiceActivity subscription
-  const userMetadataVar = makeVar<Record<string, {
-    name: string;
-    speechLocale?: string;
-  }>>({});
+  const userMetadataVar = makeVar<Record<string, VoiceUserMetadata>>({});
 
   const setTalkingUserLoading = (loading: boolean) => loadingVar(loading);
   const useTalkingUserConsumersCount = () => useReactiveVar(countVar);
@@ -44,7 +41,7 @@ const createUseTalkingUsersLiveKit = () => {
     if (!data) return;
 
     // Extract user metadata from voiceActivity data
-    const newUserMetadata: Record<string, { name: string; speechLocale?: string }> = {
+    const newUserMetadata: Record<string, VoiceUserMetadata> = {
       ...userMetadataVar(),
     };
 
@@ -52,6 +49,7 @@ const createUseTalkingUsersLiveKit = () => {
       const { userId, user } = voice;
       newUserMetadata[userId] = {
         name: user.name,
+        color: user?.color,
         speechLocale: user?.speechLocale,
       };
     });
@@ -189,7 +187,6 @@ const createUseTalkingUsersLiveKit = () => {
 
           userMetadata = {
             name: participant.name ?? participant.identity,
-            speechLocale: undefined,
           };
         }
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useTalkingUsersLiveKit.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useRef, useState } from 'react';
+import { makeVar, useReactiveVar } from '@apollo/client';
+import { isEqual } from 'radash';
+import {
+  useRemoteParticipants,
+  useLocalParticipant,
+  useConnectionState,
+} from '@livekit/components-react';
+import { ConnectionState, RoomEvent } from 'livekit-client';
+import { liveKitRoom } from '/imports/ui/services/livekit';
+import Auth from '/imports/ui/services/auth';
+import useWhoIsUnmuted from '../useWhoIsUnmuted';
+import useShouldUseLiveKitAudioState from './useShouldUseLiveKitAudioState';
+import useSubscribedAudioUsers from './useSubscribedAudioUsers';
+import useTalkingUsersGraphql from '../useTalkingUsersGraphql';
+import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/voiceActivity';
+import { VoiceItem, TalkingUsersHookResult } from '../types';
+import { TALKING_INDICATOR_TIMEOUT } from '../constants';
+
+const BASELINE_DATA: TalkingUsersHookResult = Object.freeze({
+  error: undefined,
+  data: {},
+  loading: false,
+});
+
+const createUseTalkingUsersLiveKit = () => {
+  const countVar = makeVar(0);
+  const loadingVar = makeVar(true);
+  const currentTalkingStateVar = makeVar<Record<string, boolean>>({});
+  // User metadata from voiceActivity subscription
+  const userMetadataVar = makeVar<Record<string, {
+    name: string;
+    speechLocale?: string;
+    role: string;
+  }>>({});
+
+  const setTalkingUserLoading = (loading: boolean) => loadingVar(loading);
+  const useTalkingUserConsumersCount = () => useReactiveVar(countVar);
+
+  const dispatchTalkingUserUpdate = (
+    data?: VoiceActivityResponse['user_voice_activity_stream'],
+  ) => {
+    if (countVar() === 0) return;
+
+    if (!data) return;
+
+    // Extract user metadata from voiceActivity data
+    const newUserMetadata: Record<string, { name: string; speechLocale?: string, role: string }> = {
+      ...userMetadataVar(),
+    };
+
+    data.forEach((voice) => {
+      const { userId, user } = voice;
+      newUserMetadata[userId] = {
+        name: user.name,
+        speechLocale: user?.speechLocale,
+        role: user.role,
+      };
+    });
+
+    userMetadataVar(newUserMetadata);
+  };
+
+  const useTalkingUsers = () => {
+    const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+    const remoteParticipants = useRemoteParticipants({
+      room: liveKitRoom,
+      updateOnlyOn: [
+        RoomEvent.ParticipantConnected,
+        RoomEvent.ParticipantDisconnected,
+        RoomEvent.ActiveSpeakersChanged,
+        RoomEvent.Connected,
+      ],
+    });
+    const { localParticipant } = useLocalParticipant({ room: liveKitRoom });
+    const connectionState = useConnectionState(liveKitRoom);
+    const subscribedAudioUsers = useSubscribedAudioUsers();
+    const { data: bbbTalkingUsers } = useTalkingUsersGraphql();
+    const { data: unmutedUsers } = useWhoIsUnmuted();
+    const userMetadataMap = useReactiveVar(userMetadataVar);
+    const loading = useReactiveVar(loadingVar);
+    const currentTalkingState = useReactiveVar(currentTalkingStateVar);
+    const mutedTimeoutRegistry = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
+    const spokeTimeoutRegistry = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
+    const [record, setRecord] = useState<Record<string, VoiceItem>>({});
+
+    useEffect(() => {
+      if (!shouldUseLiveKit) return undefined;
+
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+      };
+    }, [shouldUseLiveKit]);
+
+    useEffect(() => {
+      if (!shouldUseLiveKit) return;
+
+      const newTalkingState: Record<string, boolean> = { ...currentTalkingState };
+
+      if (localParticipant && Auth.userID) {
+        const localUserId = Auth.userID as string;
+        if (localParticipant.isSpeaking) {
+          newTalkingState[localUserId] = true;
+        } else {
+          delete newTalkingState[localUserId];
+        }
+      }
+
+      remoteParticipants.forEach((participant) => {
+        const userId = participant.identity;
+        const isSubscribed = subscribedAudioUsers[userId] ?? false;
+
+        if (isSubscribed) {
+          // Use LiveKit isSpeaking for subscribed participants
+          if (participant.isSpeaking) {
+            newTalkingState[userId] = true;
+          } else {
+            delete newTalkingState[userId];
+          }
+        } else {
+          // Use BBB fallback for unsubscribed participants
+          // LiveKit only emits speaking events for subscribed tracks of remote participants.
+          const bbbTalking = bbbTalkingUsers[userId]?.talking ?? false;
+          console.debug('Livekit fallback for unsubscribed participant', userId, bbbTalking);
+
+          if (bbbTalking) {
+            newTalkingState[userId] = true;
+          } else {
+            delete newTalkingState[userId];
+          }
+        }
+      });
+
+      if (!isEqual(currentTalkingState, newTalkingState)) {
+        currentTalkingStateVar(newTalkingState);
+      }
+    }, [remoteParticipants, localParticipant, subscribedAudioUsers, bbbTalkingUsers]);
+
+    useEffect(() => {
+      if (!shouldUseLiveKit) return;
+
+      const isConnected = connectionState === ConnectionState.Connected;
+      setTalkingUserLoading(!isConnected);
+
+      // When LiveKit is disconnected, use BBB state as fallback
+      if (!isConnected) {
+        const bbbRecord: Record<string, VoiceItem> = {};
+
+        Object.keys(bbbTalkingUsers).forEach((userId) => {
+          const talkingUser = bbbTalkingUsers[userId];
+
+          if (talkingUser) bbbRecord[userId] = talkingUser;
+        });
+
+        if (!isEqual(record, bbbRecord)) setRecord(bbbRecord);
+
+        return;
+      }
+
+      const allUserIds = new Set<string>();
+      Object.keys(currentTalkingState).forEach((id) => allUserIds.add(id));
+      Object.keys(record).forEach((id) => allUserIds.add(id));
+      Object.keys(userMetadataMap).forEach((id) => allUserIds.add(id));
+
+      const newRecord: Record<string, VoiceItem> = { ...record };
+
+      allUserIds.forEach((userId) => {
+        const talking = currentTalkingState[userId] ?? false;
+        const muted = !unmutedUsers[userId];
+        let userMetadata = userMetadataMap[userId];
+
+        // No metadata for the user is found, which means the client is likely
+        // not connected to BBB/gql. If the user is still connected to LK,
+        // generate a baseline user metadata object. This is not 100% accurate,
+        // but it's better than not having a working talking indicator while the
+        // user can be heard by others - prlanzarin Jan 05 2026
+        if (!userMetadata) {
+          const participant = remoteParticipants.find((p) => p.identity === userId);
+
+          if (!participant) {
+            if (!currentTalkingState[userId]) delete newRecord[userId];
+
+            return;
+          }
+
+          userMetadata = {
+            name: participant.name ?? participant.identity,
+            speechLocale: undefined,
+            role: window.meetingClientSettings.public.user.role_viewer,
+          };
+        }
+
+        const previousIndicator = record[userId];
+        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
+        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
+
+        // Handle unmuted users
+        if (!muted) {
+          if (!previousIndicator && !talking) {
+            // Skip if no previous state and not talking
+            return;
+          }
+
+          let startTime = previousIndicator?.startTime ?? 0;
+          let endTime = previousIndicator?.endTime ?? 0;
+
+          if (previousIndicator?.talking && !talking) {
+            endTime = Date.now();
+            startTime = 0;
+          }
+
+          if (!previousIndicator?.talking && talking) {
+            startTime = Date.now();
+            endTime = 0;
+          }
+
+          // Cancel any deletion if user has started talking
+          if (talking) {
+            if (currentSpokeTimeout) {
+              clearTimeout(currentSpokeTimeout);
+              spokeTimeoutRegistry.current[userId] = null;
+            }
+            if (currentMutedTimeout) {
+              clearTimeout(currentMutedTimeout);
+              mutedTimeoutRegistry.current[userId] = null;
+            }
+          }
+
+          // User has stopped talking
+          if (endTime && !currentSpokeTimeout) {
+            spokeTimeoutRegistry.current[userId] = setTimeout(() => {
+              setRecord((previousRecord) => {
+                const newRecord = { ...previousRecord };
+                delete newRecord[userId];
+                return newRecord;
+              });
+            }, TALKING_INDICATOR_TIMEOUT);
+          }
+
+          newRecord[userId] = {
+            ...(previousIndicator || {}),
+            userId,
+            muted,
+            talking,
+            startTime,
+            endTime,
+            user: userMetadata,
+          };
+        } else {
+          // Handle muted users
+          if (!previousIndicator) {
+            // Remove user if they have no previous talking state.
+            delete newRecord[userId];
+
+            return;
+          }
+
+          const { startTime } = previousIndicator;
+          const endTime = previousIndicator.talking
+            ? Date.now()
+            : previousIndicator.endTime;
+
+          // User has never talked or exited audio
+          if (!(endTime || startTime)) {
+            delete newRecord[userId];
+
+            return;
+          }
+
+          if (!currentMutedTimeout && !currentSpokeTimeout) {
+            mutedTimeoutRegistry.current[userId] = setTimeout(() => {
+              setRecord((previousRecord) => {
+                const newRecord = { ...previousRecord };
+                delete newRecord[userId];
+                return newRecord;
+              });
+              mutedTimeoutRegistry.current[userId] = null;
+            }, TALKING_INDICATOR_TIMEOUT);
+          }
+
+          newRecord[userId] = {
+            ...previousIndicator,
+            userId,
+            muted,
+            talking: false,
+            startTime,
+            endTime,
+            user: userMetadata,
+          };
+        }
+      });
+
+      // Clean up users that are no longer in the room and not in LK/BBB.
+      Object.keys(newRecord).forEach((userId) => {
+        if (!userMetadataMap[userId] && !currentTalkingState[userId]) {
+          const spokeTimeout = spokeTimeoutRegistry.current[userId];
+          const mutedTimeout = mutedTimeoutRegistry.current[userId];
+          if (spokeTimeout) {
+            clearTimeout(spokeTimeout);
+            spokeTimeoutRegistry.current[userId] = null;
+          }
+          if (mutedTimeout) {
+            clearTimeout(mutedTimeout);
+            mutedTimeoutRegistry.current[userId] = null;
+          }
+          delete newRecord[userId];
+        }
+      });
+
+      if (!isEqual(record, newRecord)) setRecord(newRecord);
+    }, [
+      connectionState,
+      currentTalkingState,
+      unmutedUsers,
+      userMetadataMap,
+      record,
+      remoteParticipants,
+      shouldUseLiveKit,
+      bbbTalkingUsers,
+    ]);
+
+    if (!shouldUseLiveKit) return BASELINE_DATA;
+
+    return {
+      error: undefined,
+      loading,
+      data: record,
+    };
+  };
+
+  return [
+    useTalkingUsers,
+    useTalkingUserConsumersCount,
+    setTalkingUserLoading,
+    dispatchTalkingUserUpdate,
+  ] as const;
+};
+
+const [
+  useTalkingUsers,
+  useTalkingUserConsumersCount,
+  setTalkingUserLoading,
+  dispatchTalkingUserUpdate,
+] = createUseTalkingUsersLiveKit();
+
+export {
+  useTalkingUserConsumersCount,
+  setTalkingUserLoading,
+  dispatchTalkingUserUpdate,
+};
+
+export default useTalkingUsers;

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useWhoIsTalkingLiveKit.tsx
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useWhoIsTalkingLiveKit.tsx
@@ -1,0 +1,141 @@
+import { useEffect } from 'react';
+import { isEqual } from 'radash';
+import { makeVar, useReactiveVar } from '@apollo/client';
+import {
+  useRemoteParticipants,
+  useLocalParticipant,
+  useConnectionState,
+} from '@livekit/components-react';
+import { ConnectionState, RoomEvent } from 'livekit-client';
+import { liveKitRoom } from '/imports/ui/services/livekit';
+import Auth from '/imports/ui/services/auth';
+import useShouldUseLiveKitAudioState from './useShouldUseLiveKitAudioState';
+import useSubscribedAudioUsers from './useSubscribedAudioUsers';
+import useWhoIsTalkingGraphql from '../useWhoIsTalkingGraphql';
+import { TalkingUsersState } from '../types';
+
+const BASELINE_DATA: TalkingUsersState = {
+  data: {},
+  loading: false,
+};
+
+const createUseWhoIsTalkingLiveKit = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<Record<string, boolean>>({});
+  const loadingVar = makeVar(true);
+
+  const setWhoIsTalkingState = (newState: Record<string, boolean>) => stateVar(newState);
+  const setWhoIsTalkingLoading = (loading: boolean) => loadingVar(loading);
+  const getWhoIsTalking = () => stateVar();
+  const useWhoIsTalkingConsumersCount = () => useReactiveVar(countVar);
+  const useWhoIsTalking = () => {
+    const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+    const remoteParticipants = useRemoteParticipants({
+      room: liveKitRoom,
+      updateOnlyOn: [
+        RoomEvent.ParticipantConnected,
+        RoomEvent.ParticipantDisconnected,
+        RoomEvent.ActiveSpeakersChanged,
+        RoomEvent.Connected,
+      ],
+    });
+    const { localParticipant } = useLocalParticipant({ room: liveKitRoom });
+    const connectionState = useConnectionState(liveKitRoom);
+    const subscribedAudioUsers = useSubscribedAudioUsers();
+    const { data: bbbTalkingUsers } = useWhoIsTalkingGraphql();
+    const talkingUsers = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+
+    useEffect(() => {
+      // Only track consumers when LiveKit is actually used
+      if (!shouldUseLiveKit) return undefined;
+
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+        if (countVar() === 0) setWhoIsTalkingState({});
+      };
+    }, [shouldUseLiveKit]);
+
+    useEffect(() => {
+      if (!shouldUseLiveKit) return;
+
+      const isConnected = connectionState === ConnectionState.Connected;
+
+      setWhoIsTalkingLoading(!isConnected);
+
+      // When LiveKit is disconnected, use BBB state as fallback
+      if (!isConnected) {
+        const bbbState = bbbTalkingUsers || {};
+
+        if (!isEqual(getWhoIsTalking(), bbbState)) setWhoIsTalkingState(bbbState);
+
+        return;
+      }
+
+      const newTalkingUsers: Record<string, boolean> = {};
+
+      if (localParticipant && Auth.userID) {
+        const localUserId = Auth.userID as string;
+
+        if (localParticipant.isSpeaking) {
+          newTalkingUsers[localUserId] = true;
+        }
+      }
+
+      // For remote users, use LK if subscribed, otherwise BBB.
+      // LiveKit only emits speaking events for subscribed tracks and we *want*
+      // talking state to be shown regardless.
+      remoteParticipants.forEach((participant) => {
+        const userId = participant.identity;
+        const isSubscribed = subscribedAudioUsers[userId] ?? false;
+
+        if (isSubscribed) {
+          if (participant.isSpeaking) newTalkingUsers[userId] = true;
+        } else if (bbbTalkingUsers[userId]) {
+          newTalkingUsers[userId] = true;
+        }
+      });
+
+      if (!isEqual(getWhoIsTalking(), newTalkingUsers)) {
+        setWhoIsTalkingState(newTalkingUsers);
+      }
+    }, [
+      remoteParticipants,
+      localParticipant,
+      connectionState,
+      shouldUseLiveKit,
+      subscribedAudioUsers,
+      bbbTalkingUsers,
+    ]);
+
+    // Short-circuit when LiveKit is not used to prevent unnecessary re-renders
+    // Return stable empty values to ensure no re-renders are triggered
+    if (!shouldUseLiveKit) return BASELINE_DATA;
+
+    return {
+      data: talkingUsers,
+      loading,
+    };
+  };
+
+  return [
+    useWhoIsTalking,
+    useWhoIsTalkingConsumersCount,
+    setWhoIsTalkingLoading,
+  ] as const;
+};
+
+const [
+  useWhoIsTalking,
+  useWhoIsTalkingConsumersCount,
+  setWhoIsTalkingLoading,
+] = createUseWhoIsTalkingLiveKit();
+
+export {
+  useWhoIsTalking,
+  useWhoIsTalkingConsumersCount,
+  setWhoIsTalkingLoading,
+};
+
+export default useWhoIsTalking;

--- a/bigbluebutton-html5/imports/ui/core/hooks/livekit/useWhoIsUnmutedLiveKit.tsx
+++ b/bigbluebutton-html5/imports/ui/core/hooks/livekit/useWhoIsUnmutedLiveKit.tsx
@@ -1,0 +1,143 @@
+import { useEffect } from 'react';
+import { isEqual } from 'radash';
+import { makeVar, useReactiveVar } from '@apollo/client';
+import {
+  useRemoteParticipants,
+  useLocalParticipant,
+  useConnectionState,
+} from '@livekit/components-react';
+import { ConnectionState, RoomEvent, Track } from 'livekit-client';
+import { liveKitRoom } from '/imports/ui/services/livekit';
+import Auth from '/imports/ui/services/auth';
+import useShouldUseLiveKitAudioState from './useShouldUseLiveKitAudioState';
+import useWhoIsUnmutedGraphql from '../useWhoIsUnmutedGraphql';
+import { UnmutedUsersState } from '../types';
+
+const BASELINE_DATA: UnmutedUsersState = {
+  data: {},
+  loading: false,
+};
+
+const createUseWhoIsUnmutedLiveKit = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<Record<string, boolean>>({});
+  const loadingVar = makeVar(true);
+
+  const setWhoIsUnmutedState = (newState: Record<string, boolean>) => stateVar(newState);
+  const setWhoIsUnmutedLoading = (loading: boolean) => loadingVar(loading);
+  const getWhoIsUnmuted = () => stateVar();
+  const useWhoIsUnmutedConsumersCount = () => useReactiveVar(countVar);
+  const useWhoIsUnmuted = () => {
+    const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+    const remoteParticipants = useRemoteParticipants({
+      room: liveKitRoom,
+      updateOnlyOn: [
+        RoomEvent.ParticipantConnected,
+        RoomEvent.ParticipantDisconnected,
+        RoomEvent.TrackPublished,
+        RoomEvent.TrackUnpublished,
+        RoomEvent.TrackMuted,
+        RoomEvent.TrackUnmuted,
+        RoomEvent.Connected,
+      ],
+    });
+    const { localParticipant, microphoneTrack } = useLocalParticipant({ room: liveKitRoom });
+    const connectionState = useConnectionState(liveKitRoom);
+    const { data: bbbUnmutedUsers } = useWhoIsUnmutedGraphql();
+    const unmutedUsers = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+
+    useEffect(() => {
+      // Only track consumers when LiveKit is actually used
+      if (!shouldUseLiveKit) return undefined;
+
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+        if (countVar() === 0) {
+          setWhoIsUnmutedState({});
+        }
+      };
+    }, [shouldUseLiveKit]);
+
+    useEffect(() => {
+      if (!shouldUseLiveKit) return;
+
+      const isConnected = connectionState === ConnectionState.Connected;
+      setWhoIsUnmutedLoading(!isConnected);
+
+      // When LiveKit is disconnected, use BBB state as fallback
+      if (!isConnected) {
+        const bbbState = bbbUnmutedUsers || {};
+
+        if (!isEqual(getWhoIsUnmuted(), bbbState)) setWhoIsUnmutedState(bbbState);
+
+        return;
+      }
+
+      const newUnmutedUsers: Record<string, boolean> = {};
+
+      if (localParticipant && Auth.userID) {
+        const localUserId = Auth.userID as string;
+
+        if (microphoneTrack && !microphoneTrack.isMuted) {
+          newUnmutedUsers[localUserId] = true;
+        } else {
+          localParticipant.audioTrackPublications.forEach((publication) => {
+            if (publication.source === Track.Source.Microphone && !publication.isMuted) {
+              newUnmutedUsers[localUserId] = true;
+            }
+          });
+        }
+      }
+
+      remoteParticipants.forEach((participant) => {
+        const userId = participant.identity;
+
+        participant.audioTrackPublications.forEach((publication) => {
+          if (publication.source === Track.Source.Microphone && !publication.isMuted) {
+            newUnmutedUsers[userId] = true;
+          }
+        });
+      });
+
+      if (!isEqual(getWhoIsUnmuted(), newUnmutedUsers)) {
+        setWhoIsUnmutedState(newUnmutedUsers);
+      }
+    }, [
+      remoteParticipants,
+      localParticipant,
+      connectionState,
+      microphoneTrack,
+      shouldUseLiveKit,
+      bbbUnmutedUsers,
+    ]);
+
+    if (!shouldUseLiveKit) return BASELINE_DATA;
+
+    return {
+      data: unmutedUsers,
+      loading,
+    };
+  };
+
+  return [
+    useWhoIsUnmuted,
+    useWhoIsUnmutedConsumersCount,
+    setWhoIsUnmutedLoading,
+  ] as const;
+};
+
+const [
+  useWhoIsUnmuted,
+  useWhoIsUnmutedConsumersCount,
+  setWhoIsUnmutedLoading,
+] = createUseWhoIsUnmutedLiveKit();
+
+export {
+  useWhoIsUnmuted,
+  useWhoIsUnmutedConsumersCount,
+  setWhoIsUnmutedLoading,
+};
+
+export default useWhoIsUnmuted;

--- a/bigbluebutton-html5/imports/ui/core/hooks/types.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/types.ts
@@ -1,0 +1,33 @@
+export type VoiceItem = {
+  startTime?: number;
+  endTime?: number;
+  muted: boolean;
+  talking: boolean;
+  userId: string;
+  user: { speechLocale?: string; name: string };
+};
+
+/**
+ * Return type for the useWhoIsUnmuted hook.
+ */
+export type UnmutedUsersState = {
+  data: Record<string, boolean>;
+  loading: boolean;
+};
+
+/**
+ * Return type for the useWhoIsTalking hook.
+ */
+export type TalkingUsersState = {
+  data: Record<string, boolean>;
+  loading: boolean;
+};
+
+/**
+ * Return type for the useTalkingUsers hook.
+ */
+export type TalkingUsersHookResult = {
+  error: undefined;
+  loading: boolean;
+  data: Record<string, VoiceItem>;
+};

--- a/bigbluebutton-html5/imports/ui/core/hooks/types.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/types.ts
@@ -4,7 +4,13 @@ export type VoiceItem = {
   muted: boolean;
   talking: boolean;
   userId: string;
-  user: { speechLocale?: string; name: string };
+  user: VoiceUserMetadata;
+};
+
+export type VoiceUserMetadata = {
+  color?: string;
+  speechLocale?: string;
+  name: string;
 };
 
 /**

--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsers.ts
@@ -1,213 +1,63 @@
-import { useEffect, useRef, useState } from 'react';
-import { makeVar, useReactiveVar } from '@apollo/client';
-import { partition } from '/imports/utils/array-utils';
+import { useMemo } from 'react';
+import useShouldUseLiveKitAudioState from './livekit/useShouldUseLiveKitAudioState';
+import useTalkingUsersLiveKit, {
+  useTalkingUserConsumersCount as useTalkingUserConsumersCountLiveKit,
+  setTalkingUserLoading as setTalkingUserLoadingLiveKit,
+  dispatchTalkingUserUpdate as dispatchTalkingUserUpdateLiveKit,
+} from './livekit/useTalkingUsersLiveKit';
+import useTalkingUsersGraphql, {
+  useTalkingUserConsumersCount as useTalkingUserConsumersCountGraphql,
+  dispatchTalkingUserUpdate as dispatchTalkingUserUpdateGraphql,
+  setTalkingUserLoading as setTalkingUserLoadingGraphql,
+} from './useTalkingUsersGraphql';
+import { TalkingUsersHookResult } from './types';
+import { VoiceActivityResponse } from '../graphql/queries/voiceActivity';
 
-type VoiceItem = {
-  startTime?: number;
-  endTime?: number;
-  muted: boolean;
-  talking: boolean;
-  userId: string;
-  user: { color: string; speechLocale?: string; name: string };
+/**
+ * Router hook that conditionally uses either BBB's GraphQL or LiveKit's
+ * client-side state to provide the talking users state.
+ *
+ * When `useLiveKitAudioState` is enabled AND `audioBridge === 'livekit'`,
+ * this hook uses LiveKit's participant speaking state combined with user metadata, else BBB's.
+ */
+const useTalkingUsers = (): TalkingUsersHookResult => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const bbbTalkingUsersState = useTalkingUsersGraphql();
+  const liveKitTalkingUsersState = useTalkingUsersLiveKit();
+
+  return useMemo(() => {
+    if (shouldUseLiveKit) return liveKitTalkingUsersState;
+
+    return bbbTalkingUsersState;
+  }, [shouldUseLiveKit, bbbTalkingUsersState, liveKitTalkingUsersState]);
 };
 
-const TALKING_INDICATOR_TIMEOUT = 6000;
+const useTalkingUserConsumersCount = () => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const bbbCount = useTalkingUserConsumersCountGraphql();
+  const livekitCount = useTalkingUserConsumersCountLiveKit();
 
-const createUseTalkingUsers = () => {
-  const countVar = makeVar(0);
-  const stateVar = makeVar<{
-    muted: boolean;
-    talking: boolean;
-    userId: string;
-    voiceUserId: string;
-    user: { color: string; speechLocale?: string; name: string }
-  }[] | undefined>([]);
-  const loadingVar = makeVar(true);
+  return useMemo(() => {
+    if (shouldUseLiveKit) return livekitCount;
 
-  const dispatchTalkingUserUpdate = (data?: {
-    muted: boolean;
-    talking: boolean;
-    userId: string;
-    voiceUserId: string;
-    user: { color: string; speechLocale?: string; name: string }
-  }[]) => stateVar(data);
-
-  const setTalkingUserLoading = (loading: boolean) => loadingVar(loading);
-
-  const useTalkingUserConsumersCount = () => useReactiveVar(countVar);
-
-  const useTalkingUsers = () => {
-    const voiceActivity = useReactiveVar(stateVar);
-    const loading = useReactiveVar(loadingVar);
-    const mutedTimeoutRegistry = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
-    const spokeTimeoutRegistry = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
-    const [record, setRecord] = useState<Record<string, VoiceItem>>({});
-
-    useEffect(() => {
-      countVar(countVar() + 1);
-      return () => {
-        countVar(countVar() - 1);
-      };
-    }, []);
-
-    useEffect(() => {
-      if (!voiceActivity) {
-        setRecord({});
-        return;
-      }
-
-      const [muted, unmuted] = partition(
-        voiceActivity,
-        (v) => v.muted,
-      );
-
-      unmuted.forEach((voice) => {
-        const {
-          talking, userId, muted, user,
-        } = voice;
-        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
-        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
-
-        setRecord((previousRecord) => {
-          const previousIndicator = previousRecord[userId];
-
-          if (!previousIndicator && !talking) {
-            return previousRecord;
-          }
-
-          let startTime = previousIndicator?.startTime ?? 0;
-          let endTime = previousIndicator?.endTime ?? 0;
-
-          if (previousIndicator?.talking && !talking) {
-            endTime = Date.now();
-            startTime = 0;
-          }
-
-          if (!previousIndicator?.talking && talking) {
-            startTime = Date.now();
-            endTime = 0;
-          }
-
-          // Cancel any deletion if user has started talking
-          if (talking) {
-            if (currentSpokeTimeout) {
-              clearTimeout(currentSpokeTimeout);
-              spokeTimeoutRegistry.current[userId] = null;
-            }
-            if (currentMutedTimeout) {
-              clearTimeout(currentMutedTimeout);
-              mutedTimeoutRegistry.current[userId] = null;
-            }
-          }
-
-          // User has stopped talking
-          if (endTime && !currentSpokeTimeout) {
-            spokeTimeoutRegistry.current[userId] = setTimeout(() => {
-              setRecord((previousRecord) => {
-                const newRecord = { ...previousRecord };
-                delete newRecord[userId];
-                return newRecord;
-              });
-            }, TALKING_INDICATOR_TIMEOUT);
-          }
-
-          return {
-            ...previousRecord,
-            [userId]: Object.assign(
-              previousRecord[userId] || {},
-              {
-                userId,
-                muted,
-                talking,
-                startTime,
-                endTime,
-                user,
-              },
-            ),
-          };
-        });
-      });
-
-      muted.forEach((voice) => {
-        const { userId, voiceUserId, user } = voice;
-        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
-        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
-
-        setRecord((previousRecord) => {
-          const previousIndicator = previousRecord[userId];
-
-          if (!previousIndicator) {
-            return previousRecord;
-          }
-
-          const { startTime } = previousIndicator;
-
-          const endTime = previousIndicator.talking
-            ? Date.now()
-            : previousIndicator.endTime;
-
-          // User has never talked or exited audio
-          if (!(endTime || startTime) || !voiceUserId) {
-            const newRecord = { ...previousRecord };
-            delete newRecord[userId];
-            return newRecord;
-          }
-
-          if (!currentMutedTimeout && !currentSpokeTimeout) {
-            mutedTimeoutRegistry.current[userId] = setTimeout(() => {
-              setRecord((previousRecord) => {
-                const newRecord = { ...previousRecord };
-                delete newRecord[userId];
-                return newRecord;
-              });
-              mutedTimeoutRegistry.current[userId] = null;
-            }, TALKING_INDICATOR_TIMEOUT);
-          }
-
-          return {
-            ...previousRecord,
-            [userId]: Object.assign(
-              previousRecord[userId] || {},
-              {
-                userId,
-                muted,
-                talking: false,
-                startTime,
-                endTime,
-                user,
-              },
-            ),
-          };
-        });
-      });
-    }, [voiceActivity]);
-
-    return {
-      error: undefined,
-      loading,
-      data: record,
-    };
-  };
-
-  return [
-    useTalkingUsers,
-    useTalkingUserConsumersCount,
-    dispatchTalkingUserUpdate,
-    setTalkingUserLoading,
-  ] as const;
+    return bbbCount;
+  }, [shouldUseLiveKit, bbbCount, livekitCount]);
 };
 
-const [
-  useTalkingUsers,
-  useTalkingUserConsumersCount,
-  dispatchTalkingUserUpdate,
-  setTalkingUserLoading,
-] = createUseTalkingUsers();
+const setTalkingUserLoading = (loading: boolean) => {
+  setTalkingUserLoadingGraphql(loading);
+  setTalkingUserLoadingLiveKit(loading);
+};
+
+const dispatchTalkingUserUpdate = (data?: VoiceActivityResponse['user_voice_activity_stream']) => {
+  dispatchTalkingUserUpdateLiveKit(data);
+  dispatchTalkingUserUpdateGraphql(data);
+};
 
 export {
   useTalkingUserConsumersCount,
-  dispatchTalkingUserUpdate,
   setTalkingUserLoading,
+  dispatchTalkingUserUpdate,
 };
 
 export default useTalkingUsers;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsersGraphql.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsersGraphql.ts
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState } from 'react';
+import { makeVar, useReactiveVar } from '@apollo/client';
+import { partition } from '/imports/utils/array-utils';
+import { VoiceItem } from './types';
+import { TALKING_INDICATOR_TIMEOUT } from './constants';
+import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/voiceActivity';
+
+const createUseTalkingUsersGraphql = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<{
+    muted: boolean;
+    talking: boolean;
+    userId: string;
+    voiceUserId: string;
+    user: { speechLocale?: string; name: string }
+  }[] | undefined>([]);
+  const loadingVar = makeVar(true);
+
+  const dispatchTalkingUserUpdate = (data?: VoiceActivityResponse['user_voice_activity_stream']) => stateVar(data);
+
+  const setTalkingUserLoading = (loading: boolean) => loadingVar(loading);
+
+  const useTalkingUserConsumersCount = () => useReactiveVar(countVar);
+
+  const useTalkingUsersGraphql = () => {
+    const voiceActivity = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+    const mutedTimeoutRegistry = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
+    const spokeTimeoutRegistry = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
+    const [record, setRecord] = useState<Record<string, VoiceItem>>({});
+
+    useEffect(() => {
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+      };
+    }, []);
+
+    useEffect(() => {
+      if (!voiceActivity) {
+        setRecord({});
+        return;
+      }
+
+      const [muted, unmuted] = partition(
+        voiceActivity,
+        (v) => v.muted,
+      );
+
+      unmuted.forEach((voice) => {
+        const {
+          talking, userId, muted, user,
+        } = voice;
+        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
+        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
+
+        setRecord((previousRecord) => {
+          const previousIndicator = previousRecord[userId];
+
+          if (!previousIndicator && !talking) {
+            return previousRecord;
+          }
+
+          let startTime = previousIndicator?.startTime ?? 0;
+          let endTime = previousIndicator?.endTime ?? 0;
+
+          if (previousIndicator?.talking && !talking) {
+            endTime = Date.now();
+            startTime = 0;
+          }
+
+          if (!previousIndicator?.talking && talking) {
+            startTime = Date.now();
+            endTime = 0;
+          }
+
+          // Cancel any deletion if user has started talking
+          if (talking) {
+            if (currentSpokeTimeout) {
+              clearTimeout(currentSpokeTimeout);
+              spokeTimeoutRegistry.current[userId] = null;
+            }
+            if (currentMutedTimeout) {
+              clearTimeout(currentMutedTimeout);
+              mutedTimeoutRegistry.current[userId] = null;
+            }
+          }
+
+          // User has stopped talking
+          if (endTime && !currentSpokeTimeout) {
+            spokeTimeoutRegistry.current[userId] = setTimeout(() => {
+              setRecord((previousRecord) => {
+                const newRecord = { ...previousRecord };
+                delete newRecord[userId];
+                return newRecord;
+              });
+            }, TALKING_INDICATOR_TIMEOUT);
+          }
+
+          return {
+            ...previousRecord,
+            [userId]: Object.assign(
+              previousRecord[userId] || {},
+              {
+                userId,
+                muted,
+                talking,
+                startTime,
+                endTime,
+                user,
+              },
+            ),
+          };
+        });
+      });
+
+      muted.forEach((voice) => {
+        const { userId, voiceUserId, user } = voice;
+        const currentSpokeTimeout = spokeTimeoutRegistry.current[userId];
+        const currentMutedTimeout = mutedTimeoutRegistry.current[userId];
+
+        setRecord((previousRecord) => {
+          const previousIndicator = previousRecord[userId];
+
+          if (!previousIndicator) {
+            return previousRecord;
+          }
+
+          const { startTime } = previousIndicator;
+
+          const endTime = previousIndicator.talking
+            ? Date.now()
+            : previousIndicator.endTime;
+
+          // User has never talked or exited audio
+          if (!(endTime || startTime) || !voiceUserId) {
+            const newRecord = { ...previousRecord };
+            delete newRecord[userId];
+            return newRecord;
+          }
+
+          if (!currentMutedTimeout && !currentSpokeTimeout) {
+            mutedTimeoutRegistry.current[userId] = setTimeout(() => {
+              setRecord((previousRecord) => {
+                const newRecord = { ...previousRecord };
+                delete newRecord[userId];
+                return newRecord;
+              });
+              mutedTimeoutRegistry.current[userId] = null;
+            }, TALKING_INDICATOR_TIMEOUT);
+          }
+
+          return {
+            ...previousRecord,
+            [userId]: Object.assign(
+              previousRecord[userId] || {},
+              {
+                userId,
+                muted,
+                talking: false,
+                startTime,
+                endTime,
+                user,
+              },
+            ),
+          };
+        });
+      });
+    }, [voiceActivity]);
+
+    return {
+      error: undefined,
+      loading,
+      data: record,
+    };
+  };
+
+  return [
+    useTalkingUsersGraphql,
+    useTalkingUserConsumersCount,
+    dispatchTalkingUserUpdate,
+    setTalkingUserLoading,
+  ] as const;
+};
+
+const [
+  useTalkingUsersGraphql,
+  useTalkingUserConsumersCount,
+  dispatchTalkingUserUpdate,
+  setTalkingUserLoading,
+] = createUseTalkingUsersGraphql();
+
+export {
+  useTalkingUserConsumersCount,
+  dispatchTalkingUserUpdate,
+  setTalkingUserLoading,
+};
+
+export default useTalkingUsersGraphql;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsersGraphql.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useTalkingUsersGraphql.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { makeVar, useReactiveVar } from '@apollo/client';
 import { partition } from '/imports/utils/array-utils';
-import { VoiceItem } from './types';
+import { VoiceItem, VoiceUserMetadata } from './types';
 import { TALKING_INDICATOR_TIMEOUT } from './constants';
 import { VoiceActivityResponse } from '/imports/ui/core/graphql/queries/voiceActivity';
 
@@ -12,7 +12,7 @@ const createUseTalkingUsersGraphql = () => {
     talking: boolean;
     userId: string;
     voiceUserId: string;
-    user: { speechLocale?: string; name: string }
+    user: VoiceUserMetadata;
   }[] | undefined>([]);
   const loadingVar = makeVar(true);
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalking.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalking.ts
@@ -1,90 +1,60 @@
-import { useEffect } from 'react';
-import { isEqual } from 'radash';
-import { makeVar, useReactiveVar } from '@apollo/client';
+import { useMemo } from 'react';
+import useShouldUseLiveKitAudioState from './livekit/useShouldUseLiveKitAudioState';
+import useWhoIsTalkingLiveKit, {
+  useWhoIsTalkingConsumersCount as useWhoIsTalkingConsumersCountLiveKit,
+  setWhoIsTalkingLoading as setWhoIsTalkingLoadingLiveKit,
+} from './livekit/useWhoIsTalkingLiveKit';
+import useWhoIsTalkingGraphql, {
+  useWhoIsTalkingConsumersCount as useWhoIsTalkingConsumersCountGraphql,
+  setWhoIsTalkingLoading as setWhoIsTalkingLoadingGraphql,
+  dispatchWhoIsTalkingUpdate as dispatchWhoIsTalkingUpdateGraphql,
+} from './useWhoIsTalkingGraphql';
+import { TalkingUsersState } from './types';
 
-const createUseWhoIsTalking = () => {
-  const countVar = makeVar(0);
-  const stateVar = makeVar<Record<string, boolean>>({});
-  const loadingVar = makeVar(true);
+/**
+ * Router hook that conditionally uses either BBB's GraphQL or LiveKit's
+ * client-side state to provide the talking users state.
+ *
+ * When `useLiveKitAudioState` is enabled AND `audioBridge === 'livekit'`,
+ * this hook uses LiveKit's participant speaking state, else BBB's.
+ */
+const useWhoIsTalking = (): TalkingUsersState => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const bbbTalkingState = useWhoIsTalkingGraphql();
+  const liveKitTalkingState = useWhoIsTalkingLiveKit();
 
-  const setWhoIsTalkingState = (newState: Record<string, boolean>) => stateVar(newState);
+  return useMemo(() => {
+    if (shouldUseLiveKit) return liveKitTalkingState;
 
-  const setWhoIsTalkingLoading = (loading: boolean) => loadingVar(loading);
-
-  const getWhoIsTalking = () => stateVar();
-
-  const dispatchWhoIsTalkingUpdate = (data?: { userId: string; talking: boolean; muted: boolean }[]) => {
-    if (countVar() === 0) return;
-
-    if (!data) {
-      stateVar({});
-      return;
-    }
-
-    const newTalkingUsers = { ...getWhoIsTalking() };
-
-    data.forEach((voice) => {
-      const { userId, talking, muted } = voice;
-
-      // Delete the user key instead of setting it to false
-      // to keep the state object small and easy to compare with isEqual
-      if (!talking || muted) {
-        delete newTalkingUsers[userId];
-        return;
-      }
-
-      newTalkingUsers[userId] = true;
-    });
-
-    if (isEqual(getWhoIsTalking(), newTalkingUsers)) {
-      return;
-    }
-
-    setWhoIsTalkingState(newTalkingUsers);
-  };
-
-  const useWhoIsTalkingConsumersCount = () => useReactiveVar(countVar);
-
-  const useWhoIsTalking = () => {
-    const talkingUsers = useReactiveVar(stateVar);
-    const loading = useReactiveVar(loadingVar);
-
-    useEffect(() => {
-      countVar(countVar() + 1);
-      return () => {
-        countVar(countVar() - 1);
-        if (countVar() === 0) {
-          setWhoIsTalkingState({});
-        }
-      };
-    }, []);
-
-    return {
-      data: talkingUsers,
-      loading,
-    };
-  };
-
-  return [
-    useWhoIsTalking,
-    useWhoIsTalkingConsumersCount,
-    setWhoIsTalkingLoading,
-    dispatchWhoIsTalkingUpdate,
-  ] as const;
+    return bbbTalkingState;
+  }, [shouldUseLiveKit, bbbTalkingState, liveKitTalkingState]);
 };
 
-const [
-  useWhoIsTalking,
-  useWhoIsTalkingConsumersCount,
-  setWhoIsTalkingLoading,
-  dispatchWhoIsTalkingUpdate,
-] = createUseWhoIsTalking();
+const useWhoIsTalkingConsumersCount = () => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const bbbCount = useWhoIsTalkingConsumersCountGraphql();
+  const livekitCount = useWhoIsTalkingConsumersCountLiveKit();
+
+  return useMemo(() => {
+    if (shouldUseLiveKit) return livekitCount;
+
+    return bbbCount;
+  }, [shouldUseLiveKit, bbbCount, livekitCount]);
+};
+
+const setWhoIsTalkingLoading = (loading: boolean) => {
+  setWhoIsTalkingLoadingGraphql(loading);
+  setWhoIsTalkingLoadingLiveKit(loading);
+};
+
+// Re-export GraphQL dispatch function for backward compatibility
+// Only used by adapters when BBB mode is active
+export const dispatchWhoIsTalkingUpdate = dispatchWhoIsTalkingUpdateGraphql;
 
 export {
   useWhoIsTalking,
   useWhoIsTalkingConsumersCount,
   setWhoIsTalkingLoading,
-  dispatchWhoIsTalkingUpdate,
 };
 
 export default useWhoIsTalking;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalkingGraphql.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsTalkingGraphql.ts
@@ -1,0 +1,88 @@
+import { useEffect } from 'react';
+import { isEqual } from 'radash';
+import { makeVar, useReactiveVar } from '@apollo/client';
+
+const createUseWhoIsTalkingGraphql = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<Record<string, boolean>>({});
+  const loadingVar = makeVar(true);
+
+  const setWhoIsTalkingState = (newState: Record<string, boolean>) => stateVar(newState);
+
+  const setWhoIsTalkingLoading = (loading: boolean) => loadingVar(loading);
+
+  const getWhoIsTalking = () => stateVar();
+
+  const dispatchWhoIsTalkingUpdate = (data?: { userId: string; talking: boolean; muted: boolean }[]) => {
+    if (countVar() === 0) return;
+
+    if (!data) {
+      stateVar({});
+      return;
+    }
+
+    const newTalkingUsers = { ...getWhoIsTalking() };
+
+    data.forEach((voice) => {
+      const { userId, talking, muted } = voice;
+
+      // Delete the user key instead of setting it to false
+      // to keep the state object small and easy to compare with isEqual
+      if (!talking || muted) {
+        delete newTalkingUsers[userId];
+        return;
+      }
+
+      newTalkingUsers[userId] = true;
+    });
+
+    if (isEqual(getWhoIsTalking(), newTalkingUsers)) return;
+
+    setWhoIsTalkingState(newTalkingUsers);
+  };
+
+  const useWhoIsTalkingConsumersCount = () => useReactiveVar(countVar);
+
+  const useWhoIsTalkingGraphql = () => {
+    const talkingUsers = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+
+    useEffect(() => {
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+        if (countVar() === 0) {
+          setWhoIsTalkingState({});
+        }
+      };
+    }, []);
+
+    return {
+      data: talkingUsers,
+      loading,
+    };
+  };
+
+  return [
+    useWhoIsTalkingGraphql,
+    useWhoIsTalkingConsumersCount,
+    setWhoIsTalkingLoading,
+    dispatchWhoIsTalkingUpdate,
+  ] as const;
+};
+
+const [
+  useWhoIsTalkingGraphql,
+  useWhoIsTalkingConsumersCount,
+  setWhoIsTalkingLoading,
+  dispatchWhoIsTalkingUpdate,
+] = createUseWhoIsTalkingGraphql();
+
+export {
+  useWhoIsTalkingGraphql,
+  useWhoIsTalkingConsumersCount,
+  setWhoIsTalkingLoading,
+  dispatchWhoIsTalkingUpdate,
+};
+
+export default useWhoIsTalkingGraphql;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmuted.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmuted.ts
@@ -1,90 +1,60 @@
-import { useEffect } from 'react';
-import { isEqual } from 'radash';
-import { makeVar, useReactiveVar } from '@apollo/client';
+import { useMemo } from 'react';
+import useShouldUseLiveKitAudioState from './livekit/useShouldUseLiveKitAudioState';
+import useWhoIsUnmutedLiveKit, {
+  useWhoIsUnmutedConsumersCount as useWhoIsUnmutedConsumersCountLiveKit,
+  setWhoIsUnmutedLoading as setWhoIsUnmutedLoadingLiveKit,
+} from './livekit/useWhoIsUnmutedLiveKit';
+import useWhoIsUnmutedGraphql, {
+  useWhoIsUnmutedConsumersCount as useWhoIsUnmutedConsumersCountGraphql,
+  setWhoIsUnmutedLoading as setWhoIsUnmutedLoadingGraphql,
+  dispatchWhoIsUnmutedUpdate as dispatchWhoIsUnmutedUpdateGraphql,
+} from './useWhoIsUnmutedGraphql';
+import { UnmutedUsersState } from './types';
 
-const createUseWhoIsUnmuted = () => {
-  const countVar = makeVar(0);
-  const stateVar = makeVar<Record<string, boolean>>({});
-  const loadingVar = makeVar(true);
+/**
+ * Router hook that conditionally uses either BBB's GraphQL or LiveKit's
+ * client-side state to provide the unmuted users state.
+ *
+ * When `useLiveKitAudioState` is enabled AND `audioBridge === 'livekit'`,
+ * this hook uses LiveKit's track publication state, else BBB's.
+ */
+const useWhoIsUnmuted = (): UnmutedUsersState => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const bbbMuteState = useWhoIsUnmutedGraphql();
+  const liveKitMuteState = useWhoIsUnmutedLiveKit();
 
-  const setWhoIsUnmutedState = (newState: Record<string, boolean>) => stateVar(newState);
+  return useMemo(() => {
+    if (shouldUseLiveKit) return liveKitMuteState;
 
-  const setWhoIsUnmutedLoading = (loading: boolean) => loadingVar(loading);
-
-  const getWhoIsUnmuted = () => stateVar();
-
-  const dispatchWhoIsUnmutedUpdate = (data?: { userId: string; muted: boolean; }[]) => {
-    if (countVar() === 0) return;
-
-    if (!data) {
-      stateVar({});
-      return;
-    }
-
-    const newUnmutedUsers = { ...getWhoIsUnmuted() };
-
-    data.forEach((voice) => {
-      const { userId, muted } = voice;
-
-      // Delete the user key instead of setting it to false
-      // to keep the state object small and easy to compare with isEqual
-      if (muted) {
-        delete newUnmutedUsers[userId];
-        return;
-      }
-
-      newUnmutedUsers[userId] = true;
-    });
-
-    if (isEqual(getWhoIsUnmuted(), newUnmutedUsers)) {
-      return;
-    }
-
-    setWhoIsUnmutedState(newUnmutedUsers);
-  };
-
-  const useWhoIsUnmutedConsumersCount = () => useReactiveVar(countVar);
-
-  const useWhoIsUnmuted = () => {
-    const unmutedUsers = useReactiveVar(stateVar);
-    const loading = useReactiveVar(loadingVar);
-
-    useEffect(() => {
-      countVar(countVar() + 1);
-      return () => {
-        countVar(countVar() - 1);
-        if (countVar() === 0) {
-          setWhoIsUnmutedState({});
-        }
-      };
-    }, []);
-
-    return {
-      data: unmutedUsers,
-      loading,
-    };
-  };
-
-  return [
-    useWhoIsUnmuted,
-    useWhoIsUnmutedConsumersCount,
-    setWhoIsUnmutedLoading,
-    dispatchWhoIsUnmutedUpdate,
-  ] as const;
+    return bbbMuteState;
+  }, [shouldUseLiveKit, bbbMuteState, liveKitMuteState]);
 };
 
-const [
-  useWhoIsUnmuted,
-  useWhoIsUnmutedConsumersCount,
-  setWhoIsUnmutedLoading,
-  dispatchWhoIsUnmutedUpdate,
-] = createUseWhoIsUnmuted();
+const useWhoIsUnmutedConsumersCount = () => {
+  const shouldUseLiveKit = useShouldUseLiveKitAudioState();
+  const bbbCount = useWhoIsUnmutedConsumersCountGraphql();
+  const livekitCount = useWhoIsUnmutedConsumersCountLiveKit();
+
+  return useMemo(() => {
+    if (shouldUseLiveKit) return livekitCount;
+
+    return bbbCount;
+  }, [shouldUseLiveKit, bbbCount, livekitCount]);
+};
+
+const setWhoIsUnmutedLoading = (loading: boolean) => {
+  setWhoIsUnmutedLoadingGraphql(loading);
+  setWhoIsUnmutedLoadingLiveKit(loading);
+};
+
+// Re-export GraphQL dispatch function for backward compatibility
+// Only used by adapters when BBB mode is active
+export const dispatchWhoIsUnmutedUpdate = dispatchWhoIsUnmutedUpdateGraphql;
 
 export {
   useWhoIsUnmuted,
   useWhoIsUnmutedConsumersCount,
   setWhoIsUnmutedLoading,
-  dispatchWhoIsUnmutedUpdate,
 };
 
 export default useWhoIsUnmuted;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmutedGraphql.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmutedGraphql.ts
@@ -1,0 +1,90 @@
+import { useEffect } from 'react';
+import { isEqual } from 'radash';
+import { makeVar, useReactiveVar } from '@apollo/client';
+
+const createUseWhoIsUnmutedGraphql = () => {
+  const countVar = makeVar(0);
+  const stateVar = makeVar<Record<string, boolean>>({});
+  const loadingVar = makeVar(true);
+
+  const setWhoIsUnmutedState = (newState: Record<string, boolean>) => stateVar(newState);
+
+  const setWhoIsUnmutedLoading = (loading: boolean) => loadingVar(loading);
+
+  const getWhoIsUnmuted = () => stateVar();
+
+  const dispatchWhoIsUnmutedUpdate = (data?: { userId: string; muted: boolean; }[]) => {
+    if (countVar() === 0) return;
+
+    if (!data) {
+      stateVar({});
+      return;
+    }
+
+    const newUnmutedUsers = { ...getWhoIsUnmuted() };
+
+    data.forEach((voice) => {
+      const { userId, muted } = voice;
+
+      // Delete the user key instead of setting it to false
+      // to keep the state object small and easy to compare with isEqual
+      if (muted) {
+        delete newUnmutedUsers[userId];
+        return;
+      }
+
+      newUnmutedUsers[userId] = true;
+    });
+
+    if (isEqual(getWhoIsUnmuted(), newUnmutedUsers)) {
+      return;
+    }
+
+    setWhoIsUnmutedState(newUnmutedUsers);
+  };
+
+  const useWhoIsUnmutedConsumersCount = () => useReactiveVar(countVar);
+
+  const useWhoIsUnmutedGraphql = () => {
+    const unmutedUsers = useReactiveVar(stateVar);
+    const loading = useReactiveVar(loadingVar);
+
+    useEffect(() => {
+      countVar(countVar() + 1);
+      return () => {
+        countVar(countVar() - 1);
+        if (countVar() === 0) {
+          setWhoIsUnmutedState({});
+        }
+      };
+    }, []);
+
+    return {
+      data: unmutedUsers,
+      loading,
+    };
+  };
+
+  return [
+    useWhoIsUnmutedGraphql,
+    useWhoIsUnmutedConsumersCount,
+    setWhoIsUnmutedLoading,
+    dispatchWhoIsUnmutedUpdate,
+  ] as const;
+};
+
+const [
+  useWhoIsUnmutedGraphql,
+  useWhoIsUnmutedConsumersCount,
+  setWhoIsUnmutedLoading,
+  dispatchWhoIsUnmutedUpdate,
+] = createUseWhoIsUnmutedGraphql();
+
+export {
+  useWhoIsUnmutedGraphql,
+  useWhoIsUnmutedConsumersCount,
+  setWhoIsUnmutedLoading,
+  dispatchWhoIsUnmutedUpdate,
+};
+
+export default useWhoIsUnmutedGraphql;

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -666,6 +666,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           },
           unpublishOnMute: false,
           unpublishAfterMuteMs: 5000,
+          useLiveKitAudioState: false,
         },
         camera: {
           publishOptions: {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -135,6 +135,17 @@ class AudioManager {
     checkMediaDevicesTarget();
   }
 
+  isUsingLiveKit() {
+    return this.bridge?.bridgeName === 'livekit';
+  }
+
+  shouldUseLiveKitAudioState() {
+    const livekitConfig = window?.meetingClientSettings?.public?.media?.livekit;
+    const useLiveKitAudioState = livekitConfig?.audio?.useLiveKitAudioState ?? false;
+
+    return this.isUsingLiveKit() && useLiveKitAudioState;
+  }
+
   onBeforeUnload() {
     const CONFIRMATION_ON_LEAVE = window.meetingClientSettings.public.app.askForConfirmationOnLeave;
     if (!CONFIRMATION_ON_LEAVE) {
@@ -357,7 +368,10 @@ class AudioManager {
     this._applyCachedOutputDeviceId();
     this.transparentListenOnlySupported = this.supportsTransparentListenOnly();
     this.audioEventHandler = audioEventHandler;
-    this.observeVoiceActivity();
+
+    // Only observe GraphQL voice activity if not using LiveKit's audio state
+    if (!this.shouldUseLiveKitAudioState()) this.observeVoiceActivity();
+
     this.initialized = true;
   }
 
@@ -715,15 +729,24 @@ class AudioManager {
     return this.bridge.transferCall(this.onAudioJoin.bind(this));
   }
 
-  onVoiceUserChanges(fields = {}) {
+  onVoiceUserChanges({
+    leftVoiceConf,
+    muted,
+    talking,
+  } = {}) {
+    // When using LiveKit audio state, mute/talking states are derived
+    // via the useAudioManagerStateSync hook, which pulls data from the unified
+    // audio state hooks (useWhoIsUnmuted and useWhoIsTalking).
+    if (this.shouldUseLiveKitAudioState()) return;
+
     let newMuteState;
 
     // when user leaves voice conf, set muted = false
     // as the user might have been transfered to a breakout room
-    if (fields.leftVoiceConf !== undefined && fields.leftVoiceConf) {
+    if (leftVoiceConf !== undefined && leftVoiceConf) {
       newMuteState = false;
-    } else if (fields.muted !== undefined && fields.muted !== this.isMuted) {
-      newMuteState = fields.muted;
+    } else if (muted !== undefined && muted !== this.isMuted) {
+      newMuteState = muted;
     }
 
     if (newMuteState !== undefined && newMuteState !== this.isMuted) {
@@ -736,8 +759,8 @@ class AudioManager {
       }
     }
 
-    if (fields.talking !== undefined && fields.talking !== this.isTalking) {
-      this.isTalking = fields.talking;
+    if (talking !== undefined && talking !== this.isTalking) {
+      this.isTalking = talking;
     }
 
     if (this.isMuted) {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -957,6 +957,9 @@ public:
       audio:
         # unpublishOnMute: whether to unpublish audio tracks when muted. Default is true.
         unpublishOnMute: true
+        # useLiveKitAudioState: whether to use LiveKit's client-side audio state
+        # instead of BBB's audio state. Default is false.
+        useLiveKitAudioState: false
         # publishOptions: see https://docs.livekit.io/client-sdk-js/interfaces/TrackPublishOptions.html
         publishOptions:
           audioPreset:


### PR DESCRIPTION
### What does this PR do?

- [feat(livekit): option to use LiveKit as the client's audio state source](https://github.com/bigbluebutton/bigbluebutton/commit/d0ab2f1ffc9b97998d257cd60e109628d6b01b45) 
  - This commit adds an initial implementation for using LiveKit's audio
state as the client's state source for the mute and talking states.
This can be activated through bbb-html5's
`public.media.livekit.audio.useLiveKitAudioState` (*default is false*,
preserving current behavior).
  - The changes are centered around the core useWhoisUnmuted,
useWhoIsTalking and useTalkingUsers hooks. They've been extensively
refactored into router hooks that conditionally return either:
    - The GraphQL-provided audio state data if useLiveKitAudioState=false
    - OR the derived audio states based on both LK and GraphQL data, if
    useLiveKitAudioState=true. LiveKit data supersedes GraphQL data when
    available, with GraphQL acting as a fallback.
  - The data types for the router hooks are unchanged from the original
ones, which makes those changes transparent to consumers. The GraphQL
variants were also untouched in functionality.
  - The other significant change is adapting the how AudioManager handles
local mute/talking states and mute actions:
    - If useLiveKitAudioState=false, the current implementation (E2E mute
    requests, GraphQL-based mute/talking states) is preserved
    - If useLiveKitAudioState=true, mute actions are first run _locally_
    through LiveKit. Additionally, mute and talking states are derived
    from the router hooks above, which should provide for faster state
    transitions and better accuracy.

### Closes Issue(s)

None

### Motivation

**tl;dr:** LiveKit's audio state is a more accurate source of truth.
Using it is reliable and faster (mute/unmute/talking state reactivity).

Audio state in the client is provided by BBB data sources. This works
but media has always been a partially decoupled system from BBB -
different signaling transports, different data transports, different
protocols. By consequence, it also has its own state that may be
desync'ed from BBB in scenarios where the BBB signaling pathway is down,
but media is up (or vice-versa).

Ideally, the client should always prefer the media framework's state
*first* for a few reasons, e.g.:
  - The media framework's state is what the user is actually
    _seeing_/_hearing_, so it should be the most accurate one
    when available. The idea here is to prevent mismatching scenarios
    such as:
    - User X suffers a temporary disconnection from GraphQL, but media
      stays up. X is still speaking and being heard by others, but their
      talking indicator is missing and their mute actions aren't working.
  - Some local states (e.g.: mute/talking) do not need to go E2E through
    BBB to be reflected in the interface. Using the locally provided
    state by the media framework helps with this and guarantees better
    UI reactivity.

With the current framework (bbb-webrtc-sfu/mediasoup), framework provided
media state is not available in a way that is structured and easily
usable. LiveKit does provide it in an idiomatic way through its SDKs,
which makes this work possible.