### PR TITLE
fix(chat): display message timestamp using locale-aware time format

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -411,7 +411,6 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
   const formattedTime = intl.formatTime(dateTime, {
     hour: 'numeric',
     minute: 'numeric',
-    hour12: false,
   });
   const editTime = message.editedAt ? new Date(message.editedAt) : null;
   const deleteTime = message.deletedAt ? new Date(message.deletedAt) : null;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -784,14 +784,14 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             })}
             {' '}
             &nbsp;
-            <FormattedTime value={dateTime} hour12={false} />
+            <FormattedTime value={dateTime} />
           </PluginInformationMetadata>
         )
       }
       {((sameSender || (isSystemSender && !messagesWithHeaders)) && !isCustomMessageFromPlugin) && (
         <ChatContentFooter>
           {!deleteTime && editTime && (
-            <Tooltip title={intl.formatTime(editTime, { hour12: false })}>
+            <Tooltip title={intl.formatTime(editTime)}>
               <EditLabel>
                 <Icon iconName="pen_tool" />
                 <span>{intl.formatMessage(intlMessages.edited)}</span>
@@ -799,7 +799,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
             </Tooltip>
           )}
           <ChatTime>
-            <FormattedTime value={dateTime} hour12={false} />
+            <FormattedTime value={dateTime} />
           </ChatTime>
         </ChatContentFooter>
       )}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-header/component.tsx
@@ -52,7 +52,7 @@ const ChatMessageHeader: React.FC<ChatMessageHeaderProps> = ({
         }
         <Styled.Center />
         {!deleteTime && editTime && (
-          <Tooltip title={intl.formatTime(editTime, { hour12: false })}>
+          <Tooltip title={intl.formatTime(editTime)}>
             <Styled.EditLabel data-test="chatMessageEditedLabel">
               <Icon iconName="pen_tool" />
               <span>{intl.formatMessage(intlMessages.edited)}</span>
@@ -65,7 +65,7 @@ const ChatMessageHeader: React.FC<ChatMessageHeaderProps> = ({
           </Styled.EditLabel>
         )}
         <Styled.ChatTime>
-          <FormattedTime value={dateTime} hour12={false} />
+          <FormattedTime value={dateTime} />
         </Styled.ChatTime>
       </Styled.ChatHeaderText>
     </Styled.HeaderContent>


### PR DESCRIPTION
### What does this PR do?

Chat message time were hardcoded to 24-hour format, ignoring the user locale. 

This pull request removes the override and lets `react-intl` determine the correct format based on the active locale (**3:06 PM** for en-US and **15:06** for pt-BR)

<img width="434" height="107" alt="Screenshot from 2026-03-30 15-08-17" src="https://github.com/user-attachments/assets/11223f16-3678-4c82-a591-61a4e93fba40" />

<img width="434" height="107" alt="Screenshot from 2026-03-30 15-06-47" src="https://github.com/user-attachments/assets/45d9fa88-45f5-4378-aca6-1750bfea98fb" />


### How to test
1. join a meeting with the default (en) locale
2. send a message in the chat
3. check if the time format is correct
4. switch language to pt-br
5. check if the time format is correct
