### PR TITLE
fix: audio-only tiles appear in all layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -53,6 +53,9 @@ import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
+import { layoutSelect } from '/imports/ui/components/layout/context';
+import { Layout } from '/imports/ui/components/layout/layoutTypes';
+import { LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
 import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 
@@ -421,11 +424,14 @@ const useAudioOnlySubscription = createUseSubscription(
 export const useAudioOnlyUsers = (): AudioOnlyStream[] => {
   const { data: meeting } = useMeeting((m) => ({ meetingId: m.meetingId }));
   const { data, loading, errors } = useAudioOnlySubscription();
+  const layoutType = layoutSelect((i: Layout) => i.layoutType);
   const {
     showAudioOnlyOnFirstPage,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
 
-  if (!showAudioOnlyOnFirstPage) return [];
+  const isUnifiedLayout = layoutType === LAYOUT_TYPE.UNIFIED_LAYOUT;
+
+  if (!showAudioOnlyOnFirstPage || !isUnifiedLayout) return [];
   if (loading) return [];
 
   if (errors) {
@@ -476,13 +482,18 @@ export const useVideoStreams = () => {
   let streams: StreamItem[] = [...videoStreams];
   let totalNumberOfOtherStreams: number | undefined;
 
+  const layoutType = layoutSelect((i: Layout) => i.layoutType);
+  const isUnifiedLayout = layoutType === LAYOUT_TYPE.UNIFIED_LAYOUT;
   const {
     paginationSorting: PAGINATION_SORTING,
     defaultSorting: DEFAULT_SORTING,
-    showAudioOnlyOnFirstPage,
-    maxAudioOnlyUsers,
+    showAudioOnlyOnFirstPage: showAudioOnlyOnFirstPageSetting,
+    maxAudioOnlyUsers: maxAudioOnlyUsersSetting,
     partitionPrivilegedStreams,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
+
+  const showAudioOnlyOnFirstPage = showAudioOnlyOnFirstPageSetting && isUnifiedLayout;
+  const maxAudioOnlyUsers = isUnifiedLayout ? maxAudioOnlyUsersSetting : 0;
 
   if (connectingStream) streams.push(connectingStream);
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -498,9 +498,9 @@ public:
       paginationSorting: VOICE_ACTIVITY_LOCAL
       # showAudioOnlyOnFirstPage: when enabled, shows audio-only tiles
       # for speaking users who don't have cameras on first page. These tiles appear on the right side,
-      # bumping previous off-view tiles to the left.
+      # bumping previous off-view tiles to the left. (only for unified layout)
       showAudioOnlyOnFirstPage: true
-      # maxAudioOnlyUsers: maximum number of audio-only tiles to show
+      # maxAudioOnlyUsers: maximum number of audio-only tiles to show (only for unified layout).
       # When pagination is enabled, this limits the number of slots available for audio-only users
       # When pagination is disabled, this is the limit for audio-only users
       maxAudioOnlyUsers: 2


### PR DESCRIPTION
Adjusts `showAudioOnlyOnFirstPage` and `maxAudioOnlyUsers` settings to only apply for unified layout