### PR TITLE
fix(plugin-sdk): screenshare blocks snapshot of current slide for plugin-sdk

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -217,7 +217,7 @@ const PresentationMenu = (props) => {
             uiDataGetter:
               PluginSdk.PresentationWhiteboardUiDataNames.CURRENT_PAGE_SNAPSHOT,
           },
-        }, `UI data getter failed to fetch [${PluginSdk.PresentationWhiteboardUiDataNames.CURRENT_PAGE_SNAPSHOT}]`);
+        }, `UI data getter failed to fetch [${PluginSdk.PresentationWhiteboardUiDataNames.CURRENT_PAGE_SNAPSHOT}]: ${e}`);
       }
     };
 
@@ -231,7 +231,7 @@ const PresentationMenu = (props) => {
         updateUiDataHookPCurrentWhiteboardSVGWithAnnotationsForPlugin,
       );
     };
-  }, []);
+  }, [tldrawAPI, slideNum]);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const toastId = useRef('presentation-menu-toast');
   const dropdownRef = useRef(null);


### PR DESCRIPTION
### What does this PR do?

Fixes `getUiData(CURRENT_PAGE_SNAPSHOT)` throwing an error after screenshare session (start/stop). 

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/252

### Motivation

Plugins using `getUiData(CURRENT_PAGE_SNAPSHOT)` would not work after any screenshare session, making the feature unreliable in real meetings (even changing pages would make it stop working).

### More

For testing out the issue and this fix, I'd recommend using `samples/sample-action-button-dropdown-plugin` adding the following piece of code to test the feature:

```ts
        new ActionButtonDropdownSeparator({}),
        new ActionButtonDropdownOption({
          label: 'Get presentation snapshot',
          icon: 'presentation',
          tooltip: 'Calls getUiData(CURRENT_PAGE_SNAPSHOT) and logs the result',
          allowed: true,
          onClick: () => {
            pluginApi.getUiData(
              PresentationWhiteboardUiDataNames.CURRENT_PAGE_SNAPSHOT,
            ).then((result: { base64Png: string } | undefined) => {
              pluginLogger.info('CURRENT_PAGE_SNAPSHOT result:', result);
            }).catch((e: Error) => {
              pluginLogger.error('CURRENT_PAGE_SNAPSHOT error:', e);
            });
          },
        }),
```
It needs to import some other dependency:

```
import {
  PresentationWhiteboardUiDataNames,
} from 'bigbluebutton-html-plugin-sdk';
```