### PR TITLE
fix(whiteboard): prevent presenter/viewer viewed-region desync after fullscreen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -213,6 +213,7 @@ const Whiteboard = React.memo((props) => {
   const innerWrapperPollingFrameRef = React.useRef(null);
   const isMountedPollingFrameRef = React.useRef(null);
   const hasZoomSyncedRef = useRef(false);
+  const lastForcedViewRef = useRef(null);
   const currentUserRef = useRef(currentUser);
 
   currentUserRef.current = currentUser;
@@ -1732,11 +1733,55 @@ const Whiteboard = React.memo((props) => {
       }
 
       const camera = tlEditorRef.current.getCamera();
+
       const updatedCurrentCam = {
         ...camera,
         z: adjustedZoom,
       };
-      tlEditorRef.current.store.put([updatedCurrentCam]);
+      tlEditorRef.current.store.mergeRemoteChanges(() => {
+        tlEditorRef.current.store.put([updatedCurrentCam]);
+      });
+
+      // Remote camera updates do not trigger the user-source listener,
+      // so publish the final settled presenter view explicitly.
+      if (fitToWidthRef.current) {
+        requestAnimationFrame(() => {
+          const viewportPageBounds = tlEditorRef.current?.getViewportPageBounds();
+          if (!viewportPageBounds?.w || !viewportPageBounds?.h) {
+            return;
+          }
+
+          const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
+            viewportPageBounds.w,
+            currentPresentationPageRef.current?.scaledWidth,
+          );
+          const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
+            viewportPageBounds.h,
+            currentPresentationPageRef.current?.scaledHeight,
+          );
+
+          const forcedView = {
+            pageId: curPageIdRef.current,
+            w: Number(viewedRegionW.toFixed(6)),
+            h: Number(viewedRegionH.toFixed(6)),
+            x: Number(updatedCurrentCam.x.toFixed(6)),
+            y: Number(updatedCurrentCam.y.toFixed(6)),
+          };
+
+          if (isEqual(lastForcedViewRef.current, forcedView)) {
+            return;
+          }
+
+          lastForcedViewRef.current = forcedView;
+          zoomSlide(
+            viewedRegionW,
+            viewedRegionH,
+            updatedCurrentCam.x,
+            updatedCurrentCam.y,
+            currentPresentationPageRef.current,
+          );
+        });
+      }
     } else {
       const newZoom = calculateZoomValue(
         scaledViewBoxWidth,


### PR DESCRIPTION
### What does this PR do?
Currently some zoom updates can leak to server when presenter enter/leaves presentation to fullscreen (maybe other cases also). It causes viewers and recording to have zoom, while presenter still see full slide.

This commit prevent transient in-between camera/zoom values to be propagated, while still syncing the correct final state when needed (mainly fit-to-width).

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Possbile fixes https://github.com/bigbluebutton/bigbluebutton/issues/24670

### Motivation
Wrong zoom in recordings when the presenter hasn't changed the zoom during meeting.


### How to test
The bug in question is very hard to reproduce, it's a race condition and I believe it happened more when the system is under load. But the easiest way was by putting the presentation fullscreen, sometimes the wrong zoom was applied only to viewers, not for the presenter
