### PR TITLE
fix(recording): Address A/V sync issues, glitches on cuts, ffmpeg memory usage (audio)

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -129,7 +129,7 @@ module BigBlueButton
           end
 
           entries_i[next_edl] += 1
-          done[next_idl] = true if entries_i[next_edl] >= edls[next_edl].length
+          done[next_edl] = true if entries_i[next_edl] >= edls[next_edl].length
         end
 
         merged_edl

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -21,7 +21,7 @@ module BigBlueButton
   module EDL
     module Audio
       FFMPEG_AEVALSRC = "aevalsrc=s=48000:c=stereo:exprs=0|0"
-      FFMPEG_AFORMAT = "aresample=async=1000,aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
+      FFMPEG_AFORMAT = "aresample=async=1000:first_pts=0,aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
       FFMPEG_WF_CODEC = 'libvorbis'
       FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -52,6 +52,99 @@ module BigBlueButton
         end
       end
 
+      # Merge multiple EDLs into a single EDL
+      #
+      # @param edls [Array<Array<Hash>>] The EDLs to merge
+      # @return [Array<Hash>] The merged EDL
+      def self.merge(*edls)
+        entries_i = Array.new(edls.length, 0)
+        done = Array.new(edls.length, false)
+        merged_edl = [{ timestamp: 0, audios: [] }]
+
+        while !done.all?
+          # Figure out what the next entry in each edl is
+          entries = []
+          entries_i.each_with_index do |entry, edl|
+            entries << edls[edl][entry]
+          end
+
+          # Find the next entry - the one with the lowest timestamp
+          next_edl = nil
+          next_entry = nil
+          entries.each_with_index do |entry, edl|
+            if entry
+              if !next_entry or entry[:timestamp] < next_entry[:timestamp]
+                next_edl = edl
+                next_entry = entry
+              end
+            end
+          end
+
+          # To calculate differences, need the previous entry from the same edl
+          prev_entry = nil
+          if entries_i[next_edl] > 0
+            prev_entry = edls[next_edl][entries_i[next_edl] - 1]
+          end
+
+          # Find new audios that were added
+          add_audios = []
+          if prev_entry
+            next_entry[:audios].each do |audio|
+              if !prev_entry[:audios].find { |a| a[:filename] == audio[:filename] }
+                add_audios << audio
+              end
+            end
+          else
+            add_audios = next_entry[:audios]
+          end
+
+          # Find audios that were removed
+          del_audios = []
+          if prev_entry
+            prev_entry[:audios].each do |audio|
+              if !next_entry[:audios].find { |a| a[:filename] == audio[:filename] }
+                del_audios << audio
+              end
+            end
+          end
+
+          # Determine whether to create a new entry or edit the previous one
+          merged_entry = last_entry = merged_edl.last
+          unless last_entry[:timestamp] == next_entry[:timestamp]
+            # Need to create a new entry
+            offset = next_entry[:timestamp] - last_entry[:timestamp]
+            merged_entry = {
+              timestamp: next_entry[:timestamp],
+              # Copy audios from the last entry into the new entry, updating timestamps
+              audios: last_entry[:audios].map do |audio|
+                audio.merge(timestamp: audio[:timestamp] + offset)
+              end
+            }
+            merged_edl << merged_entry
+          end
+
+          # Remove deleted videos
+          del_audios.each do |audio|
+            merged_entry[:audios].reject! { |a| a[:filename] == audio[:filename] }
+          end
+          # Add new audios
+          merged_entry[:audios].concat(add_audios)
+
+          # Pull in timestamps from the next entry to respect edit cuts
+          next_entry[:audios].each do |audio|
+            merged_audio = merged_entry[:audios].find { |a| a[:filename] == audio[:filename] }
+            merged_audio[:timestamp] = audio[:timestamp] unless merged_audio.nil?
+          end
+
+          entries_i[next_edl] += 1
+          if entries_i[next_edl] >= edls[next_edl].length
+            done[next_edl] = true
+          end
+        end
+
+        merged_edl
+      end
+
       # Edit the EDL to make sure that every cut has a minimum length
       def self.enforce_cut_lengths(edl)
         # Special case handling for the start

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -30,9 +30,9 @@ module BigBlueButton
       # inserts extra frames with bad timestamps when starting the resampler on-demand.
       FFMPEG_ARESAMPLE = "aresample=async=#{(SAMPLE_RATE / 100).round}:first_pts=0:flags=res"
       FFMPEG_AFORMAT = "aformat=sample_fmts=s16:sample_rates=#{SAMPLE_RATE}:channel_layouts=stereo"
-      FFMPEG_WF_CODEC = 'libvorbis'
-      FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
-      WF_EXT = 'ogg'
+      FFMPEG_WF_CODEC = 'flac'
+      FFMPEG_WF_ARGS = ['-sample_fmt', 's16', '-c:a', FFMPEG_WF_CODEC, '-f', 'flac']
+      WF_EXT = 'flac'
       MIN_CUT_LENGTH = 20 # ms (one frame of audio in opus)
 
       def self.dump(edl)

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -413,7 +413,10 @@ module BigBlueButton
             # Nothing to do if the next gap is after the current entry ends
             next if gap_start >= audio_out
 
-            BigBlueButton.logger.debug("Processing gap [#{gap_start}ms, #{gap_end}ms) in EDL entry #{i}")
+            BigBlueButton.logger.debug(
+              "Processing gap [#{gap_start}ms, #{gap_end}ms) " \
+              "in EDL entry #{i} (timestamp=#{entry[:timestamp]}ms)",
+            )
 
             # If gap starts in this EDL entry, then it needs to be split
             if gap_start > audio_in

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -333,7 +333,7 @@ module BigBlueButton
               # Build track label
               track_label = "t#{i}_#{idx}"
               line = "[#{input_index}]"
