### PR TITLE
fix: Breakouts: viewers sent to waiting lobby

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -856,6 +856,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.SCREEN_SHARE_BRIDGE, message.screenShareBridge);
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
       params.put(ApiParams.DISABLED_FEATURES,String.join(",", message.disabledFeatures));
+      params.put(ApiParams.GUEST_POLICY, GuestPolicy.ALWAYS_ACCEPT);
 
       // Apply private chat lock settings from parent meeting to breakout room
       params.put(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT, message.disablePrivChat.toString());


### PR DESCRIPTION
### What does this PR do?

Sets breakout room guest policy to "always accept" on breakout creation

### Closes Issue(s)
Closes #24811

### How to test
1. Set defaultGuestPolicy=ASK_MODERATOR in bbb-web.properties
2. Create a session as a moderator
3. Join this session as a viewer
4. Moderator creates a breakout room
5. Try to join breakout room as viewer
6. Enter the breakout room directly