### PR TITLE
feat(fsesl): add freeswitch.esl.enabled config flag

### DIFF
--- a/akka-bbb-fsesl/src/main/resources/application.conf
+++ b/akka-bbb-fsesl/src/main/resources/application.conf
@@ -20,6 +20,7 @@ pekko {
 
 freeswitch {
     esl {
+        enabled=true
         host="127.0.0.1"
         port=8021
         password="ClueCon"

--- a/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/Boot.scala
+++ b/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/Boot.scala
@@ -31,7 +31,7 @@ object Boot extends App with SystemConfiguration with WebApi {
 
   val eslConnection = new DefaultManagerConnection(eslHost, eslPort, eslPassword)
 
-  val healthz = HealthzService(system)
+  val healthz = HealthzService(system, eslEnabled)
 
   val voiceConfService = new VoiceConferenceService(healthz, redisPublisher)
 
@@ -41,7 +41,11 @@ object Boot extends App with SystemConfiguration with WebApi {
   val eslEventListener = new ESLEventListener(fsConfEventListener)
   val connManager = new ConnectionManager(eslConnection, eslEventListener, fsConfEventListener)
 
-  connManager.start()
+  if (eslEnabled) {
+    connManager.start()
+  } else {
+    System.out.println("FreeSWITCH ESL disabled (freeswitch.esl.enabled=false)")
+  }
 
   val fsApplication = new FreeswitchApplication(connManager, fsProfile)
   fsApplication.start()

--- a/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -12,6 +12,7 @@ trait SystemConfiguration {
   lazy val redisPassword = Try(config.getString("redis.password")).getOrElse("")
   lazy val redisExpireKey = Try(config.getInt("redis.keyExpiry")).getOrElse(1209600)
 
+  lazy val eslEnabled = Try(config.getBoolean("freeswitch.esl.enabled")).getOrElse(true)
   lazy val eslHost = Try(config.getString("freeswitch.esl.host")).getOrElse("127.0.0.1")
   lazy val eslPort = Try(config.getInt("freeswitch.esl.port")).getOrElse(8021)
   lazy val eslPassword = Try(config.getString("freeswitch.esl.password")).getOrElse("ClueCon")

--- a/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/service/HealthzService.scala
+++ b/akka-bbb-fsesl/src/main/scala/org/bigbluebutton/service/HealthzService.scala
@@ -23,14 +23,14 @@ case class FreeswitchStatus(lastUpdateOn: Long, lastUpdateOnHuman: String, statu
 case class FreeswitchHeartbeat(lastUpdateOn: Long, lastUpdateOnHuman: String, heartbeat: Map[String, String])
 
 object HealthzService {
-  def apply(system: ActorSystem) = new HealthzService(system)
+  def apply(system: ActorSystem, eslEnabled: Boolean = true) = new HealthzService(system, eslEnabled)
 }
 
-class HealthzService(system: ActorSystem) {
+class HealthzService(system: ActorSystem, eslEnabled: Boolean) {
   implicit def executionContext = system.dispatcher
   implicit val timeout: Timeout = 2.seconds
 
-  val actorRef = system.actorOf(HealthzActor.props())
+  val actorRef = system.actorOf(HealthzActor.props(eslEnabled))
 
   def getHealthz(): Future[GetHealthResponseMessage] = {
     val future = actorRef.ask(GetHealthMessage).mapTo[GetHealthResponseMessage]
@@ -56,10 +56,10 @@ class HealthzService(system: ActorSystem) {
 }
 
 object HealthzActor {
-  def props(): Props = Props(classOf[HealthzActor])
+  def props(eslEnabled: Boolean = true): Props = Props(classOf[HealthzActor], eslEnabled)
 }
 
-class HealthzActor extends Actor
+class HealthzActor(eslEnabled: Boolean) extends Actor
   with ActorLogging {
 
   val sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
@@ -77,12 +77,16 @@ class HealthzActor extends Actor
       val now = System.currentTimeMillis()
       heartbeat = FreeswitchHeartbeat(now, sdf.format(now), msg.status)
     case GetHealthMessage =>
-      val now = System.currentTimeMillis()
-      if ((now - heartbeat.lastUpdateOn < twoMins) &&
-        (now - status.lastUpdateOn < twoMins)) {
+      if (!eslEnabled) {
         sender ! GetHealthResponseMessage(isHealthy = true)
       } else {
-        sender ! GetHealthResponseMessage(isHealthy = false)
+        val now = System.currentTimeMillis()
+        if ((now - heartbeat.lastUpdateOn < twoMins) &&
+          (now - status.lastUpdateOn < twoMins)) {
+          sender ! GetHealthResponseMessage(isHealthy = true)
+        } else {
+          sender ! GetHealthResponseMessage(isHealthy = false)
+        }
       }
     case GetFreeswitchStatusMessage =>
       sender ! GetFreeswitchStatusResponseMessage(status.status.toArray, heartbeat.heartbeat)

--- a/akka-bbb-fsesl/src/universal/conf/application.conf
+++ b/akka-bbb-fsesl/src/universal/conf/application.conf
@@ -20,6 +20,7 @@ pekko {
 
 freeswitch {
     esl {
+        enabled=true
         host="127.0.0.1"
         port=8021
         password="ClueCon"


### PR DESCRIPTION
## Summary

When BigBlueButton is configured to use **LiveKit** for audio/video instead of FreeSWITCH, the `bbb-fsesl-akka` service enters an infinite ESL reconnect loop, flooding logs with connection errors every few seconds. This makes log analysis difficult and wastes resources.

This PR adds a `freeswitch.esl.enabled` configuration flag (defaults to `true`, preserving existing behavior) that, when set to `false`:

- **Skips starting the ESL `ConnectionManager`** — no reconnect attempts to a non-existent FreeSWITCH
- **Makes `HealthzService` always report healthy** — since FreeSWITCH health checks are meaningless without an active ESL connection

### Usage

Add to `/etc/bigbluebutton/bbb-fsesl-akka.conf`:

```
freeswitch.esl.enabled = false
```

### Files changed

| File | Change |
|------|--------|
| `akka-bbb-fsesl/.../application.conf` (×2) | Add `enabled=true` default in `freeswitch.esl` block |
| `SystemConfiguration.scala` | Read `freeswitch.esl.enabled` into `eslEnabled` |
| `Boot.scala` | Conditionally call `connManager.start()` based on `eslEnabled` |
| `HealthzService.scala` | Thread `eslEnabled` through to `HealthzActor`; return healthy immediately when disabled |

## Test plan

- [ ] Verify default behavior is unchanged (`enabled=true` or absent → ESL connects normally)
- [ ] Set `freeswitch.esl.enabled = false` in `bbb-fsesl-akka.conf`, restart `bbb-fsesl-akka`, confirm no ESL reconnect log spam
- [ ] Confirm `/healthz` endpoint returns healthy when ESL is disabled
- [ ] Confirm existing FreeSWITCH-based deployments are unaffected (no config change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)