-              line << "atempo=#{speed},atrim=start=#{ms_to_s(audio_date[:timestamp])}," if speed != 1.0
+              line << "atempo=#{speed},atrim=start=#{ms_to_s(audio_data[:timestamp])}," if speed != 1.0
               line << "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT},apad"
               line << "[#{track_label}];"
               filter_lines << line

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -388,12 +388,13 @@ module BigBlueButton
       # and remove the audio file from the mix for the duration of the gap.
       def self.remove_audio_gaps(edl, audio_files, process_dir)
         audio_files.each do |filename|
-          gaps = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio).each
-          next if gaps.none?
+          gaps_array = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio)
+          next if gaps_array.empty?
 
-          BigBlueButton.logger.info("Audio file #{File.basename(filename)} has #{gaps.size} gap(s), adjusting EDL")
+          BigBlueButton.logger.info("Audio file #{File.basename(filename)} has #{gaps_array.length} gap(s), adjusting EDL")
 
           next_i = 0
+          gaps = gaps_array.each
           gap_start, gap_end = gaps.next
           while next_i < edl.length - 1
             i = next_i

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -115,7 +115,7 @@ module BigBlueButton
             merged_edl << merged_entry
           end
 
-          # Remove deleted videos
+          # Remove deleted audios
           del_audios.each do |audio|
             merged_entry[:audios].reject! { |a| a[:filename] == audio[:filename] }
           end

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -22,8 +22,14 @@ require_relative 'media_utils'
 module BigBlueButton
   module EDL
     module Audio
-      FFMPEG_AEVALSRC = "aevalsrc=s=48000:c=stereo:exprs=0|0"
-      FFMPEG_AFORMAT = "aresample=async=1000:first_pts=0,aformat=sample_fmts=s16:sample_rates=48000:channel_layouts=stereo"
+      SAMPLE_RATE=48000
+      FFMPEG_AEVALSRC = "aevalsrc=s=#{SAMPLE_RATE}:c=stereo:exprs=0|0"
+      # Do audio sync to timestamps with a maximum stretch/squeeze rate of 1%
+      # Use first_pts to trim (or pad) audio to start at the correct sample
+      # Set flags=res to force resampler to be used to workaround a bug in ffmpeg 4.4 where it
+      # inserts extra frames with bad timestamps when starting the resampler on-demand.
+      FFMPEG_ARESAMPLE = "aresample=async=#{(SAMPLE_RATE / 100).round}:first_pts=0:flags=res"
+      FFMPEG_AFORMAT = "aformat=sample_fmts=s16:sample_rates=#{SAMPLE_RATE}:channel_layouts=stereo"
       FFMPEG_WF_CODEC = 'libvorbis'
       FFMPEG_WF_ARGS = ['-c:a', FFMPEG_WF_CODEC, '-q:a', '2', '-f', 'ogg']
       WF_EXT = 'ogg'
@@ -144,13 +150,14 @@ module BigBlueButton
               event[:audios].reject! { |a| corrupt_audios.include?(a[:filename]) }
             end
           end
-          dump(edl)
           corrupt_audios.each { |f| audioinfo.delete(f) }
         end
 
         process_dir = File.dirname(output_basename)
         remove_audio_gaps(edl, audioinfo.keys, process_dir)
         enforce_cut_lengths(edl)
+
+        dump(edl)
 
         # The `process_segment` method uses this to calculate cut lengths
         (0...(edl.length - 1)).each do |i|
@@ -172,11 +179,11 @@ module BigBlueButton
         File.open(concat_list_file, 'w') do |f|
           f.write("ffconcat version 1.0\n") 
           segment_files.each do |segment|
-            f.write("file #{segment[:file]}\n") 
+            f.write("file #{segment[:file]}\n")
           end
         end
 
-        merge_cmd = [*FFMPEG, '-f', 'concat', '-safe', '0', '-i', concat_list_file, '-af', "#{FFMPEG_AFORMAT},asetpts=N"]
+        merge_cmd = [*FFMPEG, '-f', 'concat', '-safe', '0', '-i', concat_list_file, '-af', "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT}"]
         output = "#{output_basename}.#{WF_EXT}"
         merge_cmd += ['-vn', *FFMPEG_WF_ARGS, output]
         BigBlueButton.logger.info "Running merge command..."
@@ -218,7 +225,8 @@ module BigBlueButton
             # if events are slightly misaligned and you get unlucky with a start/stop or chapter break.
             if seek < (info[:duration].to_f * speed)
               # For each audio, add a -ss and -i for its input
-              ffmpeg_cmd += ['-ss', ms_to_s(seek)]
+              # Use -noaccurate_seek to read frames before seek point (will be trimmed by resampler)
+              ffmpeg_cmd += ['-noaccurate_seek', '-ss', ms_to_s(seek)]
               # Ensure that the entire contents of freeswitch wav files are read
               if info[:format][:format_name] == 'wav'
                 ffmpeg_cmd += ['-ignore_length', '1']
@@ -231,16 +239,17 @@ module BigBlueButton
 
               # Build track label
               track_label = "t#{i}_#{idx}"
-              line = "[#{input_index}]#{FFMPEG_AFORMAT},apad"
-              line << ",atempo=#{speed},atrim=start=#{ms_to_s(audio_data[:timestamp])}" if speed != 1.0
-              line << ",asetpts=N[#{track_label}];"
+              line = "[#{input_index}]"
+              line << "atempo=#{speed},atrim=start=#{ms_to_s(audio_date[:timestamp])}," if speed != 1.0
+              line << "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT},apad"
+              line << "[#{track_label}];"
               filter_lines << line
               track_labels << "[#{track_label}]"
               input_index += 1
             else
               # If we're seeking past the file end => silence
               track_label = "t#{i}_silence#{idx}"
