### PR TITLE
chore (gql-middleware): Change log level for `Error on close idle websocket`

### DIFF
--- a/bbb-graphql-middleware/internal/websrv/connhandler.go
+++ b/bbb-graphql-middleware/internal/websrv/connhandler.go
@@ -519,7 +519,7 @@ func InvalidateIdleBrowserConnectionsRoutine() {
 				browserConnection.Logger.Info("Closing browser connection, reason: idle timeout")
 				errCloseWs := browserConnection.Websocket.Close(websocket.StatusNormalClosure, "idle timeout")
 				if errCloseWs != nil {
-					browserConnection.Logger.Debugf("Error on close websocket: %v", errCloseWs)
+					browserConnection.Logger.Warnf("Error on close websocket: %v", errCloseWs)
 				}
 			}
 		}


### PR DESCRIPTION
It will help to debug the reason why it was not able to close the connection (in production where log level is `INFO`).