### PR TITLE
ci: workflow to push .deb to package repo

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -273,7 +273,9 @@ jobs:
       - name: Add repo host to known_hosts
         env:
           REPO_HOST: ${{ secrets.PKG_REPO_HOST }}
-        run: ssh-keyscan -H "$REPO_HOST" >> ~/.ssh/known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          [ -n "$REPO_HOST" ] && ssh-keyscan -H "$REPO_HOST" >> ~/.ssh/known_hosts || echo "PKG_REPO_HOST not set, skipping"
       - name: Push .deb to package repo
         env:
           SSH_KEY: ${{ secrets.PKG_REPO_SSH_KEY }}
@@ -290,6 +292,7 @@ jobs:
             ${REPO_USER}@${REPO_HOST} \
             "sudo -u aptrepo /usr/local/bin/repo-process-incoming jammy-30-dev-new"
   install-and-run-bbb-tests:
+    if: false # TODO: re-enable after package push is verified
     needs:
       - unify-artifacts
       - bbb-libreoffice-image
@@ -419,6 +422,7 @@ jobs:
           path: /var/cache/apt/archives
           key: ${{ runner.os }}-apt-${{ hashFiles('bigbluebutton-config/bigbluebutton-release') }}-${{ steps.apt-manifest.outputs.hash }}
   install-and-run-plugin-tests:
+    if: false # TODO: re-enable after package push is verified
     needs:
       - unify-artifacts
       - bbb-libreoffice-image

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -260,7 +260,8 @@ jobs:
           failOnError: false
   push-debs-to-package-repo:
     needs: unify-artifacts
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request' # TODO revert to 'push' only
     runs-on: ubuntu-22.04
     environment: apt-repo
     steps:

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -258,6 +258,36 @@ jobs:
             artifacts_bbb-html5
             artifacts_others
           failOnError: false
+  push-debs-to-package-repo:
+    needs: unify-artifacts
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    environment: apt-repo
+    steps:
+      - name: Download unified artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: all-bbb-artifacts
+          path: all-artifacts
+      - name: Add repo host to known_hosts
+        env:
+          REPO_HOST: ${{ secrets.PKG_REPO_HOST }}
+        run: ssh-keyscan -H "$REPO_HOST" >> ~/.ssh/known_hosts
+      - name: Push .deb to package repo
+        env:
+          SSH_KEY: ${{ secrets.PKG_REPO_SSH_KEY }}
+          REPO_HOST: ${{ secrets.PKG_REPO_HOST }}
+          REPO_USER: ${{ secrets.PKG_REPO_USER }}
+        run: |
+          eval $(ssh-agent -s)
+          trap 'ssh-agent -k' EXIT
+          echo "$SSH_KEY" | tr -d '\r' | ssh-add -
+          rsync -avz -e "ssh -o ServerAliveInterval=60 -o ServerAliveCountMax=10" \
+            all-artifacts/*.deb ${REPO_USER}@${REPO_HOST}:/srv/apt-incoming/
+          # Trigger processing for the target codename (e.g. jammy)
+          ssh -o ServerAliveInterval=60 -o ServerAliveCountMax=10 \
+            ${REPO_USER}@${REPO_HOST} \
+            "sudo -u aptrepo /usr/local/bin/repo-process-incoming jammy-30-dev-new"
   install-and-run-bbb-tests:
     needs:
       - unify-artifacts


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Pushing signed packages to a packaging repository. Independent from the existing repo for the time being.


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

```
curl http://packages.bigbluebutton.org/public.gpg | sudo gpg --dearmor   -o /etc/apt/trusted.gpg.d/bbb-repo.gpg
echo "deb http://packages.bigbluebutton.org/ jammy-30-dev-new main"   | sudo tee /etc/apt/sources.list.d/bbb.list
...
sudo bbb-conf --setip .........
```

The result looks like

```
bbb-conf --version

BigBlueButton Server 3.0.24 (1)

ii  bbb-apps-akka                     2:3.0.24~3.0.24+0-git.0                 all          BigBlueButton Apps (Akka)
ii  bbb-config                        2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton configuration utilities
ii  bbb-etherpad                      2:3.0.24~3.0.24+0-git.0                 amd64        The EtherPad Lite components for BigBlueButton
ii  bbb-export-annotations            2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton Export Annotations
ii  bbb-freeswitch-core               2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton build of FreeSWITCH
ii  bbb-freeswitch-sounds             2:3.0.24~3.0.24+0-git.0                 amd64        FreeSWITCH Sounds
ii  bbb-fsesl-akka                    2:3.0.24~3.0.24+0-git.0                 all          BigBlueButton FS-ESL (Akka)
ii  bbb-graphql-actions               2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton GraphQL Actions
ii  bbb-graphql-middleware            2:3.0.24~3.0.24+0-git.0                 amd64        GraphQL middleware component for BigBlueButton
ii  bbb-graphql-server                2:3.0.24~3.0.24+0-git.0                 amd64        GraphQL server component for BigBlueButton
ii  bbb-html5                         2:3.0.24~3.0.24+0-git.0                 amd64        The HTML5 components for BigBlueButton
ii  bbb-learning-dashboard            2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton bbb-learning-dashboard
ii  bbb-libreoffice-docker            2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton setup for LibreOffice running in docker
ii  bbb-livekit                       2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton build of LiveKit Server
ii  bbb-mkclean                       2:3.0.24~3.0.24+0-git.0                 amd64        Clean and optimize Matroska and WebM files
ii  bbb-pads                          2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton Pads
ii  bbb-playback                      2:3.0.24~3.0.24+0-git.0                 amd64        Player for BigBlueButton presentation format recordings
ii  bbb-playback-presentation         2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton presentation recording format
ii  bbb-record-core                   2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton record and playback
ii  bbb-web                           2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton API
ii  bbb-webrtc-recorder               2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton WebRTC Recorder
ii  bbb-webrtc-sfu                    2:3.0.24~3.0.24+0-git.0                 amd64        BigBlueButton WebRTC SFU
ii  libopusenc0                       0.2.1-1bbb2                             amd64        High-level API for encoding Ogg Opus audio streams

```

TODO:
- [ ] only push the package when needed (a change in the component or in its dependencies) -- possibly reuse the caching logic or the build logic from ~3-4 years ago
- [ ] handle `bbb-presentation-video`
- [ ] ensure we handle -placeholder.sh packages like bbb-webrtc-sfu, bbb-pads properly
- [ ] re-enable the workflows for installation+testing a PR
- [ ] drop the trigger for on-pr

For BBB 3.0.x, likely these packages will only be used in dev environments. The risk is quite high to adopt this so late into the cycle.
For BBB 4.x ideally we'll use only these packages.
