### PR TITLE
fix(recording): Add check for notes_id undefined in events_worker.rb

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
@@ -42,11 +42,11 @@ module BigBlueButton
         events = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
         notes_id = BigBlueButton::Events.get_notes_id(events)
 
-        if notes_id.nil? || notes_id.empty?
+        if notes_id.nil? || notes_id.empty? || notes_id == 'undefined'
           @logger.warn("No notes_id found for #{@meeting_id}, skipping etherpad events")
           return
         end
-        
+
         events_etherpad = "#{target_dir}/events.etherpad"
         BigBlueButton.try_download("#{@notes_endpoint}/#{CGI.escape notes_id}/export/etherpad", events_etherpad)
       end

--- a/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
@@ -42,6 +42,11 @@ module BigBlueButton
         events = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
         notes_id = BigBlueButton::Events.get_notes_id(events)
 
+        if notes_id.nil? || notes_id.empty?
+          @logger.warn("No notes_id found for #{@meeting_id}, skipping etherpad events")
+          return
+        end
+        
         events_etherpad = "#{target_dir}/events.etherpad"
         BigBlueButton.try_download("#{@notes_endpoint}/#{CGI.escape notes_id}/export/etherpad", events_etherpad)
       end


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adds a guard for undefined notes_id

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # https://github.com/bigbluebutton/bigbluebutton/issues/24494

### Motivation
<!-- What inspired you to submit this pull request? -->
Hitting cases where `notes_id` is `undefined` ...

