### PR TITLE
fix(ci): refine conditions for publishing test results and handling blob reports

### DIFF
--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -90,7 +90,7 @@ jobs:
   publish-test-results:
     runs-on: ubuntu-latest
     needs: get-pr-data
-    if: ${{ needs.get-pr-data.outputs.pr-number && needs.get-pr-data.outputs.workflow-id && github.event.workflow_run.status == 'completed' && github.event.workflow_run.conclusion != 'success' }}
+    if: ${{ github.repository_owner == 'bigbluebutton' && needs.get-pr-data.outputs.pr-number && needs.get-pr-data.outputs.workflow-id && github.event.workflow_run.status == 'completed' && github.event.workflow_run.conclusion != 'success' }}
     permissions:
       actions: read
       contents: read
@@ -197,7 +197,7 @@ jobs:
           body: |
             <h2><strong>:white_check_mark:</strong> Automated tests have passed!</h2>
       - name: Failing tests comment (with report)
-        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && fromJson(steps.check-reports.outputs.exists || 'false') }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && fromJson(steps.check-reports.outputs.result || 'false') }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}
@@ -207,7 +207,7 @@ jobs:
             - [Test results](https://bigbluebutton.github.io/bbb-ci-playwright-reports/pr-${{ needs.get-pr-data.outputs.pr-number }})
             - [Github workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }})
       - name: Failing tests comment (without report)
-        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && !fromJson(steps.check-reports.outputs.exists || 'false') }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && !fromJson(steps.check-reports.outputs.result || 'false') }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ needs.get-pr-data.outputs.pr-number }}

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -533,13 +533,19 @@ jobs:
           ACTIONS_RUNNER_DEBUG: true
           BBB_URL: https://bbb-ci.test/bigbluebutton/
           BBB_SECRET: bbbci
-        run: npm run test-chromium-ci -- --grep-invert "$SDK_FLAKY_TESTS"
+        run: |
+          if [ -n "$SDK_FLAKY_TESTS" ]; then
+            npm run test-chromium-ci -- --grep-invert "$SDK_FLAKY_TESTS"
+          else
+            npm run test-chromium-ci
+          fi
       - if: failure()
         name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-plugins
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/blob-report
+          if-no-files-found: ignore
       - if: failure()
         name: Generate the plugins HTML report from blob report
         shell: bash
@@ -592,7 +598,7 @@ jobs:
         with:
           node-version: 22
       - name: Check if blob reports exist
-        if: ${{ github.event.workflow_run.conclusion != 'success' && fromJSON(env.hasFailure) }}
+        if: ${{ fromJSON(env.hasFailure) }}
         id: check-blob-reports
         uses: ./.github/actions/check-artifact-exists
         with:

--- a/.github/workflows/playwright-reports-cleanup.yml
+++ b/.github/workflows/playwright-reports-cleanup.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   cleanup-report:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'bigbluebutton' }}
     steps:
       - name: Checkout reports repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### What does this PR do?

Noticed failures in some recent CI / automated tests workflow runs. following changes made on 0991f6713ae961585fe3106dd61d6dd26d555c12:

- fix output variable of check-reports action

Additionally:
- avoid using grep-invert when`$SDK_FLAKY_TESTS` is empty for sdk tests
- check for `bigbluebutton` as repository owner
