### PR TITLE
Fix(html5): Eraser not being persisted in the batch

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1388,6 +1388,7 @@ const Whiteboard = React.memo((props) => {
           || path === 'draw.idle'
           || path === 'select.editing_shape'
           || path === 'highlight.idle'
+          || path === 'eraser.idle'
         ) {
           if (Object.keys(shapeBatchRef.current).length > 0) {
             const shapesToPersist = Object.values(shapeBatchRef.current);


### PR DESCRIPTION
### What does this PR do?
Fix the bug of the eraser causing a odd bug on shapes history and not being computed on undo and redo.


### Closes Issue(s)
Closes #24417

### How to test

1.  Draw a few shapes 
2. use the Eraser tool to remove them
3. press "ctrl+Z" to redo them


### More
Before:

[Screencast from 06-02-2026 09:04:50.webm](https://github.com/user-attachments/assets/4628ef85-88aa-4f0e-8800-466dbc2fecc9)

After:

[Screencast from 06-02-2026 09:06:52.webm](https://github.com/user-attachments/assets/ff0c98bf-e797-457e-bd02-f3c1eabf77a6)