-              line = "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},asetpts=N[#{track_label}];"
+              line = "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT}[#{track_label}];"
               filter_lines << line
               track_labels << "[#{track_label}]"
             end
@@ -258,7 +267,7 @@ module BigBlueButton
           end
         else
           BigBlueButton.logger.info "  Generating silence"
-          filter_lines << "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},asetpts=N,"
+          filter_lines << "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},"
         end
       
         # Now trim this segment to seg_duration

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
 
+require_relative 'media_utils'
+
 module BigBlueButton
   module EDL
     module Audio
@@ -112,13 +114,7 @@ module BigBlueButton
         corrupt_audios = Set.new
 
         BigBlueButton.logger.info 'Pre-processing EDL'
-        enforce_cut_lengths(edl)
 
-        # The render scripts use this to calculate cut lengths
-        (0...(edl.length - 1)).each do |i|
-          edl[i][:next_timestamp] = edl[i+1][:timestamp]
-        end
-      
         # Build a list of audio files to read information from
         edl.each do |entry|
           if entry[:audios]
@@ -149,6 +145,16 @@ module BigBlueButton
             end
           end
           dump(edl)
+          corrupt_audios.each { |f| audioinfo.delete(f) }
+        end
+
+        process_dir = File.dirname(output_basename)
+        remove_audio_gaps(edl, audioinfo.keys, process_dir)
+        enforce_cut_lengths(edl)
+
+        # The `process_segment` method uses this to calculate cut lengths
+        (0...(edl.length - 1)).each do |i|
+          edl[i][:next_timestamp] = edl[i + 1][:timestamp]
         end
 
         segment_files = []
@@ -179,6 +185,8 @@ module BigBlueButton
 
         output
       end
+
+      # The methods below should be considered private
 
       def self.process_segment(entry, output_basename, i, total_segments, audioinfo)
         BigBlueButton.logger.info "Processing segment #{i} of #{total_segments} (duration: #{entry[:next_timestamp] - entry[:timestamp]} ms, num_audios: #{entry[:audios]&.length || 0})"
@@ -278,7 +286,71 @@ module BigBlueButton
         segment_output
       end
 
-      # The methods below should be considered private
+      # Check audio files for large gaps in timestamps
+      # 
+      # When there's a large timestamp gap, the ffmpeg `aresample` filter generates silent audio to
+      # fill the gap, but it enqueues the full length of the gap into the filter chain all at once,
+      # which uses a lot of memory. To work around this issue, detect long gaps in the audio files
+      # and remove the audio file from the mix for the duration of the gap.
+      def self.remove_audio_gaps(edl, audio_files, process_dir)
+        audio_files.each do |filename|
+          gaps = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio).each
+          next if gaps.none?
+
+          BigBlueButton.logger.info("Audio file #{File.basename(filename)} has #{gaps.size} gap(s), adjusting EDL")
+
+          next_i = 0
+          gap_start, gap_end = gaps.next
+          while next_i < edl.length - 1
+            i = next_i
+            entry = edl[i]
+            next_i += 1
+
+            audio_data = entry[:audios]&.find { |a| a[:filename] == filename }
+            # Current EDL entry does not contain this file
+            next unless audio_data
+
+            audio_in = audio_data[:timestamp]
+            audio_out = audio_in + edl[next_i][:timestamp] - entry[:timestamp]
+
+            # Iterate forward through gaps until we find one that's not in the past
+            gap_start, gap_end = gaps.next while gap_end <= audio_in
+
+            # Nothing to do if the next gap is after the current entry ends
+            next if gap_start >= audio_out
+
+            BigBlueButton.logger.debug("Processing gap [#{gap_start}ms, #{gap_end}ms) in EDL entry #{i}")
+
+            # If gap starts in this EDL entry, then it needs to be split
+            if gap_start > audio_in
+              split_edl_at(edl, i, gap_start - audio_in + entry[:timestamp])
+              # No audio to remove from the current entry
+              next
+            end
+
+            # If gap ends in this EDL entry, then it needs to be split
+            if gap_end < audio_out
+              split_edl_at(edl, i, gap_end - audio_in + entry[:timestamp])
+              # Audio needs to be removed from the current entry
+            end
+
+            # Only get here if the current EDL entry is completely contained within a gap.
+            # Remove the file from the entry.
+            entry[:audios].reject! { |a| a[:filename] == filename }
+          end
+        rescue StopIteration
+          # Reached the end of the gaps list for this file, go to the next file.
+          next
+        end
+      end
+
+      def self.split_edl_at(edl, i, rec_time)
+        BigBlueButton.logger.debug("Splitting EDL entry #{i} at #{rec_time}ms")
+        entry = edl[i]
+        offset = rec_time - entry[:timestamp]
+        new_entry = BigBlueButton::Events.edl_entry_offset_audio.call(entry, offset)
+        edl.insert(i + 1, new_entry)
+      end
 
       def self.audio_info(filename)
         IO.popen([*FFPROBE, filename]) do |probe|

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -349,6 +349,7 @@ module BigBlueButton
         entry = edl[i]
         offset = rec_time - entry[:timestamp]
         new_entry = BigBlueButton::Events.edl_entry_offset_audio.call(entry, offset)
+        new_entry[:timestamp] = rec_time
         edl.insert(i + 1, new_entry)
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 # BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
 #
@@ -22,16 +22,16 @@ require_relative 'media_utils'
 module BigBlueButton
   module EDL
     module Audio
-      SAMPLE_RATE=48000
-      FFMPEG_AEVALSRC = "aevalsrc=s=#{SAMPLE_RATE}:c=stereo:exprs=0|0"
+      SAMPLE_RATE = 48_000
+      FFMPEG_AEVALSRC = "aevalsrc=s=#{SAMPLE_RATE}:c=stereo:exprs=0|0".freeze
       # Do audio sync to timestamps with a maximum stretch/squeeze rate of 1%
       # Use first_pts to trim (or pad) audio to start at the correct sample
       # Set flags=res to force resampler to be used to workaround a bug in ffmpeg 4.4 where it
       # inserts extra frames with bad timestamps when starting the resampler on-demand.
