### PR TITLE
[3.0 external video share] remove deprecated parameters

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -162,6 +162,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       youtube: {
         playerVars: {
           autoplay: 1,
+          rel: 0,
           controls: 1,
           cc_lang_pref: document.getElementsByTagName('html')[0].lang.substring(0, 2),
         },

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -162,10 +162,6 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
       youtube: {
         playerVars: {
           autoplay: 1,
-          modestbranding: 1,
-          autohide: 1,
-          rel: 0,
-          ecver: 2,
           controls: 1,
           cc_lang_pref: document.getElementsByTagName('html')[0].lang.substring(0, 2),
         },


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
Removes deprecated parameters.


### Motivation
Trying to fix #24901 (which failed so far), I realised some parameters for Youtube API are not working anymore.


### More
According to https://developers.google.com/youtube/player_parameters ,

- modestbranding: deprecated and not effective since 2023
- autohide: deprecated 2015, no change observed when the value is 0 or 1 (autohidden anyway)
- rel (kept in this PR for safety): changing since 2018, at this moment no related movies displayed either with value 0 or 1
- ecver: not documented anymore; somebody was talking about it: https://stackoverflow.com/questions/43867417/ecver-x-parameter-on-the-youtube-embed-url
- 

