### PR TITLE
Fix(html5): enforce meetingId filtering across user-related data streams

### DIFF
--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_cursor.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_pres_page_cursor.yaml
@@ -23,6 +23,7 @@ select_permissions:
       columns:
         - isCurrentPage
         - lastUpdatedAt
+        - meetingId
         - pageId
         - presentationId
         - userId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_camera.yaml
@@ -32,8 +32,9 @@ select_permissions:
     permission:
       columns:
         - contentType
-        - showAsContent
         - hasAudio
+        - meetingId
+        - showAsContent
         - streamId
         - userId
       filter:
@@ -53,8 +54,9 @@ select_permissions:
     permission:
       columns:
         - contentType
-        - showAsContent
         - hasAudio
+        - meetingId
+        - showAsContent
         - streamId
         - userId
       filter:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_connectionStatusReport.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_connectionStatusReport.yaml
@@ -26,6 +26,7 @@ select_permissions:
         - currentStatus
         - lastUnstableStatus
         - lastUnstableStatusAt
+        - meetingId
         - userId
       filter:
         _or:

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_voice_activity.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_voice_activity.yaml
@@ -22,6 +22,7 @@ select_permissions:
     permission:
       columns:
         - endTime
+        - meetingId
         - muted
         - startTime
         - talking

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_whiteboardCursorAccess.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_whiteboardCursorAccess.yaml
@@ -11,6 +11,7 @@ select_permissions:
     permission:
       columns:
         - isModerator
+        - meetingId
         - name
         - presenter
         - userId

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -27,6 +27,7 @@ import { LAYOUT_TYPE } from '../layout/enums';
 import { SET_PRESENTATION_FIT_TO_WIDTH } from './app-graphql/mutations';
 import { CURRENT_PRESENTATION_PAGE_SUBSCRIPTION } from '../whiteboard/queries';
 import { RAISED_HAND_USERS } from '/imports/ui/core/graphql/queries/users';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
 const AppContainer = (props) => {
   const {
@@ -56,8 +57,16 @@ const AppContainer = (props) => {
   }));
 
   const { data: usersData } = useDeduplicatedSubscription(RAISED_HAND_USERS);
