### PR TITLE
Fix(html5): The video preview and audio modals open even with the lock settings settings enabled

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -147,7 +147,9 @@ const AudioContainer = (props) => {
       voiceConf: m?.voiceSettings?.voiceConf,
       muteOnStart: m?.voiceSettings?.muteOnStart,
     },
+    lockSettings: m.lockSettings,
   }));
+  const lockSettingsLoaded = meeting?.lockSettings !== undefined;
 
   const { data: currentUser } = useCurrentUser((u) => ({
     userId: u.userId,
@@ -242,13 +244,15 @@ const AudioContainer = (props) => {
     // We don't know whether the meeting is a breakout or not.
     // So, postpone the decision.
     if (meetingIsBreakout === undefined) return;
+
+    if (!lockSettingsLoaded) return;
     init().then(() => {
       // Skip auto join audio if user has already joined in another tab (currentUserHasVoice)
       if (meetingIsBreakout && !Service.isUsingAudio() && !currentUserHasVoice) {
         joinAudio();
       }
     });
-  }, [meetingIsBreakout]);
+  }, [meetingIsBreakout, lockSettingsLoaded]);
 
   useEffect(() => {
     if (userIsReturningFromBreakoutRoom) {


### PR DESCRIPTION
### What does this PR do?
The bug happened because had a race condition on lock settings not being loaded when the  open modals are checkin them.


### Closes Issue(s)
Closes #24442

### How to test
1. Create a meeting with the parameters 
```
lockSettingsDisableCam=true
lockSettingsDisableMic=true
```
2. Join with a viewer
3. Verify if no modals it's open and no permission it's requested.
