### PR TITLE
feat(livekit): add retryThroughRelay flag

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -652,6 +652,7 @@ export interface LiveKitSettings {
   url?: string
   selectiveSubscription?: SelectiveSubscriptionConfig
   logLevel?: LogLevel
+  retryThroughRelay?: boolean
   roomOptions?: Partial<InternalRoomOptions>
   reconnectOnFatalFailures?: boolean
   audio?: LiveKitAudioSettings

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -54,6 +54,7 @@ interface BBBLiveKitRoomProps {
   usingScreenShare: boolean;
   withSelectiveSubscription: boolean;
   reconnectOnFatalFailures?: boolean;
+  retryThroughRelay?: boolean;
 }
 
 interface ObserverProps {
@@ -175,16 +176,23 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   usingScreenShare,
   withSelectiveSubscription,
   reconnectOnFatalFailures = false,
+  retryThroughRelay = false,
 }) => {
   const [connAttempts, setConnAttempts] = useState(0);
   const [connError, setConnError] = useState<Error | null>(null);
   const [lkRoomOptionsAvailable, setLkRoomOptionsAvailable] = useState(false);
   const [connectOptions, setConnectOptions] = useState<RoomConnectOptions | undefined>(undefined);
   const isClientConnected = useReactiveVar(connectionStatus.getConnectedStatusVar());
-  const { iceServers, isLoading: iceServersLoading } = useIceServers(bbbSessionToken);
+  const {
+    iceServers,
+    isLoading: iceServersLoading,
+    hasTurnServer,
+  } = useIceServers(bbbSessionToken);
   const speakerLevel = useSpeakerLevel();
   const intl = useIntl();
   const isReconnectingRef = useRef(false);
+  const hasEverConnectedRef = useRef(false);
+  const lastConnectUsedRelayRef = useRef(false);
 
   const onDisconnected = useCallback((reason?: DisconnectReason) => {
     logger.warn({
@@ -209,22 +217,31 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
         iceServers,
         connAttempts,
         isClientConnected,
+        hasEverConnected: hasEverConnectedRef.current,
+        forceRelay: lastConnectUsedRelayRef.current,
+        retryThroughRelay,
       },
     }, `LiveKit room error: ${error.message}`);
     setConnError(error);
     setConnAttempts((prev) => prev + 1);
-  }, [isClientConnected, url, iceServers, connAttempts]);
+  }, [isClientConnected, url, iceServers, connAttempts, retryThroughRelay]);
 
   const onConnected = useCallback(() => {
+    const initialConn = !hasEverConnectedRef.current;
+    const forceRelay = lastConnectUsedRelayRef.current;
+    hasEverConnectedRef.current = true;
     logger.info({
       logCode: 'livekit_room_connected',
       extraInfo: {
         url,
+        connAttempts,
+        initialConn,
+        forceRelay,
       },
-    }, 'LiveKit connected');
+    }, `LiveKit connected (initialConn=${initialConn}, attempts=${connAttempts}, forceRelay=${forceRelay})`);
     setConnAttempts(0);
     setConnError(null);
-  }, [url]);
+  }, [url, connAttempts]);
 
   useEffect(() => {
     if (!token
@@ -258,6 +275,19 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       return;
     }
 
+    const forceRelay = retryThroughRelay
+      && !hasEverConnectedRef.current
+      && connError instanceof ConnectionError
+      && hasTurnServer;
+
+    const effectiveConnectOptions: RoomConnectOptions = forceRelay ? {
+      ...connectOptions,
+      rtcConfig: {
+        ...(connectOptions.rtcConfig ?? {}),
+        iceTransportPolicy: 'relay',
+      },
+    } : connectOptions;
+
     logger.warn({
       logCode: 'livekit_room_conn_retry',
       extraInfo: {
@@ -267,10 +297,13 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
         errorMessage: connError?.message,
         errorStack: connError?.stack,
         errorName: connError?.name,
+        retryThroughRelay,
+        forceRelay,
       },
-    }, `LiveKit reconnect attempt ${connAttempts}`);
+    }, `LiveKit reconnect attempt ${connAttempts} (forceRelay=${forceRelay})`);
     setConnError(null);
