### PR TITLE
fix: WhiteBoard Ctrl+D work only once

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -773,7 +773,6 @@ const Whiteboard = React.memo((props) => {
         d: () => {
           tlEditorRef.current
             ?.duplicateShapes(tlEditorRef.current?.getSelectedShapes(), { x: 35, y: 35 });
-          tlEditorRef.current?.selectNone();
         },
         x: () => {
           handleCut(true);


### PR DESCRIPTION
### What does this PR do?

Adjusts duplicate shapes shortcut to not remove selection

### Closes Issue(s)
Closes #24480

### How to test
1. join a meeting as presenter
2. draw shapes in the whiteboard
3. select a shape, and use the Ctrl+D shortcut
4. it should be possible to press the shortcut multiple times without the need of re-selecting the shapes