### PR TITLE
fix(external-video): remove duplicate event listener registration & ensure volume bar is visible on YouTube player 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -370,7 +370,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     ) => changeVolume(event.detail.volume)) as EventListener;
     window.addEventListener(ExternalVideoVolumeCommandsEnum.SET, handleExternalVideoVolumeSet);
     return () => {
-      window.addEventListener(ExternalVideoVolumeCommandsEnum.SET, handleExternalVideoVolumeSet);
+      window.removeEventListener(ExternalVideoVolumeCommandsEnum.SET, handleExternalVideoVolumeSet);
     };
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -137,7 +137,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     Vimeo: true,
     Facebook: true,
     ArcPlayer: true,
-    // YouTube: true,
+    YouTube: false,
   }), []);
 
   const videoPlayConfig = useMemo(() => {


### PR DESCRIPTION
### What does this PR do?
- The cleanup function of the useEffect in the external video player was incorrectly adding the event listener again instead of removing it. The `addEventListener` call has been replaced with `removeEventListener`.
- The line that explicitly sets `hideVolume` to `false` for the YouTube player had been commented out. This change restores that assignment to ensure the volume bar is consistently displayed, even though the value was previously being interpreted as `false` due to `undefined`.