### PR TITLE
test: mark custom styles url test as flaky

### DIFF
--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -579,7 +579,7 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
     await customParam.customStyle();
   });
 
-  test('Custom Styles: URL', async ({ browser, context, page }, testInfo) => {
+  test('Custom Styles: URL', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
     const customParam = new CustomParameters(browser, context);
     await customParam.initModPage(page, { joinParameter: encodeCustomParams(c.customStyleUrl), testInfo });
     await customParam.customStyle();


### PR DESCRIPTION
### What does this PR do?

mark `Custom Parameters › Custom Styles: URL` test as flaky

### Motivation
part of the tests that need to be refactored because they rely on external assets (see #24849)