### PR TITLE
Refactor(html5): Improve deduplication logic for toastify

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -5,7 +5,6 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import { notify } from '../../services/notification';
 import {
   NotifyPublishedPoll,
-  breakoutHadNoChanges,
   layoutUpdate,
   pendingGuestAlert,
   userJoinPushAlert,
@@ -27,7 +26,6 @@ const Notifications: React.FC = () => {
         'app.notification.userJoinPushAlert': userJoinPushAlert,
         'app.notification.userLeavePushAlert': userLeavePushAlert,
         'app.layoutUpdate.label': layoutUpdate,
-        'app.toast.breakoutContentUnchangedNotConverted': breakoutHadNoChanges,
       });
 
   const {

--- a/bigbluebutton-html5/imports/ui/components/notifications/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/service.ts
@@ -7,8 +7,6 @@ const GUEST_WAITING_BELL_THROTTLE_TIME = 10000;
 
 const lastLayoutUpdateNotification = makeVar(new Date().getTime());
 
-const lastBreakoutHadNoChangesNotification = makeVar(new Date().getTime());
-
 export const NotifyPublishedPoll = (
   notification: Notification,
   notifier: (notification: Notification) => void,
@@ -119,24 +117,10 @@ export const layoutUpdate = (
   notifier(notification);
 };
 
-export const breakoutHadNoChanges = (
-  notification: Notification,
-  notifier: (notification: Notification) => void,
-) => {
-  const last = new Date(lastBreakoutHadNoChangesNotification()).getTime();
-  const now = new Date().getTime();
-  if (now - last < 1000) {
-    return;
-  }
-  lastBreakoutHadNoChangesNotification(now);
-  notifier(notification);
-};
-
 export default {
   NotifyPublishedPoll,
   pendingGuestAlert,
   userJoinPushAlert,
   userLeavePushAlert,
   layoutUpdate,
-  breakoutHadNoChanges,
 };

--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -1,23 +1,30 @@
 /* eslint react/jsx-filename-extension: 0 */
 import React from 'react';
 import { toast } from 'react-toastify';
-import { isEqual } from 'radash';
 import Styled from './styles';
 import Toast from '/imports/ui/components/common/toast/component';
 
-let lastToast = {
-  id: null,
-  message: null,
-  type: null,
-  icon: null,
-};
+/**
+ * Generates a deterministic toast ID based on props to prevent duplicates.
+ * React-toastify will automatically prevent showing a toast if one with the same ID is active.
+ */
+function generateToastId(message, type, icon) {
+  let messageKey;
+
+  if (typeof message === 'string') {
+    messageKey = message;
+  } else if (React.isValidElement(message)) {
+    // Extract id from FormattedMessage or similar components
+    messageKey = message.props?.id || message.props?.children || 'react-element';
+  } else {
+    messageKey = String(message);
+  }
+
+  return `${type}-${icon}-${messageKey}`;
+}
 
 export function notify(message, type = 'default', icon, options, content, small) {
-  const settings = {
-    ...options,
-  };
-
-  const { id: lastToastId, ...lastToastProps } = lastToast;
+  const toastId = options?.toastId ?? generateToastId(message, type, icon);
 
   const toastProps = {
     message,
@@ -27,44 +34,43 @@ export function notify(message, type = 'default', icon, options, content, small)
     small,
   };
 
-  if (!toast.isActive(lastToast.id) || !isEqual(JSON.stringify(lastToastProps),
-    JSON.stringify(toastProps))) {
-    if (options?.helpLink != null && options?.helpLabel != null) {
-      const id = toast(
-        <div role="alert">
-          <Toast {...toastProps} />
-          <Styled.HelpLinkButton
-            label={options.helpLabel}
-            color="default"
-            size="sm"
-            onClick={() => { window.open(options.helpLink); }}
-            data-test="helpLinkToastButton"
-          />
-        </div>, settings,
-      );
-
-      lastToast = { id, ...toastProps };
-
-      return id;
+  // If toast with same ID is already active, don't show duplicate
+  if (toast.isActive(toastId)) {
+    // Optionally update the existing toast if autoClose is specified
+    if (options?.autoClose > 0) {
+      toast.update(toastId, {
+        render: <Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>,
+        autoClose: options.autoClose,
+      });
     }
-    if (toast.isActive(lastToast.id)
-      && isEqual(lastToastProps.key, toastProps.key) && options?.autoClose > 0) {
-      toast.update(
-        lastToast.id,
-        {
-          render: <Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>,
-          autoClose: options.autoClose,
-        },
-      );
-    } else {
-      const id = toast(<Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>, settings);
-
-      lastToast = { id, ...toastProps };
-
-      return id;
-    }
+    return null;
   }
-  return null;
+
+  const settings = {
+    ...options,
+    toastId,
+  };
+
+  if (options?.helpLink != null && options?.helpLabel != null) {
+    return toast(
+      <div role="alert">
+        <Toast {...toastProps} />
+        <Styled.HelpLinkButton
+          label={options.helpLabel}
+          color="default"
+          size="sm"
+          onClick={() => { window.open(options.helpLink); }}
+          data-test="helpLinkToastButton"
+        />
+      </div>,
+      settings,
+    );
+  }
+
+  return toast(
+    <Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>,
+    settings,
+  );
 }
 
 export default { notify };

--- a/bigbluebutton-html5/imports/ui/services/notification/index.js
+++ b/bigbluebutton-html5/imports/ui/services/notification/index.js
@@ -11,16 +11,26 @@ import Toast from '/imports/ui/components/common/toast/component';
 function generateToastId(message, type, icon) {
   let messageKey;
 
-  if (typeof message === 'string') {
-    messageKey = message;
+  if (typeof message === 'string' || typeof message === 'number') {
+    messageKey = String(message);
   } else if (React.isValidElement(message)) {
     // Extract id from FormattedMessage or similar components
-    messageKey = message.props?.id || message.props?.children || 'react-element';
+    const child = message.props?.children;
+    messageKey = message.props?.id
+      ?? (typeof child === 'string' || typeof child === 'number' ? String(child) : undefined)
+      ?? message.key
+      ?? message.type?.displayName
+      ?? message.type?.name
+      ?? 'react-element';
   } else {
     messageKey = String(message);
   }
 
-  return `${type}-${icon}-${messageKey}`;
+  const iconKey = React.isValidElement(icon)
+    ? icon.type?.displayName ?? icon.type?.name ?? 'icon'
+    : String(icon);
+
+  return `${type}-${iconKey}-${messageKey}`;
 }
 
 export function notify(message, type = 'default', icon, options, content, small) {
@@ -34,16 +44,14 @@ export function notify(message, type = 'default', icon, options, content, small)
     small,
   };
 
-  // If toast with same ID is already active, don't show duplicate
+  // If toast with same ID is already active, update it and reset the timer
   if (toast.isActive(toastId)) {
-    // Optionally update the existing toast if autoClose is specified
-    if (options?.autoClose > 0) {
-      toast.update(toastId, {
-        render: <Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>,
-        autoClose: options.autoClose,
-      });
-    }
-    return null;
+    toast.update(toastId, {
+      render: <Styled.ToastWrapper role="alert"><Toast {...toastProps} /></Styled.ToastWrapper>,
+      autoClose: options?.autoClose,
+      progress: 0,
+    });
+    return toastId;
   }
 
   const settings = {
@@ -59,7 +67,7 @@ export function notify(message, type = 'default', icon, options, content, small)
           label={options.helpLabel}
           color="default"
           size="sm"
-          onClick={() => { window.open(options.helpLink); }}
+          onClick={() => { window.open(options.helpLink, '_blank', 'noopener,noreferrer'); }}
           data-test="helpLinkToastButton"
         />
       </div>,


### PR DESCRIPTION
### What does this PR do?
Previously, deduplication was based only on the last received props, which could cause issues when multiple notifications of the diferent types were sent at the same time.

This change introduces a customId for each notification and checks whether there is an active toast with that ID. If one exists, the notification timer is reset instead of creating a duplicate toast.

Also removes a old logic for breakouts conversion notification thats' not needed anymore.


### Closes Issue(s)
N/A


