### PR TITLE
chore(livekit): enable reconnectOnFatalFailure by default

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -174,7 +174,7 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   usingAudio,
   usingScreenShare,
   withSelectiveSubscription,
-  reconnectOnFatalFailures = false,
+  reconnectOnFatalFailures = true,
 }) => {
   const [connAttempts, setConnAttempts] = useState(0);
   const [connError, setConnError] = useState<Error | null>(null);
@@ -450,7 +450,7 @@ const BBBLiveKitRoomContainer: React.FC = () => {
     dynacast: true,
     stopLocalTrackOnUnpublish: false,
   };
-  const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? false;
+  const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? true;
   const { data: bridges } = useMeeting((m) => ({
     cameraBridge: m.cameraBridge,
     screenShareBridge: m.screenShareBridge,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -655,7 +655,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           muteDebounceMs: 2500,
         },
         logLevel: LogLevel.warn,
-        reconnectOnFatalFailures: false,
+        reconnectOnFatalFailures: true,
         roomOptions: {
           adaptiveStream: true,
           dynacast: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -954,8 +954,8 @@ public:
         muteDebounceMs: 2500
       logLevel: 3
       # reconnectOnFatalFailures: whether to trigger LK room reconnections when
-      # fatal errors occur (e.g.: unrecoverable publish timeouts). Default is false.
-      reconnectOnFatalFailures: false
+      # fatal errors occur (e.g.: unrecoverable publish timeouts).
+      reconnectOnFatalFailures: true
       roomOptions:
         adaptiveStream: true
         dynacast: true


### PR DESCRIPTION
### What does this PR do?

- [chore(livekit): enable reconnectOnFatalFailure by default](https://github.com/bigbluebutton/bigbluebutton/commit/cf946b8f7ac8d9420f36f402232a32e92fa25cf7) 
  - Enable `public.media.livekit.reconnectOnFatalFailures` by default after
sufficient fields trials proved this improves more things than it breaks
:).
  - For further context, see commit d6b09266 ("fix(livekit): trigger forced room reconnection on fatal errors").


### Closes Issue(s)

None

### Motivation

Ref https://github.com/bigbluebutton/bigbluebutton/issues/24013