### PR TITLE
feat(conf): Add firewalld support to firewall detection

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -452,16 +452,17 @@ display_bigbluebutton_status () {
 
     # Display firewall status
     echo
+    local line_offset=10   # length of "└─ Status: " in characters
     if which ufw > /dev/null 2>&1; then
-        firewall_name="ufw"; firewall_status=$(ufw status | head -1 | sed 's/Status: //'); line_offset=18
+        firewall_name="ufw"; firewall_status=$($SUDO ufw status | head -1 | sed 's/Status: //')
     elif which firewall-cmd > /dev/null 2>&1; then
-        firewall_name="firewalld"; firewall_status=$(firewall-cmd --state > /dev/null 2>&1 && echo "active" || echo "inactive"); line_offset=10
+        firewall_name="firewalld"; firewall_status=$(firewall-cmd --state > /dev/null 2>&1 && echo "active" || echo "inactive")
     else
-        firewall_name="none"; firewall_status="inactive"; line_offset=10
+        firewall_name="none"; firewall_status="inactive"
     fi
     checkmark=$([ "$firewall_status" = "active" ] && echo "✔" || echo "✘")
     echo "Firewall: $firewall_name"
-    echo "└─ Status: ${line:$line_offset} [$checkmark - $firewall_status]"
+    echo "└─ Status: ${line:$line_offset} [$checkmark - firewall:$firewall_status]"
 }
 
 if [ $# -eq 0 ]; then
@@ -799,14 +800,11 @@ check_configuration() {
 
     # Check for firewall presence (ufw or firewalld)
     FIREWALL_DETECTED=""
-    FIREWALL_CMD=""
 
     if which ufw > /dev/null 2>&1; then
         FIREWALL_DETECTED="ufw"
-        FIREWALL_CMD="ufw status"
     elif which firewall-cmd > /dev/null 2>&1; then
         FIREWALL_DETECTED="firewalld"
-        FIREWALL_CMD="firewall-cmd --state"
     fi
 
     if [ -z "$FIREWALL_DETECTED" ]; then

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -449,6 +449,19 @@ display_bigbluebutton_status () {
             printf "%s %s [✘ - $status]\n" $unit "${line:${#unit}}"
         fi
     done
+
+    # Display firewall status
+    echo
+    if which ufw > /dev/null 2>&1; then
+        firewall_name="ufw"; firewall_status=$(ufw status | head -1 | sed 's/Status: //'); line_offset=18
+    elif which firewall-cmd > /dev/null 2>&1; then
+        firewall_name="firewalld"; firewall_status=$(firewall-cmd --state > /dev/null 2>&1 && echo "active" || echo "inactive"); line_offset=10
+    else
+        firewall_name="none"; firewall_status="inactive"; line_offset=10
+    fi
+    checkmark=$([ "$firewall_status" = "active" ] && echo "✔" || echo "✘")
+    echo "Firewall: $firewall_name"
+    echo "└─ Status: ${line:$line_offset} [$checkmark - $firewall_status]"
 }
 
 if [ $# -eq 0 ]; then
@@ -784,13 +797,25 @@ check_configuration() {
        echo
     fi
 
-    if ! which ufw > /dev/null 2>&1; then
-       echo
-       echo "# Warning: No firewall detected.  Recommend using setting up a firewall for your server"
-       echo "#"
-       echo "#     https://docs.bigbluebutton.org/administration/firewall-configuration"
-       echo "#"
-       echo
+    # Check for firewall presence (ufw or firewalld)
+    FIREWALL_DETECTED=""
+    FIREWALL_CMD=""
+
+    if which ufw > /dev/null 2>&1; then
+        FIREWALL_DETECTED="ufw"
+        FIREWALL_CMD="ufw status"
+    elif which firewall-cmd > /dev/null 2>&1; then
+        FIREWALL_DETECTED="firewalld"
+        FIREWALL_CMD="firewall-cmd --state"
+    fi
+
+    if [ -z "$FIREWALL_DETECTED" ]; then
+        echo
+        echo "# Warning: No firewall detected.  Recommend using setting up a firewall for your server"
+        echo "#"
+        echo "#     https://docs.bigbluebutton.org/administration/firewall-configuration"
+        echo "#"
+        echo
     fi
 
 }


### PR DESCRIPTION
### What does this PR do?
Updates bbb-conf to detect both ufw and firewalld firewalls instead of only ufw. Adds firewall status display to --status command.

### Reference Issue
References #20971

### Motivation
Servers with firewalld were getting false "no firewall detected" warnings since the script only checked for ufw.

### How to test
- Run `bbb-conf --check` on a system with firewalld - should not show firewall warning
- Run `bbb-conf --status` - should display firewall status with tree format
- Test on systems with ufw, firewalld, and no firewall