### PR TITLE
fix: review breakout room moderator actions

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/groupchats/DeleteGroupChatMessageReqMsgHdlr.scala
@@ -54,9 +54,7 @@ trait DeleteGroupChatMessageReqMsgHdlr extends HandlerHelpers {
           val userIsOwner = gcMessage.sender.id == user.intId
 
           if ((chatIsPrivate && userIsAParticipant) || !chatIsPrivate) {
-            if (userIsOwner ||
-              (userIsModerator && !liveMeeting.props.meetingProp.isBreakout) //not allowed in breakoutRooms as everyone is moderator
-              ) {
+            if (userIsOwner || userIsModerator) {
               val updatedGroupChat = GroupChatApp.deleteGroupChatMessage(liveMeeting.props.meetingProp.intId, groupChat, state.groupChats, gcMessage, user.intId)
 
               val event = buildGroupChatMessageDeletedEvtMsg(liveMeeting.props.meetingProp.intId, msg.body.chatId, msg.header.userId, gcMessage.id)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserPinStateReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserPinStateReqMsgHdlr.scala
@@ -30,8 +30,7 @@ trait ChangeUserPinStateReqMsgHdlr extends RightsManagementTrait {
       outGW.send(msgEventChange)
     }
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.body.changedBy)
-      || liveMeeting.props.meetingProp.isBreakout) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.body.changedBy)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change pin in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.body.changedBy, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserRoleCmdMsgHdlr.scala
@@ -16,7 +16,7 @@ trait ChangeUserRoleCmdMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleChangeUserRoleCmdMsg(msg: ChangeUserRoleCmdMsg): Unit = {
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId) || liveMeeting.props.meetingProp.isBreakout) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change user role in meeting."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
@@ -74,7 +74,6 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
     )
 
     (allowModsToEjectCameras &&
-      !isBreakout &&
       hasPermission)
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/handlers/MuteAllExceptPresentersCmdMsgHdlr.scala
@@ -15,7 +15,7 @@ trait MuteAllExceptPresentersCmdMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleMuteAllExceptPresentersCmdMsg(msg: MuteAllExceptPresentersCmdMsg) {
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId) || liveMeeting.props.meetingProp.isBreakout) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to mute all except presenters."
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/component.tsx
@@ -132,7 +132,7 @@ const ChatActions: React.FC = () => {
       {
         key: uniqueIdsRef.current[2],
         enable: true,
-        disabled: !userIsModerator || meetingIsBreakout,
+        disabled: !userIsModerator,
         icon: 'delete',
         dataTest: 'chatClear',
         label: intl.formatMessage(intlMessages.clear),

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -641,7 +641,6 @@ const ChatMessageList: React.FC<ChatListProps> = ({
                       currentUserId={currentUser?.userId ?? ''}
                       currentUserIsLocked={!!currentUser?.locked}
                       currentUserIsModerator={!!currentUser?.isModerator}
-                      isBreakoutRoom={!!meeting?.isBreakout}
                       messageToolbarIsEnabled={messageToolbarIsEnabled}
                       chatDeleteEnabled={CHAT_DELETE_ENABLED}
                       chatEditEnabled={CHAT_EDIT_ENABLED}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -70,7 +70,6 @@ interface ChatMessageProps {
   currentUserIsLocked: boolean;
   currentUserId: string;
   currentUserDisablePublicChat: boolean;
-  isBreakoutRoom: boolean;
   isPublicChat: boolean;
   hasToolbar: boolean;
   chatReplyEnabled: boolean;
@@ -182,7 +181,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   currentUserId,
   currentUserIsLocked,
   currentUserIsModerator,
-  isBreakoutRoom,
   isPublicChat,
   hasToolbar,
   chatDeleteEnabled,
@@ -747,7 +745,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
         deleted={!!deleteTime}
         own={message.user?.userId === currentUserId}
         amIModerator={currentUserIsModerator}
-        isBreakoutRoom={isBreakoutRoom}
         messageSequence={message.messageSequence}
         onReactionPopoverOpenChange={setIsToolbarReactionPopoverOpen}
         reactionPopoverIsOpen={isToolbarReactionPopoverOpen}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-toolbar/component.tsx
@@ -44,7 +44,6 @@ interface ChatMessageToolbarProps {
   isCustomPluginMessage: boolean;
   own: boolean;
   amIModerator: boolean;
-  isBreakoutRoom: boolean;
   messageSequence: number;
   onReactionPopoverOpenChange(open: boolean): void;
   reactionPopoverIsOpen: boolean;
@@ -62,7 +61,7 @@ interface ChatMessageToolbarProps {
 
 const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const {
-    isCustomPluginMessage, deleted, messageSequence, own, amIModerator, isBreakoutRoom,
+    isCustomPluginMessage, deleted, messageSequence, own, amIModerator,
     locked, onReactionPopoverOpenChange, reactionPopoverIsOpen, hasToolbar,
     chatDeleteEnabled, chatEditEnabled, chatReactionsEnabled, chatReplyEnabled,
     onDelete, onEdit, onReply,
@@ -79,7 +78,7 @@ const ChatMessageToolbar: React.FC<ChatMessageToolbarProps> = (props) => {
   const showReplyButton = chatReplyEnabled;
   const showReactionsButton = chatReactionsEnabled;
   const showEditButton = chatEditEnabled && own && !isCustomPluginMessage;
-  const showDeleteButton = chatDeleteEnabled && (own || (amIModerator && !isBreakoutRoom));
+  const showDeleteButton = chatDeleteEnabled && (own || amIModerator);
   const showDivider = (showReplyButton || showReactionsButton) && (showEditButton || showDeleteButton);
 
   const container = (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/component.tsx
@@ -41,7 +41,6 @@ interface ChatListPageCommonProps {
   currentUserIsLocked: boolean;
   currentUserId: string;
   currentUserDisablePublicChat: boolean;
-  isBreakoutRoom: boolean;
   messageToolbarIsEnabled: boolean;
   chatReplyEnabled: boolean;
   chatDeleteEnabled: boolean;
@@ -123,7 +122,6 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
   currentUserDisablePublicChat,
   currentUserIsLocked,
   currentUserIsModerator,
-  isBreakoutRoom,
   isPublicChat,
   messageToolbarIsEnabled,
   chatDeleteEnabled,
@@ -261,7 +259,6 @@ const ChatListPage: React.FC<ChatListPageProps> = ({
             currentUserDisablePublicChat={currentUserDisablePublicChat}
             currentUserIsLocked={currentUserIsLocked}
             currentUserIsModerator={currentUserIsModerator}
-            isBreakoutRoom={isBreakoutRoom}
             isPublicChat={isPublicChat}
             hasToolbar={messageToolbarIsEnabled && !!message.user}
             chatDeleteEnabled={chatDeleteEnabled}
@@ -295,7 +292,6 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
   currentUserDisablePublicChat,
   currentUserIsLocked,
   currentUserIsModerator,
-  isBreakoutRoom,
   messageToolbarIsEnabled,
   chatDeleteEnabled,
   chatEditEnabled,
@@ -368,7 +364,6 @@ const ChatListPageContainer: React.FC<ChatListPageContainerProps> = ({
       currentUserDisablePublicChat={currentUserDisablePublicChat}
       currentUserIsLocked={currentUserIsLocked}
       currentUserIsModerator={currentUserIsModerator}
-      isBreakoutRoom={isBreakoutRoom}
       isPublicChat={isPublicChat}
       messageToolbarIsEnabled={messageToolbarIsEnabled}
       chatDeleteEnabled={chatDeleteEnabled}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -101,7 +101,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
       userId,
     } = talkingUser;
 
-    const isMuteActionAvailable = isModerator && !isBreakout;
+    const isMuteActionAvailable = isModerator;
 
     const ariaLabel = intl.formatMessage(talking
       ? intlMessages.isTalking : intlMessages.wasTalking, {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/component.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { uniqueId } from '/imports/utils/string-utils';
 import Styled from './styles';
 import { User } from '/imports/ui/Types/user';
@@ -10,8 +9,6 @@ import useToggleVoice from '../../../audio/audio-graphql/hooks/useToggleVoice';
 import { setTalkingIndicatorList } from '/imports/ui/core/hooks/useTalkingIndicator';
 import useTalkingUsers from '/imports/ui/core/hooks/useTalkingUsers';
 import { partition } from '/imports/utils/array-utils';
-import logger from '/imports/startup/client/logger';
-import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 
 const TALKING_INDICATORS_MAX = 8;
 
@@ -49,7 +46,6 @@ interface TalkingIndicatorProps {
     user: { color: string; speechLocale?: string; name: string };
     userId: string;
   }[];
-  isBreakout: boolean;
   moreThanMaxIndicators: boolean;
   isModerator: boolean;
   toggleVoice: (userId: string, muted: boolean) => void;
@@ -57,7 +53,6 @@ interface TalkingIndicatorProps {
 
 const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
   talkingUsers,
-  isBreakout,
   moreThanMaxIndicators,
   isModerator,
   toggleVoice,
@@ -130,7 +125,7 @@ const TalkingIndicator: React.FC<TalkingIndicatorProps> = ({
           onClick={() => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore - call signature is misse due the function being wrapped
-            muteUser(userId, muted, isBreakout, isMuteActionAvailable, toggleVoice);
+            muteUser(userId, muted, isMuteActionAvailable, toggleVoice);
           }}
           label={name}
           tooltipLabel={!muted && isMuteActionAvailable
@@ -212,14 +207,6 @@ const TalkingIndicatorContainer: React.FC = () => {
     isModerator: u?.isModerator,
   }));
 
-  const {
-    data: currentMeeting,
-    loading: isBreakoutLoading,
-    errors: isBreakoutError,
-  } = useMeeting((m) => ({
-    isBreakout: m.isBreakout,
-  }));
-
   const toggleVoice = useToggleVoice();
   const { data: talkingUsersData, loading: talkingUsersLoading } = useTalkingUsers();
   const talkingUsers = useMemo(() => {
@@ -253,28 +240,12 @@ const TalkingIndicatorContainer: React.FC = () => {
     ].slice(0, TALKING_INDICATORS_MAX);
   }, [talkingUsersData]);
 
-  if (talkingUsersLoading || isBreakoutLoading) return null;
+  if (talkingUsersLoading) return null;
 
-  if (isBreakoutError) {
-    connectionStatus.setSubscriptionFailed(true);
-    logger.error(
-      {
-        logCode: 'subscription_Failed',
-        extraInfo: {
-          error: isBreakoutError,
-        },
-      },
-      'Subscription failed to load',
-    );
-    return null;
-  }
-
-  const isBreakout = currentMeeting?.isBreakout ?? false;
   setTalkingIndicatorList(talkingUsers.map(({ user, ...rest }) => ({ ...rest, ...user })));
   return (
     <TalkingIndicator
       talkingUsers={talkingUsers}
-      isBreakout={isBreakout}
       moreThanMaxIndicators={talkingUsers.length >= TALKING_INDICATORS_MAX}
       isModerator={currentUser?.isModerator ?? false}
       toggleVoice={toggleVoice}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/service.ts
@@ -7,11 +7,10 @@ export const muteUser = debounce(
   (
     id: string,
     muted: boolean | undefined,
-    isBreakout: boolean,
     isModerator: boolean,
     toggleVoice: (userId: string, muted: boolean) => void,
   ) => {
-    if (!isModerator || isBreakout || muted) return null;
+    if (!isModerator || muted) return null;
     toggleVoice(id, true);
     return null;
   },

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/component.tsx
@@ -360,7 +360,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     )),
     {
       allowed: user?.cameras?.length > 0
-        && isVideoPinEnabledForCurrentUser(currentUser, isBreakout) && type === 'participant',
+        && isVideoPinEnabledForCurrentUser(currentUser) && type === 'participant',
       key: 'pinVideo',
       label: user?.pinned
         ? intl.formatMessage(messages.UnpinUserWebcam)
@@ -442,7 +442,6 @@ const UserActions: React.FC<UserActionsProps> = ({
     },
     {
       allowed: allowedToMuteAudio
-        && !isBreakout
         && type === 'participant',
       key: 'mute',
       label: intl.formatMessage(messages.MuteUserAudioLabel),
@@ -455,7 +454,6 @@ const UserActions: React.FC<UserActionsProps> = ({
     {
       allowed: allowedToUnmuteAudio
         && !lockSettings?.disableMic
-        && !isBreakout
         && type === 'participant',
       key: 'unmute',
       label: intl.formatMessage(messages.UnmuteUserAudioLabel),
@@ -470,8 +468,7 @@ const UserActions: React.FC<UserActionsProps> = ({
       allowed: allowedToChangeWhiteboardAccess
         && !user.presenter
         && !isVoiceOnlyUser(user.userId)
-        && pageId
-        && !isBreakout,
+        && pageId,
       key: 'changeWhiteboardAccess',
       label: hasWhiteboardAccess
         ? intl.formatMessage(messages.removeWhiteboardAccess)
@@ -563,7 +560,6 @@ const UserActions: React.FC<UserActionsProps> = ({
     {
       allowed: allowedToEjectCameras
         && user?.cameras?.length > 0
-        && !isBreakout
         && type === 'participant',
       key: 'ejectUserCameras',
       label: intl.formatMessage(messages.ejectUserCamerasLabel),

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-content/user-participants/user-list-participants/user-actions/service.ts
@@ -7,7 +7,6 @@ import Auth from '/imports/ui/services/auth';
 import logger from '/imports/startup/client/logger';
 import { toggleMuteMicrophone } from '/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service';
 import { useIsPrivateChatEnabled } from '/imports/ui/services/features';
-import getFromUserSettings from '/imports/ui/services/users-settings';
 
 export const isVoiceOnlyUser = (userId: string) => typeof userId === 'string' && userId.startsWith('v_');
 
@@ -27,9 +26,6 @@ export const generateActionsPermissions = (
   const isDialInUser = isVoiceOnlyUser(subjectUser.userId);
   const amISubjectUser = isMe(subjectUser.userId);
   const isSubjectUserModerator = subjectUser.isModerator;
-  // Breakout rooms mess up with role permissions
-  // A breakout room user that has a moderator role in it's parent room
-  const parentRoomModerator = getFromUserSettings('bbb_parent_room_moderator', false);
   const isSubjectUserGuest = subjectUser.guest;
   const hasAuthority = currentUser.isModerator || amISubjectUser;
   const allowedToChatPrivately = !amISubjectUser && !isDialInUser && useIsPrivateChatEnabled();
@@ -46,21 +42,18 @@ export const generateActionsPermissions = (
 
   // if currentUser is a moderator, allow removing other users
   const allowedToRemove = amIModerator
-    && !amISubjectUser
-    && (!isBreakout || parentRoomModerator);
+    && !amISubjectUser;
 
   const allowedToPromote = amIModerator
     && !amISubjectUser
     && !isSubjectUserModerator
     && !isDialInUser
-    && !isBreakout
     && !(isSubjectUserGuest && usersPolicies?.authenticatedGuest && !usersPolicies?.allowPromoteGuestToModerator);
 
   const allowedToDemote = amIModerator
     && !amISubjectUser
     && isSubjectUserModerator
     && !isDialInUser
-    && !isBreakout
     && !(isSubjectUserGuest && usersPolicies?.authenticatedGuest && !usersPolicies?.allowPromoteGuestToModerator);
 
   const allowedToChangeUserLockStatus = amIModerator
@@ -94,7 +87,6 @@ export const generateActionsPermissions = (
 
 export const isVideoPinEnabledForCurrentUser = (
   currentUser: User,
-  isBreakout: boolean,
 ) => {
   const { isModerator } = currentUser;
 
@@ -102,8 +94,7 @@ export const isVideoPinEnabledForCurrentUser = (
   const isPinEnabled = PIN_WEBCAM;
 
   return !!(isModerator
-    && isPinEnabled
-    && !isBreakout);
+    && isPinEnabled);
 };
 
 // actions

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -261,7 +261,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'usersJoinMuted',
       },
       {
-        allow: !isBreakout,
+        allow: true,
         key: uuids.current[1],
         label: intl.formatMessage(intlMessages.muteAllExceptPresenterLabel),
         description: intl.formatMessage(intlMessages.muteAllExceptPresenterDesc),
@@ -296,7 +296,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'downloadUserNamesList',
       },
       {
-        allow: isReactionsEnabled && isModerator && !isBreakout,
+        allow: isReactionsEnabled && isModerator,
         key: uuids.current[5],
         label: intl.formatMessage(intlMessages.clearAllReactionsLabel),
         description: intl.formatMessage(intlMessages.clearAllReactionsDesc),

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -47,7 +47,6 @@ import {
 import { DesktopPageSizes, MobilePageSizes } from '/imports/ui/Types/meetingClientSettings';
 import logger from '/imports/startup/client/logger';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
-import { useMeetingIsBreakout } from '/imports/ui/components/app/service';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
@@ -724,8 +723,7 @@ export const useShouldRenderPaginationToggle = () => {
 };
 
 export const useIsVideoPinEnabledForCurrentUser = (isModerator: boolean) => {
-  const isBreakout = useMeetingIsBreakout();
   const isPinEnabled = videoService.isPinEnabled();
 
-  return !!(isModerator && isPinEnabled && !isBreakout);
+  return !!(isModerator && isPinEnabled);
 };


### PR DESCRIPTION
### What does this PR do?

Removes the following restrictions to moderator actions in breakout rooms:
  - Remove user
  - Promote user
  - Demote user
  - Mute user audio
  - Unmute user audio
  - Grant whiteboard access
  - Eject user cameras
  - Pin user video
  - Mute all except presenter
  - Clear all reactions
  - Mute from talking indicator
  - Clear chat history
  - Delete other users chat messages

### Closes Issue(s)
Closes #24768