### PR TITLE
Show missing avatar users  in non-grid mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -128,7 +128,7 @@ const PushLayoutEngine = (props) => {
     }
 
     if (actualLayout === LAYOUT_TYPE.UNIFIED_LAYOUT) {
-      Session.setItem('isGridEnabled', !presentationIsOpen);
+      Session.setItem('isGridEnabled', true);
     } else {
       Session.setItem('isGridEnabled', actualLayout === LAYOUT_TYPE.VIDEO_FOCUS);
     }
@@ -366,9 +366,8 @@ const PushLayoutEngine = (props) => {
     }
 
     if (selectedLayout === LAYOUT_TYPE.UNIFIED_LAYOUT
-      && (selectedLayout !== prevProps.selectedLayout
-        || presentationIsOpen !== prevProps.presentationIsOpen)) {
-      Session.setItem('isGridEnabled', !presentationIsOpen);
+      && selectedLayout !== prevProps.selectedLayout) {
+      Session.setItem('isGridEnabled', true);
     }
 
     return () => {};

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -344,7 +344,7 @@ const WebcamContainer: React.FC = () => {
   const isVideoFocus = selectedLayout === LAYOUT_TYPE.VIDEO_FOCUS;
   const isUnifiedLayout = selectedLayout === LAYOUT_TYPE.UNIFIED_LAYOUT;
 
-  const isGridEnabled = isVideoFocus || (isUnifiedLayout && !presentationIsOpen);
+  const isGridEnabled = isVideoFocus || isUnifiedLayout;
 
   const { streams: videoUsers, gridUsers } = useVideoStreams();
 


### PR DESCRIPTION
Fixes: https://github.com/bigbluebutton/bigbluebutton/issues/24552



### What does this PR do?
This PR fixes a bug in the unified layout where users with custom avatars or default avatars (without webcams) were not displayed when a presentation was visible. The fix ensures that all users (with or without webcams) are shown in the unified layout regardless of presentation state, with proper overflow handling when space is limited.


### Closes Issue(s)
Closes #24552


### Motivation
In the unified layout, when a presentation was visible, the system was only showing users who had active webcams. Users without webcams (showing only avatars) were completely missing from the video area, even when there was sufficient space to display them.
Root Cause: The isGridEnabled flag was incorrectly set to false when the presentation was open in unified layout, which caused the GRID_USERS_SUBSCRIPTION to be skipped. This subscription is responsible for fetching users without active webcam streams (avatar-only users).

### How to test
1. Start a session with unified layout: meetingLayout=UNIFIED_LAYOUT on CREATE
2. Join as Presenter (moderator) without webcam
3. Join as User A (viewer) and share webcam
4. Join as User B (viewer) and share webcam
5. Join as User C with custom avatar: avatarURL=https://www.publicdomainpictures.net/pictures/50000/velka/sunset-5-1369039079YoH.jpg on JOIN (no webcam)
6. Join as User D without webcam (default avatar)
7. Switch to Presenter view

### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation


Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=191128130