### PR TITLE
fix(whiteboard): scope slide zoom state to presentation id

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1858,11 +1858,11 @@ const Whiteboard = React.memo((props) => {
     zoomValueRef.current = zoomValue;
     setPageZoomMap((prev) => ({
       ...prev,
-      [curPageIdRef.current]: zoomValue,
+      [`${presentationIdRef.current}_${curPageIdRef.current}`]: zoomValue,
     }));
 
     if (pageChanged) {
-      zoomChanger(pageZoomMap[curPageIdRef.current] || HUNDRED_PERCENT);
+      zoomChanger(pageZoomMap[`${presentationIdRef.current}_${curPageIdRef.current}`] || HUNDRED_PERCENT);
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
Ports #24728 to v3.0

_Previously, the saved zoom value in pageZoomMap used only the page index as its key. This caused the zoom level to incorrectly persist and apply when switching to a different presentation and landing on the same slide index._

_This updates the cache keys to include the presentationId alongside the page ID, ensuring zoom levels are strictly scoped to their specific presentation slide._
