### PR TITLE
fix(livekit): use LK APIs for WebRTC stats gathering, fix edge cases

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -21,7 +21,7 @@ import {
   filterSupportedConstraints,
   doGUM,
 } from '/imports/api/audio/client/bridge/service';
-import { liveKitRoom, getLKStats, LK_FATAL_ERROR_EVENT } from '/imports/ui/services/livekit';
+import { liveKitRoom, LK_FATAL_ERROR_EVENT } from '/imports/ui/services/livekit';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 
 const BRIDGE_NAME = 'livekit';
@@ -1325,11 +1325,6 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   // eslint-disable-next-line class-methods-use-this
   getPeerConnection(): RTCPeerConnection | null {
     return null;
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async getStats(): Promise<Map<string, unknown>> {
-    return getLKStats();
   }
 
   async joinAudio(

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -23,7 +23,6 @@ import {
 } from 'livekit-client';
 import {
   liveKitRoom,
-  getLKStats,
 } from '/imports/ui/services/livekit';
 import { LiveKitPresetConfig } from 'imports/ui/Types/meetingClientSettings';
 import {
@@ -547,11 +546,6 @@ export default class LiveKitScreenshareBridge {
   // eslint-disable-next-line class-methods-use-this
   getPeerConnection() {
     return null;
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async getStats(): Promise<Map<string, unknown>> {
-    return getLKStats();
   }
 
   setVolume(volume: number): number {

--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -457,6 +457,7 @@ export async function startMonitoringNetwork() {
 
 export function getWorstStatus(statuses) {
   const statusOrder = {
+    unknown: -1,
     normal: 0,
     warning: 1,
     danger: 2,

--- a/bigbluebutton-html5/imports/ui/components/connection-status/service.js
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/service.js
@@ -8,6 +8,11 @@ import ScreenshareService from '/imports/ui/components/screenshare/service';
 import VideoService from '/imports/ui/components/video-provider/service';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import getStatus from '../../core/utils/getStatus';
+import AudioManager from '/imports/ui/services/audio-manager';
+import { getLiveKitAudioNetworkData, getLiveKitVideoNetworkData } from '/imports/ui/services/livekit/stats';
+import { isLiveKitBridge, liveKitRoom } from '/imports/ui/services/livekit';
+import meetingStaticData from '/imports/ui/core/singletons/meetingStaticData';
+import logger from '/imports/startup/client/logger';
 
 const intlMessages = defineMessages({
   saved: {
@@ -25,6 +30,8 @@ export const NETWORK_MONITORING_INTERVAL_MS = 2000;
 export const lastLevel = makeVar();
 
 let monitoringInterval = null;
+let previousSfuStats = null;
+let previousLkStats = new Map();
 
 export const URL_REGEX = new RegExp(/^(http|https):\/\/[^ "]+$/);
 export const getHelp = () => {
@@ -212,35 +219,6 @@ export const getVideoData = async () => {
 };
 
 /**
- * Get the user, audio and video data from current active streams.
- * For audio, this will get information about the mic/listen-only stream.
- * @returns An Object containing all this data.
- */
-export const getNetworkData = async () => {
-  const audio = await getAudioData();
-
-  const video = await getVideoData();
-
-  const user = {
-    time: new Date(),
-    username: Auth.username,
-    meeting_name: Auth.confname,
-    meeting_id: Auth.meetingID,
-    connection_id: Auth.connectionID,
-    user_id: Auth.userID,
-    extern_user_id: Auth.externUserID,
-  };
-
-  const fullData = {
-    user,
-    audio,
-    video,
-  };
-
-  return fullData;
-};
-
-/**
  * Calculates both upload and download rates using data retrieved from getStats
  * API. For upload (outbound-rtp) we use both bytesSent and timestamp fields.
  * byteSent field contains the number of octets sent at the given timestamp,
@@ -368,6 +346,98 @@ export const calculateBitsPerSecondFromMultipleData = (currentData, previousData
   return result;
 };
 
+// Audio network data collection for the bbb-webrtc-sfu bridge
+const getSFUAudioNetworkData = async () => {
+  const rawAudio = await getAudioData();
+  const {
+    outbound: audioCurrentUploadRate,
+    inbound: audioCurrentDownloadRate,
+  } = previousSfuStats
+    ? calculateBitsPerSecond(rawAudio, previousSfuStats.audio)
+    : { outbound: 0, inbound: 0 };
+
+  const inboundRtp = getDataType(rawAudio, 'inbound-rtp')[0];
+
+  previousSfuStats = {
+    ...previousSfuStats,
+    audio: rawAudio,
+  };
+
+  return {
+    audioCurrentUploadRate,
+    audioCurrentDownloadRate,
+    jitter: inboundRtp ? inboundRtp.jitterBufferAverage : 0,
+    packetsLost: inboundRtp ? inboundRtp.packetsLost : 0,
+    transportStats: rawAudio.transportStats || {},
+  };
+};
+
+// Video network data collection for the bbb-webrtc-sfu bridge
+const getSFUVideoNetworkData = async () => {
+  const rawVideo = await getVideoData();
+  const {
+    outbound: videoCurrentUploadRate,
+    inbound: videoCurrentDownloadRate,
+  } = previousSfuStats
+    ? calculateBitsPerSecondFromMultipleData(rawVideo, previousSfuStats.video)
+    : { outbound: 0, inbound: 0 };
+
+  previousSfuStats = {
+    ...previousSfuStats,
+    video: rawVideo,
+  };
+
+  return {
+    videoCurrentUploadRate,
+    videoCurrentDownloadRate,
+  };
+};
+
+// Get computed network data (bitrates, jitter, loss) for the connection status modal.
+export const getNetworkData = async () => {
+  const user = {
+    time: new Date(),
+    username: Auth.username,
+    meeting_name: Auth.confname,
+    meeting_id: Auth.meetingID,
+    connection_id: Auth.connectionID,
+    user_id: Auth.userID,
+    extern_user_id: Auth.externUserID,
+  };
+
+  const meeting = meetingStaticData.hasData() ? meetingStaticData.getMeetingData() : null;
+  const audioIsLK = AudioManager.isUsingLiveKit();
+  const videoIsLK = isLiveKitBridge(meeting?.cameraBridge)
+    || isLiveKitBridge(meeting?.screenShareBridge);
+
+  let audio;
+
+  if (audioIsLK) {
+    const result = await getLiveKitAudioNetworkData(liveKitRoom, previousLkStats);
+    previousLkStats = new Map([...previousLkStats, ...result.previousStats]);
+    audio = result.data;
+  } else {
+    audio = await getSFUAudioNetworkData();
+  }
+
+  let video;
+
+  if (videoIsLK) {
+    const result = await getLiveKitVideoNetworkData(liveKitRoom, previousLkStats);
+    previousLkStats = new Map([...previousLkStats, ...result.previousStats]);
+    video = result.data;
+  } else {
+    video = await getSFUVideoNetworkData();
+  }
+
+  return {
+    ready: true,
+    user,
+    audio,
+    video,
+  };
+};
+
 export const sortConnectionData = (connectionData) => connectionData
   .sort(sortLevel)
   .sort(sortOnline);
@@ -375,8 +445,8 @@ export const sortConnectionData = (connectionData) => connectionData
 export const stopMonitoringNetwork = () => {
   clearInterval(monitoringInterval);
   monitoringInterval = null;
-  // Reset the network data so that we don't show old data by accident if the
-  // monitoring is started again later.
+  previousSfuStats = null;
+  previousLkStats = new Map();
   connectionStatus.setNetworkData({
     ready: false,
     audio: {
@@ -394,64 +464,24 @@ export const stopMonitoringNetwork = () => {
 };
 
 /**
-   * Start monitoring the network data.
-   * @return {Promise} A Promise that resolves when process started.
-   */
+ * Start monitoring the network data.
+ * @return {Promise} A Promise that resolves when process started.
+ */
 export async function startMonitoringNetwork() {
-  // Reset the monitoring interval if it's already running
   if (monitoringInterval) stopMonitoringNetwork();
 
-  let previousData = await getNetworkData();
-
   monitoringInterval = setInterval(async () => {
-    const data = await getNetworkData();
-
-    const {
-      outbound: audioCurrentUploadRate,
-      inbound: audioCurrentDownloadRate,
-    } = calculateBitsPerSecond(data.audio, previousData.audio);
-
-    const inboundRtp = getDataType(data.audio, 'inbound-rtp')[0];
-
-    const jitter = inboundRtp
-      ? inboundRtp.jitterBufferAverage
-      : 0;
-
-    const packetsLost = inboundRtp
-      ? inboundRtp.packetsLost
-      : 0;
-
-    const audio = {
-      audioCurrentUploadRate,
-      audioCurrentDownloadRate,
-      jitter,
-      packetsLost,
-      transportStats: data.audio.transportStats,
-    };
-
-    const {
-      outbound: videoCurrentUploadRate,
-      inbound: videoCurrentDownloadRate,
-    } = calculateBitsPerSecondFromMultipleData(data.video,
-      previousData.video);
-
-    const video = {
-      videoCurrentUploadRate,
-      videoCurrentDownloadRate,
-    };
-
-    const { user } = data;
-
-    const networkData = {
-      ready: true,
-      user,
-      audio,
-      video,
-    };
-
-    previousData = data;
-
-    connectionStatus.setNetworkData(networkData);
+    try {
+      const networkData = await getNetworkData();
+      connectionStatus.setNetworkData(networkData);
+    } catch (error) {
+      logger.debug({
+        logCode: 'connstats_network_data_error',
+        extraInfo: {
+          errorMessage: error.message,
+        },
+      }, `Network data collection error: ${error.message}`);
+    }
   }, NETWORK_MONITORING_INTERVAL_MS);
 }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
@@ -21,7 +21,6 @@ import type { Stream, StreamItem, VideoItem } from './types';
 import { VIDEO_TYPES } from './enums';
 import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
 import {
-  getLKStats,
   lkToggleMuteCameras,
 } from '/imports/ui/services/livekit';
 
@@ -530,27 +529,6 @@ class VideoService {
         stats[peerId] = videoStats;
       }),
     );
-
-    try {
-      const lkStats = await getLKStats();
-      lkStats.forEach((stat) => {
-        // @ts-expect-error -> Untyped object.
-        const { id, type: statType, kind } = stat;
-
-        if (FILTER_VIDEO_STATS.includes(statType) && (!kind || kind === 'video')) {
-          stats[id] = { [statType]: stat };
-        }
-      });
-    } catch (error) {
-      logger.error({
-        logCode: 'video_provider_livekit_stats_error',
-        extraInfo: {
-          errorName: (error as Error).name,
-          errorMessage: (error as Error).message,
-          errorStack: (error as Error).stack,
-        },
-      }, `Failed to get LiveKit video stats: ${(error as Error).message}`);
-    }
 
     return stats;
   }

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -6,6 +6,8 @@ import logger from '/imports/startup/client/logger';
 import { notify } from '/imports/ui/services/notification';
 import playAndRetry from '/imports/utils/mediaElementPlayRetry';
 import { monitorAudioConnection } from '/imports/utils/stats';
+import { monitorLiveKitAudioStats, stopLiveKitAudioStats } from '/imports/ui/services/livekit/stats';
+import { liveKitRoom } from '/imports/ui/services/livekit';
 import browserInfo from '/imports/utils/browserInfo';
 import {
   DEFAULT_INPUT_DEVICE_ID,
@@ -873,6 +875,7 @@ class AudioManager {
     window.removeEventListener('audioPlayFailed', this.handlePlayElementFailed);
     this._resetAudioJoinTime();
     this.notifyAudioExit();
+    stopLiveKitAudioStats();
     this.isConnected = false;
     this.isConnecting = false;
     this.isHangingUp = false;
@@ -1312,8 +1315,12 @@ class AudioManager {
   }
 
   monitor() {
-    const peer = this.bridge.getPeerConnection();
-    monitorAudioConnection(peer);
+    if (this.isUsingLiveKit()) {
+      const STATS_INTERVAL = window.meetingClientSettings.public.stats.interval;
+      monitorLiveKitAudioStats(liveKitRoom, STATS_INTERVAL);
+    } else {
+      monitorAudioConnection();
+    }
   }
 
   handleAllowAutoplay() {

--- a/bigbluebutton-html5/imports/ui/services/livekit/index.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/index.ts
@@ -11,30 +11,12 @@ export const LK_FATAL_ERROR_EVENT = 'liveKitFatalError';
 
 export const liveKitRoom: Room = new Room();
 
-export const getLKStats = async (): Promise<Map<string, unknown>> => {
-  const { localParticipant } = liveKitRoom;
-
-  const statsMap: Map<string, unknown> = new Map();
-
-  if (localParticipant?.engine?.pcManager?.publisher) {
-    const senderStats = await localParticipant.engine.pcManager.publisher.getStats();
-    senderStats.forEach((stat) => {
-      statsMap.set(stat.id, stat);
-    });
-  }
-
-  if (localParticipant?.engine?.pcManager?.subscriber) {
-    const receiverStats = await localParticipant.engine.pcManager.subscriber.getStats();
-    receiverStats.forEach((stat) => {
-      statsMap.set(stat.id, stat);
-    });
-  }
-
-  return statsMap;
-};
-
 export const lkIsCameraSource = (track: TrackPublication | RemoteTrack): boolean => {
   return track.kind === Track.Kind.Video && track.source === Track.Source.Camera;
+};
+
+export const isLiveKitBridge = (bridgeName: string): boolean => {
+  return bridgeName === 'livekit';
 };
 
 export const lkToggleMuteCameras = (mute: boolean): void => {
@@ -66,7 +48,7 @@ export const lkToggleMuteCameras = (mute: boolean): void => {
 
 export default {
   LK_FATAL_ERROR_EVENT,
-  getLKStats,
+  isLiveKitBridge,
   lkIsCameraSource,
   liveKitRoom,
   lkToggleMuteCameras,

--- a/bigbluebutton-html5/imports/ui/services/livekit/stats.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/stats.ts
@@ -1,0 +1,464 @@
+import {
+  type Room,
+  Track,
+  type LocalAudioTrack,
+  type RemoteAudioTrack,
+  type RemoteVideoTrack,
+  type LocalVideoTrack,
+} from 'livekit-client';
+import logger from '/imports/startup/client/logger';
+
+// Audio stats monitoring (i.e.: used by alert triggers in connection-status)
+
+const PROBES = 5;
+
+let probingTimeout: ReturnType<typeof setTimeout> | null = null;
+
+interface ProbeSnapshot {
+  packetsSent: number;
+  packetsLost: number;
+  bytesSent: number;
+  jitterMs: number;
+}
+
+let statsWindow: ProbeSnapshot[] = [];
+
+const calculateRate = (deltaSent: number, deltaLost: number): number => {
+  const total = deltaSent + deltaLost;
+
+  if (total <= 0) return 100;
+
+  const rate = ((total - deltaLost) / total) * 100;
+
+  if (rate < 0 || rate > 100) return 100;
+
+  return rate;
+};
+
+const calculateLoss = (rate: number): number => 1 - (rate / 100);
+
+const calculateMOS = (rate: number): number => (
+  1 + (0.035) * rate + (0.000007) * rate * (rate - 60) * (100 - rate)
+);
+
+const buildResult = (
+  first: ProbeSnapshot,
+  last: ProbeSnapshot,
+  single: boolean,
+) => {
+  const deltaSent = single ? 0 : last.packetsSent - first.packetsSent;
+  const deltaLost = single ? 0 : last.packetsLost - first.packetsLost;
+  const deltaBytes = single ? 0 : last.bytesSent - first.bytesSent;
+
+  const rate = calculateRate(deltaSent, deltaLost);
+  return {
+    packets: {
+      sent: deltaSent,
+      lost: deltaLost,
+    },
+    bytes: {
+      sent: deltaBytes,
+    },
+    jitter: last.jitterMs,
+    rate,
+    loss: calculateLoss(rate),
+    MOS: calculateMOS(rate),
+  };
+};
+
+const clearResult = () => ({
+  packets: { sent: 0, lost: 0 },
+  bytes: { sent: 0 },
+  jitter: 0,
+  rate: 0,
+  loss: 0,
+  MOS: 0,
+});
+
+const dispatchAudioStats = (result: ReturnType<typeof buildResult>) => {
+  const event = new CustomEvent('audiostats', { detail: result });
+
+  window.dispatchEvent(event);
+};
+
+const probe = async (room: Room) => {
+  const publication = room.localParticipant
+    ?.getTrackPublication(Track.Source.Microphone);
+  const track = publication?.track as LocalAudioTrack | undefined;
+
+  if (!track || typeof track.getSenderStats !== 'function') {
+    dispatchAudioStats(clearResult());
+
+    return;
+  }
+
+  try {
+    const senderStats = await track.getSenderStats();
+
+    if (!senderStats) return;
+
+    const remoteStats = await getRemoteInboundAudioStats(track);
+
+    const snapshot: ProbeSnapshot = {
+      packetsSent: senderStats.packetsSent ?? 0,
+      packetsLost: remoteStats.packetsLost,
+      bytesSent: senderStats.bytesSent ?? 0,
+      jitterMs: remoteStats.jitterMs,
+    };
+
+    statsWindow.push(snapshot);
+
+    while (statsWindow.length > PROBES) {
+      statsWindow.shift();
+    }
+
+    const first = statsWindow[0];
+    const last = statsWindow[statsWindow.length - 1];
+    const single = statsWindow.length === 1;
+    const result = buildResult(first, last, single);
+
+    dispatchAudioStats(result);
+  } catch (error) {
+    logger.debug({
+      logCode: 'livekit_stats_get_sender_error',
+      extraInfo: {
+        errorMessage: (error as Error).message,
+        errorName: (error as Error).name,
+      },
+    }, 'LiveKit audio sender stats not available');
+  }
+};
+
+export const monitorLiveKitAudioStats = (room: Room, interval: number): void => {
+  const probeInterval = interval / PROBES;
+  const runProbe = () => {
+    probe(room).finally(() => {
+      probingTimeout = setTimeout(runProbe, probeInterval);
+    });
+  };
+
+  stopLiveKitAudioStats();
+  runProbe();
+};
+
+export const stopLiveKitAudioStats = (): void => {
+  if (probingTimeout) {
+    clearTimeout(probingTimeout);
+    probingTimeout = null;
+  }
+
+  statsWindow = [];
+};
+
+// Stats data collection for connection-status modal (bandwidth, TURN usage etc)
+
+interface PreviousTrackStats {
+  bytesSent?: number;
+  bytesReceived?: number;
+  timestamp: number;
+}
+
+export type PreviousStatsMap = Map<string, PreviousTrackStats>;
+
+export interface AudioNetworkData {
+  audioCurrentUploadRate: number;
+  audioCurrentDownloadRate: number;
+  jitter: number;
+  packetsLost: number;
+  transportStats: { isUsingTurn?: boolean };
+}
+
+export interface VideoNetworkData {
+  videoCurrentUploadRate: number;
+  videoCurrentDownloadRate: number;
+}
+
+const computeKbps = (
+  currentBytes: number,
+  previousBytes: number,
+  currentTimestamp: number,
+  previousTimestamp: number,
+): number => {
+  const deltaBytes = currentBytes - previousBytes;
+  const deltaTimeMs = currentTimestamp - previousTimestamp;
+
+  if (deltaTimeMs <= 0 || deltaBytes < 0) return 0;
+
+  // bytes/ms -> bytes/s -> bits/s -> kbps
+  return Math.round((deltaBytes * 8 * 1000) / (deltaTimeMs * 1024));
+};
+
+/**
+ * Extract stats from the remote-inbound-rtp entry in the raw RTCStatsReport.
+ */
+interface RemoteInboundAudioStats {
+  jitterMs: number;
+  packetsLost: number;
+  fractionLost: number;
+}
+
+const getRemoteInboundAudioStats = async (
+  track: LocalAudioTrack,
+): Promise<RemoteInboundAudioStats> => {
+  const empty = { jitterMs: 0, packetsLost: 0, fractionLost: 0 };
+
+  if (typeof track.getRTCStatsReport !== 'function') return empty;
+
+  try {
+    const report = await track.getRTCStatsReport();
+    if (!report) return empty;
+
+    let result = empty;
+    report.forEach((stat) => {
+      if (stat.type === 'remote-inbound-rtp' && stat.kind === 'audio') {
+        result = {
+          jitterMs: Math.round((stat.jitter ?? 0) * 1000),
+          packetsLost: stat.packetsLost ?? 0,
+          fractionLost: stat.fractionLost ?? 0,
+        };
+      }
+    });
+
+    return result;
+  } catch {
+    return empty;
+  }
+};
+
+const findTurnUsageFromReport = (
+  report: RTCStatsReport,
+): { isUsingTurn?: boolean } => {
+  // Find the active candidate pair
+  let activePairLocalId: string | null = null;
+  report.forEach((stat) => {
+    if (stat.type === 'candidate-pair'
+      && (stat.state === 'succeeded' || stat.state === 'in-progress')
+      && stat.nominated !== false) {
+      activePairLocalId = stat.localCandidateId;
+    }
+  });
+
+  if (!activePairLocalId) return {};
+
+  // Find the local candidate referenced by the active pair
+  let candidateType: string | null = null;
+  report.forEach((stat) => {
+    if (stat.type === 'local-candidate' && stat.id === activePairLocalId) {
+      candidateType = stat.candidateType ?? null;
+    }
+  });
+
+  return { isUsingTurn: candidateType === 'relay' };
+};
+
+const getTransportStats = async (
+  room: Room,
+): Promise<{ isUsingTurn?: boolean }> => {
+  try {
+    // Try local mic track first (publisher PC)
+    const micPub = room.localParticipant?.getTrackPublication(Track.Source.Microphone);
+    const micTrack = micPub?.track as LocalAudioTrack | undefined;
+
+    if (micTrack && typeof micTrack.getRTCStatsReport === 'function') {
+      const report = await micTrack.getRTCStatsReport();
+      if (report) {
+        const result = findTurnUsageFromReport(report);
+        if (result.isUsingTurn != null) return result;
+      }
+    }
+
+    // Fallback: any subscribed remote track (subscriber PC)
+    // Covers listen-only mode where no local tracks are published
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [, participant] of room.remoteParticipants) {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const [, pub] of participant.trackPublications) {
+        const { track } = pub;
+        if (track && typeof track.getRTCStatsReport === 'function') {
+          // eslint-disable-next-line no-await-in-loop
+          const report = await track.getRTCStatsReport();
+          if (report) {
+            const result = findTurnUsageFromReport(report);
+            if (result.isUsingTurn != null) return result;
+          }
+        }
+      }
+    }
+
+    return {};
+  } catch {
+    return {};
+  }
+};
+
+export const getLiveKitAudioNetworkData = async (
+  room: Room,
+  previousStats: PreviousStatsMap,
+): Promise<{ data: AudioNetworkData; previousStats: PreviousStatsMap }> => {
+  const newPreviousStats: PreviousStatsMap = new Map();
+  let audioUpload = 0;
+  let audioDownload = 0;
+  let audioJitter = 0;
+  let audioPacketsLost = 0;
+
+  // Audio upload (local microphone track)
+  const micPub = room.localParticipant?.getTrackPublication(Track.Source.Microphone);
+  const micTrack = micPub?.track as LocalAudioTrack | undefined;
+
+  if (micPub && micTrack && typeof micTrack.getSenderStats === 'function') {
+    try {
+      const stats = await micTrack.getSenderStats();
+
+      if (stats) {
+        const sid = micPub?.trackSid;
+        const prev = previousStats.get(sid);
+
+        if (prev && prev.bytesSent != null) {
+          audioUpload = computeKbps(
+            stats.bytesSent ?? 0, prev.bytesSent,
+            stats.timestamp, prev.timestamp,
+          );
+        }
+
+        const remoteStats = await getRemoteInboundAudioStats(micTrack);
+        audioJitter = remoteStats.jitterMs;
+        audioPacketsLost = remoteStats.packetsLost;
+        newPreviousStats.set(sid, {
+          bytesSent: stats.bytesSent ?? 0,
+          timestamp: stats.timestamp,
+        });
+      }
+    } catch {
+      // Track may have been removed between check and call
+    }
+  }
+
+  // Audio download (subscribed remote audio tracks)
+  await Promise.all(
+    Array.from(room.remoteParticipants.values()).flatMap((participant) => (
+      Array.from(participant.audioTrackPublications.values()).map(async (pub) => {
+        const track = pub.track as RemoteAudioTrack | undefined;
+        if (!track || typeof track.getReceiverStats !== 'function') return;
+
+        try {
+          const stats = await track.getReceiverStats();
+          if (!stats) return;
+
+          const sid = pub.trackSid ?? `audio-${participant.identity}`;
+          const prev = previousStats.get(sid);
+          if (prev && prev.bytesReceived != null) {
+            audioDownload += computeKbps(
+              stats.bytesReceived ?? 0, prev.bytesReceived,
+              stats.timestamp, prev.timestamp,
+            );
+          }
+          newPreviousStats.set(sid, {
+            bytesReceived: stats.bytesReceived ?? 0,
+            timestamp: stats.timestamp,
+          });
+        } catch {
+          // Track may have been removed
+        }
+      })
+    )),
+  );
+
+  const transportStats = await getTransportStats(room);
+
+  return {
+    data: {
+      audioCurrentUploadRate: audioUpload,
+      audioCurrentDownloadRate: audioDownload,
+      jitter: audioJitter,
+      packetsLost: audioPacketsLost,
+      transportStats,
+    },
+    previousStats: newPreviousStats,
+  };
+};
+
+export const getLiveKitVideoNetworkData = async (
+  room: Room,
+  previousStats: PreviousStatsMap,
+): Promise<{ data: VideoNetworkData; previousStats: PreviousStatsMap }> => {
+  const newPreviousStats: PreviousStatsMap = new Map();
+  let videoUpload = 0;
+  let videoDownload = 0;
+
+  // Video upload (local camera + screenshare tracks)
+  const localVideoPubs = [
+    room.localParticipant?.getTrackPublication(Track.Source.Camera),
+    room.localParticipant?.getTrackPublication(Track.Source.ScreenShare),
+  ].filter(Boolean);
+
+  await Promise.all(localVideoPubs.map(async (pub) => {
+    const track = pub?.track as LocalVideoTrack | undefined;
+    if (!track || typeof track.getSenderStats !== 'function') return;
+
+    try {
+      // VideoSenderStats[] — one per simulcast layer
+      const statsArray = await track.getSenderStats();
+      if (!statsArray || !Array.isArray(statsArray)) return;
+
+      let totalBytesSent = 0;
+      let latestTimestamp = 0;
+      statsArray.forEach((layerStats) => {
+        totalBytesSent += layerStats.bytesSent ?? 0;
+        latestTimestamp = Math.max(latestTimestamp, layerStats.timestamp);
+      });
+
+      const sid = pub?.trackSid ?? `video-local-${track.source}`;
+      const prev = previousStats.get(sid);
+      if (prev && prev.bytesSent != null) {
+        videoUpload += computeKbps(
+          totalBytesSent, prev.bytesSent,
+          latestTimestamp, prev.timestamp,
+        );
+      }
+      newPreviousStats.set(sid, {
+        bytesSent: totalBytesSent,
+        timestamp: latestTimestamp,
+      });
+    } catch {
+      // Track may have been removed
+    }
+  }));
+
+  // Video download (subscribed remote video tracks)
+  await Promise.all(
+    Array.from(room.remoteParticipants.values()).flatMap((participant) => (
+      Array.from(participant.videoTrackPublications.values()).map(async (pub) => {
+        const track = pub.track as RemoteVideoTrack | undefined;
+        if (!track || typeof track.getReceiverStats !== 'function') return;
+
+        try {
+          const stats = await track.getReceiverStats();
+          if (!stats) return;
+
+          const sid = pub.trackSid ?? `video-${participant.identity}`;
+          const prev = previousStats.get(sid);
+          if (prev && prev.bytesReceived != null) {
+            videoDownload += computeKbps(
+              stats.bytesReceived ?? 0, prev.bytesReceived,
+              stats.timestamp, prev.timestamp,
+            );
+          }
+          newPreviousStats.set(sid, {
+            bytesReceived: stats.bytesReceived ?? 0,
+            timestamp: stats.timestamp,
+          });
+        } catch {
+          // Track may have been removed
+        }
+      })
+    )),
+  );
+
+  return {
+    data: {
+      videoCurrentUploadRate: videoUpload,
+      videoCurrentDownloadRate: videoDownload,
+    },
+    previousStats: newPreviousStats,
+  };
+};

--- a/bigbluebutton-html5/imports/utils/stats.js
+++ b/bigbluebutton-html5/imports/utils/stats.js
@@ -37,13 +37,13 @@ const calculateMOS = (rate) => 1 + (0.035) * rate + (0.000007) * rate * (rate - 
 const buildData = (inboundRTP) => {
   const builtData = {
     packets: {
-      received: inboundRTP.packetsReceived,
-      lost: inboundRTP.packetsLost,
+      received: inboundRTP.packetsReceived ?? 0,
+      lost: inboundRTP.packetsLost ?? 0,
     },
     bytes: {
-      received: inboundRTP.bytesReceived,
+      received: inboundRTP.bytesReceived ?? 0,
     },
-    jitter: inboundRTP.jitter,
+    jitter: inboundRTP.jitter ?? 0,
   };
 
   return builtData;


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): use LK APIs for stats gathering, fix edge cases](https://github.com/bigbluebutton/bigbluebutton/commit/b461b828b5b4335b8d77afc692ab2188aa1eb040) 
  - Connection status integration with LiveKit has a couple of edge cases:
    - Alert triggers use inbound-rtp from subscribed remote tracks (wrong
direction — a remote user's loss triggers a local alert), and bandwidth
calculations pick a single arbitrary stat entry via [0] index
(underreporting download, fragmented video rates, negative bitrate on
track churn).
    - Uses internal, undocumented SDK APIs (engine.pcManager.*) which will
most certainly break someday and also bork track direction context when
merging stats data.
    - Imprecise packetsLost and jitter reporting
  - Replace getLKStats() with a new livekit/stats.ts module that
uses the public per-track APIs from livekit-client via its own methods:
    - monitorLiveKitAudioStats: probes LocalAudioTrack.getSenderStats() on
    sliding window, dispatches audiostats events with packet loss from the
    server's perspective (RTCP receiver reports). Fixes wrong-direction
    alert triggers.
  - getLiveKitAudio/VideoNetworkData: iterates over all relevant tracks
    via getSenderStats/getReceiverStats, aggregates bitrate by track SID.
    Fixes bandwidth underreporting. Uses raw RTCStats reports (pulled from
    LK APIs as well) to fix packetsLost and jitter reporting.
  - Additionally, network stats gathering is split into their own A/V
variants so that we had heteregeneous bridges (e.g.: audio=livekit,
video=webrtc-sfu).
- [fix(stats): guard WebRTC stats data against undefined vals](https://github.com/bigbluebutton/bigbluebutton/commit/315ff133245dd5b0ce23d6fe7dd36a1d929c0bfd) 
  - remote-inbound-rtp stats may lack packetsReceived and bytesReceived
  When stats.js falls back to remote-inbound-rtp, buildData reads undefined
  for these fields, producing NaN in downstream calculations.
- [fix(stats): handle MetricStatus.Unknown in getWorstStatus](https://github.com/bigbluebutton/bigbluebutton/commit/9d6504e5422b93b8fd8d0bf47e8cec58ad3d131b) 
  - The liveKitConnectionStatus reactive var initializes to 'unknown'.
  getWorstStatus lacks 'unknown' in its statusOrder map, so it falls
  through to the default comparison (undefined > 0 = false), which
  works by accident.
  
### Closes Issue(s)

None