### PR TITLE
fix(export): respect autoSize property for text annotations

### DIFF
--- a/bbb-export-annotations/shapes/Shape.js
+++ b/bbb-export-annotations/shapes/Shape.js
@@ -509,14 +509,15 @@ export class Shape {
     // Do nothing if there is no text
     if (!this.text) return;
 
-    // Sticky notes have a width and height of 200 and can't be resized,
-    // unless the text becomes too long.
+    // Sticky notes have a fixed width/height of 200 and can't be resized.
+    // For other shapes, use actual dimensions or a large fallback to avoid
+    // incorrect text wrapping (see issue #24566).
     if (!this.w) {
-      this.w = 200;
+      this.w = this.type === 'note' ? 200 : Number.MAX_SAFE_INTEGER;
     }
 
     if (!this.h) {
-      this.h = 200;
+      this.h = this.type === 'note' ? 200 : Number.MAX_SAFE_INTEGER;
     }
 
     if (!this.growY) {

--- a/bbb-export-annotations/shapes/TextShape.js
+++ b/bbb-export-annotations/shapes/TextShape.js
@@ -25,6 +25,7 @@ export class TextShape extends Shape {
     this.align = this.props?.align;
     this.w = this.props?.w;
     this.h = this.props?.h;
+    this.autoSize = this.props?.autoSize;
     this.fontSize = Shape.determineFontSize(this.size);
     this.fontFamily = Shape.determineFontFromFamily(this.props?.font);
   }
@@ -52,7 +53,10 @@ export class TextShape extends Shape {
         })
         .fill(this.shapeColor);
 
-    const lines = await this.wrapText(this.text ?? '', this.w ?? 200);
+    const effectiveWidth = (this.autoSize || !this.w) ?
+      Number.MAX_SAFE_INTEGER :
+      this.w;
+    const lines = await this.wrapText(this.text ?? '', effectiveWidth);
     const lineHeight = this.fontSize * 1.35;
 
     lines.forEach((line, idx) => {


### PR DESCRIPTION
### What does this PR do?
  Fixes text annotation wrapping in PDF export by respecting the autoSize property. Previously, text was being wrapped at a hardcoded 200px width, causing overlapping text in exported presentations.                         
                                                                                                                                                                                                                               
  Changes:                                                                                                                                                                                                                     
  - Add autoSize property check in TextShape.js                                                                                                                                                                                
  - Use actual width constraint only when autoSize is false (user manually resized)                                                                                                                                            
  - Update Shape.drawLabel() fallback to only apply 200px to sticky notes                                                                                                                                                      
                                                                                                                                                                                                                               
  Closes Issue(s)                                                                                                                                                                                                              
                                                                                                                                                                                                                               
  Closes #24566                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                               
###  How to test                                                                                                                                                                                                                  
                                                                                                                                                                                                                               
  1. Start a BBB meeting as presenter                                                                                                                                                                                          
  2. Upload a presentation (test both landscape and portrait)                                                                                                                                                                  
  3. Add text annotations with:                                                                                                                                                                                                
    - Long single-line text (no newlines)                                                                                                                                                                                      
    - Multi-line text with explicit newlines                                                                                                                                                                                   
    - Large font sizes (xl)                                                                                                                                                                                                    
  4. Export the presentation with annotations                                                                                                                                                                                  
  5. Verify:                                                                                                                                                                                                                   
    - Text does NOT wrap unless user explicitly added newlines                                                                                                                                                                 
    - No overlapping text with nearby annotations                                                                                                                                                                              
    - Exported PDF matches the live session view                                                                                                                                                                               
                                                                                                                                                                                                                               
 ### More                                                                                                                                                                                                                         
                                                                                                                                                                                                                               
[Screencast from 02-02-2026 11:00:46.webm](https://github.com/user-attachments/assets/8cd5dafb-b5d2-4f6a-ade8-b8644aaf1433)
