### PR TITLE
feat(raised-hand): add notification badge to the sidebar button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
@@ -24,7 +24,7 @@ const UsersListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
     data: guestWaitingUsersData,
   } = useDeduplicatedSubscription<GuestWaitingUsers>(GET_GUEST_WAITING_USERS_SUBSCRIPTION);
   const {
-    data: usersData,
+    data: raisedHandUsersData,
   } = useDeduplicatedSubscription<RaisedHandUsersSubscriptionResponse>(
     RAISED_HAND_USERS,
     { skip: isOpened },
@@ -32,7 +32,7 @@ const UsersListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
 
   const label = intl.formatMessage(intlMessages.usersListLabel);
   const hasNotification = (guestWaitingUsersData?.user_guest?.length ?? 0) > 0
-    || (usersData?.user?.length ?? 0) > 0;
+    || (raisedHandUsersData?.user?.length ?? 0) > 0;
 
   return (
     <SidebarNavigationButton

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
@@ -7,6 +7,7 @@ import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedS
 import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
 import { BaseSidebarButtonProps } from '../types';
+import { RAISED_HAND_USERS, RaisedHandUsersSubscriptionResponse } from '/imports/ui/core/graphql/queries/users';
 
 const intlMessages = defineMessages({
   usersListLabel: {
@@ -22,9 +23,16 @@ const UsersListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
   const {
     data: guestWaitingUsersData,
   } = useDeduplicatedSubscription<GuestWaitingUsers>(GET_GUEST_WAITING_USERS_SUBSCRIPTION);
+  const {
+    data: usersData,
+  } = useDeduplicatedSubscription<RaisedHandUsersSubscriptionResponse>(
+    RAISED_HAND_USERS,
+    { skip: isOpened },
+  );
 
   const label = intl.formatMessage(intlMessages.usersListLabel);
-  const hasNotification = (guestWaitingUsersData?.user_guest?.length ?? 0) > 0;
+  const hasNotification = (guestWaitingUsersData?.user_guest?.length ?? 0) > 0
+    || (usersData?.user?.length ?? 0) > 0;
 
   return (
     <SidebarNavigationButton


### PR DESCRIPTION
### What does this PR do?
Show notification badge in the userlist sidebar button when there are participants with raised hands.
![raised-hands-badge](https://github.com/user-attachments/assets/de40b570-15f2-43e7-acaa-76efed984595)

### Closes Issue(s)
Closes #24487 