### PR TITLE
build(bbb-webrtc-sfu): v2.22.1 (up from v2.22.0)

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.22.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.22.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webrtc-sfu): v2.22.1 (up from v2.22.0)](https://github.com/bigbluebutton/bigbluebutton/commit/2115c9a0f133da65ca24b93c7b195a31e8f4fab6) 
  * fix: memory leaks in bbb-webrtc-recorder's API module
  * fix(livekit): minor listener leaks in livekit-controller
  * build(deps): livekit-server-sdk@v2.15.1 (up from v2.14.0)
  * build(deps): @livekit/rtc-node@0.13.25 (up from 0.13.20)
  * build(deps): eslint@8.57.1 (dev), nodemon@3.1.14 (dev)
  * build(deps): npm audit fix

### Closes Issue(s)

None