### PR TITLE
fix(chat): increase font-size to 14px

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/styles.ts
@@ -8,7 +8,7 @@ import {
   mdPadding,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
-  fontSizeSmall,
+  fontSizeBase,
   fontSizeSmaller,
 } from '/imports/ui/stylesheets/styled-components/typography';
 
@@ -55,7 +55,7 @@ export const ChatWrapper = styled.div<ChatWrapperProps>`
   flex-flow: column;
   gap: ${smPaddingY};
   position: relative;
-  font-size: ${fontSizeSmall};
+  font-size: ${fontSizeBase};
   position: relative;
 
   [dir='rtl'] & {


### PR DESCRIPTION
### What does this PR do?
As requested by the design team, increases the font size to 14px which is the default value in 3.0.

<img width="487" height="1065" alt="image" src="https://github.com/user-attachments/assets/c2fafc74-de01-4c35-8d03-cd27baad85fe" />