### PR TITLE
fix(html5): exclude .gz files from language selector list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/service.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/service.js
@@ -2,11 +2,13 @@ import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import { notify } from '/imports/ui/services/notification';
 import intlHolder from '../../core/singletons/intlHolder';
 
-export const isKeepPushingLayoutEnabled = () => window.meetingClientSettings.public.layout.showPushLayoutToggle;
+export const isKeepPushingLayoutEnabled = () => (
+  window.meetingClientSettings.public.layout.showPushLayoutToggle
+);
 
 export const updateSettings = (obj, msgDescriptor, mutation) => {
   const Settings = getSettingsSingletonInstance();
-  Object.keys(obj).forEach(k => (Settings[k] = obj[k]));
+  Object.keys(obj).forEach((k) => { Settings[k] = obj[k]; });
   Settings.save(mutation);
 
   if (msgDescriptor) {
@@ -22,7 +24,9 @@ export const updateSettings = (obj, msgDescriptor, mutation) => {
 
 export const getAvailableLocales = () => fetch('./locales/')
   .then((locales) => locales.json())
-  .then((locales) => locales.filter((locale) => locale.name !== 'index.json'));
+  .then((locales) => locales.filter((locale) => (
+    locale.name !== 'index.json' && !locale.name.endsWith('.gz')
+  )));
 
 export const FALLBACK_LOCALES = {
   dv: {


### PR DESCRIPTION
### What does this PR do?
Fix bug where compressed version of localization are being listed on language selector. 


### Closes Issue(s)
N/A

### Motivation
Avoid BBB crashes


### How to test
-Join a meeting 
- Open setting modal
- Click on laguage selector
- Verify listed laguages

### More
Before

[Screencast from 13-04-2026 14:34:05.webm](https://github.com/user-attachments/assets/4c814832-11e9-4a0c-8cee-b329b38d11ba)

After

[Screencast from 13-04-2026 14:38:32.webm](https://github.com/user-attachments/assets/17bd05f5-0900-4042-914e-ea8b92fded4c)
