### PR TITLE
style: Improve visual hierarchy and UX of guest lobby screen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -54,6 +54,16 @@ const intlMessages = defineMessages({
     id: 'app.guest.calculating',
     description: '',
   },
+  messageFromHost: {
+    id: 'app.guest.messageFromHost',
+    description: 'Label for host message',
+    defaultMessage: 'Message from host',
+  },
+  waitingForApproval: {
+    id: 'app.guest.waitingForApproval',
+    description: 'Waiting status text',
+    defaultMessage: 'Waiting for approval',
+  },
 });
 
 function getSearchParam(name: string) {
@@ -173,26 +183,42 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
     updatePositionInWaitingQueue,
   ]);
 
+  const hasCustomMessage = guestLobbyMessage && guestLobbyMessage.length > 0;
+
   return (
     <Styled.Container>
       <Styled.Content id="content">
         <Styled.Heading id="heading">{intl.formatMessage(intlMessages.windowTitle)}</Styled.Heading>
-        {animate && (
-          <Styled.Spinner>
-            <Styled.Bounce1 />
-            <Styled.Bounce2 />
-            <Styled.Bounce />
-          </Styled.Spinner>
-        )}
-        <p
-          aria-live="polite"
-          data-test="guestMessage"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: message }}
-        />
         <Styled.Position id="positionInWaitingQueue">
           <p aria-live="polite">{positionMessage}</p>
         </Styled.Position>
+        {hasCustomMessage && (
+          <Styled.MessageContainer>
+            <Styled.MessageLabel>
+              {intl.formatMessage(intlMessages.messageFromHost)}
+            </Styled.MessageLabel>
+            <Styled.MessageText
+              aria-live="polite"
+              data-test="guestMessage"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: message }}
+            />
+          </Styled.MessageContainer>
+        )}
+        {!hasCustomMessage && (
+          <p
+            aria-live="polite"
+            data-test="guestMessage"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: message }}
+          />
+        )}
+        {animate && (
+          <Styled.WaitingIndicator>
+            <Styled.WaitingDot />
+            <span>{intl.formatMessage(intlMessages.waitingForApproval)}</span>
+          </Styled.WaitingIndicator>
+        )}
       </Styled.Content>
     </Styled.Container>
   );

--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/styles.ts
@@ -47,10 +47,11 @@ const MessageLabel = styled.div`
   letter-spacing: 0.5px;
 `;
 
-const MessageText = styled.div`
+const MessageText = styled.p`
   font-size: 1em;
   font-weight: 500;
   line-height: 1.4;
+  margin: 0;
 `;
 
 const pulse = keyframes`

--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/styles.ts
@@ -13,17 +13,76 @@ const Content = styled.div`
   color: white;
   font-weight: bold;
   font-size: 24px;
+  max-width: 650px;
+  padding: 0 20px;
 `;
 
 const Heading = styled.h1`
   font-size: 2rem;
+  margin-bottom: 16px;
 `;
 
 const Position = styled.div`
   align-items: center;
   text-align: center;
+  font-size: 0.9em;
+  font-weight: normal;
+  opacity: 0.85;
+  margin-bottom: 24px;
 `;
 
+const MessageContainer = styled.div`
+  background-color: rgba(0, 0, 0, 0.35);
+  padding: 20px 28px;
+  border-radius: 12px;
+  margin: 8px 0 24px 0;
+`;
+
+const MessageLabel = styled.div`
+  font-size: 0.75em;
+  font-weight: normal;
+  opacity: 0.7;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`;
+
+const MessageText = styled.div`
+  font-size: 1em;
+  font-weight: 500;
+  line-height: 1.4;
+`;
+
+const pulse = keyframes`
+  0%, 100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+`;
+
+const WaitingIndicator = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 0.8em;
+  font-weight: normal;
+  opacity: 0.7;
+  margin-top: 8px;
+`;
+
+const WaitingDot = styled.span`
+  width: 8px;
+  height: 8px;
+  background-color: #4ade80;
+  border-radius: 50%;
+  display: inline-block;
+  animation: ${pulse} 2s ease-in-out infinite;
+`;
+
+// Keep old spinner components for backwards compatibility but they won't be used
 const sk_bouncedelay = keyframes`
   0%,
   80%,
