### PR TITLE
fix: userdata-bbb_auto_share_webcam=true causes webcams to stay enabled when joining breakout rooms

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -336,6 +336,7 @@ class App extends Component {
       isNotificationEnabled,
       isNonMediaLayout,
       isRaiseHandEnabled,
+      currentUserHasVoice,
     } = this.props;
 
     const {
@@ -407,7 +408,7 @@ class App extends Component {
           <UploaderContainer />
           <BreakoutJoinConfirmationContainerGraphQL />
           <BBBLiveKitRoomContainer />
-          <AudioContainer />
+          <AudioContainer currentUserHasVoice={currentUserHasVoice} />
           { (
             !hideNotificationToasts
             && isNotificationEnabled) && <ToastContainer rtl /> }

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -159,7 +159,7 @@ const AppContainer = (props) => {
           isNonMediaLayout,
           currentUserAway: currentUser.away,
           currentUserRaiseHand: currentUser?.raiseHand ?? false,
-          currentUserHasVoice: !!currentUser?.voice ?? null,
+          currentUserHasVoice: !!currentUser?.voice,
           isCurrentUserNextRaisedHand,
           captionsStyle,
           presentationIsOpen,

--- a/bigbluebutton-html5/imports/ui/components/app/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.jsx
@@ -44,6 +44,7 @@ const AppContainer = (props) => {
     raiseHand: u.raiseHand,
     userId: u.userId,
     presenter: u.presenter,
+    voice: u.voice,
   }));
 
   const {
@@ -158,6 +159,7 @@ const AppContainer = (props) => {
           isNonMediaLayout,
           currentUserAway: currentUser.away,
           currentUserRaiseHand: currentUser?.raiseHand ?? false,
+          currentUserHasVoice: !!currentUser?.voice ?? null,
           isCurrentUserNextRaisedHand,
           captionsStyle,
           presentationIsOpen,

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -188,9 +188,6 @@ const AudioContainer = (props) => {
     );
 
     if ((!autoJoin || didMountAutoJoin)) {
-      if (enableVideo && autoShareWebcam) {
-        openVideoPreviewModal();
-      }
       return Promise.resolve(false);
     }
     Session.setItem('audioModalIsOpen', true);

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -112,6 +112,7 @@ const AudioContainer = (props) => {
   const {
     intl,
     userLocks,
+    currentUserHasVoice,
   } = props;
 
   const APP_CONFIG = window.meetingClientSettings.public.app;
@@ -153,7 +154,6 @@ const AudioContainer = (props) => {
     name: u.name,
     speechLocale: u.speechLocale,
     breakoutRoomsSummary: u.breakoutRoomsSummary,
-    voice: u.voice,
   }));
 
   const hasBreakoutRooms = (currentUser?.breakoutRoomsSummary?.totalOfBreakoutRooms ?? 0) > 0;
@@ -188,18 +188,25 @@ const AudioContainer = (props) => {
     );
 
     if ((!autoJoin || didMountAutoJoin)) {
+      if (enableVideo && autoShareWebcam) {
+        openVideoPreviewModal();
+      }
       return Promise.resolve(false);
     }
     Session.setItem('audioModalIsOpen', true);
     if (enableVideo && autoShareWebcam) {
       openVideoPreviewModal();
-      openAudioModal();
+      if (!currentUserHasVoice) {
+        openAudioModal();
+      }
       didMountAutoJoin = true;
     } else if (!(
       userSelectedMicrophone
       && userSelectedListenOnly
       && meetingIsBreakout)) {
-      openAudioModal();
+      if (!currentUserHasVoice) {
+        openAudioModal();
+      }
       didMountAutoJoin = true;
     }
     return Promise.resolve(true);
@@ -235,15 +242,13 @@ const AudioContainer = (props) => {
     // We don't know whether the meeting is a breakout or not.
     // So, postpone the decision.
     if (meetingIsBreakout === undefined) return;
-    // If the user has duplicated the session and has already joined the audio.
-    if (!currentUser?.voice) {
-      init().then(() => {
-        if (meetingIsBreakout && !Service.isUsingAudio()) {
-          joinAudio();
-        }
-      });
-    }
-  }, [meetingIsBreakout, currentUser?.voice]);
+    init().then(() => {
+      // Skip auto join audio if user has already joined in another tab (currentUserHasVoice)
+      if (meetingIsBreakout && !Service.isUsingAudio() && !currentUserHasVoice) {
+        joinAudio();
+      }
+    });
+  }, [meetingIsBreakout]);
 
   useEffect(() => {
     if (userIsReturningFromBreakoutRoom) {
@@ -320,4 +325,5 @@ AudioContainer.propTypes = {
   userLocks: PropTypes.shape({
     userMic: PropTypes.bool.isRequired,
   }).isRequired,
+  currentUserHasVoice: PropTypes.bool,
 };


### PR DESCRIPTION
### What does this PR do?

Prevents an issue where webcam is not stopped when the user joins a breakout room

### Closes Issue(s)
Closes #24495

### How to test
use parameter `userdata-bbb_auto_share_webcam=true`
1. join a meeting and share audio 
2. join a breakout room
3. check if webcam is shared in the main room