-    liveKitRoom.connect(url, token, connectOptions).catch((error) => {
+    lastConnectUsedRelayRef.current = forceRelay;
+    liveKitRoom.connect(url, token, effectiveConnectOptions).catch((error) => {
       logger.debug({
         logCode: 'livekit_room_connect_error',
         extraInfo: {
@@ -278,6 +311,7 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
           errorStack: (error as Error).stack,
           connAttempts,
           url,
+          forceRelay,
         },
       }, `Failed to connect to LiveKit room: ${error?.message}`);
     });
@@ -290,6 +324,8 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
     isClientConnected,
     iceServersLoading,
     connAttempts,
+    retryThroughRelay,
+    hasTurnServer,
   ]);
 
   useEffect(() => {
@@ -314,9 +350,10 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       extraInfo: {
         url,
         iceServers,
+        retryThroughRelay,
       },
     }, 'LiveKit room will connect');
-  }, [token, url, iceServersLoading, iceServers, withSelectiveSubscription]);
+  }, [token, url, iceServersLoading, iceServers, withSelectiveSubscription, retryThroughRelay]);
 
   useEffect(() => {
     if (!url) return;
@@ -451,6 +488,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
     stopLocalTrackOnUnpublish: false,
   };
   const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? false;
+  const retryThroughRelay = meetingSettings.public.media?.livekit?.retryThroughRelay ?? false;
   const { data: bridges } = useMeeting((m) => ({
     cameraBridge: m.cameraBridge,
     screenShareBridge: m.screenShareBridge,
@@ -473,6 +511,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
       usingScreenShare={bridges?.screenShareBridge === 'livekit'}
       withSelectiveSubscription={withSelectiveSubscription}
       reconnectOnFatalFailures={reconnectOnFatalFailures}
+      retryThroughRelay={retryThroughRelay}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -655,6 +655,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           muteDebounceMs: 2500,
         },
         logLevel: LogLevel.warn,
+        retryThroughRelay: false,
         reconnectOnFatalFailures: false,
         roomOptions: {
           adaptiveStream: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -956,6 +956,9 @@ public:
       # reconnectOnFatalFailures: whether to trigger LK room reconnections when
       # fatal errors occur (e.g.: unrecoverable publish timeouts). Default is false.
       reconnectOnFatalFailures: false
+      # retryThroughRelay: when the initial LiveKit connection fails, retries
+      # will force TURN/relay until the first successful connect.
+      retryThroughRelay: false
       roomOptions:
         adaptiveStream: true
         dynacast: true


### PR DESCRIPTION
### What does this PR do?

- [feat(livekit): add retryThroughRelay flag](https://github.com/bigbluebutton/bigbluebutton/commit/22f34fcb209313fb433930710b226d9765c8c471) 
  - We're investigating connectivity failures where LK PCs are _not_ opting
for relay even though ICE ends up failing on regular candidate pairs.
With LK, we lack a counterpart of bbb-webrtc-sfu's retryThroughRelay
flag that forces TURN on connection failures - which was designed
precisely as stopgap for these scenarios.
  - Add public.media.livekit.retryThroughRelay (default false). When the
flag is on and the initial LK session fails with a ConnectionError,
retries set iceTransportPolicy='relay' on the RTCConfiguration until
the first successful connect.
  - Once the room has connected at least once, the flag no longer applies:
subsequent mid-session reconnections go through normal candidate selection,
so long-lived sessions do not pay the relay overhead after recovering.
  - The flag does not abide to forced reconnections (i.e. initiated by
ourselves), nor is it honored if no TURN server is configured.

### Closes Issue(s)

None

### Motivation

Related https://github.com/bigbluebutton/bigbluebutton/issues/24615