-      FFMPEG_ARESAMPLE = "aresample=async=#{(SAMPLE_RATE / 100).round}:first_pts=0:flags=res"
-      FFMPEG_AFORMAT = "aformat=sample_fmts=s16:sample_rates=#{SAMPLE_RATE}:channel_layouts=stereo"
+      FFMPEG_ARESAMPLE = "aresample=async=#{(SAMPLE_RATE / 100).round}:first_pts=0:flags=res".freeze
+      FFMPEG_AFORMAT = "aformat=sample_fmts=s16:sample_rates=#{SAMPLE_RATE}:channel_layouts=stereo".freeze
       FFMPEG_WF_CODEC = 'flac'
-      FFMPEG_WF_ARGS = ['-sample_fmt', 's16', '-c:a', FFMPEG_WF_CODEC, '-f', 'flac']
+      FFMPEG_WF_ARGS = ['-sample_fmt', 's16', '-c:a', FFMPEG_WF_CODEC, '-f', 'flac'].freeze
       WF_EXT = 'flac'
       MIN_CUT_LENGTH = 20 # ms (one frame of audio in opus)
 
@@ -61,7 +61,7 @@ module BigBlueButton
         done = Array.new(edls.length, false)
         merged_edl = [{ timestamp: 0, audios: [] }]
 
-        while !done.all?
+        until done.all?
           # Figure out what the next entry in each edl is
           entries = []
           entries_i.each_with_index do |entry, edl|
@@ -72,27 +72,21 @@ module BigBlueButton
           next_edl = nil
           next_entry = nil
           entries.each_with_index do |entry, edl|
-            if entry
-              if !next_entry or entry[:timestamp] < next_entry[:timestamp]
-                next_edl = edl
-                next_entry = entry
-              end
-            end
+            next if next_entry && entry[:timestamp] >= next_entry[:timestamp]
+
+            next_edl = edl
+            next_entry = entry
           end
 
           # To calculate differences, need the previous entry from the same edl
           prev_entry = nil
-          if entries_i[next_edl] > 0
-            prev_entry = edls[next_edl][entries_i[next_edl] - 1]
-          end
+          prev_entry = edls[next_edl][entries_i[next_edl] - 1] if entries_i[next_edl] > 0
 
           # Find new audios that were added
           add_audios = []
           if prev_entry
             next_entry[:audios].each do |audio|
-              if !prev_entry[:audios].find { |a| a[:filename] == audio[:filename] }
-                add_audios << audio
-              end
+              add_audios << audio unless prev_entry[:audios].find { |a| a[:filename] == audio[:filename] }
             end
           else
             add_audios = next_entry[:audios]
@@ -102,9 +96,7 @@ module BigBlueButton
           del_audios = []
           if prev_entry
             prev_entry[:audios].each do |audio|
-              if !next_entry[:audios].find { |a| a[:filename] == audio[:filename] }
-                del_audios << audio
-              end
+              del_audios << audio unless next_entry[:audios].find { |a| a[:filename] == audio[:filename] }
             end
           end
 
@@ -118,7 +110,7 @@ module BigBlueButton
               # Copy audios from the last entry into the new entry, updating timestamps
               audios: last_entry[:audios].map do |audio|
                 audio.merge(timestamp: audio[:timestamp] + offset)
-              end
+              end,
             }
             merged_edl << merged_entry
           end
@@ -137,9 +129,7 @@ module BigBlueButton
           end
 
           entries_i[next_edl] += 1
-          if entries_i[next_edl] >= edls[next_edl].length
-            done[next_edl] = true
-          end
+          done[next_idl] = true if entries_i[next_edl] >= edls[next_edl].length
         end
 
         merged_edl
@@ -239,9 +229,7 @@ module BigBlueButton
         if corrupt_audios.any?
           BigBlueButton.logger.info "Removing corrupt audio files from EDL"
           edl.each do |event|
-            if event[:audios]
-              event[:audios].reject! { |a| corrupt_audios.include?(a[:filename]) }
-            end
+            event[:audios]&.reject! { |a| corrupt_audios.include?(a[:filename]) }
           end
           corrupt_audios.each { |f| audioinfo.delete(f) }
         end
@@ -270,13 +258,17 @@ module BigBlueButton
         BigBlueButton.logger.info "Merging #{segment_files.size} segments..."
         concat_list_file = "#{output_basename}_concat_list.txt"
         File.open(concat_list_file, 'w') do |f|
-          f.write("ffconcat version 1.0\n") 
+          f.write("ffconcat version 1.0\n")
           segment_files.each do |segment|
             f.write("file #{segment[:file]}\n")
           end
         end
 
-        merge_cmd = [*FFMPEG, '-f', 'concat', '-safe', '0', '-i', concat_list_file, '-af', "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT}"]
+        # The option -safe 0 is required because the concat list file contains absolute paths
+        merge_cmd = [
+          *FFMPEG, '-f', 'concat', '-safe', '0', '-i', concat_list_file,
+          '-af', "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT}",
+        ]
         output = "#{output_basename}.#{WF_EXT}"
         merge_cmd += ['-vn', *FFMPEG_WF_ARGS, output]
         BigBlueButton.logger.info "Running merge command..."
@@ -362,7 +354,7 @@ module BigBlueButton
           BigBlueButton.logger.info "  Generating silence"
           filter_lines << "#{FFMPEG_AEVALSRC},#{FFMPEG_AFORMAT},"
         end
-      
+
         # Now trim this segment to seg_duration
         filter_lines << "atrim=end=#{ms_to_s(entry[:next_timestamp] - entry[:timestamp])}"
 
