### PR TITLE
fix(plugin-sdk): Change loading value of a subscription when data didn't change 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/chat/loaded-chat-messages/hook-manager.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/chat/loaded-chat-messages/hook-manager.ts
@@ -23,8 +23,8 @@ const LoadedChatMessagesHookContainer = (props: GeneralHookManagerProps) => {
     messageMetadata: message.messageMetadata,
   }));
 
-  const { numberOfUses } = props;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { version } = props;
+  const previousVersion = usePreviousValue(version);
 
   const updateLoadedChatMessagesForPlugin = () => {
     window.dispatchEvent(new CustomEvent<
@@ -38,11 +38,11 @@ const LoadedChatMessagesHookContainer = (props: GeneralHookManagerProps) => {
   };
 
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateLoadedChatMessagesForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
   useEffect(() => {
     updateLoadedChatMessagesForPlugin();
   }, [chatMessagesData]);

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/from-core/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/from-core/hook-manager.tsx
@@ -20,8 +20,8 @@ const MeetingHookContainer: React.FunctionComponent<
 ) => {
   const previousMeeting = useRef<GraphqlDataHookSubscriptionResponse<Partial<Meeting>> | null>(null);
 
-  const { data: meeting, numberOfUses } = props;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { data: meeting, version } = props;
+  const previousVersion = usePreviousValue(version);
   const updateMeetingForPlugin = () => {
     const meetingProjection: PluginSdk.GraphqlResponseWrapper<
     PluginSdk.Meeting> = formatMeetingResponseFromGraphql(
@@ -46,11 +46,11 @@ const MeetingHookContainer: React.FunctionComponent<
     }
   }, [meeting]);
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateMeetingForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/meeting-data/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/meeting/meeting-data/hook-manager.tsx
@@ -20,8 +20,8 @@ const MeetingDataHookContainer: React.FunctionComponent<
 ) => {
   const previousMeeting = useRef<GraphqlDataHookSubscriptionResponse<Partial<Meeting>> | null>(null);
 
-  const { data: meeting, numberOfUses } = props;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { data: meeting, version } = props;
+  const previousVersion = usePreviousValue(version);
   const updateMeetingForPlugin = () => {
     const meetingProjection: PluginSdk.GraphqlResponseWrapper<
     PluginSdk.MeetingData> = formatMeetingResponseFromGraphql(
@@ -46,11 +46,11 @@ const MeetingDataHookContainer: React.FunctionComponent<
     }
   }, [meeting]);
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateMeetingForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/presentations/current-presentation/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/presentations/current-presentation/hook-manager.tsx
@@ -16,8 +16,8 @@ const CurrentPresentationHookContainer = (props: GeneralHookManagerProps) => {
     (currentPresentationData: Partial<CurrentPresentation>) => currentPresentationData,
   );
 
