### PR TITLE
fix(LAD): Legacy dasboard data files not working with newer version of BBB

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -156,7 +156,7 @@ class App extends React.Component {
     }
 
     // Calculate points of Raise hand
-    const usersRaiseHand = allUsers.map((currUser) => currUser.raiseHand.length);
+    const usersRaiseHand = allUsers.map((currUser) => currUser?.raiseHand?.length || 0);
     const maxRaiseHand = Math.max(...usersRaiseHand);
     const totalRaiseHand = usersRaiseHand.reduce((prev, val) => prev + val, 0);
     if (maxRaiseHand > 0) {
@@ -164,7 +164,7 @@ class App extends React.Component {
     }
 
     // Calculate points of Reactions
-    const usersReactions = allUsers.map((currUser) => currUser.reactions.length);
+    const usersReactions = allUsers.map((currUser) => currUser?.reactions?.length || 0);
     const maxReactions = Math.max(...usersReactions);
     const totalReactions = usersReactions.reduce((prev, val) => prev + val, 0);
     if (maxReactions > 0) {

--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -7,14 +7,14 @@ export function getActivityScore(user, allUsers, totalOfPolls) {
   let userPoints = 0;
 
   // Calculate points of Talking
-  const usersTalkTime = allUsersArr.map((currUser) => currUser?.talk?.totalTime || 0);
+  const usersTalkTime = allUsersArr.map((currUser) => currUser.talk.totalTime);
   const maxTalkTime = Math.max(...usersTalkTime);
   if (maxTalkTime > 0) {
     userPoints += (user.talk.totalTime / maxTalkTime) * 2;
   }
 
   // Calculate points of Chatting
-  const usersTotalOfMessages = allUsersArr.map((currUser) => currUser?.totalOfMessages || 0);
+  const usersTotalOfMessages = allUsersArr.map((currUser) => currUser.totalOfMessages);
   const maxMessages = Math.max(...usersTotalOfMessages);
   if (maxMessages > 0) {
     userPoints += (user.totalOfMessages / maxMessages) * 2;

--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -7,31 +7,31 @@ export function getActivityScore(user, allUsers, totalOfPolls) {
   let userPoints = 0;
 
   // Calculate points of Talking
-  const usersTalkTime = allUsersArr.map((currUser) => currUser.talk.totalTime);
+  const usersTalkTime = allUsersArr.map((currUser) => currUser?.talk?.totalTime || 0);
   const maxTalkTime = Math.max(...usersTalkTime);
   if (maxTalkTime > 0) {
     userPoints += (user.talk.totalTime / maxTalkTime) * 2;
   }
 
   // Calculate points of Chatting
-  const usersTotalOfMessages = allUsersArr.map((currUser) => currUser.totalOfMessages);
+  const usersTotalOfMessages = allUsersArr.map((currUser) => currUser?.totalOfMessages || 0);
   const maxMessages = Math.max(...usersTotalOfMessages);
   if (maxMessages > 0) {
     userPoints += (user.totalOfMessages / maxMessages) * 2;
   }
 
   // Calculate points of Raise hand
-  const usersRaiseHand = allUsersArr.map((currUser) => currUser.raiseHand.length);
+  const usersRaiseHand = allUsersArr.map((currUser) => currUser?.raiseHand?.length || 0);
   const maxRaiseHand = Math.max(...usersRaiseHand);
-  const userRaiseHand = user.raiseHand.length;
+  const userRaiseHand = user?.raiseHand?.length || 0;
   if (maxRaiseHand > 0) {
     userPoints += (userRaiseHand / maxRaiseHand) * 2;
   }
 
   // Calculate points of Reactions
-  const usersReactions = allUsersArr.map((currUser) => currUser.reactions.length);
+  const usersReactions = allUsersArr.map((currUser) => currUser?.reactions?.length || 0);
   const maxReactions = Math.max(...usersReactions);
-  const userReactions = user.reactions.length;
+  const userReactions = user?.reactions?.length || 0;
   if (maxReactions > 0) {
     userPoints += (userReactions / maxReactions) * 2;
   }


### PR DESCRIPTION

### What does this PR do?
This PR adds some default values to nested user objects when the nested object does not exist, preventing below error

<img width="1763" height="208" alt="image" src="https://github.com/user-attachments/assets/3de70126-806b-4db9-939c-a846bd377403" />

You will observe in screenshot here with BBB  2.7 that object was not being created/populated
<img width="672" height="65" alt="image" src="https://github.com/user-attachments/assets/fc1bedad-1bd2-4ead-a8c9-13238169486b" />

After fixing that there were few other locations with same error as above that this PR addresses 

### Closes Issue(s)
No open issues regarding this, I noticed this issue this morning and thought its easy and small change to address
Closes #

### Motivation
We recently upgraded all our servers from BBB2.7 -> BBB3.0 and realised the historic learning-analytics-dashboards do not work that was generated on BBB2.7, I saw it was just a simple nesting validation bug so decided it would be quick and easy to fix rather than submit an issue


### How to test
1. Download test.json
2. Create folder "test" in /bbb-learning-dashboard/public
3. Create folder "test" in /bbb-learning-dashboard/public/test
4. Copy [learning_dashboard_data.json](https://github.com/user-attachments/files/25926968/learning_dashboard_data.json) into /bbb-learning-dashboard/public/test/test
5. cd to /bbb-learning-dashboard/
6. run npm i
7. npm start
8. In browser open: http://localhost:3000/learning-analytics-dashboard/?meeting=test&report=test
9. Observe the page loads and data shows.


