### PR TITLE
fix(audio): missing CC icon in talking indicator (mediasoup/FS)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -107,6 +107,11 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
     }
 
     def letUserEnter() = {
+      val speechLocale = Users2x.findWithIntId(liveMeeting.users2x, msg.body.intId) match {
+        case Some(u) => u.speechLocale
+        case None    => ""
+      }
+      
       VoiceApp.handleUserJoinedVoiceConfEvtMsg(
         liveMeeting,
         outGW,
@@ -118,7 +123,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
         msg.body.callerIdName,
         msg.body.callerIdNum,
         userColor,
-        speechLocale = "",
+        speechLocale,
         msg.body.muted,
         listenOnlyInputDevice = false,
         deafened = false,


### PR DESCRIPTION
### What does this PR do?

- [fix(audio): missing CC icon in talking indicator (mediasoup/FS)](https://github.com/bigbluebutton/bigbluebutton/commit/30721ccc2eb5b795bddf8a2149b9f8370fbb3ae8) 
  - When using mediasoup/FS based audio, the CC icon may be
missing in talking indicators if a transcription lang is set
*prior to joining audio*.
  - Guarantee the speechLocale is properly set when a voice user
joins by fetching it from the Users2x model instead of always
using an empty string fallback.

### Closes Issue(s)

Might close https://github.com/bigbluebutton/bigbluebutton/issues/24592

### How to test
In a mediasoup/FS audio setup (default) with transcription enabled:
  - Join a meeting with a _fresh session_ (preferably incognito)
  - In the audio settings modal, *prior to joining audio*: select a transcription language
  - Join audio
  - Speak and observe talking indicator - it should show a CC icon