### PR TITLE
Fix(html5): Recalculate time sync when a new minimal rtt is available

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -88,8 +88,10 @@ const ConnectionStatus = ({
 
   const handleUpdateConnectionAliveAt = (networkRtt, serverEpochMsec, serverRequestId) => {
     try {
-      // calculate time sync only once
-      if (timeSyncRef.current === 0) {
+      // recalculate time sync
+      // whenever a new minimum RTT is observed (lower RTT = better NTP estimate)
+      if (networkRtt < connectionStatus.getMinRtt()) {
+        connectionStatus.setMinRtt(networkRtt);
         const clientNowEpoch = Date.now();
         const oneWay = networkRtt / 2; // aproximation NTP
         // Not allow negative skew

--- a/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/singletons/connectionStatus.ts
@@ -39,6 +39,16 @@ class ConnectionStatus {
 
   private rttValue = makeVar(0);
 
+  private minRtt: number = Infinity;
+
+  public setMinRtt(value: number): void {
+    this.minRtt = value;
+  }
+
+  public getMinRtt(): number {
+    return this.minRtt;
+  }
+
   private subscriptionFailed = makeVar(false);
 
   // @ts-ignore


### PR DESCRIPTION
### What does this PR do?

Improves clock skew estimation (`timeSync`) by recalculating it whenever a new **minimum RTT** is observed, instead of only once on the first measurement.

### Closes Issue(s)
Closes N/A

### How to test

1. Open a BBB meeting in a browser with devtools console open.
2. Filter console logs for `latency_skew_calc`.
3. Confirm the log fires on the **first** RTT measurement (initial minRtt `Infinity` → first value).
4. Throttle the network briefly at meeting join (Chrome devtools → Network → Slow 3G), then remove the throttle. Confirm the log fires again when a subsequent lower RTT is measured.
5. Confirm the log does **not** fire on measurements where RTT >= current minimum.
6. Confirm `stats_application_rtt` logs continue to show correct, non-negative values.

