### PR TITLE
fix(bbb-conf): Use turnutils_stunclient instead of old stun 0.97 client

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -1132,7 +1132,7 @@ check_state() {
 
 	# stun is from the stun-client package, which is available on both bionic and focal
 	# stunclient is from the stuntman-client package, which is available on bionic but was removed from focal
-	if which stun > /dev/null 2>&1; then
+	if which stun > /dev/null 2>&1 && ! which turnutils_stunclient > /dev/null 2>&1; then
 	  # stun return codes, from its client.cxx
 	  # low nibble: open (0), various STUN combinations (2-9), firewall (a), blocked (c), unknown (e), error (f)
 	  # high nibble: hairpin (1)
@@ -1145,7 +1145,7 @@ check_state() {
             echo "#    stun $STUN_SERVER"
             echo "#"
           fi
-        elif which stunclient > /dev/null 2>&1; then
+        elif which stunclient > /dev/null 2>&1 && ! which turnutils_stunclient > /dev/null 2>&1; then
           if echo $STUN_SERVER | grep -q ':'; then
             STUN_SERVER="$(echo $STUN_SERVER | sed 's/:.*//g') $(echo $STUN_SERVER | sed 's/.*://g')"
           else
@@ -1157,6 +1157,18 @@ check_state() {
             echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
             echo "#"
             echo "#    stunclient $STUN_SERVER"
+            echo "#"
+          fi
+        elif which turnutils_stunclient > /dev/null 2>&1; then
+          # turnutils_stunclient comes from the coturn package, stun-client package uses old stun version which doesn't work with out-of-the-box security settings from coturn
+          # (no-rfc5780, no-stun-backward-compatibility, response-origin-only-with-rfc5780)
+          turnutils_stunclient $STUN_SERVER > /dev/null 2>&1
+          if [ $? -ne 0 ]; then
+            echo
+            echo "#"
+            echo "# Warning: Failed to verify STUN server at $STUN_SERVER with command"
+            echo "#"
+            echo "#    turnutils_stunclient $STUN_SERVER"
             echo "#"
           fi
         fi


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This PR changes the bbb-conf --check command, so it uses coturn's built-in turnutils-stunclient instead of the old stun-client package with version 0.97. 

### Motivation
After setting up an external TURN server today with the following security settings:
`no-rfc5780`, `no-stun-backward-compatibility`, `response-origin-only-with-rfc5780`

I realized that due to the old stun-client package, bbb-conf --check will throw an error, since it can't connect to the turn with this package.
```
#
# Warning: Failed to verify STUN server at turn-01.xxx.com with command
#
#    stun turn-01.xxx.com
#

root@bbb:~# stun turn-01.xxx.com
STUN client version 0.97
Primary: Blocked or could not reach STUN server
Return value is 0x00001c
```

Using turnutils_stunclient however works.
