### PR TITLE
fix (akka-apps): Prevent race condition when a user joins a breakout room

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -111,7 +111,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
         case Some(u) => u.speechLocale
         case None    => ""
       }
-      
+
       VoiceApp.handleUserJoinedVoiceConfEvtMsg(
         liveMeeting,
         outGW,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomDAO.scala
@@ -84,7 +84,6 @@ object BreakoutRoomDAO {
 
       val nonAssignedUsers = Users2x.findAll(liveMeeting.users2x)
         .filterNot(user => assignedUsers.contains(user.intId))
-        .filterNot(user => user.presenter)
         .filter(user => user.role != Roles.MODERATOR_ROLE || breakout.sendInviteToModerators)
         .map(_.intId)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -43,7 +43,7 @@ object BreakoutRoomUserDAO {
     )
         ON CONFLICT ("breakoutRoomMeetingId", "meetingId", "userId")
         DO UPDATE SET
-        "assignedAt" = $assignedAt,
+        "assignedAt" = coalesce($assignedAt, "breakoutRoom_user"."assignedAt"),
         "joinURL" = ${joinURL},
         "inviteDismissedAt" = null
         """

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -29,20 +29,23 @@ class BreakoutRoomUserDbTableDef(tag: Tag) extends Table[BreakoutRoomUserDbModel
 
 object BreakoutRoomUserDAO {
   def prepareInsert(breakoutRoomMeetingId: String, meetingId: String, userId: String, joinURL: String, wasAssignedByMod: Boolean) = {
-    TableQuery[BreakoutRoomUserDbTableDef].insertOrUpdate(
-      BreakoutRoomUserDbModel(
-        breakoutRoomMeetingId = breakoutRoomMeetingId,
-        breakoutRoomUserId = "",
-        meetingId = meetingId,
-        userId = userId,
-        joinURL = joinURL,
-        assignedAt = wasAssignedByMod match {
-          case true => Some(new java.sql.Timestamp(System.currentTimeMillis()))
-          case false => None
-        },
-        inviteDismissedAt = None,
-      )
+    val assignedAt: Option[java.sql.Timestamp] = if (wasAssignedByMod) Some(new java.sql.Timestamp(System.currentTimeMillis())) else None
+
+    sqlu"""
+        INSERT INTO "breakoutRoom_user" ("breakoutRoomMeetingId", "meetingId", "userId", "joinURL", "assignedAt", "inviteDismissedAt")
+        VALUES (
+       ${breakoutRoomMeetingId},
+       ${meetingId},
+       ${userId},
+       ${joinURL},
+       $assignedAt,
+       null
     )
+        ON CONFLICT ("breakoutRoomMeetingId", "meetingId", "userId")
+        DO UPDATE SET
+        "assignedAt" = $assignedAt,
+        "inviteDismissedAt" = null
+        """
   }
 
   def updateUserMovedToRoom(meetingId: String, userId: String, toBreakoutRoomMeetingId: String, joinUrl: String) = {
@@ -71,7 +74,7 @@ object BreakoutRoomUserDAO {
                 WHERE "meetingId" = ${parentMeetingUser.meetingId}
                 AND "userId" = ${parentMeetingUser.id}
                 AND "breakoutRoomMeetingId" = ${breakoutRoom.id}
-                AND "breakoutRoomUserId" != ${breakoutRoomUser.userId}"""
+                AND "breakoutRoomUserId" is distinct from ${breakoutRoomUser.userId}"""
       )
   }
 
@@ -109,10 +112,9 @@ object BreakoutRoomUserDAO {
         INSERT INTO "breakoutRoom_user" ("breakoutRoomMeetingId", "meetingId", "userId")
         SELECT b."breakoutRoomMeetingId", u."meetingId", u."userId"
         FROM "user" u
-        JOIN "breakoutRoom" b ON b."meetingId" = u."meetingId"
+        JOIN "breakoutRoom" b ON b."meetingId" = u."meetingId" AND b."endedAt" IS NULL
         WHERE u."meetingId" = ${meetingId} #${userCriteria}
         AND ( b."freeJoin" IS TRUE OR u."role" = 'MODERATOR')
-        AND b."endedAt" IS NULL
         ON CONFLICT ("breakoutRoomMeetingId", "meetingId", "userId") DO NOTHING;
 
         DELETE FROM "breakoutRoom_user"

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -44,6 +44,7 @@ object BreakoutRoomUserDAO {
         ON CONFLICT ("breakoutRoomMeetingId", "meetingId", "userId")
         DO UPDATE SET
         "assignedAt" = $assignedAt,
+        "joinURL" = ${joinURL},
         "inviteDismissedAt" = null
         """
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -59,8 +59,15 @@ object BreakoutRoomUserDAO {
   def updateUserJoined(breakoutRoomUser: BreakoutUser, parentMeetingUser: RegisteredUser, breakoutRoom: BreakoutRoom2x) = {
       DatabaseConnection.enqueue(
         sqlu"""UPDATE "breakoutRoom_user" SET
+                "breakoutRoomUserId" = ${breakoutRoomUser.userId},
                 "joinedAt" = current_timestamp,
-                "breakoutRoomUserId" = ${breakoutRoomUser.userId}
+                "isUserCurrentlyInRoom" = exists (
+                  select 1
+                  from "user"
+                  where "user"."meetingId" = ${breakoutRoom.id}
+                  and "user"."userId" = ${breakoutRoomUser.userId}
+                  and "currentlyInMeeting" is true
+                )
                 WHERE "meetingId" = ${parentMeetingUser.meetingId}
                 AND "userId" = ${parentMeetingUser.id}
                 AND "breakoutRoomMeetingId" = ${breakoutRoom.id}

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/room-managment-state/component.tsx
@@ -76,14 +76,20 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
   }>({});
 
   const recordUserMovement = (userId: string, fromRoom: number, toRoom: number) => {
+    // Use the actual running room as fromRoomId source of truth.
+    // If the user was dragged through the unassigned box (fromRoom=0),
+    // the previous movementRegistered entry still holds the real fromRoomId.
+    const runningRoom = runningRooms?.find((r) => r.participants.some((p) => p.user.userId === userId));
+    const fromRoomId = runningRoom?.breakoutRoomMeetingId
+      ?? movementRegistered[userId]?.fromRoomId;
     let updatedMovementRegistered = { ...movementRegistered };
     updatedMovementRegistered = {
       ...updatedMovementRegistered,
       [userId]: {
-        fromSequence: fromRoom,
+        fromSequence: runningRoom?.sequence ?? fromRoom,
         toSequence: toRoom,
         toRoomId: runningRooms?.find((r) => r.sequence === toRoom)?.breakoutRoomMeetingId,
-        fromRoomId: runningRooms?.find((r) => r.sequence === fromRoom)?.breakoutRoomMeetingId,
+        fromRoomId,
       },
     };
     setMovementRegistered(updatedMovementRegistered);
@@ -143,10 +149,22 @@ const RoomManagmentState: React.FC<RoomManagmentStateProps> = ({
       assignments[i] = (i % numberOfRooms) + 1;
     }
 
+    const updatedMovementRegistered = { ...movementRegistered };
     userIds.forEach((userId, index) => {
       const roomNumber = assignments[index];
+      // Find where the user actually is in the running rooms (ground truth),
+      // regardless of any UI reassignments or unassigns done in the modal.
+      const runningRoom = runningRooms?.find((r) => r.participants.some((p) => p.user.userId === userId));
       updatedUserAssignedRooms[userId] = [roomNumber];
+      updatedMovementRegistered[userId] = {
+        fromSequence: runningRoom?.sequence ?? 0,
+        toSequence: roomNumber,
+        fromRoomId: runningRoom?.breakoutRoomMeetingId,
+        toRoomId: runningRooms?.find((r) => r.sequence === roomNumber)?.breakoutRoomMeetingId,
+      };
     });
+    setMovementRegistered(updatedMovementRegistered);
+    setMoveRegisterRef(updatedMovementRegistered);
     setUserAssignedRooms(updatedUserAssignedRooms);
   };
 


### PR DESCRIPTION
Users reported that, in some cases, a participant was inside a breakout room but did not appear in that room's user list. I identified a likely race condition behind this behavior, though it is difficult to confirm because the issue is hard to reproduce (we only managed to reproduce it once on a heavily loaded server).

The user's presence in a breakout room is set by the `update_bkroom_isUserCurrentlyInRoom_trigger`, which runs when the user joins a meeting that is a breakout room. In some situations, the trigger fired before the main room had resolved the correct `userId` for that user in the breakout room, so the presence update did not happen.

To eliminate this race condition, `isUserCurrentlyInRoom` is now updated in two places: by the trigger and also when the user's `userId` is updated for the room. This ensures `isUserCurrentlyInRoom` is always set correctly.

------
More:

- Improve modal of management of breakout rooms, as it was not detecting the previous room correctly sometimes (in special for users that join in the main meeting after the breakout rooms were already created)
- Improve performance of the query to add users to breakout rooms in the database
- Now presenter non-moderator will receive the invitation to join breakout room (as there was a bug where presenter non-moderator would never be able to join a room when freeJoin was checked)
