### PR TITLE
feat: Make webcamBackgroundURL available in breakouts

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutApp2x.scala
@@ -64,13 +64,14 @@ object BreakoutRoomsUtil extends SystemConfiguration {
   }
 
   def joinParams(
-      username:          String,
-      userId:            String,
-      isBreakout:        Boolean,
-      breakoutMeetingId: String,
-      avatarURL:         String,
-      role:              String,
-      password:          String
+      username:            String,
+      userId:              String,
+      isBreakout:          Boolean,
+      breakoutMeetingId:   String,
+      avatarURL:           String,
+      webcamBackgroundURL: String,
+      role:                String,
+      password:            String
   ): (collection.immutable.Map[String, String], collection.immutable.Map[String, String]) = {
     val moderator = role == "MODERATOR"
     val params = collection.immutable.HashMap(
@@ -79,6 +80,7 @@ object BreakoutRoomsUtil extends SystemConfiguration {
       "isBreakout" -> urlEncode(isBreakout.toString()),
       "meetingID" -> urlEncode(breakoutMeetingId),
       "avatarURL" -> urlEncode(avatarURL),
+      "webcamBackgroundURL" -> urlEncode(webcamBackgroundURL),
       "userdata-bbb_parent_room_moderator" -> urlEncode(moderator.toString()),
       "password" -> urlEncode(password),
       "redirect" -> urlEncode("true")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutHdlrHelpers.scala
@@ -47,6 +47,7 @@ object BreakoutHdlrHelpers extends SystemConfiguration {
         true,
         externalMeetingId,
         user.avatar,
+        user.webcamBackground,
         user.role,
         liveMeeting.props.password.moderatorPass
       )


### PR DESCRIPTION
### What does this PR do?

Makes webcamBackgroundURL available in breakouts 

### Closes Issue(s)
Closes #24690

### How to test
1. Create a session via api-mate
2. Join as moderator passing  a valid image url in the param `webcamBackgroundURL`
3. Create breakout rooms and join one room
4. Start sharing webcam
5. Custom background image from URL should be available