### PR TITLE
fix (akka-apps): not storing user activity for breakout rooms (only main meeting)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -892,26 +892,24 @@ class LearningDashboardActor(
   }
 
   private def handleCreateMeetingReqMsg(msg: CreateMeetingReqMsg): Unit = {
-    if (msg.body.props.meetingProp.disabledFeatures.contains("learningDashboard") == false) {
-      val newMeeting = Meeting(
-        msg.body.props.meetingProp.intId,
-        msg.body.props.meetingProp.extId,
-        msg.body.props.meetingProp.name,
-        learningDashboardDisabled = msg.body.props.meetingProp.disabledFeatures.contains("learningDashboard"),
-        downloadSessionDataEnabled = !msg.body.props.meetingProp.disabledFeatures.contains("learningDashboardDownloadSessionData"),
-        pluginUserDataCardTitles = Vector(),
-        other = Map(
-          "learning-dashboard-learn-more-link"  -> msg.body.props.metadataProp.metadata.get("learning-dashboard-learn-more-link").getOrElse(""),
-          "learning-dashboard-feedback-link" -> msg.body.props.metadataProp.metadata.get("learning-dashboard-feedback-link").getOrElse("")
-        ),
-      )
+    val newMeeting = Meeting(
+      msg.body.props.meetingProp.intId,
+      msg.body.props.meetingProp.extId,
+      msg.body.props.meetingProp.name,
+      learningDashboardDisabled = msg.body.props.meetingProp.disabledFeatures.contains("learningDashboard"),
+      downloadSessionDataEnabled = !msg.body.props.meetingProp.disabledFeatures.contains("learningDashboardDownloadSessionData"),
+      pluginUserDataCardTitles = Vector(),
+      other = Map(
+        "learning-dashboard-learn-more-link"  -> msg.body.props.metadataProp.metadata.get("learning-dashboard-learn-more-link").getOrElse(""),
+        "learning-dashboard-feedback-link" -> msg.body.props.metadataProp.metadata.get("learning-dashboard-feedback-link").getOrElse("")
+      ),
+    )
 
-      meetings += (newMeeting.intId -> newMeeting)
-      meetingAccessTokens += (newMeeting.intId -> msg.body.props.password.learningDashboardAccessToken)
+    meetings += (newMeeting.intId -> newMeeting)
+    meetingAccessTokens += (newMeeting.intId -> msg.body.props.password.learningDashboardAccessToken)
 
-      if (msg.body.props.meetingProp.disabledFeatures.contains("learningDashboard")) {
-        log.info(" disabled for meeting {}.",msg.body.props.meetingProp.intId)
-      }
+    if (msg.body.props.meetingProp.disabledFeatures.contains("learningDashboard")) {
+      log.info(" disabled for meeting {}.",msg.body.props.meetingProp.intId)
     }
   }
 


### PR DESCRIPTION
It should store user activity data for breakout rooms, it was implemented at #24233.

But it was wrongly reverted by #23619, which prevent breakout rooms from recording the actions.

This PR re-enable it.