### PR TITLE
fix(conf): Avoid bbb-conf noise on empty bigbluebutton.properties

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -696,6 +696,8 @@ check_configuration() {
     ignore_configs_args+=(-e "redisPassword")
     ignore_configs_args+=(-e "disabledFeatures")
     ignore_configs_args+=(-e "pluginManifests")
+    ignore_configs_args+=(-e "fetchUrlBlockedExternalHosts")
+    ignore_configs_args+=(-e "fetchUrlAllowedLocalHosts")
 
     for file in $CONFIG_FILES ; do
         if [ ! -f $file ]; then


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
We introduced a couple new variables in BBB 3.0.23 - `fetchUrlBlockedExternalHosts`, `fetchUrlAllowedLocalHosts` which are empty by default. `bbb-conf` warns about it but it's not a concern.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Avoid noise like:

```
# Potential problems described below
# The following properties in /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties have no value:
#     fetchUrlBlockedExternalHosts
fetchUrlAllowedLocalHosts
```