### PR TITLE
fix(whiteboard): scope slide zoom state to presentation id

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1843,11 +1843,11 @@ const Whiteboard = React.memo((props) => {
     zoomValueRef.current = zoomValue;
     setPageZoomMap((prev) => ({
       ...prev,
-      [curPageIdRef.current]: zoomValue,
+      [`${presentationIdRef.current}_${curPageIdRef.current}`]: zoomValue,
     }));
 
     if (pageChanged) {
-      zoomChanger(pageZoomMap[curPageIdRef.current] || HUNDRED_PERCENT);
+      zoomChanger(pageZoomMap[`${presentationIdRef.current}_${curPageIdRef.current}`] || HUNDRED_PERCENT);
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
Previously, the saved zoom value in `pageZoomMap` used only the page index as its key. This caused the zoom level to incorrectly persist and apply when switching to a different presentation and landing on the same slide index.

This updates the cache keys to include the `presentationId` alongside the page ID, ensuring zoom levels are strictly scoped to their specific presentation slide.


### Motivation
Undesirable zoom in pages of new presentation


### How to test
- Add zoom to some pages in a first presentation
- Upload a second presentation and set as current
- Change the slide to a page with same slide number as previous presentation with zoom
- See if the zoom is applied, it should not