### PR TITLE
fix(chat-panel): text input and emojin button have incorrect color in Dark Mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -7,6 +7,7 @@ import {
   colorDanger,
   colorGrayDark,
   colorBorder,
+  colorWhite,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPaddingX,
@@ -44,7 +45,7 @@ const Wrapper = styled.div`
 
 const Input = styled(TextareaAutosize)<InputProps>`
   flex: 1;
-  background: #fff;
+  background: transparent;
   background-clip: padding-box;
   margin: 0px;
   border-radius: 0px;
@@ -117,6 +118,7 @@ const EmojiButtonWrapper = styled.div``;
 // @ts-ignore - as button comes from JS, we can't provide its props
 const EmojiButton = styled(Button)`
   margin:0 0 0 ${smPaddingX};
+  background: transparent !important;
 
   [dir="rtl"]  & {
     margin: 0 ${smPaddingX} 0 0;
@@ -184,6 +186,7 @@ const InputWrapper = styled.div`
   z-index: 0;
   border-radius: 0.75rem;
   border: 1px solid ${colorBorder};
+  background-color: ${colorWhite};
   gap: 3px;
 
   &:focus-within {


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Fix a visual issue that causes the button and text input background to have incorrect colors


#### Before
<img width="544" height="172" alt="image" src="https://github.com/user-attachments/assets/a91a2223-652b-457d-a266-8214506455e0" />


#### Now
<img width="605" height="151" alt="image" src="https://github.com/user-attachments/assets/9ffbbc20-e815-43ec-96c2-3139d1e00b2a" />
