### PR TITLE
fix(audio): additional improvements to WASM processor lifecycle, config changes

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -476,8 +476,12 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     const { deviceId = null, force = false } = options;
     const streamDeviceId = MediaStreamUtils.extractDeviceIdFromStream(stream, 'audio');
     const originalDeviceId = MediaStreamUtils.extractDeviceIdFromStream(this.originalStream, 'audio');
+    const originalStreamAlive = !!this.originalStream?.active
+      && this.originalStream.getAudioTracks().some((t) => t.readyState === 'live');
 
-    if ((!stream || this.originalStream?.id === stream.id || streamDeviceId === originalDeviceId)
+    if ((!stream
+      || this.originalStream?.id === stream.id
+      || (streamDeviceId === originalDeviceId && originalStreamAlive))
       && !force) {
       logger.debug({
         logCode: 'livekit_audio_set_input_stream_noop',

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -2,7 +2,9 @@ import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import { getStorageSingletonInstance } from '/imports/ui/services/storage';
 import {
+  adoptWasmProcessor,
   createWasmProcessorStream,
+  destroyWasmProcessor,
   isWasmProcessorSupported,
   loadWasmProcessorFiles,
   setWasmProcessorEnabled,
@@ -165,7 +167,12 @@ const loadWasmProcessor = async () => {
   return false;
 };
 
-const doGUM = async (constraints, retryOnFailure = false) => {
+const doGUM = async (
+  constraints, {
+    adoptProcessorAsPrimary = true,
+    retryOnFailure = false,
+  } = {},
+) => {
   let haveWasmProcessor = false;
   const wasmProcessingEnabled = isWasmProcessingEnabled();
 
@@ -294,9 +301,16 @@ const doGUM = async (constraints, retryOnFailure = false) => {
 
     const wasmProcessorStream = await createWasmProcessorStream(stream);
 
-    // Register the real device ID so that extractDeviceIdFromStream can
-    // resolve synthetic WebAudio-* device IDs back to it.
-    MediaStreamUtils.registerWasmDeviceId(null, realDeviceId);
+    // Register the per-stream mapping from synthetic WebAudio-* device ID
+    // to the real device ID for later resolution
+    const syntheticDeviceId = wasmProcessorStream.getAudioTracks()[0]
+      ?.getSettings()?.deviceId;
+    MediaStreamUtils.registerWasmDeviceId(syntheticDeviceId, realDeviceId);
+
+    // Promote this processor as the primary for runtime control
+    // (setWasmProcessorEnabled/Parameter/Destruction). E.g.: preview calls (audio-settings
+    // pass it false to avoid hijacking the main audioProcessor since they're transient
+    if (adoptProcessorAsPrimary) adoptWasmProcessor(wasmProcessorStream);
 
     setWasmProcessorEnabled(wasmProcessingEnabled);
     logger.debug({
@@ -357,6 +371,7 @@ export {
   getStoredAudioOutputDeviceId,
   storeAudioOutputDeviceId,
   doGUM,
+  destroyWasmProcessor,
   stereoUnsupported,
   isBBBAWasmSupported,
   isWasmProcessingEnabled,

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -127,8 +127,17 @@ const getAudioConstraints = (constraintFields = {}) => {
   return matchConstraints;
 };
 
+const getWasmProcessingSettings = () => {
+  const setting = window.meetingClientSettings.public.media.audio.audioWasmProcessing;
+
+  // Backwards compat, remove later - prlanzarin
+  if (typeof setting === 'boolean') return { enabled: setting };
+
+  return setting || {};
+};
+
 const isBBBAWasmSupported = () => isWasmProcessorSupported()
-  && window.meetingClientSettings.public.media.audio.audioWasmProcessing;
+  && getWasmProcessingSettings().enabled;
 
 // check if wasm processing is enabled
 const isWasmProcessingEnabled = (localSettingsState) => {
@@ -187,11 +196,16 @@ const doGUM = async (
         ? (deviceIdConstraint?.exact || deviceIdConstraint?.ideal)
         : deviceIdConstraint;
 
-      // eslint-disable-next-line no-param-reassign
-      constraints.audio = filterSupportedConstraints({
+      const { constraints: wasmConstraints } = getWasmProcessingSettings();
+      const defaults = {
         echoCancellation: true,
         autoGainControl: true,
         noiseSuppression: true,
+      };
+      // eslint-disable-next-line no-param-reassign
+      constraints.audio = filterSupportedConstraints({
+        ...defaults,
+        ...wasmConstraints,
       });
 
       if (rawDeviceId) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sfu-audio-bridge.js
@@ -148,7 +148,7 @@ export default class SFUAudioBridge extends BaseAudioBridge {
 
   // eslint-disable-next-line class-methods-use-this
   mediaStreamFactory(constraints) {
-    return doGUM(constraints, true);
+    return doGUM(constraints, { retryOnFailure: true });
   }
 
   setConnectionTimeout() {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/sip.js
@@ -371,7 +371,7 @@ class SIPSession {
       return Promise.resolve(new MediaStream());
     }
 
-    return doGUM(constraints, true);
+    return doGUM(constraints, { retryOnFailure: true });
   }
 
   createUserAgent(iceServers) {

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -678,11 +678,18 @@ export interface LiveKitSettings {
   screenshare?: LiveKitScreenShareSettings
 }
 
+export interface AudioWasmProcessingSettings {
+  enabled: boolean
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints
+  constraints?: Record<string, unknown>
+}
+
 export interface Audio2 {
   defaultFullAudioBridge: string
   defaultListenOnlyBridge: string
   retryThroughRelay: boolean
   allowAudioJoinCancel: boolean
+  audioWasmProcessing?: AudioWasmProcessingSettings
 }
 
 export interface Screenshare2 {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
@@ -10,8 +10,13 @@ const loadedFiles = {
   worklet: null,
 };
 
-// global audio processor so we can communicate with it
+// The active audio processor for runtime control (setWasmProcessorEnabled/Parameter etc).
+// Updated when a processor is adopted as the primary via doGUM.
 let audioProcessor = null;
+
+// Registry of all live {processor, audioContext} pairs, idx by output stream ID.
+// Allows explicit cleanup of specific processors without affecting others
+const processorRegistry = new Map();
 
 // check if wasm processor is supported, assigned to undefined if not checked yet
 let wasmProcessorUnsupportedError;
@@ -45,10 +50,9 @@ const createWasmProcessor = (audioContext, stream) => {
             processor.port.postMessage({ type: 'param', symbol: "pre_gain", value: 2 });
             processor.port.postMessage({ type: 'param', symbol: "post_gain", value: 0 });
 
-            audioProcessor = processor;
-            contextSource.connect(audioProcessor);
-            audioProcessor.connect(contextDestination);
-            resolve(contextDestination.stream);
+            contextSource.connect(processor);
+            processor.connect(contextDestination);
+            resolve({ stream: contextDestination.stream, processor });
           } else if (event.data?.type === 'error') {
             reject(event.data.error);
           }
@@ -132,54 +136,53 @@ const createWasmProcessor = (audioContext, stream) => {
           },
         };
 
-        audioProcessor = processor;
-        contextSource.connect(audioProcessor);
-        audioProcessor.connect(contextDestination);
-        resolve(contextDestination.stream);
+        contextSource.connect(processor);
+        processor.connect(contextDestination);
+        resolve({ stream: contextDestination.stream, processor });
       },
     });
   });
 };
 
 // create an audio processor on top of a stream, trigger Promise resolve with a processed stream
-const createWasmProcessorStream = (stream) => {
-  // cleanup old processor
-  if (audioProcessor) {
-    audioProcessor.port.postMessage({ type: 'destroy' });
-    audioProcessor = null;
-  }
+const createWasmProcessorStream = (stream) => new Promise((resolve, reject) => {
+  // fetch sampleRate from stream
+  const { sampleRate } = stream.getAudioTracks()[0]?.getSettings() || {};
 
-  return new Promise((resolve, reject) => {
-    // fetch sampleRate from stream
-    const sampleRate = stream.getAudioTracks()[0].getSettings().sampleRate;
+  // create audio context first
+  const audioContext = new AudioContext({ sampleRate });
+  const closeAndReject = (error) => {
+    audioContext.close?.().catch(() => {});
+    reject(error);
+  };
 
-    // create audio context first
-    const audioContext = new AudioContext({ sampleRate });
+  // function to load audio worklet, called once audio context is running
+  const loadAudioWorklet = () => {
+    createWasmProcessor(audioContext, stream).then(({ stream: outputStream, processor }) => {
+      processorRegistry.set(outputStream.id, {
+        processor,
+        context: audioContext,
+      });
+      resolve(outputStream);
+    }).catch(closeAndReject);
+  };
 
-    // function to load audio worklet, called once audio context is running
-    const loadAudioWorklet = () => {
-      createWasmProcessor(audioContext, stream).then((stream) => {
-        resolve(stream);
-      }).catch(reject);
-    };
-
-    // Firefox allows to resume right away, while Chrome does not
-    // handle both cases here
-    audioContext.resume().then(loadAudioWorklet).catch((err) => {
-      // Chrome does not allow to load worklet while audio context is suspended
-      // resuming audio context requires user interaction
-      if (audioContext.state === 'suspended') {
-        const resume = () => {
-          audioContext.resume().then(loadAudioWorklet).catch(reject);
-          document.removeEventListener('click', resume);
-        };
-        document.addEventListener('click', resume);
-      } else {
-        reject(err);
-      }
-    });
+  // Firefox allows to resume right away, while Chrome does not
+  // handle both cases here
+  audioContext.resume().then(loadAudioWorklet).catch((err) => {
+    // Chrome does not allow to load worklet while audio context is suspended
+    // resuming audio context requires user interaction
+    if (audioContext.state === 'suspended') {
+      const resume = () => {
+        audioContext.resume().then(loadAudioWorklet).catch(closeAndReject);
+        document.removeEventListener('click', resume);
+      };
+      document.addEventListener('click', resume);
+    } else {
+      closeAndReject(err);
+    }
   });
-};
+});
 
 const isWasmProcessorSupported = () => {
   if (typeof wasmProcessorUnsupportedError !== 'undefined') {
@@ -268,6 +271,34 @@ const loadWasmProcessorFiles = () => new Promise((resolve, reject) => {
   }).catch(catchHandler);
 });
 
+// Destroy a specific WASM processor by its output stream or stream ID.
+const destroyWasmProcessor = (streamOrId) => {
+  const streamId = typeof streamOrId === 'string' ? streamOrId : streamOrId?.id;
+
+  if (!streamId) return;
+
+  const entry = processorRegistry.get(streamId);
+
+  if (!entry) return;
+
+  entry.processor?.port?.postMessage({ type: 'destroy' });
+  entry.context?.close?.().catch(() => {});
+  processorRegistry.delete(streamId);
+
+  // Clear the runtime processor var if it pointed to the destroyed processor
+  if (audioProcessor === entry.processor) audioProcessor = null;
+};
+
+// Promote a processor (by its output stream) as the primary for runtime control.
+// Only called by doGUM when adoptProcessorAsPrimary=true (default). Preview/transient
+// processors should not be primary (e.g.: audio-settings/echo test)
+const adoptWasmProcessor = (streamOrId) => {
+  const streamId = typeof streamOrId === 'string' ? streamOrId : streamOrId?.id;
+  const entry = streamId ? processorRegistry.get(streamId) : null;
+
+  audioProcessor = entry?.processor || null;
+};
+
 // run-time changes to wasm processor
 const setWasmProcessorEnabled = (enabled) => {
   if (audioProcessor) {
@@ -282,7 +313,9 @@ const setWasmProcessorParameter = (index, value) => {
 };
 
 export {
+  adoptWasmProcessor,
   createWasmProcessorStream,
+  destroyWasmProcessor,
   isWasmProcessorSupported,
   loadWasmProcessorFiles,
   setWasmProcessorEnabled,

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -13,6 +13,7 @@ import { hasMediaDevicesEventTarget } from '/imports/ui/services/webrtc-base/uti
 import AudioManager from '/imports/ui/services/audio-manager';
 import Session from '/imports/ui/services/storage/in-memory';
 import AudioCaptionsSelectContainer from '../audio-graphql/audio-captions/captions/component';
+import { destroyWasmProcessor } from '/imports/ui/components/audio/audio-processor/service';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -142,6 +143,7 @@ class AudioSettings extends React.Component {
     };
 
     this._isMounted = false;
+    this._confirmedWithStream = false;
   }
 
   componentDidMount() {
@@ -202,7 +204,12 @@ class AudioSettings extends React.Component {
     this._isMounted = false;
 
     if (stream) {
-      MediaStreamUtils.stopMediaStreamTracks(stream);
+      if (!this._confirmedWithStream) {
+        // Stream was not passed from handleConfirmation to the join flow (audio-manager).
+        // We MUST clean it up here - in the other scenario, audio-manager handles it.
+        destroyWasmProcessor(stream);
+        MediaStreamUtils.stopMediaStreamTracks(stream);
+      }
     }
 
     AudioManager.isEchoTest = false;
@@ -237,10 +244,18 @@ class AudioSettings extends React.Component {
       // Stream generation disabled or there isn't any stream: just run the provided callback
       if (!produceStreams || !stream) return handleConfirmation();
 
-      // Stream generation enabled and there is a valid input stream => call
-      // the confirmation callback with the input stream as arg so it can be used
-      // in upstream components. The rationale is no surplus gUM calls.
-      // We're cloning it because the original will be cleaned up on unmount here.
+      // Not connected: pass the original stream to the join flow (audio-manager).
+      // No spurioous gUMs or processors etc
+      if (!isConnected) {
+        // Skip processor/track cleanup on unmount
+        this._confirmedWithStream = true;
+
+        return handleConfirmation(stream);
+      }
+
+      // Connected: liveChangeInputDevice already handled the device switch
+      // with its own processor. Clone for the callback; the preview processor
+      // will be cleaned up on unmount.
       const clonedStream = stream.clone();
 
       return handleConfirmation(clonedStream);
@@ -454,24 +469,55 @@ class AudioSettings extends React.Component {
   }
 
   generateInputStream(inputDeviceId) {
-    const { doGUM, getAudioConstraints } = this.props;
+    const { doGUM, getAudioConstraints, isConnected } = this.props;
     const { stream } = this.state;
 
-    if (inputDeviceId && stream) {
+    if (stream) {
       const currentDeviceId = MediaStreamUtils.extractDeviceIdFromStream(stream, 'audio');
 
       if (currentDeviceId === inputDeviceId) return Promise.resolve(stream);
 
+      destroyWasmProcessor(stream);
       MediaStreamUtils.stopMediaStreamTracks(stream);
     }
 
     if (inputDeviceId === 'listen-only') return Promise.resolve(null);
 
+    // When already connected, the bridge _should_ have a working gUM stream.
+    // Reuse it cloned instead of calling doGUM again for two reasons: no trailing
+    // gUM requests surfaced to end users in finnicky browsers (ahem FF + iframes)
+    // and no duplicated processing pipelines (WASM-based).
+    if (isConnected) {
+      const bridgeStream = AudioManager.inputStream;
+      const isBridgeStreamLive = bridgeStream?.active
+        && bridgeStream.getAudioTracks().some((t) => t.readyState === 'live');
+
+      if (isBridgeStreamLive) {
+        const bridgeDeviceId = MediaStreamUtils.extractDeviceIdFromStream(
+          bridgeStream,
+          'audio',
+        );
+
+        if (bridgeDeviceId === inputDeviceId) {
+          const clonedStream = bridgeStream.clone();
+          // Guarantee the stream is unmuted for echo test purposes.
+          // Only applies to our local clone.
+          clonedStream.getAudioTracks().forEach((track) => {
+            // eslint-disable-next-line no-param-reassign
+            track.enabled = true;
+          });
+
+          return Promise.resolve(clonedStream);
+        }
+      }
+    }
+
     const constraints = {
       audio: getAudioConstraints({ deviceId: inputDeviceId }),
     };
 
-    return doGUM(constraints, true);
+    // Preview stream — don't promote its processor as the primary.
+    return doGUM(constraints, { retryOnFailure: true, adoptProcessorAsPrimary: false });
   }
 
   renderAudioCaptionsSelector() {

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -627,6 +627,14 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         defaultListenOnlyBridge: 'fullaudio',
         retryThroughRelay: false,
         allowAudioJoinCancel: true,
+        audioWasmProcessing: {
+          enabled: false,
+          constraints: {
+            echoCancellation: true,
+            autoGainControl: true,
+            noiseSuppression: true,
+          },
+        },
       },
       stunTurnServersFetchAddress: '/bigbluebutton/api/stuns',
       cacheStunTurnServers: true,

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -17,6 +17,7 @@ import {
   storeAudioOutputDeviceId,
   getAudioConstraints,
   doGUM,
+  destroyWasmProcessor,
   isWasmProcessingEnabled,
 } from '/imports/api/audio/client/bridge/service';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
@@ -597,7 +598,7 @@ class AudioManager {
         && !callOptions.isListenOnly) {
         const constraints = getAudioConstraints({ deviceId: this?.bridge?.inputDeviceId });
 
-        this.inputStream = await doGUM({ audio: constraints }, true);
+        this.inputStream = await doGUM({ audio: constraints }, { retryOnFailure: true });
         await enumDevicesIfNecessary();
 
         // eslint-disable-next-line no-param-reassign
@@ -1100,6 +1101,7 @@ class AudioManager {
 
   liveChangeInputDevice(deviceId) {
     const currentDeviceId = this.inputDeviceId ?? 'none';
+    const prevInputStream = this.inputStream;
     const updateInputDevice = () => {
       const extractedDeviceId = MediaStreamUtils.extractDeviceIdFromStream(
         this.inputStream,
@@ -1121,6 +1123,11 @@ class AudioManager {
       .liveChangeInputDevice(deviceId)
       .then((stream) => {
         this.inputStream = stream;
+        // Clean up any previous WASM processor now that the switch succeeded.
+        if (prevInputStream && prevInputStream.id !== stream?.id) {
+          destroyWasmProcessor(prevInputStream);
+        }
+
         // Live input device change - add device ID to session storage so it
         // can be re-used on refreshes/other sessions
         const newDeviceId = updateInputDevice();
@@ -1157,6 +1164,12 @@ class AudioManager {
         }, `Input device live change failed - {${error.name}: ${error.message}}`);
         // Recover input stream from whatever is left in the bridge
         this.inputStream = this.bridge ? this.bridge.inputStream : this.inputStream;
+        // Clean up the previous stream's WASM processor if it differs from
+        // what the bridge rolled back to (avoids orphaned AudioContexts).
+        if (prevInputStream && (prevInputStream.id !== this.inputStream?.id)) {
+          destroyWasmProcessor(prevInputStream);
+        }
+
         // Rollback input device ID
         updateInputDevice();
         this.setSenderTrackEnabled(!this.isMuted);

--- a/bigbluebutton-html5/imports/utils/media-stream-utils.js
+++ b/bigbluebutton-html5/imports/utils/media-stream-utils.js
@@ -48,26 +48,20 @@ const getDeviceIdFromTrack = (track) => {
   return null;
 };
 
-// Tracks the real device ID for WASM-processed audio streams.
-// WASM processing (AudioContext.createMediaStreamDestination) creates tracks with
-// synthetic WebAudio-* device IDs. These IDs change on stream.clone(), making
-// things even more impractical. Since BBB only has one active microphone at a time
-// the most recently registered real device ID is always correct for any WebAudio-*
-// synthetic ID - prlanzarin
-let lastWasmRealDeviceId = null;
+// Maps synthetic WebAudio-* device IDs to real device IDs.
+// WASM-processed streams (from AudioContext.createMediaStreamDestination) have
+// a unique synthetic device ID per AudioContext. These IDs change on stream
+// cloning as well, making things even more impractical.
+// doGUM is charge of registering the mappings after WASM processing
+const wasmDeviceIdMap = new Map();
 
 const registerWasmDeviceId = (syntheticDeviceId, realDeviceId) => {
-  if (realDeviceId) lastWasmRealDeviceId = realDeviceId;
-};
-
-const resolveDeviceId = (deviceId) => {
-  if (deviceId && typeof deviceId === 'string'
-    && deviceId.startsWith('WebAudio-') && lastWasmRealDeviceId) {
-    return lastWasmRealDeviceId;
+  if (syntheticDeviceId && realDeviceId) {
+    wasmDeviceIdMap.set(syntheticDeviceId, realDeviceId);
   }
-
-  return deviceId;
 };
+
+const resolveDeviceId = (deviceId) => wasmDeviceIdMap.get(deviceId) ?? deviceId;
 
 const extractDeviceIdFromStream = (stream, kind) => {
   let tracks = [];

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -860,10 +860,16 @@ public:
       # by closing the audio modal while audio is being negotiated.
       # If false, the audio modal will be locked until the process finishes.
       allowAudioJoinCancel: true
-      # audioWasmProcessing: whether audio input processing through WASM/BBBA
-      # should be exposed to users. If false, browser's built in audio processing
-      # will be used instead.
-      audioWasmProcessing: false
+      # audioWasmProcessing: audio input processing through WASM/BBBA
+      #   enabled: whether BBBA should be exposed to users. If false, browser's
+      #            built-in audio processing will be used instead.
+      #   constraints: browser-level audio constraints applied ON TOP of WASM processing.
+      audioWasmProcessing:
+        enabled: false
+        constraints:
+          echoCancellation: true
+          autoGainControl: true
+          noiseSuppression: true
     stunTurnServersFetchAddress: '/bigbluebutton/api/stuns'
     cacheStunTurnServers: true
     fallbackStunServer: ''


### PR DESCRIPTION
### What does this PR do?
- [fix(audio): additional improvements to WASM processor lifecycle and ID mapping](https://github.com/bigbluebutton/bigbluebutton/commit/9265aba1c9d892cada1806e59013ae94b4d811bd) 
  - There are two issues here:
    - The WASM audio processor singleton is destroyed whenever a new
    processor is created. When audio settings generates a preview
    stream while a track is published, the published track's
    processor is killed, which breaks the main stream.
    - The synthetic WebAudio-* device ID mapping uses a global that
    any doGUM call overwrites, corrupting resolveDeviceId for the
    published track and causing unnecessary doGUM calls.
  - Do a second pass over the handling of WASM processors lifecycles and
  device ID mapping to fix the above (and other edge cases):
    - Handle BBBA WASM processors on a per-stream basis instead of globally.
    They now have isolated lifecycles with a proper create/destroy flow,
    which should prevent side effects between processors of different
    input devices.
    - Add adoptProcessorAsPrimary option to doGUM; audio settings
    passes false for preview streams. When true, defines the _active_
    processor for runtime (which is used by active published streams).
    This, alongside the previous change, allows preview streams and
    published streams to live concurrently with BBBA filters for both.
    - Re-use active published streams in audio-settings (echo test) for two
    reasons: shaves off a gUM call (less gUM = more success); one less
    WASM processor to run. Same thing we do in video-preview, but simpler.
    - Add a better stream liveness check (stream.active + track.readyState)
    to LK's setInputStream noop guard so dead streams from -unpublish are
    replaced without regressing the anti-publish-loop protection from 6d177ee
- [refactor(audio): make BBBA constraints configurable, re-structure config](https://github.com/bigbluebutton/bigbluebutton/commit/c2d0501718015daa3129fa8cede7aecf95f5a356) 
  - Make BBBA base gUM constraints configurable to make this easier to tweak
without having to change actual code.
  - Restructure the public.media.audio.audioWasmProcessing config:
    - `public.media.audio.audioWasProcessing: { enabled, constraints }`
      Old format of enabling it (pure bool) is still supported for now.

### Closes Issue(s)

None
