### PR TITLE
docs: Document lockSettingsHideViewersAnnotation /create parameter

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -265,6 +265,13 @@ const createEndpointTableData = [
     "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will prevent viewers to see other viewers cursor when multi-user whiteboard is on. (added 2.5)</>)
   },
   {
+    "name": "lockSettingsHideViewersAnnotation",
+    "required": false,
+    "type": "Boolean",
+    "default": "false",
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will prevent viewers from seeing other viewers' annotations when multi-user whiteboard is on. (added 2.7)</>)
+  },
+  {
     "name": "guestPolicy",
     "required": false,
     "type": "Enum",


### PR DESCRIPTION
### What does this PR do?

Documents the existing `lockSettingsHideViewersAnnotation` parameter in the `/create` API reference.

The parameter was implemented in 2.7 (commit `09eb68f23b`) but was never added to `docs/docs/data/create.tsx`, leaving it undocumented alongside the other `lockSettings*` entries.

### Closes Issue(s)

Closes #24880

### Motivation

`lockSettingsHideViewersAnnotation` controls whether viewers can see other viewers' annotations when multi-user whiteboard is on. It has been available since BBB 2.7 but API consumers had no way to discover it through the official docs.