### PR TITLE
tests: adjust toast element check

### DIFF
--- a/bigbluebutton-tests/playwright/core/page.ts
+++ b/bigbluebutton-tests/playwright/core/page.ts
@@ -391,8 +391,15 @@ export class Page {
     description: string,
     timeout: number = ELEMENT_WAIT_TIME,
   ): Promise<void> {
-    const locator = this.page.locator(selector).first();
-    await expect(locator, description).toContainText(text, { timeout });
+    const isToast = /toast/i.test(selector);
+    // for toast elements, check for visibility with hasText option (can't guarantee text is in the first toast)
+    if (isToast && (typeof text === 'string' || text instanceof RegExp)) {
+      const locator = this.page.locator(selector, { hasText: text });
+      await expect(locator.first(), description).toBeVisible({ timeout });
+    } else {
+      const locator = this.page.locator(selector).first();
+      await expect(locator, description).toContainText(text, { timeout });
+    }
   }
 
   async haveTitle(title: string): Promise<void> {


### PR DESCRIPTION
### What does this PR do?
When `hasText` is called with a toast selector, it now checks all matching toast elements for the expected text instead of only the first one. This prevents false negatives when the desired text appears in a toast that is not the first in the DOM.

### Motivation
`User › List › Give and remove whiteboard access` test was failing because of this. 
The test checks if the permission removal toast is visible (it is, but is not always the first toast element)