### PR TITLE
feat(user-list): add current user in search results & fix(user-list): preserve search filter across realtime updates 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/page/component.tsx
@@ -207,11 +207,17 @@ const UserListParticipantsPageContainer: React.FC<UserListParticipantsContainerP
   }), [meeting?.meetingId, meeting?.isBreakout, meeting?.lockSettings, meeting?.usersPolicies]);
 
   const displayUsers = useMemo(() => {
-    const usersWithoutCurrent = users.filter((u: User) => u.userId !== currentUser?.userId);
-    if (offset === 0 && !searchQuery) {
-      return [currentUser as User, ...usersWithoutCurrent];
+    const hasSearch = Boolean(searchQuery?.trim());
+    if (hasSearch) {
+      return users;
     }
-    return usersWithoutCurrent;
+
+    const usersWithoutCurrent = users.filter((u: User) => u.userId !== currentUser?.userId);
+    const shouldPinCurrentUser = offset === 0 && !!currentUser;
+
+    return shouldPinCurrentUser
+      ? [currentUser as User, ...usersWithoutCurrent]
+      : usersWithoutCurrent;
   }, [offset, currentUser, users, searchQuery]);
 
   const isLoading = usersLoading

--- a/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/createUseSubscription.ts
@@ -54,7 +54,7 @@ function createUseSubscription<T>(
       if (subscriptionHashRef.current !== subHash) {
         subscriptionHashRef.current = subHash;
         if (subscriptionRef.current && optionsRef.current) {
-          GrahqlSubscriptionStore.unsubscribe(subscriptionRef.current, queryVariables);
+          GrahqlSubscriptionStore.unsubscribe(subscriptionRef.current, optionsRef.current);
         }
 
         subscriptionRef.current = query;
@@ -141,7 +141,7 @@ function createUseSubscription<T>(
       GrahqlSubscriptionStore.makeSubscription(newSubscriptionGQL, queryVariables, usePatchedSubscription ? 'no-cache' : undefined);
       return () => {
         //  @ts-ignore
-        // window.removeEventListener('graphqlSubscription', listener);
+        window.removeEventListener('graphqlSubscription', listener);
       };
     }, [queryHash, skip]);
 


### PR DESCRIPTION
### What does this PR do?
- [feat(user-list): add current user in search results](https://github.com/bigbluebutton/bigbluebutton/commit/299f4265a23bb7b6830e0e5293a1cdcd384f2bf8) [Follow up of #24350]   
The search filter excludes the current user, as they always appear first in the list and no default actions are available on one's own user entry (plugins may override this). However, since an empty state message was added, searching for your own name now shows "No participants match your search. Try another name", which is a confusing and misleading UX behavior.
Include the current user in search results to eliminate this inconsistency.
- [fix(user-list): preserve search filter across realtime updates](https://github.com/bigbluebutton/bigbluebutton/commit/57643c4434d8fdd1fe9c690aac1575c376ab7706) 
The current code leaves an older subscription and its event listener active after the search query changes. When a participant update arrives, the stale subscription emits an unfiltered user list and overwrites the filtered results, showing all users even though the search field still contains the active filter.
This is reproducible with users "aa", "bb", and "cb": search for "b", then trigger a participant update such as changing whiteboard access. The list loses the filter and shows all users while the search input still contains "b".
The fix involves unsubscribing using the previous subscription variables and removing the old graphqlSubscription listener during cleanup, so only the current search-scoped subscription updates the participant list after realtime changes.


### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/pull/24350#issuecomment-4201026338
Closes #24863