### PR TITLE
fix(livekit): only display screenshare volume control if there's audio

### DIFF
--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -5,6 +5,9 @@ import {
   screenShareEndAlert,
   setOutputDeviceId,
 } from '/imports/ui/components/screenshare/service';
+import {
+  setLiveKitScreenshareHasAudio,
+} from '/imports/ui/components/screenshare/livekit-screenshare-state';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import {
   AudioPresets,
@@ -237,6 +240,7 @@ export default class LiveKitScreenshareBridge {
   clearPublications(): void {
     this.screenPublications.clear();
     this.audioPublications.clear();
+    setLiveKitScreenshareHasAudio(false);
   }
 
   private setPublication(
@@ -247,6 +251,8 @@ export default class LiveKitScreenshareBridge {
 
     if (publications) {
       publications.set(publication.trackSid, publication);
+
+      if (source === Track.Source.ScreenShareAudio) setLiveKitScreenshareHasAudio(true);
 
       if (publication.trackSid === this.streamId && this.role === RECV_ROLE) {
         this.subscribe(publication as RemoteTrackPublication);
@@ -261,7 +267,12 @@ export default class LiveKitScreenshareBridge {
     const audioPublication = this.audioPublications.get(trackSid);
 
     if (screenPublication) this.screenPublications.delete(trackSid);
-    if (audioPublication) this.audioPublications.delete(trackSid);
+
+    if (audioPublication) {
+      this.audioPublications.delete(trackSid);
+
+      if (this.audioPublications.size === 0) setLiveKitScreenshareHasAudio(false);
+    }
   }
 
   private setSubscription(
@@ -806,5 +817,6 @@ export default class LiveKitScreenshareBridge {
     }
 
     this.outputDeviceId = undefined;
+    setLiveKitScreenshareHasAudio(false);
   }
 }

--- a/bigbluebutton-html5/imports/ui/components/screenshare/livekit-screenshare-state.ts
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/livekit-screenshare-state.ts
@@ -1,0 +1,9 @@
+import { makeVar } from '@apollo/client';
+
+export const liveKitScreenshareHasAudioVar = makeVar<boolean>(false);
+
+export const setLiveKitScreenshareHasAudio = (hasAudio: boolean): void => {
+  if (liveKitScreenshareHasAudioVar() !== hasAudio) {
+    liveKitScreenshareHasAudioVar(hasAudio);
+  }
+};

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -11,6 +11,7 @@ import browserInfo from '/imports/utils/browserInfo';
 import { SCREENSHARE_SUBSCRIPTION } from './queries';
 import useDeduplicatedSubscription from '../../core/hooks/useDeduplicatedSubscription';
 import useMeeting from '../../core/hooks/useMeeting';
+import { liveKitScreenshareHasAudioVar } from './livekit-screenshare-state';
 
 let screenShareBridge = sfuScreenShareBridge;
 
@@ -258,8 +259,13 @@ export const useShouldEnableVolumeControl = () => {
   const SCREENSHARE_CONFIG = window.meetingClientSettings.public.kurento.screenshare;
   const VOLUME_CONTROL_ENABLED = SCREENSHARE_CONFIG.enableVolumeControl;
   const hasAudio = useScreenshareHasAudio();
+  // When LiveKit is the screenshare bridge, server-side hasAudio is unreliable
+  // (always true because it can't be determined at signaling time).
+  // Use client-side ScreenShareAudio track detection instead.
+  const liveKitHasAudio = useReactiveVar(liveKitScreenshareHasAudioVar);
+  const isLiveKit = screenShareBridge?.bridgeName === 'livekit';
 
-  return VOLUME_CONTROL_ENABLED && hasAudio;
+  return VOLUME_CONTROL_ENABLED && hasAudio && (!isLiveKit || liveKitHasAudio);
 };
 
 export const useShowButtonForNonPresenters = () => {


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): only display screenshare volume control if there's audio](https://github.com/bigbluebutton/bigbluebutton/commit/d6efa8a35fe6ba71a2617101fd7850501eb4edba) 
  - When using LiveKit, volume control is always shown to end users even if
the shared source does not have audio. That's caused by using only the
BBB-provided hasAudio state, which is derived in the internal
screenshare broadcast signaling. That is constructured at a point where
audio availability _cannot_ be defined for LK - so it's always true.
  - When using LK, only display screenshare volume controls when necessary
by checking if there's an actual ScreenShareAudio track present in the
bridge. Do this via a reactive state var, which is isolated in its own
file to prevent circular dependency issues between screenshare's service
and LK's bridge.
  - This is additive to the existing check, so won't affect bbb-webrtc-sfu.

### Closes Issue(s)

None
