### PR TITLE
Security: Stored/Reflected XSS via unsanitized HTML injection in chat message rendering

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import Styled from './styles';
 
 interface ChatMessageTextContentProps {
@@ -9,10 +10,12 @@ const ChatMessageTextContent: React.FC<ChatMessageTextContentProps> = ({
   text,
   dataTest = 'messageContent',
 }) => {
+  const sanitizedText = DOMPurify.sanitize(text);
+
   return (
     <Styled.ChatMessage
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: text }}
+      dangerouslySetInnerHTML={{ __html: sanitizedText }}
       data-test={dataTest}
     />
   );


### PR DESCRIPTION
## Problem

Chat message content is rendered with `dangerouslySetInnerHTML` using the `text` prop directly. If `text` can contain user-controlled HTML (directly or after insufficient markdown conversion), attackers can inject scripts or event handlers and execute code in other users' browsers.

**Severity**: `high`
**File**: `bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx`

## Solution

Sanitize message HTML before rendering (e.g., strict allowlist sanitizer such as DOMPurify configured to strip scripts/events/unsafe URLs), or avoid raw HTML rendering entirely by rendering structured markdown tokens/components. Add server-side sanitization as a defense-in-depth layer and tests for XSS payloads.

## Changes

- `bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
