### PR TITLE
refactor(profile): replace available/away toggle with status dropdown

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -1,5 +1,5 @@
 import React, {
-  useCallback, useEffect, useRef, useState,
+  useCallback, useEffect,
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useMutation } from '@apollo/client';
@@ -86,6 +86,10 @@ const intlMessages: { [key: string]: { id: string; description?: string } } = de
   availableLabel: {
     id: 'app.actionsBar.reactions.available',
     description: 'Available Label',
+  },
+  statusLabel: {
+    id: 'app.profileSettings.statusTitle',
+    description: 'Label for the status section in profile settings',
   },
   joinVideoLabel: {
     id: 'app.video.joinVideo',
@@ -183,9 +187,6 @@ const updateCameraSections = (
   return finalSections;
 };
 
-const HIDE_DIVIDER_THRESHOLD = 200;
-const SHOW_DIVIDER_THRESHOLD = 220;
-
 interface ProfileSettingsProps {
 }
 const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
@@ -196,32 +197,6 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
   const streams = useStreams();
   const isVirtualBackgroundsEnabled = useIsVirtualBackgroundsEnabled();
   const isCustomVirtualBackgroundsEnabled = useIsCustomVirtualBackgroundsEnabled();
-
-  const presenceContainerRef = useRef<HTMLDivElement>(null);
-  const [showPresenceDivider, setShowPresenceDivider] = useState(true);
-
-  useEffect(() => {
-    const container = presenceContainerRef.current;
-    if (!container) return;
-
-    const observer = new ResizeObserver((entries) => {
-      entries.forEach((entry) => {
-        const { width } = entry.contentRect;
-
-        setShowPresenceDivider((prev) => {
-          if (prev && width < HIDE_DIVIDER_THRESHOLD) return false;
-          if (!prev && width > SHOW_DIVIDER_THRESHOLD) return true;
-          return prev;
-        });
-      });
-    });
-
-    observer.observe(container);
-    // eslint-disable-next-line consistent-return
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
 
   // @ts-ignore
   const settingsStorage = window.meetingClientSettings.public.app.userSettingsStorage;
@@ -351,11 +326,12 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
 
   const [setAway] = useMutation(SET_AWAY);
 
-  const handleToggleAFK = useCallback(() => {
+  const handleSetStatus = useCallback((status: string) => {
+    const isAway = status === 'away';
     muteAway(muted, away, voiceToggle);
     setAway({
       variables: {
-        away: !away,
+        away: isAway,
       },
     });
   }, [muted, away, voiceToggle, setAway]);
@@ -790,15 +766,53 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
           <Styled.Username>{currentUserData?.name ?? ''}</Styled.Username>
         </Styled.UsernameContainer>
         <Styled.UserPresenceRoot>
-          <Styled.UserPresenceContainer ref={presenceContainerRef}>
-            <Styled.UserPresenceButton active={!currentUserData?.away} onClick={handleToggleAFK}>
-              <Styled.UserPresenceText>{formatMessage(intlMessages.availableLabel)}</Styled.UserPresenceText>
-            </Styled.UserPresenceButton>
-            {showPresenceDivider && <Styled.UserPresenceDivider />}
-            <Styled.UserPresenceButton active={currentUserData?.away} onClick={handleToggleAFK}>
-              <Styled.UserPresenceText>{formatMessage(intlMessages.awayLabel)}</Styled.UserPresenceText>
-            </Styled.UserPresenceButton>
-          </Styled.UserPresenceContainer>
+          <Styled.UsernameTitle>{formatMessage(intlMessages.statusLabel)}</Styled.UsernameTitle>
+          <Styled.UserPresenceDropdown
+            value={away ? 'away' : 'available'}
+            onChange={(e) => handleSetStatus(e.target.value as string)}
+            IconComponent={ExpandMoreIcon}
+            MenuProps={{
+              PaperProps: {
+                sx: {
+                  borderRadius: '0.75rem',
+                  border: '1px solid #E5E7EB',
+                  boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
+                  mt: 0,
+                  '& .MuiList-root': {
+                    padding: '0.5rem',
+                  },
+                  '& .MuiMenuItem-root': {
+                    borderRadius: '0.5rem',
+                    gap: '0.5rem',
+                    padding: '0.625rem 0.75rem',
+                  },
+                },
+              },
+            }}
+            renderValue={(val) => (
+              <Styled.UserPresenceValueContainer>
+                <Styled.UserPresenceStatusDot away={val === 'away'} />
+                <Styled.UserPresenceText>
+                  {val === 'away'
+                    ? formatMessage(intlMessages.awayLabel)
+                    : formatMessage(intlMessages.availableLabel)}
+                </Styled.UserPresenceText>
+              </Styled.UserPresenceValueContainer>
+            )}
+          >
+            <MenuItem value="available">
+              <Styled.UserPresenceValueContainer>
+                <Styled.UserPresenceStatusDot away={false} />
+                <Styled.UserPresenceText>{formatMessage(intlMessages.availableLabel)}</Styled.UserPresenceText>
+              </Styled.UserPresenceValueContainer>
+            </MenuItem>
+            <MenuItem value="away">
+              <Styled.UserPresenceValueContainer>
+                <Styled.UserPresenceStatusDot away />
+                <Styled.UserPresenceText>{formatMessage(intlMessages.awayLabel)}</Styled.UserPresenceText>
+              </Styled.UserPresenceValueContainer>
+            </MenuItem>
+          </Styled.UserPresenceDropdown>
         </Styled.UserPresenceRoot>
         <Styled.Separator />
         <Styled.DevicesSettingsContainer>

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -328,6 +328,9 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
 
   const handleSetStatus = useCallback((status: string) => {
     const isAway = status === 'away';
+
+    if (isAway === away) return;
+
     muteAway(muted, away, voiceToggle);
     setAway({
       variables: {
@@ -766,33 +769,16 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
           <Styled.Username>{currentUserData?.name ?? ''}</Styled.Username>
         </Styled.UsernameContainer>
         <Styled.UserPresenceRoot>
-          <Styled.UsernameTitle>{formatMessage(intlMessages.statusLabel)}</Styled.UsernameTitle>
+          <Styled.UsernameTitle id="status-label-id">{formatMessage(intlMessages.statusLabel)}</Styled.UsernameTitle>
           <Styled.UserPresenceField>
             <Styled.UserPresenceIndicator aria-hidden>
               <Styled.UserPresenceStatusDot away={away} />
             </Styled.UserPresenceIndicator>
             <Styled.UserPresenceDropdown
+              labelId="status-label-id"
               value={away ? 'away' : 'available'}
               onChange={(e) => handleSetStatus(e.target.value as string)}
               IconComponent={ExpandMoreIcon}
-              MenuProps={{
-                PaperProps: {
-                  sx: {
-                    borderRadius: '0.75rem',
-                    border: '1px solid #E5E7EB',
-                    boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
-                    mt: 0,
-                    '& .MuiList-root': {
-                      padding: '0.5rem',
-                    },
-                    '& .MuiMenuItem-root': {
-                      borderRadius: '0.5rem',
-                      gap: '0.5rem',
-                      padding: '0.625rem 0.75rem',
-                    },
-                  },
-                },
-              }}
               renderValue={(val) => (
                 <Styled.UserPresenceText>
                   {val === 'away'

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -767,52 +767,54 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
         </Styled.UsernameContainer>
         <Styled.UserPresenceRoot>
           <Styled.UsernameTitle>{formatMessage(intlMessages.statusLabel)}</Styled.UsernameTitle>
-          <Styled.UserPresenceDropdown
-            value={away ? 'away' : 'available'}
-            onChange={(e) => handleSetStatus(e.target.value as string)}
-            IconComponent={ExpandMoreIcon}
-            MenuProps={{
-              PaperProps: {
-                sx: {
-                  borderRadius: '0.75rem',
-                  border: '1px solid #E5E7EB',
-                  boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
-                  mt: 0,
-                  '& .MuiList-root': {
-                    padding: '0.5rem',
-                  },
-                  '& .MuiMenuItem-root': {
-                    borderRadius: '0.5rem',
-                    gap: '0.5rem',
-                    padding: '0.625rem 0.75rem',
+          <Styled.UserPresenceField>
+            <Styled.UserPresenceIndicator aria-hidden>
+              <Styled.UserPresenceStatusDot away={away} />
+            </Styled.UserPresenceIndicator>
+            <Styled.UserPresenceDropdown
+              value={away ? 'away' : 'available'}
+              onChange={(e) => handleSetStatus(e.target.value as string)}
+              IconComponent={ExpandMoreIcon}
+              MenuProps={{
+                PaperProps: {
+                  sx: {
+                    borderRadius: '0.75rem',
+                    border: '1px solid #E5E7EB',
+                    boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
+                    mt: 0,
+                    '& .MuiList-root': {
+                      padding: '0.5rem',
+                    },
+                    '& .MuiMenuItem-root': {
+                      borderRadius: '0.5rem',
+                      gap: '0.5rem',
+                      padding: '0.625rem 0.75rem',
+                    },
                   },
                 },
-              },
-            }}
-            renderValue={(val) => (
-              <Styled.UserPresenceValueContainer>
-                <Styled.UserPresenceStatusDot away={val === 'away'} />
+              }}
+              renderValue={(val) => (
                 <Styled.UserPresenceText>
                   {val === 'away'
                     ? formatMessage(intlMessages.awayLabel)
                     : formatMessage(intlMessages.availableLabel)}
                 </Styled.UserPresenceText>
-              </Styled.UserPresenceValueContainer>
-            )}
-          >
-            <MenuItem value="available">
-              <Styled.UserPresenceValueContainer>
-                <Styled.UserPresenceStatusDot away={false} />
-                <Styled.UserPresenceText>{formatMessage(intlMessages.availableLabel)}</Styled.UserPresenceText>
-              </Styled.UserPresenceValueContainer>
-            </MenuItem>
-            <MenuItem value="away">
-              <Styled.UserPresenceValueContainer>
-                <Styled.UserPresenceStatusDot away />
-                <Styled.UserPresenceText>{formatMessage(intlMessages.awayLabel)}</Styled.UserPresenceText>
-              </Styled.UserPresenceValueContainer>
-            </MenuItem>
-          </Styled.UserPresenceDropdown>
+              )}
+            >
+              <MenuItem value="available">
+                <Styled.UserPresenceValueContainer>
+                  <Styled.UserPresenceStatusDot away={false} />
+                  <Styled.UserPresenceText>{formatMessage(intlMessages.availableLabel)}</Styled.UserPresenceText>
+                </Styled.UserPresenceValueContainer>
+              </MenuItem>
+              <MenuItem value="away">
+                <Styled.UserPresenceValueContainer>
+                  <Styled.UserPresenceStatusDot away />
+                  <Styled.UserPresenceText>{formatMessage(intlMessages.awayLabel)}</Styled.UserPresenceText>
+                </Styled.UserPresenceValueContainer>
+              </MenuItem>
+            </Styled.UserPresenceDropdown>
+          </Styled.UserPresenceField>
         </Styled.UserPresenceRoot>
         <Styled.Separator />
         <Styled.DevicesSettingsContainer>

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
@@ -204,11 +204,26 @@ const UserPresenceRoot = styled.div`
   padding: 0px ${contentSidebarPadding};
 `;
 
+const UserPresenceField = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+`;
+
+const UserPresenceIndicator = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  flex-shrink: 0;
+`;
+
 const UserPresenceDropdown = styled(Select)`
+  flex: 1;
   height: 3rem;
   border-radius: 0.5rem !important;
   overflow: hidden;
-  width: 100%;
 `;
 
 const UserPresenceValueContainer = styled.div`
@@ -539,6 +554,8 @@ export default {
   UsernameTitle,
   Username,
   UserPresenceRoot,
+  UserPresenceField,
+  UserPresenceIndicator,
   UserPresenceDropdown,
   UserPresenceValueContainer,
   UserPresenceStatusDot,

--- a/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/styles.ts
@@ -1,7 +1,7 @@
 import styled, { css, keyframes } from 'styled-components';
 import {
   colorWhite, colorText, colorPrimary, colorDanger,
-  colorGrayDark, colorLink, listItemBgHover, colorBorder,
+  colorGrayDark, colorLink, colorBorder, colorSuccess, colorGrayLight,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
   smPadding,
@@ -30,14 +30,6 @@ import {
   HeaderContainer as BaseHeaderContainer,
 } from '/imports/ui/components/sidebar-content/styles';
 import Button from '/imports/ui/components/common/button/component';
-
-const SimpleButton = styled.button`
-  cursor: pointer;
-  border: none;
-  background: none;
-  padding: 0;
-  outline: none;
-`;
 
 const RootContainer = styled.div`
   display: flex;
@@ -204,52 +196,39 @@ const Username = styled.div`
 `;
 
 const UserPresenceRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   width: 100%;
   padding: 0px ${contentSidebarPadding};
 `;
 
-const UserPresenceContainer = styled.div`
+const UserPresenceDropdown = styled(Select)`
+  height: 3rem;
+  border-radius: 0.5rem !important;
+  overflow: hidden;
+  width: 100%;
+`;
+
+const UserPresenceValueContainer = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  min-height: 3.5rem;
-  padding: 0.5rem 1rem;
   align-items: center;
-  justify-content: center;
-  gap: 0.5rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid ${colorBorder};
+  gap: 0.5rem;
 `;
 
-const UserPresenceButton = styled(SimpleButton)<{ active?: boolean }>`
-  display: flex;
-  padding: 0.125rem 1rem;
-  justify-content: center;
-  align-items: center;
-  flex: 1 1 auto;
-  min-width: 6rem;
-  align-self: stretch;
-  border-radius: 0.5rem;
-
-  ${({ active }) => active && `
-    background: ${listItemBgHover};
-    cursor: not-allowed;
-    pointer-events: none;
-    border-radius: 1.0rem;
-  `}
-`;
-
-const UserPresenceText = styled.div`
-  color: ${colorGrayDark};
-  text-align: center;
-  font-size: ${fontSizeBase}
-  font-weight: ${textFontWeight};
-`;
-
-const UserPresenceDivider = styled.div`
-  width: 0.0625rem;
-  height: 2.5rem;
-  background: ${colorBorder};
+const UserPresenceStatusDot = styled.div<{ away?: boolean }>`
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
   flex-shrink: 0;
+  background-color: ${({ away }) => (away ? colorGrayLight : colorSuccess)};
+`;
+
+const UserPresenceText = styled.span`
+  color: ${colorGrayDark};
+  font-size: ${fontSizeBase};
+  font-weight: ${textFontWeight};
 `;
 
 const Separator = styled.hr`
@@ -560,10 +539,10 @@ export default {
   UsernameTitle,
   Username,
   UserPresenceRoot,
-  UserPresenceContainer,
-  UserPresenceButton,
+  UserPresenceDropdown,
+  UserPresenceValueContainer,
+  UserPresenceStatusDot,
   UserPresenceText,
-  UserPresenceDivider,
   Separator,
   DevicesSettingsContainer,
   DeviceContainer,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/profile-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/profile-list-item/component.tsx
@@ -3,6 +3,8 @@ import { defineMessages, useIntl } from 'react-intl';
 import { PANELS } from '../../layout/enums';
 import { BaseSidebarButtonProps } from '../types';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
+import SidebarNavButtonStyled from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
 const intlMessages = defineMessages({
   profileLabel: {
@@ -11,8 +13,10 @@ const intlMessages = defineMessages({
   },
 });
 
-const ProfileListItem:React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
+const ProfileListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
   const intl = useIntl();
+  const { data: currentUserData } = useCurrentUser((user) => ({ away: user.away }));
+  const away = currentUserData?.away ?? false;
 
   const label = intl.formatMessage(intlMessages.profileLabel);
 
@@ -25,7 +29,9 @@ const ProfileListItem:React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
       id="profile-toggle-button"
       ariaDescribedBy="profile"
       dataTest="profileSidebarButton"
-    />
+    >
+      <SidebarNavButtonStyled.StatusDot away={away} />
+    </SidebarNavigationButton>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
@@ -13,6 +13,7 @@ import {
   itemFocusBorder,
   colorGrayIcons,
   colorGrayLightest,
+  colorSuccess,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { ListItemProps } from './types';
 
@@ -99,6 +100,19 @@ export const ListItem = styled.div<ListItemProps>`
   }
 `;
 
+const StatusDot = styled.div<{ away?: boolean }>`
+  position: absolute;
+  bottom: -1px;
+  right: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: ${({ away }: { away?: boolean }) => (away ? colorGrayLight : colorSuccess)};
+  border: 1px solid ${colorWhite};
+  pointer-events: none;
+`;
+
 export default {
   ListItem,
+  StatusDot,
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -152,6 +152,7 @@
     "app.appsGallery.modal.confirmButtonLabel": "Got it",
     "app.profileSettings.title": "Profile Settings",
     "app.profileSettings.usernameTitle": "Username",
+    "app.profileSettings.statusTitle": "Status",
     "app.profileSettings.addExtraCamera": "Add Extra Camera",
     "app.pads.hint": "Press Esc to focus the pad's toolbar",
     "app.user.activityCheck": "User activity check",


### PR DESCRIPTION
### What does this PR do?
Replaces two-button presence toggle (Presente/Ausente) with an expandable MUI Select dropdown. Adds status dot to the profile button in the sidebar navigation, reflecting the current user presence state in real time

Note: colors in the demo video may appear slightly muted because the app is running with the default palette fallback values. The final appearance will match the design once the client-configured color palette is applied.


### Closes Issue(s)
Closes None

### More
[Screencast from 05-03-2026 16:46:48.webm](https://github.com/user-attachments/assets/ff235e31-8192-455e-851e-ab5e88ac52d4)
