### PR TITLE
Recording: avoid short cuts in audio processing

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -49,7 +49,7 @@ module BigBlueButton
         # Special case handling for the start
         # If there's a cut immediately after the start, the later logic would delete the first cut,
         # which would result in desync. Any cuts within MIN_CUT_LENGTH of the start have to be
-        # pushed back to avoid this situation. It multiple cuts are pushed back (they'd all get set
+        # pushed back to avoid this situation. If multiple cuts are pushed back (they'd all get set
         #  to the same timestamp), the later logic will clean them up.
         1.upto(edl.length - 1).each do |i|
           # We've made it past the problematic point near the start of the recording

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -25,6 +25,7 @@ module BigBlueButton
       FFMPEG_WF_CODEC = 'libvorbis'
       FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'
+      MIN_CUT_LENGTH = 20 # ms (one frame of audio in opus)
 
       def self.dump(edl)
         BigBlueButton.logger.debug "EDL Dump:"
@@ -41,6 +42,49 @@ module BigBlueButton
             BigBlueButton.logger.debug "    silence"
           end
         end
+      end
+
+      # Edit the EDL to make sure that every cut has a minimum length
+      def self.enforce_cut_lengths(edl)
+        # Special case handling for the start
+        # If there's a cut immediately after the start, the later logic would delete the first cut,
+        # which would result in desync. Any cuts within MIN_CUT_LENGTH of the start have to be
+        # pushed back to avoid this situation. It multiple cuts are pushed back (they'd all get set
+        #  to the same timestamp), the later logic will clean them up.
+        1.upto(edl.length - 1).each do |i|
+          # We've made it past the problematic point near the start of the recording
+          break if edl[i][:timestamp] >= MIN_CUT_LENGTH
+
+          BigBlueButton.logger.debug("Pushing EDL entry index #{i} from #{edl[i][:timestamp]} to #{MIN_CUT_LENGTH}")
+          offset = MIN_CUT_LENGTH - edl[i][:timestamp]
+          # Move the cut to start at MIN_CUT_LENGTH
+          edl[i][:timestamp] = MIN_CUT_LENGTH
+          # And offset the start times of every video to compensate
+          edl[i][:audios].each_value do |audio_data|
+            audio_data[:timestamp] += offset
+          end
+        end
+
+        # Iterate through the edl entries from end to just after the start
+        (edl.length - 1).downto(1).each do |i|
+          duration = edl[i][:timestamp] - edl[i - 1][:timestamp]
+          # If the cut that *ends* at EDL entry i is less than the minimum cut length
+          next unless duration < MIN_CUT_LENGTH
+
+          # Then delete edl entry i - 1 from the list
+          BigBlueButton.logger.debug("Dropping EDL entry index #{i - 1} (#{duration} < #{MIN_CUT_LENGTH})")
+          edl.delete_at(i - 1)
+          # On the next iteration through the loop, we'll be re-checking from the same end point, but a new start
+        end
+
+        # What if all of the cuts got deleted?
+        if edl.length == 1
+          BigBlueButton.logger.debug('EDL contains no cuts - enforcing minimum length')
+          # Add a new end point at the minimum cut length
+          edl << { timestamp: MIN_CUT_LENGTH, audios: [] }
+        end
+
+        nil
       end
 
       def self.mixer(inputs, output_basename)
@@ -67,7 +111,9 @@ module BigBlueButton
 
         corrupt_audios = Set.new
 
-        BigBlueButton.logger.info "Pre-processing EDL"
+        BigBlueButton.logger.info 'Pre-processing EDL'
+        enforce_cut_lengths(edl)
+
         # The render scripts use this to calculate cut lengths
         (0...(edl.length - 1)).each do |i|
           edl[i][:next_timestamp] = edl[i+1][:timestamp]

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -59,8 +59,8 @@ module BigBlueButton
           offset = MIN_CUT_LENGTH - edl[i][:timestamp]
           # Move the cut to start at MIN_CUT_LENGTH
           edl[i][:timestamp] = MIN_CUT_LENGTH
-          # And offset the start times of every video to compensate
-          edl[i][:audios].each_value do |audio_data|
+          # And offset the start times of every audio track to compensate
+          edl[i][:audios]&.each do |audio_data|
             audio_data[:timestamp] += offset
           end
         end


### PR DESCRIPTION
With LiveKit audio, it's possible for events for multiple audio start or stop to happen at the same time or very close together, which can result in problems in the audio processing. In particular, having a 0-length segment can result in the final audio track being truncated, resulting in missing audio and other playback issues.

The code being added to audio processing here is based on code which solves a similar problem in video processing: https://github.com/bigbluebutton/bigbluebutton/blob/4c896a7559e1528c3f574f76f77e85d71678a634/record-and-playback/core/lib/recordandplayback/edl/video.rb#L195-L196

This fix is complementary to the changes in https://github.com/bigbluebutton/bigbluebutton/pull/24481 (both can be merged separately, conflicts are minimal/trivial).

Fixes https://github.com/bigbluebutton/bigbluebutton/issues/24631