### PR TITLE
fix(audio): legacy listen only broken due to undefined argument

### DIFF
--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -667,7 +667,7 @@ class AudioManager {
       this.inputDeviceId = 'listen-only';
     }
 
-    return this.onAudioJoining()
+    return this.onAudioJoining({ muted: true })
       .then(() => {
         const callOptions = {
           isListenOnly: true,
@@ -678,7 +678,7 @@ class AudioManager {
       });
   }
 
-  onAudioJoining({ muted }) {
+  onAudioJoining({ muted } = {}) {
     this.isConnecting = true;
     this.isMuted = (typeof muted === 'boolean') ? muted : true;
     this.error = false;


### PR DESCRIPTION

### What does this PR do?

- [fix(audio): legacy listen only broken due to undefined argument](https://github.com/bigbluebutton/bigbluebutton/commit/2e0b25910fbf703c78539ecb84563f44e14d4470) 
  - Joining audio via the legacy listen only mode is failing due to a
missing argument in a call to the onAudioJoining callback in
AudioManager.
  - Provide the callback with the appropriate argument in legacy listen only
mode, as well as add a default value to the onAudioJoining method so
this doesn't happen again.

### Closes Issue(s)

None