### PR TITLE
fix(bbb-web): Disable External Entity Parsing in XML Services

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/XmlServiceImpl.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/impl/XmlServiceImpl.java
@@ -415,7 +415,13 @@ public class XmlServiceImpl implements XmlService {
     }
 
     private void setup() throws ParserConfigurationException {
-        if(factory == null) factory = DocumentBuilderFactory.newInstance();
+        if(factory == null) {
+            factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setExpandEntityReferences(false);
+        }
         if(builder == null) builder = factory.newDocumentBuilder();
     }
 

--- a/bbb-recording-imex/src/main/java/org/bigbluebutton/RecordingExportHandler.java
+++ b/bbb-recording-imex/src/main/java/org/bigbluebutton/RecordingExportHandler.java
@@ -88,6 +88,10 @@ public class RecordingExportHandler {
                 String xml = xmlService.recordingToXml(recording);
 
                 DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setExpandEntityReferences(false);
                 DocumentBuilder builder = factory.newDocumentBuilder();
                 Document document = builder.parse(new InputSource(new StringReader(xml)));
 


### PR DESCRIPTION
### What does this PR do?

Adds protection to recording XML parsing by disabling the parsing of external entities.

### Motivation

It is good practice to harden XML parsers by disabling features like external entity parsing.