### PR TITLE
[3.0] Youtube CC lang preference not reflected

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -168,6 +168,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
           ecver: 2,
           controls: 1,
           cc_lang_pref: document.getElementsByTagName('html')[0].lang.substring(0, 2),
+          cc_load_policy: 1,
         },
         embedOptions: {
           host: 'https://www.youtube-nocookie.com',


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
Turn on CC of external Youtube video according to the language preference by default.

### Motivation
<!-- What inspired you to submit this pull request? -->
The parameter cc_lang_pref does not work alone for Youtube, even though the document (https://developers.google.com/youtube/player_parameters) says differently. To reflect the parameter, we need to add cc_load_policy: 1.

### How to test
Since I don't know when, Youtube video played on the external video sharing function does not reflect the language setting of closed caption. Even when the html lang is set 'ja', BBB shows English subtitle when the CC button is pushed. To show Japanese caption, we need to change the language setting from the gear icon. This behaviour is confirmed on Brave and Firefox of MacOS. 
With this PR, the language setting of browser is correctly reflected on CC, however, the CC is shown by default as a consequence. For teachers or students, turning off an unnecessary CC is much easier than choosing a correct language from a dropdown when they need CC (in my personal opinion).


### More
<!-- Anything else we should know when reviewing? -->
By adding this PR, the language setting of the browser is reflected on the caption displayed, but the caption appears by default. I am not sure if it's good for all user. For me, showing Japanese caption even for a Japanese video (it's like an automatic transcription) is fine for the sake of accessibility.
