### PR TITLE
fix (ci): attempt to fix: `Error: Input required and not supplied: token` for `Cleanup Playwright reports` workflow

### DIFF
--- a/.github/workflows/playwright-reports-cleanup.yml
+++ b/.github/workflows/playwright-reports-cleanup.yml
@@ -1,6 +1,6 @@
 name: Cleanup Playwright reports
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 jobs:


### PR DESCRIPTION
attempt to fix: `Error: Input required and not supplied: token` for `Cleanup Playwright reports` workflow:

<img width="400" src="https://github.com/user-attachments/assets/1767e523-dcd0-4e12-a7ce-c913e67c2cd3" />


https://github.com/bigbluebutton/bigbluebutton/actions/runs/22311827856/job/64545742314

The `Cleanup Playwright reports` workflow was failing with "Input required and not supplied: token" on the `Checkout reports repository` step whenever a fork PR was closed. This happens because `pull_request` events originating from forks run in the fork's context, where GitHub intentionally blocks access to base repository secrets, so `secrets.PLAYWRIGHT_REPORTS_REPO_TOKEN` resolved to an empty string. The fix is to change the trigger from `pull_request` to `pull_request_target`, which always runs in the base repository context and therefore has full access to its secrets. This is safe in this workflow because it never checks out or executes any code from the PR branch (it only interacts with the separate `bbb-ci-playwright-reports` repository to remove a report directory).