### PR TITLE
fix: NFS-safe cleanup in notes and podcast publish scripts

### DIFF
--- a/record-and-playback/notes/scripts/publish/notes.rb
+++ b/record-and-playback/notes/scripts/publish/notes.rb
@@ -129,10 +129,10 @@ begin
       end
 
       BigBlueButton.logger.info("Removing processed files.")
-      FileUtils.rm_r(process_dir)
+      FileUtils.rm_r(Dir.glob("#{process_dir}/*"))
 
       BigBlueButton.logger.info("Removing published files.")
-      FileUtils.rm_r(target_dir)
+      FileUtils.rm_r(Dir.glob("#{target_dir}/*"))
 
       publish_done = File.new("#{recording_dir}/status/published/#{meeting_id}-notes.done", "w")
       publish_done.write("Published #{meeting_id}")

--- a/record-and-playback/podcast/scripts/publish/podcast.rb
+++ b/record-and-playback/podcast/scripts/publish/podcast.rb
@@ -124,10 +124,10 @@ begin
       BigBlueButton.logger.info("Finished publishing script podcast.rb successfully.")
 
       BigBlueButton.logger.info("Removing processed files.")
-      FileUtils.rm_r(process_dir)
+      FileUtils.rm_r(Dir.glob("#{process_dir}/*"))
 
       BigBlueButton.logger.info("Removing published files.")
-      FileUtils.rm_r(target_dir)
+      FileUtils.rm_r(Dir.glob("#{target_dir}/*"))
 
       publish_done = File.new("#{recording_dir}/status/published/#{meeting_id}-podcast.done", "w")
       publish_done.write("Published #{meeting_id}")


### PR DESCRIPTION
## Summary

- Replace `FileUtils.rm_r(dir)` with `FileUtils.rm_r(Dir.glob("#{dir}/*"))` in **notes.rb** and **podcast.rb** publish scripts
- On NFS4 filesystems, `rmdir` can fail with `Errno::ENOTEMPTY` when file deletions haven't been flushed from the NFS client cache; deleting contents instead of the directory itself avoids this
- Matches the pattern already used by `presentation.rb`

## Test plan

- [x] Verified that recording `random-8987579` published successfully with no `Errno::ENOTEMPTY`
- [ ] Confirm no regressions on non-NFS filesystems (standard ext4/xfs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)