### PR TITLE
ref(LAD): changes to enhance coherence

### DIFF
--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -279,7 +279,7 @@ class App extends React.Component {
     };
 
     if (learningDashboardAccessToken !== '') {
-      fetch(`${meetingId}/${learningDashboardAccessToken}/learning_dashboard_data.json`)
+      fetch(`${window.location.pathname.replace(/\/?$/, '/')}${meetingId}/${learningDashboardAccessToken}/learning_dashboard_data.json`)
         .then((response) => response.json())
         .then((json) => {
           this.setState({
@@ -319,9 +319,11 @@ class App extends React.Component {
       this.setState({ loading: false });
     }
 
-    setTimeout(() => {
-      this.fetchActivitiesJson();
-    }, 10000 * (2 ** invalidSessionCount));
+    if (learningDashboardAccessToken !== 'playback') {
+      setTimeout(() => {
+        this.fetchActivitiesJson();
+      }, 10000 * (2 ** invalidSessionCount));
+    }
   }
 
   totalOfReactions() {


### PR DESCRIPTION
### What does this PR do?

It does 2 things:

- Refactors the relative Path when fetching data (currently all the relative URLs will be redirected to `/learning-analytics-dashboard/`, because of `"homepage": "/learning-analytics-dashboard/"`, this makes it impossible for other locations to re-use the same LAD front-end);
- Remove constant fetching when `report` flag is set `playback`;

### Motivation

Some other services might set location to use the same LAD front-end as we currently have, but pointing to different `data.json` - relative to that different location.

### How to test

Just test a normal flow with learning-dashboard, the behavior should remain the exact same
