### PR TITLE
refactor: replace connection error banner with toast notifications

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import MeetingRemainingTime from '/imports/ui/components/common/remaining-time/meeting-duration/component';
 import { useReactiveVar } from '@apollo/client';
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 import { layoutSelectInput, layoutDispatch } from '../layout/context';
 import { ACTIONS } from '../layout/enums';
 
@@ -47,7 +47,6 @@ const intlMessages = defineMessages({
 const STATUS_CRITICAL = 'critical';
 const COLOR_PRIMARY = 'primary';
 const CONNECTION_ERROR_TOAST_ID = 'connection-error-notification';
-const CONNECTION_ERROR_CONTAINER_ID = 'connection-error-toast-container';
 
 const NotificationsBarContainer = () => {
   const intl = useIntl();
@@ -174,6 +173,8 @@ const NotificationsBarContainer = () => {
     return null;
   }, [meeting?.isBreakout, meeting?.componentsFlags?.showRemainingTime]);
 
+  const connectionToastRef = useRef(null);
+
   useEffect(() => {
     if (errorMessage) {
       const reloadContent = subscriptionFailed ? (
@@ -198,22 +199,24 @@ const NotificationsBarContainer = () => {
         </ToastStyled.ToastWrapper>
       );
 
-      if (toast.isActive(CONNECTION_ERROR_TOAST_ID)) {
-        toast.update(CONNECTION_ERROR_TOAST_ID, { render: toastContent });
+      if (connectionToastRef.current && toast.isActive(connectionToastRef.current)) {
+        toast.update(connectionToastRef.current, { render: toastContent });
       } else {
-        toast(toastContent, {
+        connectionToastRef.current = toast(toastContent, {
           toastId: CONNECTION_ERROR_TOAST_ID,
-          containerId: CONNECTION_ERROR_CONTAINER_ID,
           autoClose: false,
         });
       }
-    } else if (toast.isActive(CONNECTION_ERROR_TOAST_ID)) {
-      toast.dismiss(CONNECTION_ERROR_TOAST_ID);
+    } else if (connectionToastRef.current) {
+      toast.dismiss(connectionToastRef.current);
+      connectionToastRef.current = null;
     }
   }, [errorMessage, subscriptionFailed, intl]);
 
   useEffect(() => () => {
-    toast.dismiss(CONNECTION_ERROR_TOAST_ID);
+    if (connectionToastRef.current) {
+      toast.dismiss(connectionToastRef.current);
+    }
   }, []);
 
   useEffect(() => {
@@ -223,27 +226,12 @@ const NotificationsBarContainer = () => {
     }
   }, [meetingMessage, hasNotification, dispatch]);
 
-  if (!meetingMessage || !hasNotification) {
-    return (
-      <ToastContainer
-        containerId={CONNECTION_ERROR_CONTAINER_ID}
-        enableMultiContainer
-        rtl
-      />
-    );
-  }
+  if (!meetingMessage || !hasNotification) return null;
 
   return (
-    <>
-      <ToastContainer
-        containerId={CONNECTION_ERROR_CONTAINER_ID}
-        enableMultiContainer
-        rtl
-      />
-      <NotificationsBar color={COLOR_PRIMARY}>
-        {meetingMessage}
-      </NotificationsBar>
-    </>
+    <NotificationsBar color={COLOR_PRIMARY}>
+      {meetingMessage}
+    </NotificationsBar>
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import MeetingRemainingTime from '/imports/ui/components/common/remaining-time/meeting-duration/component';
 import { useReactiveVar } from '@apollo/client';
+import { toast } from 'react-toastify';
 import { layoutSelectInput, layoutDispatch } from '../layout/context';
 import { ACTIONS } from '../layout/enums';
 
@@ -9,6 +10,8 @@ import NotificationsBar from './component';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import useMeeting from '../../core/hooks/useMeeting';
 import logger from '/imports/startup/client/logger';
+import ToastComponent from '/imports/ui/components/common/toast/component';
+import ToastStyled from '/imports/ui/services/notification/styles';
 
 const intlMessages = defineMessages({
   connectionCode3001: {
@@ -35,10 +38,15 @@ const intlMessages = defineMessages({
     id: 'app.notificationBar.issueLoadingDataCode3006',
     description: 'Subscription failed alert',
   },
+  reloadPage: {
+    id: 'app.errorBoundary.reloadPage',
+    defaultMessage: 'Reload Page',
+  },
 });
 
 const STATUS_CRITICAL = 'critical';
 const COLOR_PRIMARY = 'primary';
+const CONNECTION_ERROR_TOAST_ID = 'connection-error-notification';
 
 const NotificationsBarContainer = () => {
   const intl = useIntl();
@@ -165,20 +173,59 @@ const NotificationsBarContainer = () => {
     return null;
   }, [meeting?.isBreakout, meeting?.componentsFlags?.showRemainingTime]);
 
-  const message = errorMessage || meetingMessage;
+  useEffect(() => {
+    if (errorMessage) {
+      const reloadContent = subscriptionFailed ? (
+        <ToastStyled.HelpLinkButton
+          label={intl.formatMessage(intlMessages.reloadPage)}
+          color="default"
+          size="sm"
+          onClick={() => { window.location.reload(); }}
+          data-test="notificationBannerReloadButton"
+        />
+      ) : null;
+
+      const toastContent = (
+        <ToastStyled.ToastWrapper role="alert">
+          <ToastComponent
+            type="warning"
+            icon="warning"
+            message={errorMessage}
+            content={reloadContent}
+            showSeparator={!!reloadContent}
+          />
+        </ToastStyled.ToastWrapper>
+      );
+
+      if (toast.isActive(CONNECTION_ERROR_TOAST_ID)) {
+        toast.update(CONNECTION_ERROR_TOAST_ID, { render: toastContent });
+      } else {
+        toast(toastContent, {
+          toastId: CONNECTION_ERROR_TOAST_ID,
+          autoClose: false,
+        });
+      }
+    } else if (toast.isActive(CONNECTION_ERROR_TOAST_ID)) {
+      toast.dismiss(CONNECTION_ERROR_TOAST_ID);
+    }
+  }, [errorMessage, subscriptionFailed, intl]);
+
+  useEffect(() => () => {
+    toast.dismiss(CONNECTION_ERROR_TOAST_ID);
+  }, []);
 
   useEffect(() => {
-    const wantsNotification = !!message;
+    const wantsNotification = !!meetingMessage;
     if (wantsNotification !== hasNotification) {
       dispatch({ type: ACTIONS.SET_HAS_NOTIFICATIONS_BAR, value: wantsNotification });
     }
-  }, [message, hasNotification, dispatch]);
+  }, [meetingMessage, hasNotification, dispatch]);
 
-  if (!message || !hasNotification) return null;
+  if (!meetingMessage || !hasNotification) return null;
 
   return (
-    <NotificationsBar color={COLOR_PRIMARY} showReloadButton={subscriptionFailed}>
-      {message}
+    <NotificationsBar color={COLOR_PRIMARY}>
+      {meetingMessage}
     </NotificationsBar>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications-bar/container.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import MeetingRemainingTime from '/imports/ui/components/common/remaining-time/meeting-duration/component';
 import { useReactiveVar } from '@apollo/client';
-import { toast } from 'react-toastify';
+import { toast, ToastContainer } from 'react-toastify';
 import { layoutSelectInput, layoutDispatch } from '../layout/context';
 import { ACTIONS } from '../layout/enums';
 
@@ -47,6 +47,7 @@ const intlMessages = defineMessages({
 const STATUS_CRITICAL = 'critical';
 const COLOR_PRIMARY = 'primary';
 const CONNECTION_ERROR_TOAST_ID = 'connection-error-notification';
+const CONNECTION_ERROR_CONTAINER_ID = 'connection-error-toast-container';
 
 const NotificationsBarContainer = () => {
   const intl = useIntl();
@@ -202,6 +203,7 @@ const NotificationsBarContainer = () => {
       } else {
         toast(toastContent, {
           toastId: CONNECTION_ERROR_TOAST_ID,
+          containerId: CONNECTION_ERROR_CONTAINER_ID,
           autoClose: false,
         });
       }
@@ -221,12 +223,27 @@ const NotificationsBarContainer = () => {
     }
   }, [meetingMessage, hasNotification, dispatch]);
 
-  if (!meetingMessage || !hasNotification) return null;
+  if (!meetingMessage || !hasNotification) {
+    return (
+      <ToastContainer
+        containerId={CONNECTION_ERROR_CONTAINER_ID}
+        enableMultiContainer
+        rtl
+      />
+    );
+  }
 
   return (
-    <NotificationsBar color={COLOR_PRIMARY}>
-      {meetingMessage}
-    </NotificationsBar>
+    <>
+      <ToastContainer
+        containerId={CONNECTION_ERROR_CONTAINER_ID}
+        enableMultiContainer
+        rtl
+      />
+      <NotificationsBar color={COLOR_PRIMARY}>
+        {meetingMessage}
+      </NotificationsBar>
+    </>
   );
 };
 


### PR DESCRIPTION
### What does this PR do?
Replace the NotificationsBar-based display with react-toastify toast notifications, consistent with the style already used for screenshare errors. A single toast with a fixed ID is used so it updates in-place when the error condition changes.

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/24701

### More
<img width="385" height="178" alt="Screenshot from 2026-03-23 13-20-24" src="https://github.com/user-attachments/assets/85d2eb48-d706-45ab-8663-bd910f7ffc6d" />

