### PR TITLE
fix(layout): stop layout sync broadcasts on webcam join/leave, window resize and sidebar toggle

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -22,6 +22,11 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
     } else {
       if (LayoutsType.layoutsType.contains(msg.body.layout)) {
         val newlayout = LayoutsType.layoutsType.getOrElse(msg.body.layout, "")
+        val prevLayout = Layouts.getCurrentLayout(liveMeeting.layouts)
+        val prevPresentationIsOpen = Layouts.getPresentationIsOpen(liveMeeting.layouts)
+        val prevCameraPosition = Layouts.getCameraPosition(liveMeeting.layouts)
+        val prevFocusedCamera = Layouts.getFocusedCamera(liveMeeting.layouts)
+        val prevPushLayout = Layouts.getPushLayout(liveMeeting.layouts)
 
         Layouts.setCurrentLayout(liveMeeting.layouts, newlayout)
         Layouts.setPushLayout(liveMeeting.layouts, msg.body.pushLayout)
@@ -32,13 +37,19 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
         Layouts.setPresentationVideoRate(liveMeeting.layouts, msg.body.presentationVideoRate)
         Layouts.setRequestedBy(liveMeeting.layouts, msg.header.userId)
 
+        val meaningfulChange = prevLayout != newlayout ||
+          prevPresentationIsOpen != msg.body.presentationIsOpen ||
+          prevCameraPosition != msg.body.cameraPosition ||
+          prevFocusedCamera != msg.body.focusedCamera ||
+          prevPushLayout != msg.body.pushLayout
+
         LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
-        sendBroadcastLayoutEvtMsg(msg.header.userId)
+        sendBroadcastLayoutEvtMsg(msg.header.userId, meaningfulChange)
       }
     }
   }
 
