### PR TITLE
Ref(html5): Remove non-used settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -13,7 +13,6 @@ export interface Public {
   app: App
   externalVideoPlayer: ExternalVideoPlayer
   kurento: Kurento
-  syncUsersWithConnectionManager: SyncUsersWithConnectionManager
   poll: Poll
   captions: Captions
   timer: Timer
@@ -29,7 +28,6 @@ export interface Public {
   whiteboard: Whiteboard
   clientLog: ClientLog
   virtualBackgrounds: VirtualBackgrounds
-  minBrowserVersions: MinBrowserVersions
 }
 export interface Locales {
   locale: string
@@ -38,7 +36,6 @@ export interface Locales {
 export interface App {
   mobileFontSize: string
   desktopFontSize: string
-  audioChatNotification: boolean
   autoJoin: boolean
   listenOnlyMode: boolean
   forceListenOnly: boolean
@@ -46,7 +43,6 @@ export interface App {
   skipCheckOnJoin: boolean
   enableDynamicAudioDeviceSelection: boolean
   clientTitle: string
-  appName: string
   bbbServerVersion: string
   displayBbbServerVersion: boolean
   copyright: string
@@ -83,7 +79,6 @@ export interface App {
   warnAboutUnsavedContentOnMeetingEnd: boolean
   audioCaptions: AudioCaptions
   mutedAlert: MutedAlert
-  remainingTimeThreshold: number
   remainingTimeAlertThresholdArray: number[]
   enableDebugWindow: boolean
   breakouts: Breakouts
@@ -99,9 +94,7 @@ export interface App {
   branding: Branding
   connectionTimeout: number
   showHelpButton: boolean
-  effectiveConnection: string[]
   fallbackOnEmptyLocaleString: boolean
-  disableWebsocketFallback: boolean
   maxMutationPayloadSize: number
   enableApolloDevTools: boolean
   terminateAndRetryConnection: number
@@ -324,7 +317,7 @@ export interface Kurento {
 }
 
 export interface CameraWsOptions {
-  wsConnectionTimeout: number
+  connectionTimeout: number
   maxRetries: number
   debug: boolean
   heartbeat: Heartbeat
@@ -461,11 +454,6 @@ export interface DesktopPageSizes2 {
   viewer: number
 }
 
-export interface SyncUsersWithConnectionManager {
-  enabled: boolean
-  syncInterval: number
-}
-
 export interface Poll {
   enabled: boolean
   allowCustomResponseInput: boolean
@@ -480,16 +468,11 @@ export interface Poll {
 }
 
 export interface Captions {
-  enabled: boolean
-  id: string
-  dictation: boolean
   background: string
   font: Font
   lines: number
   time: number
   locales: Locales[]
-  defaultPad: string
-  showButton: boolean
   lineLimit: number
   captionLimit: number
 }
@@ -500,14 +483,7 @@ export interface Font {
   size: string
 }
 
-export interface Timer {
-  enabled: boolean
-  alarm: boolean
-  music: Music
-  time: number
-}
-
-export interface Music {
+export interface TimerMusic {
   enabled: boolean
   volume: number
   track1: string
@@ -515,16 +491,19 @@ export interface Music {
   track3: string
 }
 
+export interface Timer {
+  enabled: boolean
+  time: number
+  music: TimerMusic
+}
+
 export interface Chat {
   enabled: boolean
   itemsPerPage: number
-  timeBetweenFetchs: number
   enableSaveAndCopyPublicChat: boolean
-  bufferChatInsertsMs: number
   startClosed: boolean
   min_message_length: number
   max_message_length: number
-  grouping_messages_window: number
   type_system: string
   type_public: string
   type_private: string
@@ -834,18 +813,14 @@ export interface VirtualBackgrounds {
 export interface Private {
   analytics: Analytics
   app: App2
-  prometheus: Prometheus
 }
 
-export interface Analytics {
-  includeChat: boolean
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Analytics {}
 
 export interface App2 {
   host: string
   localesUrl: string
-  pencilChunkLength: number
-  loadSlidesFromHttpAlways: boolean
 }
 
 export interface Metrics {
@@ -858,25 +833,6 @@ export interface Metrics {
 export interface Channels {
   toAkkaApps: string
   toThirdParty: string
-}
-
-export interface mobileBrowsers {
-  safari: string
-  chrome: string
-}
-
-export interface MinBrowserVersions {
-  safari: string
-  chrome: string
-  firefox: string
-  edge: string
-  mobile: mobileBrowsers
-}
-
-export interface Prometheus {
-  enabled: boolean
-  path: string
-  collectDefaultMetrics: boolean
 }
 
 export default MeetingClientSettings;

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -815,8 +815,7 @@ export interface Private {
   app: App2
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Analytics {}
+export type Analytics = Record<string, never>
 
 export interface App2 {
   host: string

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -7,7 +7,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       terminateAndRetryConnection: 30000,
       mobileFontSize: '16px',
       desktopFontSize: '14px',
-      audioChatNotification: false,
       autoJoin: true,
       listenOnlyMode: true,
       forceListenOnly: false,
@@ -15,7 +14,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       skipCheckOnJoin: false,
       enableDynamicAudioDeviceSelection: true,
       clientTitle: 'BigBlueButton',
-      appName: 'BigBlueButton HTML5 Client',
       bbbServerVersion: 'HTML5_FULL_BBB_VERSION',
       displayBbbServerVersion: true,
       copyright: '©2023 BigBlueButton Inc.',
@@ -82,7 +80,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         threshold: -50,
         duration: 4000,
       },
-      remainingTimeThreshold: 30,
       remainingTimeAlertThresholdArray: [
         1,
         5,
@@ -203,13 +200,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       },
       connectionTimeout: 60000,
       showHelpButton: true,
-      effectiveConnection: [
-        'critical',
-        'danger',
-        'warning',
-      ],
       fallbackOnEmptyLocaleString: true,
-      disableWebsocketFallback: true,
       maxMutationPayloadSize: 10485760, // 10MB
       timeoutBeforeRedirectOnMeetingEnd: 20000,
       showConnectionErrors: [3001, 3002, 3003, 3004, 3005, 3006],
@@ -220,7 +211,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     kurento: {
       wsUrl: 'HOST',
       cameraWsOptions: {
-        wsConnectionTimeout: 4000,
+        connectionTimeout: 4000,
         maxRetries: 7,
         debug: false,
         heartbeat: {
@@ -474,10 +465,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         ],
       },
     },
-    syncUsersWithConnectionManager: {
-      enabled: false,
-      syncInterval: 60000,
-    },
     poll: {
       enabled: true,
       allowCustomResponseInput: true,
@@ -491,9 +478,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       },
     },
     captions: {
-      enabled: true,
-      id: 'captions',
-      dictation: false,
       background: '#000000',
       font: {
         color: '#ffffff',
@@ -508,14 +492,12 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       ],
       lines: 2,
       time: 5000,
-      showButton: false,
-      defaultPad: 'en',
       captionLimit: 3,
       lineLimit: 60,
     },
     timer: {
       enabled: true,
-      alarm: true,
+      time: 5,
       music: {
         enabled: false,
         volume: 0.4,
@@ -523,18 +505,14 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         track2: 'CalmMusic',
         track3: 'aristocratDrums',
       },
-      time: 5,
     },
     chat: {
       enabled: true,
       itemsPerPage: 100,
-      timeBetweenFetchs: 1000,
       enableSaveAndCopyPublicChat: true,
-      bufferChatInsertsMs: 0,
       startClosed: false,
       min_message_length: 1,
       max_message_length: 5000,
-      grouping_messages_window: 10000,
       type_system: 'SYSTEM_MESSAGE',
       type_public: 'PUBLIC_ACCESS',
       type_private: 'PRIVATE_ACCESS',
@@ -941,16 +919,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         'board.jpg',
       ],
     },
-    minBrowserVersions: {
-      safari: '>=14',
-      chrome: '>=87',
-      firefox: '>=80',
-      edge: '>=85',
-      mobile: {
-        safari: '>=14',
-        chrome: '>=87',
-      },
-    },
   },
   private: {
     analytics: {
@@ -959,13 +927,6 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     app: {
       host: '127.0.0.1',
       localesUrl: '/locale-list',
-      pencilChunkLength: 100,
-      loadSlidesFromHttpAlways: false,
-    },
-    prometheus: {
-      enabled: false,
-      path: '/metrics',
-      collectDefaultMetrics: false,
     },
   },
 };

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -921,9 +921,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     },
   },
   private: {
-    analytics: {
-      includeChat: true,
-    },
+    analytics: {},
     app: {
       host: '127.0.0.1',
       localesUrl: '/locale-list',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -591,8 +591,6 @@ public:
       enabled: true
       quickPollCorrectAnswerSuffix: "__"
   captions:
-    enabled: true
-    showButton: true
     background: '#000000'
     font:
       color: '#ffffff'
@@ -733,7 +731,7 @@ public:
     enabled: true
     time: 10
     music:
-      enabled: true
+      enabled: false
       volume: 0.4
       track1: "RelaxingMusic"
       track2: "CalmMusic"

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -2,7 +2,6 @@ public:
   app:
     mobileFontSize: 16px
     desktopFontSize: 14px
-    audioChatNotification: false
     # Shows the audio modal when user joins the room. The audio modal prompts
     # user to select an option ("Microphone" and/or "Listen only") for joining
     # audio
@@ -28,7 +27,6 @@ public:
     #
     skipEchoTestIfPreviousDevice: false
     clientTitle: BigBlueButton
-    appName: BigBlueButton HTML5 Client
     bbbServerVersion: HTML5_FULL_BBB_VERSION
     displayBbbServerVersion: true
     copyright: '©2026 BigBlueButton Inc.'
@@ -129,7 +127,6 @@ public:
       interval: 200
       threshold: -50
       duration: 4000
-    remainingTimeThreshold: 30
     remainingTimeAlertThresholdArray: [1,5]
     enableDebugWindow: true
     # Warning: increasing the limit of breakout rooms per meeting
@@ -292,15 +289,10 @@ public:
       displayBrandingArea: true
     connectionTimeout: 60000
     showHelpButton: true
-    effectiveConnection:
-      - critical
-      - danger
-      - warning
     # Whether the fallback mechanism should be used
     # when the locale string is empty. If false, the empty
     # string will be returned.
     fallbackOnEmptyLocaleString: true
-    disableWebsocketFallback: true
     # Maximum number of bytes allowed in each mutation message payload.
     # Defaults to 10485760 (10MB)
     maxMutationPayloadSize: 10485760
@@ -323,12 +315,8 @@ public:
   kurento:
     wsUrl: HOST
     cameraWsOptions:
-      # Valid for video-provider. Time (ms) before its WS connection times out
-      # and tries to reconnect.
-      wsConnectionTimeout: 4000
-      # maxRetries: max reconnection retries
+      connectionTimeout: 4000
       maxRetries: 7
-      # debug: console trace logging for video-provider's ws
       debug: false
       heartbeat:
         interval: 15000
@@ -592,9 +580,6 @@ public:
           desktopPageSizes:
             moderator: 6
             viewer: 4
-  syncUsersWithConnectionManager:
-    enabled: false
-    syncInterval: 60000
   poll:
     enabled: true
     allowCustomResponseInput: true
@@ -607,8 +592,7 @@ public:
       quickPollCorrectAnswerSuffix: "__"
   captions:
     enabled: true
-    id: captions
-    dictation: false
+    showButton: true
     background: '#000000'
     font:
       color: '#ffffff'
@@ -622,9 +606,6 @@ public:
     lines: 2
     # time the captions will hang on screen after last updated
     time: 5000
-    # Default pad which will store automatically generated captions
-    defaultPad: en
-    showButton: false
     locales:
       - locale: "af"
         name: "Afrikaans"
@@ -750,24 +731,20 @@ public:
         name: "中文（台灣"
   timer:
     enabled: true
-    alarm: true
+    time: 5
     music:
-      enabled: false
+      enabled: true
       volume: 0.4
       track1: "RelaxingMusic"
       track2: "CalmMusic"
       track3: "aristocratDrums"
-    time: 5
   chat:
     enabled: true
     itemsPerPage: 100
-    timeBetweenFetchs: 1000
     enableSaveAndCopyPublicChat: true
-    bufferChatInsertsMs: 0
     startClosed: false
     min_message_length: 1
     max_message_length: 5000
-    grouping_messages_window: 10000
     type_system: SYSTEM_MESSAGE
     type_public: PUBLIC_ACCESS
     type_private: PRIVATE_ACCESS
@@ -972,7 +949,6 @@ public:
         adaptiveStream: true
         dynacast: true
         stopLocalTrackOnUnpublish: false
-        singlePeerConnection: false
       audio:
         # unpublishOnMute: whether to unpublish audio tracks when muted. Default is true.
         unpublishOnMute: true
@@ -1008,7 +984,6 @@ public:
       danger: 1000
       critical: 2000
     help: STATS_HELP_URL
-    lastEntriesCap: 20
   presentation:
     allowDownloadOriginal: true
     allowDownloadWithAnnotations: true
@@ -1196,18 +1171,7 @@ public:
       - coffeeshop.jpg
       - board.jpg
 private:
-  analytics:
-    includeChat: true
+  analytics: {}
   app:
     host: 127.0.0.1
     localesUrl: /locale-list
-    pencilChunkLength: 100
-    loadSlidesFromHttpAlways: false
-  # Direct Prometheus instrumentation.
-  # EXPERIMENTAL, so disabled by default.
-  prometheus:
-    enabled: false
-    # Metrics endpoint path
-    path: '/metrics'
-    # Whether default metrics for Node.js processes should be exported
-    collectDefaultMetrics: false

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -729,7 +729,7 @@ public:
         name: "中文（台灣"
   timer:
     enabled: true
-    time: 10
+    time: 5
     music:
       enabled: false
       volume: 0.4

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -731,7 +731,7 @@ public:
         name: "中文（台灣"
   timer:
     enabled: true
-    time: 5
+    time: 10
     music:
       enabled: true
       volume: 0.4
@@ -949,6 +949,7 @@ public:
         adaptiveStream: true
         dynacast: true
         stopLocalTrackOnUnpublish: false
+        singlePeerConnection: false
       audio:
         # unpublishOnMute: whether to unpublish audio tracks when muted. Default is true.
         unpublishOnMute: true


### PR DESCRIPTION
### What does this PR do?
Removed  settings I didn't find references through system

  public.app                                                                                                                                                                                                                   
  - audioChatNotification - being handle on defaultSettings.chatAudioAlerts
  - appName  - not used                                                                                                                                                                                                      
  - remainingTimeThreshold  - not used  
  - effectiveConnection - not used 
  - disableWebsocketFallback - not used

  public.syncUsersWithConnectionManager (entire section)
  - enabled
  - syncInterval

  public.captions - mostly of them removed -  - removed here https://github.com/bigbluebutton/bigbluebutton/pull/20050
  - enabled
  - id
  - dictation
  - defaultPad
  - showButton

  public.timer
  - alarm - not used

  public.chat - Meteor chat stream
  - timeBetweenFetchs - not used
  - bufferChatInsertsMs - not used
  - grouping_messages_window - not used

  private.app
  - pencilChunkLength
  - loadSlidesFromHttpAlways

  private.prometheus (entire section): Meteor server prometheus
  - enabled
  - path
  - collectDefaultMetrics
