### PR TITLE
[3.0 WB] Viewer's cursor misaligned upon zooming slide or changing window size

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2204,6 +2204,10 @@ const Whiteboard = React.memo((props) => {
     }
   }, [whiteboardToolbarAutoHide]);
 
+  const slideZoom = tlEditorRef.current?.getCamera().z / initialZoomRef.current;
+  const { scaledWidth, scaledHeight } = currentPresentationPageRef.current;
+  const containerZoom = calculateZoomValue(scaledWidth, scaledHeight);
+
   return (
     <div
       ref={whiteboardRef}
@@ -2230,6 +2234,8 @@ const Whiteboard = React.memo((props) => {
           presentationHeight,
           cursorType,
           pointerDiameter,
+          slideZoom,
+          containerZoom,
         }}
       />
     </div>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -71,8 +71,8 @@ const TldrawV2GlobalStyle = createGlobalStyle`
       : 5;
     const scale = safeDiameter / 100;
     const scaleRatio = safeDiameter / 5;
-    const leftOffset = (-18 * scaleRatio + 13 * (containerZoom - 0.38)) / slideZoom;
-    const topOffset = (-10 * scaleRatio + 7 * (containerZoom - 0.38)) / slideZoom;
+    const leftOffset = (-18 * scaleRatio + 27 * (containerZoom - 0.38)) / slideZoom;
+    const topOffset = (-10 * scaleRatio + 15 * (containerZoom - 0.38)) / slideZoom;
     return !isPresenter && !isMultiUserActive && `
     .tl-cursor use {
       transform: scale(${scale})!important;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/styles.js
@@ -64,15 +64,15 @@ const TldrawV2GlobalStyle = createGlobalStyle`
     left: -50px !important;
   }
 
-  ${({ isPresenter, isMultiUserActive, pointerDiameter = 5 }) => {
+  ${({ isPresenter, isMultiUserActive, pointerDiameter = 5, containerZoom, slideZoom }) => {
     const numericDiameter = Number(pointerDiameter);
     const safeDiameter = Number.isFinite(numericDiameter) && numericDiameter > 0
       ? numericDiameter
       : 5;
     const scale = safeDiameter / 100;
     const scaleRatio = safeDiameter / 5;
-    const leftOffset = -18 * scaleRatio;
-    const topOffset = -10 * scaleRatio;
+    const leftOffset = (-18 * scaleRatio + 13 * (containerZoom - 0.38)) / slideZoom;
+    const topOffset = (-10 * scaleRatio + 7 * (containerZoom - 0.38)) / slideZoom;
     return !isPresenter && !isMultiUserActive && `
     .tl-cursor use {
       transform: scale(${scale})!important;


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
This is not a PR, but a small hack to show there are still some problems on the cursor (red circle) position in the viewer's screen.

### Closes Issue(s)
Related to #24595 .

### Motivation
Even before the PR #24595, I noticed that the presenter's cursor on the viewer's screen is misaligned when the presenter zooms the slide. See the screenshot below (tested on the demo server).
<img width="322" height="267" alt="image" src="https://github.com/user-attachments/assets/c0edb8a2-2e41-4a66-bab9-a509ecabb5d1" />
This is a viewer's screen showing the position of presenter's cursor, which is, in the presenter's screen, perfectly positioned at the center of the letter 'o'. You see the red circle is positioned slightly on the right (this bahaviour has been improved by the PR #24595, but it's another story). 

Now, when the presenter zooms the slide by wheel, the misalignment becomes more obvious. 
<img width="562" height="407" alt="image" src="https://github.com/user-attachments/assets/8902db72-d36c-4a04-bc07-a410799df936" />

And when the viewer enlarges the window after turning back the slide zoom to 100%, another misalignment emerges.
<img width="974" height="587" alt="image" src="https://github.com/user-attachments/assets/8ee7a39f-df36-4870-a099-80b643695338" />

Then when the PR #24595 is applied, the problem becomes worse, while the problem is partially fixed when there is no zooming. See below the cursor positioned at outside of the letter 'o'.
<img width="641" height="460" alt="image" src="https://github.com/user-attachments/assets/bbb16b27-0c38-41ef-b8bf-cf7f9f95c0a1" />

So my conclusion is there are at least two different bugs behind this problem, namely:
1. the slide zoom is not considered
2. the size change of the viewer's screen (presentation container) is not considered

To nail down the problem, I generated this draft PR. With this hack, I can probably fix the problem 1, but I can only partially fix the problem 2. 

What I did is basically pass the slide zoom value and the presentation container zoom value to the styles.js and compensate the cursor offset. For the problem 1, I was able to (probably completely) eliminate by simply dividing the cursor offset by the slide zoom value (so I skip to show the evidence). But I could only improve the problem 2 by an empirical, dirty hack . 

  const leftOffset = (-18 * scaleRatio + <b><i>27 * (containerZoom - 0.38)</i></b>) / slideZoom;
  const topOffset = (-10 * scaleRatio + <b><i>15 * (containerZoom - 0.38)</i></b>) / slideZoom;
    
This hack works more or less well. I guess not many users would realise the problem. However this is obviously not the final solution.

That's where I have been so far. I will post if I found something more. Hopefully it will help.