### PR TITLE
Fix(akka): Add Disable feature support for plugins

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -572,7 +572,7 @@ public class MeetingService implements MessageListener {
       meetings.put(m.getInternalId(), m);
       Map<String, Object> pluginsMap;
       ArrayList<Object> sharedNotesInitialContentMap = getSharedNotesInitialContent(m);
-      if (m.isBreakout()) {
+      if (m.isBreakout() || m.getDisabledFeatures().contains("plugins")) {
         pluginsMap = plugins;
       } else {
         pluginsMap = requestPluginManifests(m);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -743,7 +743,7 @@ public class ParamsProcessorUtil {
 
         // Parse Plugins Manifests from config and param
         ArrayList<PluginManifest> listOfPluginManifests = new ArrayList<PluginManifest>();
-        if (!isBreakout){
+        if (!isBreakout && !listOfDisabledFeatures.contains("plugins")){
             //Process plugins from config
             if (defaultPluginManifests != null && !defaultPluginManifests.isEmpty()) {
                 try {


### PR DESCRIPTION
### What does this PR do?
Make the disable feature for plugins works


### Closes Issue(s)
Closes #24881 

### How to test
- Add a plugin to a meeting
- Add the `disabledFeatures=plugins`
- Create a meeting
- Join a meeting
- See if the plugin is loaded

