### PR TITLE
fix: suppress join/leave notifications for locked viewers when hideUserList is active

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -101,12 +101,12 @@ trait HandlerHelpers extends SystemConfiguration {
             val event = UserJoinedMeetingEvtMsgBuilder.build(liveMeeting.props.meetingProp.intId, newUser)
             outGW.send(event)
 
-            if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList) {
+            if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList && newUser.role != Roles.MODERATOR_ROLE) {
               Users2x.findAll(liveMeeting.users2x)
-                .filter(u => !u.userLeftFlag.left && (!u.locked || u.role == Roles.MODERATOR_ROLE))
-                .foreach { u =>
+                .filter(r => !r.userLeftFlag.left && (!r.locked || r.role == Roles.MODERATOR_ROLE))
+                .foreach { r =>
                   val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
-                    u.intId,
+                    r.intId,
                     liveMeeting.props.meetingProp.intId,
                     "info",
                     "user",

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -112,7 +112,7 @@ trait HandlerHelpers extends SystemConfiguration {
                     "user",
                     "app.notification.userJoinPushAlert",
                     "Notification for a user joins the meeting",
-                    Map("userName" -> s"${newUser.name}")
+                    Map("userName" -> newUser.name)
                   )
                   outGW.send(notifyEvent)
                   NotificationDAO.insert(notifyEvent)
@@ -124,7 +124,7 @@ trait HandlerHelpers extends SystemConfiguration {
                 "user",
                 "app.notification.userJoinPushAlert",
                 "Notification for a user joins the meeting",
-                Map("userName" -> s"${newUser.name}")
+                Map("userName" -> newUser.name)
               )
               outGW.send(notifyEvent)
               NotificationDAO.insert(notifyEvent)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -101,16 +101,34 @@ trait HandlerHelpers extends SystemConfiguration {
             val event = UserJoinedMeetingEvtMsgBuilder.build(liveMeeting.props.meetingProp.intId, newUser)
             outGW.send(event)
 
-            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
-              liveMeeting.props.meetingProp.intId,
-              "info",
-              "user",
-              "app.notification.userJoinPushAlert",
-              "Notification for a user joins the meeting",
-              Map("userName"->s"${newUser.name}")
-            )
-            outGW.send(notifyEvent)
-            NotificationDAO.insert(notifyEvent)
+            if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList) {
+              Users2x.findAll(liveMeeting.users2x)
+                .filter(u => !u.userLeftFlag.left && (!u.locked || u.role == Roles.MODERATOR_ROLE))
+                .foreach { u =>
+                  val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
+                    u.intId,
+                    liveMeeting.props.meetingProp.intId,
+                    "info",
+                    "user",
+                    "app.notification.userJoinPushAlert",
+                    "Notification for a user joins the meeting",
+                    Map("userName" -> s"${newUser.name}")
+                  )
+                  outGW.send(notifyEvent)
+                  NotificationDAO.insert(notifyEvent)
+                }
+            } else {
+              val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+                liveMeeting.props.meetingProp.intId,
+                "info",
+                "user",
+                "app.notification.userJoinPushAlert",
+                "Notification for a user joins the meeting",
+                Map("userName" -> s"${newUser.name}")
+              )
+              outGW.send(notifyEvent)
+              NotificationDAO.insert(notifyEvent)
+            }
 
             val newState = startRecordingIfAutoStart2x(outGW, liveMeeting, state)
             if (!Users2x.hasPresenter(liveMeeting.users2x)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -1153,8 +1153,8 @@ class MeetingActor(
         val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, u.intId)
         outGW.send(userLeftMeetingEvent)
 
+        val leaverName = u.name
         if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList && u.role != Roles.MODERATOR_ROLE) {
-          val leaverName = u.name
           Users2x.findAll(liveMeeting.users2x)
             .filter(recipient => !recipient.userLeftFlag.left && (!recipient.locked || recipient.role == Roles.MODERATOR_ROLE))
             .foreach { recipient =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -1153,7 +1153,7 @@ class MeetingActor(
         val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, u.intId)
         outGW.send(userLeftMeetingEvent)
 
-        if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList) {
+        if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList && u.role != Roles.MODERATOR_ROLE) {
           val leaverName = u.name
           Users2x.findAll(liveMeeting.users2x)
             .filter(recipient => !recipient.userLeftFlag.left && (!recipient.locked || recipient.role == Roles.MODERATOR_ROLE))

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -1177,7 +1177,7 @@ class MeetingActor(
             "user",
             "app.notification.userLeavePushAlert",
             "Notification for a user leaves the meeting",
-            Map("userName" -> s"${u.name}")
+            Map("userName" -> leaverName)
           )
           outGW.send(notifyEvent)
           NotificationDAO.insert(notifyEvent)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -1154,17 +1154,18 @@ class MeetingActor(
         outGW.send(userLeftMeetingEvent)
 
         if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList) {
+          val leaverName = u.name
           Users2x.findAll(liveMeeting.users2x)
-            .filter(u => !u.userLeftFlag.left && (!u.locked || u.role == Roles.MODERATOR_ROLE))
-            .foreach { u =>
+            .filter(recipient => !recipient.userLeftFlag.left && (!recipient.locked || recipient.role == Roles.MODERATOR_ROLE))
+            .foreach { recipient =>
               val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
-                u.intId,
+                recipient.intId,
                 liveMeeting.props.meetingProp.intId,
                 "info",
                 "user",
                 "app.notification.userLeavePushAlert",
                 "Notification for a user leaves the meeting",
-                Map("userName" -> s"${u.name}")
+                Map("userName" -> leaverName)
               )
               outGW.send(notifyEvent)
               NotificationDAO.insert(notifyEvent)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -578,14 +578,14 @@ class MeetingActor(
       case m: DestroyMediaGroupReqMsg =>
         state = mediaGroupHdlrs.handle(m, state, liveMeeting, msgBus)
         updateUserLastActivity(m.header.userId)
-      case m: GetMediaGroupsReqMsg                 => state = mediaGroupHdlrs.handle(m, state, liveMeeting, msgBus)
+      case m: GetMediaGroupsReqMsg => state = mediaGroupHdlrs.handle(m, state, liveMeeting, msgBus)
       case m: SetUserMediaGroupStateReqMsg =>
         state = mediaGroupHdlrs.handle(m, state, liveMeeting, msgBus)
         updateUserLastActivity(m.header.userId)
 
       // Voice
-      case m: UserLeftVoiceConfEvtMsg              => handleUserLeftVoiceConfEvtMsg(m)
-      case m: UserMutedInVoiceConfEvtMsg           => handleUserMutedInVoiceConfEvtMsg(m)
+      case m: UserLeftVoiceConfEvtMsg    => handleUserLeftVoiceConfEvtMsg(m)
+      case m: UserMutedInVoiceConfEvtMsg => handleUserMutedInVoiceConfEvtMsg(m)
       case m: UserTalkingInVoiceConfEvtMsg =>
         updateVoiceUserLastActivity(m.body.voiceUserId)
         handleUserTalkingInVoiceConfEvtMsg(m)
@@ -1153,16 +1153,34 @@ class MeetingActor(
         val userLeftMeetingEvent = MsgBuilder.buildUserLeftMeetingEvtMsg(liveMeeting.props.meetingProp.intId, u.intId)
         outGW.send(userLeftMeetingEvent)
 
-        val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
-          liveMeeting.props.meetingProp.intId,
-          "info",
-          "user",
-          "app.notification.userLeavePushAlert",
-          "Notification for a user leaves the meeting",
-          Map("userName" -> s"${u.name}")
-        )
-        outGW.send(notifyEvent)
-        NotificationDAO.insert(notifyEvent)
+        if (MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList) {
+          Users2x.findAll(liveMeeting.users2x)
+            .filter(u => !u.userLeftFlag.left && (!u.locked || u.role == Roles.MODERATOR_ROLE))
+            .foreach { u =>
+              val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
+                u.intId,
+                liveMeeting.props.meetingProp.intId,
+                "info",
+                "user",
+                "app.notification.userLeavePushAlert",
+                "Notification for a user leaves the meeting",
+                Map("userName" -> s"${u.name}")
+              )
+              outGW.send(notifyEvent)
+              NotificationDAO.insert(notifyEvent)
+            }
+        } else {
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId,
+            "info",
+            "user",
+            "app.notification.userLeavePushAlert",
+            "Notification for a user leaves the meeting",
+            Map("userName" -> s"${u.name}")
+          )
+          outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
+        }
 
         if (u.presenter) {
           log.info("removeUsersWithExpiredUserLeftFlag will cause an automaticallyAssignPresenter because user={} left", u)

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/notification/component.jsx
@@ -188,6 +188,7 @@ class NotificationMenu extends BaseMenu {
                   onChange={() => this.handleToggle('userLeavePushAlerts')}
                   ariaLabel={`${intl.formatMessage(intlMessages.userLeaveLabel)} ${intl.formatMessage(intlMessages.pushAlertLabel)} - ${displaySettingsStatus(settings.userLeavePushAlerts, true)}`}
                   showToggleLabel={showToggleLabel}
+                  data-test="userLeavePopupAlerts"
                 />
               </Styled.FormElementCenter>
             </Styled.Col>

--- a/bigbluebutton-tests/playwright/core/constants.ts
+++ b/bigbluebutton-tests/playwright/core/constants.ts
@@ -20,4 +20,6 @@ export const MAX_PARTICIPANTS_TO_JOIN: number = 4;
 // MEDIA CONNECTION TIMEOUTS
 export const VIDEO_LOADING_WAIT_TIME: number = 15000;
 export const UPLOAD_PDF_WAIT_TIME: number = 30000 * MULTIPLIER;
+// userLeftFlag expires after ~10s, audit tick runs every ~10s → notification can take up to ~20s
+export const USER_LEFT_NOTIFICATION_WAIT_TIME: number = 30000 * MULTIPLIER;
 export const CUSTOM_MEETING_ID: string = 'custom-meeting';

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -242,6 +242,7 @@ export const elements = {
   chatPopupAlertsBtn: 'input[data-test="chatPopupAlertsBtn"]',
   hasUnreadMessages: 'div[data-test="unreadMessages"]',
   userJoinPushAlerts: 'input[data-test="userJoinPopupAlerts"]',
+  userLeavePushAlerts: 'input[data-test="userLeavePopupAlerts"]',
   toastContainer: 'div[data-test="toastContainer"]',
   processingPresentationItem: 'span[data-test="processingPresentationItem"]',
   uploadDoneIcon: 'i[data-test="uploadDoneIcon"]',

--- a/bigbluebutton-tests/playwright/notifications/util.ts
+++ b/bigbluebutton-tests/playwright/notifications/util.ts
@@ -13,6 +13,11 @@ export async function enableUserJoinPopup(testPage: Page) {
   await testPage.waitAndClickElement(e.userJoinPushAlerts);
 }
 
+export async function enableUserLeavePopup(testPage: Page) {
+  await testPage.waitAndClick(e.notificationsTab);
+  await testPage.waitAndClickElement(e.userLeavePushAlerts);
+}
+
 export async function saveSettings(testPage: Page) {
   await testPage.waitAndClick(e.modalConfirmButton);
 }

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -6,9 +6,6 @@ export const CUSTOM_STYLE_URL = 'http://bbb-test-stub.local/css-test-file.css';
 
 const serverOrigin = parameters.server ? new URL(parameters.server).origin : '';
 
-export const CUSTOM_STYLE_CSS = `${e.presentationTitle}{display: none;}`;
-export const CUSTOM_STYLE_URL = 'http://bbb-test-stub.local/css-test-file.css';
-
 export const constants = {
   // Create Parameters
   bannerText: 'bannerText=some+text',

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -1,8 +1,10 @@
 import { expect } from '@playwright/test';
 
 import { hoverLastMessage } from '../chat/util';
-import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME, UPLOAD_PDF_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
+import { enableUserJoinPopup, enableUserLeavePopup, saveSettings } from '../notifications/util';
+import { openSettings } from '../options/util';
 import { getNotesLocator } from '../sharednotes/etherpad/util';
 import { MultiUsers } from './multiusers';
 import { drawArrow, openLockViewers } from './util';
@@ -406,6 +408,284 @@ export class LockViewers extends MultiUsers {
       e.whiteboardCursorIndicator,
       1,
       'should be displayed the other viewer whiteboard cursor indicator when unlocking user is unlocked',
+    );
+  }
+
+  /**
+   * Regression test for issue #24888:
+   * When hideUserList (lockUserList) is active, a locked viewer must NOT receive
+   * join notifications for other users — those names were leaking via the
+   * notification stream even though the user list was hidden.
+   *
+   * Fix (PR #24924): when hideUserList=true the backend sends per-user
+   * NotifyUserInMeetingEvtMsg only to moderators and unlocked viewers, instead of
+   * broadcasting NotifyAllInMeetingEvtMsg to everyone.
+   *
+   * Flow that reproduces the original bug:
+   *   1. Mod joins.
+   *   2. Mod enables lockUserList (hideUserList=true, lockOnJoin=true).
+   *   3. Viewer1 joins → automatically locked (lockOnJoin=true).
+   *   4. Both mod and Viewer1 enable "user join" push alerts.
+   *   5. Viewer2 joins.
+   *   Expected: Viewer1 sees NO toast; Mod DOES see the toast.
+   */
+  async hideUserListSuppressesJoinNotification() {
+    // Step 2: apply hideUserList lock BEFORE the viewer joins so that the
+    // viewer gets locked=true via lockOnJoin.
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClickElement(e.lockUserList);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+    await this.modPage.closeAllToastNotifications();
+
+    // Step 3: Viewer1 joins after lock is active → locked=true.
+    await this.initUserPage();
+
+    // Step 4: both pages enable join push alerts.
+    await openSettings(this.modPage);
+    await enableUserJoinPopup(this.modPage);
+    await saveSettings(this.modPage);
+
+    await openSettings(this.userPage);
+    await enableUserJoinPopup(this.userPage);
+    await saveSettings(this.userPage);
+
+    // Clear any notifications that appeared during setup.
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
+
+    // Step 5: Viewer2 joins.
+    await this.initUserPage2();
+
+    // Wait until Viewer2 is confirmed as present in the mod's user list before
+    // asserting the absence of a notification on Viewer1's page.
+    await expect(
+      this.modPage.page.locator(e.userListItem, { hasText: this.userPage2.username }),
+      'Viewer2 should appear in the moderator user list after joining',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Locked viewer must NOT receive the join notification (regression for #24888).
+    await this.userPage.wasRemoved(
+      e.smallToastMsg,
+      'Locked viewer must not receive a join notification when hideUserList is active',
+      ELEMENT_WAIT_TIME,
+    );
+
+    // Moderator MUST still receive the join notification (per-user route after fix).
+    await this.modPage.hasText(
+      e.smallToastMsg,
+      `${this.userPage2.username} joined the session`,
+      'Moderator must still receive the join notification when hideUserList is active',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+  }
+
+  /**
+   * Regression test for issue #24888 — leave notification variant.
+   * Same root cause: the leave notification also used NotifyAllInMeetingEvtMsg,
+   * leaking the departing user's name to locked viewers.
+   *
+   * Flow:
+   *   1. Mod joins.
+   *   2. Mod enables lockUserList.
+   *   3. Viewer1 joins (locked).
+   *   4. Viewer2 joins (locked).
+   *   5. Both mod and Viewer1 enable "user leave" push alerts.
+   *   6. Viewer2 leaves.
+   *   Expected: Viewer1 sees NO toast; Mod DOES see the toast.
+   */
+  async hideUserListSuppressesLeaveNotification() {
+    // Step 2: enable hideUserList before viewers join.
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClickElement(e.lockUserList);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+    await this.modPage.closeAllToastNotifications();
+
+    // Steps 3 & 4: both viewers join while lockOnJoin=true → locked=true.
+    await this.initUserPage();
+    await this.initUserPage2();
+
+    // Wait for Viewer2 to fully join before setting up notifications.
+    await expect(
+      this.modPage.page.locator(e.userListItem, { hasText: this.userPage2.username }),
+      'Viewer2 should appear in the moderator user list',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Step 5: enable leave push alerts on mod and Viewer1.
+    await openSettings(this.modPage);
+    await enableUserLeavePopup(this.modPage);
+    await saveSettings(this.modPage);
+
+    await openSettings(this.userPage);
+    await enableUserLeavePopup(this.userPage);
+    await saveSettings(this.userPage);
+
+    // Clear any notifications accumulated during setup.
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
+
+    // Step 6: Viewer2 leaves the meeting.
+    const leavingUsername = this.userPage2.username;
+    await this.userPage2.waitAndClick(e.leaveMeetingDropdown, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage2.waitAndClick(e.directLogoutButton, ELEMENT_WAIT_LONGER_TIME);
+
+    // Moderator MUST receive the notification. The leave notification is deferred:
+    // the backend sets a userLeftFlag on V2, then after a 10s expiry the periodic
+    // audit removes the user and sends the notification (monitor ticks every 10s),
+    // so the toast can take up to ~20s to arrive — use a 30s timeout.
+    await this.modPage.hasText(
+      e.smallToastMsg,
+      `${leavingUsername} left the session`,
+      'Moderator must still receive the leave notification when hideUserList is active',
+      UPLOAD_PDF_WAIT_TIME,
+    );
+
+    // Locked viewer must NOT have received any notification (regression for #24888).
+    await this.userPage.wasRemoved(
+      e.smallToastMsg,
+      'Locked viewer must not receive a leave notification when hideUserList is active',
+      ELEMENT_WAIT_TIME,
+    );
+  }
+
+  /**
+   * Regression test for issue #24888, including the unlocked-viewer route.
+   *
+   * Expected behavior when hideUserList is active:
+   * - locked viewer: no join notification
+   * - unlocked viewer: receives join notification
+   * - moderator: receives join notification
+   */
+  async hideUserListJoinNotificationVisibleForUnlockedAndModOnly() {
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClickElement(e.lockUserList);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+    await this.modPage.closeAllToastNotifications();
+
+    // Viewer1 joins locked.
+    await this.initUserPage();
+    // Viewer2 joins locked, then is explicitly unlocked.
+    await this.initUserPage2();
+
+    const unlockedViewerName = this.userPage2.username;
+    await this.modPage.page.locator(e.userListItem).filter({ hasText: unlockedViewerName }).click();
+    await this.modPage.waitAndClick(`${e.unlockUserButton}>>nth=1`);
+    const unlockedViewer = this.userPage2;
+
+    await openSettings(this.modPage);
+    await enableUserJoinPopup(this.modPage);
+    await saveSettings(this.modPage);
+
+    await openSettings(this.userPage);
+    await enableUserJoinPopup(this.userPage);
+    await saveSettings(this.userPage);
+
+    await openSettings(unlockedViewer);
+    await enableUserJoinPopup(unlockedViewer);
+    await saveSettings(unlockedViewer);
+
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
+    await unlockedViewer.closeAllToastNotifications();
+
+    // Viewer3 joins after subscriptions are active.
+    await this.initUserPage2(undefined, { fullName: 'Attendee3' });
+    const viewer3 = this.userPage2;
+
+    await expect(
+      this.modPage.page.locator(e.userListItem, { hasText: viewer3.username }),
+      'Viewer3 should appear in moderator user list after joining',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await this.userPage.wasRemoved(
+      e.smallToastMsg,
+      'Locked viewer must not receive join notification when hideUserList is active',
+      ELEMENT_WAIT_TIME,
+    );
+
+    await this.modPage.hasText(
+      e.smallToastMsg,
+      `${viewer3.username} joined the session`,
+      'Moderator must receive join notification when hideUserList is active',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    await unlockedViewer.hasText(
+      e.smallToastMsg,
+      `${viewer3.username} joined the session`,
+      'Unlocked viewer must receive join notification when hideUserList is active',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+  }
+
+  /**
+   * Regression test for issue #24888, including the unlocked-viewer route.
+   *
+   * Expected behavior when hideUserList is active:
+   * - locked viewer: no leave notification
+   * - unlocked viewer: receives leave notification
+   * - moderator: receives leave notification
+   */
+  async hideUserListLeaveNotificationVisibleForUnlockedAndModOnly() {
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClickElement(e.lockUserList);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+    await this.modPage.closeAllToastNotifications();
+
+    // Viewer1 joins locked.
+    await this.initUserPage();
+    // Viewer2 joins locked, then is explicitly unlocked.
+    await this.initUserPage2();
+    const unlockedViewerName = this.userPage2.username;
+    await this.modPage.page.locator(e.userListItem).filter({ hasText: unlockedViewerName }).click();
+    await this.modPage.waitAndClick(`${e.unlockUserButton}>>nth=1`);
+    const unlockedViewer = this.userPage2;
+
+    // Viewer3 stays locked and will leave.
+    await this.initUserPage2(undefined, { fullName: 'Attendee3' });
+    const leavingViewer = this.userPage2;
+
+    await expect(
+      this.modPage.page.locator(e.userListItem, { hasText: leavingViewer.username }),
+      'Viewer3 should appear in moderator user list before leaving',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await openSettings(this.modPage);
+    await enableUserLeavePopup(this.modPage);
+    await saveSettings(this.modPage);
+
+    await openSettings(this.userPage);
+    await enableUserLeavePopup(this.userPage);
+    await saveSettings(this.userPage);
+
+    await openSettings(unlockedViewer);
+    await enableUserLeavePopup(unlockedViewer);
+    await saveSettings(unlockedViewer);
+
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
+    await unlockedViewer.closeAllToastNotifications();
+
+    await leavingViewer.waitAndClick(e.leaveMeetingDropdown, ELEMENT_WAIT_LONGER_TIME);
+    await leavingViewer.waitAndClick(e.directLogoutButton, ELEMENT_WAIT_LONGER_TIME);
+
+    await this.modPage.hasText(
+      e.smallToastMsg,
+      `${leavingViewer.username} left the session`,
+      'Moderator must receive leave notification when hideUserList is active',
+      UPLOAD_PDF_WAIT_TIME,
+    );
+
+    await unlockedViewer.hasText(
+      e.smallToastMsg,
+      `${leavingViewer.username} left the session`,
+      'Unlocked viewer must receive leave notification when hideUserList is active',
+      UPLOAD_PDF_WAIT_TIME,
+    );
+
+    await this.userPage.wasRemoved(
+      e.smallToastMsg,
+      'Locked viewer must not receive leave notification when hideUserList is active',
+      ELEMENT_WAIT_TIME,
     );
   }
 }

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { hoverLastMessage } from '../chat/util';
-import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME, UPLOAD_PDF_WAIT_TIME } from '../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME, USER_LEFT_NOTIFICATION_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { enableUserJoinPopup, enableUserLeavePopup, saveSettings } from '../notifications/util';
 import { openSettings } from '../options/util';
@@ -417,7 +417,7 @@ export class LockViewers extends MultiUsers {
    * join notifications for other users — those names were leaking via the
    * notification stream even though the user list was hidden.
    *
-   * Fix (PR #24924): when hideUserList=true the backend sends per-user
+   * Fix (issue #24888): when hideUserList=true the backend sends per-user
    * NotifyUserInMeetingEvtMsg only to moderators and unlocked viewers, instead of
    * broadcasting NotifyAllInMeetingEvtMsg to everyone.
    *
@@ -463,19 +463,21 @@ export class LockViewers extends MultiUsers {
       'Viewer2 should appear in the moderator user list after joining',
     ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
 
-    // Locked viewer must NOT receive the join notification (regression for #24888).
-    await this.userPage.wasRemoved(
-      e.smallToastMsg,
-      'Locked viewer must not receive a join notification when hideUserList is active',
-      ELEMENT_WAIT_TIME,
-    );
-
     // Moderator MUST still receive the join notification (per-user route after fix).
+    // Assert positive first to confirm the notification was actually emitted before
+    // checking the locked viewer never received it.
     await this.modPage.hasText(
       e.smallToastMsg,
       `${this.userPage2.username} joined the session`,
       'Moderator must still receive the join notification when hideUserList is active',
       ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    // Locked viewer must NOT receive the join notification (regression for #24888).
+    await this.userPage.wasRemoved(
+      e.smallToastMsg,
+      'Locked viewer must not receive a join notification when hideUserList is active',
+      ELEMENT_WAIT_TIME,
     );
   }
 
@@ -536,7 +538,7 @@ export class LockViewers extends MultiUsers {
       e.smallToastMsg,
       `${leavingUsername} left the session`,
       'Moderator must still receive the leave notification when hideUserList is active',
-      UPLOAD_PDF_WAIT_TIME,
+      USER_LEFT_NOTIFICATION_WAIT_TIME,
     );
 
     // Locked viewer must NOT have received any notification (regression for #24888).
@@ -596,12 +598,8 @@ export class LockViewers extends MultiUsers {
       'Viewer3 should appear in moderator user list after joining',
     ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
 
-    await this.userPage.wasRemoved(
-      e.smallToastMsg,
-      'Locked viewer must not receive join notification when hideUserList is active',
-      ELEMENT_WAIT_TIME,
-    );
-
+    // Assert positives first to confirm notifications were emitted before checking
+    // the locked viewer never received one.
     await this.modPage.hasText(
       e.smallToastMsg,
       `${viewer3.username} joined the session`,
@@ -614,6 +612,12 @@ export class LockViewers extends MultiUsers {
       `${viewer3.username} joined the session`,
       'Unlocked viewer must receive join notification when hideUserList is active',
       ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    await this.userPage.wasRemoved(
+      e.smallToastMsg,
+      'Locked viewer must not receive join notification when hideUserList is active',
+      ELEMENT_WAIT_TIME,
     );
   }
 
@@ -672,14 +676,14 @@ export class LockViewers extends MultiUsers {
       e.smallToastMsg,
       `${leavingViewer.username} left the session`,
       'Moderator must receive leave notification when hideUserList is active',
-      UPLOAD_PDF_WAIT_TIME,
+      USER_LEFT_NOTIFICATION_WAIT_TIME,
     );
 
     await unlockedViewer.hasText(
       e.smallToastMsg,
       `${leavingViewer.username} left the session`,
       'Unlocked viewer must receive leave notification when hideUserList is active',
-      UPLOAD_PDF_WAIT_TIME,
+      USER_LEFT_NOTIFICATION_WAIT_TIME,
     );
 
     await this.userPage.wasRemoved(
@@ -789,14 +793,14 @@ export class LockViewers extends MultiUsers {
       e.smallToastMsg,
       `${mod2Name} left the session`,
       'Mod1 must receive leave notification when a moderator leaves (hideUserList active)',
-      UPLOAD_PDF_WAIT_TIME,
+      USER_LEFT_NOTIFICATION_WAIT_TIME,
     );
 
     await this.userPage.hasText(
       e.smallToastMsg,
       `${mod2Name} left the session`,
       'Locked viewer must receive leave notification when a MODERATOR leaves (hideUserList active)',
-      UPLOAD_PDF_WAIT_TIME,
+      USER_LEFT_NOTIFICATION_WAIT_TIME,
     );
   }
 }

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -688,4 +688,115 @@ export class LockViewers extends MultiUsers {
       ELEMENT_WAIT_TIME,
     );
   }
+
+  /**
+   * Regression test for Ramon's review on PR #24924.
+   *
+   * When hideUserList is active and a MODERATOR joins, even locked viewers must
+   * receive the notification — moderators are never hidden by hideUserList.
+   *
+   * Flow:
+   *   1. Mod1 joins.
+   *   2. Mod1 enables lockUserList (lockOnJoin=true).
+   *   3. Viewer joins (automatically locked).
+   *   4. Both Mod1 and Viewer enable "user join" push alerts.
+   *   5. Mod2 joins as a moderator.
+   *   Expected: Viewer DOES see Mod2's join toast; Mod1 DOES see it too.
+   */
+  async hideUserListModeratorJoinNotificationVisibleToAll() {
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClickElement(e.lockUserList);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+    await this.modPage.closeAllToastNotifications();
+
+    await this.initUserPage();
+
+    await openSettings(this.modPage);
+    await enableUserJoinPopup(this.modPage);
+    await saveSettings(this.modPage);
+
+    await openSettings(this.userPage);
+    await enableUserJoinPopup(this.userPage);
+    await saveSettings(this.userPage);
+
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
+
+    await this.initModPage2();
+    const mod2Name = this.modPage2.username;
+
+    await expect(
+      this.modPage.page.locator(e.userListItem, { hasText: mod2Name }),
+      'Mod2 should appear in Mod1 user list after joining',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await this.modPage.hasText(
+      e.smallToastMsg,
+      `${mod2Name} joined the session`,
+      'Mod1 must receive join notification when a moderator joins (hideUserList active)',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    await this.userPage.hasText(
+      e.smallToastMsg,
+      `${mod2Name} joined the session`,
+      'Locked viewer must receive join notification when a MODERATOR joins (hideUserList active)',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+  }
+
+  /**
+   * Regression test for Ramon's review on PR #24924 — leave variant.
+   *
+   * When hideUserList is active and a MODERATOR leaves, even locked viewers must
+   * receive the leave notification.
+   *
+   * Flow:
+   *   1. Mod1 joins.
+   *   2. Mod2 joins as moderator.
+   *   3. Mod1 enables lockUserList.
+   *   4. Viewer joins (automatically locked).
+   *   5. Mod1 and Viewer enable "user leave" push alerts.
+   *   6. Mod2 leaves.
+   *   Expected: Viewer DOES see Mod2's leave toast; Mod1 DOES see it too.
+   */
+  async hideUserListModeratorLeaveNotificationVisibleToAll() {
+    await this.initModPage2();
+    const mod2Name = this.modPage2.username;
+
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClickElement(e.lockUserList);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+    await this.modPage.closeAllToastNotifications();
+
+    await this.initUserPage();
+
+    await openSettings(this.modPage);
+    await enableUserLeavePopup(this.modPage);
+    await saveSettings(this.modPage);
+
+    await openSettings(this.userPage);
+    await enableUserLeavePopup(this.userPage);
+    await saveSettings(this.userPage);
+
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
+
+    await this.modPage2.waitAndClick(e.leaveMeetingDropdown, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage2.waitAndClick(e.directLogoutButton, ELEMENT_WAIT_LONGER_TIME);
+
+    await this.modPage.hasText(
+      e.smallToastMsg,
+      `${mod2Name} left the session`,
+      'Mod1 must receive leave notification when a moderator leaves (hideUserList active)',
+      UPLOAD_PDF_WAIT_TIME,
+    );
+
+    await this.userPage.hasText(
+      e.smallToastMsg,
+      `${mod2Name} left the session`,
+      'Locked viewer must receive leave notification when a MODERATOR leaves (hideUserList active)',
+      UPLOAD_PDF_WAIT_TIME,
+    );
+  }
 }

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -245,6 +245,38 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
         await lockViewers.initPages(page, testInfo);
         await lockViewers.lockSeeOtherViewersCursor();
       });
+
+      // Regression tests for issue #24888:
+      // usernames must not leak through join/leave notifications when hideUserList is active.
+      test('Hide user list suppresses join notification for locked viewer', async ({ browser, context, page }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListSuppressesJoinNotification();
+      });
+
+      test('Hide user list suppresses leave notification for locked viewer', async ({ browser, context, page }, testInfo) => {
+        const lockViewers = new LockViewers(browser, context);
+        await lockViewers.initModPage(page, { testInfo });
+        await lockViewers.hideUserListSuppressesLeaveNotification();
+      });
+
+      test(
+        'Hide user list join notification is shown only to moderator and unlocked viewer',
+        async ({ browser, context, page }, testInfo) => {
+          const lockViewers = new LockViewers(browser, context);
+          await lockViewers.initModPage(page, { testInfo });
+          await lockViewers.hideUserListJoinNotificationVisibleForUnlockedAndModOnly();
+        },
+      );
+
+      test(
+        'Hide user list leave notification is shown only to moderator and unlocked viewer',
+        async ({ browser, context, page }, testInfo) => {
+          const lockViewers = new LockViewers(browser, context);
+          await lockViewers.initModPage(page, { testInfo });
+          await lockViewers.hideUserListLeaveNotificationVisibleForUnlockedAndModOnly();
+        },
+      );
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#saving-usernames

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -277,6 +277,24 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
           await lockViewers.hideUserListLeaveNotificationVisibleForUnlockedAndModOnly();
         },
       );
+
+      test(
+        'Hide user list join notification is visible to locked viewer when a moderator joins',
+        async ({ browser, context, page }, testInfo) => {
+          const lockViewers = new LockViewers(browser, context);
+          await lockViewers.initModPage(page, { testInfo });
+          await lockViewers.hideUserListModeratorJoinNotificationVisibleToAll();
+        },
+      );
+
+      test(
+        'Hide user list leave notification is visible to locked viewer when a moderator leaves',
+        async ({ browser, context, page }, testInfo) => {
+          const lockViewers = new LockViewers(browser, context);
+          await lockViewers.initModPage(page, { testInfo });
+          await lockViewers.hideUserListModeratorLeaveNotificationVisibleToAll();
+        },
+      );
     });
 
     // https://docs.bigbluebutton.org/3.0/testing/release-testing/#saving-usernames


### PR DESCRIPTION
### What does this PR do?
Add a Filter for Locked Viewer not see joined/left users.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #24888

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test
- Join a mod
- Apply the lock settings to hide viewers on user list
- join a viewer
- enable notification to receive notification of join/left viewers


