### PR TITLE
refactor: camera custom pagination settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -399,6 +399,7 @@ export interface Constraints2 {
 export interface CameraSortingModes {
   defaultSorting: string
   paginationSorting: string
+  partitionPrivilegedStreams: boolean
 }
 
 export interface CameraQualityThresholds {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -422,6 +422,7 @@ export const useVideoStreams = () => {
   const {
     paginationSorting: PAGINATION_SORTING,
     defaultSorting: DEFAULT_SORTING,
+    partitionPrivilegedStreams,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
 
   if (connectingStream) streams.push(connectingStream);
@@ -436,9 +437,9 @@ export const useVideoStreams = () => {
     const sortingConfig = getSortingMethod(sortingMethod);
 
     // Check if this sorting method uses custom pagination logic
-    if (sortingConfig.customPagination) {
-      // For PRESENTER_LOCAL_PINNED mode, paginate all streams equally
-      // This means local cameras will only appear on their page (where they belong in sort order)
+    if (!partitionPrivilegedStreams) {
+      // When partitionPrivilegedStreams is false, paginate all streams equally
+      // This means local/pinned cameras will only appear on their page (where they belong in sort order)
       const sortedStreams = sortVideoStreams(streams, sortingMethod);
 
       totalNumberOfOtherStreams = sortedStreams.length;
@@ -457,7 +458,7 @@ export const useVideoStreams = () => {
 
       streams = [...paginatedStreams, ...localStreamsWithRenderFlag];
     } else {
-      // Original pagination logic for other sorting methods
+      // Original pagination logic (show pinned/local cameras on every page)
       const [filtered, others] = partition(
         streams,
         (vs: StreamItem) => videoService.isLocalStream(vs.stream)

--- a/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.ts
@@ -9,7 +9,6 @@ const DEFAULT_SORTING_MODE = 'LOCAL_ALPHABETICAL';
 export interface SortingMethodConfig {
   sortingMethod: (s1: StreamItem, s2: StreamItem) => number;
   localFirst: boolean;
-  customPagination?: boolean;
 }
 
 // pin first, ignore connecting streams
@@ -149,9 +148,6 @@ const SORTING_METHODS = Object.freeze({
   PRESENTER_LOCAL_PINNED: {
     sortingMethod: sortPresenterLocalPinned,
     localFirst: false,
-    // Custom pagination: this method handles its own sorting logic
-    // and should not have streams pre-separated by the pagination handler
-    customPagination: true,
   },
 });
 

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -356,6 +356,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       cameraSortingModes: {
         defaultSorting: 'LOCAL_ALPHABETICAL',
         paginationSorting: 'VOICE_ACTIVITY_LOCAL',
+        partitionPrivilegedStreams: true,
       },
       cameraQualityThresholds: {
         enabled: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -496,6 +496,8 @@ public:
     cameraSortingModes:
       defaultSorting: LOCAL_ALPHABETICAL
       paginationSorting: VOICE_ACTIVITY_LOCAL
+      # If set to true (default), always show priviliged streams (pinned users and local cameras)
+      partitionPrivilegedStreams: true
     # Entry `thresholds` is an array of:
     # - threshold: minimum number of cameras being shared for profile to applied
     #   profile: a camera profile id from the cameraProfiles configuration array

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -496,7 +496,7 @@ public:
     cameraSortingModes:
       defaultSorting: LOCAL_ALPHABETICAL
       paginationSorting: VOICE_ACTIVITY_LOCAL
-      # If set to true (default), always show priviliged streams (pinned users and local cameras)
+      # If set to true (default), always show privileged streams (pinned users and local cameras)
       partitionPrivilegedStreams: true
     # Entry `thresholds` is an array of:
     # - threshold: minimum number of cameras being shared for profile to applied


### PR DESCRIPTION
### What does this PR do?

Refactored camera sorting configuration by moving the customPagination flag from code to a configurable setting `partitionPrivilegedStreams`.

### Motivation
https://github.com/bigbluebutton/bigbluebutton/pull/24250#pullrequestreview-3558523574

### How to test
default value:
1. join a meeting with enough users to enable camera pagination
2. with the default value for partitionPrivilegedStreams (true), the local camera should appear in each page

custom pagination:
1. change the value for partitionPrivilegedStreams to `false` and restart the server
2. join a meeting with enough users to enable camera pagination
3. the local camera should be paginated like other cameras

### More
Prior to this change, custom pagination sorting was integrated into the **PRESENTER_LOCAL_PINNED** sorting method. 

To achieve the same behavior, when paginationSorting is configured as **PRESENTER_LOCAL_PINNED**, set `partitionPrivilegedStreams` to **false**.