### PR TITLE
[Follow up of #24350] feat(bbb-graphql-server): improve db index for `user search` by filtering only active users

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -319,7 +319,6 @@ CREATE UNLOGGED TABLE "user" (
 );
 CREATE INDEX "idx_user_pk_reverse" on "user" ("userId", "meetingId");
 CREATE INDEX "idx_user_meetingId_extId" ON "user"("meetingId", "extId");
-CREATE INDEX "idx_user_name_trgm" ON "user" USING gin ("name" gin_trgm_ops);
 
 -- user (on update raiseHand or away: set new time)
 CREATE OR REPLACE FUNCTION update_user_raiseHand_away_time_trigger_func()
@@ -970,6 +969,7 @@ LEFT JOIN "user_connectionStatusMetrics" csm ON csm."meetingId" = u."meetingId" 
 order by u."meetingId", u."userId", cs."sessionToken", csm."lastOccurrenceAt" desc;
 
 CREATE INDEX "idx_user_connectionStatusMetrics_UnstableReport" ON "user_connectionStatusMetrics" ("meetingId", "userId") WHERE "status" != 'normal';
+CREATE INDEX "idx_user_name_trgm" ON "user" USING gin ("name" gin_trgm_ops) WHERE "currentlyInMeeting" IS TRUE;
 
 --ALTER TABLE "user_connectionStatus" ADD COLUMN "applicationRttInMs" NUMERIC GENERATED ALWAYS AS
 --(CASE WHEN  "connectionAliveAt" IS NULL OR "userClientResponseAt" IS NULL THEN NULL


### PR DESCRIPTION
### What does this PR do?
This PR is a follow up of #24350, and implements the suggestion that @gustavotrott pointed out:

- move `idx_user_name_trgm` creation to a point after `currentlyInMeeting` is defined
- make `idx_user_name_trgm` a partial index with `WHERE currentlyInMeeting IS TRUE`
- prevent schema load failure and align index usage with `v_user` filtering


### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/pull/24350#discussion_r3045886663