### PR TITLE
Fix(html5): presentation moving to old position when enable infinite WB

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -131,12 +131,10 @@ class PresentationToolbar extends PureComponent {
   }
 
   handleSkipToSlideChange(event) {
-    const { skipToSlide, currentSlide, setPresentationPageInfiniteWhiteboard } = this.props;
+    const { skipToSlide, currentSlide } = this.props;
     const requestedSlideNum = Number.parseInt(event.target.value, 10);
 
-    const isInfiniteWhiteboard = currentSlide?.infiniteWhiteboard;
-
-    if (isInfiniteWhiteboard) setPresentationPageInfiniteWhiteboard(false);
+    if (currentSlide?.infiniteWhiteboard) this.disableInfiniteWhiteboard();
 
     if (event) event.currentTarget.blur();
     skipToSlide(requestedSlideNum);
@@ -152,6 +150,17 @@ class PresentationToolbar extends PureComponent {
       return setMultiUserWhiteboardDisabled();
     }
     return setMultiUserWhiteboardEnabled();
+  }
+
+  disableInfiniteWhiteboard() {
+    const {
+      tldrawAPI, resetSlide, zoomChanger, setPresentationPageInfiniteWhiteboard,
+    } = this.props;
+
+    tldrawAPI?.setCamera({ x: 0, y: 0 });
+    resetSlide();
+    zoomChanger(100);
+    setPresentationPageInfiniteWhiteboard(false);
   }
 
   fullscreenToggleHandler() {
@@ -177,25 +186,18 @@ class PresentationToolbar extends PureComponent {
   }
 
   nextSlideHandler(event) {
-    const {
-      nextSlide, currentSlide, setPresentationPageInfiniteWhiteboard,
-    } = this.props;
-    const isInfiniteWhiteboard = currentSlide?.infiniteWhiteboard;
+    const { nextSlide, currentSlide } = this.props;
 
-    if (isInfiniteWhiteboard) setPresentationPageInfiniteWhiteboard(false);
+    if (currentSlide?.infiniteWhiteboard) this.disableInfiniteWhiteboard();
 
     if (event) event.currentTarget.blur();
     nextSlide();
   }
 
   previousSlideHandler(event) {
-    const {
-      previousSlide, currentSlide, setPresentationPageInfiniteWhiteboard,
-    } = this.props;
+    const { previousSlide, currentSlide } = this.props;
 
-    const isInfiniteWhiteboard = currentSlide?.infiniteWhiteboard;
-
-    if (isInfiniteWhiteboard) setPresentationPageInfiniteWhiteboard(false);
+    if (currentSlide?.infiniteWhiteboard) this.disableInfiniteWhiteboard();
 
     if (event) event.currentTarget.blur();
     previousSlide();
@@ -471,11 +473,10 @@ class PresentationToolbar extends PureComponent {
             circle
             onClick={() => {
               if (isInfiniteWhiteboard) {
-                tldrawAPI.setCamera({ x: 0, y: 0 });
-                resetSlide();
-                zoomChanger(100);
+                this.disableInfiniteWhiteboard();
+              } else {
+                setPresentationPageInfiniteWhiteboard(true);
               }
-              setPresentationPageInfiniteWhiteboard(!isInfiniteWhiteboard);
             }}
             label={
               isInfiniteWhiteboard


### PR DESCRIPTION
### What does this PR do?
This issue was caused by an inconsistency between how the feature was disabled when turning off the button and when slide changes occurred. To fix this, a shared utility function was introduced to handle the disable logic, ensuring consistent behavior across all places where the feature is triggered.


### Closes Issue(s)
Closes #24535

### How to test
1. Join as Presenter
2. Join as Viewer
3. Presenter draws "A" on the slide.
4. Presenter enables Infinite wb, pans away to outside of the slide and draws "B"
5. Move to next slide
6. turn back 
7. enable infinite wb
8. Everything should be fine

### More
Before:

[Before.webm](https://github.com/user-attachments/assets/7a06b68e-0b73-46d0-ba4e-77f186669ba8)


After:

[Screencast from 27-01-2026 11:03:31.webm](https://github.com/user-attachments/assets/296286c0-b202-4544-80e6-cff5bb0a9c01)

