### PR TITLE
feat: add unsaved changes confirmation to Permissions modal

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/component.jsx
@@ -5,7 +5,7 @@ import Styled from './styles';
 
 const intlMessages = defineMessages({
   title: {
-    id: 'app.appsGallery.modal.title',
+    id: 'app.settings.unsavedChanges.title',
     description: 'Title for the unsaved changes confirmation modal',
   },
   message: {
@@ -44,10 +44,10 @@ const UnsavedChangesModal = ({ isOpen, onCancel, onConfirm }) => {
           {intl.formatMessage(intlMessages.ignoreMessage)}
         </Styled.IgnoreText>
         <Styled.ActionsContainer>
-          <Styled.ActionButton onClick={onCancel}>
+          <Styled.ActionButton onClick={onCancel} data-test="unsavedChangesCancel">
             {intl.formatMessage(intlMessages.cancelLabel)}
           </Styled.ActionButton>
-          <Styled.ActionButton onClick={onConfirm}>
+          <Styled.ActionButton onClick={onConfirm} data-test="unsavedChangesIgnore">
             {intl.formatMessage(intlMessages.ignoreButtonLabel)}
           </Styled.ActionButton>
         </Styled.ActionsContainer>

--- a/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/component.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, useIntl } from 'react-intl';
+import Styled from './styles';
+
+const intlMessages = defineMessages({
+  title: {
+    id: 'app.appsGallery.modal.title',
+    description: 'Title for the unsaved changes confirmation modal',
+  },
+  message: {
+    id: 'app.settings.unsavedChanges.message',
+    description: 'Unsaved changes warning message',
+  },
+  ignoreMessage: {
+    id: 'app.settings.unsavedChanges.ignoreMessage',
+    description: 'Description shown when ignoring unsaved changes',
+  },
+  cancelLabel: {
+    id: 'app.settings.main.cancel.label',
+    description: 'Cancel button label',
+  },
+  ignoreButtonLabel: {
+    id: 'app.settings.unsavedChanges.ignoreButtonLabel',
+    description: 'Ignore changes button label',
+  },
+});
+
+const UnsavedChangesModal = ({ isOpen, onCancel, onConfirm }) => {
+  const intl = useIntl();
+
+  return (
+    <Styled.Modal
+      title={intl.formatMessage(intlMessages.title)}
+      modalIsOpen={isOpen}
+      dismiss={{ callback: onCancel }}
+      onRequestClose={onCancel}
+    >
+      <Styled.Content>
+        <Styled.Text>
+          {intl.formatMessage(intlMessages.message)}
+        </Styled.Text>
+        <Styled.IgnoreText>
+          {intl.formatMessage(intlMessages.ignoreMessage)}
+        </Styled.IgnoreText>
+        <Styled.ActionsContainer>
+          <Styled.ActionButton onClick={onCancel}>
+            {intl.formatMessage(intlMessages.cancelLabel)}
+          </Styled.ActionButton>
+          <Styled.ActionButton onClick={onConfirm}>
+            {intl.formatMessage(intlMessages.ignoreButtonLabel)}
+          </Styled.ActionButton>
+        </Styled.ActionsContainer>
+      </Styled.Content>
+    </Styled.Modal>
+  );
+};
+
+UnsavedChangesModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};
+
+export default UnsavedChangesModal;

--- a/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/styles.js
@@ -1,0 +1,75 @@
+import styled from 'styled-components';
+import {
+  titlesFontWeight,
+  textFontWeight,
+} from '/imports/ui/stylesheets/styled-components/typography';
+import { colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
+import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
+import ModalSimple from '/imports/ui/components/common/modal/simple/component';
+
+const Modal = styled(ModalSimple)`
+  border-radius: 0.5rem;
+  width: 35rem;
+`;
+
+const Content = styled.div`
+  padding: 0 1rem;
+`;
+
+const Text = styled.div`
+  font-weight: ${titlesFontWeight};
+  margin-bottom: 0.25rem;
+`;
+
+const IgnoreText = styled.div`
+  font-weight: ${textFontWeight};
+`;
+
+const ActionsContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1.5rem;
+  padding: 1.5rem;
+
+  @media ${smallOnly} {
+    padding: 1rem;
+    gap: 1rem;
+    position: relative;
+    bottom: auto;
+    background: transparent;
+    box-shadow: none;
+  }
+`;
+
+const ActionButton = styled.button`
+  width: 12.75rem;
+  height: 3.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 1rem;
+  cursor: pointer;
+  font-size: 16px;
+  color: #fff;
+
+  &:first-child {
+    background-color: transparent;
+    color: #ccc;
+  }
+
+  &:last-child {
+    background-color: ${colorPrimary};
+  }
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+export default {
+  Modal,
+  Content,
+  Text,
+  IgnoreText,
+  ActionsContainer,
+  ActionButton,
+};

--- a/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/unsaved-changes/styles.js
@@ -2,13 +2,21 @@ import styled from 'styled-components';
 import {
   titlesFontWeight,
   textFontWeight,
+  fontSizeBase,
 } from '/imports/ui/stylesheets/styled-components/typography';
-import { colorPrimary } from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  colorPrimary,
+  colorWhite,
+} from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  lgBorderRadius,
+  borderRadiusRounded,
+} from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 
 const Modal = styled(ModalSimple)`
-  border-radius: 0.5rem;
+  border-radius: ${borderRadiusRounded};
   width: 35rem;
 `;
 
@@ -46,10 +54,10 @@ const ActionButton = styled.button`
   height: 3.5rem;
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 1rem;
+  border-radius: ${lgBorderRadius};
   cursor: pointer;
-  font-size: 16px;
-  color: #fff;
+  font-size: ${fontSizeBase};
+  color: ${colorWhite};
 
   &:first-child {
     background-color: transparent;

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
+import { clone } from 'radash';
 import { MenuItem } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -195,8 +196,8 @@ class LockViewersComponent extends Component {
 
     this.state = {
       selectedTab: 0,
-      lockSettingsProps: lockSettings,
-      usersProp: usersPolicies,
+      lockSettingsProps: clone(lockSettings),
+      usersProp: clone(usersPolicies),
       guestPolicy: usersPolicies.guestPolicy || 'ASK_MODERATOR',
       lobbyMessageEnabled: !!props.guestLobbyMessage,
       lobbyMessage: props.guestLobbyMessage || '',
@@ -205,8 +206,8 @@ class LockViewersComponent extends Component {
     };
 
     this.initialState = {
-      lockSettingsProps: lockSettings,
-      usersProp: usersPolicies,
+      lockSettingsProps: clone(lockSettings),
+      usersProp: clone(usersPolicies),
       guestPolicy: usersPolicies.guestPolicy || 'ASK_MODERATOR',
       lobbyMessageEnabled: !!props.guestLobbyMessage,
       lobbyMessage: props.guestLobbyMessage || '',
@@ -561,6 +562,7 @@ class LockViewersComponent extends Component {
       intl,
       isOpen,
       priority,
+      closeModal,
     } = this.props;
 
     const { selectedTab, unsavedModalOpen } = this.state;
@@ -595,7 +597,6 @@ class LockViewersComponent extends Component {
 
     return (
       <Styled.LockViewersModal
-        onRequestClose={this.handleClose}
         contentLabel={intl.formatMessage(intlMessages.ariaModalTitle)}
         title={intl.formatMessage(intlMessages.lockViewersTitle)}
         {...{
@@ -633,7 +634,7 @@ class LockViewersComponent extends Component {
         </Styled.SettingsTabs>
         <Styled.ActionsContainer>
           <Styled.ActionButton
-            onClick={this.handleClose}
+            onClick={closeModal}
             data-test="cancelLockSettings"
           >
             {intl.formatMessage(intlMessages.buttonCancel)}

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -5,6 +5,7 @@ import { MenuItem } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
+import UnsavedChangesModal from '/imports/ui/components/common/modal/unsaved-changes/component';
 import Styled from './styles';
 
 const PRESENTATION_POLICY = {
@@ -181,7 +182,6 @@ const propTypes = {
   isPrivateChatEnabled: PropTypes.bool.isRequired,
   isSharedNotesEnabled: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool,
-  onRequestClose: PropTypes.func,
   priority: PropTypes.string,
 };
 
@@ -201,11 +201,34 @@ class LockViewersComponent extends Component {
       lobbyMessageEnabled: !!props.guestLobbyMessage,
       lobbyMessage: props.guestLobbyMessage || '',
       presentationPolicy,
+      unsavedModalOpen: false,
     };
+
+    this.initialState = {
+      lockSettingsProps: lockSettings,
+      usersProp: usersPolicies,
+      guestPolicy: usersPolicies.guestPolicy || 'ASK_MODERATOR',
+      lobbyMessageEnabled: !!props.guestLobbyMessage,
+      lobbyMessage: props.guestLobbyMessage || '',
+      presentationPolicy,
+    };
+
+    this.handleClose = this.handleClose.bind(this);
+    this.handleIgnoreChanges = this.handleIgnoreChanges.bind(this);
   }
 
-  handleSelectTab(tabIndex) {
-    this.setState({ selectedTab: tabIndex });
+  handleClose() {
+    const { closeModal } = this.props;
+    if (this.hasChanges()) {
+      this.setState({ unsavedModalOpen: true });
+      return;
+    }
+    closeModal();
+  }
+
+  handleIgnoreChanges() {
+    const { closeModal } = this.props;
+    this.setState({ unsavedModalOpen: false }, closeModal);
   }
 
   handleSave() {
@@ -240,6 +263,26 @@ class LockViewersComponent extends Component {
     }
 
     closeModal();
+  }
+
+  handleSelectTab(tabIndex) {
+    this.setState({ selectedTab: tabIndex });
+  }
+
+  hasChanges() {
+    const {
+      lockSettingsProps, usersProp, guestPolicy,
+      lobbyMessageEnabled, lobbyMessage, presentationPolicy,
+    } = this.state;
+    const i = this.initialState;
+    return (
+      JSON.stringify(lockSettingsProps) !== JSON.stringify(i.lockSettingsProps)
+      || JSON.stringify(usersProp) !== JSON.stringify(i.usersProp)
+      || guestPolicy !== i.guestPolicy
+      || lobbyMessageEnabled !== i.lobbyMessageEnabled
+      || lobbyMessage !== i.lobbyMessage
+      || presentationPolicy !== i.presentationPolicy
+    );
   }
 
   toggleLockSettings(property) {
@@ -515,14 +558,22 @@ class LockViewersComponent extends Component {
 
   render() {
     const {
-      closeModal,
       intl,
       isOpen,
-      onRequestClose,
       priority,
     } = this.props;
 
-    const { selectedTab } = this.state;
+    const { selectedTab, unsavedModalOpen } = this.state;
+
+    if (unsavedModalOpen) {
+      return (
+        <UnsavedChangesModal
+          isOpen={unsavedModalOpen}
+          onCancel={() => this.setState({ unsavedModalOpen: false })}
+          onConfirm={this.handleIgnoreChanges}
+        />
+      );
+    }
 
     const tabs = [
       {
@@ -544,12 +595,12 @@ class LockViewersComponent extends Component {
 
     return (
       <Styled.LockViewersModal
-        onRequestClose={closeModal}
+        onRequestClose={this.handleClose}
         contentLabel={intl.formatMessage(intlMessages.ariaModalTitle)}
         title={intl.formatMessage(intlMessages.lockViewersTitle)}
         {...{
           isOpen,
-          onRequestClose,
+          onRequestClose: this.handleClose,
           priority,
         }}
       >
@@ -582,7 +633,7 @@ class LockViewersComponent extends Component {
         </Styled.SettingsTabs>
         <Styled.ActionsContainer>
           <Styled.ActionButton
-            onClick={closeModal}
+            onClick={this.handleClose}
             data-test="cancelLockSettings"
           >
             {intl.formatMessage(intlMessages.buttonCancel)}

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -12,6 +12,7 @@ import Styled from './styles';
 import { formatLocaleCode } from '/imports/utils/string-utils';
 import { setUseCurrentLocale } from '../../core/local-states/useCurrentLocale';
 import Transcription from '/imports/ui/components/settings/submenus/transcription/component';
+import UnsavedChangesModal from '/imports/ui/components/common/modal/unsaved-changes/component';
 
 const intlMessages = defineMessages({
   appTabLabel: {
@@ -81,22 +82,6 @@ const intlMessages = defineMessages({
   transcriptionLabel: {
     id: 'app.settings.transcriptionTab.label',
     description: 'label for transcriptions tab',
-  },
-  unsavedChangesModalTitle: {
-    id: 'app.appsGallery.modal.title',
-    description: 'label for the title of the unsaved changes modal',
-  },
-  unsavedChangesMessage: {
-    id: 'app.settings.unsavedChanges.message',
-    description: 'label for the title of the unsaved changes modal',
-  },
-  unsavedChangesIgnoreMessage: {
-    id: 'app.settings.unsavedChanges.ignoreMessage',
-    description: 'label for the title of the unsaved changes modal',
-  },
-  unsavedChangesIgnoreButtonLabel: {
-    id: 'app.settings.unsavedChanges.ignoreButtonLabel',
-    description: 'label for the title of the unsaved changes modal',
   },
 });
 
@@ -413,31 +398,11 @@ class Settings extends Component {
 
     if (unsavedModalOpen) {
       return (
-        <Styled.UnsavedChangesModal
-          title={intl.formatMessage(intlMessages.unsavedChangesModalTitle)}
-          modalIsOpen={unsavedModalOpen}
-          dismiss={{
-            callback: () => this.setState({ unsavedModalOpen: false }),
-          }}
-          onRequestClose={() => this.setState({ unsavedModalOpen: false })}
-        >
-          <Styled.UnsavedChangesContent>
-            <Styled.UnsavedChangesText>
-              {intl.formatMessage(intlMessages.unsavedChangesMessage)}
-            </Styled.UnsavedChangesText>
-            <Styled.UnsavedChangesIgnoreText>
-              {intl.formatMessage(intlMessages.unsavedChangesIgnoreMessage)}
-            </Styled.UnsavedChangesIgnoreText>
-            <Styled.UnsavedActionsContainer>
-              <Styled.ActionButton onClick={() => this.setState({ unsavedModalOpen: false })}>
-                {intl.formatMessage(intlMessages.CancelLabel)}
-              </Styled.ActionButton>
-              <Styled.ActionButton onClick={this.handleIgnoreChanges}>
-                {intl.formatMessage(intlMessages.unsavedChangesIgnoreButtonLabel)}
-              </Styled.ActionButton>
-            </Styled.UnsavedActionsContainer>
-          </Styled.UnsavedChangesContent>
-        </Styled.UnsavedChangesModal>
+        <UnsavedChangesModal
+          isOpen={unsavedModalOpen}
+          onCancel={() => this.setState({ unsavedModalOpen: false })}
+          onConfirm={this.handleIgnoreChanges}
+        />
       );
     }
 

--- a/bigbluebutton-html5/imports/ui/components/settings/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/styles.js
@@ -11,7 +11,7 @@ import {
   settingsModalTabSelected,
   colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { fontSizeLarge, titlesFontWeight, textFontWeight } from '/imports/ui/stylesheets/styled-components/typography';
+import { fontSizeLarge } from '/imports/ui/stylesheets/styled-components/typography';
 import {
   Tab, Tabs, TabList, TabPanel,
 } from 'react-tabs';
@@ -199,7 +199,7 @@ const ActionButton = styled.button`
   color: #fff;
 
   &:first-child {
-    background-color: transparent; 
+    background-color: transparent;
     color: #ccc;
   }
 
@@ -253,40 +253,6 @@ const Modal = styled(ModalSimple)`
   }
 `;
 
-const UnsavedChangesModal = styled(ModalSimple)`
-  border-radius: 0.5rem;
-  width: 35rem;
-`;
-
-const UnsavedChangesContent = styled.div`
-  padding: 0 1rem;
-`;
-
-const UnsavedChangesText = styled.div`
-  font-weight: ${titlesFontWeight};
-  margin-bottom: 0.25rem;
-`;
-
-const UnsavedChangesIgnoreText = styled.div`
-  font-weight: ${textFontWeight};
-`;
-
-const UnsavedActionsContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: 1.5rem;
-  padding: 1.5rem;
-
-  @media ${smallOnly} {
-    padding: 1rem;
-    gap: 1rem;
-    position: relative;
-    bottom: auto;
-    background: transparent;
-    box-shadow: none;
-  }
-`;
-
 export default {
   ToggleLabel,
   SettingsTabs,
@@ -297,9 +263,4 @@ export default {
   ActionsContainer,
   ActionButton,
   Modal,
-  UnsavedChangesModal,
-  UnsavedChangesContent,
-  UnsavedActionsContainer,
-  UnsavedChangesText,
-  UnsavedChangesIgnoreText,
 };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -737,6 +737,7 @@
     "app.settings.transcriptionTab.minUtteranceLength": "Minimum utterances length (seconds)",
     "app.settings.shortcutsTab.label": "Keyboard shortcuts",
     "app.settings.save-notification.label": "Settings have been saved",
+    "app.settings.unsavedChanges.title": "Oops!",
     "app.settings.unsavedChanges.message": "You have unsaved changes.",
     "app.settings.unsavedChanges.ignoreMessage": "If you ignore the changes they will not be applied.",
     "app.settings.unsavedChanges.ignoreButtonLabel": "Ignore changes",


### PR DESCRIPTION
### What does this PR do?
The Permissions and Policies modal now shows a confirmation dialog when closed with pending changes, matching the behavior of the client settings modal. A reusable UnsavedChangesModal component was extracted from the settings modal and placed in common/modal/unsaved-changes/ so both modals share the same confirmation UX. The settings modal was refactored to use this shared component.

### Closes Issue(s)
Closes None

### More
[Screencast from 07-04-2026 11:40:16.webm](https://github.com/user-attachments/assets/01e7bcae-cf83-4164-9c6e-b3006d1ca876)

