### PR TITLE
fix: State events leak between user sessions or tabs

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -20,7 +20,7 @@ import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Tooltip from '/imports/ui/components/common/tooltip/component';
 import SessionDetailsModal from '/imports/ui/components/session-details/component';
 import Icon from '/imports/ui/components/common/icon/icon-ts/component';
-import getStorageSingletonInstance from '../../services/storage';
+import SessionStorage from '../../services/storage/session';
 import { ModalRegistration } from '../../core/singletons/modalController';
 
 const intlMessages = defineMessages({
@@ -208,7 +208,7 @@ class NavBar extends Component {
       showSessionDetailsOnJoin,
       meetingId,
     } = this.props;
-    const ShownId = getStorageSingletonInstance().getItem('alreadyShowSessionDetailsOnJoin');
+    const ShownId = SessionStorage.getItem('alreadyShowSessionDetailsOnJoin');
     if (showSessionDetailsOnJoin && ShownId !== meetingId) {
       this.setModalIsOpen(true);
     }
@@ -413,7 +413,7 @@ class NavBar extends Component {
                     this.setModalIsOpen = (value) => {
                       if (!value) {
                         const { meetingId } = this.props;
-                        getStorageSingletonInstance().setItem('alreadyShowSessionDetailsOnJoin', meetingId);
+                        SessionStorage.setItem('alreadyShowSessionDetailsOnJoin', meetingId);
                       }
                       if (value) open();
                       else close();


### PR DESCRIPTION
### What does this PR do?

Adjust session details check to always use session storage.

### Closes Issue(s)
Closes #24836

### How to test
1. Configure public.app.userSettingsStorage = 'local'
2. Open a meeting in Tab 1, close the "Session Details" modal.
3. Open a second meeting in Tab 2, close the "Session Details" modal.
4. Trigger a state change in Tab 1 (e.g. change the slide). The "Session Details" modal should not open again