### PR TITLE
Fix(html5): missing space in some locales on waiting room queue

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -112,7 +112,7 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
       if (positionInWaitingQueueRef.current === '1') {
         setPositionMessage(intl.formatMessage(intlMessages.firstPosition));
       } else {
-        setPositionMessage(intl.formatMessage(intlMessages.position) + positionInWaitingQueueRef.current);
+        setPositionMessage(`${intl.formatMessage(intlMessages.position).trim()} ${positionInWaitingQueueRef.current}`);
       }
     }
   }, [intl]);


### PR DESCRIPTION
### What does this PR do?
The bug occurred because, in some locales, the translator trimmed the trailing space from the string, causing the issue. I moved the space into the code to ensure consistent behavior across all locales.


### Closes Issue(s)
N/A


### How to test
- Join as moderator
- Change guest policy to portuguese
- Join with two or more guests 
- Look at the position message