@@ -389,7 +381,7 @@ module BigBlueButton
       end
 
       # Check audio files for large gaps in timestamps
-      # 
+      #
       # When there's a large timestamp gap, the ffmpeg `aresample` filter generates silent audio to
       # fill the gap, but it enqueues the full length of the gap into the filter chain all at once,
       # which uses a lot of memory. To work around this issue, detect long gaps in the audio files
@@ -446,13 +438,13 @@ module BigBlueButton
         end
       end
 
-      def self.split_edl_at(edl, i, rec_time)
-        BigBlueButton.logger.debug("Splitting EDL entry #{i} at #{rec_time}ms")
-        entry = edl[i]
+      def self.split_edl_at(edl, entry_i, rec_time)
+        BigBlueButton.logger.debug("Splitting EDL entry #{entry_i} at #{rec_time}ms")
+        entry = edl[entry_i]
         offset = rec_time - entry[:timestamp]
         new_entry = BigBlueButton::Events.edl_entry_offset_audio.call(entry, offset)
         new_entry[:timestamp] = rec_time
-        edl.insert(i + 1, new_entry)
+        edl.insert(entry_i + 1, new_entry)
       end
 
       def self.audio_info(filename)

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 # BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
 #
@@ -37,8 +37,8 @@ module BigBlueButton
       #   start of the gap (the moment when the last frame of media before the gap finishes) and
       #   the second element is the end of the gap (the moment when the next frame of media after
       #   the gap starts). All timestamps in ms.
-      def self.pts_gaps(process_dir, filename, stream_type, min_gap=60_000)
-        stream_specifier = \
+      def self.pts_gaps(process_dir, filename, stream_type, min_gap = 60_000)
+        stream_specifier =
           case stream_type
           when :audio then 'a:0'
           when :video then 'v:0'
@@ -47,10 +47,13 @@ module BigBlueButton
         ffprobe_cmd = [
           'ffprobe', '-v', 'warning', '-select_streams', stream_specifier,
           '-show_entries', 'packet=pts_time,duration_time', '-of', 'csv=p=0',
-          filename
+          filename,
         ]
 
-        BigBlueButton.logger.debug("Getting #{stream_type} packet PTS times for #{File.basename(filename).inspect}: #{Shellwords.join(ffprobe_cmd)}")
+        BigBlueButton.logger.debug(
+          "Getting #{stream_type} packet PTS times for #{File.basename(filename).inspect}: " \
+          "#{Shellwords.join(ffprobe_cmd)}",
+        )
 
         pts_gaps = []
         Tempfile.create(['ffprobe', '.log'], process_dir) do |log_file|
@@ -67,7 +70,13 @@ module BigBlueButton
 
               prev_end = 0
 
-              csv = CSV.new(r, headers: %i[pts_time duration_time], converters: %i[float float], skip_blanks: true, empty_value: 'N/A')
+              csv = CSV.new(
+                r,
+                headers: %i[pts_time duration_time],
+                converters: %i[float float],
+                skip_blanks: true,
+                empty_value: 'N/A',
+              )
               csv.each do |row|
                 next if row[:pts_time] == 'N/A'
 
@@ -82,7 +91,6 @@ module BigBlueButton
                 prev_end = pts
                 prev_end += (row[:duration_time] * 1000).round unless row[:duration_time] == 'N/A'
               end
-
             ensure
               _pid, status = Process.wait2(pid)
               BigBlueButton.logger.debug("ffprobe #{status}")
@@ -95,7 +103,6 @@ module BigBlueButton
         end
 
         pts_gaps
-
       rescue StandardError => e
         BigBlueButton.logger.warn("Failed to probe PTS: #{e}")
         []

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -60,7 +60,7 @@ module BigBlueButton
               close_others: true,
               in: :close,
               out: w,
-              err: %i[child out],
+              err: log_file,
             )
             w.close
 

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -88,7 +88,7 @@ module BigBlueButton
               BigBlueButton.logger.debug("ffprobe #{status}")
               log_file.rewind
               log_file.each_line do |line|
-                BigBlueButton.logger.debug(line.chomp!)
+                BigBlueButton.logger.debug(line.chomp)
               end
             end
           end

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -73,7 +73,7 @@ module BigBlueButton
               pts = (row[:pts_time] * 1000).round
 
               gap = pts - prev_end
-              if gap > min_gap
+              if gap >= min_gap
                 BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and #{pts}ms (#{gap}ms long)")
                 pts_gaps << [prev_end, pts]
               end

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -42,7 +42,7 @@ module BigBlueButton
           case stream_type
           when :audio then 'a:0'
           when :video then 'v:0'
