### PR TITLE
ci: avoid running GH workflows after PR is merged when it's not necessary at this point

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -1,14 +1,5 @@
 name: "Automated tests"
 on:
-  push:
-    branches:
-      - "develop"
-      - "v2.[5-9].x-release"
-      - "v[3-9].*.x-release"
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - "bigbluebutton-html5/public/locales/*.json"
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -1,5 +1,14 @@
 name: "Automated tests"
 on:
+  push:
+    branches:
+      - "develop"
+      - "v2.[5-9].x-release"
+      - "v[3-9].*.x-release"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "bigbluebutton-html5/public/locales/*.json"
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -1,6 +1,5 @@
 name: Merge conflict check
 on:
-  push:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/plugin-sdk-version-check.yml
+++ b/.github/workflows/plugin-sdk-version-check.yml
@@ -1,10 +1,5 @@
 name: Plugin SDK - Match version of html5 package.json with bigbluebutton.properties
 on:
-  push:
-    branches:
-      - "develop"
-      - "v2.[5-9].x-release"
-      - "v[3-9].*.x-release"
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -1,6 +1,6 @@
 name: publiccode.yml validation
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
   publiccode_yml_validation:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,10 +1,5 @@
 name: Run ShellCheck
 on:
-  push:
-    branches:
-      - "develop"
-      - "v2.[5-9].x-release"
-      - "v[3-9].*.x-release"
   pull_request:
     types: [opened, synchronize, reopened]
 permissions:

--- a/.github/workflows/ts-code-compilation.yml
+++ b/.github/workflows/ts-code-compilation.yml
@@ -1,15 +1,5 @@
 name: Typescript - compile code
 on:
-  push:
-    branches:
-      - "develop"
-      - "v2.[5-9].x-release"
-      - "v[3-9].*.x-release"
-    paths:
-      - "bigbluebutton-html5/**.ts"
-      - "bigbluebutton-html5/**.tsx"
-      - "bigbluebutton-html5/package.json"
-      - "bigbluebutton-html5/package-lock.json"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/ts-code-validation.yml
+++ b/.github/workflows/ts-code-validation.yml
@@ -1,15 +1,5 @@
 name: Typescript - validate code (eslint)
 on:
-  push:
-    branches:
-      - "develop"
-      - "v2.[5-9].x-release"
-      - "v[3-9].*.x-release"
-    paths:
-      - "bigbluebutton-html5/**.ts"
-      - "bigbluebutton-html5/**.tsx"
-      - "bigbluebutton-html5/package.json"
-      - "bigbluebutton-html5/package-lock.json"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:


### PR DESCRIPTION
Several CI workflows were configured to trigger on both `pull_request` and `push` events, causing them to re-run unnecessarily after a PR is merged. 
Workflows like `Merge conflict check`, `Run ShellCheck`, `publiccode.yml validation`, `Plugin SDK version check`, and the `TypeScript compilation/validation` checks exist solely as merge gates, their purpose is to catch problems before code lands on a protected branch, not to validate code that has already been accepted. 
Running them on `push` wastes CI minutes.

The fix removes the `push` trigger from all of these PR gate workflows, restricting them to `pull_request` events only (`opened`, `synchronize`, `reopened`). 


### Changed (removed `push` trigger) (makes no sense on a branch push)
- `check-merge-conflict.yml`
- `shellcheck.yml`
- `publiccode-yml-validation.yml`
- `plugin-sdk-version-check.yml`
- `ts-code-compilation.yml`
- `ts-code-validation.yml`

### Left untouched (correctly designed to run post-merge)
- `automated-tests.yml` (it’s useful because it generates caches to be used by new PRs)
- `cleanup-caches.yml`
- `playwright-reports-cleanup.yml`
-  `automated-tests-publish-results.yml` (already guarded at the job level with `if: github.event.workflow_run.event == 'pull_request'`)
