### PR TITLE
fix(livekit): disable single peer connection (Firefox audio issue)

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -972,6 +972,7 @@ public:
         adaptiveStream: true
         dynacast: true
         stopLocalTrackOnUnpublish: false
+        singlePeerConnection: false
       audio:
         # unpublishOnMute: whether to unpublish audio tracks when muted. Default is true.
         unpublishOnMute: true


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): disable single peer connection (Firefox audio issue)](https://github.com/bigbluebutton/bigbluebutton/commit/f664c5ecc198d829b237964923aad6facac61c69) 
  - livekit-server and the livekit-client SDK were recently updated to
v1.9.11 and v2.17.1. This introduced the ability to use a single PC
per session, which is enabled by default.
While this is a good thing in general, there's a race condition in Firefox when coupled with selective subscription where subscribing
to remote tracks may silently fail, intermittently - and that is caused
by trailing negotiation requests sent to the single PC.
  - Temporarily rollback to the dual PC approach which seems
less prone (or even unaffected) by the above race condition.
Single PCs will be re-enabled once the issue has been fixed
upstream and undergone testing on our side.

### Closes Issue(s)

None