### PR TITLE
fix: audio modal should have precedence over video modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -137,7 +137,7 @@ const AudioContainer = (props) => {
 
   const audioModal = useModalRegistration({
     id: 'audioModal',
-    priority: 'medium',
+    priority: 'high',
   });
 
   const meetingIsBreakout = useMeetingIsBreakout();
@@ -195,10 +195,10 @@ const AudioContainer = (props) => {
     }
     Session.setItem('audioModalIsOpen', true);
     if (enableVideo && autoShareWebcam) {
-      openVideoPreviewModal();
       if (!currentUserHasVoice) {
         openAudioModal();
       }
+      openVideoPreviewModal();
       didMountAutoJoin = true;
     } else if (!(
       userSelectedMicrophone
@@ -294,7 +294,7 @@ const AudioContainer = (props) => {
       {audioModal.isOpen ? (
         <AudioModalContainer
           {...{
-            priority: 'medium',
+            priority: 'high',
             setIsOpen: audioModal.isOpen ? audioModal.close : audioModal.open,
             isOpen: audioModal.isOpen,
           }}


### PR DESCRIPTION
### What does this PR do?

- [fix: audio modal should have precedence over the video modal](https://github.com/bigbluebutton/bigbluebutton/commit/1f67bfda1e05888705d618b49c5999d1a70c7b5d) 
  - When video auto sharing is activated (via settings or userdata), the
video preview modal opens _before_ the audio modal. This is an
unintended regression introduced by relatively recent changes (circa 3.0.14-18)
to modal hierarchy.
  - As a rule of thumb, the audio modal should always have precedence over
the video preview modal. Change the priority of audio's to "high", as
well as trigger its open call first, so that it supersedes video
(priority medium). Overall, high priority makes sense for the audio
modal, and I didn't see any conflict with other "high" priority modals.

### Closes Issue(s)

None

### How to test

- Join a meeting with userdata-bbb_auto_share_webcam=true
- Observe which modal opens first: video or audio