-          else raise ArgumentError("Unexpected stream_type #{stream_type.inspect}")
+          else raise ArgumentError, "Unexpected stream_type #{stream_type.inspect}"
           end
         ffprobe_cmd = [
           'ffprobe', '-v', 'warning', '-select_streams', stream_specifier,

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -1,0 +1,101 @@
+# encoding: UTF-8
+
+# BigBlueButton open source conferencing system - http://www.bigbluebutton.org/
+#
+# Copyright (c) 2024 BigBlueButton Inc. and by respective authors.
+#
+# BigBlueButton is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# BigBlueButton is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BigBlueButton.  If not, see <http://www.gnu.org/licenses/>.
+
+require 'shellwords'
+require 'csv'
+
+module BigBlueButton
+  module EDL
+    module MediaUtils
+      # Get a list of gaps in PTS values.
+      #
+      # @param process_dir [String] path to directory for temporary processing files
+      # @param filename [String] path to the media file
+      # @param stream_type [:audio, :video] The type of media stream to inspect
+      # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
+      #   Default is 60 seconds, long enough that it won't be hit for short dropouts, but short
+      #   enough that it won't cause excessive memory use when ffmpeg fills the gap.
+      #
+      # @return [Array<Array<Numeric>>] A list of gaps. For each gap, the first element is the
+      #   start of the gap (the moment when the last frame of media before the gap finishes) and
+      #   the second element is the end of the gap (the moment when the next frame of media after
+      #   the gap starts). All timestamps in ms.
+      def self.pts_gaps(process_dir, filename, stream_type, min_gap=60_000)
+        stream_specifier = \
+          case stream_type
+          when :audio then 'a:0'
+          when :video then 'v:0'
+          else raise ArgumentError("Unexpected stream_type #{stream_type.inspect}")
+          end
+        ffprobe_cmd = [
+          'ffprobe', '-v', 'warning', '-select_streams', stream_specifier,
+          '-show_entries', 'packet=pts_time,duration_time', '-of', 'csv=p=0',
+          filename
+        ]
+
+        BigBlueButton.logger.debug("Getting #{stream_type} packet PTS times for #{File.basename(filename).inspect}: #{Shellwords.join(ffprobe_cmd)}")
+
+        pts_gaps = []
+        Tempfile.create(['ffprobe', '.log'], process_dir) do |log_file|
+          IO.pipe do |r, w|
+            pid = spawn(
+              *ffprobe_cmd,
+              close_others: true,
+              in: :close,
+              out: w,
+              err: %i[child out],
+            )
+            w.close
+
+            prev_end = 0
+
+            csv = CSV.new(r, headers: %i[pts_time duration_time], converters: %i[float float], skip_blanks: true, empty_value: 'N/A')
+            csv.each do |row|
+              next if row[:pts_time] == 'N/A'
+
+              pts = (row[:pts_time] * 1000).round
+
+              gap = pts - prev_end
+              if gap > min_gap
+                BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and #{pts}ms (#{gap}ms long)")
+                pts_gaps << [prev_end, pts]
+              end
+
+              prev_end = pts
+              prev_end += (row[:duration_time] * 1000).round unless row[:duration_time] == 'N/A'
+            end
+
+            _pid, status = Process.wait2(pid)
+            BigBlueButton.logger.debug("ffprobe #{status}")
+            log_file.rewind
+            log_file.each_line do |line|
+              BigBlueButton.logger.debug(line.chomp!)
+            end
+          end
+        end
+
+        pts_gaps
+
+      rescue StandardError => e
+        BigBlueButton.logger.warn("Failed to probe PTS: #{e}")
+        []
+      end
+    end
+  end
+end

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -19,6 +19,7 @@
 
 require 'shellwords'
 require 'csv'
+require 'tempfile'
 
 module BigBlueButton
   module EDL

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -62,31 +62,34 @@ module BigBlueButton
               out: w,
               err: log_file,
             )
-            w.close
+            begin
+              w.close
 
-            prev_end = 0
+              prev_end = 0
 
-            csv = CSV.new(r, headers: %i[pts_time duration_time], converters: %i[float float], skip_blanks: true, empty_value: 'N/A')
-            csv.each do |row|
-              next if row[:pts_time] == 'N/A'
+              csv = CSV.new(r, headers: %i[pts_time duration_time], converters: %i[float float], skip_blanks: true, empty_value: 'N/A')
+              csv.each do |row|
+                next if row[:pts_time] == 'N/A'
 
-              pts = (row[:pts_time] * 1000).round
+                pts = (row[:pts_time] * 1000).round
 
-              gap = pts - prev_end
-              if gap >= min_gap
-                BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and #{pts}ms (#{gap}ms long)")
-                pts_gaps << [prev_end, pts]
+                gap = pts - prev_end
+                if gap >= min_gap
+                  BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and #{pts}ms (#{gap}ms long)")
+                  pts_gaps << [prev_end, pts]
+                end
+
+                prev_end = pts
+                prev_end += (row[:duration_time] * 1000).round unless row[:duration_time] == 'N/A'
               end
 
-              prev_end = pts
-              prev_end += (row[:duration_time] * 1000).round unless row[:duration_time] == 'N/A'
-            end
-
-            _pid, status = Process.wait2(pid)
-            BigBlueButton.logger.debug("ffprobe #{status}")
-            log_file.rewind
-            log_file.each_line do |line|
-              BigBlueButton.logger.debug(line.chomp!)
+            ensure
+              _pid, status = Process.wait2(pid)
+              BigBlueButton.logger.debug("ffprobe #{status}")
+              log_file.rewind
+              log_file.each_line do |line|
+                BigBlueButton.logger.debug(line.chomp!)
+              end
             end
           end
         end

--- a/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
@@ -43,6 +43,16 @@ module BigBlueButton
                       events, archive_dir)
       BigBlueButton::EDL::Audio.dump(audio_edl)
 
+      # Include deskshare audio
+      deskshare_dir = "#{archive_dir}/deskshare"
+      if BigBlueButton::Events.screenshare_has_audio?(events, deskshare_dir)
+        BigBlueButton.logger.info("AudioProcessor.process: processing Deskshare audio...")
+        deskshare_audio_edl = BigBlueButton::AudioEvents.create_deskshare_audio_edl(events, deskshare_dir)
+        audio_edl = BigBlueButton::EDL::Audio.merge(audio_edl, deskshare_audio_edl)
+      else
+        BigBlueButton.logger.info("AudioProcessor.process: no Deskshare audio to process.")
+      end
+
       BigBlueButton.logger.info("Applying recording start stop events:")
       start_time = BigBlueButton::Events.first_event_timestamp(events)
       end_time = BigBlueButton::Events.last_event_timestamp(events)
@@ -53,33 +63,7 @@ module BigBlueButton
       target_dir = File.dirname(file_basename)
 
       # getting users audio...
