### PR TITLE
fix(html5: remove empty guest-lobby gap and adjust leave button spacing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/leave-meeting-button/styles.js
@@ -21,11 +21,6 @@ const LeaveButton = styled(Button)`
   }
 `}
 
-  ${({ $isMobile }) => !$isMobile && `
-    margin-left: 1.0rem;
-    margin-right: 0.5rem;
-  `}
-
   ${({ state }) => state === 'closed' && `
     z-index: 3;
     display: flex;

--- a/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/guest-management/waiting-users/styles.ts
@@ -115,7 +115,7 @@ const Users = styled.div`
 const Panel = styled.div<PanelProps>`
   background-color: ${colorWhite};
   display: flex;
-  flex-grow: 1;
+  flex: 0 0 auto;
   flex-direction: column;
   justify-content: flex-start;
   overflow: hidden;


### PR DESCRIPTION
### What does this PR do?
- Prevent the guest management area from expanding when Ask Moderator is enabled but there are no waiting users, avoiding the large blank space above raised hands.
- Fix extra margin on the leave meeting button to keep navbar spacing consistent (and without empty clickable area).


Before:
<img width="255" height="867" alt="image" src="https://github.com/user-attachments/assets/dc6e8bec-f053-4a4f-97d2-0ad11023d849" />
<img width="347" height="58" alt="image" src="https://github.com/user-attachments/assets/e7cf2a1c-dbb3-4960-b8b0-96d716acb385" />

After:
<img width="323" height="869" alt="image" src="https://github.com/user-attachments/assets/5b927ed2-18e4-4e37-8af6-3f020dc3edfc" />
<img width="354" height="68" alt="image" src="https://github.com/user-attachments/assets/28a4e54d-49c3-49f0-8fa1-675943a09132" />


