### PR TITLE
feat: Enhance PR comments for test outcomes and handle cancellations

### DIFF
--- a/.github/actions/check-artifact-exists/action.yml
+++ b/.github/actions/check-artifact-exists/action.yml
@@ -16,11 +16,11 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
-          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+          const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: context.payload.workflow_run.id,
           });
-          const artifactExists = artifacts.data.artifacts.some(a => a.name === '${{ inputs.artifact-name }}');
-          console.log(`Artifact '${{ inputs.artifact-name }}' found: ${artifactExists}`);
+          const artifactExists = artifacts.some(a => a.name.includes('${{ inputs.artifact-name }}'));
+          console.log(`Artifact containing '${{ inputs.artifact-name }}' found: ${artifactExists}`);
           return artifactExists;

--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -149,6 +149,9 @@ jobs:
           report-path: ${{ env.REPORT_PATH }}
   comment-pr:
     runs-on: ubuntu-latest
+    concurrency:
+      group: comment-pr-${{ needs.get-pr-data.outputs.pr-number }}
+      cancel-in-progress: true
     permissions:
       pull-requests: write
     needs: get-pr-data
@@ -196,7 +199,7 @@ jobs:
             <h1>Automated tests Summary</h1>
             <h3><strong>:white_check_mark:</strong> All the CI tests have passed!</h3>
       - name: Failing tests comment (with report)
-        if: ${{ github.event.workflow_run.conclusion != 'success' && fromJson(env.isCompleted) && fromJson(steps.check-reports.outputs.exists || 'false') }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && fromJson(steps.check-reports.outputs.exists || 'false') }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
@@ -206,11 +209,29 @@ jobs:
             - [Test results](https://bigbluebutton.github.io/bbb-ci-playwright-reports/pr-${{ needs.get-pr-data.outputs.pr-number }})
             - [Github workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }})
       - name: Failing tests comment (without report)
-        if: ${{ github.event.workflow_run.conclusion != 'success' && fromJson(env.isCompleted) && !fromJson(steps.check-reports.outputs.exists || 'false') }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && !fromJson(steps.check-reports.outputs.exists || 'false') }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
           body: |
             <h2><strong>:rotating_light:</strong> Automated tests failed</h2>
+
+            - [Github workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }})
+      - name: Comment on cancellation
+        if: ${{ github.event.workflow_run.conclusion == 'cancelled' && fromJson(env.isCompleted) }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          body: |
+            <h2><strong>:warning:</strong> Automated tests were cancelled</h2>
+
+            - [Github workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }})
+      - name: Skipped tests comment
+        if: ${{ github.event.workflow_run.conclusion == 'skipped' && fromJson(env.isCompleted) }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          body: |
+            <h2><strong>:fast_forward:</strong> Automated tests were skipped</h2>
 
             - [Github workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }})


### PR DESCRIPTION
### What does this PR do?
- Handles `cancelled` and `skipped` workflow (Automated tests) conclusions separetely
- Uses `concurrency` on `comment-pr` to avoid race condition or conflicts when the automated tests workflow is triggered while the previous is running - triggering `publish-results` wrkflow multiple times

### More

- Changed artifact search logic in `.github/actions/check-artifact-exists/action.yml` to match artifact names **containing** the input string rather than exact matches