-      @audio_file = BigBlueButton::EDL::Audio.render(
-        audio_edl, File.join(target_dir, 'recording'))
-
-      # and mixing it with deskshare audio	
-      deskshare_dir = "#{archive_dir}/deskshare"
-      if BigBlueButton::Events.screenshare_has_audio?(events, deskshare_dir)
-        BigBlueButton.logger.info("AudioProcessor.process: processing Deskshare audio...")	
-
-        mixed_dir = "#{archive_dir}/mixed"
-
-        deskshare_audio_edl = BigBlueButton::AudioEvents.create_deskshare_audio_edl(events, deskshare_dir)
-        BigBlueButton::EDL::Audio.dump(deskshare_audio_edl)	
-
-        BigBlueButton.logger.info "Applying recording start/stop events to Deskshare audio"
-        deskshare_audio_edl = BigBlueButton::Events.edl_match_recording_marks_audio(
-          deskshare_audio_edl, events, start_time, end_time)
-        BigBlueButton.logger.debug "Trimmed Deskshare Audio EDL:"
-        BigBlueButton::EDL::Audio.dump(deskshare_audio_edl)
-
-        audio_inputs = []	
-        audio_inputs << @audio_file	
-        audio_inputs << BigBlueButton::EDL::Audio.render(deskshare_audio_edl, deskshare_dir)	
-
-        @audio_file = BigBlueButton::EDL::Audio.mixer(audio_inputs, mixed_dir)	
-      else
-        BigBlueButton.logger.info("AudioProcessor.process: no Deskshare audio to process.")	
-      end
+      @audio_file = BigBlueButton::EDL::Audio.render(audio_edl, File.join(target_dir, 'recording'))
 
       ogg_format = {
         :extension => 'ogg',

--- a/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
@@ -67,7 +67,7 @@ module BigBlueButton
 
       ogg_format = {
         :extension => 'ogg',
-        :parameters => [ [ '-c:a', 'copy', '-f', 'ogg' ] ]
+        :parameters => [ [ '-c:a', 'libvorbis', '-q:a', '2', '-f', 'ogg' ] ]
       }
       BigBlueButton::EDL.encode(@audio_file, nil, ogg_format, file_basename)
 
@@ -76,7 +76,7 @@ module BigBlueButton
         :parameters => [ [ '-c:a', 'copy', '-f', 'webm' ] ],
         :postprocess => [ [ 'mkclean', '--quiet', ':input', ':output' ] ]
       }
-      BigBlueButton::EDL.encode(@audio_file, nil, webm_format, file_basename)
+      BigBlueButton::EDL.encode("#{file_basename}.ogg", nil, webm_format, file_basename)
     end
 
     def self.get_processed_audio_file(archive_dir, file_basename)

--- a/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
@@ -39,18 +39,17 @@ module BigBlueButton
       events_xml = "#{archive_dir}/events.xml"
       events = Nokogiri::XML(File.open(events_xml))
 
-      audio_edl = BigBlueButton::AudioEvents.create_audio_edl(
-                      events, archive_dir)
+      audio_edl = BigBlueButton::AudioEvents.create_audio_edl(events, archive_dir)
       BigBlueButton::EDL::Audio.dump(audio_edl)
 
       # Include deskshare audio
       deskshare_dir = "#{archive_dir}/deskshare"
       if BigBlueButton::Events.screenshare_has_audio?(events, deskshare_dir)
-        BigBlueButton.logger.info("AudioProcessor.process: processing Deskshare audio...")
+        BigBlueButton.logger.info('AudioProcessor.process: processing Deskshare audio...')
         deskshare_audio_edl = BigBlueButton::AudioEvents.create_deskshare_audio_edl(events, deskshare_dir)
         audio_edl = BigBlueButton::EDL::Audio.merge(audio_edl, deskshare_audio_edl)
       else
-        BigBlueButton.logger.info("AudioProcessor.process: no Deskshare audio to process.")
+        BigBlueButton.logger.info('AudioProcessor.process: no Deskshare audio to process.')
       end
 
       BigBlueButton.logger.info("Applying recording start stop events:")
@@ -66,15 +65,15 @@ module BigBlueButton
       @audio_file = BigBlueButton::EDL::Audio.render(audio_edl, File.join(target_dir, 'recording'))
 
       ogg_format = {
-        :extension => 'ogg',
-        :parameters => [ [ '-c:a', 'libvorbis', '-q:a', '2', '-f', 'ogg' ] ]
+        extension: 'ogg',
+        parameters: [['-c:a', 'libvorbis', '-q:a', '2', '-f', 'ogg']],
       }
       BigBlueButton::EDL.encode(@audio_file, nil, ogg_format, file_basename)
 
       webm_format = {
-        :extension => 'webm',
-        :parameters => [ [ '-c:a', 'copy', '-f', 'webm' ] ],
-        :postprocess => [ [ 'mkclean', '--quiet', ':input', ':output' ] ]
+        extension: 'webm',
+        parameters: [['-c:a', 'copy', '-f', 'webm']],
+        postprocess: [['mkclean', '--quiet', ':input', ':output']],
       }
       BigBlueButton::EDL.encode("#{file_basename}.ogg", nil, webm_format, file_basename)
     end

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -229,7 +229,7 @@ unless FileTest.directory?(target_dir)
       end
 
       webcam_framerate = 15 if webcam_framerate.nil?
-      processed_audio_file = BigBlueButton::AudioProcessor.get_processed_audio_file(raw_archive_dir, "#{target_dir}/audio")
+      processed_audio_file = "#{target_dir}/audio.ogg"
       BigBlueButton.process_webcam_videos(target_dir, raw_archive_dir, webcam_width, webcam_height, webcam_framerate, presentation_props['audio_offset'], processed_audio_file, presentation_props['video_formats'], props['show_moderator_viewpoint'])
     end
 

