### PR TITLE
fix(html5): Notifications being clipped on mobile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/toast/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/container.jsx
@@ -13,19 +13,22 @@ class ToastContainer extends React.Component {
     const { animations } = Settings.application;
 
     return (
-      <Styled.ToastifyContainer
-        closeButton={(<Styled.CloseIcon data-test="closeToastBtn" iconName="close" animations={animations} />)}
-        autoClose={5000}
-        toastClassName="toastClass"
-        bodyClassName="toastBodyClass"
-        progressClassName="toastProgressClass"
-        newestOnTop={false}
-        hideProgressBar={false}
-        closeOnClick
-        pauseOnHover
-        icon={false}
-        theme="colored"
-      />
+      <>
+        <Styled.ToastifyGlobalStyle />
+        <Styled.ToastifyContainer
+          closeButton={(<Styled.CloseIcon data-test="closeToastBtn" iconName="close" animations={animations} />)}
+          autoClose={5000}
+          toastClassName="toastClass"
+          bodyClassName="toastBodyClass"
+          progressClassName="toastProgressClass"
+          newestOnTop={false}
+          hideProgressBar={false}
+          closeOnClick
+          pauseOnHover
+          icon={false}
+          theme="colored"
+        />
+      </>
     );
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 import { ToastContainer as Toastify } from 'react-toastify';
 import Icon from '/imports/ui/components/common/icon/component';
 import {
@@ -118,7 +118,10 @@ const ToastMessage = styled.div`
   margin-bottom: auto;
   font-size: ${fontSizeSmall};
   max-height: 15vh;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overflow-wrap: break-word;
+  word-break: break-word;
   color: black !important;
   font-family: Arial, sans-serif;
 
@@ -179,25 +182,28 @@ const Toast = styled.div`
   `}
 `;
 
-const ToastifyContainer = styled(Toastify)`
-  z-index: 998;
-  position: fixed;
-  min-width: 240px !important;
-  max-width: 320px !important;
-  box-sizing: border-box;
-  right: ${jumboPaddingY};
-  left: auto;
-  top: 4.5rem;
-  max-height: 75vh;
-  overflow: hidden;
+const ToastifyContainer = Toastify;
 
-  [dir="rtl"] & {
-    right: auto;
-    left: ${jumboPaddingY};
+const ToastifyGlobalStyle = createGlobalStyle`
+  .Toastify__toast-container {
+    z-index: 998 !important;
+    position: fixed !important;
+    box-sizing: border-box !important;
+    right: ${jumboPaddingY} !important;
+    left: auto !important;
+    top: 4.5rem !important;
+    max-height: 75vh !important;
+    overflow: hidden !important;
+    /* Never exceed the available space between the right margin and the left viewport edge */
+    max-width: min(320px, calc(100vw - 2 * ${jumboPaddingY})) !important;
+    width: auto !important;
+    /* Make individual toasts fill the container instead of using their default fixed width */
+    --toastify-toast-width: 100%;
   }
 
-  @media ${smallOnly} {
-    width: 75%;
+  [dir="rtl"] .Toastify__toast-container {
+    right: auto !important;
+    left: ${jumboPaddingY} !important;
   }
 `;
 
@@ -210,4 +216,5 @@ export default {
   Separator,
   Toast,
   ToastifyContainer,
+  ToastifyGlobalStyle,
 };


### PR DESCRIPTION
### What does this PR do?
The bug happened because the react toastify changed how styles should be applied over the notifications.


### Closes Issue(s)
N/A

### How to test
- Create a meeting
- Join with a user on desk and one on mobile 
- generate a notification to appear on mobile


### More
Before:
![WhatsApp Image 2026-03-12 at 10 02 51](https://github.com/user-attachments/assets/6e3d7970-e712-4d36-a842-3b8f75a7a8bf)

After:
![WhatsApp Image 2026-03-12 at 10 42 28](https://github.com/user-attachments/assets/5ec48088-badd-49d5-9b61-726772fa48d4)

