### PR TITLE
feat(conf): Warn about retired bbb-web properties

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -176,6 +176,22 @@ fi
 
 BBB_WEB_CONFIG="$SERVLET_DIR/WEB-INF/classes/bigbluebutton.properties"
 BBB_WEB_ETC_CONFIG="/etc/bigbluebutton/bbb-web.properties"
+
+# Properties that have been retired and should no longer be set by administrators.
+# bbb-conf --check will warn if any of these are found in $BBB_WEB_ETC_CONFIG.
+RETIRED_BBB_WEB_PROPERTIES=(
+    breakoutRoomsEnabled              # Removed in BBB 3.0
+    learningDashboardEnabled          # Removed in BBB 3.0
+    defaultGuestWaitURL               # Removed in BBB 3.0
+    pdfToSvgTimeout                   # Removed in BBB 3.0.13
+    pngCreationWait                   # Removed in BBB 3.0.13
+    maxConversionTime                 # Removed in BBB 3.0.15
+    pngCreationExecTimeoutInMs        # Renamed in BBB 3.0.17 (use pngCreationExecTimeout instead)
+    thumbnailCreationExecTimeoutInMs  # Renamed in BBB 3.0.17 (use thumbnailCreationExecTimeout instead)
+    textFileCreationExecTimeoutInMs   # Renamed in BBB 3.0.17 (use textFileCreationExecTimeout instead)
+    insertDocumentSupportedProtocols  # Renamed in BBB 3.0.23 (use fetchUrlSupportedProtocols instead)
+    insertDocumentBlockedHosts        # Renamed in BBB 3.0.23 (use fetchUrlBlockedExternalHosts instead)
+)
 NGINX_IP=$(cat /etc/nginx/sites-available/bigbluebutton | grep -v '#' | sed -n '/server_name/{s/.*server_name[ ]*//;s/;//;p}' | cut -d' ' -f1 | head -n 1)
 SIP_CONFIG=/usr/share/bigbluebutton/nginx/sip.nginx
 SIP_NGINX_IP=$(cat $SIP_CONFIG |  grep -v '#' | sed -n '/proxy_pass/{s/.*proxy_pass http[s]*:\/\///;s/:.*//;p}' | head -n 1)
@@ -793,6 +809,24 @@ check_configuration() {
        echo "#     https://docs.bigbluebutton.org/administration/firewall-configuration"
        echo "#"
        echo
+    fi
+
+    #
+    # Check for retired bbb-web properties that should no longer be used
+    #
+    RETIRED_FOUND=0
+    for prop in "${RETIRED_BBB_WEB_PROPERTIES[@]}"; do
+        if grep -q "^${prop}[[:space:]]*=" "$BBB_WEB_ETC_CONFIG" 2>/dev/null; then
+            if [ $RETIRED_FOUND -eq 0 ]; then
+                echo
+                echo "# Warning: The following retired bbb-web properties were found in $BBB_WEB_ETC_CONFIG and should be removed:"
+                RETIRED_FOUND=1
+            fi
+            echo "#   $prop"
+        fi
+    done
+    if [ $RETIRED_FOUND -eq 1 ]; then
+        echo
     fi
 
 }

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -408,6 +408,9 @@ Removed
 - `breakoutRoomsEnabled` removed (was previously deprecated)
 - `learningDashboardEnabled` removed (was previously deprecated)
 - `defaultGuestWaitURL` removed (now handled on the same page as the client)
+- `pdfToSvgTimeout` removed in BBB 3.0.13
+- `pngCreationWait` removed in BBB 3.0.13
+- `maxConversionTime` removed in BBB 3.0.15
 
 Value changed
 - `defaultHTML5ClientUrl` changed -- dropped the `/join` ending


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Introduces a list of removed bbb-web properties (starting with BBB 3.0) which should not be used. They were removed or renamed. Before this list was just a mention in the what's new docs, in release notes too. Now, it's part of the bbb-conf --check routine.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
BBB 3.0.23 comes with some bbb-web properties renamings

### How to test

Appending

```
insertDocumentBlockedHosts=localhost
breakoutRoomsEnabled=true
```

to `/etc/bigbluebutton/bbb-web.properties`

produces:

```
# Potential problems described below

# Warning: The following retired bbb-web properties were found in /etc/bigbluebutton/bbb-web.properties and should be removed:
#   breakoutRoomsEnabled
#   insertDocumentBlockedHosts

```

when `bbb-conf --check` is ran


### More

As per documentation, changes to config files should be limited to `/etc/bigbluebutton/*` overrides, not directly to the config files shipped with BBB packaging. This is the reason I am not checking bigbluebutton.properties.