### PR TITLE
fix(actions-bar): removes ShareScreen in ations bar for mobile view

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -205,7 +205,7 @@ class ActionsBar extends PureComponent {
                 <JoinVideoOptionsContainer />
               )
               : null}
-            {shouldShowPresentationButton && (
+            {shouldShowPresentationButton && !isMobile && (
               <ScreenshareButtonContainer {...{
                 amIPresenter,
                 isConnected,


### PR DESCRIPTION
### What does this PR do?
Don't show 'Share screen' icon action bar in mobile view


### Closes Issue(s)
Closes None


### More
<img width="788" height="983" alt="image" src="https://github.com/user-attachments/assets/1fe390b5-3302-45a8-bae6-0451647fe043" />