### PR TITLE
Revert "Build(html5): Change webpack minifier to preserve class and function names"

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -135,14 +135,7 @@ if (env === prodEnv) {
   config.mode = prodEnv;
   config.optimization = {
     minimize: true,
-    minimizer: isSafariTarget ? [] : [new TerserPlugin({
-      terserOptions: {
-        keep_classnames: true,
-        keep_fnames: true,
-      },
-      extractComments: false,
-      parallel: true,
-    })],
+    minimizer: isSafariTarget ? [] : [new TerserPlugin()],
   };
   config.performance = {
     hints: 'warning',


### PR DESCRIPTION
Reverts bigbluebutton/bigbluebutton#24010

I have not really been able to take advantage of the additional information in the logs, so might as well reduce the build by a megabyte again.