### PR TITLE
ci: remove 3rd-party packages pull + install

### DIFF
--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -102,9 +102,7 @@ runs:
         sudo -i <<EOF
         set -e
         apt install -yq dpkg-dev
-        cd /root && wget -nv http://ci.bbb.imdt.dev/cache-3rd-part-packages.tar
         cp -r /home/runner/work/bigbluebutton/bigbluebutton/artifacts/ /artifacts/
-        cd /artifacts && tar xf /root/cache-3rd-part-packages.tar
         cd /artifacts && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
         echo "deb [trusted=yes] file:/artifacts/ ./" >> /etc/apt/sources.list
         EOF


### PR DESCRIPTION
### What does this PR do?

- [ci: remove 3rd-party packages pull + install](https://github.com/bigbluebutton/bigbluebutton/commit/47083c9a1b17c4cb62c860daa5f2a29215e7952d) 
  - When inspecting test artifacts, I found an assortment of gstreamer,
boost and KMS packages in them that should not be present as they're all
Kurento related and should not exist in 3.0.
  - I traced it back to the install-bbb action's "Setup local repository"
step, which pulls those dependency packages from an externally-sourced
tarball. I do not think any of those are necessary anymore, so this
commits remove both the download and installation of the above. Let's see
if CI agrees.

List of externally sourced packages:
- libx264-152_0.152.2854+gite9a5903-2_amd64.deb
- gstreamer1.0-nice_0.1.18-0kurento1.20.04_amd64.deb
- libnice10_0.1.18-0kurento1.20.04_amd64.deb
- gstreamer1.5-nice_0.1.18-0kurento1.20.04_amd64.deb
- gir1.2-nice-0.1_0.1.18-0kurento1.20.04_amd64.deb
- libmimic0_1.0.4-2.3_amd64.deb
- openwebrtc-gst-plugins_0.10.0-1kurento1.20.04_amd64.deb
- openh264-gst-plugin_1.0.0-0kurento1.20.04_amd64.deb
- libssl1.0.0_1.0.2n-1ubuntu5.7_amd64.deb
- openh264_1.5.0-0kurento1.20.04_amd64.deb
- srtp-docs_1.6.0-0kurento1.20.04_all.deb
- libsrtp0_1.6.0-0kurento1.20.04_amd64.deb
- srtp-utils_1.6.0-0kurento1.20.04_amd64.deb
- libboost-log1.65.1_1.65.1+dfsg-0ubuntu5_amd64.deb
- libboost-filesystem1.65.1_1.65.1+dfsg-0ubuntu5_amd64.deb
- libboost-regex1.65.1_1.65.1+dfsg-0ubuntu5_amd64.deb
- libboost-program-options1.65.1_1.65.1+dfsg-0ubuntu5_amd64.deb
- libboost-system1.65.1_1.65.1+dfsg-0ubuntu5_amd64.deb
- libboost-thread1.65.1_1.65.1+dfsg-0ubuntu5_amd64.deb
- libicu60_60.2-3ubuntu3.2_amd64.deb
- libusrsctp_0.9.2-1kurento1.20.04_amd64.deb
- gstreamer1.5-plugins-ugly_1.8.1-1kurento1.20.04_amd64.deb
- libgstreamer1.5-0_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-tools_1.8.1-1kurento2.20.04_amd64.deb
- gir1.2-gstreamer-1.5_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-pulseaudio_1.8.1-1kurento5.20.04_amd64.deb
- gstreamer1.5-plugins-good_1.8.1-1kurento5.20.04_amd64.deb
- gstreamer1.5-plugins-bad_1.8.1-1kurento5.20.04_amd64.deb
- gir1.2-gst-plugins-bad-1.5_1.8.1-1kurento5.20.04_amd64.deb
- openh264-gst-plugins-bad-1.5_1.8.1-1kurento5.20.04_amd64.deb
- libgstreamer-plugins-bad1.5-0_1.8.1-1kurento5.20.04_amd64.deb
- gir1.2-gst-plugins-base-1.5_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-alsa_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-plugins-base-apps_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-x_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-plugins-base_1.8.1-1kurento2.20.04_amd64.deb
- libgstreamer-plugins-base1.5-0_1.8.1-1kurento2.20.04_amd64.deb
- gstreamer1.5-libav_1.8.1-1kurento1.20.04_amd64.deb
- kms-filters_6.16.0-0kurento1.20.04_amd64.deb
- kmsjsoncpp_1.6.3-1kurento1.20.04_amd64.deb
- kms-elements_6.16.0-0kurento1.20.04_amd64.deb
- kms-core_6.16.0-0kurento1.20.04_amd64.deb
- kurento-module-creator_6.16.0-0kurento1.20.04_all.deb
- kms-jsonrpc_6.16.0-0kurento1.20.04_amd64.deb
- kurento-media-server_6.16.0-0kurento1.20.04_amd64.deb


### Closes Issue(s)

None