### PR TITLE
fix(layout): reduce unnecessary 'layout updates applied' notifications

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -23,8 +23,10 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
       if (LayoutsType.layoutsType.contains(msg.body.layout)) {
         val newlayout = LayoutsType.layoutsType.getOrElse(msg.body.layout, "")
         val isInitialSetup = Layouts.getCurrentLayout(liveMeeting.layouts).isEmpty
+        val pushLayoutJustEnabled = msg.body.pushLayout && !Layouts.getPushLayout(liveMeeting.layouts)
 
         val significantChange = !isInitialSetup && (
+          pushLayoutJustEnabled ||
           Layouts.getCurrentLayout(liveMeeting.layouts) != newlayout ||
           Layouts.getPresentationIsOpen(liveMeeting.layouts) != msg.body.presentationIsOpen ||
           Layouts.getCameraPosition(liveMeeting.layouts) != msg.body.cameraPosition ||

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/layout/BroadcastLayoutMsgHdlr.scala
@@ -22,6 +22,14 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
     } else {
       if (LayoutsType.layoutsType.contains(msg.body.layout)) {
         val newlayout = LayoutsType.layoutsType.getOrElse(msg.body.layout, "")
+        val isInitialSetup = Layouts.getCurrentLayout(liveMeeting.layouts).isEmpty
+
+        val significantChange = !isInitialSetup && (
+          Layouts.getCurrentLayout(liveMeeting.layouts) != newlayout ||
+          Layouts.getPresentationIsOpen(liveMeeting.layouts) != msg.body.presentationIsOpen ||
+          Layouts.getCameraPosition(liveMeeting.layouts) != msg.body.cameraPosition ||
+          Layouts.getFocusedCamera(liveMeeting.layouts) != msg.body.focusedCamera
+        )
 
         Layouts.setCurrentLayout(liveMeeting.layouts, newlayout)
         Layouts.setPushLayout(liveMeeting.layouts, msg.body.pushLayout)
@@ -33,12 +41,12 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
         Layouts.setRequestedBy(liveMeeting.layouts, msg.header.userId)
 
         LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
-        sendBroadcastLayoutEvtMsg(msg.header.userId)
+        sendBroadcastLayoutEvtMsg(msg.header.userId, significantChange)
       }
     }
   }
 
-  def sendBroadcastLayoutEvtMsg(fromUserId: String): Unit = {
+  def sendBroadcastLayoutEvtMsg(fromUserId: String, significantChange: Boolean = true): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, fromUserId)
     val envelope = BbbCoreEnvelope(BroadcastLayoutEvtMsg.NAME, routing)
     val header = BbbClientMsgHeader(BroadcastLayoutEvtMsg.NAME, liveMeeting.props.meetingProp.intId, fromUserId)