--- a/record-and-playback/screenshare/scripts/process/screenshare.rb
+++ b/record-and-playback/screenshare/scripts/process/screenshare.rb
@@ -113,6 +113,18 @@ audio_edl = BigBlueButton::AudioEvents.create_audio_edl(events, raw_archive_dir)
 logger.debug "Audio EDL:"
 BigBlueButton::EDL::Audio.dump(audio_edl)
 
+if BigBlueButton::Events.screenshare_has_audio?(events, "#{raw_archive_dir}/deskshare")
+  logger.info('Generating audio events list for deskshare')
+  deskshare_audio_edl = BigBlueButton::AudioEvents.create_deskshare_audio_edl(events, "#{raw_archive_dir}/deskshare")
+  logger.debug('Deskshare audio EDL:')
+  BigBlueButton::EDL::Audio.dump(deskshare_audio_edl)
+
+  audio_edl = BigBlueButton::EDL::Audio.merge(audio_edl, deskshare_audio_edl)
+
+  logger.debug 'Merged Audio EDL:'
+  BigBlueButton::EDL::Audio.dump(audio_edl)
+end
+
 logger.info "Applying recording start/stop events to audio"
 audio_edl = BigBlueButton::Events.edl_match_recording_marks_audio(audio_edl, events, start_time, end_time)
 logger.debug "Trimmed Audio EDL:"

--- a/record-and-playback/video/scripts/process/video.rb
+++ b/record-and-playback/video/scripts/process/video.rb
@@ -203,6 +203,18 @@ audio_edl = BigBlueButton::AudioEvents.create_audio_edl(events, raw_archive_dir)
 logger.debug 'Audio EDL:'
 BigBlueButton::EDL::Audio.dump(audio_edl)
 
+if BigBlueButton::Events.screenshare_has_audio?(events, "#{raw_archive_dir}/deskshare")
+  logger.info('Generating audio events list for deskshare')
+  deskshare_audio_edl = BigBlueButton::AudioEvents.create_deskshare_audio_edl(events, "#{raw_archive_dir}/deskshare")
+  logger.debug('Deskshare audio EDL:')
+  BigBlueButton::EDL::Audio.dump(deskshare_audio_edl)
+
+  audio_edl = BigBlueButton::EDL::Audio.merge(audio_edl, deskshare_audio_edl)
+
+  logger.debug 'Merged Audio EDL:'
+  BigBlueButton::EDL::Audio.dump(audio_edl)
+end
+
 logger.info 'Applying recording start/stop events to audio'
 audio_edl = BigBlueButton::Events.edl_match_recording_marks_audio(audio_edl, events, initial_timestamp, final_timestamp)
 logger.debug 'Trimmed Audio EDL:'
@@ -210,26 +222,6 @@ BigBlueButton::EDL::Audio.dump(audio_edl)
 
 logger.info 'Rendering audio'
 audio = BigBlueButton::EDL::Audio.render(audio_edl, "#{process_dir}/audio")
-
-if BigBlueButton::Events.screenshare_has_audio?(events, "#{raw_archive_dir}/deskshare")
-  logger.info('Generating audio events list for deskshare')
-  deskshare_audio_edl = BigBlueButton::AudioEvents.create_deskshare_audio_edl(events, "#{raw_archive_dir}/deskshare")
-  logger.debug('Deskshare audio EDL:')
-  BigBlueButton::EDL::Audio.dump(deskshare_audio_edl)
-
-  logger.info('Applying recording start/stop events to deskshare audio')
-  deskshare_audio_edl = BigBlueButton::Events.edl_match_recording_marks_audio(
-    deskshare_audio_edl, events, initial_timestamp, final_timestamp
-  )
-  logger.debug('Trimmed deskshare audio EDL:')
-  BigBlueButton::EDL::Audio.dump(deskshare_audio_edl)
-
-  logger.info('Rendering deskshare audio')
-  deskshare_audio = BigBlueButton::EDL::Audio.render(deskshare_audio_edl, "#{process_dir}/deskshare_audio")
-
-  logger.info('Mixing meeting audio and deskshare audio')
-  audio = BigBlueButton::EDL::Audio.mixer([audio, deskshare_audio], "#{process_dir}/mixed_audio")
-end
 
 logger.info 'Rendering video'
 video = BigBlueButton::EDL::Video.render(


### PR DESCRIPTION
This is a replacement for https://github.com/bigbluebutton/bigbluebutton/pull/24481.

An approach is taken where after analyzing the audio files to check for gaps, the audio file is removed from the EDL structure for the duration of the "gap" to prevent ffmpeg from processing the file during this time period. This fixes the excessive memory usage in the ffmpeg `aresample` filter.

The `start_pts` feature of the `aresample` filter is used to ensure sample-accurate alignment of audio during cuts.

While analyzing some recordings that had A/V sync issues after applying these changes, I discovered that the `aresample` filter in ffmpeg 4.4 (Ubuntu 22.04) was injecting several seconds of silent audio with incorrect timestamps into some audio tracks, causing A/V sync issues. This happened due to a bug in a performance optimization in the filter, where it is intended to "pass through" audio until it detects a need to start resampling to correct drift, and then start resampling afterwards. The silent audio with incorrect timestamps was generated when the filter switched to resampling mode. A workaround is available - set a flag that forces it to use resampling mode from the start of the file.

The remaining changes are:
* A performance fix, to remove the second audio processing pass and mixing step needed to handle deskshare audio. Now that all of the issues with multiple audio tracks and audio sync during cuts have been fixed, it's possible to combine the microphone and deskshare audio into a single pass.
* Switch to 'flac' as the intermediate file format. The previously used 'vorbis' codec has fixed size blocks, which means that when concatenated with the method previously used, it would sometimes introduce audio glitches at cut points. The variable block size in 'flac' avoids this issue, without using as much disk space as uncompressed 'wav' would need for temporary files.