### PR TITLE
fix(akka-apps): Remove Unnecessary Akka Apps Logging

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectionAliveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectionAliveReqMsgHdlr.scala
@@ -14,8 +14,6 @@ trait UserConnectionAliveReqMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleUserConnectionAliveReqMsg(msg: UserConnectionAliveReqMsg): Unit = {
-    log.info("handleUserConnectionAliveReqMsg: networkRttInMs={} userId={} serverRequestId={}", msg.body.networkRttInMs, msg.body.userId, msg.body.serverRequestId)
-
     val traceLog = {
       if (msg.body.traceLog != "") {
         log.info(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectionAliveReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserConnectionAliveReqMsgHdlr.scala
@@ -14,6 +14,8 @@ trait UserConnectionAliveReqMsgHdlr extends RightsManagementTrait {
   val outGW: OutMsgRouter
 
   def handleUserConnectionAliveReqMsg(msg: UserConnectionAliveReqMsg): Unit = {
+    log.info("handleUserConnectionAliveReqMsg: networkRttInMs={} userId={} serverRequestId={}", msg.body.networkRttInMs, msg.body.userId, msg.body.serverRequestId)
+
     val traceLog = {
       if (msg.body.traceLog != "") {
         log.info(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -64,17 +64,9 @@ object DatabaseConnection {
     }
 
     if (batch.nonEmpty) {
-      val startTime = System.nanoTime()
       val combinedAction = DBIO.sequence(batch.toList)
       db.run(combinedAction).onComplete {
         case scala.util.Success(_) =>
-          val endTime = System.nanoTime()
-          val duration = (endTime - startTime) / 1e6 // convert to milliseconds
-          if (duration > 2000) {
-            logger.warn(s"${batch.size} actions executed in the database in $duration ms.")
-          } else {
-            logger.debug(s"${batch.size} actions executed in the database in $duration ms.")
-          }
           isProcessing.set(false)
           if (!queue.isEmpty) tryProcessBatch()
         case scala.util.Failure(e) =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -64,9 +64,15 @@ object DatabaseConnection {
     }
 
     if (batch.nonEmpty) {
+      val startTime = System.nanoTime()
       val combinedAction = DBIO.sequence(batch.toList)
       db.run(combinedAction).onComplete {
         case scala.util.Success(_) =>
+          val endTime = System.nanoTime()
+          val duration = (endTime - startTime) / 1e6 // convert to milliseconds
+          if (duration > 2000) {
+            logger.warn(s"${batch.size} actions executed in the database in $duration ms.")
+          }
           isProcessing.set(false)
           if (!queue.isEmpty) tryProcessBatch()
         case scala.util.Failure(e) =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -74,7 +74,6 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
       case m: UserDisconnectedFromGlobalAudioMsg             => logMessage(msg)
       case m: AssignPresenterReqMsg                          => logMessage(msg)
       case m: ChangeUserPinStateReqMsg                       => logMessage(msg)
-      case m: UserConnectionAliveReqMsg                      => logMessage(msg)
       case m: ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg => logMessage(msg)
       case m: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg => logMessage(msg)
       case m: ScreenshareRtmpBroadcastStartedEvtMsg          => logMessage(msg)


### PR DESCRIPTION
### What does this PR do?

Removes overwhelmingly frequent and unnecessary logging of user connection heartbeats and database action execution times.

### Motivation

Excessive logging on servers under heavy load appears to be causing interruptions in Akka Apps functionality.
