### PR TITLE
feat(livekit): add a last N-like system to selective subscription (audio)

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -512,14 +512,14 @@ export default class LiveKitScreenshareBridge {
   private unsubscribe(mainPublication: RemoteTrackPublication): void {
     if (this.role === RECV_ROLE) {
       // @ts-ignore
-      const withSelectiveSubscription = window.meetingClientSettings.public.media?.livekit?.selectiveSubscription
-        || false;
+      const withSelectiveSub = window.meetingClientSettings?.public?.media?.livekit?.selectiveSubscription?.enabled
+        ?? false;
       const { track } = mainPublication;
       const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG) as HTMLMediaElement;
 
       if (track) track.detach(mediaElement);
 
-      if (withSelectiveSubscription) {
+      if (withSelectiveSub) {
         const audioPublications = Array.from(this.audioPublications.values()) as RemoteTrackPublication[];
 
         if (audioPublications.length > 0) {

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -513,7 +513,7 @@ export default class LiveKitScreenshareBridge {
     if (this.role === RECV_ROLE) {
       // @ts-ignore
       const withSelectiveSub = window.meetingClientSettings?.public?.media?.livekit?.selectiveSubscription?.enabled
-        ?? false;
+        ?? true;
       const { track } = mainPublication;
       const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG) as HTMLMediaElement;
 

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -642,9 +642,15 @@ export interface LiveKitAudioSettings {
   useLiveKitAudioState?: boolean
 }
 
+export type SelectiveSubscriptionConfig = {
+  enabled: boolean;
+  audioSubscriptionPoolSize: number;
+  muteDebounceMs: number;
+};
+
 export interface LiveKitSettings {
   url?: string
-  selectiveSubscription?: boolean
+  selectiveSubscription?: SelectiveSubscriptionConfig
   logLevel?: LogLevel
   roomOptions?: Partial<InternalRoomOptions>
   reconnectOnFatalFailures?: boolean

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -443,7 +443,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
   const [meetingSettings] = useMeetingSettings();
   const url = meetingSettings.public.media?.livekit?.url
     || `wss://${window.location.hostname}/livekit`;
-  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription ?? false;
+  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? false;
   const logLevel = meetingSettings.public.media?.livekit?.logLevel ?? LogLevel.warn;
   const roomOptions = meetingSettings.public.media?.livekit?.roomOptions ?? {
     adaptiveStream: true,

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -443,7 +443,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
   const [meetingSettings] = useMeetingSettings();
   const url = meetingSettings.public.media?.livekit?.url
     || `wss://${window.location.hostname}/livekit`;
-  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? false;
+  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? true;
   const logLevel = meetingSettings.public.media?.livekit?.logLevel ?? LogLevel.warn;
   const roomOptions = meetingSettings.public.media?.livekit?.roomOptions ?? {
     adaptiveStream: true,

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/component.tsx
@@ -6,7 +6,7 @@ import { useMediaSubscriptions } from './hooks';
 
 const SelectiveSubscription: React.FC = () => {
   const connectionState = useConnectionState(liveKitRoom);
-  const { handleSubscriptionChanges } = useMediaSubscriptions();
+  const { handleSubscriptionChanges } = useMediaSubscriptions(liveKitRoom);
 
   useEffect(() => {
     if (connectionState !== ConnectionState.Connected) return;

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -127,45 +127,53 @@ const useDebouncedMuteState = (
 ): Record<string, boolean> => {
   const { data: unmutedUsers } = useWhoIsUnmuted();
   const [debouncedState, setDebouncedState] = useState<Record<string, boolean>>(unmutedUsers || {});
+  const debouncedStateRef = useRef(debouncedState);
+  debouncedStateRef.current = debouncedState;
   const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   useEffect(() => {
     participants.forEach((participant) => {
       const userId = participant.identity;
       const currUnmuted = unmutedUsers[userId] ?? false;
-      const prevUnmuted = debouncedState[userId] ?? false;
+      const prevUnmuted = debouncedStateRef.current[userId] ?? false;
 
-      if (currUnmuted !== prevUnmuted) {
-        const existingTimer = debounceTimers.current.get(userId);
+      if (currUnmuted === prevUnmuted && !debounceTimers.current.has(userId)) return;
 
-        if (existingTimer) clearTimeout(existingTimer);
+      const existingTimer = debounceTimers.current.get(userId);
 
-        // Immediately apply transitions from muted -> unmuted (subscription)
-        if (currUnmuted) {
-          setDebouncedState((prev) => ({
-            ...prev,
-            [userId]: true,
-          }));
-        } else {
-          // Debounce transitions from unmuted -> muted (unsubscription)
-          const timer = setTimeout(() => {
-            setDebouncedState((prev) => ({
-              ...prev,
-              [userId]: false,
-            }));
-            debounceTimers.current.delete(userId);
-          }, debounceMs);
-
-          debounceTimers.current.set(userId, timer);
+      // Immediately apply transitions from muted -> unmuted (subscription)
+      if (currUnmuted) {
+        if (existingTimer) {
+          clearTimeout(existingTimer);
+          debounceTimers.current.delete(userId);
         }
+
+        setDebouncedState((prev) => {
+          if (prev[userId] === true) return prev;
+
+          return { ...prev, [userId]: true };
+        });
+      } else if (!existingTimer) {
+        // Debounce transitions from unmuted -> muted (unsubscription).
+        // Only set a timer if one isn't already pending.
+        const timer = setTimeout(() => {
+          setDebouncedState((prev) => {
+            if (prev[userId] === false || !(userId in prev)) return prev;
+            return { ...prev, [userId]: false };
+          });
+          debounceTimers.current.delete(userId);
+        }, debounceMs);
+        debounceTimers.current.set(userId, timer);
       }
     });
+  }, [participants, unmutedUsers]);
 
+  useEffect(() => {
     return () => {
       debounceTimers.current.forEach(clearTimeout);
       debounceTimers.current.clear();
     };
-  }, [participants, unmutedUsers]);
+  }, []);
 
   return debouncedState;
 };

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -55,7 +55,7 @@ const useMediaGroupStreamsSubscription = createUseSubscription(
 
 const getSelectiveSubscriptionConfig = () => {
   const selSubConfig = window.meetingClientSettings?.public?.media?.livekit?.selectiveSubscription;
-  const selectiveSubscriptionEnabled = selSubConfig?.enabled ?? false;
+  const selectiveSubscriptionEnabled = selSubConfig?.enabled ?? true;
   const audioSubscriptionPoolSize = selectiveSubscriptionEnabled
     ? selSubConfig?.audioSubscriptionPoolSize ?? 0
     : 0;

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -8,10 +9,10 @@ import {
   RemoteParticipant,
   Track,
   type RemoteTrackPublication,
+  type Room,
 } from 'livekit-client';
 import { useReactiveVar } from '@apollo/client';
-import { useRemoteParticipants } from '@livekit/components-react';
-import { liveKitRoom } from '/imports/ui/services/livekit';
+import { useRemoteParticipants, useSpeakingParticipants } from '@livekit/components-react';
 import logger from '/imports/startup/client/logger';
 import Auth from '/imports/ui/services/auth';
 import {
@@ -20,19 +21,17 @@ import {
 import {
   MediaGroupStream,
   MediaSendersData,
-  SUBSCRIPTION_RETRY,
   MediaType,
   PUBLIC_GROUP_IDS,
 } from '/imports/ui/components/livekit/selective-subscription/types';
+import {
+  isAudioSource,
+  selectParticipantsToSubscribe,
+} from '/imports/ui/components/livekit/selective-subscription/service';
 import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
 import AudioManager from '/imports/ui/services/audio-manager';
 import { useAutoplayState } from '/imports/ui/components/livekit/autoplay-modal/hooks';
-
-const useMediaGroupStreamsSubscription = createUseSubscription(
-  MEDIA_GROUP_STREAMS_SUBSCRIPTION,
-  {},
-  true,
-);
+import useWhoIsUnmuted from '/imports/ui/core/hooks/useWhoIsUnmuted';
 
 const PARTICIPANTS_UPDATE_FILTER = [
   RoomEvent.ParticipantConnected,
@@ -45,11 +44,131 @@ const PARTICIPANTS_UPDATE_FILTER = [
   RoomEvent.TrackSubscribed,
   RoomEvent.TrackUnsubscribed,
   RoomEvent.TrackSubscriptionFailed,
+  RoomEvent.ActiveSpeakersChanged,
 ];
 
-const isValidSource = (source: Track.Source) => (
-  source === Track.Source.Microphone || source === Track.Source.ScreenShareAudio
+const useMediaGroupStreamsSubscription = createUseSubscription(
+  MEDIA_GROUP_STREAMS_SUBSCRIPTION,
+  {},
+  true,
 );
+
+const getSelectiveSubscriptionConfig = () => {
+  const selSubConfig = window.meetingClientSettings?.public?.media?.livekit?.selectiveSubscription;
+  const selectiveSubscriptionEnabled = selSubConfig?.enabled ?? false;
+  const audioSubscriptionPoolSize = selectiveSubscriptionEnabled
+    ? selSubConfig?.audioSubscriptionPoolSize ?? 0
+    : 0;
+
+  return {
+    selectiveSubscriptionEnabled,
+    audioSubscriptionPoolSize,
+    muteDebounceMs: selSubConfig?.muteDebounceMs ?? 2500,
+  };
+};
+
+/**
+ * Hook to track LiveKit participant's speaking activity timestamps
+ * @param liveKitRoom - The LiveKit room
+ * @returns A map of participant IDs to their last spoke timestamp
+ */
+const useParticipantsLastSpokeAt = (
+  liveKitRoom: Room,
+): Map<string, number> => {
+  const speakingParticipants = useSpeakingParticipants();
+  const participantsLastSpokeAtMap = useRef<Map<string, number>>(new Map());
+  const [participantLastSpokeAt, setParticipantLastSpokeAt] = useState<Map<string, number>>(new Map());
+
+  const handleParticipantDisconnected = useCallback((participant: RemoteParticipant) => {
+    if (participantsLastSpokeAtMap.current.delete(participant.identity)) {
+      setParticipantLastSpokeAt(new Map(participantsLastSpokeAtMap.current));
+    }
+  }, []);
+
+  useEffect(() => {
+    let changed = false;
+
+    speakingParticipants.forEach((participant) => {
+      const { lastSpokeAt, identity } = participant;
+      const existing = participantsLastSpokeAtMap.current.get(identity);
+      const lastSpokeAtMs = lastSpokeAt instanceof Date
+        ? lastSpokeAt.getTime()
+        : undefined;
+
+      if (lastSpokeAtMs !== undefined && existing !== lastSpokeAtMs) {
+        participantsLastSpokeAtMap.current.set(identity, lastSpokeAtMs);
+        changed = true;
+      }
+    });
+
+    if (changed) setParticipantLastSpokeAt(new Map(participantsLastSpokeAtMap.current));
+  }, [speakingParticipants]);
+
+  useEffect(() => {
+    liveKitRoom.on(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected);
+
+    return () => {
+      liveKitRoom.off(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected);
+    };
+  }, [handleParticipantDisconnected]);
+
+  return participantLastSpokeAt;
+};
+
+/**
+ * Provides a debounced mute state for LiveKit participants.
+ * @param participants - The remote participants
+ * @param debounceMs - The debounce time in milliseconds
+ * @returns A record of participant IDs to their debounced mute state
+ */
+const useDebouncedMuteState = (
+  participants: RemoteParticipant[],
+  debounceMs: number = 2500,
+): Record<string, boolean> => {
+  const { data: unmutedUsers } = useWhoIsUnmuted();
+  const [debouncedState, setDebouncedState] = useState<Record<string, boolean>>(unmutedUsers || {});
+  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => {
+    participants.forEach((participant) => {
+      const userId = participant.identity;
+      const currUnmuted = unmutedUsers[userId] ?? false;
+      const prevUnmuted = debouncedState[userId] ?? false;
+
+      if (currUnmuted !== prevUnmuted) {
+        const existingTimer = debounceTimers.current.get(userId);
+
+        if (existingTimer) clearTimeout(existingTimer);
+
+        // Immediately apply transitions from muted -> unmuted (subscription)
+        if (currUnmuted) {
+          setDebouncedState((prev) => ({
+            ...prev,
+            [userId]: true,
+          }));
+        } else {
+          // Debounce transitions from unmuted -> muted (unsubscription)
+          const timer = setTimeout(() => {
+            setDebouncedState((prev) => ({
+              ...prev,
+              [userId]: false,
+            }));
+            debounceTimers.current.delete(userId);
+          }, debounceMs);
+
+          debounceTimers.current.set(userId, timer);
+        }
+      }
+    });
+
+    return () => {
+      debounceTimers.current.forEach(clearTimeout);
+      debounceTimers.current.clear();
+    };
+  }, [participants, unmutedUsers]);
+
+  return debouncedState;
+};
 
 export const useMediaSenders = (
   remoteParticipants: RemoteParticipant[],
@@ -116,12 +235,7 @@ export const useMediaSenders = (
   return { senders, inAnyGroup };
 };
 
-interface RetryState {
-  attempts: number;
-  timer: ReturnType<typeof setTimeout> | null;
-}
-
-export const useMediaSubscriptions = () => {
+export const useMediaSubscriptions = (liveKitRoom: Room) => {
   const [autoplayState] = useAutoplayState(liveKitRoom);
   /* eslint no-underscore-dangle: 0 */
   // @ts-ignore
@@ -132,122 +246,47 @@ export const useMediaSubscriptions = () => {
   });
   // For now we're only handling audio, but this is ready for other media types
   const { senders, inAnyGroup } = useMediaSenders(remoteParticipants, deafened, MediaType.AUDIO);
-  const retryMap = useRef<Map<string, RetryState>>(new Map());
-  const [subscriptionErrors, setSubscriptionErrors] = useState<Map<string, Error>>(new Map());
-
-  const clearRetryTimer = (userId: string) => {
-    const state = retryMap.current.get(userId);
-    if (state?.timer) {
-      clearTimeout(state.timer);
-      state.timer = null;
-    }
-  };
-
-  const retrySubscription = useCallback((userId: string, publication: RemoteTrackPublication) => {
-    const { trackSid } = publication;
-    const state = retryMap.current.get(userId) || { attempts: 0, timer: null };
-    const { attempts } = state;
-
-    if (attempts >= SUBSCRIPTION_RETRY.MAX_RETRIES) {
-      logger.error({
-        logCode: 'livekit_audio_sel_subscription_max_retries',
-        extraInfo: {
-          trackSid,
-        },
-      }, `LiveKit: ${publication.source} maxed retries - ${trackSid}`);
-      retryMap.current.delete(userId);
-      return;
-    }
-
-    const delay = SUBSCRIPTION_RETRY.RETRY_INTERVAL
-      ** (SUBSCRIPTION_RETRY.BACKOFF_MULTIPLIER, attempts);
-
-    clearRetryTimer(userId);
-
-    state.timer = setTimeout(async () => {
-      try {
-        publication.setSubscribed(true);
-        logger.info({
-          logCode: 'livekit_audio_sel_subscription_retry_success',
-          extraInfo: { userId, attempts: attempts + 1 },
-        }, `Successfully subscribed to ${userId} after ${attempts + 1} attempts`);
-        retryMap.current.delete(userId);
-        setSubscriptionErrors((prev) => {
-          const next = new Map(prev);
-          next.delete(userId);
-          return next;
-        });
-      } catch (error) {
-        state.attempts += 1;
-        retryMap.current.set(userId, state);
-        setSubscriptionErrors((prev) => {
-          const next = new Map(prev);
-          next.set(userId, error as Error);
-          return next;
-        });
-        retrySubscription(userId, publication);
-      }
-    }, delay);
-
-    retryMap.current.set(userId, state);
-  }, []);
+  const { audioSubscriptionPoolSize, muteDebounceMs } = getSelectiveSubscriptionConfig();
+  const participantsLastSpokeAt = useParticipantsLastSpokeAt(liveKitRoom);
+  const debouncedUnmutedUsers = useDebouncedMuteState(
+    remoteParticipants,
+    muteDebounceMs,
+  );
 
   const handleSubscriptionChanges = useCallback(async () => {
     if (!liveKitRoom) return;
 
-    const currentSubscriptions = {
+    const currentSubscriptions: Record<Track.Source.Microphone | Track.Source.ScreenShareAudio, Set<string>> = {
       [Track.Source.Microphone]: new Set<string>(),
       [Track.Source.ScreenShareAudio]: new Set<string>(),
     };
 
     remoteParticipants.forEach((participant) => {
       participant.audioTrackPublications.forEach((publication: RemoteTrackPublication) => {
-        if (isValidSource(publication.source) && publication.isSubscribed) {
-          currentSubscriptions[publication.source].add(participant.identity);
+        if (isAudioSource(publication.source) && publication.isSubscribed) {
+          const source = publication.source as Track.Source.Microphone | Track.Source.ScreenShareAudio;
+          currentSubscriptions[source].add(participant.identity);
         }
       });
     });
 
-    const desiredSubscriptions = new Set(
-      senders.map((sender) => sender.userId),
-    );
+    // List of potential senders prior to any Last N filtering
+    const availableSenderIds = new Set(senders.map((sender) => sender.userId));
+    const availableParticipants = remoteParticipants
+      .filter((participant) => availableSenderIds.has(participant.identity));
 
-    Object.values(currentSubscriptions).forEach((subscriptions) => {
-      subscriptions.forEach((participantId) => {
-        if (!desiredSubscriptions.has(participantId)) {
-          const participant = remoteParticipants.find((p) => p.identity === participantId);
-          if (participant) {
-            participant.audioTrackPublications.forEach((publication) => {
-              const { trackSid } = publication;
+    // By default, subscribe to all available senders as defined by the useMediaSenders hook
+    let desiredSubscriptions: Set<string> = availableSenderIds;
 
-              if (publication.isSubscribed) {
-                clearRetryTimer(participantId);
-                retryMap.current.delete(participantId);
-                try {
-                  publication.setSubscribed(false);
-                  logger.debug({
-                    logCode: 'livekit_audio_sel_unsubscribed',
-                    extraInfo: {
-                      userId: participantId,
-                      inAnyGroup,
-                    },
-                  }, `LiveKit: Unsubscribed from ${publication.source} - ${trackSid}`);
-                } catch (error) {
-                  logger.error({
-                    logCode: 'livekit_audio_sel_unsubscription_failed',
-                    extraInfo: {
-                      trackSid,
-                      errorMessage: (error as Error).message,
-                      errorStack: (error as Error).stack,
-                    },
-                  }, `LiveKit: Failed to unsubscribe from ${publication.source} - ${trackSid}`);
-                }
-              }
-            });
-          }
-        }
-      });
-    });
+    // Last N filtering is active, restrict subscriptions
+    if (audioSubscriptionPoolSize > 0) {
+      desiredSubscriptions = selectParticipantsToSubscribe(
+        availableParticipants,
+        participantsLastSpokeAt,
+        debouncedUnmutedUsers,
+        audioSubscriptionPoolSize,
+      );
+    }
 
     // Handle new subscriptions
     desiredSubscriptions.forEach((participantId) => {
@@ -259,33 +298,41 @@ export const useMediaSubscriptions = () => {
               const { trackSid } = publication;
 
               if (!publication.isSubscribed && publication.source === source) {
-                try {
-                  publication.setSubscribed(true);
-                  logger.debug({
-                    logCode: 'livekit_audio_sel_subscribed',
-                    extraInfo: {
-                      trackSid,
-                      inAnyGroup,
-                    },
-                  }, `LiveKit: Subscribed to ${publication.source} - ${trackSid}`);
-                } catch (error) {
-                  logger.error({
-                    logCode: 'livekit_audio_sel_subscription_failed',
-                    extraInfo: {
-                      trackSid,
-                      errorMessage: (error as Error).message,
-                      errorStack: (error as Error).stack,
-                    },
-                  }, `LiveKit: Failed to subscribe to ${publication.source} - ${trackSid}`);
+                publication.setSubscribed(true);
+                logger.debug({
+                  logCode: 'livekit_audio_sel_subscribed',
+                  extraInfo: {
+                    trackSid,
+                    participantId,
+                    inAnyGroup,
+                    source: publication.source,
+                  },
+                }, `LiveKit: Subscribed to ${publication.source} - ${trackSid}`);
+              }
+            });
+          }
+        }
+      });
+    });
 
-                  setSubscriptionErrors((prev) => {
-                    const next = new Map(prev);
-                    next.set(participantId, error as Error);
-                    return next;
-                  });
+    Object.values(currentSubscriptions).forEach((subscriptions) => {
+      subscriptions.forEach((participantId) => {
+        if (!desiredSubscriptions.has(participantId)) {
+          const participant = remoteParticipants.find((p) => p.identity === participantId);
+          if (participant) {
+            participant.audioTrackPublications.forEach((publication) => {
+              const { trackSid } = publication;
 
-                  retrySubscription(participantId, publication);
-                }
+              if (publication.isSubscribed) {
+                publication.setSubscribed(false);
+                logger.debug({
+                  logCode: 'livekit_audio_sel_unsubscribed',
+                  extraInfo: {
+                    userId: participantId,
+                    inAnyGroup,
+                    source: publication.source,
+                  },
+                }, `LiveKit: Unsubscribed from ${publication.source} - ${trackSid}`);
               }
             });
           }
@@ -295,13 +342,13 @@ export const useMediaSubscriptions = () => {
   }, [
     senders,
     inAnyGroup,
-    retrySubscription,
     remoteParticipants,
     deafened,
+    participantsLastSpokeAt,
+    debouncedUnmutedUsers,
   ]);
 
   return {
     handleSubscriptionChanges,
-    subscriptionErrors,
   };
 };

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -205,10 +205,19 @@ export const useMediaSenders = (
   // Exclude only senders in non-public groups.
   if (!inAnyGroup) {
     const senderIdsInNonPublicGroups = new Set(groups
-      .filter((group) => group.sender === true && group.groupId !== PUBLIC_GROUP_IDS[mediaType])
+      .filter((group) => group.sender === true && group.active && group.groupId !== PUBLIC_GROUP_IDS[mediaType])
       .map((group) => group.userId));
+    const senderIdsInPublicGroup = new Set(groups
+      .filter((g) => g.sender === true && g.active && g.groupId === PUBLIC_GROUP_IDS[mediaType])
+      .map((g) => g.userId));
+    // Exclude only senders who are active in non-public groups but NOT in the public group.
+    // Users concurrently sending in both public and non-public groups should still be
+    // heard by public receivers.
+    const senderIdsOnlyInNonPublic = new Set(
+      [...senderIdsInNonPublicGroups].filter((id) => !senderIdsInPublicGroup.has(id)),
+    );
     const senders = remoteParticipants
-      .filter((participant) => !senderIdsInNonPublicGroups.has(participant.identity))
+      .filter((participant) => !senderIdsOnlyInNonPublic.has(participant.identity))
       .map((participant) => ({
         userId: participant.identity,
         groupId: 'default',
@@ -217,6 +226,7 @@ export const useMediaSenders = (
         receiver: true,
         active: true,
       }));
+
     return { senders, inAnyGroup: false };
   }
 
@@ -244,7 +254,8 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
   const remoteParticipants = useRemoteParticipants({
     updateOnlyOn: PARTICIPANTS_UPDATE_FILTER,
   });
-  // For now we're only handling audio, but this is ready for other media types
+  // Audio group-based filtering; screen share audio is handled separately
+  // (always subscribed regardless of groups) in handleSubscriptionChanges.
   const { senders, inAnyGroup } = useMediaSenders(remoteParticipants, deafened, MediaType.AUDIO);
   const { audioSubscriptionPoolSize, muteDebounceMs } = getSelectiveSubscriptionConfig();
   const participantsLastSpokeAt = useParticipantsLastSpokeAt(liveKitRoom);
@@ -260,12 +271,25 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
       [Track.Source.Microphone]: new Set<string>(),
       [Track.Source.ScreenShareAudio]: new Set<string>(),
     };
+    // Collect unsubscribed screen share audio publications upfront so we can
+    // forcefully subscribe them.
+    const pendingScreenShareAudio: Array<{
+      publication: RemoteTrackPublication;
+      participantId: string;
+    }> = [];
 
     remoteParticipants.forEach((participant) => {
       participant.audioTrackPublications.forEach((publication: RemoteTrackPublication) => {
-        if (isAudioSource(publication.source) && publication.isSubscribed) {
-          const source = publication.source as Track.Source.Microphone | Track.Source.ScreenShareAudio;
-          currentSubscriptions[source].add(participant.identity);
+        if (isAudioSource(publication.source)) {
+          if (publication.isSubscribed) {
+            const source = publication.source as Track.Source.Microphone | Track.Source.ScreenShareAudio;
+            currentSubscriptions[source].add(participant.identity);
+          } else if (publication.source === Track.Source.ScreenShareAudio) {
+            pendingScreenShareAudio.push({
+              publication,
+              participantId: participant.identity,
+            });
+          }
         }
       });
     });
@@ -321,6 +345,9 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
           const participant = remoteParticipants.find((p) => p.identity === participantId);
           if (participant) {
             participant.audioTrackPublications.forEach((publication) => {
+              // Screen share audio is always subscribed regardless of group membership
+              if (publication.source === Track.Source.ScreenShareAudio) return;
+
               const { trackSid } = publication;
 
               if (publication.isSubscribed) {
@@ -338,6 +365,22 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
           }
         }
       });
+    });
+
+    // Force-subscribe any screen share audio not already handled by the
+    // desired-subscription pass above.
+    pendingScreenShareAudio.forEach(({ publication, participantId }) => {
+      if (!publication.isSubscribed && !desiredSubscriptions.has(participantId)) {
+        publication.setSubscribed(true);
+        logger.debug({
+          logCode: 'livekit_audio_sel_subscribed',
+          extraInfo: {
+            trackSid: publication.trackSid,
+            participantId,
+            source: publication.source,
+          },
+        }, `LiveKit: Subscribed to ${publication.source} - ${publication.trackSid} (always-on)`);
+      }
     });
   }, [
     senders,

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/service.ts
@@ -1,0 +1,105 @@
+import { RemoteParticipant, Track } from 'livekit-client';
+
+type AudioTrackPriorityData = {
+  participantId: string;
+  trackSid: string;
+  source: Track.Source;
+  isActiveSpeaker: boolean;
+  isUnmuted: boolean;
+  lastSpokeAt?: number;
+};
+
+export const isAudioSource = (source: Track.Source): boolean => (
+  source === Track.Source.Microphone || source === Track.Source.ScreenShareAudio
+);
+
+/**
+ * Calculate audio track subscription priorities.
+ * Sorts by:
+ *   1) active speakers
+ *   2) unmuted users
+ *   3) most recent speakers (even if not active)
+ */
+const calculateAudioTrackPriorities = (
+  remoteParticipants: RemoteParticipant[],
+  participantsLastSpokeAt: Map<string, number>,
+  unmutedUsers: Record<string, boolean>,
+): AudioTrackPriorityData[] => {
+  const priorities: AudioTrackPriorityData[] = [];
+
+  remoteParticipants.forEach((participant) => {
+    const participantId = participant.identity;
+    const lastSpokeAt = participantsLastSpokeAt.get(participantId);
+    const isActiveSpeaker = participant.isSpeaking;
+    const isUnmuted = unmutedUsers[participantId] ?? false;
+
+    participant.audioTrackPublications.forEach((publication) => {
+      if (!isAudioSource(publication.source)) return;
+
+      priorities.push({
+        participantId,
+        trackSid: publication.trackSid,
+        source: publication.source,
+        isActiveSpeaker,
+        isUnmuted,
+        lastSpokeAt,
+      });
+    });
+  });
+
+  priorities.sort((a, b) => {
+    // 1) Active speakers
+    if (a.isActiveSpeaker !== b.isActiveSpeaker) return a.isActiveSpeaker ? -1 : 1;
+
+    // 2) Unmuted users
+    if (a.isUnmuted !== b.isUnmuted) return a.isUnmuted ? -1 : 1;
+
+    // 3) Most recent speakers (even if muted)
+    const aLastSpoke = a.lastSpokeAt ?? 0;
+    const bLastSpoke = b.lastSpokeAt ?? 0;
+
+    return bLastSpoke - aLastSpoke;
+  });
+
+  return priorities;
+};
+
+/**
+ * Select participants to subscribe to with a priority-based algorithm and maximum
+ * subscription pool size.
+ * @param remoteParticipants - All remote participants
+ * @param participantsLastSpokeAt - A map of participant IDs with their last speaking timestamp
+ * @param unmutedUsers - A record of participant IDs with their unmuted state
+ * @param poolSize - Maximum subscription pool size (excluding exemptions: screen share audio and unmuted users)
+ * @returns A set of participant IDs to subscribe to
+ */
+export const selectParticipantsToSubscribe = (
+  remoteParticipants: RemoteParticipant[],
+  participantsLastSpokeAt: Map<string, number>,
+  unmutedUsers: Record<string, boolean>,
+  poolSize: number,
+): Set<string> => {
+  const tracks = calculateAudioTrackPriorities(
+    remoteParticipants,
+    participantsLastSpokeAt,
+    unmutedUsers,
+  );
+  const participants = new Set<string>();
+
+  tracks.forEach((track) => {
+    if (poolSize > 0) {
+      // Always subscribe to screen share audio and unmuted tracks
+      if (track.source === Track.Source.ScreenShareAudio || track.isUnmuted) {
+        participants.add(track.participantId);
+      } else if (participants.size < poolSize) {
+        // Subscribe to at most N tracks - sorted by priority
+        participants.add(track.participantId);
+      }
+    } else {
+      // Subscribe to all tracks - last N is disabled
+      participants.add(track.participantId);
+    }
+  });
+
+  return participants;
+};

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/types.ts
@@ -20,6 +20,14 @@ export type MediaGroupParticipant = {
   active: boolean;
 }
 
+export type MediaGroupStateEntry = {
+  groupId: string;
+  mediaType: string;
+  sender: boolean;
+  receiver: boolean;
+  active: boolean;
+}
+
 export type MediaGroupStream = {
   userId: string;
   groupId: string;

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/types.ts
@@ -33,9 +33,3 @@ export type MediaSendersData = {
   senders: MediaGroupStream[];
   inAnyGroup: boolean;
 }
-
-export const SUBSCRIPTION_RETRY = {
-  MAX_RETRIES: 3,
-  RETRY_INTERVAL: 2000,
-  BACKOFF_MULTIPLIER: 1.5,
-};

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -61,7 +61,7 @@ import {
   MEDIA_GROUP_STREAMS_SUBSCRIPTION,
 } from '/imports/ui/components/livekit/selective-subscription/queries';
 import {
-  MediaGroupStream,
+  MediaGroupParticipant,
   MediaType,
   PUBLIC_GROUP_IDS,
 } from '/imports/ui/components/livekit/selective-subscription/types';
@@ -495,37 +495,48 @@ const useVideoSenders = () => {
           errorMessage: error.message,
           mediaType: MediaType.CAMERA,
         },
-      }, `VideoProvider: ${MediaType.CAMERA} group streams subscription failed.`);
+      }, `VideoProvider: ${MediaType.CAMERA} group participants subscription failed.`);
     });
   }
 
-  const groups = (data as MediaGroupStream[] || []).filter(
-    (group) => group.mediaType === MediaType.CAMERA,
+  const mediaGroupParticipants = (data as MediaGroupParticipant[] || []).filter(
+    (mgp) => mgp.mediaType === MediaType.CAMERA,
   );
 
   // Groups where I am a receiver - I see the union of senders from all of these
-  const myInboundGroupIds = groups.filter(
-    (group) => group.userId === Auth.userID && group.receiver === true,
-  ).map((group) => group.groupId);
+  const myInboundGroupIds = mediaGroupParticipants.filter(
+    (mgp) => mgp.userId === Auth.userID && mgp.receiver === true,
+  ).map((mgp) => mgp.groupId);
 
   const inAnyGroup = myInboundGroupIds.length > 0;
 
   // No explicit group membership = treat as public receiver.
   // Public receivers receive from: groupless senders + public group senders.
-  // Exclude only senders in non-public groups.
+  // Exclude only senders in non-public mediaGroupParticipants.
   if (!inAnyGroup) {
-    const senderIdsInNonPublicGroups = new Set(groups
-      .filter((group) => group.sender === true && group.groupId !== PUBLIC_GROUP_IDS[MediaType.CAMERA])
-      .map((group) => group.userId));
+    const senderIdsInPublicGroup = new Set(mediaGroupParticipants
+      .filter((mgp) => mgp.sender === true && mgp.active
+        && mgp.groupId === PUBLIC_GROUP_IDS[MediaType.CAMERA])
+      .map((mgp) => mgp.userId));
+    const senderIdsInNonPublicGroups = new Set(mediaGroupParticipants
+      .filter((mgp) => mgp.sender === true && mgp.active
+        && mgp.groupId !== PUBLIC_GROUP_IDS[MediaType.CAMERA])
+      .map((mgp) => mgp.userId));
+    // Exclude only senders who are active in non-public groups but NOT in the public group.
+    // Users concurrently sending in both public and non-public groups should still be
+    // visible to public receivers.
+    const senderIdsOnlyInNonPublic = new Set(
+      [...senderIdsInNonPublicGroups].filter((id) => !senderIdsInPublicGroup.has(id)),
+    );
 
-    return { senderIds: null, senderIdsInGroups: senderIdsInNonPublicGroups, inAnyGroup: false };
+    return { senderIds: null, senderIdsInGroups: senderIdsOnlyInNonPublic, inAnyGroup: false };
   }
 
-  // Union of senders from all groups where I am a receiver (public + interpretation, etc.)
-  const senderIds = new Set(groups
-    .filter((group) => myInboundGroupIds.includes(group.groupId))
-    .filter((stream) => stream.sender === true && stream.active)
-    .map((stream) => stream.userId));
+  // Union of senders from all mediaGroupParticipants where I am a receiver (public + explicit groups)
+  const senderIds = new Set(mediaGroupParticipants
+    .filter((mgp) => myInboundGroupIds.includes(mgp.groupId))
+    .filter((participant) => participant.sender === true && participant.active)
+    .map((participant) => participant.userId));
 
   return { senderIds, senderIdsInGroups: null, inAnyGroup: true };
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -133,7 +133,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   const streamsRef = useRef(streams);
   streamsRef.current = streams;
 
-  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription || false;
+  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? false;
 
   const handleStreamFailure = useCallback((error: Error, stream: string, isLocal: boolean) => {
     const { name: errorName, message: errorMessage } = error;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -133,7 +133,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   const streamsRef = useRef(streams);
   streamsRef.current = streams;
 
-  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? false;
+  const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? true;
 
   const handleStreamFailure = useCallback((error: Error, stream: string, isLocal: boolean) => {
     const { name: errorName, message: errorMessage } = error;

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -649,7 +649,11 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       },
       livekit: {
         url: `wss://${window.location.hostname}/livekit`,
-        selectiveSubscription: false,
+        selectiveSubscription: {
+          enabled: true,
+          audioSubscriptionPoolSize: 0,
+          muteDebounceMs: 2500,
+        },
         logLevel: LogLevel.warn,
         reconnectOnFatalFailures: false,
         roomOptions: {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -941,9 +941,8 @@ public:
     livekit:
       # livekit.url is the URL of the LiveKit server. Default value is 'wss://{window.location.hostname}/livekit'
       #url: wss://LIVEKIT_HOST/livekit
-      # livekit.selectiveSubscription: whether to use selective subscription all
-      # applicable track sources. Default value is false. This overrides autoSubscribe
-      # when set to true and in effect (conditional to client behavior).
+      # livekit.selectiveSubscription: whether to use selective subscription for all
+      # applicable track sources. This overrides autoSubscribe.
       selectiveSubscription:
         enabled: true
         # audioSubscriptionPoolSize: maximum number of simultaneously subscribed

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -944,7 +944,15 @@ public:
       # livekit.selectiveSubscription: whether to use selective subscription all
       # applicable track sources. Default value is false. This overrides autoSubscribe
       # when set to true and in effect (conditional to client behavior).
-      selectiveSubscription: true
+      selectiveSubscription:
+        enabled: true
+        # audioSubscriptionPoolSize: maximum number of simultaneously subscribed
+        # audio tracks. 0 means unlimited. Exemptions that may exceed the pool:
+        # screen audio, unmuted users.
+        audioSubscriptionPoolSize: 0
+        # muteDebounceMs: debounce time in milliseconds for mute state
+        # transitions that would trigger unsubscribe operations.
+        muteDebounceMs: 2500
       logLevel: 3
       # reconnectOnFatalFailures: whether to trigger LK room reconnections when
       # fatal errors occur (e.g.: unrecoverable publish timeouts). Default is false.


### PR DESCRIPTION
### What does this PR do?

**DEPENDS ON:**
- https://github.com/bigbluebutton/bigbluebutton/pull/24427
- https://github.com/bigbluebutton/bigbluebutton/pull/24506

**Changes:**
- [feat(livekit): add a last N-like system to selective subscription (audio](https://github.com/bigbluebutton/bigbluebutton/commit/e5c979dbe203b8d0b99e65500307ddc0fce3e006) 
  - All audio tracks are published and unpublished on mute actions *by
default*. This introduces some issues such as higher mute/unmute latency
and increased failure rates. It also has a few benefits, such as
forcefully constraining the number of concurrent subscribed tracks and
active recorded streams.
  - Mute/unmute latency specifically is a sore point. Having a smarter system
where tracks are not always unpublished on mute alleviates that, but we
need supporting mechanisms for that to scale properly (see benefits above).
  - Extend the selective subscription mechanism with a last N-like system
that constrains the number of concurrent subscribed streams. This can be
controlled by
`public.media.livekit.selectiveSubscription.audioSubscriptionPoolSize`,
which defines the subscription pool size (N). 0 means disabled
(unrestricted), which is the default configuration for now.
  - Screen share audio and unmuted tracks are exempted from the limit.
Remaining slots are filled by active speaker and recency of speech
priorities.
- [fix(livekit): edge cases in selective subscription routines (A/V)](https://github.com/bigbluebutton/bigbluebutton/commit/af0e8b2d13c2378e636c802695594e5d05720065) 
  - The selective subscription logic for both audio and video has some rough
edges after the recent media groups + public groups refactor, them
being:
    - Users in both public and explicit groups may are incorrectly
    excluded from public receivers; i.e.: won't be heard by the general
    public
    - Users that are not active in any explicit groups are not treated as
    public senders - but they should
    - Screen share audio tracks are incorrectly abiding to audio groups.
     While they're _audio_, their intrinsic media type is content/screen
    share. Screen share does not do selective subscription currently, so
    they should always be subscribed to

### Closes Issue(s)

None