### PR TITLE
Fix audio desync when seek point doesn't match an audio frame start

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -21,7 +21,7 @@ module BigBlueButton
   module EDL
     module Audio
       FFMPEG_AEVALSRC = "aevalsrc=s=48000:c=stereo:exprs=0|0"
-      FFMPEG_AFORMAT = "aresample=async=1000,aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
+      FFMPEG_AFORMAT = "aresample=async=1000:first_pts=0,aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
       FFMPEG_WF_CODEC = 'libvorbis'
       FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'


### PR DESCRIPTION
By default, the `aresample` filter assumes that the timestamp of the first audio frame it sees is the start of the audio, and the output timestamps will be offset so that point becomes 0 in the output. If the seek point happened to be in a gap where there were no audio frames, this will cause the audio to be earlier than expected (desynced).

Setting the `first_pts=0` option causes the filter to trim or pad the start of the output audio to preserve the correct offset relative to 0, where 0 is the seek point (set with the `-ss` option).