### PR TITLE
refactor(livekit): review camera and screen sharing quality presets and simulcast layers

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -43,44 +43,146 @@ const SEND_ROLE = 'send';
 const RECV_ROLE = 'recv';
 const DEFAULT_VOLUME = 1;
 const ROOM_CONNECTION_TIMEOUT = 15000;
+const LOW_TIER_FPS = 5;
+const LOW_TIER_BITRATE = 500_000;
+const HIGH_TIER_FPS = 15;
+const HIGH_TIER_BITRATE = 1_500_000;
+const DEFAULT_WIDTH = 1920;
+const DEFAULT_HEIGHT = 1080;
 
-const FALLBACK_PRESET_ORG_HIGH = new VideoPreset(1920, 1080, 2_000_000, 15, 'medium');
+interface CaptureSettings {
+  width: number;
+  height: number;
+  frameRate: number | undefined;
+}
 
-const getDefaultPresets = (mediaStream: MediaStream): VideoPreset[] => {
-  const fallbackPresets = [FALLBACK_PRESET_ORG_HIGH];
+const getCaptureSettings = (stream: MediaStream): CaptureSettings => {
+  // @ts-ignore
+  const configVideo = window.meetingClientSettings.public.media?.livekit?.screenshare
+    ?.constraints?.video;
+  const configWidth = configVideo?.width?.max ?? DEFAULT_WIDTH;
+  const configHeight = configVideo?.height?.max ?? DEFAULT_HEIGHT;
+  const configFps = configVideo?.frameRate?.ideal ?? configVideo?.frameRate?.max;
 
   try {
-    if (!mediaStream.getVideoTracks().length) return fallbackPresets;
+    const track = stream.getVideoTracks()[0];
+    const trackFps = track?.getSettings().frameRate;
 
-    const { width = 1920, height = 1080 } = mediaStream.getVideoTracks()[0].getSettings();
-
-    return [
-      new VideoPreset(width, height, 2_000_000, 15, 'medium'),
-    ];
-  } catch (error) {
-    logger.error({
-      logCode: 'livekit_screenshare_get_presets_error',
-      extraInfo: {
-        errorName: (error as Error).name,
-        errorMessage: (error as Error).message,
-        errorStack: (error as Error).stack,
-      },
-    }, `LiveKit: failed to get screen share presets: ${(error as Error).message}`);
-
-    return fallbackPresets;
+    return {
+      width: configWidth,
+      height: configHeight,
+      frameRate: trackFps ?? configFps,
+    };
+  } catch {
+    return { width: configWidth, height: configHeight, frameRate: configFps };
   }
 };
 
-const assemblePresetFromConfig = (config: LiveKitPresetConfig): VideoPreset => {
-  const {
-    width,
-    height,
-    maxBitrate,
-    maxFramerate,
-    priority,
-  } = config;
+const getDefaultPresets = (stream: MediaStream): VideoPreset[] => {
+  const { width, height, frameRate: captureFrameRate } = getCaptureSettings(stream);
 
-  return new VideoPreset(width, height, maxBitrate, maxFramerate, priority);
+  // If capture FPS is at or below the low-tier FPS, FPS-differentiated
+  // layers would encode at the same rate. Fall back to bitrate-only
+  // differentiation: two layers at same resolution + same FPS, different
+  // bitrate caps.
+  if (captureFrameRate != null && captureFrameRate <= LOW_TIER_FPS) {
+    return [
+      new VideoPreset(width, height, LOW_TIER_BITRATE, captureFrameRate, 'medium'),
+      new VideoPreset(width, height, HIGH_TIER_BITRATE, captureFrameRate, 'medium'),
+    ];
+  }
+
+  // Cap the high-tier FPS to the actual capture rate
+  const effectiveHighFps = captureFrameRate != null
+    ? Math.min(captureFrameRate, HIGH_TIER_FPS)
+    : HIGH_TIER_FPS;
+
+  return [
+    new VideoPreset(width, height, LOW_TIER_BITRATE, LOW_TIER_FPS, 'medium'),
+    new VideoPreset(width, height, HIGH_TIER_BITRATE, effectiveHighFps, 'medium'),
+  ];
+};
+
+interface PresetDefaults {
+  width: number;
+  height: number;
+  maxBitrate: number;
+  maxFramerate: number;
+  priority: RTCPriorityType;
+}
+
+const assemblePresetFromConfig = (
+  config: LiveKitPresetConfig,
+  defaults: PresetDefaults,
+): VideoPreset => new VideoPreset(
+  config.width ?? defaults.width,
+  config.height ?? defaults.height,
+  config.maxBitrate ?? defaults.maxBitrate,
+  config.maxFramerate ?? defaults.maxFramerate,
+  config.priority ?? defaults.priority,
+);
+
+// Merges partially-specified config presets with capture-aware defaults.
+// Config presets are ordered lowest-to-highest quality. For each preset,
+// a normalized position t \E [0,1] is computed from its index. Missing
+// bitrate/FPS values are filled by linearly interpolating between the
+// auto-generated low (t=0) and high (t=1) defaults from getDefaultPresets.
+// Resolution always defaults to capture resolution for all positions.
+// It can be overriden on individual presets via explicit width/height (e.g.
+// for a lower-resolution layer).
+// This is bound to change _significantly_ once we support VP9/AV1 (SVC) - prlanzarin
+const resolveConfigPresets = (
+  configPresets: LiveKitPresetConfig[],
+  stream: MediaStream,
+): VideoPreset[] => {
+  const defaults = getDefaultPresets(stream);
+  const first = defaults[0];
+  const last = defaults[defaults.length - 1];
+
+  const interpolatedPresets = configPresets.map((config, index) => {
+    const t = configPresets.length > 1 ? index / (configPresets.length - 1) : 1;
+    const positionalDefaults: PresetDefaults = {
+      width: last.width,
+      height: last.height,
+      maxBitrate: Math.round(
+        first.encoding.maxBitrate + t * (last.encoding.maxBitrate - first.encoding.maxBitrate),
+      ),
+      maxFramerate: Math.round(
+        (first.encoding.maxFramerate ?? LOW_TIER_FPS)
+          + t * ((last.encoding.maxFramerate ?? HIGH_TIER_FPS)
+          - (first.encoding.maxFramerate ?? LOW_TIER_FPS)),
+      ),
+      priority: 'medium',
+    };
+
+    return assemblePresetFromConfig(config, positionalDefaults);
+  });
+
+  // Deduplicate layers that are identical across all three preset dimensions
+  const { frameRate: captureFrameRate } = getCaptureSettings(stream);
+
+  if (captureFrameRate == null || interpolatedPresets.length <= 1) return interpolatedPresets;
+
+  const effectiveFps = (preset: VideoPreset): number => Math.min(
+    preset.encoding.maxFramerate ?? captureFrameRate,
+    captureFrameRate,
+  );
+
+  const deduped: VideoPreset[] = [];
+
+  for (let i = 0; i < interpolatedPresets.length; i += 1) {
+    const preset = interpolatedPresets[i];
+    const isDuplicate = deduped.some(
+      (p) => p.width === preset.width
+        && p.height === preset.height
+        && p.encoding.maxBitrate === preset.encoding.maxBitrate
+        && effectiveFps(p) === effectiveFps(preset),
+    );
+
+    if (!isDuplicate) deduped.push(preset);
+  }
+
+  return deduped;
 };
 
 export default class LiveKitScreenshareBridge {
@@ -624,12 +726,25 @@ export default class LiveKitScreenshareBridge {
     // @ts-ignore
     const configScreenPubOpts = window.meetingClientSettings.public.media?.livekit?.screenshare?.publishOptions
       || {};
-    const presets = window.meetingClientSettings.public.media?.livekit?.screenshare?.presets;
-    const screenSharePresets = presets
-      ? presets.map((preset: LiveKitPresetConfig) => assemblePresetFromConfig(preset))
+    const configPresets = window.meetingClientSettings.public.media?.livekit?.screenshare?.presets;
+    const presets = configPresets?.length
+      ? resolveConfigPresets(configPresets, stream)
       : getDefaultPresets(stream);
-    const screenShareEncoding = screenSharePresets[screenSharePresets.length - 1]?.encoding
+    const layers = presets.length > 1
+      ? presets.slice(0, -1)
+      : [];
+    const screenShareEncoding = presets[presets.length - 1]?.encoding
       || ScreenSharePresets.h1080fps15.encoding;
+    logger.debug({
+      logCode: 'livekit_screenshare_presets',
+      extraInfo: {
+        presetCount: presets.length,
+        simulcastLayerCount: layers?.length,
+        presets: presets.map((p) => ({
+          width: p.width, height: p.height, maxBitrate: p.encoding.maxBitrate, maxFramerate: p.encoding.maxFramerate,
+        })),
+      },
+    }, `LiveKit: resolved screen share presets (p=${presets.length}, l=${layers?.length})`);
     // @ts-ignore
     const configAudioPubOpts = window.meetingClientSettings.public.media?.livekit?.audio?.publishOptions || {};
     const baseAudioOptions: TrackPublishOptions = {
@@ -643,6 +758,7 @@ export default class LiveKitScreenshareBridge {
       videoCodec: 'vp8',
       simulcast: true,
       screenShareEncoding,
+      screenShareSimulcastLayers: layers,
       ...configScreenPubOpts,
     };
 

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -26,6 +26,11 @@ import {
   getLKStats,
 } from '/imports/ui/services/livekit';
 import { LiveKitPresetConfig } from 'imports/ui/Types/meetingClientSettings';
+import {
+  assemblePresetFromConfig,
+  deduplicatePresets,
+  type PresetDefaults,
+} from '/imports/ui/services/livekit/presets';
 
 interface Options {
   hasAudio?: boolean;
@@ -103,25 +108,6 @@ const getDefaultPresets = (stream: MediaStream): VideoPreset[] => {
   ];
 };
 
-interface PresetDefaults {
-  width: number;
-  height: number;
-  maxBitrate: number;
-  maxFramerate: number;
-  priority: RTCPriorityType;
-}
-
-const assemblePresetFromConfig = (
-  config: LiveKitPresetConfig,
-  defaults: PresetDefaults,
-): VideoPreset => new VideoPreset(
-  config.width ?? defaults.width,
-  config.height ?? defaults.height,
-  config.maxBitrate ?? defaults.maxBitrate,
-  config.maxFramerate ?? defaults.maxFramerate,
-  config.priority ?? defaults.priority,
-);
-
 // Merges partially-specified config presets with capture-aware defaults.
 // Config presets are ordered lowest-to-highest quality. For each preset,
 // a normalized position t \E [0,1] is computed from its index. Missing
@@ -158,31 +144,9 @@ const resolveConfigPresets = (
     return assemblePresetFromConfig(config, positionalDefaults);
   });
 
-  // Deduplicate layers that are identical across all three preset dimensions
   const { frameRate: captureFrameRate } = getCaptureSettings(stream);
 
-  if (captureFrameRate == null || interpolatedPresets.length <= 1) return interpolatedPresets;
-
-  const effectiveFps = (preset: VideoPreset): number => Math.min(
-    preset.encoding.maxFramerate ?? captureFrameRate,
-    captureFrameRate,
-  );
-
-  const deduped: VideoPreset[] = [];
-
-  for (let i = 0; i < interpolatedPresets.length; i += 1) {
-    const preset = interpolatedPresets[i];
-    const isDuplicate = deduped.some(
-      (p) => p.width === preset.width
-        && p.height === preset.height
-        && p.encoding.maxBitrate === preset.encoding.maxBitrate
-        && effectiveFps(p) === effectiveFps(preset),
-    );
-
-    if (!isDuplicate) deduped.push(preset);
-  }
-
-  return deduped;
+  return deduplicatePresets(interpolatedPresets, captureFrameRate);
 };
 
 export default class LiveKitScreenshareBridge {

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/service.js
@@ -21,10 +21,9 @@ const getBoundGDM = () => {
   }
 }
 
-const getScreenStream = async () => {
-  const {
-    constraints: GDM_CONSTRAINTS,
-  } = window.meetingClientSettings.public.kurento.screenshare;
+const getScreenStream = async (constraints) => {
+  const effectiveConstraints = constraints
+    || window.meetingClientSettings.public.kurento.screenshare.constraints;
 
   const gDMCallback = (stream) => {
     // Some older Chromium variants choke on gDM when audio: true by NOT generating
@@ -35,10 +34,10 @@ const getScreenStream = async () => {
     }
 
     if (typeof stream.getVideoTracks === 'function'
-      && typeof GDM_CONSTRAINTS.video === 'object') {
+      && typeof effectiveConstraints.video === 'object') {
       stream.getVideoTracks().forEach(track => {
         if (typeof track.applyConstraints  === 'function') {
-          track.applyConstraints(GDM_CONSTRAINTS.video).catch(error => {
+          track.applyConstraints(effectiveConstraints.video).catch(error => {
             logger.warn({
               logCode: 'screenshare_videoconstraint_failed',
               extraInfo: { errorName: error.name, errorCode: error.code },
@@ -50,10 +49,10 @@ const getScreenStream = async () => {
     }
 
     if (typeof stream.getAudioTracks === 'function'
-      && typeof GDM_CONSTRAINTS.audio === 'object') {
+      && typeof effectiveConstraints.audio === 'object') {
       stream.getAudioTracks().forEach(track => {
         if (typeof track.applyConstraints  === 'function') {
-          track.applyConstraints(GDM_CONSTRAINTS.audio).catch(error => {
+          track.applyConstraints(effectiveConstraints.audio).catch(error => {
             logger.warn({
               logCode: 'screenshare_audioconstraint_failed',
               extraInfo: { errorName: error.name, errorCode: error.code },
@@ -69,7 +68,7 @@ const getScreenStream = async () => {
   const getDisplayMedia = getBoundGDM();
 
   if (typeof getDisplayMedia === 'function') {
-    return getDisplayMedia(GDM_CONSTRAINTS)
+    return getDisplayMedia(effectiveConstraints)
       .then(gDMCallback)
       .catch(error => {
         const normalizedError = normalizeGetDisplayMediaError(error);

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -631,10 +631,10 @@ export interface Media {
 }
 
 export interface LiveKitPresetConfig {
-  width: number
-  height: number
-  maxBitrate: number
-  maxFramerate: number
+  width?: number
+  height?: number
+  maxBitrate?: number
+  maxFramerate?: number
   priority?: RTCPriorityType
 }
 
@@ -646,6 +646,7 @@ export interface LiveKitCameraSettings {
 export interface LiveKitScreenShareSettings {
   publishOptions?: TrackPublishOptions
   presets?: LiveKitPresetConfig[]
+  constraints?: Constraints
 }
 
 export interface LiveKitAudioSettings {

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -327,7 +327,11 @@ export const shareScreen = async (
     let stream;
     let contentType = CONTENT_TYPE_SCREENSHARE;
     if (options.stream == null) {
-      stream = await BridgeService.getScreenStream();
+      const isLiveKit = screenShareBridge.bridgeName === 'livekit';
+      const constraints = isLiveKit
+        ? window.meetingClientSettings.public.media?.livekit?.screenshare?.constraints
+        : undefined;
+      stream = await BridgeService.getScreenStream(constraints);
     } else {
       contentType = CONTENT_TYPE_CAMERA;
       stream = options.stream;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -18,6 +18,7 @@ import {
 import { useConnectionState, useTracks } from '@livekit/components-react';
 import { debounce } from '/imports/utils/debounce';
 import VideoService from '/imports/ui/components/video-provider/service';
+import { getCameraPublishOptions } from './service';
 import VideoListContainer from '/imports/ui/components/video-provider/video-list/container';
 import logger from '/imports/startup/client/logger';
 import { notifyStreamStateChange } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
@@ -301,18 +302,6 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   const startStream = useCallback(async (stream: string, isLocal: boolean) => {
     if (bridgeRefs.current.localTracks[stream] || bridgeRefs.current.connectingStreams[stream]) return;
 
-    const LIVEKIT_SETTINGS = meetingSettings.public.media.livekit?.camera;
-    const source = Track.Source.Camera;
-    const defaultPubOptions = LIVEKIT_SETTINGS?.publishOptions || {
-      dtx: true,
-      videoCodec: 'vp8',
-    };
-    const publishOptions = {
-      ...defaultPubOptions,
-      source,
-      name: stream,
-    };
-
     if (!isLocal) {
       subscribeToRemotePub(stream);
       return;
@@ -324,6 +313,20 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       const localBBBStream = VideoService.getPreloadedStream();
       bridgeRefs.current.localVideoStreams[stream] = localBBBStream;
       const { mediaStream } = localBBBStream;
+      const LIVEKIT_SETTINGS = meetingSettings.public.media.livekit?.camera;
+      const basePubOptions = {
+        dtx: true,
+        videoCodec: 'vp8' as const,
+        ...LIVEKIT_SETTINGS?.publishOptions,
+      };
+      const simulcastOptions = getCameraPublishOptions(mediaStream);
+      const publishOptions = {
+        ...basePubOptions,
+        ...simulcastOptions,
+        source: Track.Source.Camera,
+        name: stream,
+      };
+
       const publishers: Promise<LocalTrackPublication>[] = mediaStream
         .getTracks()
         .map((track: MediaStreamTrack) => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/service.ts
@@ -1,0 +1,267 @@
+import { VideoPreset, type TrackPublishOptions } from 'livekit-client';
+import logger from '/imports/startup/client/logger';
+import { type CameraProfile, type LiveKitPresetConfig } from '/imports/ui/Types/meetingClientSettings';
+import VideoService from '/imports/ui/components/video-provider/service';
+import {
+  assemblePresetFromConfig,
+  deduplicatePresets,
+  type PresetDefaults,
+} from '/imports/ui/services/livekit/presets';
+
+const DEFAULT_CAM_WIDTH = 640;
+const DEFAULT_CAM_HEIGHT = 480;
+const DEFAULT_CAM_FPS = 15;
+const DEFAULT_CAM_BITRATE = 500_000;
+const MAX_SIMULCAST_LAYERS = 3;
+
+interface CaptureSettings {
+  width: number;
+  height: number;
+  frameRate: number | undefined;
+}
+
+const getCameraCaptureSettings = (stream: MediaStream): CaptureSettings => {
+  const profile = VideoService.getCameraProfile();
+  const profileWidth = profile?.constraints?.width ?? DEFAULT_CAM_WIDTH;
+  const profileHeight = profile?.constraints?.height ?? DEFAULT_CAM_HEIGHT;
+  const profileFps = profile?.constraints?.frameRate ?? DEFAULT_CAM_FPS;
+
+  try {
+    const track = stream.getVideoTracks()[0];
+
+    if (!track) {
+      return { width: profileWidth, height: profileHeight, frameRate: profileFps };
+    }
+
+    const settings = track.getSettings();
+
+    return {
+      width: settings.width ?? profileWidth,
+      height: settings.height ?? profileHeight,
+      frameRate: settings.frameRate ?? profileFps,
+    };
+  } catch {
+    return { width: profileWidth, height: profileHeight, frameRate: profileFps };
+  }
+};
+
+const getVisibleProfiles = (): CameraProfile[] => {
+  // @ts-ignore
+  const profiles = window.meetingClientSettings.public.kurento?.cameraProfiles ?? [];
+
+  return profiles.filter((p: CameraProfile) => !p.hidden);
+};
+
+// Maps a BBB CameraProfile to a VideoPreset (LiveKit's encoding descriptor).
+//
+// There are two paths here:
+// 1. Profile HAS explicit constraints (width/height) → use them directly.
+//    Example: "high" profile with { width: 1280, height: 720, frameRate: 15 }
+//    => VideoPreset(1280, 720, 500000, 15)
+// 2. Profile has NO constraints (e.g., "low", "medium") → derive resolution
+//    proportionally from the *capture* (MediaStream) dimensions and the bitrate
+//    ratio to the top (selected) profile. Bitrate scales *roughly* (because we're
+//    ignoring FPS, see comment below) with pixel count (area), so:
+//      bitrate_ratio = profile.bitrate / topProfile.bitrate
+//      area_ratio ≈ bitrate_ratio
+//      dimension_scale = sqrt(area_ratio)  (area = scale² × original_area)
+//    Example: top=500kbps at 1280x720, medium=200kbps
+//      scale = sqrt(200/500) = sqrt(0.4) ≈ 0.632
+//      width = round(1280 × 0.632) = 810, height = round(720 × 0.632) = 456
+//    Dimensions are clamped to even numbers to avoid borking encoders.
+//
+// FPS is only set when the profile explicitly defines it via
+// constraints.frameRate. If unset, it'll trickle down as undefined for the browser
+// to decide how to best manage encoding. This is the same thing we do with
+// bbb-webrtc-sfu/mediasoup.
+const profileToPreset = (
+  profile: CameraProfile,
+  captureWidth: number,
+  captureHeight: number,
+  topBitrate: number,
+): VideoPreset => {
+  const bitrate = profile?.bitrate || 0;
+  const bitrateInBps = bitrate * 1000 || DEFAULT_CAM_BITRATE;
+  const fps = profile.constraints?.frameRate;
+
+  // We have constraints with the required fields, map directly
+  if (profile.constraints?.width && profile.constraints?.height) {
+    return new VideoPreset(
+      profile.constraints.width,
+      profile.constraints.height,
+      bitrateInBps,
+      fps,
+      'medium',
+    );
+  }
+
+  if (!bitrate || bitrate <= 0 || !topBitrate || topBitrate <= 0) {
+    logger.warn({
+      logCode: 'livekit_camera_profile_misconfigured',
+      extraInfo: {
+        profileId: profile?.id,
+        profileBitrate: profile?.bitrate,
+        topBitrate,
+      },
+    }, `LiveKit: camera profile "${profile?.id}" has invalid bitrate (${profile?.bitrate}), using defaults`);
+
+    return new VideoPreset(captureWidth, captureHeight, bitrateInBps, fps, 'medium');
+  }
+
+  // Incomplete or undefined constraints: derive resolution from bitrate ratio
+  const scale = Math.sqrt(profile.bitrate / topBitrate);
+  const w = Math.max(2, Math.round(captureWidth * scale));
+  const h = Math.max(2, Math.round(captureHeight * scale));
+
+  return new VideoPreset(
+    w - (w % 2), // even width
+    h - (h % 2), // even height
+    bitrateInBps,
+    fps,
+    'medium',
+  );
+};
+
+const getDefaultCameraPresets = (stream: MediaStream): VideoPreset[] => {
+  const { width, height, frameRate } = getCameraCaptureSettings(stream);
+
+  return [new VideoPreset(width, height, DEFAULT_CAM_BITRATE, frameRate ?? DEFAULT_CAM_FPS, 'medium')];
+};
+
+// Derives simulcast presets from camera quality profiles.
+//
+// The selected profile is the TOP (highest quality) layer. The user's
+// choice represents their intended max quality — we never publish above
+// it. Lower visible profiles become lower simulcast layers, giving the
+// SFU/adaptive streaming room to downgrade for constrained subscribers.
+//
+// Layer selection (given visible profiles sorted low→high):
+//   selected = "high" (index 2): layers = [low, medium, high] (3 layers)
+//   selected = "medium" (index 1): layers = [low, medium]     (2 layers)
+//   selected = "low" (index 0): layers = [low]                (1 layer, no simulcast)
+//   selected = hidden profile:   layers = [selected]           (1 layer — don't
+//     fight the system's choice)
+//
+// Each profile is mapped to a VideoPreset via profileToPreset, then
+// deduplicated (identical resolution + effective FPS + bitrate collapsed).
+const getProfileBasedPresets = (stream: MediaStream): VideoPreset[] => {
+  const visibleProfiles = getVisibleProfiles();
+  const selectedProfile = VideoService.getCameraProfile();
+
+  if (!selectedProfile || visibleProfiles.length === 0) {
+    return getDefaultCameraPresets(stream);
+  }
+
+  const selectedIndex = visibleProfiles.findIndex((p) => p.id === selectedProfile.id);
+
+  // Hidden profile (e.g., threshold system selected "low-u12") — single
+  // layer. Honor it indefinitely for now (single layer), but we'll need to
+  // adjust it further later when quality thresholds are fully supported by the LK bridge - prlanzarin
+  if (selectedIndex < 0) {
+    const { width, height } = getCameraCaptureSettings(stream);
+
+    return [profileToPreset(selectedProfile, width, height, selectedProfile.bitrate)];
+  }
+
+  const start = Math.max(0, selectedIndex - (MAX_SIMULCAST_LAYERS - 1));
+  const layerProfiles = visibleProfiles.slice(start, selectedIndex + 1);
+  const { width, height, frameRate } = getCameraCaptureSettings(stream);
+  const topBitrate = selectedProfile.bitrate;
+  const presets = layerProfiles.map(
+    (p) => profileToPreset(p, width, height, topBitrate),
+  );
+
+  return deduplicatePresets(presets, frameRate);
+};
+
+// Override mode: when livekit.camera.presets is explicitly configured,
+// bypasses profile-based mapping entirely. Admins use this for direct
+// control over simulcast layers (same pattern as screenshare presets).
+//
+// Partially-specified presets are filled via linear interpolation between the
+// auto-generated profile-based defaults.
+//
+// Interpolated fields:
+// - maxBitrate (linear between first/last defaults).
+// - FPS: interpolated only when both endpoints have defined FPS. When both
+//  are undefined (common for camera profiles without constraints), FPS
+//  remains undefined — the browser decides. When only one endpoint has
+//  FPS, that value is used for all positions.
+// - Resolution defaults to the top profile's resolution for all positions
+//
+// Config values always win over interpolated defaults when present.
+const resolveExplicitPresets = (
+  configPresets: LiveKitPresetConfig[],
+  stream: MediaStream,
+): VideoPreset[] => {
+  const defaults = getProfileBasedPresets(stream);
+  const first = defaults[0];
+  const last = defaults[defaults.length - 1];
+  const firstFps = first.encoding.maxFramerate;
+  const lastFps = last.encoding.maxFramerate;
+
+  // Interpolate FPS only when both endpoints are defined. Otherwise use
+  // whichever is defined, or undefined if neither is (browser decides).
+  const interpolateFps = (t: number): number | undefined => {
+    if (firstFps != null && lastFps != null) {
+      return Math.round(firstFps + t * (lastFps - firstFps));
+    }
+
+    return firstFps ?? lastFps;
+  };
+
+  const resolved = configPresets.map((config, index) => {
+    const t = configPresets.length > 1 ? index / (configPresets.length - 1) : 1;
+    const positionalDefaults: PresetDefaults = {
+      width: last.width,
+      height: last.height,
+      maxBitrate: Math.round(
+        first.encoding.maxBitrate + t * (last.encoding.maxBitrate - first.encoding.maxBitrate),
+      ),
+      maxFramerate: interpolateFps(t),
+      priority: 'medium',
+    };
+
+    return assemblePresetFromConfig(config, positionalDefaults);
+  });
+
+  const { frameRate } = getCameraCaptureSettings(stream);
+
+  return deduplicatePresets(resolved, frameRate);
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const getCameraPublishOptions = (
+  stream: MediaStream,
+): Partial<TrackPublishOptions> => {
+  // @ts-ignore
+  const configPresets = window.meetingClientSettings.public.media?.livekit?.camera?.presets;
+
+  const presets = configPresets?.length
+    ? resolveExplicitPresets(configPresets, stream)
+    : getProfileBasedPresets(stream);
+
+  const layers = presets.length > 1 ? presets.slice(0, -1) : [];
+  const topEncoding = presets[presets.length - 1]?.encoding;
+
+  logger.debug({
+    logCode: 'livekit_camera_presets',
+    extraInfo: {
+      selectedProfile: VideoService.getCameraProfile()?.id,
+      presetCount: presets.length,
+      simulcastLayerCount: layers.length,
+      presets: presets.map((p) => ({
+        width: p.width,
+        height: p.height,
+        maxBitrate: p.encoding.maxBitrate,
+        maxFramerate: p.encoding.maxFramerate,
+      })),
+    },
+  }, `LiveKit: resolved camera presets (p=${presets.length}, l=${layers.length})`);
+
+  return {
+    simulcast: presets.length > 1,
+    videoEncoding: topEncoding,
+    videoSimulcastLayers: layers.length > 0 ? layers : undefined,
+  };
+};

--- a/bigbluebutton-html5/imports/ui/services/livekit/presets.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/presets.ts
@@ -1,0 +1,71 @@
+import { VideoPreset } from 'livekit-client';
+import logger from '/imports/startup/client/logger';
+import { LiveKitPresetConfig } from '/imports/ui/Types/meetingClientSettings';
+
+export interface PresetDefaults {
+  width: number;
+  height: number;
+  maxBitrate: number;
+  maxFramerate?: number;
+  priority: RTCPriorityType;
+}
+
+export const assemblePresetFromConfig = (
+  config: LiveKitPresetConfig,
+  defaults: PresetDefaults,
+): VideoPreset => {
+  const width = config.width ?? defaults.width;
+  const height = config.height ?? defaults.height;
+  const maxBitrate = config.maxBitrate ?? defaults.maxBitrate;
+  const maxFramerate = config.maxFramerate ?? defaults.maxFramerate;
+  const priority = config.priority ?? defaults.priority;
+
+  if (!maxBitrate || maxBitrate <= 0) {
+    logger.warn({
+      logCode: 'livekit_preset_invalid_bitrate',
+      extraInfo: {
+        configBitrate: config.maxBitrate,
+        defaultBitrate: defaults.maxBitrate,
+        width,
+        height,
+      },
+    }, `LiveKit: preset has invalid maxBitrate (${config.maxBitrate}), using default (${defaults.maxBitrate})`);
+
+    return new VideoPreset(width, height, defaults.maxBitrate, maxFramerate, priority);
+  }
+
+  return new VideoPreset(width, height, maxBitrate, maxFramerate, priority);
+};
+
+// Removes presets that are identical across all three encoding dimensions:
+// resolution, effective FPS (capped to capture rate), AND bitrate.
+// Different bitrates at the same FPS/resolution are preserved — the encoder
+// produces meaningfully different output and the SFU can select between
+// them for bandwidth adaptation.
+export const deduplicatePresets = (
+  presets: VideoPreset[],
+  captureFrameRate: number | undefined,
+): VideoPreset[] => {
+  if (captureFrameRate == null || presets.length <= 1) return presets;
+
+  const effectiveFps = (preset: VideoPreset): number => Math.min(
+    preset.encoding.maxFramerate ?? captureFrameRate,
+    captureFrameRate,
+  );
+
+  const deduped: VideoPreset[] = [];
+
+  for (let i = 0; i < presets.length; i += 1) {
+    const preset = presets[i];
+    const isDuplicate = deduped.some(
+      (p) => p.width === preset.width
+        && p.height === preset.height
+        && p.encoding.maxBitrate === preset.encoding.maxBitrate
+        && effectiveFps(p) === effectiveFps(preset),
+    );
+
+    if (!isDuplicate) deduped.push(preset);
+  }
+
+  return deduped;
+};

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -991,6 +991,28 @@ public:
       screenshare:
         publishOptions:
           videoCodec: 'vp8'
+        # constraints: independent from kurento.screenshare.constraints
+        constraints:
+          video:
+            frameRate:
+              ideal: 15
+              max: 15
+            width:
+              max: 2560
+            height:
+              max: 1600
+          audio: true
+        # livekit.screenshare.presets: ordered lowest to highest quality.
+        # Entries are VideoPreset objects (see https://docs.livekit.io/reference/client-sdk-js/variables/VideoPresets.html).
+        # Presets may be partially specified - missing bitrate/FPS entries will
+        # be interpolated by the client. Resolution defaults to capture resolution.
+        presets:
+          - maxBitrate: 500000
+            maxFramerate: 5
+            priority: medium
+          - maxBitrate: 1500000
+            maxFramerate: 15
+            priority: medium
   stats:
     enabled: true
     interval: 10000

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -988,6 +988,11 @@ public:
       camera:
         publishOptions:
           videoCodec: 'vp8'
+        # presets: optional explicit simulcast presets. When specified,
+        # overrides automatic profile-to-layer mapping from cameraProfiles.
+        # Ordered lowest to highest quality.
+        # Array of VideoPreset objects (see https://docs.livekit.io/reference/client-sdk-js/variables/VideoPresets.html).
+        #presets: []
       screenshare:
         publishOptions:
           videoCodec: 'vp8'


### PR DESCRIPTION
### What does this PR do?

- [refactor(livekit): review screenshare quality presets and simulcast layers](https://github.com/bigbluebutton/bigbluebutton/commit/a32efba5a2425eaa6beecffd8b20a276b29a2941)
  - LiveKit's default screen sharing simulcast creates layers by halving
resolution while keeping the same FPS. Combined with adaptiveStream,
this causes blurry screenshare when the viewer resizes to a smaller
viewport — which is the wrong tradeoff for screenshare content in _our_
scenario (text, code, presentations).
Especially relevant since we only support VP8 (no SVC).
  - Restructure simulcast to scale via FPS+bitrate rather than resolution:
    - Explicitly configure screenShareSimulcastLayers for published
    screenshare tracks
    - Default to 2-layer FPS/bitrate diff'ed stack: all layers share
    capture resolution (5fps@500kbps, 15fps@1dot5Mbps)
  - When capture FPS is too low for FPS differentiation (<=5fps),
    fall back to bitrate-only tiers: same resolution, same FPS,
    different bitrate caps (500kbps vs 1.5Mbps) so the SFU has a
    congestion fallback
  - Add independent capture constraint config for LK under
  `livekit.screenshare.constraints`, decoupled from the shared
  `kurento.screenshare.constraints` (bbb-webrtc-sfu). This allows us to
  provide higher capture FPS for LK without affecting bbb-webrtc-sfu - and
  makes for a clean break when phasing out the kurento.* configs.
  - Make screenshare presets resilient to partial configuration.
  Presets config fields are now optional — missing values are
  filled via linear interpolation between the lowest and highest
  auto-generated defaults (based on array position). Resolution
  defaults to configured constraint resolution for all positions.
  Admins can override resolution on individual presets via explicit
  width/height.
- [refactor(livekit): review camera quality presets and simulcast layers](https://github.com/bigbluebutton/bigbluebutton/pull/24800/commits/ee71b3909a053964465b2d3aafd52fb3712bdc37)
  - The camera bridge publishes with no explicit simulcast layers.
    The SDK falls back to room-level defaults (h180/h360/h720)
    which are disconnected from the user's selected camera profile.
  - Map camera profiles to simulcast layers:
    - Selected profile = top layer (user intent = max quality)
    - Lower visible profiles become lower layers, up to 3 total
    - Profiles without explicit constraints derive resolution via
      sqrt(bitrate_ratio) from capture dimensions
    - FPS is only set when the profile explicitly defines it —
      otherwise left undefined for the browser to optimize within
      the bitrate budget. This matches how bbb-webrtc-sfu handles it
    - Hidden profiles get single-layer publish for now
    - Optional livekit.camera.presets override bypasses profile
      mapping for admin control - more as a debugging measure first, but
      with plans for the future (disabling user quality selection)

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/24473