### PR TITLE
Update external video label to remove unsupported platform

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1409,7 +1409,7 @@
     "app.externalVideo.autoPlayWarning": "Play the video to enable media synchronization",
     "app.externalVideo.refreshLabel": "Refresh Video Player",
     "app.externalVideo.fullscreenLabel": "Video Player",
-    "app.externalVideo.noteLabel": "Note: Shared external videos will not appear in the recording. YouTube, Vimeo, Instructure Media, Twitch, Dailymotion and media file URLs (e.g. https://example.com/xy.mp4) are supported.",
+    "app.externalVideo.noteLabel": "Note: Shared external videos will not appear in the recording. YouTube, Vimeo, Instructure Media, Twitch and media file URLs (e.g. https://example.com/xy.mp4) are supported.",
     "app.externalVideo.subtitlesOn": "Turn off",
     "app.externalVideo.subtitlesOff": "Turn on (if available)",
     "app.externalVideo.stopShareExternalVideo": "Stop sharing external video",


### PR DESCRIPTION
### What does this PR do?

Update external video text to remove Dailymotion, as it is currently not supported.

### Closes Issue(s)
Closes #24630

### Motivation
Dailymotion integration has been deprecated (https://github.com/cookpete/react-player/issues/1772)