### PR TITLE
fix: client crashes when a invalid layout is set in local storage/settings

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -14,7 +14,7 @@ import {
   PANELS,
   HIDDEN_LAYOUTS,
 } from '../enums';
-import { LAYOUTS_SYNC } from '../utils';
+import { isValidSynchronizationLayout, LAYOUTS_SYNC } from '../utils';
 import { updateSettings } from '/imports/ui/components/settings/service';
 import Session from '/imports/ui/services/storage/in-memory';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
@@ -197,7 +197,7 @@ const PushLayoutEngine = (props) => {
   }, [hasMeetingLayout, enforceLayoutResult]);
 
   useEffect(() => {
-    if (!selectedLayout) return () => { };
+    if (!isValidSynchronizationLayout(selectedLayout)) return () => {};
     const meetingLayoutDidChange = prevProps.meetingLayout !== undefined
       && meetingLayout !== prevProps.meetingLayout;
     const pushLayoutMeetingDidChange = prevProps.pushLayoutMeeting !== undefined

--- a/bigbluebutton-html5/imports/ui/components/layout/utils.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/utils.js
@@ -170,6 +170,8 @@ const getSupportedLayouts = (deviceType) => suportedLayouts.filter(
   (layout) => layout.suportedDevices.includes(deviceType),
 );
 
+const isValidSynchronizationLayout = (layout) => layout && LAYOUTS_SYNC[layout] != null;
+
 const layoutAllowedInSettings = (layout) => layout !== LAYOUT_TYPE.CAMERAS_ONLY
   && layout !== LAYOUT_TYPE.PRESENTATION_ONLY
   && layout !== LAYOUT_TYPE.PARTICIPANTS_AND_CHAT_ONLY
@@ -189,4 +191,5 @@ const getDeviceType = () => {
 export {
   suportedLayouts, LAYOUTS_SYNC, getSupportedLayouts, isLayoutSupported, layoutAllowedInSettings,
   getWaitLayout, getDeviceType,
+  isValidSynchronizationLayout,
 };


### PR DESCRIPTION
### What does this PR do?

- [fix: client crashes when a invalid layout is set in local storage](https://github.com/bigbluebutton/bigbluebutton/commit/8437ba7d575cb6b5a3681818b29e9fe1637c1478) 
  - The HTML5 client may crash when an invalid layout is saved in the local
storage ('layout' key) or misconfigured on the server
(layout.selectedLayout). The crash is caused by an undefined access to
the synchronizable layouts' dictionary.
  - The crash resolves itself on subsequent client loads for the session as
other layout hooks handle falling back when an invalid layout is set -
but that usually happens later on the React lifecycle than the affected
useEffect.
  - Check whether the selectedLayout is valid in the synchronization effect
of PushLayoutEngine. This prevents undefined accesses and client crashes
in the above scenarios.

### Closes Issue(s)

Nonoe

### How to test

This is mostly a side effect of the refactoring the layout system and the removal of pre-existing layout types.
The easiest way to reproduce is setting an invalid layout in settings.yml, e.g.: `custom`.