### PR TITLE
fix(whiteboard): prevent presenter/viewer viewed-region desync after fullscreen

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -211,6 +211,7 @@ const Whiteboard = React.memo((props) => {
   const innerWrapperPollingFrameRef = React.useRef(null);
   const isMountedPollingFrameRef = React.useRef(null);
   const hasZoomSyncedRef = useRef(false);
+  const lastForcedViewRef = useRef(null);
   const currentUserRef = useRef(currentUser);
 
   currentUserRef.current = currentUser;
@@ -1745,11 +1746,55 @@ const Whiteboard = React.memo((props) => {
       }
 
       const camera = tlEditorRef.current.getCamera();
+
       const updatedCurrentCam = {
         ...camera,
         z: adjustedZoom,
       };
-      tlEditorRef.current.store.put([updatedCurrentCam]);
+      tlEditorRef.current.store.mergeRemoteChanges(() => {
+        tlEditorRef.current.store.put([updatedCurrentCam]);
+      });
+
+      // Remote camera updates do not trigger the user-source listener,
+      // so publish the final settled presenter view explicitly.
+      if (fitToWidthRef.current) {
+        requestAnimationFrame(() => {
+          const viewportPageBounds = tlEditorRef.current?.getViewportPageBounds();
+          if (!viewportPageBounds?.w || !viewportPageBounds?.h) {
+            return;
+          }
+
+          const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
+            viewportPageBounds.w,
+            currentPresentationPageRef.current?.scaledWidth,
+          );
+          const viewedRegionH = SlideCalcUtil.calcViewedRegionHeight(
+            viewportPageBounds.h,
+            currentPresentationPageRef.current?.scaledHeight,
+          );
+
+          const forcedView = {
+            pageId: curPageIdRef.current,
+            w: Number(viewedRegionW.toFixed(6)),
+            h: Number(viewedRegionH.toFixed(6)),
+            x: Number(updatedCurrentCam.x.toFixed(6)),
+            y: Number(updatedCurrentCam.y.toFixed(6)),
+          };
+
+          if (isEqual(lastForcedViewRef.current, forcedView)) {
+            return;
+          }
+
+          lastForcedViewRef.current = forcedView;
+          zoomSlide(
+            viewedRegionW,
+            viewedRegionH,
+            updatedCurrentCam.x,
+            updatedCurrentCam.y,
+            currentPresentationPageRef.current,
+          );
+        });
+      }
     } else {
       const newZoom = calculateZoomValue(
         scaledViewBoxWidth,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1764,6 +1764,13 @@ const Whiteboard = React.memo((props) => {
             return;
           }
 
+          const settledCamera = tlEditorRef.current?.getCamera();
+          if (!settledCamera) {
+            return;
+          }
+          const settledX = settledCamera.x;
+          const settledY = settledCamera.y;
+
           const viewedRegionW = SlideCalcUtil.calcViewedRegionWidth(
             viewportPageBounds.w,
             currentPresentationPageRef.current?.scaledWidth,
@@ -1777,8 +1784,8 @@ const Whiteboard = React.memo((props) => {
             pageId: curPageIdRef.current,
             w: Number(viewedRegionW.toFixed(6)),
             h: Number(viewedRegionH.toFixed(6)),
-            x: Number(updatedCurrentCam.x.toFixed(6)),
-            y: Number(updatedCurrentCam.y.toFixed(6)),
+            x: Number(settledX.toFixed(6)),
+            y: Number(settledY.toFixed(6)),
           };
 
           if (isEqual(lastForcedViewRef.current, forcedView)) {
@@ -1789,8 +1796,8 @@ const Whiteboard = React.memo((props) => {
           zoomSlide(
             viewedRegionW,
             viewedRegionH,
-            updatedCurrentCam.x,
-            updatedCurrentCam.y,
+            settledX,
+            settledY,
             currentPresentationPageRef.current,
           );
         });


### PR DESCRIPTION
### What does this PR do?

Ports #24735 to v3.0.

_Currently some zoom updates can leak to server when presenter enter/leaves presentation to fullscreen (maybe other cases also). It causes viewers and recording to have zoom, while presenter still see full slide._

_This commit prevent transient in-between camera/zoom values to be propagated, while still syncing the correct final state when needed (mainly fit-to-width)._