-  const isCurrentUserNextRaisedHand = usersData?.user && currentUser?.raiseHand
-    ? usersData.user[0]?.userId === currentUser?.userId
+  const raisedHandUsers = currentMeeting?.meetingId
+    ? filterByMeetingId(
+      usersData?.user,
+      currentMeeting.meetingId,
+      RAISED_HAND_USERS,
+      (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+    )
+    : [];
+  const isCurrentUserNextRaisedHand = raisedHandUsers.length > 0 && currentUser?.raiseHand
+    ? raisedHandUsers[0]?.userId === currentUser?.userId
     : false;
 
   const { data: currentPageInfo } = useDeduplicatedSubscription(

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -6,6 +6,7 @@ import { uniqueId } from '/imports/utils/string-utils';
 import { useIsImportPresentationWithAnnotationsFromBreakoutRoomsEnabled, useIsImportSharedNotesFromBreakoutRoomsEnabled } from '/imports/ui/services/features';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { useLazyQuery, useQuery, useMutation } from '@apollo/client';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 import Styled from './styles';
 import {
   getBreakouts,
@@ -652,6 +653,7 @@ const CreateBreakoutRoomContainer: React.FC<CreateBreakoutRoomContainerProps> = 
     breakoutPolicies: m.breakoutPolicies,
     durationInSeconds: m.durationInSeconds,
     createdTime: m.createdTime,
+    meetingId: m.meetingId,
   }));
 
   const {
@@ -720,7 +722,14 @@ const CreateBreakoutRoomContainer: React.FC<CreateBreakoutRoomContainerProps> = 
       priority={priority}
       isUpdate={isUpdate}
       isBreakoutRecordable={currentMeeting?.breakoutPolicies?.record ?? true}
-      users={usersData?.user ?? []}
+      users={currentMeeting?.meetingId
+        ? filterByMeetingId(
+          usersData?.user,
+          currentMeeting.meetingId,
+          getUser,
+          (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+        )
+        : []}
       runningRooms={breakoutsData?.breakoutRoom ?? []}
       presentations={presentations}
       currentPresentation={currentPresentation}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/queries.ts
@@ -60,6 +60,7 @@ export const getUser = gql`
         {registeredAt: asc},
         {userId: asc}
       ]) {
+      meetingId
       extId
       userId
       name

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
@@ -23,7 +23,7 @@ const ConnectionStatusContainer = (props) => {
       CONNECTION_STATUS_REPORT_SUBSCRIPTION,
       (item) => ({ mismatchedUserId: item.user?.userId, mismatchedName: item.user?.name }),
     )
-    : [];
+    : (data?.user_connectionStatusReport ?? []);
   const connectionData = sortConnectionData(filteredData);
   const { data: currentUser } = useCurrentUser((u) => ({ isModerator: u.isModerator }));
   const amIModerator = !!currentUser?.isModerator;

--- a/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/modal/container.jsx
@@ -10,10 +10,21 @@ import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { useReactiveVar } from '@apollo/client';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
 const ConnectionStatusContainer = (props) => {
+  const { data: meeting } = useMeeting((m) => ({ meetingId: m.meetingId }));
   const { data } = useDeduplicatedSubscription(CONNECTION_STATUS_REPORT_SUBSCRIPTION);
-  const connectionData = data ? sortConnectionData(data.user_connectionStatusReport) : [];
+  const filteredData = meeting?.meetingId
+    ? filterByMeetingId(
+      data?.user_connectionStatusReport,
+      meeting.meetingId,
+      CONNECTION_STATUS_REPORT_SUBSCRIPTION,
+      (item) => ({ mismatchedUserId: item.user?.userId, mismatchedName: item.user?.name }),
+    )
+    : [];
+  const connectionData = sortConnectionData(filteredData);
   const { data: currentUser } = useCurrentUser((u) => ({ isModerator: u.isModerator }));
   const amIModerator = !!currentUser?.isModerator;
 

--- a/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/queries.jsx
@@ -10,6 +10,7 @@ export const CONNECTION_STATUS_REPORT_SUBSCRIPTION = gql`subscription ConnStatus
   },
   order_by: {lastUnstableStatusAt: desc}
   ) {
+    meetingId
     user {
       userId
       name

--- a/bigbluebutton-html5/imports/ui/components/raisehand-notifier/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/raisehand-notifier/container.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import logger from '/imports/startup/client/logger';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { RAISED_HAND_USERS, RaisedHandUsersSubscriptionResponse } from '/imports/ui/core/graphql/queries/users';
 import RaiseHandNotifier from './component';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { User } from '/imports/ui/Types/user';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
 const RaiseHandNotifierContainer: React.FC = () => {
   const { data: currentUser } = useCurrentUser((user: Partial<User>) => ({
@@ -20,7 +22,10 @@ const RaiseHandNotifierContainer: React.FC = () => {
     data: usersData,
     error: usersError,
   } = useDeduplicatedSubscription<RaisedHandUsersSubscriptionResponse>(RAISED_HAND_USERS);
-  const raiseHandUsers = usersData?.user ?? [];
+
+  const { data: meeting } = useMeeting((m) => ({
+    meetingId: m.meetingId,
+  }));
 
   if (usersError) {
     connectionStatus.setSubscriptionFailed(true);
@@ -31,7 +36,14 @@ const RaiseHandNotifierContainer: React.FC = () => {
   }
   // @ts-ignore
   const { raiseHandAudioAlerts, raiseHandPushAlerts } = useSettings(SETTINGS.APPLICATION);
-  if (!currentUser) return null;
+  if (!currentUser || !meeting) return null;
+
+  const raiseHandUsers = filterByMeetingId(
+    usersData?.user,
+    meeting?.meetingId,
+    RAISED_HAND_USERS,
+    (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+  );
 
   return (
     <RaiseHandNotifier

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/raised-hands/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/raised-hands/component.tsx
@@ -5,6 +5,7 @@ import logger from '/imports/startup/client/logger';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import Styled from './styles';
 import { RAISED_HAND_USERS, RaisedHandUser, RaisedHandUsersSubscriptionResponse } from '/imports/ui/core/graphql/queries/users';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 import { SET_RAISE_HAND } from '/imports/ui/core/graphql/mutations/userMutations';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import UserListStyles from '../user-participants/user-list-participants/list-item/styles';
@@ -184,7 +185,6 @@ const RaisedHandsContainer: React.FC = () => {
     data: usersData,
     error: usersError,
   } = useDeduplicatedSubscription<RaisedHandUsersSubscriptionResponse>(RAISED_HAND_USERS);
-  const raisedHands: RaisedHandUser[] = usersData?.user ?? [];
 
   const [setRaiseHand] = useMutation(SET_RAISE_HAND);
 
@@ -236,6 +236,13 @@ const RaisedHandsContainer: React.FC = () => {
   if (!meeting || !currentUser || meetingLoading || presentationLoading) {
     return null;
   }
+
+  const raisedHands: RaisedHandUser[] = filterByMeetingId(
+    usersData?.user,
+    meeting?.meetingId,
+    RAISED_HAND_USERS,
+    (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+  );
 
   const currentUserRaisedHand = currentUser && currentUser.raiseHand;
   const hideUserList = (currentUser?.locked && meeting?.lockSettings?.hideUserList) ?? false;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
@@ -15,7 +15,8 @@ import SkeletonUserListItem from '../list-item/skeleton/component';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { LockSettings, Meeting, UsersPolicies } from '/imports/ui/Types/meeting';
-import logger from '/imports/startup/client/logger';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
+import { USER_LIST_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
 
 interface UserListParticipantsContainerProps {
   index: number;
@@ -113,28 +114,13 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
     loading: usersLoading,
   } = useLoadedUserList({ offset, limit: limit.current }, (u) => u) as GraphqlDataHookSubscriptionResponse<Array<User>>;
 
-  const users = meeting && usersData
-    ? (usersData as User[]).filter((u: User) => {
-      const isInMeeting = u.meetingId === meeting?.meetingId;
-      if (!isInMeeting) {
-        logger.warn({
-          logCode: 'userlist_meetingid_mismatch',
-          extraInfo: {
-            name: u.name,
-            userId: u.userId,
-            meetingId: u.meetingId,
-            bot: u.bot,
-            disconnected: u.disconnected,
-            guest: u.guest,
-            isDialIn: u.isDialIn,
-            isModerator: u.isModerator,
-            loggedOut: u.loggedOut,
-            presenter: u.presenter,
-          },
-        }, 'userlist: meetingId mismatch, filtering out user');
-      }
-      return isInMeeting;
-    })
+  const users = meeting?.meetingId
+    ? filterByMeetingId(
+      usersData as User[],
+      meeting.meetingId,
+      USER_LIST_SUBSCRIPTION,
+      (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+    )
     : [];
 
   const { data: currentUser, loading: currentUserLoading } = useCurrentUser((c: Partial<User>) => ({

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/page/component.tsx
@@ -116,7 +116,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
 
   const users = meeting?.meetingId
     ? filterByMeetingId(
-      usersData as User[],
+      (usersData ?? []) as User[],
       meeting.meetingId,
       USER_LIST_SUBSCRIPTION,
       (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -28,8 +28,20 @@ import { SET_MUTED } from './mutations';
 import { CLEAR_ALL_REACTION } from '/imports/ui/core/graphql/mutations/userMutations';
 import { GET_USER_NAMES } from '/imports/ui/core/graphql/queries/users';
 import logger from '/imports/startup/client/logger';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 import { notify } from '/imports/ui/services/notification';
 import { useModalRegistration } from '/imports/ui/core/singletons/modalController';
+
+interface GetUserNamesResponse {
+  user: Array<{
+    meetingId: string;
+    name: string;
+    nameSortable: string;
+    firstNameSortable: string;
+    lastNameSortable: string;
+    userId: string;
+  }>;
+}
 
 const intlMessages = defineMessages({
   optionsLabel: {
@@ -134,6 +146,7 @@ interface UserTitleOptionsProps {
   hasBreakoutRooms: boolean | undefined;
   meetingName: string | undefined;
   learningDashboardToken: string | undefined;
+  meetingId: string | undefined;
 }
 
 const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
@@ -144,6 +157,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
   hasBreakoutRooms,
   meetingName,
   learningDashboardToken,
+  meetingId,
 }) => {
   const intl = useIntl();
   const { locale } = intl;
@@ -165,7 +179,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
 
   const [setMuted] = useMutation(SET_MUTED);
   const [clearAllReaction] = useMutation(CLEAR_ALL_REACTION);
-  const [getUsers, { data: usersData, error: usersError }] = useLazyQuery(GET_USER_NAMES, { fetchPolicy: 'no-cache' });
+  const [getUsers, { data: usersData, error: usersError }] = useLazyQuery<GetUserNamesResponse>(GET_USER_NAMES, { fetchPolicy: 'no-cache' });
   const users = usersData?.user || [];
   const isLearningDashboardEnabled = useIsLearningDashboardEnabled();
   const isBreakoutRoomsEnabled = useIsBreakoutRoomsEnabled();
@@ -184,10 +198,16 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
 
   // users will only be fetched when getUsers is called
   useEffect(() => {
-    if (users.length > 0) {
-      onSaveUserNames(intl, meetingName ?? '', users);
+    if (users.length > 0 && meetingId) {
+      const filteredUsers = filterByMeetingId(
+        users,
+        meetingId,
+        GET_USER_NAMES,
+        (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+      );
+      onSaveUserNames(intl, meetingName ?? '', filteredUsers);
     }
-  }, [users]);
+  }, [users, meetingId]);
 
   const callSetMuted = (muted: boolean, exceptPresenter: boolean) => {
     setMuted({
@@ -394,6 +414,7 @@ const UserTitleOptionsContainer: React.FC = () => {
     componentsFlags: meeting?.componentsFlags,
     name: meeting?.name,
     learningDashboardAccessToken: meeting.learningDashboardAccessToken,
+    meetingId: meeting?.meetingId,
   }));
 
   const { data: currentUser } = useCurrentUser((user: Partial<User>) => ({
@@ -414,6 +435,7 @@ const UserTitleOptionsContainer: React.FC = () => {
       hasBreakoutRooms={hasBreakoutRooms}
       meetingName={meetingInfo?.name}
       learningDashboardToken={meetingInfo?.learningDashboardAccessToken}
+      meetingId={meetingInfo?.meetingId}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/service.ts
@@ -20,7 +20,7 @@ const intlMessages = defineMessages({
   },
 });
 
-export const onSaveUserNames = (intl: IntlShape, meetingName: string, users: [User]) => {
+export const onSaveUserNames = (intl: IntlShape, meetingName: string, users: Partial<User>[]) => {
   const Settings = getSettingsSingletonInstance();
   // @ts-ignore - temporary while settings are still in .js
   const lang = Settings.application.locale;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -51,6 +51,7 @@ import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
 import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
 const useVideoStreamsSubscription = createUseSubscription(
   VIDEO_STREAMS_SUBSCRIPTION,
@@ -299,6 +300,10 @@ export const useGridUsers = (visibleStreamCount: number) => {
   const gridItems = useRef<GridItem[]>([]);
   const overflowCount = useRef<number>(0);
 
+  const { data: meeting } = useMeeting((m) => ({
+    meetingId: m.meetingId,
+  }));
+
   const {
     data: gridData,
     error: gridError,
@@ -323,8 +328,14 @@ export const useGridUsers = (visibleStreamCount: number) => {
     }, 'Grid users subscription failed.');
   }
 
-  if (gridData) {
-    const newGridUsers = gridData.user.map((user) => ({
+  if (gridData && meeting?.meetingId) {
+    const filteredUsers = filterByMeetingId(
+      gridData.user,
+      meeting.meetingId,
+      GRID_USERS_SUBSCRIPTION,
+      (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+    );
+    const newGridUsers = filteredUsers.map((user) => ({
       ...user,
       type: VIDEO_TYPES.GRID,
     }));

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -60,6 +60,7 @@ const useVideoStreamsSubscription = createUseSubscription(
 );
 
 export const useStreams = () => {
+  const { data: meeting } = useMeeting((m) => ({ meetingId: m.meetingId }));
   const { data, loading, errors } = useVideoStreamsSubscription();
 
   if (loading) return [];
@@ -75,7 +76,16 @@ export const useStreams = () => {
     });
   }
 
-  const mappedStreams = (data as StreamSubscriptionData[]).map(({ streamId, user, voice }) => {
+  const filteredStreams = meeting?.meetingId
+    ? filterByMeetingId(
+      data as StreamSubscriptionData[],
+      meeting.meetingId,
+      VIDEO_STREAMS_SUBSCRIPTION,
+      (s) => ({ mismatchedUserId: s.user?.userId, mismatchedName: s.user?.name }),
+    )
+    : [];
+
+  const mappedStreams = filteredStreams.map(({ streamId, user, voice }) => {
     if (!streamId) {
       logger.warn({
         logCode: 'missing_stream_id',

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -81,6 +81,7 @@ export const GRID_USERS_SUBSCRIPTION = gql`
         userId: asc,
       },
     ) {
+      meetingId
       name
       userId
       nameSortable

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -11,6 +11,7 @@ export interface ViewerVideoStreamsSubscriptionResponse {
 export const VIDEO_STREAMS_SUBSCRIPTION = gql`
   subscription VideoStreams {
     user_camera {
+      meetingId
       streamId
       user {
         name

--- a/bigbluebutton-html5/imports/ui/components/video-provider/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/types.ts
@@ -30,6 +30,7 @@ interface Voice extends GridVoice {
 
 export interface VideoStreamsResponse {
   user_camera: {
+    meetingId: string;
     streamId: string;
     user: User;
     voice?: Voice;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/container.tsx
@@ -18,6 +18,7 @@ import { UserCameraHelperAreas } from '../../../plugins-engine/extensible-areas/
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { RAISED_HAND_USERS } from '/imports/ui/core/graphql/queries/users';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
 interface VideoListItemContainerProps {
   numOfStreams: number;
@@ -67,6 +68,7 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
 
   const { data: currentMeeting } = useMeeting((m) => ({
     lockSettings: m.lockSettings,
+    meetingId: m.meetingId,
   }));
 
   const hideUserList = currentUserData?.locked && currentMeeting?.lockSettings?.hideUserList;
@@ -89,7 +91,14 @@ const VideoListItemContainer: React.FC<VideoListItemContainerProps> = (props) =>
   const {
     data: usersData,
   } = useDeduplicatedSubscription<{ user: RaisedHandUser[] }>(RAISED_HAND_USERS);
-  const raisedHands: RaisedHandUser[] = usersData?.user ?? [];
+  const raisedHands: RaisedHandUser[] = currentMeeting?.meetingId
+    ? filterByMeetingId(
+      usersData?.user,
+      currentMeeting.meetingId,
+      RAISED_HAND_USERS,
+      (u) => ({ mismatchedUserId: u.userId }),
+    )
+    : [];
   const raisedHandIndex = !hideUserList
     ? raisedHands.findIndex((user) => user.userId === userId) + 1
     : 0;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.ts
@@ -8,11 +8,17 @@ import {
   UserWhiteboardCursorResponse,
 } from './queries';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
 interface mergedData extends CursorCoordinates, UserWhiteboardCursor { }
 
 // Custom hook to fetch and merge data
 export const useMergedCursorData = () => {
+  const { data: meeting } = useMeeting((m) => ({
+    meetingId: m.meetingId,
+  }));
+
   const [
     cursorCoordinates,
     setCursorCoordinates,
@@ -31,7 +37,15 @@ export const useMergedCursorData = () => {
   const { data: cursorUsersSubscriptionData } = useDeduplicatedSubscription<UserWhiteboardCursorResponse>(
     CURRENT_CURSORS_SUBSCRIPTION,
   );
-  const cursorUsersSubscriptionDataString = JSON.stringify(cursorUsersSubscriptionData);
+  const filteredCursorUsers = meeting?.meetingId
+    ? filterByMeetingId(
+      cursorUsersSubscriptionData?.user_whiteboardCursorAccess,
+      meeting.meetingId,
+      CURRENT_CURSORS_SUBSCRIPTION,
+      (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+    )
+    : [];
+  const cursorUsersSubscriptionDataString = JSON.stringify(filteredCursorUsers);
 
   const { data: cursorCoordinatesData } = useDeduplicatedSubscription<CursorCoordinatesResponse>(
     CURRENT_PAGE_CURSORS_COORDINATES_STREAM,
@@ -54,8 +68,8 @@ export const useMergedCursorData = () => {
   }, [cursorCoordinatesDataString]);
 
   useEffect(() => {
-    if (cursorUsersSubscriptionData) {
-      const cursorData = cursorUsersSubscriptionData.user_whiteboardCursorAccess.reduce((acc, cursor) => {
+    if (filteredCursorUsers.length > 0) {
+      const cursorData = filteredCursorUsers.reduce((acc, cursor) => {
         acc[cursor.userId] = cursor;
         return acc;
       }, {} as { [key: string]: UserWhiteboardCursor });

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -24,6 +24,7 @@ export interface CurrentPageWritersResponse {
 }
 
 export interface UserWhiteboardCursor {
+  meetingId: string;
   userId: string;
   name: string;
   presenter: boolean;
@@ -202,6 +203,7 @@ export const CURRENT_CURSORS_SUBSCRIPTION = gql`
     user_whiteboardCursorAccess(
       order_by: { userId: asc }
     ) {
+      meetingId
       userId
       name
       presenter

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/users.ts
@@ -78,8 +78,10 @@ export const USER_AGGREGATE_COUNT_SUBSCRIPTION = gql`
 `;
 
 export const GET_USER_NAMES = gql`
-  query Users {
+  query GetUserNames {
     user(where: { bot: { _eq: false } } ) {
+      userId
+      meetingId
       name
       nameSortable
       firstNameSortable
@@ -90,6 +92,7 @@ export const GET_USER_NAMES = gql`
 
 export type RaisedHandUser = Pick<
 User,
+| 'meetingId'
 | 'userId'
 | 'name'
 | 'color'
@@ -115,6 +118,7 @@ subscription RaisedHandUsers {
     order_by: [
       {raiseHandTime: asc_nulls_last},
     ]) {
+    meetingId
     userId
     name
     color

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/usersBasicInfo.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/usersBasicInfo.ts
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client';
 const USERS_BASIC_INFO_SUBSCRIPTION = gql`
   subscription UsersBasicInfo {
     user(order_by: {nameSortable: asc, userId: asc}) {
+      meetingId
       userId
       extId
       name

--- a/bigbluebutton-html5/imports/ui/core/hooks/useUsersBasicInfo.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useUsersBasicInfo.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import createUseSubscription from './createUseSubscription';
+import useMeeting from './useMeeting';
 import { UserBasicInfo } from '../../Types/user';
 import USERS_BASIC_INFO_SUBSCRIPTION from '../graphql/queries/usersBasicInfo';
+import { filterByMeetingId } from '../utils/subscriptionFilters';
 
 const useUsersBasicInfoSubscription = createUseSubscription<UserBasicInfo>(
   USERS_BASIC_INFO_SUBSCRIPTION,
@@ -9,10 +11,28 @@ const useUsersBasicInfoSubscription = createUseSubscription<UserBasicInfo>(
 
 const useUsersBasicInfo = (fn: (c: Partial<UserBasicInfo>) => Partial<UserBasicInfo>) => {
   const response = useUsersBasicInfoSubscription(fn);
+
+  const { data: meeting } = useMeeting((m) => ({
+    meetingId: m.meetingId,
+  }));
+
+  const filteredData = useMemo(() => {
+    if (!response.data || !meeting?.meetingId) {
+      return response.data;
+    }
+    return filterByMeetingId(
+      response.data,
+      meeting.meetingId,
+      USERS_BASIC_INFO_SUBSCRIPTION,
+      (u) => ({ mismatchedUserId: u.userId, mismatchedName: u.name }),
+    );
+  }, [response.data, meeting?.meetingId]);
+
   const returnObject = useMemo(() => ({
     ...response,
-    data: response.data ? response.data : undefined,
-  }), [response]);
+    data: filteredData || undefined,
+  }), [response, filteredData]);
+
   return returnObject;
 };
 

--- a/bigbluebutton-html5/imports/ui/core/utils/subscriptionFilters.ts
+++ b/bigbluebutton-html5/imports/ui/core/utils/subscriptionFilters.ts
@@ -1,0 +1,75 @@
+import { DocumentNode } from 'graphql';
+import logger from '/imports/startup/client/logger';
+import Auth from '/imports/ui/services/auth';
+
+function getOperationName(document: DocumentNode): string {
+  const definition = document.definitions[0];
+  if (definition.kind === 'OperationDefinition' && definition.name) {
+    return definition.name.value;
+  }
+  return 'unknown_subscription';
+}
+
+function generateLogCode(subscriptionName: string): string {
+  return `${subscriptionName.toLowerCase()}_meetingid_mismatch`;
+}
+
+interface WithMeetingId {
+  meetingId?: string;
+}
+
+export function createMeetingIdFilter<T extends object>(
+  expectedMeetingId: string | undefined,
+  subscription: DocumentNode,
+  extractExtraInfo?: (item: T) => Record<string, unknown>,
+): (item: T) => boolean {
+  const subscriptionName = getOperationName(subscription);
+  const logCode = generateLogCode(subscriptionName);
+
+  return (item: T): boolean => {
+    // If no expected meetingId, pass through (meeting data not yet loaded)
+    if (!expectedMeetingId) {
+      return true;
+    }
+
+    // Cast to access meetingId (added at runtime via GraphQL)
+    const itemWithMeetingId = item as T & WithMeetingId;
+
+    // If item has no meetingId field, pass through (field not available)
+    if (itemWithMeetingId.meetingId === undefined) {
+      return true;
+    }
+
+    const isInMeeting = itemWithMeetingId.meetingId === expectedMeetingId;
+
+    if (!isInMeeting) {
+      const extraInfo = extractExtraInfo ? extractExtraInfo(item) : {};
+      logger.warn({
+        logCode,
+        extraInfo: {
+          subscriptionName,
+          itemMeetingId: itemWithMeetingId.meetingId,
+          expectedMeetingId,
+          currentUserId: Auth.userID,
+          ...extraInfo,
+        },
+      }, `${subscriptionName}: meetingId mismatch, filtering out item`);
+    }
+
+    return isInMeeting;
+  };
+}
+
+export function filterByMeetingId<T extends object>(
+  items: T[] | null | undefined,
+  expectedMeetingId: string | undefined,
+  subscription: DocumentNode,
+  extractExtraInfo?: (item: T) => Record<string, unknown>,
+): T[] {
+  if (!items || items.length === 0) {
+    return [];
+  }
+
+  const filterFn = createMeetingIdFilter(expectedMeetingId, subscription, extractExtraInfo);
+  return items.filter(filterFn);
+}


### PR DESCRIPTION
### What does this PR do?

* Adds a centralized `filterByMeetingId` utility to scope user-related GraphQL data by `meetingId`.
* Updates relevant queries and subscriptions to include `meetingId`.
* Applies the filter at data boundaries so all consumers receive meeting-scoped results.
* Logs and filters out mismatched meeting data.

### Closes Issue(s)
N/A
