### PR TITLE
chore: temporarily disable breakout audio transfer UI when using LiveKit

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/component.tsx
@@ -32,6 +32,7 @@ interface BreakoutRoomProps {
   meetingId: string;
   createdTime: number;
   isConnected: boolean;
+  audioBridge: string;
 }
 
 const intlMessages = defineMessages({
@@ -111,6 +112,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
   meetingId,
   createdTime,
   isConnected,
+  audioBridge,
 }) => {
   const [breakoutRoomEndAll] = useMutation(BREAKOUT_ROOM_END_ALL);
   const [breakoutRoomTransfer] = useMutation(USER_TRANSFER_VOICE_TO_MEETING);
@@ -253,7 +255,7 @@ const BreakoutRoom: React.FC<BreakoutRoomProps> = ({
                           )
                       }
                       {
-                      isModerator && (userJoinedAudio || userJoinedDialin)
+                      isModerator && (userJoinedAudio || userJoinedDialin) && audioBridge !== 'livekit'
                         ? [
                           ('|'),
                           (
@@ -300,6 +302,7 @@ const BreakoutRoomContainer: React.FC = () => {
   const {
     data: meetingData,
   } = useMeeting((m) => ({
+    audioBridge: m.audioBridge,
     durationInSeconds: m.durationInSeconds,
     createdTime: m.createdTime,
     meetingId: m.meetingId,
@@ -352,6 +355,7 @@ const BreakoutRoomContainer: React.FC = () => {
       meetingId={meetingData.meetingId ?? ''}
       createdTime={meetingData.createdTime ?? 0}
       isConnected={connected}
+      audioBridge={meetingData.audioBridge ?? 'livekit'}
     />
   );
 };


### PR DESCRIPTION
### What does this PR do?

- [chore: temporarily disable audio transfer when using LiveKit](https://github.com/bigbluebutton/bigbluebutton/commit/8a5752b13ad91b60c9f046a8ab5dcf81d1e5ab30) 
  - Temporarily disable breakout audio transfer UI when using LiveKit as it's
not fully implemented right now.
  - The valid substitute for now is for moderators to join breakouts
directly. The UI should not be shown if it's a no-op.

### Closes Issue(s)

None

### 

Ref: #21059 , #24546 