### PR TITLE
feat(media-area): remove settings icon from buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
@@ -211,7 +211,6 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
             <MediaButton
               dataTest="managePresentations"
               color={hasPresentation ? 'active' : 'default'}
-              showSettingsIcon
               text={intl.formatMessage(intlMessages.mediaSharingSlides)}
               // @ts-ignore - jsx code
               icon={(<Icon iconName="file" color={hasPresentation ? colorPrimary : undefined} />)}
@@ -222,7 +221,6 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
             <MediaButton
               dataTest="shareExternalVideo"
               color={isSharingVideo ? 'primary' : 'default'}
-              showSettingsIcon
               text={intl.formatMessage(intlMessages.mediaSharingVideoLink)}
               icon={<Icon iconName="external-video" />}
               onClick={handleExternalVideoClick}


### PR DESCRIPTION
### What does this PR do?
Removes the settings icon in the top right corner of the presentation and external video buttons in the media area.

<img width="451" height="298" alt="Screenshot from 2026-01-21 13-43-08" src="https://github.com/user-attachments/assets/a42fbef1-249e-42b2-abc1-394764d67857" />


### Closes Issue(s)
Closes #24485