### PR TITLE
fix(recording): Detect system sender correctly in breakouts recording

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -991,7 +991,7 @@ module BigBlueButton
             in: timestamp - offset,
             out: nil,
             sender_id: sender_id,
-            sender: sender_id.nil? ? sender : user_map.fetch(sender_id),
+            sender: sender_id.nil? ? sender : user_map.fetch(sender_id, sender_id),
             senderRole: senderRole,
             chatEmphasizedText: chatEmphasizedText,
             replyToMessageId: replyToMessageId,


### PR DESCRIPTION
In breakout rooms we dispatch system messages whose sender did not get correctly mapped

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Allow breakouts recording to process correctly even if system messages were present.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes https://github.com/bigbluebutton/bigbluebutton/issues/24639

### Motivation
<!-- What inspired you to submit this pull request? -->
Recording processing stalling.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Enable breakouts recording (bbb-web.properties)
`breakoutRoomsRecord=true`
Enable breakouts recordings in bbb-html5.yml
```
public:
  app:
    breakouts:
      offerRecordingForBreakouts: true
      recordRoomByDefault: true
```
Create a session and join as moderator
start recording the main session
Create breakouts with Record enabled
Join a breakout and start recording
In the main room change the remaining time of the breakouts to 2 mins.
At the 1min mark there will be a notification
From the main room broadcast to the breakouts "Hi all!"
End the breakouts
End the main room.
Wait for the recording processing.
(You can use api-mate's getRecordings)
if you're not finding a presentation playback for the breakouts, just swap the meeting id portion with the id of the breakout you recorded.

Before the fix:
no processed/published breakout recording as it got blocked (see issue)

After the fix:
<img width="579" height="563" alt="image" src="https://github.com/user-attachments/assets/484efd6b-96ad-47a2-8d15-6dca46efb365" />



### More
Thanks @mitchell-accipio for reporting the issue and the fix. I just had to reproduce and confirm it, and now to submit the patch.

