### PR TITLE
fix: userdata-bbb_override_default_locale is ineffective in guest lobby

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -98,6 +98,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   const [normalizedLocale, setNormalizedLocale] = React.useState(navigator.language.replace('_', '-'));
   const [messages, setMessages] = React.useState<LocaleJson>({});
   const [fallbackOnEmptyLocaleString, setFallbackOnEmptyLocaleString] = React.useState(false);
+  const skipInitialLocaleFetch = React.useRef(true);
 
   const fetchLocalizedMessages = useCallback((locale: string, init: boolean) => {
     setFetching(true);
@@ -154,10 +155,19 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
 
   useEffect(() => {
     const language = navigator.languages ? navigator.languages[0] : navigator.language;
-    fetchLocalizedMessages(language, true);
+    // if currentLocale was already overridden before this component mounted, use it instead
+    if (currentLocale !== normalizedLocale) {
+      fetchLocalizedMessages(currentLocale, false);
+    } else {
+      fetchLocalizedMessages(language, true);
+    }
   }, []);
 
   useEffect(() => {
+    if (skipInitialLocaleFetch.current) {
+      skipInitialLocaleFetch.current = false;
+      return;
+    }
     if (currentLocale !== normalizedLocale) {
       fetchLocalizedMessages(currentLocale, false);
     }

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -164,6 +164,8 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   }, []);
 
   useEffect(() => {
+    // Skip first run since initial locale is already fetched in the previous useEffect
+    // Prevents redundant initial locale fetches when a locale override is detected at mount time
     if (skipInitialLocaleFetch.current) {
       skipInitialLocaleFetch.current = false;
       return;

--- a/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { setUserSettings } from '/imports/ui/core/local-states/useUserSettings';
+import { setUseCurrentLocale } from '/imports/ui/core/local-states/useCurrentLocale';
 import BBBWeb from '/imports/api/bbb-web-api';
 import Session from '/imports/ui/services/storage/in-memory';
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
@@ -68,7 +69,11 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
               }
               return { [parameter]: parsedValue };
             });
-            setUserSettings(filteredData.reduce((acc, item) => Object.assign(acc, item), {}));
+            const mergedSettings = filteredData.reduce((acc, item) => Object.assign(acc, item), {});
+            setUserSettings(mergedSettings);
+            if (typeof mergedSettings.bbb_override_default_locale === 'string') {
+              setUseCurrentLocale(mergedSettings.bbb_override_default_locale);
+            }
             setFetched(true);
             if (timeoutRef.current) {
               clearTimeout(timeoutRef.current);


### PR DESCRIPTION
### What does this PR do?

Fix bbb_override_default_locale not working in the guest lobby by reading the locale override before IntlLoader fetches messages on mount.

### Closes Issue(s)
Closes #24682