### PR TITLE
feat(meeting-ended): attach reason code to logout URL

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -156,7 +156,7 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
       const reason = intl.formatMessage(intlMessages[reasonCode]);
       setMessage(reason);
       setTimeout(() => {
-        const url = `${logoutUrl}?reason=${encodeURIComponent(reason)}&reasonCode=${encodeURIComponent(reasonCode)}`;
+        const url = `${logoutUrl}${logoutUrl.includes('?') ? '&' : '?'}reason=${encodeURIComponent(reason)}&reasonCode=${encodeURIComponent(reasonCode)}`;
         window.location.assign(url);
       }, REDIRECT_TIMEOUT);
       return;

--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { LoadingContext } from '../../common/loading-screen/loading-screen-HOC/component';
+import { JoinErrorCodeTable } from '/imports/ui/components/meeting-ended/service';
 import Styled from './styles';
 
 const REDIRECT_TIMEOUT = 15000;
@@ -38,7 +39,7 @@ const intlMessages = defineMessages({
     id: 'app.guest.allow',
     description: '',
   },
-  deny: {
+  [JoinErrorCodeTable.GUEST_DENY]: {
     id: 'app.guest.guestDeny',
     description: '',
   },
@@ -151,9 +152,12 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
     if (guestStatus === GUEST_STATUSES.DENY) {
       setAnimate(false);
       setPositionMessage('');
-      setMessage(intl.formatMessage(intlMessages.deny));
+      const reasonCode = JoinErrorCodeTable.GUEST_DENY;
+      const reason = intl.formatMessage(intlMessages[reasonCode]);
+      setMessage(reason);
       setTimeout(() => {
-        window.location.assign(logoutUrl);
+        const url = `${logoutUrl}?reason=${encodeURIComponent(reason)}&reasonCode=${encodeURIComponent(reasonCode)}`;
+        window.location.assign(url);
       }, REDIRECT_TIMEOUT);
       return;
     }

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -219,6 +219,7 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
     extId: u.extId,
     userId: u.userId,
     bot: u.bot,
+    logoutUrl: u.logoutUrl,
   }));
 
   const { error, data } = useDeduplicatedSubscription<GetGuestLobbyInfo>(getGuestLobbyInfo, {
@@ -247,12 +248,12 @@ const PresenceManagerContainer: React.FC<PresenceManagerContainerProps> = ({ chi
     extId,
     name,
     bot = false,
+    logoutUrl,
   } = currentUserData;
 
   const guestStatusDetails = data?.user_current?.[0]?.guestStatusDetails;
 
   const {
-    logoutUrl,
     meetingId,
     name: meetingName,
     bannerColor,

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/component.tsx
@@ -186,23 +186,26 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
     authToken,
     meetingId,
   }] = useAuthData();
+  const endMessageCode = meetingEndedCode || joinErrorCode || '410';
 
-  const generateEndMessage = useCallback((joinErrorCode: string, meetingEndedCode: string, endedBy: string) => {
+  const generateEndMessage = useCallback((endMessageCode: string, endedBy: string) => {
     if (!isEmpty(endedBy)) {
       return intl.formatMessage(intlMessage.messageEndedByUser, { userName: endedBy });
     }
-    // OR opetaror always returns the first truthy value
 
-    const code = meetingEndedCode || joinErrorCode || '410';
-    return intl.formatMessage(intlMessage[code]);
+    if (intlMessage[endMessageCode]) {
+      return intl.formatMessage(intlMessage[endMessageCode]);
+    }
+    logger.error(`No meeting end message found for code: ${endMessageCode}`);
+    return intl.formatMessage(intlMessage.messageEnded);
   }, []);
 
   const confirmRedirect = (isBreakout: boolean, allowRedirect: boolean) => {
     if (isBreakout) window.close();
     if (allowRedirect) {
-      const reason = generateEndMessage(joinErrorCode, meetingEndedCode, endedBy);
+      const reason = generateEndMessage(endMessageCode, endedBy);
       const finalUrl = reason
-        ? `${logoutUrl}${logoutUrl.includes('?') ? '&' : '?'}reason=${encodeURIComponent(reason)}`
+        ? `${logoutUrl}${logoutUrl.includes('?') ? '&' : '?'}reason=${encodeURIComponent(reason)}&reasonCode=${encodeURIComponent(endMessageCode)}`
         : logoutUrl;
       window.location.href = finalUrl;
     }
@@ -322,7 +325,7 @@ const MeetingEnded: React.FC<MeetingEndedProps> = ({
       <Styled.Modal data-test="meetingEndedModal">
         <Styled.Content>
           <Styled.Title>
-            {generateEndMessage(joinErrorCode, meetingEndedCode, endedBy)}
+            {generateEndMessage(endMessageCode, endedBy)}
           </Styled.Title>
           {allowRedirect ? logoutButton : null}
         </Styled.Content>

--- a/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/meeting-ended/service.ts
@@ -9,6 +9,7 @@ export const JoinErrorCodeTable = {
   BANNED_USER_REJOINING: 'banned_user_rejoining_reason',
   USER_LOGGED_OUT: 'user_logged_out_reason',
   MAX_PARTICIPANTS: 'max_participants_reason',
+  GUEST_DENY: 'guest_deny_reason',
 };
 
 export const MeetingEndedTable = {


### PR DESCRIPTION
### What does this PR do?
Currently, only the reason message is included as a query parameter in the logout URL. For integrations with third-party applications, it is more reliable to provide a stable error code rather than a user-facing message, since codes are less volatile and easier to use for conditional logic.

This change adds the reason code as the `reasonCode` query parameter.