### PR TITLE
fix: trim spaces of external video url

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
@@ -102,7 +102,7 @@ const ExternalVideoPlayerModal: React.FC<ExternalVideoPlayerModalProps> = ({
             {intl.formatMessage(intlMessages.input)}
             <input
               id="video-modal-input"
-              onChange={(e) => setVideoUrl(e.target.value)}
+              onChange={(e) => setVideoUrl(e.target.value.trim())}
               name="video-modal-input"
               placeholder={intl.formatMessage(intlMessages.urlInput)}
               aria-describedby="exernal-video-note"


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Trim extra spacing around links for external video sharing.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #24661 

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Use url `https://download.samplelib.com/mp4/sample-5s.mp4`
Add a few spaces before/after the url and you'll see you can still share it.
[Screencast from 2026-02-19 06-59-39.webm](https://github.com/user-attachments/assets/59fec24d-b756-4a90-94ca-e3a79ebb2c32)
