### PR TITLE
build: bbb-shared-notes-server packaging finishing touches

### DIFF
--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -456,6 +456,10 @@ display_bigbluebutton_status () {
         units="$units livekit-server"
     fi
 
+    if [ -f /usr/lib/systemd/system/bbb-shared-notes-server.service ]; then
+        units="$units bbb-shared-notes-server"
+    fi
+
     line='—————————————————————————————►'
     for unit in $units; do
         status=$(systemctl is-active "$unit")

--- a/build/packages-template/bbb-html5/opts-jammy.sh
+++ b/build/packages-template/bbb-html5/opts-jammy.sh
@@ -2,4 +2,4 @@
 
 . ./opts-global.sh
 
-OPTS="$OPTS -d bc,bbb-pads,bbb-shared-notes-server,bbb-webrtc-sfu,bbb-export-annotations,bbb-web,bbb-graphql-middleware,bbb-graphql-actions,yq,nginx,unzip -t deb"
+OPTS="$OPTS -d bc,bbb-pads,bbb-webrtc-sfu,bbb-export-annotations,bbb-web,bbb-graphql-middleware,bbb-graphql-actions,yq,nginx,unzip -t deb"


### PR DESCRIPTION
`bbb-shared-notes-server` was marked as a requirement for `bbb-html5` but at this point is an optional (opt-in) package

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
- No longer marks `bbb-shared-notes-server` as required.
- Adds `bbb-shared-notes-server` to list of monitored services for `bbb-conf --status`

TODO: ensure the docs include installing `bbb-shared-notes-server` when opting in.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
It's an opt-in package. We still default to the Etherpad based shared notes.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Run bbb-install.sh of BBB and not have `bbb-shared-notes-server` package installed until the administrator opts in.
