### PR TITLE
remove: Remove deprecated /api/rest/clientSettings endpoint

### DIFF
--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -1,13 +1,6 @@
 - name: allowed-queries
   definition:
     queries:
-      - name: clientSettings
-        query: |
-          query clientStartupSettings {
-            meeting_clientSettings {
-              clientSettingsJson
-            }
-          }
       - name: userMetadata
         query: |
           query getUserMetadata {

--- a/bbb-graphql-server/metadata/rest_endpoints.yaml
+++ b/bbb-graphql-server/metadata/rest_endpoints.yaml
@@ -2,15 +2,6 @@
   definition:
     query:
       collection_name: allowed-queries
-      query_name: clientSettings
-  methods:
-    - GET
-  name: clientSettings
-  url: clientSettings
-- comment: ""
-  definition:
-    query:
-      collection_name: allowed-queries
       query_name: meetingStaticData
   methods:
     - GET

--- a/build/packages-template/bbb-graphql-middleware/graphql.nginx
+++ b/build/packages-template/bbb-graphql-middleware/graphql.nginx
@@ -8,33 +8,6 @@ location /graphql {
 	proxy_pass         http://127.0.0.1:8378; #Graphql Middleware
 }
 
-#DEPRECATED:
-#This endpoint is being replaced by /api/rest/meetingStaticData (which contain clientSettings and more)
-#It will be removed in BBB 3.1
-location /api/rest/clientSettings {
-    auth_request /bigbluebutton/connection/checkGraphqlAuthorization;
-    auth_request_set $meeting_id $sent_http_meeting_id;
-
-    proxy_cache client_settings_cache;
-    proxy_cache_key "$uri|$meeting_id";
-    proxy_cache_use_stale updating;
-    proxy_cache_valid 24h;
-    proxy_cache_lock on;
-    proxy_cache_lock_timeout 5s;   # how long other requests may wait for the first one holding the cache lock
-    proxy_cache_lock_age 10s;      # consider the lock stale after this time (prevents a stuck lock if upstream hangs)
-    # proxy_cache_background_update on;  # optional: serve stale while refreshing the cache in background
-
-    add_header X-Cached $upstream_cache_status;
-
-    proxy_http_version 1.1;
-    proxy_set_header Connection "";
-    proxy_connect_timeout 3s;      # max time to establish TCP connection to Hasura
-    proxy_send_timeout 15s;        # max time to send the request to Hasura
-    proxy_read_timeout 30s;        # max time to wait for Hasura’s response
-    proxy_set_header Host $host;
-    proxy_pass http://127.0.0.1:8185; #Hasura
-}
-
 #Set cache system for meeting static data
 location /api/rest/meetingStaticData {
     auth_request /bigbluebutton/connection/checkGraphqlAuthorization;


### PR DESCRIPTION
### What does this PR do?
Removes the deprecated /api/rest/clientSettings endpoint.

This endpoint has been replaced by /api/rest/meetingStaticData and was marked for removal in BBB 3.1. No remaining references to the deprecated endpoint were found in the codebase.


### Closes Issue(s)
Closes #24655


### Motivation
The /api/rest/clientSettings endpoint was marked as deprecated and scheduled for removal. Since it has already been replaced and is no longer used anywhere in the project, this PR cleans up obsolete code and reduces maintenance overhead.


### How to test
1. Ensure the application builds and runs normally.
2. Verify that the Nginx configuration loads without errors.
3. Confirm that /api/rest/meetingStaticData continues to work as expected.
4. Attempting to access /api/rest/clientSettings should no longer be possible.

No additional setup is required beyond the default environment.


### More
- [ ] Added/updated documentation
