### PR TITLE
Security: Open redirect risk in logout flow

### DIFF
--- a/bigbluebutton-html5/imports/utils/logoutRouteHandler.js
+++ b/bigbluebutton-html5/imports/utils/logoutRouteHandler.js
@@ -4,8 +4,18 @@ const logoutRouteHandler = () => {
   Auth.logout()
     .then((logoutURL) => {
       if (logoutURL) {
-        const protocolPattern = /^((http|https):\/\/)/;
-        window.location.href = protocolPattern.test(logoutURL) ? logoutURL : `http://${logoutURL}`;
+        try {
+          const parsedURL = new URL(logoutURL, window.location.origin);
+          const isRelativePath = logoutURL.startsWith('/') && !logoutURL.startsWith('//');
+
+          if (isRelativePath || parsedURL.origin === window.location.origin) {
+            window.location.href = isRelativePath
+              ? `${parsedURL.pathname}${parsedURL.search}${parsedURL.hash}`
+              : parsedURL.href;
+          }
+        } catch {
+          window.location.href = '/';
+        }
       }
     });
 };


### PR DESCRIPTION
## Problem

After logout, the code redirects the browser to a `logoutURL` value returned at runtime. It only checks for `http/https` and otherwise prepends `http://`, allowing redirects to arbitrary external domains. This enables phishing and token/session confusion patterns via attacker-controlled redirect targets if `logoutURL` is influenced by untrusted input or compromised backend config.

**Severity**: `medium`
**File**: `bigbluebutton-html5/imports/utils/logoutRouteHandler.js`

## Solution

Enforce a strict allowlist of approved logout redirect origins/paths (prefer same-origin relative paths), reject protocol-relative/absolute untrusted URLs, and validate on both server and client. Consider using URL parsing and explicit host comparison instead of regex.

## Changes

- `bigbluebutton-html5/imports/utils/logoutRouteHandler.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
