### PR TITLE
feat(apps-gallery): persist and cache pinned apps across sessions

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-observer/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-observer/component.tsx
@@ -98,6 +98,7 @@ const BreakoutRoomsAppObserver = () => {
       value: {
         id,
         pin: true,
+        isDefault: true,
       },
     });
   };

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -12,6 +12,7 @@ import useUpdatePresentationAreaContentForPlugin from '/imports/ui/components/pl
 import { useIsPresentationEnabled } from '/imports/ui/services/features';
 import { usePrevious } from '../whiteboard/utils';
 import Session from '/imports/ui/services/storage/in-memory';
+import Local from '/imports/ui/services/storage/local';
 import logger from '/imports/startup/client/logger';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 
@@ -61,34 +62,18 @@ const initState = {
   output: INITIAL_OUTPUT_STATE,
 };
 
-let _cachedPinnedApps = null;
-const BBB_PINNED_APPS_KEY = 'bbb-pinned-apps';
+let _cachedPinnedApps;
+const PINNED_APPS_STORAGE_KEY = 'pinnedApps';
 
 const getPersistedPinnedApps = () => {
-  if (_cachedPinnedApps !== null) return _cachedPinnedApps;
-  try {
-    const raw = localStorage.getItem(BBB_PINNED_APPS_KEY);
-    _cachedPinnedApps = raw ? JSON.parse(raw) : [];
-  } catch (e) {
-    logger.debug({
-      logCode: 'apps_gallery_localstorage_read_error',
-      extraInfo: { error: e },
-    }, 'Failed to read pinned apps from localStorage');
-    _cachedPinnedApps = [];
-  }
+  if (_cachedPinnedApps !== undefined) return _cachedPinnedApps;
+  _cachedPinnedApps = Local.getItem(PINNED_APPS_STORAGE_KEY);
   return _cachedPinnedApps;
 };
 
 const setPersistedPinnedApps = (apps) => {
   _cachedPinnedApps = apps;
-  try {
-    localStorage.setItem(BBB_PINNED_APPS_KEY, JSON.stringify(apps));
-  } catch (e) {
-    logger.debug({
-      logCode: 'apps_gallery_localstorage_write_error',
-      extraInfo: { error: e },
-    }, 'Failed to save pinned apps to localStorage');
-  }
+  Local.setItem(PINNED_APPS_STORAGE_KEY, apps);
 };
 
 const reducer = (state, action) => {
@@ -537,18 +522,10 @@ const reducer = (state, action) => {
       if (pin && pinnedApps.length === MAX_PINNED_APPS_GALLERY) return state;
 
       if (isDefault && pin) {
-        if (_cachedPinnedApps !== null) {
-          if (Array.isArray(_cachedPinnedApps) && !_cachedPinnedApps.includes(appId)) {
-            return state;
-          }
-        } else {
-          const savedPinnedApps = getPersistedPinnedApps();
-
-          if (localStorage.getItem(BBB_PINNED_APPS_KEY) !== null
-            && Array.isArray(savedPinnedApps)
-            && !savedPinnedApps.includes(appId)) {
-            return state;
-          }
+        const savedPinnedApps = getPersistedPinnedApps();
+        if (savedPinnedApps !== null
+          && Array.isArray(savedPinnedApps) && !savedPinnedApps.includes(appId)) {
+          return state;
         }
       }
 

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -61,6 +61,36 @@ const initState = {
   output: INITIAL_OUTPUT_STATE,
 };
 
+let _cachedPinnedApps = null;
+const BBB_PINNED_APPS_KEY = 'bbb-pinned-apps';
+
+const getPersistedPinnedApps = () => {
+  if (_cachedPinnedApps !== null) return _cachedPinnedApps;
+  try {
+    const raw = localStorage.getItem(BBB_PINNED_APPS_KEY);
+    _cachedPinnedApps = raw ? JSON.parse(raw) : [];
+  } catch (e) {
+    logger.debug({
+      logCode: 'apps_gallery_localstorage_read_error',
+      extraInfo: { error: e },
+    }, 'Failed to read pinned apps from localStorage');
+    _cachedPinnedApps = [];
+  }
+  return _cachedPinnedApps;
+};
+
+const setPersistedPinnedApps = (apps) => {
+  _cachedPinnedApps = apps;
+  try {
+    localStorage.setItem(BBB_PINNED_APPS_KEY, JSON.stringify(apps));
+  } catch (e) {
+    logger.debug({
+      logCode: 'apps_gallery_localstorage_write_error',
+      extraInfo: { error: e },
+    }, 'Failed to save pinned apps to localStorage');
+  }
+};
+
 const reducer = (state, action) => {
   debugActions(action.type, action.value);
   switch (action.type) {
@@ -434,6 +464,21 @@ const reducer = (state, action) => {
         .slice()
         .sort((a, b) => newRegisteredApps[a].name.localeCompare(newRegisteredApps[b].name));
 
+      let restoredPinnedApps = sortedPinnedApps;
+      const savedPinnedApps = getPersistedPinnedApps();
+
+      if (
+        Array.isArray(savedPinnedApps)
+        && savedPinnedApps.includes(id)
+        && !sortedPinnedApps.includes(id)
+      ) {
+        const MAX_PINNED = window.meetingClientSettings.public.app.appsGallery.maxPinnedApps;
+        if (sortedPinnedApps.length < MAX_PINNED) {
+          restoredPinnedApps = [...sortedPinnedApps, id]
+            .sort((a, b) => newRegisteredApps[a].name.localeCompare(newRegisteredApps[b].name));
+        }
+      }
+
       return {
         ...state,
         input: {
@@ -441,7 +486,7 @@ const reducer = (state, action) => {
           sidebarNavigation: {
             ...sidebarNavigation,
             registeredApps: sortedRegisteredApps,
-            pinnedApps: sortedPinnedApps,
+            pinnedApps: restoredPinnedApps,
           },
         },
       };
@@ -480,7 +525,7 @@ const reducer = (state, action) => {
     case ACTIONS.SET_SIDEBAR_NAVIGATION_PIN_APP: {
       const APP_CONFIG = window.meetingClientSettings.public.app;
       const MAX_PINNED_APPS_GALLERY = APP_CONFIG.appsGallery.maxPinnedApps;
-      const { id: appId, pin } = action.value;
+      const { id: appId, pin, isDefault = false } = action.value;
       const { sidebarNavigation } = state.input;
       const { pinnedApps, registeredApps = [] } = sidebarNavigation;
 
@@ -491,11 +536,29 @@ const reducer = (state, action) => {
       if ((pin && isAppPinned) || (!pin && !isAppPinned)) return state;
       if (pin && pinnedApps.length === MAX_PINNED_APPS_GALLERY) return state;
 
+      if (isDefault && pin) {
+        if (_cachedPinnedApps !== null) {
+          if (Array.isArray(_cachedPinnedApps) && !_cachedPinnedApps.includes(appId)) {
+            return state;
+          }
+        } else {
+          const savedPinnedApps = getPersistedPinnedApps();
+
+          if (localStorage.getItem(BBB_PINNED_APPS_KEY) !== null
+            && Array.isArray(savedPinnedApps)
+            && !savedPinnedApps.includes(appId)) {
+            return state;
+          }
+        }
+      }
+
       const updatedPinnedApps = pin
         ? [...pinnedApps, appId].sort(
           (a, b) => registeredApps[a].name.localeCompare(registeredApps[b].name),
         )
         : pinnedApps.filter((pinnedApp) => pinnedApp !== appId);
+
+      setPersistedPinnedApps(updatedPinnedApps);
 
       return {
         ...state,

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -63,11 +63,13 @@ const initState = {
 };
 
 let _cachedPinnedApps;
+let _initialPersistedPinnedApps;
 const PINNED_APPS_STORAGE_KEY = 'pinnedApps';
 
 const getPersistedPinnedApps = () => {
   if (_cachedPinnedApps !== undefined) return _cachedPinnedApps;
   _cachedPinnedApps = Local.getItem(PINNED_APPS_STORAGE_KEY);
+  _initialPersistedPinnedApps = _cachedPinnedApps;
   return _cachedPinnedApps;
 };
 
@@ -522,7 +524,8 @@ const reducer = (state, action) => {
       if (pin && pinnedApps.length === MAX_PINNED_APPS_GALLERY) return state;
 
       if (isDefault && pin) {
-        const savedPinnedApps = getPersistedPinnedApps();
+        if (_initialPersistedPinnedApps === undefined) getPersistedPinnedApps();
+        const savedPinnedApps = _initialPersistedPinnedApps;
         if (savedPinnedApps !== null
           && Array.isArray(savedPinnedApps) && !savedPinnedApps.includes(appId)) {
           return state;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
@@ -85,6 +85,7 @@ const SidebarNavigationContainer = () => {
       value: {
         id,
         pin: true,
+        isDefault: true,
       },
     });
   };


### PR DESCRIPTION
### What does this PR do?
Introduces state persistence for the Apps Gallery's pinned applications using `localStorage`, ensuring user layouts stay consistent across reloads and new sessions. 

### Closes Issue(s)
Closes None



