### PR TITLE
fix(layout): Layout observer with userdata-bbb_hide_sidebar_navigation=true now properly resolves

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -236,18 +236,6 @@ const LayoutObserver: React.FC = () => {
         const Settings = getSettingsSingletonInstance();
         Settings.save(setLocalSettings);
 
-        if (getFromUserSettings('bbb_hide_sidebar_navigation', false)) {
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
-            value: false,
-          });
-          layoutContextDispatch({
-            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
-            value: false,
-          });
-          return;
-        }
-
         layoutContextDispatch({
           type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
           value: true,
@@ -280,6 +268,17 @@ const LayoutObserver: React.FC = () => {
           layoutContextDispatch({
             type: ACTIONS.SET_ID_CHAT_OPEN,
             value: PUBLIC_GROUP_CHAT_ID,
+          });
+        }
+
+        if (getFromUserSettings('bbb_hide_sidebar_navigation', false)) {
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_NAVIGATION_IS_OPEN,
+            value: false,
+          });
+          layoutContextDispatch({
+            type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+            value: false,
           });
         }
 


### PR DESCRIPTION
This fixes a bug where joining with `userdata-bbb_hide_sidebar_navigation=true` caused the client to spam `SetUserClientSettingsReqMsg` and overload the server. This happened because of the return clause that was reached before `checkedUserSettings.current = true;` was called. The solution was to move the event propagation to after all the other events and the removal of the return clause.