### PR TITLE
feat(sidebar-navigation): add participants count badge to user list button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
@@ -90,8 +90,8 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
         $disabled={isDisabled}
         $locked={isLocked}
       >
-        {children}
         <Icon iconName={iconName} />
+        {children}
       </Styled.ListItem>
     </TooltipContainer>
   );

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
@@ -6,8 +6,10 @@ import { GET_GUEST_WAITING_USERS_SUBSCRIPTION, GuestWaitingUsers } from '/import
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
+import { RAISED_HAND_USERS, RaisedHandUsersSubscriptionResponse, USER_AGGREGATE_COUNT_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
+import { UserAggregateCountSubscriptionResponse } from '/imports/ui/components/user-list/types';
 import { BaseSidebarButtonProps } from '../types';
-import { RAISED_HAND_USERS, RaisedHandUsersSubscriptionResponse } from '/imports/ui/core/graphql/queries/users';
+import Styled from './styles';
 
 const intlMessages = defineMessages({
   usersListLabel: {
@@ -19,6 +21,11 @@ const intlMessages = defineMessages({
 const UsersListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
   const TOGGLE_USER_LIST_SHORTCUT = useShortcut('toggleUserList');
   const intl = useIntl();
+
+  const {
+    data: usersCountData,
+  } = useDeduplicatedSubscription<UserAggregateCountSubscriptionResponse>(USER_AGGREGATE_COUNT_SUBSCRIPTION);
+  const usersCount = usersCountData?.user_aggregate?.aggregate?.count ?? 0;
 
   const {
     data: guestWaitingUsersData,
@@ -45,7 +52,13 @@ const UsersListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
       ariaDescribedBy="usersList"
       dataTest="usersListSidebarButton"
       hasNotification={hasNotification}
-    />
+    >
+      <Styled.GuestNumberIndicatorWrapper $count={usersCount}>
+        <Styled.GuestNumberIndicator>
+          {usersCount}
+        </Styled.GuestNumberIndicator>
+      </Styled.GuestNumberIndicatorWrapper>
+    </SidebarNavigationButton>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { colorGrayIcons, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { fontSizeSmaller, fontSizeXS, titlesFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
+
+const GuestNumberIndicatorWrapper = styled.div<{ $count: number }>`
+  position: absolute;
+  top: -0.4rem;
+  right: -0.4rem;
+  background-color: ${colorGrayIcons};
+  width: ${({ $count }) => ($count >= 100 ? '1.4rem' : '1.35rem')};
+  height: ${({ $count }) => ($count >= 100 ? '1.4rem' : '1.35rem')};
+  font-size: ${({ $count }) => ($count >= 100 ? `${fontSizeXS}` : `${fontSizeSmaller}`)};
+  border-radius: 50%;
+`;
+
+const GuestNumberIndicator = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: ${colorWhite};
+  font-style: normal;
+  font-weight: ${titlesFontWeight};
+  line-height: normal;
+  text-align: center;
+`;
+
+export default {
+  GuestNumberIndicatorWrapper,
+  GuestNumberIndicator,
+};


### PR DESCRIPTION
### What does this PR do?
Adds a badge to the user list button in the navigation sidebar displaying the current number of participants in the meeting. This
allows users to quickly check how many participants are present without opening the user list panel.

<img width="300" alt="a" src="https://github.com/user-attachments/assets/76fad810-5f1e-4080-926a-8af86954d0b7" />
<img width="300" alt="b" src="https://github.com/user-attachments/assets/eca64021-00f2-4062-885b-1778fd2db987" />

![c](https://github.com/user-attachments/assets/d2efe496-8e73-44da-9254-9b750d22737f)

<img width="487" height="855" alt="d" src="https://github.com/user-attachments/assets/53502df8-39fd-44c4-9d05-e05d2cb5c46d" />



### Closes Issue(s)
Closes #24559 
