### PR TITLE
refactor (gql-middleware): Reduce cache key collision risk by switching to uint64 message keys

### DIFF
--- a/bbb-graphql-middleware/internal/common/CustomCache.go
+++ b/bbb-graphql-middleware/internal/common/CustomCache.go
@@ -12,17 +12,17 @@ type refMutex struct {
 }
 
 type CacheLocks struct {
-	locks map[uint32]*refMutex
+	locks map[uint64]*refMutex
 	mutex sync.Mutex // Protects the 'locks' map
 }
 
 func NewCacheLocks() *CacheLocks {
 	return &CacheLocks{
-		locks: make(map[uint32]*refMutex),
+		locks: make(map[uint64]*refMutex),
 	}
 }
 
-func (c *CacheLocks) Lock(id uint32) {
+func (c *CacheLocks) Lock(id uint64) {
 	var rm *refMutex
 
 	c.mutex.Lock()
@@ -42,7 +42,7 @@ func (c *CacheLocks) Lock(id uint32) {
 	rm.mutex.Lock()
 }
 
-func (c *CacheLocks) Unlock(id uint32) {
+func (c *CacheLocks) Unlock(id uint64) {
 	var rm *refMutex
 
 	c.mutex.Lock()

--- a/bbb-graphql-middleware/internal/common/GlobalState.go
+++ b/bbb-graphql-middleware/internal/common/GlobalState.go
@@ -1,10 +1,12 @@
 package common
 
 import (
-	"bbb-graphql-middleware/config"
-	"github.com/google/uuid"
 	"sync"
 	"time"
+
+	"bbb-graphql-middleware/config"
+
+	"github.com/google/uuid"
 )
 
 var uniqueID string
@@ -17,10 +19,12 @@ func GetUniqueID() string {
 	return uniqueID
 }
 
-var PatchedMessageCache = make(map[uint32][]byte)
-var PatchedMessageCacheMutex sync.RWMutex
+var (
+	PatchedMessageCache      = make(map[uint64][]byte)
+	PatchedMessageCacheMutex sync.RWMutex
+)
 
-func GetPatchedMessageCache(cacheKey uint32) ([]byte, bool) {
+func GetPatchedMessageCache(cacheKey uint64) ([]byte, bool) {
 	PatchedMessageCacheMutex.RLock()
 	defer PatchedMessageCacheMutex.RUnlock()
 
@@ -28,17 +32,17 @@ func GetPatchedMessageCache(cacheKey uint32) ([]byte, bool) {
 	return jsonDiffPatch, jsonDiffPatchExists
 }
 
-func StorePatchedMessageCache(cacheKey uint32, data []byte) {
+func StorePatchedMessageCache(cacheKey uint64, data []byte) {
 	PatchedMessageCacheMutex.Lock()
 	defer PatchedMessageCacheMutex.Unlock()
 
 	PatchedMessageCache[cacheKey] = data
 
-	//Remove the cache after 30 seconds
+	// Remove the cache after 30 seconds
 	go RemovePatchedMessageCache(cacheKey, 30)
 }
 
-func RemovePatchedMessageCache(cacheKey uint32, delayInSecs time.Duration) {
+func RemovePatchedMessageCache(cacheKey uint64, delayInSecs time.Duration) {
 	time.Sleep(delayInSecs * time.Second)
 
 	PatchedMessageCacheMutex.Lock()
@@ -46,9 +50,11 @@ func RemovePatchedMessageCache(cacheKey uint32, delayInSecs time.Duration) {
 	delete(PatchedMessageCache, cacheKey)
 }
 
-var HasuraMessageCache = make(map[uint32]HasuraMessage)
-var HasuraMessageKeyCache = make(map[uint32]string)
-var HasuraMessageCacheMutex sync.RWMutex
+var (
+	HasuraMessageCache      = make(map[uint32]HasuraMessage)
+	HasuraMessageKeyCache   = make(map[uint32]string)
+	HasuraMessageCacheMutex sync.RWMutex
+)
 
 func GetHasuraMessageCache(cacheKey uint32) (string, HasuraMessage, bool) {
 	HasuraMessageCacheMutex.RLock()
@@ -66,7 +72,7 @@ func StoreHasuraMessageCache(cacheKey uint32, dataKey string, hasuraMessage Hasu
 	HasuraMessageKeyCache[cacheKey] = dataKey
 	HasuraMessageCache[cacheKey] = hasuraMessage
 
-	//Remove the cache after 30 seconds
+	// Remove the cache after 30 seconds
 	go RemoveHasuraMessageCache(cacheKey, 30)
 }
 
@@ -79,8 +85,10 @@ func RemoveHasuraMessageCache(cacheKey uint32, delayInSecs time.Duration) {
 	delete(HasuraMessageCache, cacheKey)
 }
 
-var StreamCursorValueCache = make(map[uint32]interface{})
-var StreamCursorValueCacheMutex sync.RWMutex
+var (
+	StreamCursorValueCache      = make(map[uint32]interface{})
+	StreamCursorValueCacheMutex sync.RWMutex
+)
 
 func GetStreamCursorValueCache(cacheKey uint32) (interface{}, bool) {
 	StreamCursorValueCacheMutex.RLock()
@@ -96,7 +104,7 @@ func StoreStreamCursorValueCache(cacheKey uint32, streamCursorValue interface{})
 
 	StreamCursorValueCache[cacheKey] = streamCursorValue
 
-	//Remove the cache after 30 seconds
+	// Remove the cache after 30 seconds
 	go RemoveStreamCursorValueCache(cacheKey, 30)
 }
 
@@ -108,8 +116,10 @@ func RemoveStreamCursorValueCache(cacheKey uint32, delayInSecs time.Duration) {
 	delete(StreamCursorValueCache, cacheKey)
 }
 
-var MaxConnPerSessionToken = config.GetConfig().Server.MaxConnectionsPerSessionToken
-var MaxConnGlobal = config.GetConfig().Server.MaxConnections
+var (
+	MaxConnPerSessionToken = config.GetConfig().Server.MaxConnectionsPerSessionToken
+	MaxConnGlobal          = config.GetConfig().Server.MaxConnections
+)
 
 func GetMaxConnectionsPerSessionToken() int {
 	return MaxConnPerSessionToken
@@ -119,9 +129,11 @@ func GetMaxConnectionsGlobal() int {
 	return MaxConnGlobal
 }
 
-var GlobalConnectionsCount int
-var UserConnectionsCount = make(map[string]int)
-var UserConnectionsCountMutex sync.RWMutex
+var (
+	GlobalConnectionsCount    int
+	UserConnectionsCount      = make(map[string]int)
+	UserConnectionsCountMutex sync.RWMutex
+)
 
 func HasReachedMaxGlobalConnections() bool {
 	if GetMaxConnectionsGlobal() == 0 {

--- a/bbb-graphql-middleware/internal/common/StreamCursorUtils.go
+++ b/bbb-graphql-middleware/internal/common/StreamCursorUtils.go
@@ -3,11 +3,12 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"hash/crc32"
 	"regexp"
 	"strconv"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func GetStreamCursorPropsFromBrowserMessage(browserMessage BrowserSubscribeMessage) (string, string, interface{}) {
@@ -34,15 +35,15 @@ func GetStreamCursorPropsFromBrowserMessage(browserMessage BrowserSubscribeMessa
 
 func GetLastStreamCursorValueFromReceivedMessage(message []byte, streamCursorField string) interface{} {
 	dataChecksum := crc32.ChecksumIEEE(message)
-	GlobalCacheLocks.Lock(dataChecksum)
+	GlobalCacheLocks.Lock(uint64(dataChecksum))
 
 	if streamCursorValueCache, streamCursorValueCacheExists := GetStreamCursorValueCache(dataChecksum); streamCursorValueCacheExists {
-		//Unlock immediately once the cache was already created by other routine
-		GlobalCacheLocks.Unlock(dataChecksum)
+		// Unlock immediately once the cache was already created by other routine
+		GlobalCacheLocks.Unlock(uint64(dataChecksum))
 		return streamCursorValueCache
 	} else {
-		//It will create the cache and then Unlock (others will wait to benefit from this cache)
-		defer GlobalCacheLocks.Unlock(dataChecksum)
+		// It will create the cache and then Unlock (others will wait to benefit from this cache)
+		defer GlobalCacheLocks.Unlock(uint64(dataChecksum))
 	}
 
 	var lastStreamCursorValue interface{}
@@ -51,12 +52,12 @@ func GetLastStreamCursorValueFromReceivedMessage(message []byte, streamCursorFie
 	err := json.Unmarshal(message, &messageAsMap)
 	if err != nil {
 		log.Errorf("failed to unmarshal message: %v", err)
-		//return
+		return nil
 	}
 
 	if payload, okPayload := messageAsMap["payload"].(map[string]interface{}); okPayload {
 		if data, okData := payload["data"].(map[string]interface{}); okData {
-			//Data will have only one prop, `range` because its name is unknown
+			// Data will have only one prop, `range` because its name is unknown
 			for _, dataItem := range data {
 				currentDataProp, okCurrentDataProp := dataItem.([]interface{})
 				if okCurrentDataProp && len(currentDataProp) > 0 {
@@ -115,7 +116,7 @@ func PatchQuerySettingLastCursorValue(subscription GraphQlSubscription) []byte {
 			case string:
 				newValue = v
 
-				//Append quotes if it is missing, it will be necessary when appending to the query
+				// Append quotes if it is missing, it will be necessary when appending to the query
 				if !strings.HasPrefix(v, "\"") {
 					newValue = "\"" + newValue
 				}

--- a/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
@@ -189,7 +189,7 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, message *[]byte, sub
 
 	lastDataChecksumWas := subscription.LastReceivedDataChecksum
 	lastReceivedDataWas := subscription.LastReceivedData
-	cacheKey := mergeUint32(subscription.LastReceivedDataChecksum, dataChecksum)
+	cacheKey := combineUint32ToUint64(subscription.LastReceivedDataChecksum, dataChecksum)
 
 	// Store LastReceivedData Checksum
 	subscription.LastReceivedData = messageData
@@ -206,8 +206,8 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, message *[]byte, sub
 	return true
 }
 
-func mergeUint32(a, b uint32) uint32 {
-	return (a << 16) | (b >> 16)
+func combineUint32ToUint64(a, b uint32) uint64 {
+	return (uint64(a) << 32) | uint64(b)
 }
 
 func handleStreamingMessage(hc *common.HasuraConnection, message []byte, subscription common.GraphQlSubscription, queryId string) {
@@ -247,8 +247,8 @@ func handleConnectionAckMessage(hc *common.HasuraConnection, message []byte) {
 func getHasuraMessage(message []byte, subscription common.GraphQlSubscription, logger *logrus.Entry) (uint32, string, common.HasuraMessage) {
 	dataChecksum := crc32.ChecksumIEEE(message)
 
-	common.GlobalCacheLocks.Lock(dataChecksum)
-	defer common.GlobalCacheLocks.Unlock(dataChecksum)
+	common.GlobalCacheLocks.Lock(uint64(dataChecksum))
+	defer common.GlobalCacheLocks.Unlock(uint64(dataChecksum))
 
 	dataKey, hasuraMessage, dataMapExists := common.GetHasuraMessageCache(dataChecksum)
 	if dataMapExists {

--- a/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
+++ b/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
@@ -1,52 +1,56 @@
 package msgpatch
 
 import (
-	"bbb-graphql-middleware/internal/common"
 	"encoding/json"
+	"strconv"
+
+	"bbb-graphql-middleware/internal/common"
+
 	"github.com/mattbaird/jsonpatch"
 	log "github.com/sirupsen/logrus"
-	"strconv"
 )
 
-var minLengthToPatch = 250    //250 chars
-var minShrinkToUsePatch = 0.5 //50% percent
+var (
+	minLengthToPatch    = 250 // 250 chars
+	minShrinkToUsePatch = 0.5 // 50% percent
+)
 
 func GetPatchedMessage(
 	receivedMessage []byte,
 	dataKey string,
 	lastHasuraMessage common.HasuraMessage,
 	hasuraMessage common.HasuraMessage,
-	cacheKey uint32,
+	cacheKey uint64,
 	lastDataChecksum uint32,
-	currDataChecksum uint32) []byte {
-
+	currDataChecksum uint32,
+) []byte {
 	if lastDataChecksum != 0 {
-		common.JsonPatchBenchmarkingStarted(strconv.Itoa(int(cacheKey)))
-		defer common.JsonPatchBenchmarkingCompleted(strconv.Itoa(int(cacheKey)))
+		common.JsonPatchBenchmarkingStarted(strconv.FormatUint(cacheKey, 10))
+		defer common.JsonPatchBenchmarkingCompleted(strconv.FormatUint(cacheKey, 10))
 	}
 
-	//Lock to avoid other routines from processing the same message
+	// Lock to avoid other routines from processing the same message
 	common.GlobalCacheLocks.Lock(cacheKey)
 	if patchedMessageCache, patchedMessageCacheExists := common.GetPatchedMessageCache(cacheKey); patchedMessageCacheExists {
-		//Unlock immediately once the cache was already created by other routine
+		// Unlock immediately once the cache was already created by other routine
 		common.GlobalCacheLocks.Unlock(cacheKey)
 		return patchedMessageCache
 	} else {
-		//It will create the cache and then Unlock (others will wait to benefit from this cache)
+		// It will create the cache and then Unlock (others will wait to benefit from this cache)
 		defer common.GlobalCacheLocks.Unlock(cacheKey)
 	}
 
 	var jsonDiffPatch []byte
 
 	if currDataChecksum == lastDataChecksum {
-		//Content didn't change, set message as null to avoid sending it to the browser
-		//This case is usual when the middleware reconnects with Hasura and receives the data again
+		// Content didn't change, set message as null to avoid sending it to the browser
+		// This case is usual when the middleware reconnects with Hasura and receives the data again
 		jsonData, _ := json.Marshal(nil)
 		common.StorePatchedMessageCache(cacheKey, jsonData)
 		return jsonData
 	} else {
-		//Content was changed, creating json patch
-		//If data is small (< minLengthToPatch) it's not worth creating the patch
+		// Content was changed, creating json patch
+		// If data is small (< minLengthToPatch) it's not worth creating the patch
 		if len(hasuraMessage.Payload.Data[dataKey]) > minLengthToPatch {
 			if string(lastHasuraMessage.Payload.Data[dataKey]) != "" {
 				var shouldUseCustomJsonPatch bool
@@ -67,10 +71,10 @@ func GetPatchedMessage(
 		}
 	}
 
-	//Use patch if the length is {minShrinkToUsePatch}% smaller than the original msg
+	// Use patch if the length is {minShrinkToUsePatch}% smaller than the original msg
 	if jsonDiffPatch != nil && float64(len(string(jsonDiffPatch)))/float64(len(string(hasuraMessage.Payload.Data[dataKey]))) < minShrinkToUsePatch {
-		//Modify receivedMessage to include the Patch and remove the previous data
-		//The key of the original message is kept to avoid errors (Apollo-client expects to receive this prop)
+		// Modify receivedMessage to include the Patch and remove the previous data
+		// The key of the original message is kept to avoid errors (Apollo-client expects to receive this prop)
 
 		hasuraMessage.Payload.Data = map[string]json.RawMessage{
 			"patch": jsonDiffPatch,


### PR DESCRIPTION
This PR improves the cache key strategy used for storing JSON diffs between messages.

Previously, the cache key was created by merging two `uint32` values (`previousMessage` and `newMessage`) into a single key, which increased the risk of different message pairs producing the same key.

The new approach converts the two `uint32` values into a single `uint64` key that preserves both original values in full. By keeping each message identifier intact, the likelihood of key collisions is significantly reduced.
