### PR TITLE
feat(user-list): add empty state message to search results

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/component.tsx
@@ -92,7 +92,8 @@ const UserListParticipants: React.FC<UserListParticipantsProps> = ({
   // --- End of plugin related code ---
 
   const renderedPaginatedUsers = useMemo(() => {
-    const amountOfPages = Math.ceil(count / usersPerUserListPage);
+    // Render one page even if there are no users to show the empty state message if needed
+    const amountOfPages = count === 0 ? 1 : Math.ceil(count / usersPerUserListPage);
 
     return Array.from({ length: amountOfPages }).map((_, i) => {
       const isLastItem = amountOfPages === (i + 1);

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   memo,
 } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { setLocalUserList, useLoadedUserList } from '/imports/ui/core/hooks/useLoadedUserList';
@@ -14,6 +15,7 @@ import { User } from '/imports/ui/Types/user';
 import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
 import { getUsersPerUserListPage } from '/imports/ui/components/user-list/service';
 import Styled from '../styles';
+import LocalStyled from './styles';
 import ListItem from '../list-item/component';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
@@ -45,6 +47,13 @@ interface UsersListParticipantsPage {
   offset: number;
   isBreakout: boolean;
 }
+
+const intlMessages = defineMessages({
+  noSearchResults: {
+    id: 'app.userList.noSearchResults',
+    description: 'Message shown when a search query is entered but no participants match the query',
+  },
+});
 
 const UsersListParticipantsPage: React.FC<UsersListParticipantsPage> = ({
   users,
@@ -101,6 +110,7 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   setVisibleUsers,
   searchQuery,
 }) => {
+  const intl = useIntl();
   const usersPerUserListPage = getUsersPerUserListPage();
   const offset = index * usersPerUserListPage;
   const limit = useRef(usersPerUserListPage);
@@ -221,6 +231,14 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
 
   if (!meeting || !currentUser) {
     return null;
+  }
+
+  if (index === 0 && displayUsers.length === 0) {
+    return (
+      <LocalStyled.EmptySearchMessage>
+        {intl.formatMessage(intlMessages.noSearchResults)}
+      </LocalStyled.EmptySearchMessage>
+    );
   }
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import { colorNeutral2 } from '/imports/ui/stylesheets/styled-components/palette';
+import { fontSizeSmall } from '/imports/ui/stylesheets/styled-components/typography';
+
+const EmptySearchMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  font-size: ${fontSizeSmall};
+  color: ${colorNeutral2};
+`;
+
+export default {
+  EmptySearchMessage,
+};

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -1,6 +1,7 @@
 const colorWhite = 'var(--color-white, #FFF)';
 const colorOffWhite = 'var(--color-off-white, #F3F6F9)';
 const colorTldrawBackground = 'var(--color-tldraw-background, #F9FAFB)';
+const colorNeutral2 = 'var(--color-neutral-2, #717C91)';
 
 const colorBlack = 'var(--color-black, #000000)';
 
@@ -177,6 +178,7 @@ export {
   colorWhite,
   colorOffWhite,
   colorTldrawBackground,
+  colorNeutral2,
   colorBlack,
   colorGray,
   colorGrayDark,

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -184,6 +184,7 @@
     "app.userList.mobile": "Mobile",
     "app.userList.guest": "Guest",
     "app.userList.searchUsers": "Search users",
+    "app.userList.noSearchResults": "No participants match your search. Try another name.",
     "app.userList.clearSearch": "Clear search",
     "app.userList.sharingWebcam": "Webcam",
     "app.userList.menuTitleContext": "Available options",


### PR DESCRIPTION
### What does this PR do?
Adds a message to the user list when a search returns no results, making it clear to the user that the search completed with no matches.

Follow up to https://github.com/bigbluebutton/bigbluebutton/pull/24350

![feat_demo](https://github.com/user-attachments/assets/4f15e984-74af-40bf-9dde-cc828dc47a69)


### Closes Issue(s)

Closes #24835 