### PR TITLE
fix: talking indicator behind webcam area - custom and smart layouts

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/customLayout.jsx
@@ -348,7 +348,7 @@ const CustomLayout = (props) => {
         );
       }
 
-      cameraDockBounds.top = navBarHeight;
+      cameraDockBounds.top = navBarHeight + bannerAreaHeight();
       cameraDockBounds.left = mediaAreaBounds.left;
       cameraDockBounds.right = isRTL ? sidebarSize : null;
       cameraDockBounds.minWidth = mediaAreaBounds.width;

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/smartLayout.jsx
@@ -173,7 +173,7 @@ const SmartLayout = (props) => {
         ? mediaBounds.width
         : presentationToolbarMinWidth;
 
-    cameraDockBounds.top = navBarHeight;
+    cameraDockBounds.top = navBarHeight + bannerAreaHeight();
     cameraDockBounds.left = mediaAreaBounds.left;
     cameraDockBounds.right = isRTL ? sidebarSize : null;
     cameraDockBounds.zIndex = 1;


### PR DESCRIPTION
### What does this PR do?

Adjusts custom and smart layouts to include banner area when calculating webcam area position

### Closes Issue(s)
Closes #24643

### How to test
1. start a meeting with a duration of 10 minutes
2. Join the meeting with a user and set the layout to custom or smart
3. share a webcam
4. join audio
5. start talking
