### PR TITLE
fix: restore WebRTC compat check, localization and UI in unsupported UA screen

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -221,14 +221,24 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           var firefoxVersion = parseVersion(/Firefox\/(\d+)/);
           var edgeVersion = parseVersion(/Edg\/(\d+)/);
           var miuiVersion = parseVersion(/MiuiBrowser\/(\d+)/);
-
-          var supported = !(
+          // WebRTC support check is based on LiveKit's isBrowserSupported util
+          var supportsWebRTC = !!(
+            typeof RTCPeerConnection !== 'undefined'
+            && RTCPeerConnection
+            && navigator.mediaDevices
+            && RTCPeerConnection.prototype
+            && 'addTransceiver' in RTCPeerConnection.prototype
+            && 'addTrack' in RTCPeerConnection.prototype
+          );
+          var supportedUA = !(
             (safariVersion && safariVersion < MIN_VERSIONS.safari) ||
             (chromeVersion && chromeVersion < MIN_VERSIONS.chrome) ||
             (firefoxVersion && firefoxVersion < MIN_VERSIONS.firefox) ||
             (edgeVersion && edgeVersion < MIN_VERSIONS.edge)||
             (miuiVersion !== null)
           );
+          var supported = supportedUA && supportsWebRTC;
+
 
           if (supported) {
             var bundleHash = '<%= bundleHash %>';

--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -210,25 +210,27 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             return match ? parseInt(match[1], 10) : null;
           }
 
+          function replaceLocalePlaceholders(msg) {
+              return msg
+                .replace('{supportedBrowser1}', CHROME_LINK)
+                .replace('{supportedBrowser2}', FIREFOX_LINK);
+          }
+
           var safariVersion = parseVersion(/Version\/(\d+).*Safari/);
           var chromeVersion = parseVersion(/(?:Chrome|CriOS)\/(\d+)/);
           var firefoxVersion = parseVersion(/Firefox\/(\d+)/);
           var edgeVersion = parseVersion(/Edg\/(\d+)/);
           var miuiVersion = parseVersion(/MiuiBrowser\/(\d+)/);
 
-          var tooOld =
+          var supported = !(
             (safariVersion && safariVersion < MIN_VERSIONS.safari) ||
             (chromeVersion && chromeVersion < MIN_VERSIONS.chrome) ||
             (firefoxVersion && firefoxVersion < MIN_VERSIONS.firefox) ||
             (edgeVersion && edgeVersion < MIN_VERSIONS.edge)||
-            (miuiVersion !== null);
+            (miuiVersion !== null)
+          );
 
-          if (tooOld) {
-            var banner = document.createElement('p');
-            banner.className = 'browserWarning';
-            banner.innerHTML = 'It looks like you&#39;re using a browser that is not fully supported. Please use either <a href="https://www.google.com/chrome/" rel="noopener noreferrer">Chrome</a> or <a href="https://getfirefox.com" rel="noopener noreferrer">Firefox</a> for full support.';
-            document.getElementById('app').appendChild(banner);
-          } else {
+          if (supported) {
             var bundleHash = '<%= bundleHash %>';
             var isProduction = '<%= isProduction %>' === 'true';
             var script = document.createElement('script');
@@ -241,6 +243,120 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             }
 
             document.head.appendChild(script);
+          } else {
+            var msgKey;
+
+            if (miuiVersion !== null) {
+              msgKey = 'app.legacy.unsupportedBrowser';
+            } else if (isSafari && safariVersion && safariVersion < MIN_VERSIONS.safari) {
+              msgKey = 'app.legacy.unsupportedSafari';
+            } else if (chromeVersion || firefoxVersion || edgeVersion) {
+              msgKey = 'app.legacy.upgradeBrowser';
+            } else {
+              msgKey = 'app.legacy.unsupportedBrowser';
+            }
+
+            var CHROME_LINK = '<a href="https://www.google.com/chrome/" rel="noopener noreferrer">Chrome</a>';
+            var FIREFOX_LINK = '<a href="https://getfirefox.com" rel="noopener noreferrer">Firefox</a>';
+            var FALLBACK = {};
+            FALLBACK['app.legacy.unsupportedBrowser'] = replaceLocalePlaceholders('It looks like you\'re using a browser that is not supported. Please use a recent version of either {supportedBrowser1} or {supportedBrowser2} for full support.');
+            FALLBACK['app.legacy.upgradeBrowser'] = 'It looks like you\'re using an older version of a supported browser. Please upgrade your browser to a recent version for full support.';
+            FALLBACK['app.legacy.unsupportedSafari'] = 'Please upgrade your browser to Safari 14 or newer for full support.';
+
+            var banner = document.createElement('p');
+            banner.className = 'browserWarning';
+            banner.innerHTML = FALLBACK[msgKey];
+            document.getElementById('app').appendChild(banner);
+
+            // Manual locale fetching so the unsupported browser page is localized
+            // This is a simplified version of what intlLoader does, minus:
+            // - locale merging: see hardcoded english fallbacks
+            // - handling of user-defined language preferences (no access to cli settings etc)
+            var RTL_LANGS = ['ar', 'dv', 'fa', 'he'];
+            var browserLang = (navigator.languages && navigator.languages[0]) || navigator.language || 'en';
+            var langParts = browserLang.replace(/-/g, '_').split('_');
+
+            function applyLocale(messages) {
+              var msg = messages[msgKey];
+
+              if (!msg) return;
+
+              banner.innerHTML = replaceLocalePlaceholders(msg);
+
+              if (RTL_LANGS.indexOf(langParts[0]) !== -1) {
+                banner.setAttribute('dir', 'rtl');
+              }
+            }
+
+            function tryFetchLocale(candidates, index) {
+              if (index >= candidates.length) return;
+
+              fetch('locales/' + candidates[index] + '.json?v=VERSION')
+                .then(function (resp) {
+                  if (!resp.ok) throw new Error('not found');
+
+                  return resp.json();
+                })
+                .then(applyLocale)
+                .catch(function () {
+                  tryFetchLocale(candidates, index + 1);
+                });
+            }
+
+            function buildCandidates(parts, localeFiles) {
+              if (!localeFiles) {
+                var guesses = [];
+                if (parts.length > 1) {
+                  guesses.push(parts[0] + '_' + parts[1].toUpperCase());
+                }
+                guesses.push(parts[0]);
+                return guesses;
+              }
+
+              var available = localeFiles.map(function (f) {
+                return f.replace('.json', '');
+              });
+              var candidates = [];
+
+              if (parts.length > 1) {
+                var exact = parts[0] + '_' + parts[1].toUpperCase();
+                if (available.indexOf(exact) !== -1) {
+                  candidates.push(exact);
+                }
+              }
+
+              if (available.indexOf(parts[0]) !== -1) {
+                candidates.push(parts[0]);
+              }
+
+              for (var j = 0; j < available.length; j++) {
+                if (available[j].split('_')[0] === parts[0] && candidates.indexOf(available[j]) === -1) {
+                  candidates.push(available[j]);
+                  break;
+                }
+              }
+
+              return candidates;
+            }
+
+            if (typeof fetch === 'function' && langParts[0] !== 'en') {
+              fetch('locales/index.json?v=VERSION')
+                .then(function (resp) {
+                  if (!resp.ok) throw new Error('index not found');
+                  return resp.json();
+                })
+                .then(function (localeFiles) {
+                  return buildCandidates(langParts, localeFiles);
+                })
+                .catch(function () {
+                  return buildCandidates(langParts, null);
+                })
+                .then(function (candidates) {
+                  if (candidates.length > 0) {
+                    tryFetchLocale(candidates, 0);
+                  }
+                });
+            }
           }
 
           

--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -119,6 +119,30 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     .fade-out {
       opacity: 0 !important;
     }
+
+    .browserWarning {
+      border: 5px solid #F3F6F9;
+      border-radius: 0.5rem;
+      color: #F3F6F9;
+      text-align: center;
+      width: 500px;
+      position: fixed;
+      left: 50%;
+      margin-left: -250px;
+      top: 50%;
+      margin-top: -4rem;
+      font-size: 1.5rem;
+      padding: 10px;
+      font-family: 'Source Sans Pro', Arial, sans-serif;
+    }
+
+    @media only screen and (max-width: 40em) {
+      .browserWarning {
+        width: 95%;
+        left: 2.5%;
+        margin-left: 0;
+      }
+    }
   </style>
   <script>
     document.addEventListener('gesturestart', function (e) {
@@ -200,10 +224,10 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
             (miuiVersion !== null);
 
           if (tooOld) {
-            var banner = document.createElement('div');
-            banner.innerHTML = '<strong>Browser not supported</strong><br>Please update your browser or contact support service.';
-            banner.style.cssText = 'background:#ffdddd;color:#a00;padding:1em;margin:1em 0;text-align:center;font-family:sans-serif;';
-            document.body.insertBefore(banner, document.body.firstChild);
+            var banner = document.createElement('p');
+            banner.className = 'browserWarning';
+            banner.innerHTML = 'It looks like you&#39;re using a browser that is not fully supported. Please use either <a href="https://www.google.com/chrome/" rel="noopener noreferrer">Chrome</a> or <a href="https://getfirefox.com" rel="noopener noreferrer">Firefox</a> for full support.';
+            document.getElementById('app').appendChild(banner);
           } else {
             var bundleHash = '<%= bundleHash %>';
             var isProduction = '<%= isProduction %>' === 'true';

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1526,7 +1526,6 @@
     "app.actionsBar.actionsDropdown.stopShareExternalVideo": "Stop sharing external video",
     "app.legacy.unsupportedBrowser": "It looks like you're using a browser that is not supported. Please use a recent version of either {supportedBrowser1} or {supportedBrowser2} for full support.",
     "app.legacy.upgradeBrowser": "It looks like you're using an older version of a supported browser. Please upgrade your browser to a recent version for full support.",
-    "app.legacy.criosBrowser": "On iOS please use a recent version of Safari for full support.",
     "app.legacy.unsupportedSafari": "Please upgrade your browser to Safari 14 or newer for full support.",
     "app.debugWindow.windowTitle": "Debug",
     "app.debugWindow.form.userAgentLabel": "User Agent",


### PR DESCRIPTION
### What does this PR do?

- [fix: restore unsupported browser screen UI to match previous design](https://github.com/bigbluebutton/bigbluebutton/pull/24763/commits/103756fd51474f8b2182080c831ebc43ded94ab0)
  - Restore the old UI design of the unsupported user agent screen - adapted
for use in an HTML-only environment
- [fix: add locale support for unsupported browser screen](https://github.com/bigbluebutton/bigbluebutton/pull/24763/commits/04490d1da0da16edfa98a33038e92a04b5c96c8a) 
  - Recent changes to the unsupported UA screen made it drop localization -
the warning message is hardcoded to English. This is a regression of sorts
and not ideal for an error screen.
  - Add localization back to the unsupported UA view. The implementation
here is a crude version of what intlAdapter does - adapted for the
"React-less" main.html.
- [fix: restore WebRTC compatibility check in UA blocker](https://github.com/bigbluebutton/bigbluebutton/commit/199d96a69beeb5cedf1eb947da99cc04dcf34e38) 
  - The unsupported UA screen had a WebRTC check that was inadvertently
  removed once it was refactored into the main.html page.
  - The runtime check for WebRTC API support in the browser alongside the
  existing user-agent version check is necessary because some user
  agents lacking proper WebRTC support were bypassing the user-agent-based
  block.
  - Restore the WebRTC check introduced originally in commit https://github.com/bigbluebutton/bigbluebutton/commit/3f8542c1457bd7026bf27c643f8e08bd13dfaf1e.
  This includes porting the isBrowserSupported check logic from livekit-client.
- [refactor: remove unused app.legacy.criosBrowser locale](https://github.com/bigbluebutton/bigbluebutton/pull/24763/commits/b17e265a96e275cb8ad2e1986fa491688284d27b)

### Closes Issue(s)

None, reported internally

### More

Current:
<img width="746" height="407" alt="image" src="https://github.com/user-attachments/assets/b5e25d48-f121-427f-87b9-214d8fd3226a" />


New (based on how it was <= v3.0.17):
<img width="746" height="424" alt="image" src="https://github.com/user-attachments/assets/92f00dc4-83ff-4e94-9b5e-e0b653a0b6af" />


