### PR TITLE
refactor (gql-middleware): Make message caches meeting-scoped

### DIFF
--- a/bbb-graphql-middleware/internal/common/GlobalState.go
+++ b/bbb-graphql-middleware/internal/common/GlobalState.go
@@ -20,100 +20,134 @@ func GetUniqueID() string {
 }
 
 var (
-	PatchedMessageCache      = make(map[uint64][]byte)
+	PatchedMessageCache      = make(map[string]map[uint64][]byte)
 	PatchedMessageCacheMutex sync.RWMutex
 )
 
-func GetPatchedMessageCache(cacheKey uint64) ([]byte, bool) {
+func GetPatchedMessageCache(meetingId string, cacheKey uint64) ([]byte, bool) {
 	PatchedMessageCacheMutex.RLock()
 	defer PatchedMessageCacheMutex.RUnlock()
 
-	jsonDiffPatch, jsonDiffPatchExists := PatchedMessageCache[cacheKey]
+	jsonDiffPatch, jsonDiffPatchExists := PatchedMessageCache[meetingId][cacheKey]
 	return jsonDiffPatch, jsonDiffPatchExists
 }
 
-func StorePatchedMessageCache(cacheKey uint64, data []byte) {
+func StorePatchedMessageCache(meetingId string, cacheKey uint64, data []byte) {
 	PatchedMessageCacheMutex.Lock()
 	defer PatchedMessageCacheMutex.Unlock()
 
-	PatchedMessageCache[cacheKey] = data
+	if _, jsonDiffPatchExists := PatchedMessageCache[meetingId]; !jsonDiffPatchExists {
+		PatchedMessageCache[meetingId] = make(map[uint64][]byte)
+	}
+
+	PatchedMessageCache[meetingId][cacheKey] = data
 
 	// Remove the cache after 30 seconds
-	go RemovePatchedMessageCache(cacheKey, 30)
+	go RemovePatchedMessageCache(meetingId, cacheKey, 30)
 }
 
-func RemovePatchedMessageCache(cacheKey uint64, delayInSecs time.Duration) {
+func RemovePatchedMessageCache(meetingId string, cacheKey uint64, delayInSecs time.Duration) {
 	time.Sleep(delayInSecs * time.Second)
 
 	PatchedMessageCacheMutex.Lock()
 	defer PatchedMessageCacheMutex.Unlock()
-	delete(PatchedMessageCache, cacheKey)
+	delete(PatchedMessageCache[meetingId], cacheKey)
+}
+
+func RemoveMeetingPatchedMessageCache(meetingId string) {
+	PatchedMessageCacheMutex.Lock()
+	defer PatchedMessageCacheMutex.Unlock()
+	delete(PatchedMessageCache, meetingId)
 }
 
 var (
-	HasuraMessageCache      = make(map[uint32]HasuraMessage)
-	HasuraMessageKeyCache   = make(map[uint32]string)
+	HasuraMessageCache      = make(map[string]map[uint32]HasuraMessage)
+	HasuraMessageKeyCache   = make(map[string]map[uint32]string)
 	HasuraMessageCacheMutex sync.RWMutex
 )
 
-func GetHasuraMessageCache(cacheKey uint32) (string, HasuraMessage, bool) {
+func GetHasuraMessageCache(meetingId string, cacheKey uint32) (string, HasuraMessage, bool) {
 	HasuraMessageCacheMutex.RLock()
 	defer HasuraMessageCacheMutex.RUnlock()
 
-	hasuraMessageDataKey, _ := HasuraMessageKeyCache[cacheKey]
-	hasuraMessage, hasuraMessageExists := HasuraMessageCache[cacheKey]
+	hasuraMessageDataKey, _ := HasuraMessageKeyCache[meetingId][cacheKey]
+	hasuraMessage, hasuraMessageExists := HasuraMessageCache[meetingId][cacheKey]
 	return hasuraMessageDataKey, hasuraMessage, hasuraMessageExists
 }
 
-func StoreHasuraMessageCache(cacheKey uint32, dataKey string, hasuraMessage HasuraMessage) {
+func StoreHasuraMessageCache(meetingId string, cacheKey uint32, dataKey string, hasuraMessage HasuraMessage) {
 	HasuraMessageCacheMutex.Lock()
 	defer HasuraMessageCacheMutex.Unlock()
 
-	HasuraMessageKeyCache[cacheKey] = dataKey
-	HasuraMessageCache[cacheKey] = hasuraMessage
+	if _, jsonDiffPatchExists := HasuraMessageKeyCache[meetingId]; !jsonDiffPatchExists {
+		HasuraMessageKeyCache[meetingId] = make(map[uint32]string)
+	}
+	if _, jsonDiffPatchExists := HasuraMessageCache[meetingId]; !jsonDiffPatchExists {
+		HasuraMessageCache[meetingId] = make(map[uint32]HasuraMessage)
+	}
+
+	HasuraMessageKeyCache[meetingId][cacheKey] = dataKey
+	HasuraMessageCache[meetingId][cacheKey] = hasuraMessage
 
 	// Remove the cache after 30 seconds
-	go RemoveHasuraMessageCache(cacheKey, 30)
+	go RemoveHasuraMessageCache(meetingId, cacheKey, 30)
 }
 
-func RemoveHasuraMessageCache(cacheKey uint32, delayInSecs time.Duration) {
+func RemoveHasuraMessageCache(meetingId string, cacheKey uint32, delayInSecs time.Duration) {
 	time.Sleep(delayInSecs * time.Second)
 
 	HasuraMessageCacheMutex.Lock()
 	defer HasuraMessageCacheMutex.Unlock()
-	delete(HasuraMessageKeyCache, cacheKey)
-	delete(HasuraMessageCache, cacheKey)
+	delete(HasuraMessageKeyCache[meetingId], cacheKey)
+	delete(HasuraMessageCache[meetingId], cacheKey)
+}
+
+func RemoveMeetingHasuraMessageCache(meetingId string) {
+	HasuraMessageCacheMutex.Lock()
+	defer HasuraMessageCacheMutex.Unlock()
+	delete(HasuraMessageKeyCache, meetingId)
+	delete(HasuraMessageCache, meetingId)
 }
 
 var (
-	StreamCursorValueCache      = make(map[uint32]interface{})
+	StreamCursorValueCache      = make(map[string]map[uint32]interface{})
 	StreamCursorValueCacheMutex sync.RWMutex
 )
 
-func GetStreamCursorValueCache(cacheKey uint32) (interface{}, bool) {
+func GetStreamCursorValueCache(meetingId string, cacheKey uint32) (interface{}, bool) {
 	StreamCursorValueCacheMutex.RLock()
 	defer StreamCursorValueCacheMutex.RUnlock()
 
-	streamCursorValue, streamCursorValueExists := StreamCursorValueCache[cacheKey]
+	streamCursorValue, streamCursorValueExists := StreamCursorValueCache[meetingId][cacheKey]
 	return streamCursorValue, streamCursorValueExists
 }
 
-func StoreStreamCursorValueCache(cacheKey uint32, streamCursorValue interface{}) {
+func StoreStreamCursorValueCache(meetingId string, cacheKey uint32, streamCursorValue interface{}) {
 	StreamCursorValueCacheMutex.Lock()
 	defer StreamCursorValueCacheMutex.Unlock()
 
-	StreamCursorValueCache[cacheKey] = streamCursorValue
+	if _, jsonDiffPatchExists := StreamCursorValueCache[meetingId]; !jsonDiffPatchExists {
+		StreamCursorValueCache[meetingId] = make(map[uint32]interface{})
+	}
+
+	StreamCursorValueCache[meetingId][cacheKey] = streamCursorValue
 
 	// Remove the cache after 30 seconds
-	go RemoveStreamCursorValueCache(cacheKey, 30)
+	go RemoveStreamCursorValueCache(meetingId, cacheKey, 30)
 }
 
-func RemoveStreamCursorValueCache(cacheKey uint32, delayInSecs time.Duration) {
+func RemoveStreamCursorValueCache(meetingId string, cacheKey uint32, delayInSecs time.Duration) {
 	time.Sleep(delayInSecs * time.Second)
 
 	StreamCursorValueCacheMutex.Lock()
 	defer StreamCursorValueCacheMutex.Unlock()
-	delete(StreamCursorValueCache, cacheKey)
+	delete(StreamCursorValueCache[meetingId], cacheKey)
+}
+
+func RemoveMeetingStreamCursorValueCache(meetingId string) {
+	StreamCursorValueCacheMutex.Lock()
+	defer StreamCursorValueCacheMutex.Unlock()
+	delete(StreamCursorValueCache, meetingId)
 }
 
 var (

--- a/bbb-graphql-middleware/internal/common/StreamCursorUtils.go
+++ b/bbb-graphql-middleware/internal/common/StreamCursorUtils.go
@@ -33,11 +33,11 @@ func GetStreamCursorPropsFromBrowserMessage(browserMessage BrowserSubscribeMessa
 	return streamCursorField, streamCursorVariableName, streamCursorInitialValue
 }
 
-func GetLastStreamCursorValueFromReceivedMessage(message []byte, streamCursorField string) interface{} {
+func GetLastStreamCursorValueFromReceivedMessage(message []byte, streamCursorField string, meetingId string) interface{} {
 	dataChecksum := crc32.ChecksumIEEE(message)
 	GlobalCacheLocks.Lock(uint64(dataChecksum))
 
-	if streamCursorValueCache, streamCursorValueCacheExists := GetStreamCursorValueCache(dataChecksum); streamCursorValueCacheExists {
+	if streamCursorValueCache, streamCursorValueCacheExists := GetStreamCursorValueCache(meetingId, dataChecksum); streamCursorValueCacheExists {
 		// Unlock immediately once the cache was already created by other routine
 		GlobalCacheLocks.Unlock(uint64(dataChecksum))
 		return streamCursorValueCache
@@ -73,7 +73,7 @@ func GetLastStreamCursorValueFromReceivedMessage(message []byte, streamCursorFie
 		}
 	}
 
-	StoreStreamCursorValueCache(dataChecksum, lastStreamCursorValue)
+	StoreStreamCursorValueCache(meetingId, dataChecksum, lastStreamCursorValue)
 	return lastStreamCursorValue
 }
 

--- a/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
+++ b/bbb-graphql-middleware/internal/hasura/conn/reader/reader.go
@@ -124,7 +124,7 @@ func handleMessageReceivedFromHasura(hc *common.HasuraConnection, message []byte
 
 			// Inject pg + gql-middleware time to traceLog
 			if subscription.OperationName == "ConnStatusWithTraceLog" {
-				_, _, messageData := getHasuraMessage(message, subscription, hc.BrowserConn.Logger)
+				_, _, messageData := getHasuraMessage(message, subscription, hc.BrowserConn.MeetingId, hc.BrowserConn.Logger)
 				if _, existsConnectionStatusKey := messageData.Payload.Data["user_connectionStatus"]; existsConnectionStatusKey {
 					type ConnectionStatusMessage struct {
 						MeetingId          string `json:"meetingId"`
@@ -179,7 +179,7 @@ func handleMessageReceivedFromHasura(hc *common.HasuraConnection, message []byte
 }
 
 func handleSubscriptionMessage(hc *common.HasuraConnection, message *[]byte, subscription common.GraphQlSubscription, queryId string) bool {
-	dataChecksum, messageDataKey, messageData := getHasuraMessage(*message, subscription, hc.BrowserConn.Logger)
+	dataChecksum, messageDataKey, messageData := getHasuraMessage(*message, subscription, hc.BrowserConn.MeetingId, hc.BrowserConn.Logger)
 
 	// Check whether ReceivedData is different from the LastReceivedData
 	// Otherwise stop forwarding this message
@@ -200,7 +200,7 @@ func handleSubscriptionMessage(hc *common.HasuraConnection, message *[]byte, sub
 
 	// Apply msg patch when it supports it
 	if subscription.JsonPatchSupported {
-		*message = msgpatch.GetPatchedMessage(*message, messageDataKey, lastReceivedDataWas, messageData, cacheKey, lastDataChecksumWas, dataChecksum)
+		*message = msgpatch.GetPatchedMessage(*message, messageDataKey, lastReceivedDataWas, messageData, cacheKey, lastDataChecksumWas, dataChecksum, hc.BrowserConn.MeetingId)
 	}
 
 	return true
@@ -211,7 +211,7 @@ func combineUint32ToUint64(a, b uint32) uint64 {
 }
 
 func handleStreamingMessage(hc *common.HasuraConnection, message []byte, subscription common.GraphQlSubscription, queryId string) {
-	lastCursor := common.GetLastStreamCursorValueFromReceivedMessage(message, subscription.StreamCursorField)
+	lastCursor := common.GetLastStreamCursorValueFromReceivedMessage(message, subscription.StreamCursorField, hc.BrowserConn.MeetingId)
 	if lastCursor != nil && subscription.StreamCursorCurrValue != lastCursor {
 		subscription.StreamCursorCurrValue = lastCursor
 
@@ -244,13 +244,13 @@ func handleConnectionAckMessage(hc *common.HasuraConnection, message []byte) {
 	go retransmiter.RetransmitSubscriptionStartMessages(hc)
 }
 
-func getHasuraMessage(message []byte, subscription common.GraphQlSubscription, logger *logrus.Entry) (uint32, string, common.HasuraMessage) {
+func getHasuraMessage(message []byte, subscription common.GraphQlSubscription, meetingId string, logger *logrus.Entry) (uint32, string, common.HasuraMessage) {
 	dataChecksum := crc32.ChecksumIEEE(message)
 
 	common.GlobalCacheLocks.Lock(uint64(dataChecksum))
 	defer common.GlobalCacheLocks.Unlock(uint64(dataChecksum))
 
-	dataKey, hasuraMessage, dataMapExists := common.GetHasuraMessageCache(dataChecksum)
+	dataKey, hasuraMessage, dataMapExists := common.GetHasuraMessageCache(meetingId, dataChecksum)
 	if dataMapExists {
 		return dataChecksum, dataKey, hasuraMessage
 	}
@@ -265,7 +265,7 @@ func getHasuraMessage(message []byte, subscription common.GraphQlSubscription, l
 		break
 	}
 
-	common.StoreHasuraMessageCache(dataChecksum, dataKey, hasuraMessage)
+	common.StoreHasuraMessageCache(meetingId, dataChecksum, dataKey, hasuraMessage)
 
 	// Add Prometheus metrics only once for each dataChecksum
 	dataSize := len(string(message))

--- a/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
+++ b/bbb-graphql-middleware/internal/msgpatch/jsonpatch.go
@@ -23,6 +23,7 @@ func GetPatchedMessage(
 	cacheKey uint64,
 	lastDataChecksum uint32,
 	currDataChecksum uint32,
+	meetingId string,
 ) []byte {
 	if lastDataChecksum != 0 {
 		common.JsonPatchBenchmarkingStarted(strconv.FormatUint(cacheKey, 10))
@@ -31,7 +32,7 @@ func GetPatchedMessage(
 
 	// Lock to avoid other routines from processing the same message
 	common.GlobalCacheLocks.Lock(cacheKey)
-	if patchedMessageCache, patchedMessageCacheExists := common.GetPatchedMessageCache(cacheKey); patchedMessageCacheExists {
+	if patchedMessageCache, patchedMessageCacheExists := common.GetPatchedMessageCache(meetingId, cacheKey); patchedMessageCacheExists {
 		// Unlock immediately once the cache was already created by other routine
 		common.GlobalCacheLocks.Unlock(cacheKey)
 		return patchedMessageCache
@@ -46,7 +47,7 @@ func GetPatchedMessage(
 		// Content didn't change, set message as null to avoid sending it to the browser
 		// This case is usual when the middleware reconnects with Hasura and receives the data again
 		jsonData, _ := json.Marshal(nil)
-		common.StorePatchedMessageCache(cacheKey, jsonData)
+		common.StorePatchedMessageCache(meetingId, cacheKey, jsonData)
 		return jsonData
 	} else {
 		// Content was changed, creating json patch
@@ -58,7 +59,7 @@ func GetPatchedMessage(
 					lastHasuraMessage.Payload.Data[dataKey],
 					hasuraMessage.Payload.Data[dataKey],
 					"userId"); shouldUseCustomJsonPatch {
-					common.StorePatchedMessageCache(cacheKey, jsonDiffPatch)
+					common.StorePatchedMessageCache(meetingId, cacheKey, jsonDiffPatch)
 				} else if diffPatch, diffPatchErr := jsonpatch.CreatePatch(lastHasuraMessage.Payload.Data[dataKey], hasuraMessage.Payload.Data[dataKey]); diffPatchErr == nil {
 					var err error
 					if jsonDiffPatch, err = json.Marshal(diffPatch); err != nil {
@@ -84,6 +85,6 @@ func GetPatchedMessage(
 		receivedMessage = hasuraMessageJson
 	}
 
-	common.StorePatchedMessageCache(cacheKey, receivedMessage)
+	common.StorePatchedMessageCache(meetingId, cacheKey, receivedMessage)
 	return receivedMessage
 }

--- a/bbb-graphql-middleware/internal/streaming_server/chatMessageStream.go
+++ b/bbb-graphql-middleware/internal/streaming_server/chatMessageStream.go
@@ -23,8 +23,6 @@ func HandleGroupChatMessageBroadcastEvtMsg(receivedMessage common.RedisMessage, 
 	browserConnectionsMutex.RLock()
 	for _, bc := range browserConnections {
 		if bc.MeetingId == receivedMessage.Core.Header.MeetingId {
-			fmt.Println(chatParticipants)
-			fmt.Println(bc.UserId)
 			if len(chatParticipants) == 0 || slices.Contains(chatParticipants, any(bc.UserId)) {
 				browserConnectionsToSendData = append(browserConnectionsToSendData, bc)
 			}

--- a/bbb-graphql-middleware/internal/websrv/rediscli.go
+++ b/bbb-graphql-middleware/internal/websrv/rediscli.go
@@ -108,6 +108,9 @@ func StartRedisListener() {
 			log.Debugf("Removing cursor positions for meeting: %s", receivedMessage.Core.Body["meetingId"].(string))
 			go streamingserver.RemoveMeetingCursorsCache(receivedMessage.Core.Body["meetingId"].(string))
 			go streamingserver.RemoveMeetingUserVoiceStatesCache(receivedMessage.Core.Body["meetingId"].(string))
+			go common.RemoveMeetingHasuraMessageCache(receivedMessage.Core.Body["meetingId"].(string))
+			go common.RemoveMeetingPatchedMessageCache(receivedMessage.Core.Body["meetingId"].(string))
+			go common.RemoveMeetingStreamCursorValueCache(receivedMessage.Core.Body["meetingId"].(string))
 		}
 		if messageName == "UserLeftMeetingEvtMsg" {
 			log.Debugf("Removing cursor positions for meeting: %s, user: %s", receivedMessage.Core.Header.MeetingId, receivedMessage.Core.Header.UserId)


### PR DESCRIPTION
Refactors message cache maps to be scoped by `meetingId`, changing flat cache maps into nested maps. This prevents cross-meeting cache collisions and makes cache ownership explicit per meeting.