### PR TITLE
fix(html5): force GraphQL reconnect on role change to fix breakout vi…

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -13,6 +13,7 @@ import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import deviceInfo from '/imports/utils/deviceInfo';
 import BBBWeb from '/imports/api/bbb-web-api';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
 interface ConnectionManagerProps {
   children: React.ReactNode;
@@ -150,8 +151,7 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
         } else if (tsNow - tsLastPingMessageRef.current < boundary.current && !connectionStatus.getPingIsComing()) {
           connectionStatus.setPingIsComing(true);
         }
-      }
-    }, 5_000);
+      }, 5_000);
     return () => {
       clearInterval(interval);
       if (terminateTimeoutRef.current !== undefined) {
@@ -159,6 +159,34 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
       }
     };
   }, []);
+
+  const { data: currentUser } = useCurrentUser((u) => ({ isModerator: u.isModerator }));
+  const isModerator = currentUser?.isModerator;
+  // Initialize with current value to avoid reconnection on mount
+  const isModeratorRef = useRef(isModerator);
+
+  useEffect(() => {
+    // Skip the first run or if isModerator is undefined (loading)
+    if (isModeratorRef.current === undefined && isModerator !== undefined) {
+      isModeratorRef.current = isModerator;
+      return;
+    }
+
+    if (isModeratorRef.current !== isModerator && isModerator !== undefined) {
+      logger.info(
+        {
+          logCode: 'GRAPHQL_CONNECTION_REFRESH_ON_ROLE_CHANGE',
+          extraInfo: {
+            oldRoleModerator: isModeratorRef.current,
+            newRoleModerator: isModerator,
+          },
+        },
+        'User role changed, terminating GraphQL connection to force permission refresh',
+      );
+      apolloContextHolder.getLink().terminate();
+      isModeratorRef.current = isModerator;
+    }
+  }, [isModerator]);
 
   useEffect(() => {
     if (errorCounts === numberOfAttempts.current) {
@@ -352,7 +380,7 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
       }
     }
   },
-  [graphqlUrl]);
+    [graphqlUrl]);
   return (
     apolloClient
       ? (


### PR DESCRIPTION
### What does this PR do?

Modifies the ConnectionManager component (./bigbluebutton/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx) in the HTML5 client to force the a GraphQL WebSocket reconnection when a user's role changes (specifically, when `isModerator` status updates.)


### Closes Issue(s)

Closes #24500 

### Motivation

Seems like an annoying bug

### How to test

- Start a BigBlueButton meeting.
- User A joins as a Moderator and creates Breakout Rooms.
- User B joins as a Viewer. Verify User B cannot see the Breakout Rooms in the sidebar
- User A promotes User B to Moderator.
- Verify User B's client should log "User role changed, terminating GraphQL connection to force permission refresh".
- Verify that the connection automatically reconnects.
- Verift the "Breakout Room" item should appear in User B's sidebar, and the list of rooms should be visible.


### More
