### PR TITLE
Fix(html5): Annotations get transferred to another presentation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1418,8 +1418,15 @@ const Whiteboard = React.memo((props) => {
       }
 
       const hasShapes = shapes && Object.keys(shapes).length > 0;
+      // Filter shapes to only include those belonging to the current presentation
+      const currentPresId = presentationIdRef.current;
       const remoteShapesArray = hasShapes
-        ? Object.values(shapes).map((shape) => sanitizeShape(shape))
+        ? Object.values(shapes)
+          .filter((shape) => {
+            const shapePresId = shape.meta?.presentationId;
+            return !shapePresId || shapePresId === currentPresId;
+          })
+          .map((shape) => sanitizeShape(shape))
         : [];
 
       editor.store.mergeRemoteChanges(() => {
@@ -1428,7 +1435,7 @@ const Whiteboard = React.memo((props) => {
           editor.store.put(assets);
           editor.setCurrentPage(`page:${curPageIdRef.current}`);
           editor.store.put(bgShape);
-          if (hasShapes) {
+          if (remoteShapesArray.length > 0) {
             editor.store.put(remoteShapesArray);
           }
           editor.history.clear();


### PR DESCRIPTION
### What does this PR do?
This was caused by a race condition during slide updates. The solution adds a filter to the annotation registration logic to ensure that a slide only receives annotations from its corresponding presentation.


### Closes Issue(s)
Closes #24298 

### How to test
(Run on a remote server)
1. Join a Presenter on a meeting
2. Draw something on the slide
3. Upload a presentation
4. See no annotation on this presentation

