### PR TITLE
fix(whiteboard): fix background color inversion in Dark Mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -7,6 +7,7 @@ import {
   colorPrimaryDarkTheme,
   colorHoverBgDark,
   colorToggleBgDisabledDarkTheme,
+  colorTldrawBackground,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Layout = styled(FlexColumn)``;
@@ -58,6 +59,9 @@ const DtfInvert = `
   .tl-container {
     .tl-image {
       background-color: white !important;
+    }
+    .tl-background {
+      background-color: ${colorTldrawBackground} !important;
     }
   }
   .tlui-slider__thumb {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -32,17 +32,17 @@ const infiniteWhiteboardIcon = (isinfiniteWhiteboard) => {
              3.14924 14.8508 3 14.6667 3ZM1.33333 2C0.596954 2 0 2.59695 0 3.33333V13.3333C0 14.0697
              0.596953 14.6667 1.33333 14.6667H14.6667C15.403 14.6667 16 14.0697 16 13.3333V3.33333C16
              2.59695 15.403 2 14.6667 2H1.33333Z"
-          fill="#4E5A66"
+          fill="currentColor"
         />
         <path
           d="M12.875 11.875L9.125 8.125M9.125 8.125L9.125 10.9375M9.125 8.125L11.9375 8.125"
-          stroke="#4E5A66"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
           d="M3.125 5.125L6.875 8.875M6.875 8.875L6.875 6.0625M6.875 8.875L4.0625 8.875"
-          stroke="#4E5A66"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
@@ -65,17 +65,17 @@ const infiniteWhiteboardIcon = (isinfiniteWhiteboard) => {
              3.14924 14.8508 3 14.6667 3ZM1.33333 2C0.596954 2 0 2.59695 0 3.33333V13.3333C0 14.0697
              0.596953 14.6667 1.33333 14.6667H14.6667C15.403 14.6667 16 14.0697 16 13.3333V3.33333C16
              2.59695 15.403 2 14.6667 2H1.33333Z"
-        fill="#4E5A66"
+        fill="currentColor"
       />
       <path
         d="M9.125 8.125L12.875 11.875M12.875 11.875L12.875 9.0625M12.875 11.875L10.0625 11.875"
-        stroke="#4E5A66"
+        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M6.875 8.875L3.125 5.125M3.125 5.125L3.125 7.9375M3.125 5.125L5.9375 5.125"
-        stroke="#4E5A66"
+        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -1,5 +1,6 @@
 const colorWhite = 'var(--color-white, #FFF)';
 const colorOffWhite = 'var(--color-off-white, #F3F6F9)';
+const colorTldrawBackground = 'var(--color-tldraw-background, #F9FAFB)';
 
 const colorBlack = 'var(--color-black, #000000)';
 
@@ -172,6 +173,7 @@ const colorGreen100 = 'var(--color-green-100, #DCFCE7)';
 export {
   colorWhite,
   colorOffWhite,
+  colorTldrawBackground,
   colorBlack,
   colorGray,
   colorGrayDark,


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Prevents the infinite whiteboard background from being automatically inverted when Dark Mode is enabled. Ensures the whiteboard background remains white for usability.


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Enable Dark Mode in the application.
2. Open the Whiteboard feature.
3. Verify that the infinite whiteboard background remains white.
4. Disable Dark Mode and confirm there is no change in whiteboard behavior.