-  const { numberOfUses } = props;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { version } = props;
+  const previousVersion = usePreviousValue(version);
 
   const updatePresentationForPlugin = () => {
     const formattedCurrentPresentation:
@@ -39,11 +39,11 @@ const CurrentPresentationHookContainer = (props: GeneralHookManagerProps) => {
   };
 
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updatePresentationForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   useEffect(() => {
     updatePresentationForPlugin();

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/hook-manager.tsx
@@ -13,9 +13,9 @@ import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const CustomSubscriptionHookContainer = (props: SubscriptionHookWithArgumentsContainerProps) => {
-  const { hookArguments, numberOfUses } = props;
+  const { hookArguments, version } = props;
   const { query: queryFromPlugin, variables } = hookArguments;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const previousVersion = usePreviousValue(version);
 
   const customSubscriptionData = useDeduplicatedSubscription(gql`${queryFromPlugin}`, {
     variables,
@@ -43,11 +43,11 @@ const CustomSubscriptionHookContainer = (props: SubscriptionHookWithArgumentsCon
     updateCustomSubscriptionForPlugin();
   }, [customSubscriptionData]);
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateCustomSubscriptionForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/shared/custom-subscription/types.ts
@@ -6,7 +6,7 @@ import { EssentialHookInformation } from '../types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface SubscriptionHookWithArgumentsContainerProps {
-  numberOfUses: number;
+  version: number;
   hookArguments: CustomSubscriptionArguments;
 }
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/hook-manager.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/user-voice/talking-indicator/hook-manager.ts
@@ -21,8 +21,8 @@ const TalkingIndicatorHookContainer = (props: GeneralHookManagerProps) => {
     }) as Partial<UserVoice>,
   );
 
-  const { numberOfUses } = props;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { version } = props;
+  const previousVersion = usePreviousValue(version);
 
   const updateTalkingIndicatorForPlugin = () => {
     window.dispatchEvent(new CustomEvent<
@@ -36,11 +36,11 @@ const TalkingIndicatorHookContainer = (props: GeneralHookManagerProps) => {
   };
 
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateTalkingIndicatorForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
   useEffect(() => {
     updateTalkingIndicatorForPlugin();
   }, [userVoice]);

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/current-user/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/current-user/hook-manager.tsx
@@ -20,8 +20,8 @@ const CurrentUserHookContainer: React.FunctionComponent<
 ) => {
   const previousCurrentUser = useRef<GraphqlDataHookSubscriptionResponse<Partial<User>> | null>(null);
 
-  const { data: currentUser, numberOfUses } = props;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { data: currentUser, version } = props;
+  const previousVersion = usePreviousValue(version);
   const updateUserForPlugin = () => {
     const currentUserProjection: PluginSdk.GraphqlResponseWrapper<
     PluginSdk.CurrentUserData> = formatCurrentUserResponseFromGraphql(
@@ -46,11 +46,11 @@ const CurrentUserHookContainer: React.FunctionComponent<
     }
   }, [currentUser]);
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateUserForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/loaded-user-list/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/loaded-user-list/hook-manager.tsx
@@ -18,8 +18,8 @@ const LoadedUserListHookContainer = (prop: GeneralHookManagerProps) => {
     role: user.role,
   }));
 
-  const { numberOfUses } = prop;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { version } = prop;
+  const previousVersion = usePreviousValue(version);
 
   const updateLoadedUserListForPlugin = () => {
     window.dispatchEvent(new CustomEvent<
@@ -33,11 +33,11 @@ const LoadedUserListHookContainer = (prop: GeneralHookManagerProps) => {
   };
 
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateLoadedUserListForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   useEffect(() => {
     updateLoadedUserListForPlugin();

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/users-basic-info/hook-manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/users/users-basic-info/hook-manager.tsx
@@ -25,8 +25,8 @@ const UsersBasicInfoHookContainer = (prop: GeneralHookManagerProps) => {
     presenter: user.presenter,
   }));
 
-  const { numberOfUses } = prop;
-  const previousNumberOfUses = usePreviousValue(numberOfUses);
+  const { version } = prop;
+  const previousVersion = usePreviousValue(version);
 
   const updateUsersBasicInfoForPlugin = () => {
     window.dispatchEvent(new CustomEvent<
@@ -40,11 +40,11 @@ const UsersBasicInfoHookContainer = (prop: GeneralHookManagerProps) => {
   };
 
   useEffect(() => {
-    const previousNumberOfUsesValue = previousNumberOfUses || 0;
-    if (numberOfUses > previousNumberOfUsesValue) {
+    const previousVersionValue = previousVersion ?? 0;
+    if (version > previousVersionValue) {
       updateUsersBasicInfoForPlugin();
     }
-  }, [numberOfUses]);
+  }, [version]);
 
   useEffect(() => {
     updateUsersBasicInfoForPlugin();

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
@@ -179,8 +179,8 @@ const PluginDataConsumptionManager: React.FC = () => {
             const usage = hookInfo.get(hookName)!;
             return (
               <HookComponent
-                numberOfUses={usage.count}
-                key={`${hookName}-${usage.version}`}
+                key={hookName}
+                version={usage.version}
                 data={data}
               />
             );
@@ -191,16 +191,14 @@ const PluginDataConsumptionManager: React.FC = () => {
           const HookComponent = hookWithArguments.componentToRender;
           return (
             <CustomDataConsumptionHooksErrorBoundary
-              key={`${makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}-${hookWithArguments.version}`}
+              key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
               hookWithArguments={hookWithArguments}
               dataConsumptionHook={DataConsumptionHooks.CUSTOM_SUBSCRIPTION}
               setDataConsumptionHookWithArgumentUtilizationCount={setSubscriptionHookWithArgumentInfo}
             >
               <HookComponent
-                key={
-                  `${makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}-${hookWithArguments.version}`
-                }
-                numberOfUses={hookWithArguments.numberOfUses}
+                key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
+                version={hookWithArguments.version}
                 hookArguments={hookWithArguments.hookArguments}
               />
             </CustomDataConsumptionHooksErrorBoundary>

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/manager.tsx
@@ -210,15 +210,13 @@ const PluginDataConsumptionManager: React.FC = () => {
           const HookComponent = hookWithArguments.componentToRender;
           return (
             <CustomDataConsumptionHooksErrorBoundary
-              key={`${makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}-${hookWithArguments.version}`}
+              key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
               hookWithArguments={hookWithArguments}
               dataConsumptionHook={DataConsumptionHooks.CUSTOM_QUERY}
               setDataConsumptionHookWithArgumentUtilizationCount={setQueryHookWithArgumentInfo}
             >
               <HookComponent
-                key={
-                  `${makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}-${hookWithArguments.version}`
-                }
+                key={makeCustomHookIdentifierFromArgs(hookWithArguments.hookArguments)}
                 hookArguments={hookWithArguments.hookArguments}
                 resolveQuery={() => {
                   updateHookUsage(() => {}, () => {}, setQueryHookWithArgumentInfo,

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/types.ts
@@ -4,7 +4,7 @@ import { ObjectToCustomSubscriptionHookContainerMap } from './domain/shared/cust
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface GeneralHookManagerProps<T = any> {
     data: T;
-    numberOfUses: number;
+    version: number;
 }
 
 export type ObjectToCustomHookContainerMap =

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/utils.ts
@@ -22,9 +22,10 @@ const hookUsageSetStateCallback = (
     if (removeEntry) {
       mapToBeSet.delete(hookArgumentsAsKey);
     } else {
+      const versionIncrement = (delta > 0 ? 1 : 0);
       mapToBeSet.set(hookArgumentsAsKey, {
         count: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.count || 0) + delta,
-        version: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.version || 0) + 1,
+        version: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.version ?? 0) + versionIncrement,
         hookArguments,
       });
     }
@@ -48,9 +49,10 @@ const updateHookUsage = (
     && hookName !== DataConsumptionHooks.CUSTOM_QUERY) {
     setHookUtilizationCount((mapObj) => {
       const newMap = new Map<string, EssentialHookInformation>(mapObj.entries());
+      const versionIncrement = (delta > 0 ? 1 : 0);
       newMap.set(hookName, {
         count: (mapObj.get(hookName)?.count || 0) + delta,
-        version: (mapObj.get(hookName)?.version || 0) + 1,
+        version: (mapObj.get(hookName)?.version ?? 0) + versionIncrement,
       });
       return newMap;
     });


### PR DESCRIPTION
### What does this PR do?

This PR fixes a problem that the loading value of a subscription changes even though data is left untouched for plugins. 

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/251

### Motivation

Loading value should never change once data has arrived from subscription. It should be trustworthy.

### How to test

One need to mount a useSubscription hook after another, so use the following code in a plugin (Ideally `samples/sample-action-button-dropdown-plugin`):

```ts
return (
    <>
      {
        showSecondComponent && (
          <ScreenshareConsumerB identifier={2} pluginApi={pluginApi} />
        )
      }
      <ScreenshareConsumerB identifier={1} pluginApi={pluginApi} />
    </>
  );
```

Then create the components like so:

```ts
interface ScreenshareSubscriptionResult {
  screenshare: { stream: string }[];
}

export const SCREENSHARE = `
  subscription Screenshare {
    screenshare {
      stream
    }
  }
`;

export const useScreenshare = (pluginApi: PluginApi, identifier: number) => {
  const { loading, data } = pluginApi.useCustomSubscription!<ScreenshareSubscriptionResult>(
    SCREENSHARE,
  );
  // eslint-disable-next-line no-console
  console.log('Some test log to see the result', identifier, { data, loading });
  return loading;
};

// Second independent consumer — having two components call the same hook reproduces the bug
function ScreenshareConsumerB(
  { pluginApi, identifier }: { pluginApi: PluginApi, identifier: number },
): React.ReactElement | null {
  useScreenshare(pluginApi, identifier);
  return null;
}
```