@@ -64,6 +123,11 @@ export default {
   Content,
   Heading,
   Position,
+  MessageContainer,
+  MessageLabel,
+  MessageText,
+  WaitingIndicator,
+  WaitingDot,
   Bounce,
   Bounce1,
   Bounce2,

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -982,6 +982,8 @@
     "app.guest.guestInvalid": "Guest user is invalid",
     "app.guest.meetingForciblyEnded": "You cannot join a session that has already been forcibly ended",
     "app.guest.calculating": "Calculating position in waiting queue",
+    "app.guest.messageFromHost": "Message from host",
+    "app.guest.waitingForApproval": "Waiting for approval",
     "app.userList.guest.waitingUsers": "Waiting Users",
     "app.userList.guest.waitingUsersTitle": "User Management",
     "app.userList.guest.optionTitle": "Review Pending Users",


### PR DESCRIPTION
Current implementation

<img width="1502" height="815" alt="Screenshot 2026-02-16 at 9 52 59 AM" src="https://github.com/user-attachments/assets/2b5d95aa-d806-495e-b295-21fccf0bee22" />

Recommended changes within this PR.

<img width="1505" height="813" alt="Screenshot 2026-02-16 at 9 43 38 AM" src="https://github.com/user-attachments/assets/f7d0311b-7e38-4536-875c-aa79b7f1552e" />


  ### What does this PR do?                                                                                                                                                                                                               
  Improves the visual hierarchy and UX of the guest waiting/lobby screen:                                                                                                                                                                 
                                                                                                                                                                                                                                          
  - Replaces the misleading bouncing dots spinner with a subtle "Waiting for approval" indicator (green pulsing dot + text)                                                                                                               
  - Adds a visually distinct container with dark semi-transparent background for the host message                                                                                                                                         
  - Adds "MESSAGE FROM HOST" label above the message to clearly identify its source                                                                                                                                                       
  - Reorders content so queue position appears before the host message                                                                                                                                                                    
  - Makes position text lighter weight (smaller, less bold) for better visual hierarchy                                                                                                                                                   
                                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                                     
  ### Closes Issue(s)                                                                                                                                                                                                                     
  (remove the "Closes #" line if there's no issue to reference)                                                                                                                                                                           
                                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                                     
  ### Motivation                                                                                                                                                                                                                          
  Customer feedback indicated that the host message was difficult to find because it visually looked identical to other system text on the screen. Additionally, the bouncing dots spinner implied "loading content" rather than "waiting 
  for moderator approval," which confused users about the actual system state.                                                                                                                                                            
                                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                                     
  ### How to test                                                                                                                                                                                                                         
  1. Create a meeting with guestPolicy=ASK_MODERATOR                                                                                                                                                                                      
  2. Set a custom lobby message for the meeting via the API or moderator controls                                                                                                                                                         
  3. Join the meeting as a guest/attendee                                                                                                                                                                                                 
  4. Verify the guest lobby screen shows:                                                                                                                                                                                                 
     - Queue position ("You are the first in line!") in lighter text                                                                                                                                                                      
     - Host message in a dark rounded container with "MESSAGE FROM HOST" label                                                                                                                                                            
     - Green pulsing dot with "Waiting for approval" at the bottom                                                                                                                                                                        
     - No bouncing loading spinner                                                                                                                                                                                                        
                                                                                                                                                                                                                                          
  ---                                                                                                                                                                                                                                     
  ### More                                                                                                                                                                                                                                
  -  Added/updated documentation                                                                                                                                                                                                       
                                                                                                                                                                                                                                          
  No new dependencies added. Changes are limited to styled-components in the guest-wait component.                                                                                                                                        
                                                                                                       