### PR TITLE
fix(captions): Move place where captionLimit is enforced

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/live/component.tsx
@@ -5,7 +5,7 @@ import logger from '/imports/startup/client/logger';
 import Styled from './styles';
 import useAudioCaptionEnable from '/imports/ui/core/local-states/useAudioCaptionEnable';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
-import { splitTranscript } from '../service';
+import { splitTranscript, captionLimit } from '../service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 
@@ -102,7 +102,7 @@ const AudioCaptionsLiveContainer: React.FC = () => {
       captions={AudioCaptionsLiveData.caption.map((c) => {
         const splits = splitTranscript(c);
         return splits;
-      }).flat().filter((c) => c.captionText)}
+      }).flat().filter((c) => c.captionText).slice(-captionLimit())}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -16,7 +16,7 @@ export const splitTranscript = (obj: Caption) => {
   const CHARACTERS_PER_LINE = CAPTIONS_CONFIG.lineLimit;
   const LINES_PER_MESSAGE = CAPTIONS_CONFIG.lines;
 
-  let transcripts = [];
+  const transcripts = [];
   const words = obj.captionText.split(' ');
 
   let currentLine = '';

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -6,11 +6,15 @@ import { Caption } from './live/queries';
 import Session from '/imports/ui/services/storage/in-memory';
 import { hasSpeechRecognitionSupport } from './speech/service';
 
+export const captionLimit = () => {
+  const CAPTIONS_CONFIG = window.meetingClientSettings.public.captions;
+  return CAPTIONS_CONFIG.captionLimit;
+};
+
 export const splitTranscript = (obj: Caption) => {
   const CAPTIONS_CONFIG = window.meetingClientSettings.public.captions;
   const CHARACTERS_PER_LINE = CAPTIONS_CONFIG.lineLimit;
   const LINES_PER_MESSAGE = CAPTIONS_CONFIG.lines;
-  const CAPTION_LIMIT = CAPTIONS_CONFIG.captionLimit;
 
   let transcripts = [];
   const words = obj.captionText.split(' ');
@@ -37,10 +41,6 @@ export const splitTranscript = (obj: Caption) => {
     transcripts.push(result);
   }
   transcripts.push(currentLine.trim());
-
-  // If there are more caption objects than CAPTION_LIMIT
-  // just get the last N captions
-  transcripts = transcripts.slice(-CAPTION_LIMIT);
 
   let i = 0;
   return transcripts.map((t) => {
@@ -122,4 +122,5 @@ export default {
   isGladia,
   splitTranscript,
   getLocaleName,
+  captionLimit,
 };


### PR DESCRIPTION
The captionLimit value was being used right before captions were displayed and not when they were split. This caused a bug where very long captions would split the text into n+1, n+2 or even more of the captionLimit, e.g., we could see upwards of 5-6 caption lines even if limited to 3 lines) 

Also it's the initial work towards: https://github.com/bigbluebutton/bigbluebutton/issues/24677