-  def sendBroadcastLayoutEvtMsg(fromUserId: String): Unit = {
+  def sendBroadcastLayoutEvtMsg(fromUserId: String, meaningfulChange: Boolean): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, fromUserId)
     val envelope = BbbCoreEnvelope(BroadcastLayoutEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(BroadcastLayoutEvtMsg.NAME, liveMeeting.props.meetingProp.intId, fromUserId)
@@ -58,7 +69,7 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
 
     outGW.send(msgEvent)
 
-    if (body.pushLayout) {
+    if (body.pushLayout && meaningfulChange) {
       val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
         fromUserId,
         liveMeeting.props.meetingProp.intId,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -27,6 +27,7 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
         val prevCameraPosition = Layouts.getCameraPosition(liveMeeting.layouts)
         val prevFocusedCamera = Layouts.getFocusedCamera(liveMeeting.layouts)
         val prevPushLayout = Layouts.getPushLayout(liveMeeting.layouts)
+        val prevPresentationVideoRate = Layouts.getPresentationVideoRate(liveMeeting.layouts)
 
         Layouts.setCurrentLayout(liveMeeting.layouts, newlayout)
         Layouts.setPushLayout(liveMeeting.layouts, msg.body.pushLayout)
@@ -41,7 +42,8 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
           prevPresentationIsOpen != msg.body.presentationIsOpen ||
           prevCameraPosition != msg.body.cameraPosition ||
           prevFocusedCamera != msg.body.focusedCamera ||
-          prevPushLayout != msg.body.pushLayout
+          prevPushLayout != msg.body.pushLayout ||
+          prevPresentationVideoRate != msg.body.presentationVideoRate
 
         LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
         sendBroadcastLayoutEvtMsg(msg.header.userId, meaningfulChange)

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -5,7 +5,7 @@ import { Input, Layout, Output } from '../layoutTypes';
 import { calculatePresentationVideoRate } from './service';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
-import { layoutDispatch, layoutSelect } from '../context';
+import { layoutDispatch, layoutSelect, layoutSelectOutput } from '../context';
 import logger from '/imports/startup/client/logger';
 import { isLayoutSupported } from '../utils';
 import { LAYOUT_TYPE } from '../defaultValues';
@@ -33,6 +33,7 @@ const useMeetingLayoutUpdater = (
   layoutSettings: { pushLayout: boolean, selectedLayout: boolean },
 ) => {
   const [setMeetingLayoutProps] = useMutation(SET_LAYOUT_PROPS);
+  const mediaAreaSize = layoutSelectOutput((i: Output) => i.mediaArea);
 
   const { focusedId, position } = cameraDockOutput;
   const { isResizing } = cameraDockInput;
@@ -48,7 +49,7 @@ const useMeetingLayoutUpdater = (
         isResizing,
         cameraPosition: position || 'contentTop',
         focusedCamera: focusedId || 'none',
-        presentationVideoRate: calculatePresentationVideoRate(cameraDockOutput),
+        presentationVideoRate: calculatePresentationVideoRate(cameraDockOutput, mediaAreaSize),
       },
     });
   };

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -71,6 +71,8 @@ const propTypes = {
   setLocalSettings: PropTypes.func.isRequired,
   hasMeetingLayout: PropTypes.bool,
   meetingLayoutSetByUserId: PropTypes.string,
+  mediaAreaWidth: PropTypes.number,
+  mediaAreaHeight: PropTypes.number,
 };
 
 const PushLayoutEngine = (props) => {
@@ -109,6 +111,8 @@ const PushLayoutEngine = (props) => {
     hasMeetingLayout,
     isChatEnabled,
     meetingLayoutSetByUserId,
+    mediaAreaWidth,
+    mediaAreaHeight,
   } = props;
 
   useEffect(() => {
@@ -165,11 +169,11 @@ const PushLayoutEngine = (props) => {
         if (!equalDouble(meetingLayoutVideoRate, 0)) {
           let w; let h;
           if (horizontalPosition) {
-            w = window.innerWidth * meetingLayoutVideoRate;
+            w = (mediaAreaWidth || window.innerWidth) * meetingLayoutVideoRate;
             h = cameraHeight;
           } else {
             w = cameraWidth;
-            h = window.innerHeight * meetingLayoutVideoRate;
+            h = (mediaAreaHeight || window.innerHeight) * meetingLayoutVideoRate;
           }
 
           layoutContextDispatch({
@@ -258,11 +262,11 @@ const PushLayoutEngine = (props) => {
         || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
         let w; let h;
         if (horizontalPosition) {
-          w = window.innerWidth * meetingLayoutVideoRate;
+          w = (mediaAreaWidth || window.innerWidth) * meetingLayoutVideoRate;
           h = cameraHeight;
         } else {
           w = cameraWidth;
-          h = window.innerHeight * meetingLayoutVideoRate;
+          h = (mediaAreaHeight || window.innerHeight) * meetingLayoutVideoRate;
         }
 
         if (isMeetingLayoutResizing !== prevProps.isMeetingLayoutResizing) {
@@ -326,11 +330,13 @@ const PushLayoutEngine = (props) => {
     // PROPAGATE LAYOUT
     const layoutChanged = presentationIsOpen !== prevProps.presentationIsOpen
       || selectedLayout !== prevProps.selectedLayout
-      || cameraIsResizing !== prevProps.cameraIsResizing
       || cameraPosition !== prevProps.cameraPosition
       || focusedCamera !== prevProps.focusedCamera
-      || enforceLayoutResult !== prevProps.enforceLayoutResult
-      || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
+      || enforceLayoutResult !== prevProps.enforceLayoutResult;
+
+    const userFinishedResizing = prevProps.cameraIsResizing
+      && !cameraIsResizing
+      && !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
 
     if (pushLayoutMeeting !== undefined
       && pushLayout !== prevProps.pushLayout
@@ -351,7 +357,8 @@ const PushLayoutEngine = (props) => {
       // server and overwriting the meeting configured layout type.
       && hasInitiallyPropagated.current
     ) {
-      if (pushLayout && (layoutChanged || pushLayout !== prevProps.pushLayout)) {
+      if (pushLayout
+        && (layoutChanged || userFinishedResizing || pushLayout !== prevProps.pushLayout)) {
         setMeetingLayout(pushLayout);
       }
     }
@@ -380,6 +387,7 @@ const PushLayoutEngineContainer = (props) => {
   const cameraDockOutput = layoutSelectOutput((i) => i.cameraDock);
   const cameraDockInput = layoutSelectInput((i) => i.cameraDock);
   const presentationInput = layoutSelectInput((i) => i.presentation);
+  const mediaAreaOutput = layoutSelectOutput((i) => i.mediaArea);
   const layoutContextDispatch = layoutDispatch();
   const isChatEnabled = useIsChatEnabled();
 
@@ -455,7 +463,7 @@ const PushLayoutEngineContainer = (props) => {
     });
   }, [enforcedLayoutLoading]);
 
-  const presentationVideoRate = calculatePresentationVideoRate(cameraDockOutput);
+  const presentationVideoRate = calculatePresentationVideoRate(cameraDockOutput, mediaAreaOutput);
 
   const setLocalSettings = useUserChangedLocalSettings();
   const setPushLayout = usePushLayoutUpdater(pushLayout);
@@ -511,6 +519,8 @@ const PushLayoutEngineContainer = (props) => {
         setPushLayout,
         hasMeetingLayout: !!meetingLayout,
         meetingLayoutSetByUserId,
+        mediaAreaWidth: mediaAreaOutput?.width,
+        mediaAreaHeight: mediaAreaOutput?.height,
         ...props,
       }}
     />

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -169,11 +169,11 @@ const PushLayoutEngine = (props) => {
         if (!equalDouble(meetingLayoutVideoRate, 0)) {
           let w; let h;
           if (horizontalPosition) {
-            w = (mediaAreaWidth || window.innerWidth) * meetingLayoutVideoRate;
+            w = (mediaAreaWidth ?? window.innerWidth) * meetingLayoutVideoRate;
             h = cameraHeight;
           } else {
             w = cameraWidth;
-            h = (mediaAreaHeight || window.innerHeight) * meetingLayoutVideoRate;
+            h = (mediaAreaHeight ?? window.innerHeight) * meetingLayoutVideoRate;
           }
 
           layoutContextDispatch({
@@ -262,11 +262,11 @@ const PushLayoutEngine = (props) => {
         || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
         let w; let h;
         if (horizontalPosition) {
-          w = (mediaAreaWidth || window.innerWidth) * meetingLayoutVideoRate;
+          w = (mediaAreaWidth ?? window.innerWidth) * meetingLayoutVideoRate;
           h = cameraHeight;
         } else {
           w = cameraWidth;
-          h = (mediaAreaHeight || window.innerHeight) * meetingLayoutVideoRate;
+          h = (mediaAreaHeight ?? window.innerHeight) * meetingLayoutVideoRate;
         }
 
         if (isMeetingLayoutResizing !== prevProps.isMeetingLayoutResizing) {

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/service.ts
@@ -15,8 +15,8 @@ const calculatePresentationVideoRate = (
     width,
   } = cameraDockOutput;
   const horizontalPosition = position === 'contentLeft' || position === 'contentRight';
-  const refWidth = mediaAreaSize?.width || window.innerWidth;
-  const refHeight = mediaAreaSize?.height || window.innerHeight;
+  const refWidth = mediaAreaSize?.width ?? window.innerWidth;
+  const refHeight = mediaAreaSize?.height ?? window.innerHeight;
   let presentationVideoRate;
   if (horizontalPosition) {
     presentationVideoRate = refWidth > 0 ? width / refWidth : 0;

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/service.ts
@@ -1,17 +1,27 @@
 import { Output } from '../layoutTypes';
 
-const calculatePresentationVideoRate = (cameraDockOutput: Output['cameraDock']) => {
+interface MediaAreaSize {
+  width: number;
+  height: number;
+}
+
+const calculatePresentationVideoRate = (
+  cameraDockOutput: Output['cameraDock'],
+  mediaAreaSize?: MediaAreaSize,
+) => {
   const {
     position,
     height,
     width,
   } = cameraDockOutput;
   const horizontalPosition = position === 'contentLeft' || position === 'contentRight';
+  const refWidth = mediaAreaSize?.width || window.innerWidth;
+  const refHeight = mediaAreaSize?.height || window.innerHeight;
   let presentationVideoRate;
   if (horizontalPosition) {
-    presentationVideoRate = width / window.innerWidth;
+    presentationVideoRate = refWidth > 0 ? width / refWidth : 0;
   } else {
-    presentationVideoRate = height / window.innerHeight;
+    presentationVideoRate = refHeight > 0 ? height / refHeight : 0;
   }
   return parseFloat(presentationVideoRate.toFixed(2));
 };


### PR DESCRIPTION
### What does this PR do?
The toast was firing on every automatic layout recalculation triggered by webcam share/unshare, browser window resize, and sidebar open/close, as well as once on initial room join.

Root cause: `presentationVideoRate` is calculated as cameraDock pixels divided by window.innerWidth/Height. Since the camera dock is sized relative to the media area (which excludes the sidebar), opening or closing the sidebar changes the dock's pixel value while the window dimension stays the same, producing a different ratio and triggering propagation even though nothing intentional changed.

Changes:
- `calculatePresentationVideoRate()` now divides by the media area size
  instead of window.innerWidth/Height, keeping the ratio stable across
  sidebar toggles, resizes, and camera count changes
- Both sender (hooks.ts) and receiver (pushLayoutEngine replicateCameraDockSize)
  use the media area size as reference, improving cross-client fidelity
- `cameraIsResizing` and `presentationVideoRate` removed from `layoutChanged`
  detection; rate changes only propagate when the user finishes a manual
  camera dock resize (detected via isResizing going false)
- Backend (BroadcastLayoutMsgHdlr) now gates the notification on whether
  a meaningful property actually changed (layout type, presentation open/
  close, camera position, focused camera, pushLayout flag), suppressing
  the spurious notification on initial join and any recalculations that
  pass through the frontend filter


### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/24824