### PR TITLE
fix(learning-dashboard): group short overlapping sessions to prevent duplicate entries

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -18,7 +18,7 @@ import StatusTable from './components/StatusTable';
 import PollsTable from './components/PollsTable';
 import PluginsTable from './components/PluginsTable';
 import ErrorMessage from './components/ErrorMessage';
-import { makeUserCSVData, tsToHHmmss } from './services/UserService';
+import { makeUserCSVData, tsToHHmmss, mergeOverlappingUsers } from './services/UserService';
 import QuizzesTable from './components/QuizzesTable';
 import QuizzesChart from './components/QuizzesChart';
 
@@ -254,7 +254,7 @@ class App extends React.Component {
           }
         });
       });
-      return newActivivies;
+      return mergeOverlappingUsers(newActivivies);
     };
 
     if (learningDashboardAccessToken !== '') {
@@ -279,7 +279,7 @@ class App extends React.Component {
           if (json.response.returncode === 'SUCCESS') {
             const jsonData = JSON.parse(json.response.data);
             this.setState({
-              activitiesJson: jsonData,
+              activitiesJson: mergeOverlappingUsers(jsonData),
               loading: false,
               invalidSessionCount: 0,
               lastUpdated: Date.now(),

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   FormattedMessage, FormattedDate, FormattedNumber, injectIntl,
 } from 'react-intl';
@@ -580,6 +581,20 @@ class UsersTable extends React.Component {
     );
   }
 }
+
+UsersTable.propTypes = {
+  allUsers: PropTypes.shape({}),
+  totalOfPolls: PropTypes.number,
+  totalOfActivityTime: PropTypes.number,
+  tab: PropTypes.string,
+};
+
+UsersTable.defaultProps = {
+  allUsers: {},
+  totalOfPolls: 0,
+  totalOfActivityTime: 0,
+  tab: 'overview',
+};
 
 UsersTable.contextType = UserDetailsContext;
 

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -71,19 +71,8 @@ class UsersTable extends React.Component {
 
   onlineTimeOrder(a, b) {
     const { onlineTimeOrder } = this.state;
-    const onlineTimeA = Object.values(a.intIds).reduce((prev, intId) => (
-      prev + intId.sessions.reduce((prev2, session) => (
-        prev2 + (session.leftOn > 0
-          ? session.leftOn
-          : (new Date()).getTime()) - session.registeredOn), 0)
-    ), 0);
-
-    const onlineTimeB = Object.values(b.intIds).reduce((prev, intId) => (
-      prev + intId.sessions.reduce((prev2, session) => (
-        prev2 + (session.leftOn > 0
-          ? session.leftOn
-          : (new Date()).getTime()) - session.registeredOn), 0)
-    ), 0);
+    const onlineTimeA = getSumOfTime(Object.values(a.intIds));
+    const onlineTimeB = getSumOfTime(Object.values(b.intIds));
 
     if (onlineTimeA < onlineTimeB) {
       return onlineTimeOrder === 'desc' ? 1 : -1;
@@ -321,8 +310,10 @@ class UsersTable extends React.Component {
                         >
                           {user.name}
                         </button>
-                        { Object.values(user.intIds || {}).map((intId, index) => intId.sessions
-                          .map((session, sessionIndex) => (
+                        { Object.values(user.intIds || {})
+                          .flatMap((intId) => intId.sessions)
+                          .sort((a, b) => a.registeredOn - b.registeredOn)
+                          .map((session, sessionIndex, sessionsArr) => (
                             <>
                               <p className="text-xs text-gray-700 dark:text-gray-400">
                                 <svg
@@ -377,14 +368,13 @@ class UsersTable extends React.Component {
                                   </p>
                                 )
                                 : null }
-                              { index === Object.values(user.intIds).length - 1
-                                && sessionIndex === intId?.sessions.length - 1
+                              { sessionIndex === sessionsArr.length - 1
                                 ? null
                                 : (
                                   <hr className="my-1" />
                                 ) }
                             </>
-                          ))) }
+                          )) }
                       </div>
                     </td>
                     <td className={`px-4 py-3 text-sm text-center items-center ${opacity}`} data-test="userOnlineTimeDashboard">
@@ -403,19 +393,16 @@ class UsersTable extends React.Component {
                         />
                       </svg>
                       &nbsp;
-                      { tsToHHmmss(Object.values(user.intIds).reduce((prev, intId) => (
-                        prev + intId.sessions.reduce((prev2, session) => ((session.leftOn > 0
-                          ? prev2 + session.leftOn
-                          : prev2 + (new Date()).getTime()) - session.registeredOn), 0)), 0)) }
+                      { tsToHHmmss(getSumOfTime(Object.values(user.intIds))) }
                       <br />
                       {
                         ((function getPercentage() {
                           const { intIds } = user;
-                          const percentage = Object.values(intIds || {}).reduce((prev, intId) => (
-                            prev + intId.sessions.reduce((prev2, session) => (
-                              prev2 + this.getOnlinePercentage(session.registeredOn, session.leftOn)
-                            ), 0)
-                          ), 0);
+                          const { totalOfActivityTime } = this.props;
+                          let percentage = Math.ceil(
+                            (getSumOfTime(Object.values(intIds || {})) / totalOfActivityTime) * 100,
+                          );
+                          if (percentage > 100) percentage = 100;
 
                           return (
                             <div

--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -46,7 +46,7 @@ export function getActivityScore(user, allUsers, totalOfPolls) {
 
 export function getSumOfTime(eventsArr) {
   const intervals = [];
-  const now = new Date().getTime();
+  const now = Date.now();
 
   eventsArr.forEach((elem) => {
     if (elem?.sessions) {
@@ -69,7 +69,7 @@ export function getSumOfTime(eventsArr) {
 
   const merged = [intervals[0]];
   for (let i = 1; i < intervals.length; i += 1) {
-    const lastMerged = merged[merged.length - 1];
+    const lastMerged = merged.at(-1);
     const current = intervals[i];
     if (current[0] <= lastMerged[1]) {
       // Overlapping intervals, union them securely
@@ -247,6 +247,93 @@ export function makeUserCSVData(users, polls, intl) {
   ].join('\r\n');
 }
 
+// Helper to extract a single flat array of all session objects across all internal IDs of a user
+const getSessions = (user) => {
+  const sessions = [];
+  Object.values(user.intIds || {}).forEach((intIdObj) => {
+    if (intIdObj.sessions) {
+      sessions.push(...intIdObj.sessions);
+    }
+  });
+  return sessions;
+};
+
+// Checks if two user objects have sessions that genuinely run in parallel.
+// Overlaps shorter than `overlapThreshold` are considered "ghost connections"
+// (where a dropping connection overlaps briefly with a new connection) and return false.
+const hasRealOverlap = (u1, u2, endedOn, overlapThreshold) => {
+  const s1 = getSessions(u1);
+  const s2 = getSessions(u2);
+  // eslint-disable-next-line no-restricted-syntax
+  for (const sa of s1) {
+    // eslint-disable-next-line no-restricted-syntax
+    for (const sb of s2) {
+      // Find the intersection window between the two sessions
+      const start = Math.max(sa.registeredOn, sb.registeredOn);
+      const endA = sa.leftOn > 0 ? sa.leftOn : (endedOn || Date.now());
+      const endB = sb.leftOn > 0 ? sb.leftOn : (endedOn || Date.now());
+      const end = Math.min(endA, endB);
+
+      // If intersection lasts longer than threshold, it is a real concurrent overlap
+      if (end - start > overlapThreshold) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+// Consolidates all metrics and sessions from `otherUser` into `mainUser`
+// eslint-disable-next-line no-param-reassign
+const mergeTwoUsers = (mainUser, otherUser) => {
+  const mergedUser = mainUser;
+
+  // Merge internal IDs (sessions will be combined)
+  mergedUser.intIds = { ...mergedUser.intIds, ...otherUser.intIds };
+
+  // Accumulate time counters safely without accidentally discarding metadata
+  mergedUser.talk.totalTime = (mergedUser.talk.totalTime || 0) + (otherUser.talk.totalTime || 0);
+  mergedUser.talk.lastTalkStartedOn = Math.max(
+    mergedUser.talk.lastTalkStartedOn || 0,
+    otherUser.talk.lastTalkStartedOn || 0,
+  );
+
+  // Merge array-based interactions mapping (polls, messages, hands raised)
+  const concatArrays = (arr1, arr2) => [...(arr1 || []), ...(arr2 || [])];
+  mergedUser.reactions = concatArrays(mergedUser.reactions, otherUser.reactions);
+  mergedUser.raiseHand = concatArrays(mergedUser.raiseHand, otherUser.raiseHand);
+  mergedUser.away = concatArrays(mergedUser.away, otherUser.away);
+  mergedUser.webcams = concatArrays(mergedUser.webcams, otherUser.webcams);
+
+  // Aggregate scalar counters
+  mergedUser.totalOfMessages = (mergedUser.totalOfMessages || 0)
+    + (otherUser.totalOfMessages || 0);
+  mergedUser.totalOfSharedNotes = (mergedUser.totalOfSharedNotes || 0)
+    + (otherUser.totalOfSharedNotes || 0);
+  mergedUser.totalOfWhiteboardAnnotations = (mergedUser.totalOfWhiteboardAnnotations || 0)
+    + (otherUser.totalOfWhiteboardAnnotations || 0);
+
+  // Merge poll answers
+  mergedUser.answers = { ...mergedUser.answers, ...otherUser.answers };
+
+  // Merge plugin data and last-seen state
+  mergedUser.pluginUserData = { ...mergedUser.pluginUserData, ...otherUser.pluginUserData };
+  mergedUser.leftOn = (mergedUser.leftOn === 0 || otherUser.leftOn === 0)
+    ? 0
+    : Math.max(mergedUser.leftOn || 0, otherUser.leftOn || 0);
+
+  // Promote privilege if either session had moderator rights
+  mergedUser.isModerator = mergedUser.isModerator || otherUser.isModerator;
+
+  return mergedUser;
+};
+
+const getFirstReg = (u) => {
+  const sessions = getSessions(u);
+  if (!sessions.length) return Number.MAX_VALUE;
+  return Math.min(...sessions.map((s) => s.registeredOn));
+};
+
 /**
  * Merges duplicate user entries caused by rapid reconnects (ghost connections)
  * while keeping genuinely concurrent sessions (e.g., dual-device usage) separate.
@@ -256,7 +343,7 @@ export function makeUserCSVData(users, polls, intl) {
  * @returns {Object} A new activities object with correctly merged user sessions
  */
 export function mergeOverlappingUsers(activitiesJson, overlapThreshold = 210000) {
-  if (!activitiesJson || !activitiesJson.users) return activitiesJson;
+  if (!activitiesJson?.users) return activitiesJson;
   const newActivivies = activitiesJson;
 
   // Group users by their external ID to find duplicate entries for the same physical person
@@ -264,110 +351,28 @@ export function mergeOverlappingUsers(activitiesJson, overlapThreshold = 210000)
   const newUsers = {};
 
   Object.entries(newActivivies.users).forEach(([userKey, user]) => {
-    if (!user.extId) {
-      newUsers[userKey] = user;
-    } else {
+    if (user.extId) {
       if (!extIdGroups[user.extId]) extIdGroups[user.extId] = [];
       extIdGroups[user.extId].push({ ...user });
+    } else {
+      newUsers[userKey] = user;
     }
   });
 
-  // Helper to extract a single flat array of all session objects across all internal IDs of a user
-  const getSessions = (user) => {
-    const sessions = [];
-    Object.values(user.intIds || {}).forEach((intIdObj) => {
-      if (intIdObj.sessions) {
-        sessions.push(...intIdObj.sessions);
-      }
-    });
-    return sessions;
-  };
-
-  // Checks if two user objects have sessions that genuinely run in parallel.
-  // Overlaps shorter than `overlapThreshold` are considered "ghost connections"
-  // (where a dropping connection overlaps briefly with a new connection) and return false.
-  const hasRealOverlap = (u1, u2) => {
-    const s1 = getSessions(u1);
-    const s2 = getSessions(u2);
-    for (let i = 0; i < s1.length; i += 1) {
-      for (let j = 0; j < s2.length; j += 1) {
-        const sa = s1[i];
-        const sb = s2[j];
-
-        // Find the intersection window between the two sessions
-        const start = Math.max(sa.registeredOn, sb.registeredOn);
-        const endA = sa.leftOn > 0 ? sa.leftOn : (newActivivies.endedOn || Date.now());
-        const endB = sb.leftOn > 0 ? sb.leftOn : (newActivivies.endedOn || Date.now());
-        const end = Math.min(endA, endB);
-
-        // If intersection lasts longer than threshold, it is a real concurrent overlap
-        if (end - start > overlapThreshold) {
-          return true;
-        }
-      }
-    }
-    return false;
-  };
-
-  // Consolidates all metrics and sessions from `otherUser` into `mainUser`
-  // eslint-disable-next-line no-param-reassign
-  const mergeTwoUsers = (mainUser, otherUser) => {
-    const mergedUser = mainUser;
-
-    // Merge internal IDs (sessions will be combined)
-    mergedUser.intIds = { ...mergedUser.intIds, ...otherUser.intIds };
-
-    // Accumulate time counters safely without accidentally discarding metadata
-    mergedUser.talk.totalTime = (mergedUser.talk.totalTime || 0) + (otherUser.talk.totalTime || 0);
-    mergedUser.talk.lastTalkStartedOn = Math.max(
-      mergedUser.talk.lastTalkStartedOn || 0,
-      otherUser.talk.lastTalkStartedOn || 0,
-    );
-
-    // Merge array-based interactions mapping (polls, messages, hands raised)
-    const concatArrays = (arr1, arr2) => [...(arr1 || []), ...(arr2 || [])];
-    mergedUser.reactions = concatArrays(mergedUser.reactions, otherUser.reactions);
-    mergedUser.raiseHand = concatArrays(mergedUser.raiseHand, otherUser.raiseHand);
-    mergedUser.away = concatArrays(mergedUser.away, otherUser.away);
-    mergedUser.webcams = concatArrays(mergedUser.webcams, otherUser.webcams);
-
-    // Aggregate scalar counters
-    mergedUser.totalOfMessages = (mergedUser.totalOfMessages || 0)
-      + (otherUser.totalOfMessages || 0);
-    mergedUser.totalOfSharedNotes = (mergedUser.totalOfSharedNotes || 0)
-      + (otherUser.totalOfSharedNotes || 0);
-    mergedUser.totalOfWhiteboardAnnotations = (mergedUser.totalOfWhiteboardAnnotations || 0)
-      + (otherUser.totalOfWhiteboardAnnotations || 0);
-
-    // Merge poll answers
-    mergedUser.answers = { ...mergedUser.answers, ...otherUser.answers };
-
-    // Promote privilege if either session had moderator rights
-    mergedUser.isModerator = mergedUser.isModerator || otherUser.isModerator;
-
-    return mergedUser;
-  };
-
   // Process all instances of each unique extId
-  Object.keys(extIdGroups).forEach((extId) => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const extId of Object.keys(extIdGroups)) {
     const users = extIdGroups[extId];
 
     // Sort to consistently process the oldest user session first
-    users.sort((a, b) => {
-      const getFirstReg = (u) => {
-        const sessions = getSessions(u);
-        if (!sessions.length) return Number.MAX_VALUE;
-        return Math.min(...sessions.map((s) => s.registeredOn));
-      };
-      return getFirstReg(a) - getFirstReg(b);
-    });
+    users.sort((a, b) => getFirstReg(a) - getFirstReg(b));
 
     // Merge logic: try joining to an existing profile unless there is a real overlap
     const mergedList = [];
     users.forEach((u) => {
       // Find a previously merged instance that does NOT have a real overlap and combine them
       const placed = mergedList.some((m) => {
-        if (!hasRealOverlap(m, u)) {
+        if (!hasRealOverlap(m, u, activitiesJson.endedOn, overlapThreshold)) {
           mergeTwoUsers(m, u);
           return true;
         }
@@ -397,7 +402,7 @@ export function mergeOverlappingUsers(activitiesJson, overlapThreshold = 210000)
       }
       newUsers[u.userKey] = u;
     });
-  });
+  }
 
   newActivivies.users = newUsers;
   return newActivivies;

--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -45,20 +45,42 @@ export function getActivityScore(user, allUsers, totalOfPolls) {
 }
 
 export function getSumOfTime(eventsArr) {
-  return eventsArr.reduce((prevVal, elem) => {
+  const intervals = [];
+  const now = new Date().getTime();
+
+  eventsArr.forEach((elem) => {
     if (elem?.sessions) {
-      return prevVal + elem.sessions.reduce((prevVal2, session) => {
-        if (session.leftOn > 0) {
-          return prevVal2 + (session.leftOn - session.registeredOn);
-        }
-        return prevVal2 + (new Date().getTime() - session.registeredOn);
-      }, 0);
+      elem.sessions.forEach((session) => {
+        const start = session.registeredOn;
+        const end = session.leftOn > 0 ? session.leftOn : now;
+        intervals.push([start, end]);
+      });
+    } else {
+      const start = elem.startedOn || elem.registeredOn;
+      const end = (elem.stoppedOn || elem.leftOn) > 0 ? (elem.stoppedOn || elem.leftOn) : now;
+      intervals.push([start, end]);
     }
-    if ((elem.stoppedOn || elem.leftOn) > 0) {
-      return prevVal + ((elem.stoppedOn || elem.leftOn) - (elem.startedOn || elem.registeredOn));
+  });
+
+  if (intervals.length === 0) return 0;
+
+  // Sort intervals by start time
+  intervals.sort((a, b) => a[0] - b[0]);
+
+  const merged = [intervals[0]];
+  for (let i = 1; i < intervals.length; i += 1) {
+    const lastMerged = merged[merged.length - 1];
+    const current = intervals[i];
+    if (current[0] <= lastMerged[1]) {
+      // Overlapping intervals, union them securely
+      lastMerged[1] = Math.max(lastMerged[1], current[1]);
+    } else {
+      merged.push(current);
     }
-    return prevVal + (new Date().getTime() - (elem.startedOn || elem.registeredOn));
-  }, 0);
+  }
+
+  // Sum all distinctly separate times
+  return merged.reduce((sum, [start, end]) => sum + (end - start), 0);
 }
 
 export function getJoinTime(eventsArr) {
@@ -223,4 +245,160 @@ export function makeUserCSVData(users, polls, intl) {
     header,
     Object.values(userRecords).join('\r\n'),
   ].join('\r\n');
+}
+
+/**
+ * Merges duplicate user entries caused by rapid reconnects (ghost connections)
+ * while keeping genuinely concurrent sessions (e.g., dual-device usage) separate.
+ *
+ * @param {Object} activitiesJson - The full JSON data object containing meeting and user activities
+ * @param {number} overlapThreshold - Maximum overlap duration in ms to be counted as concurrent
+ * @returns {Object} A new activities object with correctly merged user sessions
+ */
+export function mergeOverlappingUsers(activitiesJson, overlapThreshold = 210000) {
+  if (!activitiesJson || !activitiesJson.users) return activitiesJson;
+  const newActivivies = activitiesJson;
+
+  // Group users by their external ID to find duplicate entries for the same physical person
+  const extIdGroups = {};
+  const newUsers = {};
+
+  Object.entries(newActivivies.users).forEach(([userKey, user]) => {
+    if (!user.extId) {
+      newUsers[userKey] = user;
+    } else {
+      if (!extIdGroups[user.extId]) extIdGroups[user.extId] = [];
+      extIdGroups[user.extId].push({ ...user });
+    }
+  });
+
+  // Helper to extract a single flat array of all session objects across all internal IDs of a user
+  const getSessions = (user) => {
+    const sessions = [];
+    Object.values(user.intIds || {}).forEach((intIdObj) => {
+      if (intIdObj.sessions) {
+        sessions.push(...intIdObj.sessions);
+      }
+    });
+    return sessions;
+  };
+
+  // Checks if two user objects have sessions that genuinely run in parallel.
+  // Overlaps shorter than `overlapThreshold` are considered "ghost connections"
+  // (where a dropping connection overlaps briefly with a new connection) and return false.
+  const hasRealOverlap = (u1, u2) => {
+    const s1 = getSessions(u1);
+    const s2 = getSessions(u2);
+    for (let i = 0; i < s1.length; i += 1) {
+      for (let j = 0; j < s2.length; j += 1) {
+        const sa = s1[i];
+        const sb = s2[j];
+
+        // Find the intersection window between the two sessions
+        const start = Math.max(sa.registeredOn, sb.registeredOn);
+        const endA = sa.leftOn > 0 ? sa.leftOn : (newActivivies.endedOn || Date.now());
+        const endB = sb.leftOn > 0 ? sb.leftOn : (newActivivies.endedOn || Date.now());
+        const end = Math.min(endA, endB);
+
+        // If intersection lasts longer than threshold, it is a real concurrent overlap
+        if (end - start > overlapThreshold) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  // Consolidates all metrics and sessions from `otherUser` into `mainUser`
+  // eslint-disable-next-line no-param-reassign
+  const mergeTwoUsers = (mainUser, otherUser) => {
+    const mergedUser = mainUser;
+
+    // Merge internal IDs (sessions will be combined)
+    mergedUser.intIds = { ...mergedUser.intIds, ...otherUser.intIds };
+
+    // Accumulate time counters safely without accidentally discarding metadata
+    mergedUser.talk.totalTime = (mergedUser.talk.totalTime || 0) + (otherUser.talk.totalTime || 0);
+    mergedUser.talk.lastTalkStartedOn = Math.max(
+      mergedUser.talk.lastTalkStartedOn || 0,
+      otherUser.talk.lastTalkStartedOn || 0,
+    );
+
+    // Merge array-based interactions mapping (polls, messages, hands raised)
+    const concatArrays = (arr1, arr2) => [...(arr1 || []), ...(arr2 || [])];
+    mergedUser.reactions = concatArrays(mergedUser.reactions, otherUser.reactions);
+    mergedUser.raiseHand = concatArrays(mergedUser.raiseHand, otherUser.raiseHand);
+    mergedUser.away = concatArrays(mergedUser.away, otherUser.away);
+    mergedUser.webcams = concatArrays(mergedUser.webcams, otherUser.webcams);
+
+    // Aggregate scalar counters
+    mergedUser.totalOfMessages = (mergedUser.totalOfMessages || 0)
+      + (otherUser.totalOfMessages || 0);
+    mergedUser.totalOfSharedNotes = (mergedUser.totalOfSharedNotes || 0)
+      + (otherUser.totalOfSharedNotes || 0);
+    mergedUser.totalOfWhiteboardAnnotations = (mergedUser.totalOfWhiteboardAnnotations || 0)
+      + (otherUser.totalOfWhiteboardAnnotations || 0);
+
+    // Merge poll answers
+    mergedUser.answers = { ...mergedUser.answers, ...otherUser.answers };
+
+    // Promote privilege if either session had moderator rights
+    mergedUser.isModerator = mergedUser.isModerator || otherUser.isModerator;
+
+    return mergedUser;
+  };
+
+  // Process all instances of each unique extId
+  Object.keys(extIdGroups).forEach((extId) => {
+    const users = extIdGroups[extId];
+
+    // Sort to consistently process the oldest user session first
+    users.sort((a, b) => {
+      const getFirstReg = (u) => {
+        const sessions = getSessions(u);
+        if (!sessions.length) return Number.MAX_VALUE;
+        return Math.min(...sessions.map((s) => s.registeredOn));
+      };
+      return getFirstReg(a) - getFirstReg(b);
+    });
+
+    // Merge logic: try joining to an existing profile unless there is a real overlap
+    const mergedList = [];
+    users.forEach((u) => {
+      // Find a previously merged instance that does NOT have a real overlap and combine them
+      const placed = mergedList.some((m) => {
+        if (!hasRealOverlap(m, u)) {
+          mergeTwoUsers(m, u);
+          return true;
+        }
+        return false;
+      });
+
+      // If we couldn't merge (meaning this is a real parallel session), keep them separate
+      if (!placed) mergedList.push(u);
+    });
+
+    // Bring the finalized, merged users into the global return object.
+    // We sort their internal IDs chronologically so they cluster naturally in by time.
+    mergedList.forEach((u) => {
+      if (u.intIds) {
+        const sortedIntIds = {};
+        Object.entries(u.intIds)
+          .sort(([, a], [, b]) => {
+            const tA = a.sessions?.[0]?.registeredOn || 0;
+            const tB = b.sessions?.[0]?.registeredOn || 0;
+            return tA - tB;
+          })
+          .forEach(([key, val]) => {
+            sortedIntIds[key] = val;
+          });
+        // eslint-disable-next-line no-param-reassign
+        u.intIds = sortedIntIds;
+      }
+      newUsers[u.userKey] = u;
+    });
+  });
+
+  newActivivies.users = newUsers;
+  return newActivivies;
 }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
When users with same external ID rapidly reconnect/join again, if they enter before the previous user was removed from the server, it generates two distinct entries in the learning dashboard for the same user. Because these "ghost connections" run concurrently for a few seconds/minutes, the Dashboard would separate them into different rows.
This also happens when users unintentionally join with two tabs and then short time later close the previous one.

This PR fixes it by:

- Intelligent Merging: Introduced mergeOverlappingUsers inside UserService.js. It groups activities for identical extIds directly into one profile if their concurrent overlap is under a specific threshold (resolving ghost drops). If the overlap extends beyond the threshold, it correctly treats them as genuine dual-device parallel sessions and keeps them separate.
- Accurate Duration Math: Updated getSumOfTime to use an interval-union algorithm. It now flattens all internal session timestamps arrays, clusters them, and unions any intersecting windows before summing. 
- Chronological Table Fixes: Patched UsersTable.jsx to dynamically flatten and sort the visual session timestamps so multiple mapped intIds interleave their joins/leaves perfectly by chronological time.

### Motivation
Several duplications of users in some production sessions where the sessions were all "ghost" short sessions.

### How to test
- Join a meeting with a setted userID
- Close the tab for few seconds and rejoin with the same userID
- Open learning dashboard if the user is duplicated (it should not, it should be merged with two sessions)
