### PR TITLE
fix(workflow): Publish test-results under workflow ID

### DIFF
--- a/.github/actions/publish-playwright-report/action.yml
+++ b/.github/actions/publish-playwright-report/action.yml
@@ -45,6 +45,11 @@ runs:
         fi
 
         pr_dir="reports-repo/pr-$PR_NUMBER"
+        if [ -d "$pr_dir" ]; then
+          commit_action="Update"
+        else
+          commit_action="Add"
+        fi
         dest_dir="$pr_dir/$WORKFLOW_ID"
         rm -rf "$pr_dir"
         mkdir -p "$dest_dir"
@@ -54,7 +59,7 @@ runs:
         git -C reports-repo config user.email "github-actions[bot]@users.noreply.github.com"
         if [ -n "$(git -C reports-repo status --porcelain)" ]; then
           git -C reports-repo add .
-          git -C reports-repo commit -m "Add Playwright report for PR #$PR_NUMBER"
+          git -C reports-repo commit -m "$commit_action Playwright report for PR #$PR_NUMBER - workflow $WORKFLOW_ID"
           git -C reports-repo push
         else
           echo "No changes to publish"

--- a/.github/actions/publish-playwright-report/action.yml
+++ b/.github/actions/publish-playwright-report/action.yml
@@ -13,6 +13,9 @@ inputs:
   report-path:
     description: Local path to the Playwright HTML report directory
     required: true
+  workflow-id:
+    description: Workflow run ID used for pr-<number>/<workflow_id> folder
+    required: true
 runs:
   using: composite
   steps:
@@ -27,6 +30,7 @@ runs:
       env:
         REPORT_PATH: ${{ inputs.report-path }}
         PR_NUMBER: ${{ inputs.pr-number }}
+        WORKFLOW_ID: ${{ inputs.workflow-id }}
       run: |
         set -euo pipefail
 
@@ -40,8 +44,9 @@ runs:
           exit 1
         fi
 
-        dest_dir="reports-repo/pr-$PR_NUMBER"
-        rm -rf "$dest_dir"
+        pr_dir="reports-repo/pr-$PR_NUMBER"
+        dest_dir="$pr_dir/$WORKFLOW_ID"
+        rm -rf "$pr_dir"
         mkdir -p "$dest_dir"
         rsync -a --delete "$REPORT_PATH/" "$dest_dir/"
         touch reports-repo/.nojekyll

--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -187,6 +187,7 @@ jobs:
           reports-repo: ${{ github.repository_owner }}/bbb-ci-playwright-reports
           token: ${{ secrets.PLAYWRIGHT_REPORTS_REPO_TOKEN }}
           pr-number: ${{ needs.get-pr-data.outputs.pr-number }}
+          workflow-id: ${{ needs.get-pr-data.outputs.workflow-id }}
           report-path: ${{ env.REPORT_PATH }}
   comment-pr:
     runs-on: ubuntu-latest
@@ -266,7 +267,7 @@ jobs:
             ${{ env.AUTO_COMMENT_MARKER }}
             <h2><strong>:rotating_light:</strong> Automated tests failed</h2>
 
-            - [Test results](https://bigbluebutton.github.io/bbb-ci-playwright-reports/pr-${{ needs.get-pr-data.outputs.pr-number }})
+            - [Test results](https://bigbluebutton.github.io/bbb-ci-playwright-reports/pr-${{ needs.get-pr-data.outputs.pr-number }}/${{ needs.get-pr-data.outputs.workflow-id }})
             - [Github workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.get-pr-data.outputs.workflow-id }})
       - name: Failing tests comment (without report)
         if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJson(env.isCompleted) && !fromJson(steps.check-reports.outputs.result || 'false') }}


### PR DESCRIPTION
### What does this PR do?
- Changes the published folder of test-results from `/pr-<PR_NUMBER>` to `/pr-<PR_NUMBER>/<WORKFLOW_ID>`

### Motivation
- Accessing previously loaded test results pages displays incorrect data due to caching. a different URL prevents this
