### PR TITLE
Breakouts: ensure moderator only functionality is not shown 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -101,6 +101,8 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
       userId,
     } = talkingUser;
 
+    const isMuteActionAvailable = isModerator && !isBreakout;
+
     const ariaLabel = intl.formatMessage(talking
       ? intlMessages.isTalking : intlMessages.wasTalking, {
       userName: name,
@@ -123,15 +125,15 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
         <Styled.TalkingIndicatorButton
           $spoke={!talking || undefined}
           $muted={muted || undefined}
-          $isViewer={!isModerator || undefined}
+          $isViewer={!isMuteActionAvailable || undefined}
           key={userId}
           onClick={() => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore - call signature is misse due the function being wrapped
-            muteUser(userId, muted, isBreakout, isModerator, toggleVoice);
+            muteUser(userId, muted, isBreakout, isMuteActionAvailable, toggleVoice);
           }}
           label={name}
-          tooltipLabel={!muted && isModerator
+          tooltipLabel={!muted && isMuteActionAvailable
             ? `${intl.formatMessage(intlMessages.muteLabel)} ${name}`
             : null}
           data-test={talking ? 'isTalking' : 'wasTalking'}
@@ -141,7 +143,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
           icon={icon}
           size="lg"
           style={
-            isModerator
+            isMuteActionAvailable
               ? {
                 backgroundColor: color,
                 border: `solid 2px ${color}`,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -474,7 +474,8 @@ const UserActions: React.FC<UserActionsProps> = ({
       allowed: allowedToChangeWhiteboardAccess
         && !user.presenter
         && !isVoiceOnlyUser(user.userId)
-        && pageId,
+        && pageId
+        && !isBreakout,
       key: 'changeWhiteboardAccess',
       label: hasWhiteboardAccess
         ? intl.formatMessage(messages.removeWhiteboardAccess)

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -261,7 +261,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'usersJoinMuted',
       },
       {
-        allow: true,
+        allow: !isBreakout,
         key: uuids.current[1],
         label: intl.formatMessage(intlMessages.muteAllExceptPresenterLabel),
         description: intl.formatMessage(intlMessages.muteAllExceptPresenterDesc),
@@ -279,7 +279,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'lockViewersButton',
       },
       {
-        allow: dynamicGuestPolicy,
+        allow: dynamicGuestPolicy && !isBreakout,
         key: uuids.current[3],
         icon: 'user',
         label: intl.formatMessage(intlMessages.guestPolicyLabel),
@@ -296,7 +296,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'downloadUserNamesList',
       },
       {
-        allow: isReactionsEnabled && isModerator,
+        allow: isReactionsEnabled && isModerator && !isBreakout,
         key: uuids.current[5],
         label: intl.formatMessage(intlMessages.clearAllReactionsLabel),
         description: intl.formatMessage(intlMessages.clearAllReactionsDesc),


### PR DESCRIPTION
### What does this PR do?

Removes the following items from breakout rooms: 
- change guest policy
- clear all reactions
- mute all except presenter
- hover change in talking indicator
- remove whiteboard rights

### Closes Issue(s)
Closes #24696