### PR TITLE
feat: option to show "isNew" label for native apps in the gallery

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -21,6 +21,7 @@ export interface Public {
   userReaction: UserReaction
   notes: Notes
   layout: Layout
+  sidebarNavigation: SidebarNavigation
   pads: Pads
   media: Media
   stats: Stats
@@ -602,6 +603,10 @@ export interface Layout {
   showParticipantsOnLogin: boolean
   showScreenshareQuickSwapButton: boolean
   showLeaveSessionLabel: boolean
+}
+
+export interface SidebarNavigation {
+  appsToLabelAsNew: string[]
 }
 
 export interface Pads {

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -1,4 +1,9 @@
-import React, { memo, useMemo, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { AppsGalleryProps } from './types';
 import { layoutDispatch, layoutSelect } from '/imports/ui/components/layout/context';
@@ -9,6 +14,7 @@ import TooManyPinnedAppsModal from './modal/component';
 import AppItem from './app-item/component';
 import ExternalAppItem from './external-app-item/component';
 import { isPluginNew } from './service';
+import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
 
 const intlMessages = defineMessages({
   appsGalleryTitle: {
@@ -44,6 +50,9 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
   const intl = useIntl();
   const title = intl.formatMessage(intlMessages.appsGalleryTitle);
   const [error, setError] = useState(false);
+  const [meetingSettings] = useMeetingSettings();
+  const appsToLabelAsNew = meetingSettings?.public?.sidebarNavigation?.appsToLabelAsNew || [];
+  const shouldAddIsNewLabel = useCallback((id: string) => appsToLabelAsNew.includes(id), [appsToLabelAsNew]);
 
   const renderedPinnedApps = useMemo(() => (
     pinnedApps.map((pinnedAppKey) => {
@@ -54,7 +63,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
         pluginName,
       } = registeredApps[pinnedAppKey];
 
-      const isNew = isPluginNew(pluginName);
+      const isNew = isPluginNew(pluginName) || shouldAddIsNewLabel(pinnedAppKey);
 
       // type guard
       const { onClick } = registeredApps[pinnedAppKey] as InjectedAppGalleryItem;
@@ -78,7 +87,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
         />
       );
     })
-  ), [registeredApps, pinnedApps]);
+  ), [registeredApps, pinnedApps, shouldAddIsNewLabel]);
 
   const renderedUnpinnedApps = useMemo(() => (
     Object.keys(registeredApps)
@@ -91,7 +100,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           pluginName,
         } = registeredApps[unpinnedAppKey];
 
-        const isNew = isPluginNew(pluginName);
+        const isNew = isPluginNew(pluginName) || shouldAddIsNewLabel(unpinnedAppKey);
 
         // type guard
         const { onClick } = registeredApps[unpinnedAppKey] as InjectedAppGalleryItem;
@@ -115,7 +124,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           />
         );
       })
-  ), [registeredApps, pinnedApps]);
+  ), [registeredApps, pinnedApps, shouldAddIsNewLabel]);
 
   return (
     <>

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -618,6 +618,9 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       showScreenshareQuickSwapButton: true,
       showLeaveSessionLabel: false,
     },
+    sidebarNavigation: {
+      appsToLabelAsNew: [],
+    },
     pads: {
       url: 'ETHERPAD_HOST',
     },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -837,6 +837,11 @@ public:
     showLeaveSessionLabel: false
     usersPerUserListPage: 50
     syncCameraDockSizeAndPosition: true
+  sidebarNavigation:
+    # Controls which apps should have the "new" label in the apps gallery.
+    # Possible values: 'poll', 'breakoutroom', 'timer', 'audio-captions'.
+    # For plugins, refer to the isNew flag in the plugin's own settings.
+    appsToLabelAsNew: []
   pads:
     url: ETHERPAD_HOST
   media:


### PR DESCRIPTION
### What does this PR do?

This is the native apps variant of https://github.com/bigbluebutton/bigbluebutton/pull/24003

- [feat: option to show "isNew" label for native apps in the gallery](https://github.com/bigbluebutton/bigbluebutton/commit/9b725b2b3c62738821780126d86ef526b3df6ba0) 
  - The apps gallery is able to render "New" indicator labels for plugin
    entries to identify them as new features. This can be activated via
    plugin configs, but we cannot do the same for native apps (e.g. polls).
  - Add an option to display the isNew label for any native app in the
apps-gallery.
    This can be enabled via public.sidebarNavigation.appsToLabelAsNew.
    Default is [] (no app).
    The configuration is an array of native app keys. Possible values are:
    - 'poll', 'breakoutroom', 'timer' and 'audio-captions'.

### Closes Issue(s)

None