### PR TITLE
ci: Move permissions into individual jobs

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -15,14 +15,14 @@ on:
       - "docs/**"
       - "**/*.md"
       - "bigbluebutton-html5/public/locales/*.json"
-permissions:
-  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   build-package:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -135,6 +135,8 @@ jobs:
           path: artifacts/
   bbb-libreoffice-image:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
@@ -163,6 +165,9 @@ jobs:
   unify-artifacts:
     needs: build-package
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Create all-artifacts directory
         run: mkdir -p all-artifacts
@@ -263,6 +268,8 @@ jobs:
       - unify-artifacts
       - bbb-libreoffice-image
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -392,6 +399,8 @@ jobs:
       - unify-artifacts
       - bbb-libreoffice-image
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     env:
@@ -590,6 +599,8 @@ jobs:
       - install-and-run-bbb-tests
       - install-and-run-plugin-tests
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     env:
       hasFailure: ${{ needs.install-and-run-bbb-tests.result == 'failure' || needs.install-and-run-plugin-tests.result == 'failure' }}
     steps:


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Moving the permissions (read) into the individual jobs

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->

SonarQube reporting

```
Granting read permissions at the workflow level applies those permissions to all jobs in the workflow by default. This violates the principle of least privilege, as jobs that don’t require these read permissions will still inherit them unnecessarily.

What is the potential impact?
When read permissions are granted at the workflow level, all jobs inherit these permissions regardless of whether they need them.
...
```

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
CI still runs and correctly completes the automated tests
