### PR TITLE
fix(callback): drain response entity to prevent NIO selector leak

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/web/services/callback/CallbackUrlService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/web/services/callback/CallbackUrlService.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,6 +165,11 @@ public class CallbackUrlService {
 			HttpResponse response = future.get();
 			// Consider 2xx response code as success.
 			success = (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300);
+			// Drain the response entity so the underlying NIO connection
+			// (and its Selector) can be released. Without this, every call
+			// leaks one eventpoll/eventfd pair, eventually exhausting the
+			// process file descriptor limit.
+			EntityUtils.consumeQuietly(response.getEntity());
 		} catch (java.lang.InterruptedException ex) {
 			log.error("Interrupted exception while calling url {}", callbackUrl);
 		} catch (java.util.concurrent.ExecutionException ex) {


### PR DESCRIPTION
## Summary

Fixes a per-call NIO Selector leak in `CallbackUrlService#fetchCallbackUrl` that exhausts `bbb-apps-akka`'s file-descriptor limit over time, eventually throwing `java.net.SocketException: Too many open files` and breaking new meeting joins (blank HTML5 client).

Closes #24912.

## Change

Single-line addition: `EntityUtils.consumeQuietly(response.getEntity())` after the status code is read, before the `finally` block closes the `HttpAsyncClient`. Apache `HttpAsyncClient` only releases the request's NIO reactor state when the entity is drained — without it, `httpclient.close()` leaves an `eventpoll` + `eventfd` pair leaked per call.

## Why this fixes it

See #24912 for field evidence (one BBB server leaked 416 selectors over 25 days, exactly correlating with meeting volume). The fix follows the standard Apache HttpComponents recommendation: always consume the response entity, even when only the status line is needed.

## Test plan

- [x] Confirmed the leak reproduces on v3.0.0-beta.7 in production (eventpoll count grows by 1 per ended meeting).
- [x] Code-verified the same pattern exists in `develop` and `v3.0.x-develop` as of 2026-04-14.
- [ ] Reviewer can verify the fix locally by running a few hundred end-meeting callbacks against a test endpoint and confirming the eventpoll count stays flat.

## Risk

Minimal. `EntityUtils.consumeQuietly` swallows IOExceptions during drain, matching the existing exception-tolerant style of the method. No behavior change for callers — the success/failure decision is still based solely on the HTTP status code.