@@ -58,7 +66,7 @@ trait BroadcastLayoutMsgHdlr extends RightsManagementTrait {
 
     outGW.send(msgEvent)
 
-    if (body.pushLayout) {
+    if (body.pushLayout && significantChange) {
       val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
         fromUserId,
         liveMeeting.props.meetingProp.intId,

--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -956,6 +956,19 @@ const reducer = (state, action) => {
     }
 
     // PRESENTATION
+    case ACTIONS.SET_PRESENTATION_CONTENT_UPDATED: {
+      const { presentation } = state.input;
+      return {
+        ...state,
+        input: {
+          ...state.input,
+          presentation: {
+            ...presentation,
+            contentUpdatedAt: Date.now(),
+          },
+        },
+      };
+    }
     case ACTIONS.SET_PRESENTATION_IS_OPEN: {
       const { presentation } = state.input;
       if (presentation.isOpen === action.value) {
@@ -1583,6 +1596,9 @@ const updatePresentationAreaContent = (
     layoutContextDispatch({
       type: ACTIONS.SET_PRESENTATION_IS_OPEN,
       value: shouldOpenPresentation,
+    });
+    layoutContextDispatch({
+      type: ACTIONS.SET_PRESENTATION_CONTENT_UPDATED,
     });
   }
 };

--- a/bigbluebutton-html5/imports/ui/components/layout/enums.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/enums.js
@@ -110,6 +110,7 @@ export const ACTIONS = {
   SET_DROP_AREAS: 'setDropAreas',
 
   SET_PRESENTATION_IS_OPEN: 'setPresentationIsOpen',
+  SET_PRESENTATION_CONTENT_UPDATED: 'setPresentationContentUpdated',
   SET_PRESENTATION_CURRENT_SLIDE_SIZE: 'setPresentationCurrentSlideSize',
   SET_PRESENTATION_NUM_CURRENT_SLIDE: 'setPresentationNumCurrentSlide',
   SET_PRESENTATION_SLIDES_LENGTH: 'setPresentationSlidesLength',

--- a/bigbluebutton-html5/imports/ui/components/layout/initState.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/initState.ts
@@ -70,6 +70,7 @@ export const INITIAL_INPUT_STATE = {
     focusedId: 'none',
   },
   presentation: {
+    contentUpdatedAt: 0,
     isOpen: true,
     slidesLength: 0,
     currentSlide: {

--- a/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/layoutTypes.ts
@@ -127,6 +127,7 @@ interface CurrentSlide {
 interface Presentation {
     browserHeight?: number;
     browserWidth?: number;
+    contentUpdatedAt?: number;
     currentSlide?: CurrentSlide;
     isOpen?: boolean;
     slidesLength?: number;

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -329,7 +329,8 @@ const PushLayoutEngine = (props) => {
       || cameraIsResizing !== prevProps.cameraIsResizing
       || cameraPosition !== prevProps.cameraPosition
       || focusedCamera !== prevProps.focusedCamera
-      || enforceLayoutResult !== prevProps.enforceLayoutResult;
+      || enforceLayoutResult !== prevProps.enforceLayoutResult
+      || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
 
     if (pushLayoutMeeting !== undefined
       && pushLayout !== prevProps.pushLayout

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -59,6 +59,7 @@ const propTypes = {
   meetingPresentationIsOpen: PropTypes.bool,
   meetingLayoutUpdatedAt: PropTypes.number,
   presentationIsOpen: PropTypes.bool,
+  presentationContentUpdatedAt: PropTypes.number,
   presentationVideoRate: PropTypes.number,
   pushLayout: PropTypes.bool,
   pushLayoutMeeting: PropTypes.bool,
@@ -100,6 +101,7 @@ const PushLayoutEngine = (props) => {
     isPresenter,
     layoutContextDispatch,
     meetingLayoutUpdatedAt,
+    presentationContentUpdatedAt,
     presentationIsOpen,
     presentationVideoRate,
     pushLayout,
@@ -330,7 +332,8 @@ const PushLayoutEngine = (props) => {
       || cameraPosition !== prevProps.cameraPosition
       || focusedCamera !== prevProps.focusedCamera
       || enforceLayoutResult !== prevProps.enforceLayoutResult
-      || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
+      || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate)
+      || presentationContentUpdatedAt !== prevProps.presentationContentUpdatedAt;
 
     if (pushLayoutMeeting !== undefined
       && pushLayout !== prevProps.pushLayout
@@ -440,7 +443,10 @@ const PushLayoutEngineContainer = (props) => {
     setByUserId: meetingLayoutSetByUserId,
   } = (currentMeeting?.layout || {});
 
-  const { isOpen: presentationIsOpen } = presentationInput;
+  const {
+    isOpen: presentationIsOpen,
+    contentUpdatedAt: presentationContentUpdatedAt,
+  } = presentationInput;
 
   const { data: currentUserData, loading: enforcedLayoutLoading } = useCurrentUser((user) => ({
     enforceLayout: user.sessionCurrent?.enforceLayout,
@@ -503,6 +509,7 @@ const PushLayoutEngineContainer = (props) => {
         isChatEnabled,
         layoutContextDispatch,
         meetingLayoutUpdatedAt,
+        presentationContentUpdatedAt,
         presentationIsOpen,
         presentationVideoRate,
         pushLayout,

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -329,8 +329,7 @@ const PushLayoutEngine = (props) => {
       || cameraIsResizing !== prevProps.cameraIsResizing
       || cameraPosition !== prevProps.cameraPosition
       || focusedCamera !== prevProps.focusedCamera
-      || enforceLayoutResult !== prevProps.enforceLayoutResult
-      || !equalDouble(presentationVideoRate, prevProps.presentationVideoRate);
+      || enforceLayoutResult !== prevProps.enforceLayoutResult;
 
     if (pushLayoutMeeting !== undefined
       && pushLayout !== prevProps.pushLayout


### PR DESCRIPTION
### What does this PR do?
The "Layout updates applied to everyone" notification shows up too frequently and in scenarios where no intentional layout change occurred:

- Another user shares or unshares a webcam
- The presenter resizes their browser window
- The presenter opens or closes the content sidebar (chat)

Frontend: remove presentationVideoRate from the layoutChanged condition in pushLayoutEngine. The rate is still sent in the
mutation payload when triggered by other intentional changes, so layout sync is preserved.

Backend: only send the notification toast when significant layout properties actually changed (layout type, presentation open state, camera position, focused camera). The layout event broadcast itself is always sent to keep clients in sync.

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton/issues/24824