### PR TITLE
feat(screenshare): multi-screenshare for viewers with disableMultiScreenshare lock setting

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -16,6 +16,7 @@ import org.bigbluebutton.core.models.{
   Webcams,
   WebcamStream
 }
+import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
 
 object LockSettingsUtil {
 
@@ -167,5 +168,14 @@ object LockSettingsUtil {
     Users2x.findLockedViewers(liveMeeting.users2x).foreach { user =>
       enforceCamLockSettingsForUser(user, liveMeeting, outGW)
     }
+  }
+
+  def isScreenshareBroadcastLocked(user: UserState, liveMeeting: LiveMeeting): Boolean = {
+    val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+    user.role == Roles.VIEWER_ROLE && user.locked && permissions.disableMultiScreenshare
+  }
+
+  def enforceScreenshareLockSettingsForAllViewers(liveMeeting: LiveMeeting, outGW: OutMsgRouter): Unit = {
+    ScreenshareApp2x.enforceScreenshareLockSettingsForAllViewers(outGW, liveMeeting)
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
@@ -2,8 +2,9 @@ package org.bigbluebutton.core2.message.handlers
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core.models.{ Users2x, Roles }
 import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetScreenBroadcastPermissionReqMsgHdlr {
@@ -17,14 +18,23 @@ trait GetScreenBroadcastPermissionReqMsgHdlr {
     for {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
-      if (permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL,
-        liveMeeting.users2x, msg.header.userId)) {
+      // Guests are never allowed to broadcast screenshare.
+      if (!user.authed) {
         val meetingId = liveMeeting.props.meetingProp.intId
-        val reason = "No permission to share the screen."
+        val reason = "Guests may not share the screen."
         PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
       } else if (liveMeeting.props.meetingProp.intId == msg.body.meetingId
         && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
-        allowed = true
+        // Viewers that are locked and disableMultiScreenshare is active are denied.
+        val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+        val isLockedViewer = user.role == Roles.VIEWER_ROLE && user.locked
+        if (isLockedViewer && permissions.disableMultiScreenshare) {
+          val meetingId = liveMeeting.props.meetingProp.intId
+          val reason = "Screen sharing is disabled for locked viewers."
+          PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
+        } else {
+          allowed = true
+        }
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenBroadcastPermissionReqMsgHdlr.scala
@@ -28,11 +28,7 @@ trait GetScreenBroadcastPermissionReqMsgHdlr {
         // Viewers that are locked and disableMultiScreenshare is active are denied.
         val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
         val isLockedViewer = user.role == Roles.VIEWER_ROLE && user.locked
-        if (isLockedViewer && permissions.disableMultiScreenshare) {
-          val meetingId = liveMeeting.props.meetingProp.intId
-          val reason = "Screen sharing is disabled for locked viewers."
-          PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)
-        } else {
+        if (!(isLockedViewer && permissions.disableMultiScreenshare)) {
           allowed = true
         }
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
@@ -30,12 +30,18 @@ trait GetScreenSubscribePermissionReqMsgHdlr {
           val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
           val isLockedViewer = user.role == Roles.VIEWER_ROLE && user.locked
           if (isLockedViewer && permissions.hideViewersScreenshare) {
-            // Check whether the stream belongs to a viewer.
-            val broadcasterIsViewer = Screenshares.findByStream(liveMeeting.screenshares, streamId)
-              .exists { entry =>
-                Users2x.findWithIntId(liveMeeting.users2x, entry.userId)
-                  .exists(_.role == Roles.VIEWER_ROLE)
-              }
+            // Resolve the broadcaster's userId from the collection, falling back to the singleton.
+            val broadcasterUserId = Screenshares.findByStream(liveMeeting.screenshares, streamId)
+              .map(_.userId)
+              .orElse(
+                if (ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == streamId)
+                  Some(ScreenshareModel.getUserId(liveMeeting.screenshareModel))
+                else None
+              )
+            val broadcasterIsViewer = broadcasterUserId.exists { uid =>
+              Users2x.findWithIntId(liveMeeting.users2x, uid)
+                .exists(_.role == Roles.VIEWER_ROLE)
+            }
             if (!broadcasterIsViewer) allowed = true
             // Subscription to viewer streams is blocked; to moderator/presenter streams it is not.
           } else {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/GetScreenSubscribePermissionReqMsgHdlr.scala
@@ -2,8 +2,9 @@ package org.bigbluebutton.core2.message.handlers
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
-import org.bigbluebutton.core.models.Users2x
+import org.bigbluebutton.core.models.{ Users2x, Screenshares, Roles }
 import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 trait GetScreenSubscribePermissionReqMsgHdlr {
@@ -18,9 +19,29 @@ trait GetScreenSubscribePermissionReqMsgHdlr {
       user <- Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
     } yield {
       if (liveMeeting.props.meetingProp.intId == msg.body.meetingId
-        && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf
-        && ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == msg.body.streamId) {
-        allowed = true
+        && liveMeeting.props.voiceProp.voiceConf == msg.body.voiceConf) {
+        val streamId = msg.body.streamId
+        // Check in the multi-screenshare collection first, then fall back to the legacy singleton.
+        val streamKnown = Screenshares.hasStream(liveMeeting.screenshares, streamId) ||
+          ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == streamId
+
+        if (streamKnown) {
+          // Apply hideViewersScreenshare: locked viewers cannot subscribe to other viewers' streams.
+          val permissions = MeetingStatus2x.getPermissions(liveMeeting.status)
+          val isLockedViewer = user.role == Roles.VIEWER_ROLE && user.locked
+          if (isLockedViewer && permissions.hideViewersScreenshare) {
+            // Check whether the stream belongs to a viewer.
+            val broadcasterIsViewer = Screenshares.findByStream(liveMeeting.screenshares, streamId)
+              .exists { entry =>
+                Users2x.findWithIntId(liveMeeting.users2x, entry.userId)
+                  .exists(_.role == Roles.VIEWER_ROLE)
+              }
+            if (!broadcasterIsViewer) allowed = true
+            // Subscription to viewer streams is blocked; to moderator/presenter streams it is not.
+          } else {
+            allowed = true
+          }
+        }
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -21,14 +21,14 @@ object ScreenshareApp2x {
     }
   }
 
-  /** Stop all active screenshares belonging to locked viewers.
+  /** Stop active screenshares belonging to locked viewers.
    *  Called when disableMultiScreenshare is activated by a moderator. */
   def enforceScreenshareLockSettingsForAllViewers(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
     val allShares = Screenshares.findAll(liveMeeting.screenshares)
     allShares.foreach { entry =>
-      val isViewer = Users2x.findWithIntId(liveMeeting.users2x, entry.userId)
-        .exists(u => u.role == Roles.VIEWER_ROLE)
-      if (isViewer) {
+      val isLockedViewer = Users2x.findWithIntId(liveMeeting.users2x, entry.userId)
+        .exists(u => u.role == Roles.VIEWER_ROLE && u.locked)
+      if (isLockedViewer) {
         val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
           liveMeeting.props.meetingProp.intId,
           entry.voiceConf,
@@ -38,15 +38,15 @@ object ScreenshareApp2x {
         outGW.send(event)
       }
     }
-    // Also stop the singleton if it belongs to a viewer.
+    // Also stop the singleton if it belongs to a locked viewer.
     if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
       val singletonUserId = ScreenshareModel.getUserId(liveMeeting.screenshareModel)
       val singletonNotInCollection = !Screenshares.hasStream(
         liveMeeting.screenshares, ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
       if (singletonNotInCollection) {
-        val isViewer = Users2x.findWithIntId(liveMeeting.users2x, singletonUserId)
-          .exists(u => u.role == Roles.VIEWER_ROLE)
-        if (isViewer) {
+        val isLockedViewer = Users2x.findWithIntId(liveMeeting.users2x, singletonUserId)
+          .exists(u => u.role == Roles.VIEWER_ROLE && u.locked)
+        if (isLockedViewer) {
           val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
             liveMeeting.props.meetingProp.intId,
             ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -3,6 +3,7 @@ package org.bigbluebutton.core.apps.screenshare
 import org.apache.pekko.actor.ActorContext
 import org.apache.pekko.event.Logging
 import org.bigbluebutton.core.apps.ScreenshareModel
+import org.bigbluebutton.core.models.{ Screenshares, Roles, Users2x }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -16,8 +17,45 @@ object ScreenshareApp2x {
         ScreenshareModel.getUserId(liveMeeting.screenshareModel),
         ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel),
       )
-
       outGW.send(event)
+    }
+  }
+
+  /** Stop all active screenshares belonging to locked viewers.
+   *  Called when disableMultiScreenshare is activated by a moderator. */
+  def enforceScreenshareLockSettingsForAllViewers(outGW: OutMsgRouter, liveMeeting: LiveMeeting): Unit = {
+    val allShares = Screenshares.findAll(liveMeeting.screenshares)
+    allShares.foreach { entry =>
+      val isViewer = Users2x.findWithIntId(liveMeeting.users2x, entry.userId)
+        .exists(u => u.role == Roles.VIEWER_ROLE)
+      if (isViewer) {
+        val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
+          liveMeeting.props.meetingProp.intId,
+          entry.voiceConf,
+          entry.userId,
+          entry.stream
+        )
+        outGW.send(event)
+      }
+    }
+    // Also stop the singleton if it belongs to a viewer.
+    if (ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
+      val singletonUserId = ScreenshareModel.getUserId(liveMeeting.screenshareModel)
+      val singletonNotInCollection = !Screenshares.hasStream(
+        liveMeeting.screenshares, ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
+      if (singletonNotInCollection) {
+        val isViewer = Users2x.findWithIntId(liveMeeting.users2x, singletonUserId)
+          .exists(u => u.role == Roles.VIEWER_ROLE)
+        if (isViewer) {
+          val event = MsgBuilder.buildScreenBroadcastStopSysMsg(
+            liveMeeting.props.meetingProp.intId,
+            ScreenshareModel.getVoiceConf(liveMeeting.screenshareModel),
+            singletonUserId,
+            ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel)
+          )
+          outGW.send(event)
+        }
+      }
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareApp2x.scala
@@ -89,7 +89,8 @@ object ScreenshareApp2x {
 class ScreenshareApp2x(implicit val context: ActorContext)
   extends GetScreenshareStatusReqMsgHdlr
   with ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr
-  with ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
+  with ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr
+  with SetScreenshareShowAsContentReqMsgHdlr {
 
   val log = Logging(context.system, getClass)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
@@ -102,7 +102,7 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         msg.body.userId, msg.body.stream, showAsContent
       )
 
-      ScreenshareDAO.insert(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.stream, liveMeeting.screenshareModel, showAsContent)
+      ScreenshareDAO.insertEntry(liveMeeting.props.meetingProp.intId, entry)
 
       // Notify all participants in the meeting.
       val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.userId, msg.body.stream,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
@@ -5,7 +5,7 @@ import org.bigbluebutton.core.apps.layout.ScreenshareAsContenthdlrHelper
 import org.bigbluebutton.core.apps.{ ExternalVideoModel, ScreenshareModel }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.db.{ LayoutDAO, ScreenshareDAO }
-import org.bigbluebutton.core.models.{ Layouts, Screenshares, ScreenshareEntry, Users2x, Roles }
+import org.bigbluebutton.core.models.{ Layouts, Screenshares, ScreenshareEntry }
 import org.bigbluebutton.core.models.Users2x.findPresenter
 import org.bigbluebutton.core.running.LiveMeeting
 
@@ -46,15 +46,11 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
       val meetingId = liveMeeting.props.meetingProp.intId
       log.error("Screen sharing is disabled for this meeting, meetingID = {}", meetingId)
     } else {
-      // Determine whether this broadcaster is the presenter or a moderator.
-      val broadcasterIsPresenterOrMod = Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
-        .exists(u => u.presenter || u.role == Roles.MODERATOR_ROLE)
-
-      // showAsContent=true only when no other share already occupies the content area AND this user
-      // is the presenter or moderator.  Non-presenter viewer shares always go to the camera dock.
+      // showAsContent=true for the first share that occupies the content area, regardless of role.
+      // Subsequent shares (any role) go to the camera dock.
       val alreadyHasContent = Screenshares.findAll(liveMeeting.screenshares).exists(_.showAsContent) ||
         ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)
-      val showAsContent = broadcasterIsPresenterOrMod && !alreadyHasContent
+      val showAsContent = !alreadyHasContent
 
       // Register in the multi-share collection (keyed by stream URL).
       val entry = ScreenshareEntry(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
@@ -102,7 +102,7 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         msg.body.userId, msg.body.stream, showAsContent
       )
 
-      ScreenshareDAO.insert(liveMeeting.props.meetingProp.intId, msg.body.userId, liveMeeting.screenshareModel, showAsContent)
+      ScreenshareDAO.insert(liveMeeting.props.meetingProp.intId, msg.body.userId, msg.body.stream, liveMeeting.screenshareModel, showAsContent)
 
       // Notify all participants in the meeting.
       val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.userId, msg.body.stream,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr.scala
@@ -5,7 +5,7 @@ import org.bigbluebutton.core.apps.layout.ScreenshareAsContenthdlrHelper
 import org.bigbluebutton.core.apps.{ ExternalVideoModel, ScreenshareModel }
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.db.{ LayoutDAO, ScreenshareDAO }
-import org.bigbluebutton.core.models.Layouts
+import org.bigbluebutton.core.models.{ Layouts, Screenshares, ScreenshareEntry, Users2x, Roles }
 import org.bigbluebutton.core.models.Users2x.findPresenter
 import org.bigbluebutton.core.running.LiveMeeting
 
@@ -32,9 +32,10 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
       BbbCommonEnvCoreMsg(envelope, event)
     }
 
-    log.info("handleScreenshareRTMPBroadcastStartedRequest: isBroadcastingRTMP=" +
-      ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel) +
-      " URL:" + ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
+    log.info(
+      "handleScreenshareRTMPBroadcastStartedRequest: stream={} userId={}",
+      msg.body.stream, msg.body.userId
+    )
 
     if (msg.body.contentType == "camera" && liveMeeting.props.meetingProp.disabledFeatures.contains("cameraAsContent")) {
       log.error(
@@ -45,11 +46,35 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
       val meetingId = liveMeeting.props.meetingProp.intId
       log.error("Screen sharing is disabled for this meeting, meetingID = {}", meetingId)
     } else {
-      // only valid if not broadcasting yet
-      if (!ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
-        // Stop external video if it's running
-        ExternalVideoModel.stop(bus.outGW, liveMeeting)
+      // Determine whether this broadcaster is the presenter or a moderator.
+      val broadcasterIsPresenterOrMod = Users2x.findWithIntId(liveMeeting.users2x, msg.body.userId)
+        .exists(u => u.presenter || u.role == Roles.MODERATOR_ROLE)
 
+      // showAsContent=true only when no other share already occupies the content area AND this user
+      // is the presenter or moderator.  Non-presenter viewer shares always go to the camera dock.
+      val alreadyHasContent = Screenshares.findAll(liveMeeting.screenshares).exists(_.showAsContent) ||
+        ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)
+      val showAsContent = broadcasterIsPresenterOrMod && !alreadyHasContent
+
+      // Register in the multi-share collection (keyed by stream URL).
+      val entry = ScreenshareEntry(
+        screenshareId = msg.body.stream,
+        userId = msg.body.userId,
+        stream = msg.body.stream,
+        voiceConf = msg.body.voiceConf,
+        screenshareConf = msg.body.screenshareConf,
+        vidWidth = msg.body.vidWidth,
+        vidHeight = msg.body.vidHeight,
+        hasAudio = msg.body.hasAudio,
+        contentType = msg.body.contentType,
+        showAsContent = showAsContent,
+        startedAt = System.currentTimeMillis()
+      )
+      Screenshares.add(liveMeeting.screenshares, entry)
+
+      // Keep the legacy singleton model in sync for backward compatibility with existing consumers
+      // that still reference liveMeeting.screenshareModel (subscribe permission handler, broadcastStopped).
+      if (!ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {
         ScreenshareModel.setRTMPBroadcastingUrl(liveMeeting.screenshareModel, msg.body.stream)
         ScreenshareModel.broadcastingRTMPStarted(liveMeeting.screenshareModel)
         ScreenshareModel.setScreenshareVideoWidth(liveMeeting.screenshareModel, msg.body.vidWidth)
@@ -60,10 +85,11 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
         ScreenshareModel.setHasAudio(liveMeeting.screenshareModel, msg.body.hasAudio)
         ScreenshareModel.setContentType(liveMeeting.screenshareModel, msg.body.contentType)
         ScreenshareModel.setUserId(liveMeeting.screenshareModel, msg.body.userId)
+      }
 
-        log.info("START broadcast ALLOWED when isBroadcastingRTMP=false")
-
-        ScreenshareDAO.insert(liveMeeting.props.meetingProp.intId, liveMeeting.screenshareModel)
+      // When a presenter/mod share takes the content area, stop external video if running.
+      if (showAsContent) {
+        ExternalVideoModel.stop(bus.outGW, liveMeeting)
         if (!Layouts.getScreenshareAsContent(liveMeeting.layouts)) {
           Layouts.setScreenshareAsContent(liveMeeting.layouts, true)
           LayoutDAO.insertOrUpdate(liveMeeting.props.meetingProp.intId, liveMeeting.layouts)
@@ -73,14 +99,19 @@ trait ScreenshareRtmpBroadcastStartedVoiceConfEvtMsgHdlr {
             ScreenshareAsContenthdlrHelper.sendSetScreenshareAsContentEvtMsg(presenter.intId, liveMeeting, bus.outGW)
           }
         }
-
-        // Notify viewers in the meeting that there's an rtmp stream to view
-        val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.userId, msg.body.stream,
-          msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp, msg.body.hasAudio, msg.body.contentType)
-        bus.outGW.send(msgEvent)
-      } else {
-        log.info("START broadcast NOT ALLOWED when isBroadcastingRTMP=true")
       }
+
+      log.info(
+        "START broadcast ALLOWED: userId={} stream={} showAsContent={}",
+        msg.body.userId, msg.body.stream, showAsContent
+      )
+
+      ScreenshareDAO.insert(liveMeeting.props.meetingProp.intId, msg.body.userId, liveMeeting.screenshareModel, showAsContent)
+
+      // Notify all participants in the meeting.
+      val msgEvent = broadcastEvent(msg.body.voiceConf, msg.body.screenshareConf, msg.body.userId, msg.body.stream,
+        msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp, msg.body.hasAudio, msg.body.contentType)
+      bus.outGW.send(msgEvent)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
@@ -2,22 +2,56 @@ package org.bigbluebutton.core.apps.screenshare
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.ScreenshareModel
-import org.bigbluebutton.core.apps.ScreenshareModel.getRTMPBroadcastingUrl
 import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.ScreenshareDAO
+import org.bigbluebutton.core.models.Screenshares
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x.broadcastStopped
-import org.bigbluebutton.core.db.ScreenshareDAO
 
 trait ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
   this: ScreenshareApp2x =>
 
   def handle(msg: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-    log.info("handleScreenshareRTMPBroadcastStoppedRequest: isBroadcastingRTMP=" +
-      ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel) + " URL:" +
-      ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
+    val stream = msg.body.stream
+    log.info("handleScreenshareRTMPBroadcastStoppedRequest: stream={}", stream)
 
-    ScreenshareDAO.updateStopped(liveMeeting.props.meetingProp.intId, getRTMPBroadcastingUrl(liveMeeting.screenshareModel))
+    // Remove from the multi-share collection first.
+    val removedEntry = Screenshares.remove(liveMeeting.screenshares, stream)
+    log.info("Removed screenshare entry from collection: {}", removedEntry.isDefined)
 
-    broadcastStopped(bus.outGW, liveMeeting)
+    // Update the database record for this stream.
+    ScreenshareDAO.updateStopped(liveMeeting.props.meetingProp.intId, stream)
+
+    // If the stopped stream was the one tracked by the legacy singleton, clear it.
+    // The singleton will reflect the next active stream if any, or remain cleared.
+    if (ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == stream) {
+      broadcastStopped(bus.outGW, liveMeeting)
+      // After clearing the singleton, restore it to the next active stream if one exists.
+      Screenshares.findAll(liveMeeting.screenshares).headOption.foreach { next =>
+        ScreenshareModel.setRTMPBroadcastingUrl(liveMeeting.screenshareModel, next.stream)
+        ScreenshareModel.broadcastingRTMPStarted(liveMeeting.screenshareModel)
+        ScreenshareModel.setUserId(liveMeeting.screenshareModel, next.userId)
+        ScreenshareModel.setVoiceConf(liveMeeting.screenshareModel, next.voiceConf)
+        ScreenshareModel.setScreenshareConf(liveMeeting.screenshareModel, next.screenshareConf)
+      }
+    } else {
+      // The stopped stream is not the singleton; send a targeted stop event without clearing the model.
+      val routing = Routing.addMsgToClientRouting(
+        MessageTypes.BROADCAST_TO_MEETING,
+        liveMeeting.props.meetingProp.intId, "not-used"
+      )
+      val envelope = BbbCoreEnvelope(ScreenshareRtmpBroadcastStoppedEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(
+        ScreenshareRtmpBroadcastStoppedEvtMsg.NAME,
+        liveMeeting.props.meetingProp.intId, "not-used"
+      )
+      val body = ScreenshareRtmpBroadcastStoppedEvtMsgBody(
+        msg.body.voiceConf, msg.body.screenshareConf,
+        removedEntry.map(_.userId).getOrElse(msg.body.userId),
+        stream,
+        msg.body.vidWidth, msg.body.vidHeight, msg.body.timestamp
+      )
+      bus.outGW.send(BbbCommonEnvCoreMsg(envelope, ScreenshareRtmpBroadcastStoppedEvtMsg(header, body)))
+    }
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr.scala
@@ -19,15 +19,20 @@ trait ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsgHdlr {
     val removedEntry = Screenshares.remove(liveMeeting.screenshares, stream)
     log.info("Removed screenshare entry from collection: {}", removedEntry.isDefined)
 
-    // Update the database record for this stream.
-    ScreenshareDAO.updateStopped(liveMeeting.props.meetingProp.intId, stream)
+    // Update the database record only for streams we were actually tracking.
+    val singletonMatches = ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == stream
+    if (removedEntry.isDefined || singletonMatches) {
+      ScreenshareDAO.updateStopped(liveMeeting.props.meetingProp.intId, stream)
+    }
 
     // If the stopped stream was the one tracked by the legacy singleton, clear it.
     // The singleton will reflect the next active stream if any, or remain cleared.
-    if (ScreenshareModel.getRTMPBroadcastingUrl(liveMeeting.screenshareModel) == stream) {
+    if (singletonMatches) {
       broadcastStopped(bus.outGW, liveMeeting)
-      // After clearing the singleton, restore it to the next active stream if one exists.
-      Screenshares.findAll(liveMeeting.screenshares).headOption.foreach { next =>
+      // After clearing the singleton, prefer the share that occupies the content area for continuity.
+      val remaining = Screenshares.findAll(liveMeeting.screenshares)
+      val nextOpt = remaining.find(_.showAsContent).orElse(remaining.headOption)
+      nextOpt.foreach { next =>
         ScreenshareModel.setRTMPBroadcastingUrl(liveMeeting.screenshareModel, next.stream)
         ScreenshareModel.broadcastingRTMPStarted(liveMeeting.screenshareModel)
         ScreenshareModel.setUserId(liveMeeting.screenshareModel, next.userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SetScreenshareShowAsContentReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SetScreenshareShowAsContentReqMsgHdlr.scala
@@ -22,7 +22,7 @@ trait SetScreenshareShowAsContentReqMsgHdlr {
       bus.outGW.send(BbbCommonEnvCoreMsg(envelope, event))
     }
 
-    val notPresenter = PermissionCheck.permissionFailed(
+    val notPresenter = !PermissionCheck.isAllowed(
       PermissionCheck.GUEST_LEVEL,
       PermissionCheck.PRESENTER_LEVEL,
       liveMeeting.users2x,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SetScreenshareShowAsContentReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/screenshare/SetScreenshareShowAsContentReqMsgHdlr.scala
@@ -1,0 +1,53 @@
+package org.bigbluebutton.core.apps.screenshare
+
+import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.PermissionCheck
+import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.db.ScreenshareDAO
+import org.bigbluebutton.core.models.Screenshares
+import org.bigbluebutton.core.running.LiveMeeting
+
+trait SetScreenshareShowAsContentReqMsgHdlr {
+  this: ScreenshareApp2x =>
+
+  def handle(msg: SetScreenshareShowAsContentReqMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+    val meetingId = liveMeeting.props.meetingProp.intId
+
+    def broadcastEvt(streamId: String, showAsContent: Boolean, setBy: String): Unit = {
+      val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, setBy)
+      val envelope = BbbCoreEnvelope(SetScreenshareShowAsContentEvtMsg.NAME, routing)
+      val header = BbbClientMsgHeader(SetScreenshareShowAsContentEvtMsg.NAME, meetingId, setBy)
+      val body = SetScreenshareShowAsContentEvtMsgBody(streamId, showAsContent, setBy)
+      val event = SetScreenshareShowAsContentEvtMsg(header, body)
+      bus.outGW.send(BbbCommonEnvCoreMsg(envelope, event))
+    }
+
+    val notPresenter = PermissionCheck.permissionFailed(
+      PermissionCheck.GUEST_LEVEL,
+      PermissionCheck.PRESENTER_LEVEL,
+      liveMeeting.users2x,
+      msg.header.userId
+    )
+
+    if (notPresenter) {
+      val reason = "No permission to toggle screenshare showAsContent."
+      PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
+    } else {
+      Screenshares.findByStream(liveMeeting.screenshares, msg.body.streamId).foreach { entry =>
+        if (msg.body.showAsContent) {
+          // Mutual exclusion: clear showAsContent on every other active stream first.
+          Screenshares.findAll(liveMeeting.screenshares)
+            .filter(s => s.stream != entry.stream && s.showAsContent)
+            .foreach { other =>
+              Screenshares.add(liveMeeting.screenshares, other.copy(showAsContent = false))
+              ScreenshareDAO.updateShowAsContent(meetingId, other.stream, false)
+              broadcastEvt(other.stream, false, msg.body.setBy)
+            }
+        }
+        Screenshares.add(liveMeeting.screenshares, entry.copy(showAsContent = msg.body.showAsContent))
+        ScreenshareDAO.updateShowAsContent(meetingId, entry.stream, msg.body.showAsContent)
+        broadcastEvt(entry.stream, msg.body.showAsContent, msg.body.setBy)
+      }
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -35,7 +35,9 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
         lockOnJoinConfigurable = msg.body.lockOnJoinConfigurable,
         hideViewersCursor = msg.body.hideViewersCursor,
         hideViewersAnnotation = msg.body.hideViewersAnnotation,
-        presenterPolicy = msg.body.presenterPolicy
+        presenterPolicy = msg.body.presenterPolicy,
+        disableMultiScreenshare = msg.body.disableMultiScreenshare,
+        hideViewersScreenshare = msg.body.hideViewersScreenshare
       )
 
       if (!MeetingStatus2x.permissionsEqual(liveMeeting.status, settings) || !MeetingStatus2x.permisionsInitialized(liveMeeting.status)) {
@@ -234,6 +236,45 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
           }
         }
 
+        if (oldPermissions.disableMultiScreenshare != settings.disableMultiScreenshare) {
+          if (settings.disableMultiScreenshare) {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.disableMultiScreenshare",
+              "Label to disable multi screenshare notification",
+              Map()
+            )
+            outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
+            LockSettingsUtil.enforceScreenshareLockSettingsForAllViewers(liveMeeting, outGW)
+          } else {
+            val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+              liveMeeting.props.meetingProp.intId,
+              "info",
+              "lock",
+              "app.userList.userOptions.enableMultiScreenshare",
+              "Label to enable multi screenshare notification",
+              Map()
+            )
+            outGW.send(notifyEvent)
+            NotificationDAO.insert(notifyEvent)
+          }
+        }
+
+        if (oldPermissions.hideViewersScreenshare != settings.hideViewersScreenshare) {
+          val (msgId, msgDesc) = if (settings.hideViewersScreenshare)
+            ("app.userList.userOptions.hideViewersScreenshare", "Label to hide viewers screenshare notification")
+          else
+            ("app.userList.userOptions.showViewersScreenshare", "Label to show viewers screenshare notification")
+          val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
+            liveMeeting.props.meetingProp.intId, "info", "lock", msgId, msgDesc, Map()
+          )
+          outGW.send(notifyEvent)
+          NotificationDAO.insert(notifyEvent)
+        }
+
         if (oldPermissions.presenterPolicy != settings.presenterPolicy) {
           val (messageId, messageDescription) = settings.presenterPolicy match {
             case "moderatorOnly" =>
@@ -277,7 +318,9 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
           hideViewersCursor = settings.hideViewersCursor,
           hideViewersAnnotation = settings.hideViewersAnnotation,
           presenterPolicy = settings.presenterPolicy,
-          msg.body.setBy
+          msg.body.setBy,
+          disableMultiScreenshare = settings.disableMultiScreenshare,
+          hideViewersScreenshare = settings.hideViewersScreenshare
         )
         val header = BbbClientMsgHeader(
           LockSettingsInMeetingChangedEvtMsg.NAME,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingLockSettingsDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingLockSettingsDAO.scala
@@ -17,7 +17,9 @@ case class MeetingLockSettingsDbModel(
     lockOnJoinConfigurable:  Boolean,
     hideViewersCursor:       Boolean,
     hideViewersAnnotation:   Boolean,
-    presenterPolicy:         String
+    presenterPolicy:         String,
+    disableMultiScreenshare: Boolean,
+    hideViewersScreenshare:  Boolean
 )
 
 class MeetingLockSettingsDbTableDef(tag: Tag) extends Table[MeetingLockSettingsDbModel](tag, "meeting_lockSettings") {
@@ -33,10 +35,10 @@ class MeetingLockSettingsDbTableDef(tag: Tag) extends Table[MeetingLockSettingsD
   val hideViewersCursor = column[Boolean]("hideViewersCursor")
   val hideViewersAnnotation = column[Boolean]("hideViewersAnnotation")
   val presenterPolicy = column[String]("presenterPolicy")
+  val disableMultiScreenshare = column[Boolean]("disableMultiScreenshare")
+  val hideViewersScreenshare = column[Boolean]("hideViewersScreenshare")
 
-  //  def fk_meetingId: ForeignKeyQuery[MeetingDbTableDef, MeetingDbModel] = foreignKey("fk_meetingId", meetingId, TableQuery[MeetingDbTableDef])(_.meetingId)
-
-  override def * : ProvenShape[MeetingLockSettingsDbModel] = (meetingId, disableCam, disableMic, disablePrivateChat, disablePublicChat, disableNotes, hideUserList, lockOnJoin, lockOnJoinConfigurable, hideViewersCursor, hideViewersAnnotation, presenterPolicy) <> (MeetingLockSettingsDbModel.tupled, MeetingLockSettingsDbModel.unapply)
+  override def * : ProvenShape[MeetingLockSettingsDbModel] = (meetingId, disableCam, disableMic, disablePrivateChat, disablePublicChat, disableNotes, hideUserList, lockOnJoin, lockOnJoinConfigurable, hideViewersCursor, hideViewersAnnotation, presenterPolicy, disableMultiScreenshare, hideViewersScreenshare) <> (MeetingLockSettingsDbModel.tupled, MeetingLockSettingsDbModel.unapply)
 }
 
 object MeetingLockSettingsDAO {
@@ -56,6 +58,8 @@ object MeetingLockSettingsDAO {
           hideViewersCursor = lockSettingsProps.hideViewersCursor,
           hideViewersAnnotation = lockSettingsProps.hideViewersAnnotation,
           presenterPolicy = lockSettingsProps.presenterPolicy,
+          disableMultiScreenshare = lockSettingsProps.disableMultiScreenshare,
+          hideViewersScreenshare = lockSettingsProps.hideViewersScreenshare,
         )
       )
     )
@@ -77,9 +81,10 @@ object MeetingLockSettingsDAO {
           hideViewersCursor = permissions.hideViewersCursor,
           hideViewersAnnotation = permissions.hideViewersAnnotation,
           presenterPolicy = permissions.presenterPolicy,
+          disableMultiScreenshare = permissions.disableMultiScreenshare,
+          hideViewersScreenshare = permissions.hideViewersScreenshare,
         ),
       )
     )
   }
-
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.core.db
 
 import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.apps.ScreenshareModel.{ getContentType, getHasAudio, getRTMPBroadcastingUrl, getScreenshareConf, getScreenshareVideoHeight, getScreenshareVideoWidth, getVoiceConf }
+import org.bigbluebutton.core.models.ScreenshareEntry
 import org.bigbluebutton.core.util.RandomStringGenerator
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.ProvenShape
@@ -40,6 +41,28 @@ class ScreenshareDbTableDef(tag: Tag) extends Table[ScreenshareDbModel](tag, "sc
 }
 
 object ScreenshareDAO {
+  def insertEntry(meetingId: String, entry: ScreenshareEntry) = {
+    DatabaseConnection.enqueue(
+      TableQuery[ScreenshareDbTableDef].forceInsert(
+        ScreenshareDbModel(
+          screenshareId = entry.screenshareId,
+          meetingId = meetingId,
+          voiceConf = entry.voiceConf,
+          screenshareConf = entry.screenshareConf,
+          contentType = entry.contentType,
+          stream = entry.stream,
+          vidWidth = entry.vidWidth,
+          vidHeight = entry.vidHeight,
+          hasAudio = entry.hasAudio,
+          userId = entry.userId,
+          showAsContent = entry.showAsContent,
+          startedAt = new java.sql.Timestamp(entry.startedAt),
+          stoppedAt = None
+        )
+      )
+    )
+  }
+
   def insert(meetingId: String, userId: String, stream: String, screenshareModel: ScreenshareModel, showAsContent: Boolean) = {
     DatabaseConnection.enqueue(
       TableQuery[ScreenshareDbTableDef].forceInsert(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
@@ -40,7 +40,7 @@ class ScreenshareDbTableDef(tag: Tag) extends Table[ScreenshareDbModel](tag, "sc
 }
 
 object ScreenshareDAO {
-  def insert(meetingId: String, userId: String, screenshareModel: ScreenshareModel, showAsContent: Boolean) = {
+  def insert(meetingId: String, userId: String, stream: String, screenshareModel: ScreenshareModel, showAsContent: Boolean) = {
     DatabaseConnection.enqueue(
       TableQuery[ScreenshareDbTableDef].forceInsert(
         ScreenshareDbModel(
@@ -49,7 +49,7 @@ object ScreenshareDAO {
           voiceConf = getVoiceConf(screenshareModel),
           screenshareConf = getScreenshareConf(screenshareModel),
           contentType = getContentType(screenshareModel),
-          stream = getRTMPBroadcastingUrl(screenshareModel),
+          stream = stream,
           vidWidth = getScreenshareVideoWidth(screenshareModel),
           vidHeight = getScreenshareVideoHeight(screenshareModel),
           hasAudio = getHasAudio(screenshareModel),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/ScreenshareDAO.scala
@@ -16,6 +16,8 @@ case class ScreenshareDbModel(
     vidWidth:        Int,
     vidHeight:       Int,
     hasAudio:        Boolean,
+    userId:          String,
+    showAsContent:   Boolean,
     startedAt:       java.sql.Timestamp         = new java.sql.Timestamp(System.currentTimeMillis()),
     stoppedAt:       Option[java.sql.Timestamp]
 )
@@ -30,13 +32,15 @@ class ScreenshareDbTableDef(tag: Tag) extends Table[ScreenshareDbModel](tag, "sc
   val vidWidth = column[Int]("vidWidth")
   val vidHeight = column[Int]("vidHeight")
   val hasAudio = column[Boolean]("hasAudio")
+  val userId = column[String]("userId")
+  val showAsContent = column[Boolean]("showAsContent")
   val startedAt = column[java.sql.Timestamp]("startedAt")
   val stoppedAt = column[Option[java.sql.Timestamp]]("stoppedAt")
-  override def * : ProvenShape[ScreenshareDbModel] = (screenshareId, meetingId, voiceConf, screenshareConf, contentType, stream, vidWidth, vidHeight, hasAudio, startedAt, stoppedAt) <> (ScreenshareDbModel.tupled, ScreenshareDbModel.unapply)
+  override def * : ProvenShape[ScreenshareDbModel] = (screenshareId, meetingId, voiceConf, screenshareConf, contentType, stream, vidWidth, vidHeight, hasAudio, userId, showAsContent, startedAt, stoppedAt) <> (ScreenshareDbModel.tupled, ScreenshareDbModel.unapply)
 }
 
 object ScreenshareDAO {
-  def insert(meetingId: String, screenshareModel: ScreenshareModel) = {
+  def insert(meetingId: String, userId: String, screenshareModel: ScreenshareModel, showAsContent: Boolean) = {
     DatabaseConnection.enqueue(
       TableQuery[ScreenshareDbTableDef].forceInsert(
         ScreenshareDbModel(
@@ -49,6 +53,8 @@ object ScreenshareDAO {
           vidWidth = getScreenshareVideoWidth(screenshareModel),
           vidHeight = getScreenshareVideoHeight(screenshareModel),
           hasAudio = getHasAudio(screenshareModel),
+          userId = userId,
+          showAsContent = showAsContent,
           startedAt = new java.sql.Timestamp(System.currentTimeMillis()),
           stoppedAt = None
         )
@@ -67,4 +73,14 @@ object ScreenshareDAO {
     )
   }
 
+  def updateShowAsContent(meetingId: String, stream: String, showAsContent: Boolean) = {
+    DatabaseConnection.enqueue(
+      TableQuery[ScreenshareDbTableDef]
+        .filter(_.meetingId === meetingId)
+        .filter(_.stream === stream)
+        .filter(_.stoppedAt.isEmpty)
+        .map(_.showAsContent)
+        .update(showAsContent)
+    )
+  }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Screenshares.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Screenshares.scala
@@ -1,0 +1,55 @@
+package org.bigbluebutton.core.models
+
+import scala.collection.mutable
+
+case class ScreenshareEntry(
+    screenshareId:   String,
+    userId:          String,
+    stream:          String,
+    voiceConf:       String,
+    screenshareConf: String,
+    vidWidth:        Int,
+    vidHeight:       Int,
+    hasAudio:        Boolean,
+    contentType:     String,
+    showAsContent:   Boolean,
+    startedAt:       Long
+)
+
+object Screenshares {
+  def add(ss: Screenshares, entry: ScreenshareEntry): Unit = {
+    ss.entries(entry.stream) = entry
+  }
+
+  def remove(ss: Screenshares, stream: String): Option[ScreenshareEntry] = {
+    ss.entries.remove(stream)
+  }
+
+  def findByStream(ss: Screenshares, stream: String): Option[ScreenshareEntry] = {
+    ss.entries.get(stream)
+  }
+
+  def findByUser(ss: Screenshares, userId: String): Option[ScreenshareEntry] = {
+    ss.entries.values.find(_.userId == userId)
+  }
+
+  def findAll(ss: Screenshares): Seq[ScreenshareEntry] = {
+    ss.entries.values.toSeq
+  }
+
+  def hasStream(ss: Screenshares, stream: String): Boolean = {
+    ss.entries.contains(stream)
+  }
+
+  def hasAnyActiveScreenshare(ss: Screenshares): Boolean = {
+    ss.entries.nonEmpty
+  }
+
+  def userScreenshareCount(ss: Screenshares, userId: String): Int = {
+    ss.entries.values.count(_.userId == userId)
+  }
+}
+
+class Screenshares {
+  private[models] val entries: mutable.Map[String, ScreenshareEntry] = mutable.Map()
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -282,6 +282,8 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[BroadcastPushLayoutMsg](envelope, jsonNode)
       case SetScreenshareAsContentReqMsg.NAME =>
         routeGenericMsg[SetScreenshareAsContentReqMsg](envelope, jsonNode)
+      case SetScreenshareShowAsContentReqMsg.NAME =>
+        routeGenericMsg[SetScreenshareShowAsContentReqMsg](envelope, jsonNode)
 
       case UserLeaveReqMsg.NAME =>
         routeGenericMsg[UserLeaveReqMsg](envelope, jsonNode)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -11,6 +11,7 @@ class LiveMeeting(
     val props:               DefaultProps,
     val status:              MeetingStatus2x,
     val screenshareModel:    ScreenshareModel,
+    val screenshares:        Screenshares,
     val audioCaptions:       AudioCaptions,
     val timerModel:          TimerModel,
     val chatModel:           ChatModel,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -329,7 +329,9 @@ class MeetingActor(
       lockOnJoinConfigurable = lockSettingsProp.lockOnJoinConfigurable,
       hideViewersCursor = lockSettingsProp.hideViewersCursor,
       hideViewersAnnotation = lockSettingsProp.hideViewersAnnotation,
-      presenterPolicy = lockSettingsProp.presenterPolicy
+      presenterPolicy = lockSettingsProp.presenterPolicy,
+      disableMultiScreenshare = lockSettingsProp.disableMultiScreenshare,
+      hideViewersScreenshare = lockSettingsProp.hideViewersScreenshare
     )
 
     MeetingStatus2x.initializePermissions(liveMeeting.status)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -735,8 +735,8 @@ class MeetingActor(
       case m: SetScreenshareShowAsContentReqMsg =>
         screenshareApp2x.handle(m, liveMeeting, msgBus)
         updateUserLastActivity(m.header.userId)
-      case m: GetScreenBroadcastPermissionReqMsg             => handleGetScreenBroadcastPermissionReqMsg(m)
-      case m: GetScreenSubscribePermissionReqMsg             => handleGetScreenSubscribePermissionReqMsg(m)
+      case m: GetScreenBroadcastPermissionReqMsg => handleGetScreenBroadcastPermissionReqMsg(m)
+      case m: GetScreenSubscribePermissionReqMsg => handleGetScreenSubscribePermissionReqMsg(m)
 
       // AudioCaptions
       case m: UpdateTranscriptPubMsg =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -732,6 +732,9 @@ class MeetingActor(
       case m: ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg => screenshareApp2x.handle(m, liveMeeting, msgBus)
       case m: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg => screenshareApp2x.handle(m, liveMeeting, msgBus)
       case m: GetScreenshareStatusReqMsg                     => screenshareApp2x.handle(m, liveMeeting, msgBus)
+      case m: SetScreenshareShowAsContentReqMsg =>
+        screenshareApp2x.handle(m, liveMeeting, msgBus)
+        updateUserLastActivity(m.header.userId)
       case m: GetScreenBroadcastPermissionReqMsg             => handleGetScreenBroadcastPermissionReqMsg(m)
       case m: GetScreenSubscribePermissionReqMsg             => handleGetScreenSubscribePermissionReqMsg(m)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
@@ -31,6 +31,7 @@ class RunningMeeting(val props: DefaultProps, outGW: OutMessageGateway,
   private val polls2x = new Polls
   private val guestsWaiting = new GuestsWaiting
   private val deskshareModel = new ScreenshareModel
+  private val screenshares = new Screenshares
   private val audioCaptions = new AudioCaptions
   private val timerModel = new TimerModel
   private val clientSettingsBeforePluginValidation: Map[String, Object] = ClientSettings.getClientSettingsWithOverride(props.overrideClientSettings)
@@ -42,7 +43,7 @@ class RunningMeeting(val props: DefaultProps, outGW: OutMessageGateway,
 
   // We extract the meeting handlers into this class so it is
   // easy to test.
-  private val liveMeeting = new LiveMeeting(props, meetingStatux2x, deskshareModel, audioCaptions, timerModel,
+  private val liveMeeting = new LiveMeeting(props, meetingStatux2x, deskshareModel, screenshares, audioCaptions, timerModel,
     chatModel, externalVideoModel, layouts, pads, registeredUsers, polls2x, wbModel, presModel,
     webcams, voiceUsers, users2x, guestsWaiting, clientSettings, plugins)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -79,6 +79,7 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
       case m: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg => logMessage(msg)
       case m: ScreenshareRtmpBroadcastStartedEvtMsg          => logMessage(msg)
       case m: ScreenshareRtmpBroadcastStoppedEvtMsg          => logMessage(msg)
+      case m: SetScreenshareShowAsContentReqMsg              => logMessage(msg)
       case m: StartRecordingVoiceConfSysMsg                  => logMessage(msg)
       case m: StopRecordingVoiceConfSysMsg                   => logMessage(msg)
       case m: RecordAndClearPreviousMarkersCmdMsg            => logMessage(msg)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/MeetingStatus2x.scala
@@ -4,17 +4,19 @@ import java.util.concurrent.TimeUnit
 import org.bigbluebutton.core.util.TimeUtil
 
 case class Permissions(
-    disableCam:             Boolean = false,
-    disableMic:             Boolean = false,
-    disablePrivChat:        Boolean = false,
-    disablePubChat:         Boolean = false,
-    disableNotes:           Boolean = false,
-    hideUserList:           Boolean = false,
-    lockOnJoin:             Boolean = true,
-    lockOnJoinConfigurable: Boolean = false,
-    hideViewersCursor:      Boolean = false,
-    hideViewersAnnotation:  Boolean = false,
-    presenterPolicy:        String  = "requireApproval"
+    disableCam:              Boolean = false,
+    disableMic:              Boolean = false,
+    disablePrivChat:         Boolean = false,
+    disablePubChat:          Boolean = false,
+    disableNotes:            Boolean = false,
+    hideUserList:            Boolean = false,
+    lockOnJoin:              Boolean = true,
+    lockOnJoinConfigurable:  Boolean = false,
+    hideViewersCursor:       Boolean = false,
+    hideViewersAnnotation:   Boolean = false,
+    presenterPolicy:         String  = "requireApproval",
+    disableMultiScreenshare: Boolean = false,
+    hideViewersScreenshare:  Boolean = false
 )
 
 case class MeetingExtensionProp(maxExtensions: Int = 2, numExtensions: Int = 0, extendByMinutes: Int = 20,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -1,5 +1,6 @@
 package org.bigbluebutton.common2.domain
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.util
 
 case class DurationProps(duration: Int, createdTime: Long, createdDate: String,
@@ -74,9 +75,9 @@ case class LockSettingsProps(
     lockOnJoinConfigurable:  Boolean,
     hideViewersCursor:       Boolean,
     hideViewersAnnotation:   Boolean,
-    presenterPolicy:         String,
-    disableMultiScreenshare: Boolean = false,
-    hideViewersScreenshare:  Boolean = false
+    presenterPolicy:                               String,
+    @JsonProperty(required = false) disableMultiScreenshare: Boolean = false,
+    @JsonProperty(required = false) hideViewersScreenshare:  Boolean = false
 )
 
 case class SystemProps(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -74,7 +74,9 @@ case class LockSettingsProps(
     lockOnJoinConfigurable:  Boolean,
     hideViewersCursor:       Boolean,
     hideViewersAnnotation:   Boolean,
-    presenterPolicy:         String
+    presenterPolicy:         String,
+    disableMultiScreenshare: Boolean = false,
+    hideViewersScreenshare:  Boolean = false
 )
 
 case class SystemProps(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/UsersMsgs.scala
@@ -377,7 +377,8 @@ case class ChangeLockSettingsInMeetingCmdMsg(
 case class ChangeLockSettingsInMeetingCmdMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                                  disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockOnJoin: Boolean,
                                                  lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, hideViewersAnnotation: Boolean,
-                                                 presenterPolicy: String, setBy: String)
+                                                 presenterPolicy: String, setBy: String,
+                                                 disableMultiScreenshare: Boolean = false, hideViewersScreenshare: Boolean = false)
 
 object LockSettingsInMeetingChangedEvtMsg { val NAME = "LockSettingsInMeetingChangedEvtMsg" }
 case class LockSettingsInMeetingChangedEvtMsg(
@@ -387,7 +388,8 @@ case class LockSettingsInMeetingChangedEvtMsg(
 case class LockSettingsInMeetingChangedEvtMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                                   disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockOnJoin: Boolean,
                                                   lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, hideViewersAnnotation: Boolean,
-                                                  presenterPolicy: String, setBy: String)
+                                                  presenterPolicy: String, setBy: String,
+                                                  disableMultiScreenshare: Boolean = false, hideViewersScreenshare: Boolean = false)
 
 /**
  * Response to the query for lock settings.
@@ -397,7 +399,8 @@ case class GetLockSettingsRespMsg(header: BbbClientMsgHeader, body: GetLockSetti
 case class GetLockSettingsRespMsgBody(disableCam: Boolean, disableMic: Boolean, disablePrivChat: Boolean,
                                       disablePubChat: Boolean, disableNotes: Boolean, hideUserList: Boolean, lockOnJoin: Boolean,
                                       lockOnJoinConfigurable: Boolean, hideViewersCursor: Boolean, hideViewersAnnotation: Boolean,
-                                      presenterPolicy: String)
+                                      presenterPolicy:         String,
+                                      disableMultiScreenshare: Boolean = false, hideViewersScreenshare: Boolean = false)
 
 object LockSettingsNotInitializedRespMsg { val NAME = "LockSettingsNotInitializedRespMsg" }
 case class LockSettingsNotInitializedRespMsg(header: BbbClientMsgHeader, body: LockSettingsNotInitializedRespMsgBody) extends BbbCoreMsg

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/VoiceConfMsgs.scala
@@ -134,6 +134,20 @@ case class ScreenBroadcastStopSysMsgBody(
 )
 
 /**
+ * Sent from client to toggle which screenshare stream occupies the content area.
+ */
+object SetScreenshareShowAsContentReqMsg { val NAME = "SetScreenshareShowAsContentReqMsg" }
+case class SetScreenshareShowAsContentReqMsg(header: BbbClientMsgHeader, body: SetScreenshareShowAsContentReqMsgBody) extends StandardMsg
+case class SetScreenshareShowAsContentReqMsgBody(streamId: String, showAsContent: Boolean, setBy: String)
+
+/**
+ * Broadcast to all clients that a screenshare stream's showAsContent flag changed.
+ */
+object SetScreenshareShowAsContentEvtMsg { val NAME = "SetScreenshareShowAsContentEvtMsg" }
+case class SetScreenshareShowAsContentEvtMsg(header: BbbClientMsgHeader, body: SetScreenshareShowAsContentEvtMsgBody) extends BbbCoreMsg
+case class SetScreenshareShowAsContentEvtMsgBody(streamId: String, showAsContent: Boolean, setBy: String)
+
+/**
  * Sent to FS to eject all users from the voice conference.
  */
 object EjectAllFromVoiceConfMsg { val NAME = "EjectAllFromVoiceConfMsg" }

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/util/JsonUtil.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/util/JsonUtil.scala
@@ -13,7 +13,7 @@ object JsonUtil {
   val mapper = new ObjectMapper() with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
   mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-  mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true)
+  mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
 
   def toJson(value: Map[Symbol, Any]): String = {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -104,6 +104,8 @@ public class ApiParams {
     public static final String LOCK_SETTINGS_HIDE_VIEWERS_CURSOR = "lockSettingsHideViewersCursor";
     public static final String LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION = "lockSettingsHideViewersAnnotation";
     public static final String LOCK_SETTINGS_PRESENTER_POLICY = "lockSettingsPresenterPolicy";
+    public static final String LOCK_SETTINGS_DISABLE_MULTI_SCREENSHARE = "lockSettingsDisableMultiScreenshare";
+    public static final String LOCK_SETTINGS_HIDE_VIEWERS_SCREENSHARE = "lockSettingsHideViewersScreenshare";
 
     // New param passed on create call to callback when meeting ends.
     // This is a duplicate of the endCallbackUrl meta param as we want this

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -1446,7 +1446,9 @@ public class MeetingService implements MessageListener {
                 msg.lockOnJoinConfigurable,
                 msg.hideViewersCursor,
                 msg.hideViewersAnnotation,
-                msg.presenterPolicy)
+                msg.presenterPolicy,
+                msg.disableMultiScreenshare,
+                msg.hideViewersScreenshare)
       );
     }
   }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -427,6 +427,18 @@ public class ParamsProcessorUtil {
                 lockSettingsPresenterPolicy = lockSettingsPresenterPolicyParam;
 			}
 
+            Boolean lockSettingsDisableMultiScreenshare = false;
+            String lockSettingsDisableMultiScreenshareParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_MULTI_SCREENSHARE);
+            if (!StringUtils.isEmpty(lockSettingsDisableMultiScreenshareParam)) {
+                lockSettingsDisableMultiScreenshare = Boolean.parseBoolean(lockSettingsDisableMultiScreenshareParam);
+            }
+
+            Boolean lockSettingsHideViewersScreenshare = false;
+            String lockSettingsHideViewersScreenshareParam = params.get(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_SCREENSHARE);
+            if (!StringUtils.isEmpty(lockSettingsHideViewersScreenshareParam)) {
+                lockSettingsHideViewersScreenshare = Boolean.parseBoolean(lockSettingsHideViewersScreenshareParam);
+            }
+
 			return new LockSettingsParams(lockSettingsDisableCam,
 							lockSettingsDisableMic,
 							lockSettingsDisablePrivateChat,
@@ -437,7 +449,9 @@ public class ParamsProcessorUtil {
 							lockSettingsLockOnJoinConfigurable,
                             lockSettingsHideViewersCursor,
                             lockSettingsHideViewersAnnotation,
-                            lockSettingsPresenterPolicy);
+                            lockSettingsPresenterPolicy,
+                            lockSettingsDisableMultiScreenshare,
+                            lockSettingsHideViewersScreenshare);
 		}
 
     private ArrayList<Group> processGroupsParams(Map<String, String> params) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/LockSettingsParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/LockSettingsParams.java
@@ -12,6 +12,8 @@ public class LockSettingsParams {
 	public final Boolean hideViewersCursor;
 	public final Boolean hideViewersAnnotation;
 	public final String presenterPolicy;
+	public final Boolean disableMultiScreenshare;
+	public final Boolean hideViewersScreenshare;
 
 	public LockSettingsParams(Boolean disableCam,
 				Boolean disableMic,
@@ -23,7 +25,9 @@ public class LockSettingsParams {
 				Boolean lockOnJoinConfigurable,
 				Boolean hideViewersCursor,
 				Boolean hideViewersAnnotation,
-				String presenterPolicy) {
+				String presenterPolicy,
+				Boolean disableMultiScreenshare,
+				Boolean hideViewersScreenshare) {
 		this.disableCam = disableCam;
 		this.disableMic = disableMic;
 		this.disablePrivateChat = disablePrivateChat;
@@ -35,5 +39,7 @@ public class LockSettingsParams {
 		this.hideViewersCursor = hideViewersCursor;
 		this.hideViewersAnnotation = hideViewersAnnotation;
 		this.presenterPolicy = presenterPolicy;
+		this.disableMultiScreenshare = disableMultiScreenshare;
+		this.hideViewersScreenshare = hideViewersScreenshare;
 	}
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/LockSettingsChanged.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/LockSettingsChanged.java
@@ -14,6 +14,8 @@ public class LockSettingsChanged implements IMessage {
     public final Boolean hideViewersCursor;
     public final Boolean hideViewersAnnotation;
     public final String presenterPolicy;
+    public final Boolean disableMultiScreenshare;
+    public final Boolean hideViewersScreenshare;
 
     public LockSettingsChanged(String meetingId,
                                Boolean disableCam,
@@ -26,7 +28,9 @@ public class LockSettingsChanged implements IMessage {
                                Boolean lockOnJoinConfigurable,
                                Boolean hideViewersCursor,
                                Boolean hideViewersAnnotation,
-                               String presenterPolicy) {
+                               String presenterPolicy,
+                               Boolean disableMultiScreenshare,
+                               Boolean hideViewersScreenshare) {
         this.meetingId = meetingId;
         this.disableCam = disableCam;
         this.disableMic = disableMic;
@@ -39,5 +43,7 @@ public class LockSettingsChanged implements IMessage {
         this.hideViewersCursor = hideViewersCursor;
         this.hideViewersAnnotation = hideViewersAnnotation;
         this.presenterPolicy = presenterPolicy;
+        this.disableMultiScreenshare = disableMultiScreenshare;
+        this.hideViewersScreenshare = hideViewersScreenshare;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -253,7 +253,9 @@ class BbbWebApiGWApp(
       lockOnJoinConfigurable = lockSettingsParams.lockOnJoinConfigurable.booleanValue(),
       hideViewersCursor = lockSettingsParams.hideViewersCursor.booleanValue(),
       hideViewersAnnotation = lockSettingsParams.hideViewersAnnotation.booleanValue(),
-      presenterPolicy = lockSettingsParams.presenterPolicy
+      presenterPolicy = lockSettingsParams.presenterPolicy,
+      disableMultiScreenshare = lockSettingsParams.disableMultiScreenshare.booleanValue(),
+      hideViewersScreenshare = lockSettingsParams.hideViewersScreenshare.booleanValue()
     )
 
     val systemProps = SystemProps(

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -69,6 +69,8 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
                                             msg.body.hideViewersCursor,
                                             msg.body.hideViewersAnnotation,
                                             msg.body.presenterPolicy,
+                                            msg.body.disableMultiScreenshare,
+                                            msg.body.hideViewersScreenshare,
     ))
   }
 

--- a/bbb-graphql-actions/src/actions/meetingLockSettingsSetProps.ts
+++ b/bbb-graphql-actions/src/actions/meetingLockSettingsSetProps.ts
@@ -16,6 +16,8 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'hideViewersCursor', type: 'boolean', required: true},
         {name: 'hideViewersAnnotation', type: 'boolean', required: true},
         {name: 'presenterPolicy', type: 'string', required: true},
+        {name: 'disableMultiScreenshare', type: 'boolean', required: false},
+        {name: 'hideViewersScreenshare', type: 'boolean', required: false},
       ]
   )
 
@@ -50,6 +52,8 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     hideViewersCursor: input.hideViewersCursor,
     hideViewersAnnotation: input.hideViewersAnnotation,
     presenterPolicy: input.presenterPolicy,
+    disableMultiScreenshare: input.disableMultiScreenshare ?? false,
+    hideViewersScreenshare: input.hideViewersScreenshare ?? false,
   };
 
   return { eventName, routing, header, body };

--- a/bbb-graphql-actions/src/actions/screenshareSetShowAsContent.ts
+++ b/bbb-graphql-actions/src/actions/screenshareSetShowAsContent.ts
@@ -1,0 +1,33 @@
+import { RedisMessage } from '../types';
+import { throwErrorIfInvalidInput, throwErrorIfNotPresenter } from '../imports/validation';
+
+export default function buildRedisMessage(
+  sessionVariables: Record<string, unknown>,
+  input: Record<string, unknown>,
+): RedisMessage {
+  throwErrorIfNotPresenter(sessionVariables);
+  throwErrorIfInvalidInput(input, [
+    { name: 'streamId', type: 'string', required: true },
+    { name: 'showAsContent', type: 'boolean', required: true },
+  ]);
+
+  const eventName = 'SetScreenshareShowAsContentReqMsg';
+  const routing = {
+    meetingId: sessionVariables['x-hasura-meetingid'] as String,
+    userId: sessionVariables['x-hasura-userid'] as String,
+  };
+
+  const header = {
+    name: eventName,
+    meetingId: routing.meetingId,
+    userId: routing.userId,
+  };
+
+  const body = {
+    setBy: routing.userId,
+    streamId: input.streamId,
+    showAsContent: input.showAsContent,
+  };
+
+  return { eventName, routing, header, body };
+}

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2479,9 +2479,9 @@ select "meeting"."meetingId",
         exists (
             select 1
             from "v_screenshare"
-            join "v_layout" on "v_layout"."meetingId" = "v_screenshare"."meetingId" and "v_layout"."screenshareAsContent" is true
             where "v_screenshare"."meetingId" = "meeting"."meetingId"
             and "contentType" = 'screenshare'
+            and "showAsContent" is true
         ) as "hasScreenshareAsContent",
         exists (
             select 1

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -195,7 +195,9 @@ create unlogged table "meeting_lockSettings" (
     "lockOnJoinConfigurable" boolean,
     "hideViewersCursor"      boolean,
     "hideViewersAnnotation"  boolean,
-    "presenterPolicy"        varchar(50) DEFAULT 'requireApproval' NOT NULL
+    "presenterPolicy"        varchar(50) DEFAULT 'requireApproval' NOT NULL,
+    "disableMultiScreenshare" boolean DEFAULT FALSE NOT NULL,
+    "hideViewersScreenshare"  boolean DEFAULT FALSE NOT NULL
 );
 
 CREATE OR REPLACE VIEW "v_meeting_lockSettings" AS
@@ -212,6 +214,8 @@ SELECT
 	mls."presenterPolicy",
 	mls."lockOnJoin",
     mls."lockOnJoinConfigurable",
+	mls."disableMultiScreenshare",
+	mls."hideViewersScreenshare",
 	mup."webcamsOnlyForModerator",
 	CASE WHEN
 	mls."disableCam" IS TRUE THEN TRUE
@@ -223,6 +227,8 @@ SELECT
 	WHEN mls."hideViewersCursor"  IS TRUE THEN TRUE
 	WHEN mls."hideViewersAnnotation"  IS TRUE THEN TRUE
 	WHEN mls."presenterPolicy" = 'moderatorOnly' THEN TRUE
+	WHEN mls."disableMultiScreenshare" IS TRUE THEN TRUE
+	WHEN mls."hideViewersScreenshare" IS TRUE THEN TRUE
 	WHEN mup."webcamsOnlyForModerator"  IS TRUE THEN TRUE
 	ELSE FALSE
 	END "hasActiveLockSetting"
@@ -1849,9 +1855,10 @@ create unlogged table "screenshare"(
 "vidWidth" integer,
 "vidHeight" integer,
 "hasAudio" boolean,
+"userId" varchar(50) DEFAULT '' NOT NULL,
+"showAsContent" boolean DEFAULT FALSE NOT NULL,
 "startedAt" timestamp with time zone,
 "stoppedAt" timestamp with time zone
-
 );
 create index "screenshare_meetingId" on "screenshare"("meetingId");
 create index "screenshare_meetingId_current" on "screenshare"("meetingId") WHERE "stoppedAt" IS NULL;

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -112,6 +112,13 @@ type Mutation {
 }
 
 type Mutation {
+  screenshareSetShowAsContent(
+    streamId: String!
+    showAsContent: Boolean!
+  ): Boolean
+}
+
+type Mutation {
   captionAddLocale(
     locale: String!
   ): Boolean

--- a/bbb-graphql-server/metadata/actions.yaml
+++ b/bbb-graphql-server/metadata/actions.yaml
@@ -112,6 +112,12 @@ actions:
       handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
     permissions:
       - role: bbb_client
+  - name: screenshareSetShowAsContent
+    definition:
+      kind: synchronous
+      handler: '{{HASURA_BBB_GRAPHQL_ACTIONS_ADAPTER_URL}}'
+    permissions:
+      - role: bbb_client
   - name: captionAddLocale
     definition:
       kind: synchronous

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_lockSettings.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting_lockSettings.yaml
@@ -23,6 +23,8 @@ select_permissions:
         - lockOnJoin
         - lockOnJoinConfigurable
         - webcamsOnlyForModerator
+        - disableMultiScreenshare
+        - hideViewersScreenshare
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_screenshare.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_screenshare.yaml
@@ -20,6 +20,8 @@ select_permissions:
         - vidHeight
         - vidWidth
         - voiceConf
+        - userId
+        - showAsContent
       filter:
         meetingId:
           _eq: X-Hasura-MeetingId

--- a/bigbluebutton-html5/.eslintrc.js
+++ b/bigbluebutton-html5/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
   },
   globals: {
     browser: 'writable',
+    globalThis: 'readonly',
   },
   overrides: [
     {

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -278,7 +278,7 @@ export default class KurentoScreenshareBridge {
   _handleViewerStartForStream(streamId, mediaElementId, broker) {
     const mediaElement = document.getElementById(mediaElementId);
 
-    if (mediaElement && broker && broker.webRtcPeer) {
+    if (mediaElement && broker?.webRtcPeer) {
       const stream = broker.webRtcPeer.getRemoteStream();
 
       if (this.hasAudio && this.outputDeviceId && typeof this.outputDeviceId === 'string') {
@@ -401,7 +401,7 @@ export default class KurentoScreenshareBridge {
     this.broker = broker;
 
     broker.onstart = this._handleViewerStartForStream.bind(this, streamId, mediaElementId, broker);
-    broker.onerror = this.handleBrokerFailure.bind(this);
+    broker.onerror = (error) => { this.handleBrokerFailure(error); };
     if (!this.reconnecting) {
       broker.onended = this.handleEnded.bind(this);
     }
@@ -486,7 +486,7 @@ export default class KurentoScreenshareBridge {
       };
 
       const publisherSessionBridge = Auth.userID
-        ? `${BridgeService.getConferenceBridge()}:${Auth.userID}`
+        ? `${BridgeService.getConferenceBridge()}:${String(Auth.userID)}`
         : BridgeService.getConferenceBridge();
       this.broker = new ScreenshareBroker(
         Auth.authenticateURL(SFU_URL),
@@ -533,7 +533,9 @@ export default class KurentoScreenshareBridge {
     this._viewerBrokers.forEach(({ broker, mediaElementId }) => {
       try {
         broker.stop();
-      } catch (_) { /* ignore */ }
+      } catch (e) {
+        logger.warn({ logCode: 'screenshare_stop_broker_ignored' }, `Ignoring error stopping viewer broker: ${e?.message}`);
+      }
       const el = document.getElementById(mediaElementId);
       if (el && typeof el.pause === 'function') {
         el.pause();

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/kurento.js
@@ -24,6 +24,7 @@ const ERROR_MAP = {
   1310: SCREENSHARING_ERRORS.ENDED_WHILE_STARTING,
 };
 
+/* eslint-disable no-param-reassign */
 const mapErrorCode = (error) => {
   const { errorCode } = error;
   const mappedError = ERROR_MAP[errorCode];
@@ -34,10 +35,12 @@ const mapErrorCode = (error) => {
   error.message = mappedError.errorMessage;
 
   return error;
-}
+};
+/* eslint-enable no-param-reassign */
 
 export default class KurentoScreenshareBridge {
   constructor() {
+    /* eslint-disable no-unused-expressions */
     this.role;
     this.broker;
     this._gdmStream;
@@ -46,9 +49,12 @@ export default class KurentoScreenshareBridge {
     this.reconnecting = false;
     this.reconnectionTimeout;
     this._restartIntervalMs = null;
+    /* eslint-enable no-unused-expressions */
     this.startedOnce = false;
     this.outputDeviceId = null;
     this.bridgeName = BRIDGE_NAME;
+    // Map<streamId, { broker, mediaElementId }> for concurrent viewer subscriptions
+    this._viewerBrokers = new Map();
   }
 
   get restartIntervalMs() {
@@ -183,12 +189,13 @@ export default class KurentoScreenshareBridge {
           errorMessage: error.errorMessage,
           reconnecting: this.reconnecting,
           role: this.role,
-          bridge: BRIDGE_NAME
+          bridge: BRIDGE_NAME,
         },
       }, 'Screensharing reconnect failed');
     });
   }
 
+  // eslint-disable-next-line consistent-return
   handleConnectionTimeoutExpiry() {
     this.reconnecting = true;
 
@@ -212,7 +219,7 @@ export default class KurentoScreenshareBridge {
     }
   }
 
-  maxConnectionAttemptsReached () {
+  maxConnectionAttemptsReached() {
     return this.connectionAttempts > BridgeService.MAX_CONN_ATTEMPTS();
   }
 
@@ -230,7 +237,7 @@ export default class KurentoScreenshareBridge {
     }
   }
 
-  clearReconnectionTimeout () {
+  clearReconnectionTimeout() {
     this.reconnecting = false;
     this.restartIntervalMs = BridgeService.BASE_MEDIA_TIMEOUT();
 
@@ -240,8 +247,14 @@ export default class KurentoScreenshareBridge {
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  _getPrimaryMediaElement() {
+    return document.getElementById(SCREENSHARE_VIDEO_TAG)
+      || document.querySelector(`video[id^="${SCREENSHARE_VIDEO_TAG}"]`);
+  }
+
   setVolume(volume) {
-    const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG);
+    const mediaElement = this._getPrimaryMediaElement();
 
     if (mediaElement) {
       if (typeof volume === 'number' && volume >= 0 && volume <= 1) {
@@ -255,24 +268,24 @@ export default class KurentoScreenshareBridge {
   }
 
   getVolume() {
-    const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG);
+    const mediaElement = this._getPrimaryMediaElement();
 
     if (mediaElement) return mediaElement.volume;
 
     return DEFAULT_VOLUME;
   }
 
-  handleViewerStart() {
-    const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG);
+  _handleViewerStartForStream(streamId, mediaElementId, broker) {
+    const mediaElement = document.getElementById(mediaElementId);
 
-    if (mediaElement && this.broker && this.broker.webRtcPeer) {
-      const stream = this.broker.webRtcPeer.getRemoteStream();
+    if (mediaElement && broker && broker.webRtcPeer) {
+      const stream = broker.webRtcPeer.getRemoteStream();
 
       if (this.hasAudio && this.outputDeviceId && typeof this.outputDeviceId === 'string') {
         setOutputDeviceId(this.outputDeviceId);
       }
 
-      BridgeService.screenshareLoadAndPlayMediaStream(stream, mediaElement, !this.broker.hasAudio);
+      BridgeService.screenshareLoadAndPlayMediaStream(stream, mediaElement, !broker.hasAudio);
     }
 
     this.startedOnce = true;
@@ -282,12 +295,20 @@ export default class KurentoScreenshareBridge {
       logger.info({
         logCode: 'screenshare_viewer_start_success',
         extraInfo: {
-          role: this.broker?.role || this.role,
+          role: broker?.role || this.role,
           bridge: BRIDGE_NAME,
+          streamId,
+          mediaElementId,
           stats,
         },
-      }, 'Screenshare presenter started succesfully');
+      }, 'Screenshare viewer started successfully');
     });
+  }
+
+  handleViewerStart() {
+    const mediaElementId = this._viewerBrokers.get(this.streamId)?.mediaElementId
+      || SCREENSHARE_VIDEO_TAG;
+    this._handleViewerStartForStream(this.streamId, mediaElementId, this.broker);
   }
 
   handleBrokerFailure(error) {
@@ -333,6 +354,7 @@ export default class KurentoScreenshareBridge {
   async view(streamId, options = {
     hasAudio: false,
     outputDeviceId: null,
+    mediaElementId: null,
   }) {
     const SETTINGS = window.meetingClientSettings;
     const SFU_CONFIG = SETTINGS.public.kurento;
@@ -341,6 +363,7 @@ export default class KurentoScreenshareBridge {
     const SIGNAL_CANDIDATES = SFU_CONFIG.signalCandidates;
     const TRACE_LOGS = SFU_CONFIG.traceLogs;
     const GATHERING_TIMEOUT = SFU_CONFIG.gatheringTimeout;
+    const mediaElementId = options.mediaElementId || SCREENSHARE_VIDEO_TAG;
     this.streamId = streamId;
     this.hasAudio = options.hasAudio;
     this.outputDeviceId = options.outputDeviceId;
@@ -361,21 +384,28 @@ export default class KurentoScreenshareBridge {
       restartIce: false,
     };
 
-    this.broker = new ScreenshareBroker(
+    const viewerSessionBridge = options.publisherUserId
+      ? `${BridgeService.getConferenceBridge()}:${options.publisherUserId}`
+      : BridgeService.getConferenceBridge();
+    const broker = new ScreenshareBroker(
       Auth.authenticateURL(SFU_URL),
-      BridgeService.getConferenceBridge(),
+      viewerSessionBridge,
       Auth.userID,
       Auth.meetingID,
       this.role,
       brokerOptions,
     );
 
-    this.broker.onstart = this.handleViewerStart.bind(this);
-    this.broker.onerror = this.handleBrokerFailure.bind(this);
+    this._viewerBrokers.set(streamId, { broker, mediaElementId });
+    // Keep this.broker pointing to the most recently created broker for backward compat
+    this.broker = broker;
+
+    broker.onstart = this._handleViewerStartForStream.bind(this, streamId, mediaElementId, broker);
+    broker.onerror = this.handleBrokerFailure.bind(this);
     if (!this.reconnecting) {
-      this.broker.onended = this.handleEnded.bind(this);
+      broker.onended = this.handleEnded.bind(this);
     }
-    return this.broker.view().finally(this.scheduleReconnect.bind(this));
+    return broker.view().finally(this.scheduleReconnect.bind(this));
   }
 
   handlePresenterStart() {
@@ -395,11 +425,13 @@ export default class KurentoScreenshareBridge {
     });
   }
 
+  // eslint-disable-next-line class-methods-use-this
   handleEnded() {
     screenShareEndAlert();
   }
 
   share(stream, onFailure, contentType) {
+    // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       const SETTINGS = window.meetingClientSettings;
       const SFU_CONFIG = SETTINGS.public.kurento;
@@ -440,7 +472,7 @@ export default class KurentoScreenshareBridge {
         userName: Auth.fullname,
         stream,
         hasAudio: this.hasAudio,
-        contentType: contentType,
+        contentType,
         bitrate: BridgeService.BASE_BITRATE(),
         offering: true,
         mediaServer: BridgeService.getMediaServerAdapter(),
@@ -453,9 +485,12 @@ export default class KurentoScreenshareBridge {
         restartIceMaxRetries: RESTART_ICE_RETRIES,
       };
 
+      const publisherSessionBridge = Auth.userID
+        ? `${BridgeService.getConferenceBridge()}:${Auth.userID}`
+        : BridgeService.getConferenceBridge();
       this.broker = new ScreenshareBroker(
         Auth.authenticateURL(SFU_URL),
-        BridgeService.getConferenceBridge(),
+        publisherSessionBridge,
         Auth.userID,
         Auth.meetingID,
         this.role,
@@ -494,16 +529,24 @@ export default class KurentoScreenshareBridge {
     this.clearReconnectionTimeout();
   }
 
-  stop() {
-    const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG);
+  _stopViewerBrokers() {
+    this._viewerBrokers.forEach(({ broker, mediaElementId }) => {
+      try {
+        broker.stop();
+      } catch (_) { /* ignore */ }
+      const el = document.getElementById(mediaElementId);
+      if (el && typeof el.pause === 'function') {
+        el.pause();
+        el.srcObject = null;
+      }
+    });
+    this._viewerBrokers.clear();
+  }
 
+  stop() {
+    this._stopViewerBrokers();
     this._stop();
     this.connectionAttempts = 0;
-
-    if (mediaElement && typeof mediaElement.pause === 'function') {
-      mediaElement.pause();
-      mediaElement.srcObject = null;
-    }
 
     if (this.gdmStream) {
       MediaStreamUtils.stopMediaStreamTracks(this.gdmStream);

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -92,6 +92,9 @@ export default class LiveKitScreenshareBridge {
 
   private readonly subscriptions: Map<string, PublicationData> = new Map();
 
+  // Maps each subscribed streamId to the DOM element id it should render into
+  private readonly streamElementIds: Map<string, string> = new Map();
+
   private readonly bridgeName: string;
 
   private role?: string;
@@ -182,7 +185,8 @@ export default class LiveKitScreenshareBridge {
     if (publications) {
       publications.set(publication.trackSid, publication);
 
-      if (publication.trackSid === this.streamId && this.role === RECV_ROLE) {
+      // Subscribe for any stream we are watching (supports concurrent multi-stream views)
+      if (this.streamElementIds.has(publication.trackSid) && this.role === RECV_ROLE) {
         this.subscribe(publication as RemoteTrackPublication);
       }
     }
@@ -284,7 +288,8 @@ export default class LiveKitScreenshareBridge {
 
     const { trackSid, source, trackName } = publication;
     this.setSubscription(trackSid, track, publication);
-    if (trackSid === this.streamId) this.handleViewerStart(trackSid);
+    // Trigger viewer start for any trackSid we are explicitly watching
+    if (this.streamElementIds.has(trackSid)) this.handleViewerStart(trackSid);
     logger.debug({
       logCode: 'livekit_screenshare_subscribed',
       extraInfo: {
@@ -332,47 +337,49 @@ export default class LiveKitScreenshareBridge {
   }
 
   private resyncOnReconnection(): void {
-    if (this.role !== RECV_ROLE || !this.streamId) return;
+    if (this.role !== RECV_ROLE || this.streamElementIds.size === 0) return;
 
     this.findInitialRemotePublications();
 
-    const publication = this.getPublication(this.streamId);
+    this.streamElementIds.forEach((_elementId, sid) => {
+      const publication = this.getPublication(sid);
 
-    if (!publication || !(publication instanceof RemoteTrackPublication)) {
-      logger.error({
-        logCode: 'livekit_screenshare_reconnection_pub_not_found',
-        extraInfo: {
-          bridgeName: this.bridgeName,
-          streamId: this.streamId,
-          role: this.role,
-        },
-      }, `LiveKit: screenshare pub not found on reconnection - streamId: ${this.streamId}`);
-      return;
-    }
+      if (!publication || !(publication instanceof RemoteTrackPublication)) {
+        logger.error({
+          logCode: 'livekit_screenshare_reconnection_pub_not_found',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            streamId: sid,
+            role: this.role,
+          },
+        }, `LiveKit: screenshare pub not found on reconnection - streamId: ${sid}`);
+        return;
+      }
 
-    if (publication.isSubscribed && publication.track) {
-      this.setSubscription(this.streamId, publication.track, publication);
-      this.handleViewerStart(this.streamId);
+      if (publication.isSubscribed && publication.track) {
+        this.setSubscription(sid, publication.track, publication);
+        this.handleViewerStart(sid);
 
-      logger.warn({
-        logCode: 'livekit_screenshare_reconnection_reattached',
-        extraInfo: {
-          bridgeName: this.bridgeName,
-          streamId: this.streamId,
-          role: this.role,
-        },
-      }, `LiveKit: screenshare track reattached on reconnection - streamId: ${this.streamId}`);
-    } else {
-      this.subscribe(publication);
-      logger.warn({
-        logCode: 'livekit_screenshare_reconnection_resubscribed',
-        extraInfo: {
-          bridgeName: this.bridgeName,
-          streamId: this.streamId,
-          role: this.role,
-        },
-      }, `LiveKit: screenshare resubscribed on reconnection - streamId: ${this.streamId}`);
-    }
+        logger.warn({
+          logCode: 'livekit_screenshare_reconnection_reattached',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            streamId: sid,
+            role: this.role,
+          },
+        }, `LiveKit: screenshare track reattached on reconnection - streamId: ${sid}`);
+      } else {
+        this.subscribe(publication);
+        logger.warn({
+          logCode: 'livekit_screenshare_reconnection_resubscribed',
+          extraInfo: {
+            bridgeName: this.bridgeName,
+            streamId: sid,
+            role: this.role,
+          },
+        }, `LiveKit: screenshare resubscribed on reconnection - streamId: ${sid}`);
+      }
+    });
   }
 
   private handleConnectionStateChanged(): void {
@@ -448,10 +455,12 @@ export default class LiveKitScreenshareBridge {
       // @ts-ignore
       const withSelectiveSubscription = window.meetingClientSettings.public.media?.livekit?.selectiveSubscription
         || false;
-      const { track } = mainPublication;
-      const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG) as HTMLMediaElement;
+      const { track, trackSid } = mainPublication;
+      const elementId = this.streamElementIds.get(trackSid) || SCREENSHARE_VIDEO_TAG;
+      const mediaElement = document.getElementById(elementId) as HTMLMediaElement;
 
       if (track) track.detach(mediaElement);
+      this.streamElementIds.delete(trackSid);
 
       if (withSelectiveSubscription) {
         const audioPublications = Array.from(this.audioPublications.values()) as RemoteTrackPublication[];
@@ -549,7 +558,8 @@ export default class LiveKitScreenshareBridge {
     if (publicationData && publicationData.track) {
       try {
         const { track } = publicationData;
-        const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG) as HTMLMediaElement;
+        const elementId = this.streamElementIds.get(streamId) || SCREENSHARE_VIDEO_TAG;
+        const mediaElement = document.getElementById(elementId) as HTMLMediaElement;
 
         if (mediaElement) {
           if (this.hasAudio && this.outputDeviceId && typeof this.outputDeviceId === 'string') {
@@ -575,11 +585,12 @@ export default class LiveKitScreenshareBridge {
 
   async view(
     streamId: string,
-    options: Options = { hasAudio: false, outputDeviceId: '' },
+    options: Options & { mediaElementId?: string } = { hasAudio: false, outputDeviceId: '' },
   ): Promise<void> {
     this.streamId = streamId;
     this.role = RECV_ROLE;
     this.hasAudio = options.hasAudio || false;
+    this.streamElementIds.set(streamId, options.mediaElementId || SCREENSHARE_VIDEO_TAG);
 
     const doSubscribe = () => {
       this.findInitialRemotePublications();
@@ -705,8 +716,6 @@ export default class LiveKitScreenshareBridge {
   }
 
   async stop(): Promise<void> {
-    const mediaElement = document.getElementById(SCREENSHARE_VIDEO_TAG) as HTMLMediaElement;
-
     if (this.role === SEND_ROLE) {
       try {
         await this.liveKitRoom.localParticipant.setScreenShareEnabled(false);
@@ -714,7 +723,6 @@ export default class LiveKitScreenshareBridge {
         logger.error({
           logCode: 'livekit_screenshare_exit_error',
           extraInfo: {
-
             errorName: (error as Error).name,
             errorMessage: (error as Error).message,
             errorStack: (error as Error).stack,
@@ -724,15 +732,25 @@ export default class LiveKitScreenshareBridge {
           },
         }, 'Failed to exit screenshare');
       }
-    } else if (this.role === RECV_ROLE && this.streamId) {
-      const publication = this.getPublication(this.streamId) as RemoteTrackPublication;
-
-      if (publication) this.unsubscribe(publication);
+    } else if (this.role === RECV_ROLE) {
+      // Unsubscribe and clear all tracked viewer streams
+      this.streamElementIds.forEach((elementId, sid) => {
+        const publication = this.getPublication(sid) as RemoteTrackPublication;
+        if (publication) this.unsubscribe(publication);
+        const el = document.getElementById(elementId) as HTMLMediaElement;
+        if (el && typeof el.pause === 'function') {
+          el.pause();
+          el.srcObject = null;
+        }
+      });
+      this.streamElementIds.clear();
     }
 
-    if (mediaElement && typeof mediaElement.pause === 'function') {
-      mediaElement.pause();
-      mediaElement.srcObject = null;
+    // Clean up the primary element too (for SEND role or single-stream legacy path)
+    const primaryEl = document.getElementById(SCREENSHARE_VIDEO_TAG) as HTMLMediaElement;
+    if (primaryEl && typeof primaryEl.pause === 'function') {
+      primaryEl.pause();
+      primaryEl.srcObject = null;
     }
 
     if (this.gdmStream) {

--- a/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/screenshare/client/bridge/livekit.ts
@@ -585,12 +585,12 @@ export default class LiveKitScreenshareBridge {
 
   async view(
     streamId: string,
-    options: Options & { mediaElementId?: string } = { hasAudio: false, outputDeviceId: '' },
+    options?: Options & { mediaElementId?: string },
   ): Promise<void> {
     this.streamId = streamId;
     this.role = RECV_ROLE;
-    this.hasAudio = options.hasAudio || false;
-    this.streamElementIds.set(streamId, options.mediaElementId || SCREENSHARE_VIDEO_TAG);
+    this.hasAudio = options?.hasAudio || false;
+    this.streamElementIds.set(streamId, options?.mediaElementId || SCREENSHARE_VIDEO_TAG);
 
     const doSubscribe = () => {
       this.findInitialRemotePublications();

--- a/bigbluebutton-html5/imports/ui/Types/meeting.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meeting.ts
@@ -11,6 +11,8 @@ export interface LockSettings {
   hideViewersAnnotation: boolean,
   meetingId: boolean;
   webcamsOnlyForModerator: boolean;
+  disableMultiScreenshare: boolean;
+  hideViewersScreenshare: boolean;
 }
 
 export interface groups {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
@@ -6,7 +6,7 @@ import { btnDefaultColor, colorPrimary } from '/imports/ui/stylesheets/styled-co
 import CoPresentIcon from '@mui/icons-material/CoPresent';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import KEYS from '/imports/utils/keys';
-import { useIsScreenGloballyBroadcasting, screenshareHasEnded } from '/imports/ui/components/screenshare/service';
+import { useIsScreenGloballyBroadcasting, screenshareHasEnded, useShowButtonForNonPresenters } from '/imports/ui/components/screenshare/service';
 import { defineMessages, IntlShape } from 'react-intl';
 import { MediaAreaItemType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/media-area-item/enums';
 import Styled from './styles';
@@ -164,6 +164,7 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
   const animations = getSettingsSingletonInstance().application?.animations ?? true;
   const actionsBarStyle = layoutSelectOutput((i: Output) => i.actionBar);
   const { screenIsShared: isScreenGloballyBroadcasting } = useIsScreenGloballyBroadcasting();
+  const showScreenshareForNonPresenter = useShowButtonForNonPresenters();
   const [currentView, setCurrentView] = useState<'main' | 'presentation' | 'externalVideo' | 'cameraAsContent'>('main');
   const [localRequestingPresenter, setLocalRequestingPresenter] = useState(false);
 
@@ -453,7 +454,18 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
         reducedWidth={!amIPresenter && amIModerator}
       >
         {!amIPresenter
-          ? renderTakePresenterView()
+          ? (
+            <>
+              {showScreenshareForNonPresenter && (
+                <Styled.ContentContainer>
+                  <Styled.MediaGrid isMobile={isMobile}>
+                    <ScreenshareButtonContainer {...{ amIPresenter, isConnected }} />
+                  </Styled.MediaGrid>
+                </Styled.ContentContainer>
+              )}
+              {renderTakePresenterView()}
+            </>
+          )
           : (
             <>
               <Styled.HeaderContainer>

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/screenshare/component.jsx
@@ -192,8 +192,7 @@ const ScreenshareButton = ({
           ? (
             <MediaButton
               disabled={
-                (!isConnected && !isScreenBroadcasting) || !screenshareDataSavingSetting
-                || !amIPresenter || loading
+                (!isConnected && !isScreenBroadcasting) || !screenshareDataSavingSetting || loading
               }
               data-test={dataTest}
               color={amIBroadcasting ? 'primary' : 'default'}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -30,6 +30,9 @@ const propTypes = {
   isScreenBroadcasting: PropTypes.bool.isRequired,
   isScreenGloballyBroadcasting: PropTypes.bool.isRequired,
   isConnected: PropTypes.bool.isRequired,
+  isScreenshareLocked: PropTypes.bool,
+  isLocked: PropTypes.bool,
+  amIPersonallySharing: PropTypes.bool,
 };
 
 const intlMessages = defineMessages({
@@ -149,6 +152,9 @@ const ScreenshareButton = ({
   amIPresenter = false,
   isConnected,
   screenshareDataSavingSetting,
+  isScreenshareLocked = false,
+  isLocked = false,
+  amIPersonallySharing = false,
 }) => {
   const TROUBLESHOOTING_URLS = window.meetingClientSettings.public.media.screenshareTroubleshootingLinks;
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
@@ -209,26 +215,28 @@ const ScreenshareButton = ({
     </Styled.ScreenShareModal>
   );
 
-  const amIBroadcasting = isScreenBroadcasting && amIPresenter;
+  // True only when this client is personally sharing (not just observing a global share).
+  const amIBroadcasting = amIPersonallySharing;
 
-  // this part handles the label/desc intl for the screenshare button
-  // basically: if you are not a presenter, the label/desc will be 'the screen cannot be shared'.
-  // if you are: the label/desc intl will be 'stop/start screenshare'.
+  // Label/desc selection
   let info = screenshareDataSavingSetting ? 'desktopShare' : 'lockedDesktopShare';
-  if (!amIPresenter) {
-    info = 'notPresenterDesktopShare';
-  } else if (isScreenBroadcasting) {
+  if (amIBroadcasting) {
     info = 'stopDesktopShare';
   }
 
   const showButtonForNonPresenters = useShowButtonForNonPresenters();
 
+  // Show the share button to all non-mobile users who are not specifically locked out of
+  // screenshare (isScreenshareLocked = userIsLocked && disableMultiScreenshare).
+  // Presenters, moderators (never locked), and viewers when disableMultiScreenshare=false
+  // can all share screens.
+  const canShare = amIPresenter || showButtonForNonPresenters || !isScreenshareLocked;
   const shouldAllowScreensharing = enabled
     && (!isMobile || isTabletApp)
-    && (amIPresenter || showButtonForNonPresenters);
+    && canShare;
 
-  const dataTest = isScreenBroadcasting ? 'stopScreenShare' : 'startScreenShare';
-  const loading = isScreenBroadcasting && !isScreenGloballyBroadcasting;
+  const dataTest = amIBroadcasting ? 'stopScreenShare' : 'startScreenShare';
+  const loading = amIBroadcasting && !isScreenGloballyBroadcasting;
 
   return (
     <>
@@ -237,7 +245,7 @@ const ScreenshareButton = ({
           ? (
             <Styled.Container>
               <Button
-                disabled={(!isConnected && !isScreenBroadcasting) || !screenshareDataSavingSetting || !amIPresenter}
+                disabled={(!isConnected && !amIBroadcasting) || !screenshareDataSavingSetting}
                 icon={amIBroadcasting ? 'desktop' : 'desktop_off'}
                 data-test={dataTest}
                 label={intl.formatMessage(intlMessages[`${info}Label`])}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -152,7 +152,7 @@ const ScreenshareButton = ({
   isScreenshareLocked = false,
   amIPersonallySharing = false,
 }) => {
-  const TROUBLESHOOTING_URLS = window.meetingClientSettings
+  const TROUBLESHOOTING_URLS = globalThis.meetingClientSettings
     .public.media.screenshareTroubleshootingLinks;
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
   const isCameraAsContentBroadcasting = useIsCameraAsContentBroadcasting();

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/component.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import deviceInfo from '/imports/utils/deviceInfo';
@@ -27,11 +27,9 @@ const propTypes = {
   intl: PropTypes.objectOf(Object).isRequired,
   enabled: PropTypes.bool.isRequired,
   amIPresenter: PropTypes.bool,
-  isScreenBroadcasting: PropTypes.bool.isRequired,
   isScreenGloballyBroadcasting: PropTypes.bool.isRequired,
   isConnected: PropTypes.bool.isRequired,
   isScreenshareLocked: PropTypes.bool,
-  isLocked: PropTypes.bool,
   amIPersonallySharing: PropTypes.bool,
 };
 
@@ -99,7 +97,7 @@ const intlMessages = defineMessages({
   toastHelpLabel: {
     id: 'app.screenshare.screenshareToastHelpLabel',
     description: 'Label of the help button in toast notifications that opens external link',
-  }
+  },
 });
 
 const getErrorLocale = (errorCode) => {
@@ -147,16 +145,15 @@ const getToastType = (errorCode) => {
 const ScreenshareButton = ({
   intl,
   enabled,
-  isScreenBroadcasting,
   isScreenGloballyBroadcasting,
   amIPresenter = false,
   isConnected,
   screenshareDataSavingSetting,
   isScreenshareLocked = false,
-  isLocked = false,
   amIPersonallySharing = false,
 }) => {
-  const TROUBLESHOOTING_URLS = window.meetingClientSettings.public.media.screenshareTroubleshootingLinks;
+  const TROUBLESHOOTING_URLS = window.meetingClientSettings
+    .public.media.screenshareTroubleshootingLinks;
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
   const isCameraAsContentBroadcasting = useIsCameraAsContentBroadcasting();
 
@@ -188,7 +185,7 @@ const ScreenshareButton = ({
     } = error;
 
     const localizedError = getErrorLocale(errorCode);
-    const helpInfo =  getHelpInfoForError(errorCode);
+    const helpInfo = getHelpInfoForError(errorCode);
     const toastType = getToastType(errorCode);
 
     if (localizedError) {
@@ -230,7 +227,7 @@ const ScreenshareButton = ({
   // screenshare (isScreenshareLocked = userIsLocked && disableMultiScreenshare).
   // Presenters, moderators (never locked), and viewers when disableMultiScreenshare=false
   // can all share screens.
-  const canShare = amIPresenter || showButtonForNonPresenters || !isScreenshareLocked;
+  const canShare = amIPresenter || (showButtonForNonPresenters && !isScreenshareLocked);
   const shouldAllowScreensharing = enabled
     && (!isMobile || isTabletApp)
     && canShare;

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
@@ -18,7 +18,7 @@ const ScreenshareButtonContainer = (props) => {
   const screenIsBroadcasting = useIsScreenBroadcasting();
   const { screenIsShared: isScreenGloballyBroadcasting } = useIsScreenGloballyBroadcasting();
   const enabled = useIsScreenSharingEnabled();
-  const { userLocks, isLocked } = useLockContext();
+  const { userLocks } = useLockContext();
   const isScreenshareLocked = userLocks.userScreenshare;
   // True only when THIS client is personally sharing a screenshare (local state).
   const isSharing = useIsSharing();
@@ -40,7 +40,6 @@ const ScreenshareButtonContainer = (props) => {
       isScreenGloballyBroadcasting={isScreenGloballyBroadcasting}
       enabled={enabled}
       isScreenshareLocked={isScreenshareLocked}
-      isLocked={isLocked}
       amIPersonallySharing={amIPersonallySharing}
       {...props}
     />

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ScreenshareButton from './component';
 import { useIsScreenSharingEnabled } from '/imports/ui/services/features';
 import {
@@ -7,6 +7,7 @@ import {
   useIsSharing,
   useSharingContentType,
   CONTENT_TYPE_SCREENSHARE,
+  screenshareHasEnded,
 } from '/imports/ui/components/screenshare/service';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
@@ -23,6 +24,15 @@ const ScreenshareButtonContainer = (props) => {
   const isSharing = useIsSharing();
   const sharingContentType = useSharingContentType();
   const amIPersonallySharing = isSharing && sharingContentType === CONTENT_TYPE_SCREENSHARE;
+
+  const prevIsScreenshareLocked = useRef(isScreenshareLocked);
+  useEffect(() => {
+    if (!prevIsScreenshareLocked.current && isScreenshareLocked && amIPersonallySharing) {
+      screenshareHasEnded();
+    }
+    prevIsScreenshareLocked.current = isScreenshareLocked;
+  }, [isScreenshareLocked, amIPersonallySharing]);
+
   return (
     <ScreenshareButton
       screenshareDataSavingSetting={screenshareDataSavingSetting}

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/screenshare/container.jsx
@@ -1,21 +1,37 @@
 import React from 'react';
 import ScreenshareButton from './component';
 import { useIsScreenSharingEnabled } from '/imports/ui/services/features';
-import { useIsScreenBroadcasting, useIsScreenGloballyBroadcasting } from '/imports/ui/components/screenshare/service';
+import {
+  useIsScreenBroadcasting,
+  useIsScreenGloballyBroadcasting,
+  useIsSharing,
+  useSharingContentType,
+  CONTENT_TYPE_SCREENSHARE,
+} from '/imports/ui/components/screenshare/service';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
+import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockContext';
 
 const ScreenshareButtonContainer = (props) => {
   const { viewScreenshare: screenshareDataSavingSetting } = useSettings(SETTINGS.DATA_SAVING);
   const screenIsBroadcasting = useIsScreenBroadcasting();
   const { screenIsShared: isScreenGloballyBroadcasting } = useIsScreenGloballyBroadcasting();
   const enabled = useIsScreenSharingEnabled();
+  const { userLocks, isLocked } = useLockContext();
+  const isScreenshareLocked = userLocks.userScreenshare;
+  // True only when THIS client is personally sharing a screenshare (local state).
+  const isSharing = useIsSharing();
+  const sharingContentType = useSharingContentType();
+  const amIPersonallySharing = isSharing && sharingContentType === CONTENT_TYPE_SCREENSHARE;
   return (
     <ScreenshareButton
       screenshareDataSavingSetting={screenshareDataSavingSetting}
       isScreenBroadcasting={screenIsBroadcasting}
       isScreenGloballyBroadcasting={isScreenGloballyBroadcasting}
       enabled={enabled}
+      isScreenshareLocked={isScreenshareLocked}
+      isLocked={isLocked}
+      amIPersonallySharing={amIPersonallySharing}
       {...props}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/app/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/app/container.tsx
@@ -103,11 +103,11 @@ const AppContainer: React.FC<AppContainerProps> = ({ pluginConfig }) => {
   const {
     hasExternalVideo = false,
     hasCameraAsContent = false,
-    hasScreenshare = false,
+    hasScreenshareAsContent = false,
   } = currentMeeting?.componentsFlags || {};
   const shouldShowExternalVideo = isExternalVideoEnabled && hasExternalVideo;
   const shouldShowScreenshare = (viewScreenshare || presenter)
-    && (hasScreenshare || hasCameraAsContent) && showScreenshare;
+    && (hasScreenshareAsContent || hasCameraAsContent) && showScreenshare;
   const shouldShowPresentation = !shouldShowScreenshare && !isSharedNotesPinned
     && !shouldShowExternalVideo && (presentationIsOpen || presentationRestoreOnUpdate)
     && isPresentationEnabled;

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -17,6 +17,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import MediaService from '/imports/ui/components/media/service';
 import { useVideoStreams, useVideoStreamsCount } from '/imports/ui/components/video-provider/hooks';
 import { useIsChatEnabled, useIsPresentationEnabled, useIsScreenSharingEnabled } from '/imports/ui/services/features';
+import { useIsSharing } from '/imports/ui/components/screenshare/service';
 import useUserChangedLocalSettings from '/imports/ui/services/settings/hooks/useUserChangedLocalSettings';
 import Session from '/imports/ui/services/storage/in-memory';
 import deviceInfo from '/imports/utils/deviceInfo';
@@ -46,6 +47,7 @@ const LayoutObserver: React.FC = () => {
 
   const isThereWebcam = useVideoStreamsCount() > 0;
   const { streams: videoStream } = useVideoStreams();
+  const isSelfSharing = useIsSharing();
   const isScreenSharingEnabled = useIsScreenSharingEnabled();
   const isPresentationEnabled = useIsPresentationEnabled();
   const isChatEnabled = useIsChatEnabled();
@@ -201,9 +203,9 @@ const LayoutObserver: React.FC = () => {
   useEffect(() => {
     layoutContextDispatch({
       type: ACTIONS.SET_NUM_CAMERAS,
-      value: videoStream.length,
+      value: videoStream.length + (isSelfSharing ? 1 : 0),
     });
-  }, [videoStream.length]);
+  }, [videoStream.length, isSelfSharing]);
 
   useEffect(() => {
     if (layoutIsReady) {

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -112,6 +112,14 @@ const intlMessages = defineMessages({
     id: 'app.lock-viewers.hideAnnotationsLabel',
     description: 'label for other viewers annotation',
   },
+  disableMultiScreenshareLabel: {
+    id: 'app.lock-viewers.disableMultiScreenshareLabel',
+    description: 'label for disabling viewer screenshares',
+  },
+  hideViewersScreenshareLabel: {
+    id: 'app.lock-viewers.hideViewersScreenshareLabel',
+    description: 'label for hiding viewer screenshares from other viewers',
+  },
   submitLabel: {
     id: 'app.chat.submitLabel',
     description: 'Submit button label',
@@ -168,6 +176,8 @@ const propTypes = {
       hideViewersAnnotation: PropTypes.bool,
       lockOnJoin: PropTypes.bool,
       lockOnJoinConfigurable: PropTypes.bool,
+      disableMultiScreenshare: PropTypes.bool,
+      hideViewersScreenshare: PropTypes.bool,
     }),
     usersPolicies: PropTypes.shape({
       guestPolicy: PropTypes.string,
@@ -458,6 +468,20 @@ class LockViewersComponent extends Component {
         checked: !lockSettingsProps.hideViewersAnnotation,
         toggle: () => this.toggleLockSettings('hideViewersAnnotation'),
         dataTest: 'lockShareWhiteboard',
+      },
+      {
+        key: 'disableMultiScreenshare',
+        label: intlMessages.disableMultiScreenshareLabel,
+        checked: !lockSettingsProps.disableMultiScreenshare,
+        toggle: () => this.toggleLockSettings('disableMultiScreenshare'),
+        dataTest: 'lockScreenshare',
+      },
+      {
+        key: 'hideViewersScreenshare',
+        label: intlMessages.hideViewersScreenshareLabel,
+        checked: !lockSettingsProps.hideViewersScreenshare,
+        toggle: () => this.toggleLockSettings('hideViewersScreenshare'),
+        dataTest: 'hideViewersScreenshare',
       },
     );
 

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/container.jsx
@@ -32,6 +32,8 @@ const LockViewersContainer = (props) => {
         hideViewersCursor: lockSettings.hideViewersCursor,
         hideViewersAnnotation: lockSettings.hideViewersAnnotation,
         presenterPolicy: lockSettings.presenterPolicy,
+        disableMultiScreenshare: lockSettings.disableMultiScreenshare ?? false,
+        hideViewersScreenshare: lockSettings.hideViewersScreenshare ?? false,
       },
     });
   };

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/container.jsx
@@ -31,6 +31,8 @@ const lockContextContainer = (component) => (props) => {
     && lockSettings?.hideViewersCursor) || false;
   lockSetting.userLocks.hideViewersAnnotation = (userIsLocked
     && lockSettings?.hideViewersAnnotation) || false;
+  lockSetting.userLocks.userScreenshare = (userIsLocked
+    && lockSettings?.disableMultiScreenshare) || false;
 
   const ComponentWithContext = useMemo(() => withLockContext(component), []);
   // eslint-disable-next-line react/prop-types

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/context/context.js
@@ -20,6 +20,7 @@ export function LockStruct() {
       userPublicChat: false,
       hideViewersCursor: false,
       hideViewersAnnotation: false,
+      userScreenshare: false,
     },
   });
 }

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/hooks/useLockContext.ts
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/hooks/useLockContext.ts
@@ -32,6 +32,7 @@ const useLockContext = () => {
         userPublicChat: Boolean(userIsLocked && lockSettings?.disablePublicChat),
         hideViewersCursor: Boolean(userIsLocked && lockSettings?.hideViewersCursor),
         hideViewersAnnotation: Boolean(userIsLocked && lockSettings?.hideViewersAnnotation),
+        userScreenshare: Boolean(userIsLocked && lockSettings?.disableMultiScreenshare),
       },
     };
   }, [meeting?.lockSettings, user?.role, user?.locked]);

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/hooks/useLockContext.ts
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/hooks/useLockContext.ts
@@ -32,7 +32,7 @@ const useLockContext = () => {
         userPublicChat: Boolean(userIsLocked && lockSettings?.disablePublicChat),
         hideViewersCursor: Boolean(userIsLocked && lockSettings?.hideViewersCursor),
         hideViewersAnnotation: Boolean(userIsLocked && lockSettings?.hideViewersAnnotation),
-        userScreenshare: Boolean(userIsLocked && lockSettings?.disableMultiScreenshare),
+        userScreenshare: Boolean(user && user.role !== ROLE_MODERATOR && lockSettings?.disableMultiScreenshare),
       },
     };
   }, [meeting?.lockSettings, user?.role, user?.locked]);

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/mutations.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/mutations.jsx
@@ -12,7 +12,9 @@ export const SET_LOCK_SETTINGS_PROPS = gql`
     $lockOnJoin: Boolean!,
     $lockOnJoinConfigurable: Boolean!,
     $hideViewersAnnotation: Boolean!,
-    $presenterPolicy: String!) {
+    $presenterPolicy: String!,
+    $disableMultiScreenshare: Boolean,
+    $hideViewersScreenshare: Boolean) {
       meetingLockSettingsSetProps(
         disableCam: $disableCam,
         disableMic: $disableMic,
@@ -25,6 +27,8 @@ export const SET_LOCK_SETTINGS_PROPS = gql`
         hideViewersCursor: $hideViewersCursor,
         hideViewersAnnotation: $hideViewersAnnotation,
         presenterPolicy: $presenterPolicy,
+        disableMultiScreenshare: $disableMultiScreenshare,
+        hideViewersScreenshare: $hideViewersScreenshare,
       )
   }
 `;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -28,6 +28,7 @@ import {
 } from '/imports/ui/components/screenshare/service';
 import { ACTIONS, PRESENTATION_AREA } from '/imports/ui/components/layout/enums';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
+import Auth from '/imports/ui/services/auth';
 import deviceInfo from '/imports/utils/deviceInfo';
 import { uniqueId } from '/imports/utils/string-utils';
 import Session from '/imports/ui/services/storage/in-memory';
@@ -134,9 +135,32 @@ class ScreenshareComponent extends React.Component {
       screenshares,
     } = this.props;
 
-    if (isPresenter || isSharing()) {
-      // Broadcaster path: local presenter preview (also covers non-presenter viewers sharing)
-      screenshareHasStarted(streamId, hasAudio, isPresenter, { outputDeviceId });
+    let hasPeerShares = false;
+    if (isPresenter) {
+      // Presenter broadcaster path: local preview only
+      screenshareHasStarted(streamId, hasAudio, true, { outputDeviceId });
+    } else if (isSharing()) {
+      // Viewer-broadcaster: subscribe to any peer shares and handle own share preview
+      screenshareHasStarted(streamId, hasAudio, false, { outputDeviceId });
+      const shares = (screenshares && screenshares.length > 0) ? screenshares : [];
+      const peerShares = shares.filter((s) => s.userId !== Auth.userID);
+      hasPeerShares = peerShares.length > 0;
+      peerShares.forEach((share) => {
+        if (share.stream) {
+          screenshareHasStarted(share.stream, share.hasAudio, false, {
+            outputDeviceId,
+            mediaElementId: this.getElementIdForShare(share),
+            publisherUserId: share.userId,
+          });
+        }
+      });
+      const ownShare = shares.find((s) => s.userId === Auth.userID);
+      if (ownShare) {
+        const el = document.getElementById(this.getElementIdForShare(ownShare))
+          || document.querySelector('video[id^="screenshareVideo"]');
+        if (el) attachLocalPreviewStream(el);
+      }
+      this.subscribedShareIds = new Set(shares.map((s) => s.screenshareId).filter(Boolean));
     } else {
       // Observer: subscribe to every active screenshare, each into its own video element
       const shares = (screenshares && screenshares.length > 0) ? screenshares : [];
@@ -154,8 +178,11 @@ class ScreenshareComponent extends React.Component {
 
     // Autoplay failure handling
     window.addEventListener('screensharePlayFailed', this.handlePlayElementFailed);
-    // Attaches the local stream if it exists to serve as the local presenter preview
-    attachLocalPreviewStream(getMediaElement());
+    // Attach local preview when not a viewer-broadcaster with peer subscriptions already set up
+    // (in that case ownShare branch above already targeted the right element).
+    if (!hasPeerShares) {
+      attachLocalPreviewStream(getMediaElement());
+    }
 
     this.setState({ switched: startPreviewSizeBig });
 
@@ -187,15 +214,24 @@ class ScreenshareComponent extends React.Component {
 
   _subscribeToNewShares(prevProps) {
     const { isPresenter, screenshares, outputDeviceId } = this.props;
-    if (!isPresenter && !isSharing() && screenshares && screenshares !== prevProps.screenshares) {
+    if (!isPresenter && screenshares && screenshares !== prevProps.screenshares) {
       if (!this.subscribedShareIds) this.subscribedShareIds = new Set();
       screenshares.forEach((share) => {
         if (share.screenshareId && !this.subscribedShareIds.has(share.screenshareId)) {
-          screenshareHasStarted(share.stream, share.hasAudio, false, {
-            outputDeviceId,
-            mediaElementId: this.getElementIdForShare(share),
-            publisherUserId: share.userId,
-          });
+          const elementId = this.getElementIdForShare(share);
+          const isOwnShare = isSharing() && share.userId === Auth.userID;
+          if (isOwnShare) {
+            // Viewer-broadcaster's own share: attach local gdmStream to its DOM element
+            const el = document.getElementById(elementId)
+              || document.querySelector('video[id^="screenshareVideo"]');
+            if (el) attachLocalPreviewStream(el);
+          } else {
+            screenshareHasStarted(share.stream, share.hasAudio, false, {
+              outputDeviceId,
+              mediaElementId: elementId,
+              publisherUserId: share.userId,
+            });
+          }
           this.subscribedShareIds.add(share.screenshareId);
         }
       });
@@ -209,8 +245,13 @@ class ScreenshareComponent extends React.Component {
     const nowSharing = isSharing();
     if (nowSharing && !this.previousIsSharing && !isPresenter) {
       this.previousIsSharing = true;
-      screenshareHasStarted(streamId, hasAudio, false, { outputDeviceId });
-      attachLocalPreviewStream(getMediaElement());
+      if (!this.subscribedShareIds || this.subscribedShareIds.size === 0) {
+        // Viewer is the sole sharer; no peers subscribed yet — attach local preview immediately.
+        screenshareHasStarted(streamId, hasAudio, false, { outputDeviceId });
+        attachLocalPreviewStream(getMediaElement());
+      }
+      // When other shares are already subscribed, _subscribeToNewShares handles own share
+      // once it appears in the screenshares subscription (avoids targeting wrong element).
     } else if (!nowSharing && this.previousIsSharing) {
       this.previousIsSharing = false;
     }
@@ -744,7 +785,7 @@ class ScreenshareComponent extends React.Component {
           id="screenshareContainer"
         >
           {this.renderScreenshareButtons()}
-          {(isPresenter || isSharing())
+          {isPresenter
             ? this.renderScreensharePresenter()
             : this.renderScreenshareDefault()}
         </Styled.ScreenshareContainer>

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -17,6 +17,7 @@ import {
   SCREENSHARE_MEDIA_ELEMENT_NAME,
   screenshareHasEnded,
   screenshareHasStarted,
+  isSharing,
   setOutputDeviceId,
   getMediaElement,
   getMediaElementDimensions,
@@ -63,6 +64,9 @@ const renderPluginItems = (pluginItems, bottom, right) => {
   return (<></>);
 };
 
+// Methods are grouped by concern (lifecycle → handlers → helpers → render), not by
+// airbnb sort-comp ordering, to keep multi-stream logic together with its siblings.
+/* eslint-disable react/sort-comp */
 class ScreenshareComponent extends React.Component {
   static renderScreenshareContainerInside(mainText) {
     return (
@@ -110,6 +114,10 @@ class ScreenshareComponent extends React.Component {
 
     this.volume = getVolume();
     this.mobileHoverSetTimeout = null;
+    // Tracks which screenshare IDs have already been subscribed (observer multi-stream path)
+    this.subscribedShareIds = new Set();
+    // Tracks previous isSharing() value to detect observer→broadcaster transition
+    this.previousIsSharing = false;
   }
 
   componentDidMount() {
@@ -123,9 +131,27 @@ class ScreenshareComponent extends React.Component {
       isSharedNotesPinned,
       hasAudio,
       streamId,
+      screenshares,
     } = this.props;
 
-    screenshareHasStarted(streamId, hasAudio, isPresenter, { outputDeviceId });
+    if (isPresenter || isSharing()) {
+      // Broadcaster path: local presenter preview (also covers non-presenter viewers sharing)
+      screenshareHasStarted(streamId, hasAudio, isPresenter, { outputDeviceId });
+    } else {
+      // Observer: subscribe to every active screenshare, each into its own video element
+      const shares = (screenshares && screenshares.length > 0) ? screenshares : [];
+      shares.forEach((share) => {
+        if (share.stream) {
+          screenshareHasStarted(share.stream, share.hasAudio, false, {
+            outputDeviceId,
+            mediaElementId: this.getElementIdForShare(share),
+            publisherUserId: share.userId,
+          });
+        }
+      });
+      this.subscribedShareIds = new Set(shares.map((s) => s.screenshareId).filter(Boolean));
+    }
+
     // Autoplay failure handling
     window.addEventListener('screensharePlayFailed', this.handlePlayElementFailed);
     // Attaches the local stream if it exists to serve as the local presenter preview
@@ -150,7 +176,9 @@ class ScreenshareComponent extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { isPresenter, outputDeviceId, shouldShowScreenshare } = this.props;
+    const {
+      isPresenter, outputDeviceId, shouldShowScreenshare, screenshares,
+    } = this.props;
     const { videoTagRef } = this.state;
     if (prevProps.isPresenter && !isPresenter) {
       screenshareHasEnded();
@@ -172,6 +200,33 @@ class ScreenshareComponent extends React.Component {
 
     if ((prevState.videoTagRef !== videoTagRef) && videoTagRef) {
       videoTagRef.addEventListener('mousemove', this.handleMouseMovement);
+    }
+
+    // Subscribe to any newly added screenshare streams (observer path only)
+    if (!isPresenter && !isSharing() && screenshares && screenshares !== prevProps.screenshares) {
+      if (!this.subscribedShareIds) this.subscribedShareIds = new Set();
+      screenshares.forEach((share) => {
+        if (share.screenshareId && !this.subscribedShareIds.has(share.screenshareId)) {
+          screenshareHasStarted(share.stream, share.hasAudio, false, {
+            outputDeviceId,
+            mediaElementId: this.getElementIdForShare(share),
+            publisherUserId: share.userId,
+          });
+          this.subscribedShareIds.add(share.screenshareId);
+        }
+      });
+    }
+
+    // Detect observer→broadcaster transition: user started sharing while this component
+    // was already mounted as an observer.
+    const { streamId, hasAudio } = this.props;
+    const nowSharing = isSharing();
+    if (nowSharing && !this.previousIsSharing && !isPresenter) {
+      this.previousIsSharing = true;
+      screenshareHasStarted(streamId, hasAudio, false, { outputDeviceId });
+      attachLocalPreviewStream(getMediaElement());
+    } else if (!nowSharing && this.previousIsSharing) {
+      this.previousIsSharing = false;
     }
   }
 
@@ -326,6 +381,16 @@ class ScreenshareComponent extends React.Component {
     this.debouncedDispatchScreenShareSize();
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  getElementIdForShare(share) {
+    // Primary share keeps the plain legacy id; secondary shares get a suffixed id.
+    // Both ids start with SCREENSHARE_MEDIA_ELEMENT_NAME so video[id^="screenshareVideo"]
+    // matches all of them. Kept as an instance method to stay consistent with the other
+    // renderVideo helpers on this component.
+    if (share.showAsContent) return SCREENSHARE_MEDIA_ELEMENT_NAME;
+    return `${SCREENSHARE_MEDIA_ELEMENT_NAME}-${share.screenshareId}`;
+  }
+
   renderFullscreenButton() {
     const {
       intl,
@@ -380,7 +445,7 @@ class ScreenshareComponent extends React.Component {
     );
   }
 
-  renderMobileVolumeControlOverlay () {
+  renderMobileVolumeControlOverlay() {
     return (
       <Styled.MobileControlsOverlay
         key="mobile-overlay-screenshare"
@@ -430,29 +495,28 @@ class ScreenshareComponent extends React.Component {
     ];
   }
 
-  renderVideo(switched) {
+  renderVideo(switched, share, isPrimary) {
     const { isGloballyBroadcasting } = this.props;
     const { videoTagRef } = this.state;
+    const elementId = share ? this.getElementIdForShare(share) : SCREENSHARE_MEDIA_ELEMENT_NAME;
 
     return (
       <Styled.ScreenshareVideo
-        id={SCREENSHARE_MEDIA_ELEMENT_NAME}
-        key={SCREENSHARE_MEDIA_ELEMENT_NAME}
-        unhealthyStream={!isGloballyBroadcasting}
+        id={elementId}
+        key={elementId}
+        unhealthyStream={isPrimary && !isGloballyBroadcasting}
         style={switched
           ? { maxHeight: '100%', width: '100%', height: '100%' }
           : { maxHeight: '25%', width: '25%', height: '25%' }}
         playsInline
-        onLoadedData={this.onLoadedData}
-        onLoadedMetadata={this.onLoadedMetadata}
-        ref={(ref) => {
+        onLoadedData={isPrimary ? this.onLoadedData : undefined}
+        onLoadedMetadata={isPrimary ? this.onLoadedMetadata : undefined}
+        ref={isPrimary ? (ref) => {
           this.videoTag = ref;
           if (!videoTagRef && ref) {
-            this.setState({
-              videoTagRef: ref,
-            });
+            this.setState({ videoTagRef: ref });
           }
-        }}
+        } : undefined}
         muted
       />
     );
@@ -489,11 +553,13 @@ class ScreenshareComponent extends React.Component {
 
   renderScreensharePresenter() {
     const { switched } = this.state;
-    const { isGloballyBroadcasting, intl } = this.props;
+    const { isGloballyBroadcasting, intl, screenshares } = this.props;
+    // Presenter always shows the primary share (their own stream)
+    const primaryShare = screenshares && screenshares.find((s) => s.showAsContent);
 
     return (
       <>
-        {this.renderVideo(switched)}
+        {this.renderVideo(switched, primaryShare || null, true)}
 
         {
           isGloballyBroadcasting
@@ -514,22 +580,32 @@ class ScreenshareComponent extends React.Component {
   }
 
   renderScreenshareDefault() {
-    const { intl, enableVolumeControl } = this.props;
+    const { intl, enableVolumeControl, screenshares } = this.props;
     const { loaded } = this.state;
+    const shares = screenshares && screenshares.length > 0 ? screenshares : [];
+
+    // Always use MultiScreenshareGrid so video elements keep their DOM identity
+    // when a second share is added (avoids unmount/remount of the primary video).
+    const sortedShares = [...shares].sort((a, b) => {
+      if (a.showAsContent && !b.showAsContent) return -1;
+      if (!a.showAsContent && b.showAsContent) return 1;
+      return 0;
+    });
 
     return (
       <>
-        {this.renderVideo(true)}
-        {loaded && enableVolumeControl && this.renderVolumeSlider() }
-
+        <Styled.MultiScreenshareGrid>
+          {sortedShares.length > 0
+            ? sortedShares.map((share, idx) => this.renderVideo(true, share, idx === 0))
+            : this.renderVideo(true, null, true)}
+        </Styled.MultiScreenshareGrid>
+        {loaded && enableVolumeControl && this.renderVolumeSlider()}
         <Styled.ScreenshareContainerDefault>
-          {
-            !loaded
-              ? ScreenshareComponent.renderScreenshareContainerInside(
-                intl.formatMessage(this.locales.viewerLoadingLabel),
-              )
-              : null
-          }
+          {!loaded
+            ? ScreenshareComponent.renderScreenshareContainerInside(
+              intl.formatMessage(this.locales.viewerLoadingLabel),
+            )
+            : null}
         </Styled.ScreenshareContainerDefault>
       </>
     );
@@ -605,7 +681,11 @@ class ScreenshareComponent extends React.Component {
     const shouldRenderConnectingState = !loaded
       || (isPresenter && !isGloballyBroadcasting);
 
-    const display = (width > 0 && height > 0) && shouldShowScreenshare ? 'inherit' : 'none';
+    // For the local broadcaster (presenter or non-presenter viewer sharing), always show
+    // the preview regardless of shouldShowScreenshare which depends on server-side layout flags
+    // that are not set for non-presenter shares.
+    const isBroadcasting = isPresenter || isSharing();
+    const display = (width > 0 && height > 0) && (shouldShowScreenshare || isBroadcasting) ? 'inherit' : 'none';
     const Settings = getSettingsSingletonInstance();
     const { animations } = Settings.application;
 
@@ -653,7 +733,7 @@ class ScreenshareComponent extends React.Component {
           id="screenshareContainer"
         >
           {this.renderScreenshareButtons()}
-          {isPresenter
+          {(isPresenter || isSharing())
             ? this.renderScreensharePresenter()
             : this.renderScreenshareDefault()}
         </Styled.ScreenshareContainer>
@@ -664,6 +744,7 @@ class ScreenshareComponent extends React.Component {
 
 export default injectIntl(ScreenshareComponent);
 
+/* eslint-enable react/sort-comp */
 ScreenshareComponent.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
@@ -675,6 +756,12 @@ ScreenshareComponent.propTypes = {
   layoutContextDispatch: PropTypes.func.isRequired,
   enableVolumeControl: PropTypes.bool.isRequired,
   outputDeviceId: PropTypes.string,
-  streamId: PropTypes.string.isRequired,
+  streamId: PropTypes.string,
+  screenshares: PropTypes.arrayOf(PropTypes.shape({
+    screenshareId: PropTypes.string,
+    stream: PropTypes.string,
+    hasAudio: PropTypes.bool,
+    showAsContent: PropTypes.bool,
+  })),
   isBot: PropTypes.bool.isRequired,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -175,34 +175,18 @@ class ScreenshareComponent extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    const {
-      isPresenter, outputDeviceId, shouldShowScreenshare, screenshares,
-    } = this.props;
-    const { videoTagRef } = this.state;
-    if (prevProps.isPresenter && !isPresenter) {
-      screenshareHasEnded();
-    }
-
-    if (prevProps.outputDeviceId !== outputDeviceId && !isPresenter) {
-      setOutputDeviceId(outputDeviceId);
-    }
-
-    if (isPresenter) setStreamEnabled(shouldShowScreenshare);
-
+  _updateVolumeOnVisibilityChange(prevProps) {
+    const { shouldShowScreenshare } = this.props;
     if (prevProps.shouldShowScreenshare && !shouldShowScreenshare) {
       setVolume(0);
     } else if (!prevProps.shouldShowScreenshare && shouldShowScreenshare) {
       this.volume = this.volume || 1;
-      // if this.volume is 0, means user didn't change the volume, so we set it to 1
       setVolume(this.volume);
     }
+  }
 
-    if ((prevState.videoTagRef !== videoTagRef) && videoTagRef) {
-      videoTagRef.addEventListener('mousemove', this.handleMouseMovement);
-    }
-
-    // Subscribe to any newly added screenshare streams (observer path only)
+  _subscribeToNewShares(prevProps) {
+    const { isPresenter, screenshares, outputDeviceId } = this.props;
     if (!isPresenter && !isSharing() && screenshares && screenshares !== prevProps.screenshares) {
       if (!this.subscribedShareIds) this.subscribedShareIds = new Set();
       screenshares.forEach((share) => {
@@ -216,10 +200,12 @@ class ScreenshareComponent extends React.Component {
         }
       });
     }
+  }
 
-    // Detect observer→broadcaster transition: user started sharing while this component
-    // was already mounted as an observer.
-    const { streamId, hasAudio } = this.props;
+  _handleSharingTransition() {
+    const {
+      isPresenter, streamId, hasAudio, outputDeviceId,
+    } = this.props;
     const nowSharing = isSharing();
     if (nowSharing && !this.previousIsSharing && !isPresenter) {
       this.previousIsSharing = true;
@@ -228,6 +214,31 @@ class ScreenshareComponent extends React.Component {
     } else if (!nowSharing && this.previousIsSharing) {
       this.previousIsSharing = false;
     }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const {
+      isPresenter, outputDeviceId, shouldShowScreenshare,
+    } = this.props;
+    const { videoTagRef } = this.state;
+    if (prevProps.isPresenter && !isPresenter) {
+      screenshareHasEnded();
+    }
+
+    if (prevProps.outputDeviceId !== outputDeviceId && !isPresenter) {
+      setOutputDeviceId(outputDeviceId);
+    }
+
+    if (isPresenter) setStreamEnabled(shouldShowScreenshare);
+
+    this._updateVolumeOnVisibilityChange(prevProps);
+
+    if ((prevState.videoTagRef !== videoTagRef) && videoTagRef) {
+      videoTagRef.addEventListener('mousemove', this.handleMouseMovement);
+    }
+
+    this._subscribeToNewShares(prevProps);
+    this._handleSharingTransition();
   }
 
   componentWillUnmount() {
@@ -555,7 +566,7 @@ class ScreenshareComponent extends React.Component {
     const { switched } = this.state;
     const { isGloballyBroadcasting, intl, screenshares } = this.props;
     // Presenter always shows the primary share (their own stream)
-    const primaryShare = screenshares && screenshares.find((s) => s.showAsContent);
+    const primaryShare = screenshares?.find((s) => s.showAsContent);
 
     return (
       <>
@@ -601,11 +612,11 @@ class ScreenshareComponent extends React.Component {
         </Styled.MultiScreenshareGrid>
         {loaded && enableVolumeControl && this.renderVolumeSlider()}
         <Styled.ScreenshareContainerDefault>
-          {!loaded
-            ? ScreenshareComponent.renderScreenshareContainerInside(
+          {loaded
+            ? null
+            : ScreenshareComponent.renderScreenshareContainerInside(
               intl.formatMessage(this.locales.viewerLoadingLabel),
-            )
-            : null}
+            )}
         </Styled.ScreenshareContainerDefault>
       </>
     );
@@ -764,4 +775,7 @@ ScreenshareComponent.propTypes = {
     showAsContent: PropTypes.bool,
   })),
   isBot: PropTypes.bool.isRequired,
+  shouldShowScreenshare: PropTypes.bool,
+  hasAudio: PropTypes.bool,
+  isGloballyBroadcasting: PropTypes.bool,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -137,8 +137,20 @@ class ScreenshareComponent extends React.Component {
 
     let hasPeerShares = false;
     if (isPresenter) {
-      // Presenter broadcaster path: local preview only
+      // Presenter broadcaster path: local preview + subscribe to peer secondary shares
       screenshareHasStarted(streamId, hasAudio, true, { outputDeviceId });
+      const shares = (screenshares && screenshares.length > 0) ? screenshares : [];
+      const secondaryShares = shares.filter((s) => !s.showAsContent);
+      secondaryShares.forEach((share) => {
+        if (share.stream) {
+          screenshareHasStarted(share.stream, share.hasAudio, false, {
+            outputDeviceId,
+            mediaElementId: this.getElementIdForShare(share),
+            publisherUserId: share.userId,
+          });
+        }
+      });
+      this.subscribedShareIds = new Set(shares.map((s) => s.screenshareId).filter(Boolean));
     } else if (isSharing()) {
       // Viewer-broadcaster: subscribe to any peer shares and handle own share preview
       screenshareHasStarted(streamId, hasAudio, false, { outputDeviceId });
@@ -214,7 +226,7 @@ class ScreenshareComponent extends React.Component {
 
   _subscribeToNewShares(prevProps) {
     const { isPresenter, screenshares, outputDeviceId } = this.props;
-    if (!isPresenter && screenshares && screenshares !== prevProps.screenshares) {
+    if (screenshares && screenshares !== prevProps.screenshares) {
       if (!this.subscribedShareIds) this.subscribedShareIds = new Set();
       screenshares.forEach((share) => {
         if (share.screenshareId && !this.subscribedShareIds.has(share.screenshareId)) {
@@ -225,7 +237,9 @@ class ScreenshareComponent extends React.Component {
             const el = document.getElementById(elementId)
               || document.querySelector('video[id^="screenshareVideo"]');
             if (el) attachLocalPreviewStream(el);
-          } else {
+          } else if (!isPresenter || !share.showAsContent) {
+            // Non-presenter: subscribe to all peer shares.
+            // Presenter: subscribe only to secondary (non-primary) shares from viewers.
             screenshareHasStarted(share.stream, share.hasAudio, false, {
               outputDeviceId,
               mediaElementId: elementId,
@@ -606,12 +620,14 @@ class ScreenshareComponent extends React.Component {
   renderScreensharePresenter() {
     const { switched } = this.state;
     const { isGloballyBroadcasting, intl, screenshares } = this.props;
-    // Presenter always shows the primary share (their own stream)
     const primaryShare = screenshares?.find((s) => s.showAsContent);
+    // Secondary shares (from viewers) rendered alongside the presenter's own preview.
+    const secondaryShares = (screenshares || []).filter((s) => !s.showAsContent);
 
     return (
       <>
         {this.renderVideo(switched, primaryShare || null, true)}
+        {secondaryShares.map((share) => this.renderVideo(true, share, false))}
 
         {
           isGloballyBroadcasting

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -26,6 +26,7 @@ import {
   getVolume,
   setStreamEnabled,
 } from '/imports/ui/components/screenshare/service';
+import ScreenshareActions from './screenshare-actions/component';
 import { ACTIONS, PRESENTATION_AREA } from '/imports/ui/components/layout/enums';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Auth from '/imports/ui/services/auth';
@@ -561,19 +562,21 @@ class ScreenshareComponent extends React.Component {
     ];
   }
 
-  renderVideo(switched, share, isPrimary) {
+  renderVideo(switched, share, isPrimary, inContainer = false) {
     const { isGloballyBroadcasting } = this.props;
     const { videoTagRef } = this.state;
     const elementId = share ? this.getElementIdForShare(share) : SCREENSHARE_MEDIA_ELEMENT_NAME;
+    const fullSize = inContainer || switched;
+    const sizeStyle = fullSize
+      ? { maxHeight: '100%', width: '100%', height: '100%' }
+      : { maxHeight: '25%', width: '25%', height: '25%' };
 
     return (
       <Styled.ScreenshareVideo
         id={elementId}
         key={elementId}
         unhealthyStream={isPrimary && !isGloballyBroadcasting}
-        style={switched
-          ? { maxHeight: '100%', width: '100%', height: '100%' }
-          : { maxHeight: '25%', width: '25%', height: '25%' }}
+        style={sizeStyle}
         playsInline
         onLoadedData={isPrimary ? this.onLoadedData : undefined}
         onLoadedMetadata={isPrimary ? this.onLoadedMetadata : undefined}
@@ -585,6 +588,26 @@ class ScreenshareComponent extends React.Component {
         } : undefined}
         muted
       />
+    );
+  }
+
+  renderVideoWithActions(switched, share, isPrimary) {
+    const { isPresenter } = this.props;
+    if (!isPresenter || !share) return this.renderVideo(switched, share, isPrimary);
+
+    const containerStyle = switched
+      ? {
+        position: 'relative', width: '100%', height: '100%',
+      }
+      : {
+        position: 'relative', maxHeight: '25%', width: '25%', height: '25%',
+      };
+
+    return (
+      <div key={`wa-${this.getElementIdForShare(share)}`} style={containerStyle}>
+        {this.renderVideo(switched, share, isPrimary, true)}
+        <ScreenshareActions streamId={share.stream} showAsContent={share.showAsContent} />
+      </div>
     );
   }
 
@@ -627,8 +650,8 @@ class ScreenshareComponent extends React.Component {
 
     return (
       <>
-        {primaryShare && this.renderVideo(switched, primaryShare, true)}
-        {secondaryShares.map((share) => this.renderVideo(true, share, false))}
+        {primaryShare && this.renderVideoWithActions(switched, primaryShare, true)}
+        {secondaryShares.map((share) => this.renderVideoWithActions(true, share, false))}
 
         {
           isGloballyBroadcasting

--- a/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/component.jsx
@@ -620,23 +620,23 @@ class ScreenshareComponent extends React.Component {
   renderScreensharePresenter() {
     const { switched } = this.state;
     const { isGloballyBroadcasting, intl, screenshares } = this.props;
-    const primaryShare = screenshares?.find((s) => s.showAsContent);
-    // Secondary shares (from viewers) rendered alongside the presenter's own preview.
-    const secondaryShares = (screenshares || []).filter((s) => !s.showAsContent);
+    // Own share goes to the camera dock as a self-preview tile; exclude from main area.
+    const peerShares = (screenshares || []).filter((s) => s.userId !== Auth.userID);
+    const primaryShare = peerShares.find((s) => s.showAsContent) || null;
+    const secondaryShares = peerShares.filter((s) => !s.showAsContent);
 
     return (
       <>
-        {this.renderVideo(switched, primaryShare || null, true)}
+        {primaryShare && this.renderVideo(switched, primaryShare, true)}
         {secondaryShares.map((share) => this.renderVideo(true, share, false))}
 
         {
           isGloballyBroadcasting
             ? (
               <div data-test="isSharingScreen">
-                {!switched
-                  && ScreenshareComponent.renderScreenshareContainerInside(
-                    intl.formatMessage(this.locales.presenterSharingLabel),
-                  )}
+                {ScreenshareComponent.renderScreenshareContainerInside(
+                  intl.formatMessage(this.locales.presenterSharingLabel),
+                )}
               </div>
             )
             : ScreenshareComponent.renderScreenshareContainerInside(
@@ -652,9 +652,30 @@ class ScreenshareComponent extends React.Component {
     const { loaded } = this.state;
     const shares = screenshares && screenshares.length > 0 ? screenshares : [];
 
+    // When self-broadcasting, own share goes to camera dock; exclude from main area.
+    const sharesForMainArea = isSharing()
+      ? shares.filter((s) => s.userId !== Auth.userID)
+      : shares;
+
+    const hasPeerContentShares = sharesForMainArea.some((s) => s.showAsContent);
+
+    // Solo broadcaster with no peer asContent shares: show label, own share is in dock.
+    if (isSharing() && !hasPeerContentShares) {
+      return (
+        <>
+          <div data-test="isSharingScreen">
+            {ScreenshareComponent.renderScreenshareContainerInside(
+              intl.formatMessage(this.locales.presenterSharingLabel),
+            )}
+          </div>
+          {loaded && enableVolumeControl && this.renderVolumeSlider()}
+        </>
+      );
+    }
+
     // Always use MultiScreenshareGrid so video elements keep their DOM identity
     // when a second share is added (avoids unmount/remount of the primary video).
-    const sortedShares = [...shares].sort((a, b) => {
+    const sortedShares = [...sharesForMainArea].sort((a, b) => {
       if (a.showAsContent && !b.showAsContent) return -1;
       if (!a.showAsContent && b.showAsContent) return 1;
       return 0;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/container.jsx
@@ -13,6 +13,7 @@ import {
   useIsCameraAsContentBroadcasting,
   useScreenshareHasAudio,
   useScreenshareStreamId,
+  useScreenshares,
   useBroadcastContentType,
   setBridge,
 } from './service';
@@ -160,6 +161,7 @@ const ScreenshareContainer = (props) => {
   const isCameraAsContentBroadcasting = useIsCameraAsContentBroadcasting();
   const hasAudio = useScreenshareHasAudio();
   const streamId = useScreenshareStreamId();
+  const screenshares = useScreenshares();
 
   let pluginScreenshareHelperItems = [];
   if (pluginsExtensibleAreasAggregatedState.screenshareHelperItems) {
@@ -188,7 +190,7 @@ const ScreenshareContainer = (props) => {
           outputDeviceId,
           enableVolumeControl,
           hasAudio,
-          isGloballyBroadcasting: screenIsGloballyBroadcasting
+          isGloballyBroadcasting: screenIsGloballyBroadcasting?.screenIsShared
             || cameraAsContentIsGloballyBroadcasting,
           hidePresentationOnJoin: getFromUserSettings(
             'bbb_hide_presentation_on_join',
@@ -197,6 +199,7 @@ const ScreenshareContainer = (props) => {
           ...selectedInfo,
           isPresenter,
           streamId,
+          screenshares,
           shouldShowScreenshare,
           isBot,
         }

--- a/bigbluebutton-html5/imports/ui/components/screenshare/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/queries.ts
@@ -11,6 +11,8 @@ export interface ScreenshareResponse {
   vidHeight: number;
   vidWidth: number;
   voiceConf: string;
+  userId: string;
+  showAsContent: boolean;
 }
 
 export const SCREENSHARE_SUBSCRIPTION = gql`
@@ -26,6 +28,8 @@ export const SCREENSHARE_SUBSCRIPTION = gql`
       vidHeight
       vidWidth
       voiceConf
+      userId
+      showAsContent
     }
   }
 `;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/screenshare-actions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/screenshare-actions/component.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import { useMutation } from '@apollo/client';
+import BBBMenu from '/imports/ui/components/common/menu/component';
+import { SET_SCREENSHARE_SHOW_AS_CONTENT } from '/imports/ui/core/graphql/mutations/screenshareMutations';
+
+const intlMessages = defineMessages({
+  showAsContentLabel: {
+    id: 'app.screenshare.showAsContentLabel',
+    defaultMessage: 'Show as main content',
+  },
+  moveToThumbnailLabel: {
+    id: 'app.screenshare.moveToThumbnailLabel',
+    defaultMessage: 'Move to thumbnail',
+  },
+});
+
+interface ScreenshareActionsProps {
+  streamId: string;
+  showAsContent: boolean;
+}
+
+const ScreenshareActions: React.FC<ScreenshareActionsProps> = ({ streamId, showAsContent }) => {
+  const intl = useIntl();
+  const [setShowAsContent] = useMutation(SET_SCREENSHARE_SHOW_AS_CONTENT);
+
+  const label = showAsContent
+    ? intl.formatMessage(intlMessages.moveToThumbnailLabel)
+    : intl.formatMessage(intlMessages.showAsContentLabel);
+
+  const actions = [{
+    key: `screenshare-toggle-${streamId}`,
+    label,
+    description: label,
+    onClick: () => setShowAsContent({ variables: { streamId, showAsContent: !showAsContent } }),
+    dataTest: showAsContent ? 'screenshareMoveToThumbnailBtn' : 'screenshareShowAsContentBtn',
+  }];
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 4,
+        right: 4,
+        zIndex: 100,
+      }}
+    >
+      <BBBMenu
+        trigger={(
+          <button
+            type="button"
+            aria-label={label}
+            data-test="screenshareActionsBtn"
+            style={{
+              background: 'rgba(0,0,0,0.65)',
+              border: 'none',
+              color: '#fff',
+              borderRadius: '50%',
+              width: 22,
+              height: 22,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 0,
+              fontSize: 14,
+              lineHeight: 1,
+            }}
+          >
+            ⋮
+          </button>
+        )}
+        actions={actions}
+        opts={{
+          container: document.body,
+        }}
+      />
+    </div>
+  );
+};
+
+export default ScreenshareActions;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/self-screenshare-dock-tile.tsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/self-screenshare-dock-tile.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import { attachLocalPreviewStream } from '/imports/ui/components/screenshare/service';
+import ScreenshareActions from './screenshare-actions/component';
 
 // Video element ID for the self-screenshare preview in the camera dock.
 // Uses the same prefix as SCREENSHARE_MEDIA_ELEMENT_NAME so the service's
@@ -8,7 +9,17 @@ import { attachLocalPreviewStream } from '/imports/ui/components/screenshare/ser
 // no peer primary share occupies the main area element.
 export const SELF_DOCK_VIDEO_ID = 'screenshareVideo-self-dock';
 
-const SelfScreenshareDockTile: React.FC = () => {
+interface SelfScreenshareDockTileProps {
+  streamId?: string;
+  showAsContent?: boolean;
+  isPresenter?: boolean;
+}
+
+const SelfScreenshareDockTile: React.FC<SelfScreenshareDockTileProps> = ({
+  streamId,
+  showAsContent = false,
+  isPresenter = false,
+}) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const intl = useIntl();
 
@@ -34,7 +45,7 @@ const SelfScreenshareDockTile: React.FC = () => {
         alignItems: 'center',
         justifyContent: 'center',
       }}
-      data-test="selfScreenshareDockTile"
+      data-test="selfScreenshareDockItem"
     >
       <video
         id={SELF_DOCK_VIDEO_ID}
@@ -61,6 +72,9 @@ const SelfScreenshareDockTile: React.FC = () => {
       >
         {label}
       </span>
+      {isPresenter && streamId && (
+        <ScreenshareActions streamId={streamId} showAsContent={showAsContent} />
+      )}
     </div>
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/self-screenshare-dock-tile.tsx
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/self-screenshare-dock-tile.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef } from 'react';
+import { useIntl } from 'react-intl';
+import { attachLocalPreviewStream } from '/imports/ui/components/screenshare/service';
+
+// Video element ID for the self-screenshare preview in the camera dock.
+// Uses the same prefix as SCREENSHARE_MEDIA_ELEMENT_NAME so the service's
+// querySelector fallback ('video[id^="screenshareVideo"]') can find it when
+// no peer primary share occupies the main area element.
+export const SELF_DOCK_VIDEO_ID = 'screenshareVideo-self-dock';
+
+const SelfScreenshareDockTile: React.FC = () => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const intl = useIntl();
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (el) attachLocalPreviewStream(el);
+  }, []);
+
+  const label = intl.formatMessage({
+    id: 'app.screenshare.presenterSharingLabel',
+    defaultMessage: 'You are sharing',
+  });
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#06172a',
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+      data-test="selfScreenshareDockTile"
+    >
+      <video
+        id={SELF_DOCK_VIDEO_ID}
+        ref={videoRef}
+        autoPlay
+        muted
+        playsInline
+        style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+      />
+      <span
+        style={{
+          position: 'absolute',
+          bottom: '4px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          color: '#fff',
+          fontSize: '11px',
+          backgroundColor: 'rgba(0,0,0,0.6)',
+          padding: '2px 6px',
+          borderRadius: '3px',
+          whiteSpace: 'nowrap',
+          pointerEvents: 'none',
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+};
+
+export default SelfScreenshareDockTile;

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -362,8 +362,9 @@ export const viewScreenshare = (streamId, hasAudio, options = {}) => {
 };
 
 export const screenshareHasStarted = (streamId, hasAudio, isPresenter, options = {}) => {
-  // Presenter's screen preview is local, so skip
-  if (!isPresenter) {
+  // The local broadcaster's preview is attached from gdmStream directly; observers (including
+  // non-sharing presenters and moderators) must subscribe to receive the SFU stream.
+  if (!isSharing()) {
     viewScreenshare(streamId, hasAudio, { outputDeviceId: options.outputDeviceId });
   }
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -210,6 +210,13 @@ export const useScreenshareStreamId = () => {
   return data?.[0]?.stream;
 };
 
+// Returns the full screenshare array for multi-stream rendering
+export const useScreenshares = () => {
+  const { data } = useScreenshare();
+
+  return data || [];
+};
+
 export const screenshareHasEnded = () => {
   if (isSharingVar()) {
     setIsSharing(false);
@@ -229,7 +236,8 @@ export const _handleStreamTermination = () => {
   screenshareHasEnded();
 };
 
-export const getMediaElement = () => document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME);
+export const getMediaElement = () => document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME)
+  || document.querySelector(`video[id^="${SCREENSHARE_MEDIA_ELEMENT_NAME}"]`);
 
 export const getMediaElementDimensions = () => {
   const element = getMediaElement();
@@ -277,7 +285,8 @@ export const attachLocalPreviewStream = (mediaElement) => {
 };
 
 export const setOutputDeviceId = (outputDeviceId) => {
-  const screenShareElement = document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME);
+  const screenShareElement = document.getElementById(SCREENSHARE_MEDIA_ELEMENT_NAME)
+    || document.querySelector(`video[id^="${SCREENSHARE_MEDIA_ELEMENT_NAME}"]`);
   const sinkIdSupported = screenShareElement && typeof screenShareElement.setSinkId === 'function';
   const srcStream = screenShareElement?.srcObject;
 
@@ -349,23 +358,33 @@ export const shareScreen = async (
 };
 
 export const viewScreenshare = (streamId, hasAudio, options = {}) => {
-  screenShareBridge.view(streamId, { hasAudio, outputDeviceId: options.outputDeviceId })
-    .catch((error) => {
-      logger.error({
-        logCode: 'screenshare_view_failed',
-        extraInfo: {
-          errorName: error.name,
-          errorMessage: error.message,
-        },
-      }, 'Screenshare viewer failure');
-    });
+  screenShareBridge.view(streamId, {
+    hasAudio,
+    outputDeviceId: options.outputDeviceId,
+    mediaElementId: options.mediaElementId,
+    publisherUserId: options.publisherUserId,
+  }).catch((error) => {
+    logger.error({
+      logCode: 'screenshare_view_failed',
+      extraInfo: {
+        errorName: error.name,
+        errorMessage: error.message,
+        streamId,
+        mediaElementId: options.mediaElementId,
+      },
+    }, 'Screenshare viewer failure');
+  });
 };
 
 export const screenshareHasStarted = (streamId, hasAudio, isPresenter, options = {}) => {
   // The local broadcaster's preview is attached from gdmStream directly; observers (including
   // non-sharing presenters and moderators) must subscribe to receive the SFU stream.
   if (!isSharing()) {
-    viewScreenshare(streamId, hasAudio, { outputDeviceId: options.outputDeviceId });
+    viewScreenshare(streamId, hasAudio, {
+      outputDeviceId: options.outputDeviceId,
+      mediaElementId: options.mediaElementId,
+      publisherUserId: options.publisherUserId,
+    });
   }
 };
 
@@ -426,4 +445,5 @@ export default {
   useScreenshareHasAudio,
   useBroadcastContentType,
   useScreenshareStreamId,
+  useScreenshares,
 };

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -329,11 +329,6 @@ export const shareScreen = async (
     }
     _trackStreamTermination(stream, _handleStreamTermination);
 
-    if (!isPresenter) {
-      MediaStreamUtils.stopMediaStreamTracks(stream);
-      return;
-    }
-
     await screenShareBridge.share(stream, onFail, contentType);
 
     // Stream might have been disabled in the meantime. I love badly designed

--- a/bigbluebutton-html5/imports/ui/components/screenshare/service.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/service.js
@@ -379,7 +379,9 @@ export const viewScreenshare = (streamId, hasAudio, options = {}) => {
 export const screenshareHasStarted = (streamId, hasAudio, isPresenter, options = {}) => {
   // The local broadcaster's preview is attached from gdmStream directly; observers (including
   // non-sharing presenters and moderators) must subscribe to receive the SFU stream.
-  if (!isSharing()) {
+  // When a specific mediaElementId is provided the caller is subscribing to a peer's stream
+  // while already sharing themselves — allow it even when isSharing() is true.
+  if (!isSharing() || options.mediaElementId) {
     viewScreenshare(streamId, hasAudio, {
       outputDeviceId: options.outputDeviceId,
       mediaElementId: options.mediaElementId,

--- a/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/screenshare/styles.js
@@ -26,6 +26,22 @@ const ScreenshareVideo = styled.video`
   `}
 `;
 
+const MultiScreenshareGrid = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  gap: 4px;
+
+  & > video {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 0;
+    max-height: 100%;
+    object-fit: contain;
+  }
+`;
+
 const ScreenshareContainer = styled.div`
   position: relative;
   background-color: ${colorContentBackground};
@@ -122,6 +138,7 @@ export default {
   ScreenshareContainerInside,
   MainText,
   ScreenshareVideo,
+  MultiScreenshareGrid,
   ScreenshareContainer,
   ScreenshareContainerDefault,
   SpinnerWrapper,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
@@ -32,6 +32,7 @@ import {
   useVideoState,
 } from './state';
 import { VIDEO_TYPES } from './enums';
+import { useIsSharing } from '/imports/ui/components/screenshare/service';
 
 interface VideoProviderContainerProps {
   focusedId: string;
@@ -128,6 +129,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
   const { numberOfPages } = useVideoState();
   const isPaginationEnabled = useIsPaginationEnabled();
   const isGridEnabled = useStorageKey('isGridEnabled') as boolean;
+  const isSelfSharing = useIsSharing();
 
   useEffect(() => {
     if (isPaginationEnabled) {
@@ -162,7 +164,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
     if (streamIsConnected) setConnectingStream(null);
   }, [streams, connectingStream]);
 
-  if (!usersVideo.length && !isGridEnabled) return null;
+  if (!usersVideo.length && !isGridEnabled && !isSelfSharing) return null;
 
   const providerProps = {
     cameraDock,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -85,6 +85,8 @@ interface VideoListProps {
   onVideoItemMount: (stream: string, video: HTMLVideoElement) => void;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (stream: string, type: string, name: string, data: string) => Promise<unknown>;
+  // Self-screenshare preview tile injected by the container when user is broadcasting.
+  selfScreenshareTile?: React.ReactNode;
 }
 
 interface VideoListState {
@@ -227,11 +229,12 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       streams,
       cameraDock,
       layoutContextDispatch,
+      selfScreenshareTile,
     } = this.props;
     const visibleStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
     );
-    let numItems = visibleStreams.length;
+    let numItems = visibleStreams.length + (selfScreenshareTile ? 1 : 0);
 
     if (numItems < 1 || !this.canvas || !this.grid) {
       return;
@@ -365,6 +368,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       pluginUserCameraHelperPerPosition,
       isGridEnabled,
       overflowCount,
+      selfScreenshareTile,
     } = this.props;
     const numOfStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
@@ -438,6 +442,18 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       );
     }
 
+    if (selfScreenshareTile) {
+      videoItems.push(
+        <Styled.VideoListItem
+          key="self-screenshare-dock-tile"
+          $focused={false}
+          data-test="selfScreenshareDockItem"
+        >
+          {selfScreenshareTile}
+        </Styled.VideoListItem>,
+      );
+    }
+
     return videoItems;
   }
 
@@ -447,6 +463,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       intl,
       cameraDock,
       isGridEnabled,
+      selfScreenshareTile,
     } = this.props;
     const { optimalGrid, autoplayBlocked } = this.state;
     const { position } = cameraDock;
@@ -463,7 +480,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       >
         {this.renderPreviousPageButton()}
 
-        {!streams.length && !isGridEnabled ? null : (
+        {!streams.length && !isGridEnabled && !selfScreenshareTile ? null : (
           <Styled.VideoList
             ref={(ref) => {
               this.grid = ref;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -15,6 +15,10 @@ import { HookEvents } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/enum';
 import { DomElementManipulationHooks } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/enums';
 import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core/types';
 import { UserCameraHelperAreas } from '../../plugins-engine/extensible-areas/components/user-camera-helper/types';
+// useIsSharing: true only when the current user is actively broadcasting a screenshare.
+// useIsScreenBroadcasting returns true for all users whenever anyone in the meeting shares.
+import { useIsSharing } from '/imports/ui/components/screenshare/service';
+import SelfScreenshareDockTile from '/imports/ui/components/screenshare/self-screenshare-dock-tile';
 
 interface VideoListContainerProps {
   streams: VideoItem[];
@@ -45,6 +49,8 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
     onVirtualBgDrop,
   } = props;
   const numberOfPages = useNumberOfPages();
+  const isSelfSharing = useIsSharing();
+  const selfScreenshareTile = isSelfSharing ? <SelfScreenshareDockTile /> : undefined;
 
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 
@@ -98,28 +104,27 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
     });
   }
 
+  if (!streams.length && !selfScreenshareTile) return null;
+
   return (
-    !streams.length
-      ? null
-      : (
-        <VideoList
-          pluginUserCameraHelperPerPosition={pluginUserCameraHelperPerPosition}
-          layoutType={layoutType}
-          setUserCamerasRequestedFromPlugin={setUserCamerasRequestedFromPlugin}
-          layoutContextDispatch={layoutContextDispatch}
-          numberOfPages={numberOfPages}
-          currentVideoPageIndex={currentVideoPageIndex}
-          cameraDock={cameraDock}
-          focusedId={focusedId}
-          handleVideoFocus={handleVideoFocus}
-          isGridEnabled={isGridEnabled}
-          overflowCount={overflowCount}
-          streams={streams}
-          onVideoItemMount={onVideoItemMount}
-          onVideoItemUnmount={onVideoItemUnmount}
-          onVirtualBgDrop={onVirtualBgDrop}
-        />
-      )
+    <VideoList
+      pluginUserCameraHelperPerPosition={pluginUserCameraHelperPerPosition}
+      layoutType={layoutType}
+      setUserCamerasRequestedFromPlugin={setUserCamerasRequestedFromPlugin}
+      layoutContextDispatch={layoutContextDispatch}
+      numberOfPages={numberOfPages}
+      currentVideoPageIndex={currentVideoPageIndex}
+      cameraDock={cameraDock}
+      focusedId={focusedId}
+      handleVideoFocus={handleVideoFocus}
+      isGridEnabled={isGridEnabled}
+      overflowCount={overflowCount}
+      streams={streams}
+      onVideoItemMount={onVideoItemMount}
+      onVideoItemUnmount={onVideoItemUnmount}
+      onVirtualBgDrop={onVirtualBgDrop}
+      selfScreenshareTile={selfScreenshareTile}
+    />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -17,8 +17,11 @@ import { UpdatedEventDetails } from 'bigbluebutton-html-plugin-sdk/dist/cjs/core
 import { UserCameraHelperAreas } from '../../plugins-engine/extensible-areas/components/user-camera-helper/types';
 // useIsSharing: true only when the current user is actively broadcasting a screenshare.
 // useIsScreenBroadcasting returns true for all users whenever anyone in the meeting shares.
-import { useIsSharing } from '/imports/ui/components/screenshare/service';
+import { useIsSharing, useScreenshares } from '/imports/ui/components/screenshare/service';
+import { ScreenshareResponse } from '/imports/ui/components/screenshare/queries';
 import SelfScreenshareDockTile from '/imports/ui/components/screenshare/self-screenshare-dock-tile';
+import Auth from '/imports/ui/services/auth';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
 interface VideoListContainerProps {
   streams: VideoItem[];
@@ -50,7 +53,16 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
   } = props;
   const numberOfPages = useNumberOfPages();
   const isSelfSharing = useIsSharing();
-  const selfScreenshareTile = isSelfSharing ? <SelfScreenshareDockTile /> : undefined;
+  const screenshares = useScreenshares();
+  const { data: currentUser } = useCurrentUser((u) => ({ presenter: u.presenter }));
+  const ownShare = isSelfSharing ? screenshares.find((s: ScreenshareResponse) => s.userId === Auth.userID) : null;
+  const selfScreenshareTile = isSelfSharing ? (
+    <SelfScreenshareDockTile
+      streamId={ownShare?.stream}
+      showAsContent={ownShare?.showAsContent ?? false}
+      isPresenter={currentUser?.presenter ?? false}
+    />
+  ) : undefined;
 
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
 

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -25,6 +25,7 @@ import { VideoItem } from '/imports/ui/components/video-provider/types';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import useSettings from '../../services/settings/hooks/useSettings';
+import { useIsSharing } from '/imports/ui/components/screenshare/service';
 import { SETTINGS } from '../../services/settings/enums';
 import { INITIAL_INPUT_STATE } from '../layout/initState';
 import { contentSidebarMarginToMedia } from '../../stylesheets/styled-components/general';
@@ -368,8 +369,9 @@ const WebcamContainer: React.FC = () => {
   }
 
   const audioModalIsOpen = useStorageKey('audioModalIsOpen');
+  const isSelfSharing = useIsSharing();
 
-  return cameraDock?.display && !audioModalIsOpen && (usersVideo.length > 0 || isGridEnabled)
+  return cameraDock?.display && !audioModalIsOpen && (usersVideo.length > 0 || isGridEnabled || isSelfSharing)
     ? (
       <WebcamComponent
         {...{

--- a/bigbluebutton-html5/imports/ui/core/graphql/comparators/meetingComparator.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/comparators/meetingComparator.ts
@@ -74,6 +74,8 @@ export const meetingComparator = <T>(
   if ((als?.hideViewersAnnotation ?? false) !== (bls?.hideViewersAnnotation ?? false)) return false;
   if ((als?.meetingId ?? false) !== (bls?.meetingId ?? false)) return false;
   if ((als?.webcamsOnlyForModerator ?? false) !== (bls?.webcamsOnlyForModerator ?? false)) return false;
+  if ((als?.disableMultiScreenshare ?? false) !== (bls?.disableMultiScreenshare ?? false)) return false;
+  if ((als?.hideViewersScreenshare ?? false) !== (bls?.hideViewersScreenshare ?? false)) return false;
 
   const avs = aData.voiceSettings;
   const bvs = bData.voiceSettings;

--- a/bigbluebutton-html5/imports/ui/core/graphql/mutations/screenshareMutations.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/mutations/screenshareMutations.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+
+export const SET_SCREENSHARE_SHOW_AS_CONTENT = gql`
+  mutation SetScreenshareShowAsContent($streamId: String!, $showAsContent: Boolean!) {
+    screenshareSetShowAsContent(streamId: $streamId, showAsContent: $showAsContent)
+  }
+`;
+
+export default {
+  SET_SCREENSHARE_SHOW_AS_CONTENT,
+};

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/meetingSubscription.ts
@@ -18,6 +18,8 @@ const MEETING_SUBSCRIPTION = gql`
           webcamsOnlyForModerator
           lockOnJoin
           lockOnJoinConfigurable
+          disableMultiScreenshare
+          hideViewersScreenshare
         }
 
         learningDashboard {
@@ -35,6 +37,8 @@ const MEETING_SUBSCRIPTION = gql`
           vidHeight
           vidWidth
           voiceConf
+          userId
+          showAsContent
         }
         usersPolicies {
           guestPolicy

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -377,7 +377,7 @@ public:
       # subscribe reattempt increases the reconnection timer up to this
       maxTimeout: 60000
     screenshare:
-      showButtonForNonPresenters: false
+      showButtonForNonPresenters: true
       # Whether volume control should be allowed if screen sharing has audio
       enableVolumeControl: true
       # Experimental. True is the canonical behavior. Flip to false to reverse

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -279,6 +279,8 @@
     "app.screenshare.screenshareUnsupportedEnv": "Code {errorCode}. Browser is not supported. Try again using a different browser or device.",
     "app.screenshare.screensharePermissionError": "Code {errorCode}. Permission to capture the screen needs to be granted.",
     "app.screenshare.screenshareToastHelpLabel": "Learn more",
+    "app.screenshare.showAsContentLabel": "Show as main content",
+    "app.screenshare.moveToThumbnailLabel": "Move to thumbnail",
     "app.cameraAsContent.presenterLoadingLabel": "Your camera is loading",
     "app.cameraAsContent.viewerLoadingLabel": "The presenter's camera is loading",
     "app.cameraAsContent.presenterSharingLabel": "You are now presenting your camera",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1213,6 +1213,8 @@
     "app.lock-viewers.locked": "Locked",
     "app.lock-viewers.hideViewersCursor": "See other participants' cursors",
     "app.lock-viewers.hideAnnotationsLabel": "Seeing other participants' annotations on the whiteboard.",
+    "app.lock-viewers.disableMultiScreenshareLabel": "Share screen",
+    "app.lock-viewers.hideViewersScreenshareLabel": "See other participants' screenshares",
     "app.lock-viewers.disablePresenterRequestLabel": "Requesting to become presenter.",
     "app.lock-viewers.tabs.guestPolicy": "Guest Policy",
     "app.lock-viewers.tabs.participantPermissions": "Participant Permissions",

--- a/bigbluebutton-html5/public/locales/fr.json
+++ b/bigbluebutton-html5/public/locales/fr.json
@@ -279,6 +279,8 @@
     "app.screenshare.screenshareUnsupportedEnv": "Code {errorCode}. Le navigateur n'est pas pris en charge. Essayez à nouveau en utilisant un autre navigateur ou un appareil différent.",
     "app.screenshare.screensharePermissionError": "Code {errorCode}. Les captures d'écran sont soumises à autorisation.",
     "app.screenshare.screenshareToastHelpLabel": "En savoir plus",
+    "app.screenshare.showAsContentLabel": "Afficher comme contenu principal",
+    "app.screenshare.moveToThumbnailLabel": "Déplacer en miniature",
     "app.cameraAsContent.presenterLoadingLabel": "Votre caméra est en cours de chargement",
     "app.cameraAsContent.viewerLoadingLabel": "La caméra du présentateur est en cours de chargement",
     "app.cameraAsContent.presenterSharingLabel": "Vous présentez maintenant votre caméra",

--- a/bigbluebutton-html5/public/locales/pt_BR.json
+++ b/bigbluebutton-html5/public/locales/pt_BR.json
@@ -279,6 +279,8 @@
     "app.screenshare.screenshareUnsupportedEnv": "Código {errorCode}. O navegador não é compatível. Tente novamente usando um navegador ou dispositivo diferente.",
     "app.screenshare.screensharePermissionError": "Código {errorCode}. A permissão de compartilhamento de tela deve ser concedida.",
     "app.screenshare.screenshareToastHelpLabel": "Saber mais",
+    "app.screenshare.showAsContentLabel": "Exibir como conteúdo principal",
+    "app.screenshare.moveToThumbnailLabel": "Mover para miniatura",
     "app.cameraAsContent.presenterLoadingLabel": "Sua câmera está carregando",
     "app.cameraAsContent.viewerLoadingLabel": "A câmera do apresentador está carregando",
     "app.cameraAsContent.presenterSharingLabel": "Sua câmera está sendo transmitida",

--- a/bigbluebutton-tests/playwright/README.md
+++ b/bigbluebutton-tests/playwright/README.md
@@ -1,9 +1,11 @@
 <!-- omit from toc -->
+
 ## BigBlueButton Playwright Tests
 
 Tests for BigBlueButton using Playwright.
 
 <!-- omit from toc -->
+
 ## Table of content
 
 - [Setup](#setup)

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -19,8 +19,14 @@ export class Chat extends MultiUsers {
 
   async sendPrivateMessage() {
     await this.modPage.hasElement(e.chatBox, 'should display the chat box element when chat is open');
-    await this.modPage.wasRemoved(e.publicChatButton, 'should not display the public chat button when there is no private messages');
-    await this.modPage.wasRemoved(e.privateChatButton, 'should not display the private chat button when there is no private messages');
+    await this.modPage.wasRemoved(
+      e.publicChatButton,
+      'should not display the public chat button when there is no private messages',
+    );
+    await this.modPage.wasRemoved(
+      e.privateChatButton,
+      'should not display the private chat button when there is no private messages',
+    );
     await openPrivateChat(this.modPage);
     await this.modPage.hasElement(
       e.hidePrivateChat,
@@ -32,7 +38,10 @@ export class Chat extends MultiUsers {
     await this.modPage.fill(e.chatBox, e.message1);
     await this.modPage.waitAndClick(e.sendButton);
     await this.userPage.waitAndClick(e.privateChatButton);
-    await this.userPage.hasElement(e.privateChatItem, 'should display the private chat item when user receives a private message');
+    await this.userPage.hasElement(
+      e.privateChatItem,
+      'should display the private chat item when user receives a private message',
+    );
     await this.userPage.waitAndClick(e.privateChatItem);
     await this.userPage.hasElement(
       e.hidePrivateChat,
@@ -262,7 +271,10 @@ export class Chat extends MultiUsers {
     await this.modPage.hasElement(e.sendButton, 'should display the send button element');
     await this.modPage.waitAndClick(e.hidePublicChat);
     await this.modPage.wasRemoved(e.chatTitle, 'should not display the chat title element after hiding the messages');
-    await this.modPage.wasRemoved(e.chatOptions, 'should not display the chat options element after hiding the messages');
+    await this.modPage.wasRemoved(
+      e.chatOptions,
+      'should not display the chat options element after hiding the messages',
+    );
     await this.modPage.wasRemoved(e.chatBox, 'should not display the chat box element after hiding the messages');
     await this.modPage.wasRemoved(e.sendButton, 'should not display the send button element after hiding the messages');
   }
@@ -498,7 +510,10 @@ export class Chat extends MultiUsers {
       return;
     }
     await this.userPage.waitAndClick(e.privateChatButton);
-    await this.userPage.hasElement(e.privateChatItem, 'should display the private chat item when the user receives a private message');
+    await this.userPage.hasElement(
+      e.privateChatItem,
+      'should display the private chat item when the user receives a private message',
+    );
     await this.userPage.waitAndClick(e.privateChatItem);
     // check sent messages
     await checkLastMessageSent(this.modPage, e.convertedEmojiMessage);

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -514,6 +514,10 @@ export const elements = {
   hideViewersCursor: 'input[data-test="hideViewersCursor"]',
   lockScreenshare: 'input[data-test="lockScreenshare"]',
   hideViewersScreenshare: 'input[data-test="hideViewersScreenshare"]',
+  screenshareActionsBtn: 'button[data-test="screenshareActionsBtn"]',
+  screenshareShowAsContentBtn: 'li[data-test="screenshareShowAsContentBtn"]',
+  screenshareMoveToThumbnailBtn: 'li[data-test="screenshareMoveToThumbnailBtn"]',
+  selfScreenshareDockItem: '[data-test="selfScreenshareDockItem"]',
   whiteboardCursorIndicator: 'svg use[href="#cursor"]',
 
   // Locales

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -512,6 +512,8 @@ export const elements = {
   lockUserList: 'input[data-test="lockUserList"]',
   hideViewersAnnotation: 'input[data-test="hideViewersAnnotation"]',
   hideViewersCursor: 'input[data-test="hideViewersCursor"]',
+  lockScreenshare: 'input[data-test="lockScreenshare"]',
+  hideViewersScreenshare: 'input[data-test="hideViewersScreenshare"]',
   whiteboardCursorIndicator: 'svg use[href="#cursor"]',
 
   // Locales

--- a/bigbluebutton-tests/playwright/core/helpers.ts
+++ b/bigbluebutton-tests/playwright/core/helpers.ts
@@ -116,7 +116,7 @@ export function createMeetingUrl(createParameter?: string, customMeetingId?: str
 
 export function createMeetingPromise(createParameter?: string, customMeetingId?: string): Promise<AxiosResponse> {
   const url = createMeetingUrl(createParameter, customMeetingId);
-  return axios.get(url, { adapter: 'http' });
+  return axios.get(url, { adapter: 'http', headers: { Accept: 'text/xml' } });
 }
 
 export async function createMeeting(createParameter?: string, customMeetingId?: string): Promise<string> {

--- a/bigbluebutton-tests/playwright/core/page.ts
+++ b/bigbluebutton-tests/playwright/core/page.ts
@@ -406,7 +406,7 @@ export class Page {
           const element = document.querySelector(el);
           if (!element) return false;
 
-          const afterElement = getComputedStyle(element, 'after');
+          const afterElement = getComputedStyle(element, '::after');
           if (afterElement && afterElement.content !== 'none') {
             return true;
           }

--- a/bigbluebutton-tests/playwright/core/page.ts
+++ b/bigbluebutton-tests/playwright/core/page.ts
@@ -401,35 +401,34 @@ export class Page {
 
   async hasNotificationIcon(selector: string, description: string, timeout = ELEMENT_WAIT_TIME) {
     await expect(async () => {
-      const hasNotificationIcon = await this.page.evaluate(({
-        el,
-        publicIndicator,
-        privateIndicator,
-      }) => {
-        const element = document.querySelector(el);
-        if (!element) return false;
-        
-        const afterElement = getComputedStyle(element, 'after');
-        if (afterElement && afterElement.content !== 'none') {
-          return true;
-        }
-        
-        // Check for unread indicator in public/private buttons inside the chat panel
-        const publicBadge = element.querySelector(publicIndicator);
-        if (publicBadge) {
-          return true;
-        }
-        const privateBadge = element.querySelector(privateIndicator);
-        if (privateBadge) {
-          return true;
-        }
-        
-        return false;
-      }, {
-        el: selector,
-        publicIndicator: e.publicUnreadIndicator,
-        privateIndicator: e.privateUnreadIndicator,
-      });
+      const hasNotificationIcon = await this.page.evaluate(
+        ({ el, publicIndicator, privateIndicator }) => {
+          const element = document.querySelector(el);
+          if (!element) return false;
+
+          const afterElement = getComputedStyle(element, 'after');
+          if (afterElement && afterElement.content !== 'none') {
+            return true;
+          }
+
+          // Check for unread indicator in public/private buttons inside the chat panel
+          const publicBadge = element.querySelector(publicIndicator);
+          if (publicBadge) {
+            return true;
+          }
+          const privateBadge = element.querySelector(privateIndicator);
+          if (privateBadge) {
+            return true;
+          }
+
+          return false;
+        },
+        {
+          el: selector,
+          publicIndicator: e.publicUnreadIndicator,
+          privateIndicator: e.privateUnreadIndicator,
+        },
+      );
       expect(hasNotificationIcon).toBeTruthy();
     }, description).toPass({ timeout });
   }
@@ -542,7 +541,7 @@ export class Page {
   async checkTooltip(selector: string, text: string) {
     await this.hoverElement(selector);
     const locatorTooltip = this.page.locator(`text=${text}`);
-    await expect(locatorTooltip).toBeVisible({ timeout: 10000});
+    await expect(locatorTooltip).toBeVisible({ timeout: 10000 });
   }
 
   async getYoutubeFrame(): Promise<Frame> {

--- a/bigbluebutton-tests/playwright/core/setup/global.setup.ts
+++ b/bigbluebutton-tests/playwright/core/setup/global.setup.ts
@@ -25,7 +25,11 @@ async function validateEnvironmentAndAPI(): Promise<void> {
   }
 
   // Create a request context for API validation
-  const requestContext = await request.newContext();
+  const proxyServer = process.env.HTTPS_PROXY || process.env.https_proxy;
+  const requestContext = await request.newContext({
+    ignoreHTTPSErrors: true,
+    ...(proxyServer ? { proxy: { server: proxyServer } } : {}),
+  });
 
   try {
     // Test the /create endpoint with a temporary meeting

--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.ts
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.ts
@@ -46,7 +46,7 @@ export class LearningDashboard extends MultiUsers {
     await this.modPage.hasText(e.recordingIndicator, '00:00', 'should start recording at the initial time');
 
     const timeLocator = this.dashboardPage.page.locator(e.userOnlineTime);
-    const timeContent = await (timeLocator).textContent();
+    const timeContent = await timeLocator.textContent();
     if (!timeContent) throw new Error('Time content is null');
     const time = timeInSeconds(timeContent);
     await this.dashboardPage.page.waitForTimeout(1000);

--- a/bigbluebutton-tests/playwright/learningdashboard/util.ts
+++ b/bigbluebutton-tests/playwright/learningdashboard/util.ts
@@ -7,7 +7,7 @@ export async function openPoll(testPage: Page) {
   const { pollEnabled } = testPage.settings || {};
   test.skip(!pollEnabled, 'Polling is disabled');
 
-  await testPage.waitAndClick(e.pollSidebarButton)
+  await testPage.waitAndClick(e.pollSidebarButton);
 }
 
 export function timeInSeconds(timeTextContent: string) {

--- a/bigbluebutton-tests/playwright/notifications/chatNotifications.ts
+++ b/bigbluebutton-tests/playwright/notifications/chatNotifications.ts
@@ -13,7 +13,10 @@ export class ChatNotifications extends MultiUsers {
     await this.modPage.page.waitForTimeout(1000);
     await util.publicChatMessageToast(this.modPage, this.userPage);
     await this.modPage.waitAndClick(e.chatTitle);
-    await this.modPage.hasNotificationIcon(e.publicChatButton, 'should display the notification icon on the public messages button');
+    await this.modPage.hasNotificationIcon(
+      e.publicChatButton,
+      'should display the notification icon on the public messages button',
+    );
     await util.checkNotificationText(this.modPage, e.publicChatToast);
   }
 
@@ -30,7 +33,10 @@ export class ChatNotifications extends MultiUsers {
       e.smallToastMsg,
       'should the small toast message with the new text sent on the private chat',
     );
-    await this.modPage.hasNotificationIcon(e.privateChatButton, 'should display the notification icon on the private messages button');
+    await this.modPage.hasNotificationIcon(
+      e.privateChatButton,
+      'should display the notification icon on the private messages button',
+    );
     await util.checkNotificationText(this.modPage, e.privateChatToast);
   }
 }

--- a/bigbluebutton-tests/playwright/notifications/recordingNotifications.ts
+++ b/bigbluebutton-tests/playwright/notifications/recordingNotifications.ts
@@ -11,7 +11,11 @@ export class RecordingNotifications extends Page {
     await this.closeAllToastNotifications();
     await this.waitAndClick(e.recordingIndicator);
     await this.waitAndClick(e.cancelRecordingButton);
-    await this.hasNElements(e.smallToastMsg, 1, 'should display only the warning toast after canceling / closing recording notification');
+    await this.hasNElements(
+      e.smallToastMsg,
+      1,
+      'should display only the warning toast after canceling / closing recording notification',
+    );
     await util.checkNotificationText(this, e.noActiveMicrophoneToast);
   }
 

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -22,6 +22,8 @@ export const constants = {
   lockSettingsDisableMic: 'lockSettingsDisableMic=true',
   lockSettingsDisablePublicChat: 'lockSettingsDisablePublicChat=true',
   lockSettingsHideUserList: 'lockSettingsHideUserList=true',
+  lockSettingsDisableMultiScreenshare: 'lockSettingsDisableMultiScreenshare=true',
+  lockSettingsHideViewersScreenshare: 'lockSettingsHideViewersScreenshare=true',
   allowModsToEjectCameras: 'allowModsToEjectCameras=true',
   notifyRecordingIsOn: 'notifyRecordingIsOn=true&notifyRecordingIsOn=true',
   preUploadedPresentation:

--- a/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
+++ b/bigbluebutton-tests/playwright/parameters/disabledFeatures.ts
@@ -54,7 +54,10 @@ export class DisabledFeatures extends MultiUsers {
 
   async learningDashboard() {
     await this.modPage.hasElement(e.usersListSidebarButton, 'should display the users list button on the sidebar');
-    await this.modPage.wasRemoved(e.learningDashboardSidebarButton, 'should not display the learning dashboard button on the sidebar');
+    await this.modPage.wasRemoved(
+      e.learningDashboardSidebarButton,
+      'should not display the learning dashboard button on the sidebar',
+    );
   }
 
   async polls() {
@@ -66,7 +69,10 @@ export class DisabledFeatures extends MultiUsers {
   }
 
   async sharedNotes() {
-    await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button on the sidebar');
+    await this.modPage.wasRemoved(
+      e.sharedNotesSidebarButton,
+      'should not display the shared notes button on the sidebar',
+    );
   }
 
   async virtualBackgrounds() {
@@ -194,7 +200,10 @@ export class DisabledFeatures extends MultiUsers {
 
   async learningDashboardExclude() {
     await this.modPage.hasElement(e.usersListSidebarButton, 'should display the users list button on the sidebar');
-    await this.modPage.hasElement(e.learningDashboardSidebarButton, 'should display the learning dashboard button on the sidebar');
+    await this.modPage.hasElement(
+      e.learningDashboardSidebarButton,
+      'should display the learning dashboard button on the sidebar',
+    );
   }
 
   async pollsExclude() {

--- a/bigbluebutton-tests/playwright/playwright.config.ts
+++ b/bigbluebutton-tests/playwright/playwright.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
     trace: CI ? 'retain-on-failure' : 'on',
     video: CI ? 'retain-on-failure' : 'on',
     actionTimeout: ELEMENT_WAIT_LONGER_TIME,
+    ignoreHTTPSErrors: true,
+    ...(process.env.HTTPS_PROXY ? { proxy: { server: process.env.HTTPS_PROXY } } : {}),
   },
   projects: [
     {

--- a/bigbluebutton-tests/playwright/polling/poll.ts
+++ b/bigbluebutton-tests/playwright/polling/poll.ts
@@ -33,7 +33,6 @@ export class Polling extends MultiUsers {
     // The slide needs to be uploaded and converted, so wait a bit longer for this step
     await this.modPage.waitAndClick(e.quickPoll, ELEMENT_WAIT_LONGER_TIME);
     if (!quickPollConfirmationStep) {
-
       await this.userPage.hasElement(
         e.pollingContainer,
         'should display the polling container for the attendee to answer it',
@@ -93,7 +92,10 @@ export class Polling extends MultiUsers {
       'should not display the polling container after the poll is canceled',
     );
 
-    await this.modPage.hasElement(e.pollQuestionArea, 'should display the poll question area after the poll is canceled');
+    await this.modPage.hasElement(
+      e.pollQuestionArea,
+      'should display the poll question area after the poll is canceled',
+    );
   }
 
   async manageResponseChoices() {
@@ -109,7 +111,10 @@ export class Polling extends MultiUsers {
     await this.modPage.waitAndClick(e.addPollItem);
     await this.typeOnLastChoiceInput();
     await this.modPage.waitAndClick(e.startPoll);
-    await this.modPage.hasElementDisabled(e.publishPollingLabel, 'should display the publish poll button disabled before the poll is started');
+    await this.modPage.hasElementDisabled(
+      e.publishPollingLabel,
+      'should display the publish poll button disabled before the poll is started',
+    );
 
     await expect(initialRespCount + 1, 'should display the initial quantity of poll options itens plus 1').toEqual(
       await this.getAnswerOptionCount(),
@@ -120,7 +125,10 @@ export class Polling extends MultiUsers {
     await this.startNewPoll();
     await this.modPage.waitAndClick(e.deletePollOption);
     await this.modPage.waitAndClick(e.startPoll);
-    await this.modPage.hasElementDisabled(e.publishPollingLabel, 'should display the publish poll button disabled before the poll is started');
+    await this.modPage.hasElementDisabled(
+      e.publishPollingLabel,
+      'should display the publish poll button disabled before the poll is started',
+    );
 
     await expect(initialRespCount - 1, 'should display the initial quantity of poll options itens minus 1').toEqual(
       await this.getAnswerOptionCount(),
@@ -130,7 +138,10 @@ export class Polling extends MultiUsers {
     await this.startNewPoll();
     await this.typeOnLastChoiceInput();
     await this.modPage.waitAndClick(e.startPoll);
-    await this.modPage.hasElementDisabled(e.publishPollingLabel, 'should display the publish poll button disabled before the poll is started');
+    await this.modPage.hasElementDisabled(
+      e.publishPollingLabel,
+      'should display the publish poll button disabled before the poll is started',
+    );
 
     await expect(initialRespCount, 'should display the initial quantity of poll options itens').toEqual(
       await this.getAnswerOptionCount(),
@@ -233,7 +244,10 @@ export class Polling extends MultiUsers {
     );
 
     await this.modPage.waitAndClick(e.minimizePolling);
-    await this.modPage.wasRemoved(e.minimizePolling, 'should not display the minimize polling button after the poll is closed');
+    await this.modPage.wasRemoved(
+      e.minimizePolling,
+      'should not display the minimize polling button after the poll is closed',
+    );
   }
 
   async oneOptionAnswer() {
@@ -518,8 +532,8 @@ export class Polling extends MultiUsers {
     if (hasPollStarted) {
       await this.modPage.waitAndClick(e.cancelPollBtn);
       await this.modPage.wasRemoved(
-        e.publishPollingLabel, 
-        'should not display the publish poll button after the poll is canceled'
+        e.publishPollingLabel,
+        'should not display the publish poll button after the poll is canceled',
       );
       await this.userPage.wasRemoved(
         e.pollingContainer,

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -114,7 +114,7 @@ export class Presentation extends MultiUsers {
         e.shareExternalVideoBtn,
         'should not display the option to share an external video, since is deactivated',
       );
-      return
+      return;
     }
     await this.modPage.waitAndClick(e.shareExternalVideoBtn);
     await this.modPage.hasElement(
@@ -422,7 +422,7 @@ export class Presentation extends MultiUsers {
     //! await this.modPage.handleDownload(this.modPage.page.locator(e.presentationDownloadBtn), testInfo);
     //! await this.userPage.handleDownload(this.userPage.page.locator(e.presentationDownloadBtn), testInfo);
     // disable original presentation download
-    
+
     await this.modPage.waitAndClick(e.managePresentations);
     await this.modPage.waitAndClick(e.presentationOptionsDownloadBtn);
     await this.modPage.waitAndClick(e.disableOriginalPresentationDownloadBtn);
@@ -457,7 +457,7 @@ export class Presentation extends MultiUsers {
     }
     await this.modPage.waitAndClick(e.sendPresentationInCurrentStateBtn);
     await this.modPage.hasElement(e.downloadPresentationToast, 'should display the download presentation toast');
-     await this.userPage.hasElement(
+    await this.userPage.hasElement(
       e.downloadPresentation,
       'should display the download presentation button for the attendee',
       ELEMENT_WAIT_EXTRA_LONG_TIME,
@@ -471,7 +471,10 @@ export class Presentation extends MultiUsers {
     await this.modPage.waitAndClick(e.mediaAreaButton);
     await this.modPage.waitAndClick(e.managePresentations);
     await this.modPage.waitAndClick(e.removePresentation);
-    await this.modPage.hasElementDisabled(e.sharePresentationButton, 'should disable the share presentation button when there is no presentation');
+    await this.modPage.hasElementDisabled(
+      e.sharePresentationButton,
+      'should disable the share presentation button when there is no presentation',
+    );
 
     await this.modPage.wasRemoved(e.whiteboard, 'should not display the whiteboard for the moderator');
     await this.modPage.wasRemoved(
@@ -502,8 +505,8 @@ export class Presentation extends MultiUsers {
       2,
       'should display both default and uploaded presentation on the manage presentations modal',
     );
-    await this.modPage.waitAndClick(e.removePresentation);  // remove first presentation
-    await this.modPage.waitAndClick(e.removePresentation);  // remove second presentation
+    await this.modPage.waitAndClick(e.removePresentation); // remove first presentation
+    await this.modPage.waitAndClick(e.removePresentation); // remove second presentation
 
     await this.modPage.wasRemoved(e.whiteboard, 'should not display the whiteboard for the moderator');
     await this.modPage.wasRemoved(

--- a/bigbluebutton-tests/playwright/recording/recording.ts
+++ b/bigbluebutton-tests/playwright/recording/recording.ts
@@ -55,7 +55,11 @@ export class Recording extends MultiUsers {
 
     // start recording
     await this.modPage.waitAndClick(e.recordingIndicator);
-    await this.modPage.hasNElements(e.toastContainer, 2, 'should display 2 toasts when starting recording, one for no mic and one for the options');
+    await this.modPage.hasNElements(
+      e.toastContainer,
+      2,
+      'should display 2 toasts when starting recording, one for no mic and one for the options',
+    );
     await this.modPage.hasElement(e.cancelRecordingButton, 'should display the Cancel button in the recording toast');
     await this.modPage.hasElement(e.confirmRecordingButton, 'should display the Confirm button in the recording toast');
     await this.modPage.waitAndClick(e.confirmRecordingButton);
@@ -87,9 +91,11 @@ export class Recording extends MultiUsers {
       const match = text?.match(/(\d+):(\d+)/);
       expect(match, 'should find time pattern in recording button text').not.toBeNull();
       const [, minutes, seconds] = match!;
-      const totalSeconds = Number.parseInt(minutes) * 60 + Number.parseInt(seconds);
+      const totalSeconds = Number.parseInt(minutes, 10) * 60 + Number.parseInt(seconds, 10);
       expect(totalSeconds).toBeGreaterThan(5);
-    }, 'should display more than 5 seconds on the recording button counter').toPass({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    }, 'should display more than 5 seconds on the recording button counter').toPass({
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
     await this.modPage.waitAndClick(e.leaveMeetingDropdown);
     await this.modPage.waitAndClick(e.endMeetingButton);
     await this.modPage.hasElement(e.simpleModal, 'should display the confirm meeting end modal');

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -30,6 +30,21 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.viewerCanStartScreenshare();
   });
 
+  // R2: two screenshares coexist simultaneously; observer sees a decoded stream
+  test('[R2] Two screenshares active simultaneously, observer sees decoded stream', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.initModPage2(context, { testInfo });
+    await screenshare.twoSharesActiveSide();
+  });
+
   // R3: lockSettingsDisableMultiScreenshare=true hides the start button for locked viewers
   test('[R3] Viewer screenshare button hidden when disableMultiScreenshare is active via API', async ({
     browser,

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -56,6 +56,20 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.lockViewersUiHasScreenshareToggles();
   });
 
+  // R3 inverse / T15: with lock inactive a viewer share stays allowed and reaches a moderator observer
+  test('[R3][Inverse] viewer share stays allowed when lock inactive, observed by moderator', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.viewerShareAllowedWithLockInactive();
+  });
+
   // R4: Enabling disableMultiScreenshare via lock-viewers UI forcibly stops active viewer shares
   // Actors: broadcaster_moderator (modPage), broadcaster_viewer (userPage),
   //         moderator_controller (modPage2)

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -145,6 +145,22 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.soloPublisherDockPreview();
   });
 
+  // Phase C: presenter A and publisher B both share. A toggles B to content, then A back to content.
+  // Verifies per-stream showAsContent toggle works and mutual exclusion is enforced.
+  test('[C1][R2-inverse] Presenter toggles showAsContent between two active screenshares', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.initModPage2(context, { testInfo });
+    await screenshare.inverseR2ToggleShowAsContent();
+  });
+
   // Phase B-2: two publishers simultaneously; each sees peer in main area and own share in dock.
   // Observer sees both streams decoded; no dock tile for observer.
   test('[B2] Sibling publishers: own share in dock, peer share in main area', async ({

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -70,6 +70,21 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.viewerShareAllowedWithLockInactive();
   });
 
+  // R3 / T03 UI-toggle: moderator enables disableMultiScreenshare via lock-viewers panel,
+  // viewer's button disappears, moderator deactivates lock, viewer can share successfully
+  test('[R3][T03-ui] viewer screenshare blocked when disableMultiScreenshare activated via UI toggle', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.viewerScreenshareLockedByUiToggle();
+  });
+
   // R4: Enabling disableMultiScreenshare via lock-viewers UI forcibly stops active viewer shares
   // Actors: broadcaster_moderator (modPage), broadcaster_viewer (userPage),
   //         moderator_controller (modPage2)
@@ -85,5 +100,18 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.initUserPage(context, { testInfo });
     await screenshare.initModPage2(context, { testInfo });
     await screenshare.enableDisableMultiScreenshareStopsViewerShare();
+  });
+
+  // R14 / T14 regression: existing lock settings disableCam and lockPublicChat still apply their
+  // effects after multi-screenshare changes
+  test('[R14][Regression] existing lock settings disableCam and lockPublicChat still apply', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.lockViewersRegressionEffects();
   });
 });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -1,5 +1,6 @@
 import { linkIssue } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
+import { constants as c } from '../parameters/constants';
 import { ScreenShare } from './screenshare';
 
 test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
@@ -18,5 +19,54 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     const screenshare = new ScreenShare(browser, context);
     await screenshare.initModPage(page, { testInfo });
     await screenshare.screenshareStopsExternalVideo();
+  });
+
+  // R1: Viewer (non-presenter) can start a screenshare without being promoted
+  test('[R1] Viewer can start screenshare', async ({ browser, context, browserName, page }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.viewerCanStartScreenshare();
+  });
+
+  // R3: lockSettingsDisableMultiScreenshare=true hides the start button for locked viewers
+  test('[R3] Viewer screenshare button hidden when disableMultiScreenshare is active via API', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, {
+      testInfo,
+      createParameter: `${c.lockSettingsDisableMultiScreenshare}&lockOnJoin=true`,
+    });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.viewerScreenshareLockedByApiParam();
+  });
+
+  // R14: Lock viewers dialog exposes the two new screenshare permission toggles
+  test('[R14] Lock viewers UI has disableMultiScreenshare and hideViewersScreenshare toggles', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.lockViewersUiHasScreenshareToggles();
+  });
+
+  // R4: Enabling disableMultiScreenshare via lock-viewers UI forcibly stops active viewer shares
+  test('[R4] Enabling disableMultiScreenshare stops active viewer screenshare', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.enableDisableMultiScreenshareStopsViewerShare();
   });
 });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -30,7 +30,9 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.viewerCanStartScreenshare();
   });
 
-  // R2: two screenshares coexist simultaneously; observer sees a decoded stream
+  // R2: both screenshares must coexist and be decoded simultaneously on the observer page.
+  // The observer must see TWO independent video elements, each rendering live frames.
+  // Current build FAILS here: the frontend renders a single <video id="screenshareVideo">.
   test('[R2] Two screenshares active simultaneously, observer sees decoded stream', async ({
     browser,
     context,

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -56,7 +56,7 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     const screenshare = new ScreenShare(browser, context);
     await screenshare.initModPage(page, {
       testInfo,
-      createParameter: `${c.lockSettingsDisableMultiScreenshare}&lockOnJoin=true`,
+      createParameter: `${c.lockSettingsDisableMultiScreenshare}&lockSettingsLockOnJoin=true`,
     });
     await screenshare.initUserPage(context, { testInfo });
     await screenshare.viewerScreenshareLockedByApiParam();

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -131,4 +131,33 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     await screenshare.initUserPage(context, { testInfo });
     await screenshare.lockViewersRegressionEffects();
   });
+
+  // Phase B-1: solo publisher never sees own share in main area; it goes to camera dock.
+  test('[B1] Solo publisher self-share renders as camera dock thumbnail', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.soloPublisherDockPreview();
+  });
+
+  // Phase B-2: two publishers simultaneously; each sees peer in main area and own share in dock.
+  // Observer sees both streams decoded; no dock tile for observer.
+  test('[B2] Sibling publishers: own share in dock, peer share in main area', async ({
+    browser,
+    context,
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Screenshare tests not supported in Firefox without desktop');
+    const screenshare = new ScreenShare(browser, context);
+    await screenshare.initModPage(page, { testInfo });
+    await screenshare.initUserPage(context, { testInfo });
+    await screenshare.initModPage2(context, { testInfo });
+    await screenshare.siblingPublishersDockSelfPreview();
+  });
 });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.spec.ts
@@ -57,6 +57,8 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
   });
 
   // R4: Enabling disableMultiScreenshare via lock-viewers UI forcibly stops active viewer shares
+  // Actors: broadcaster_moderator (modPage), broadcaster_viewer (userPage),
+  //         moderator_controller (modPage2)
   test('[R4] Enabling disableMultiScreenshare stops active viewer screenshare', async ({
     browser,
     context,
@@ -67,6 +69,7 @@ test.describe.parallel('Screenshare', { tag: '@ci' }, () => {
     const screenshare = new ScreenShare(browser, context);
     await screenshare.initModPage(page, { testInfo });
     await screenshare.initUserPage(context, { testInfo });
+    await screenshare.initModPage2(context, { testInfo });
     await screenshare.enableDisableMultiScreenshareStopsViewerShare();
   });
 });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -2,7 +2,15 @@ import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
 import { openLockViewers } from '../user/util';
-import { dwellOnBehavior, expectDecodedFrames, expectVisiblyRendered, startScreenshare } from './util';
+import {
+  dwellOnBehavior,
+  expectDecodedFrames,
+  expectMultipleDecodedVideos,
+  expectVideosRenderedSideBySide,
+  expectVisiblyRendered,
+  stabilityWindow,
+  startScreenshare,
+} from './util';
 
 export class ScreenShare extends MultiUsers {
   async startSharing() {
@@ -229,30 +237,58 @@ export class ScreenShare extends MultiUsers {
     );
   }
 
-  // R2 / T02: Two screenshares active simultaneously; observer sees a decoded stream.
+  // R2 / T02: Two screenshares active simultaneously; observer must see BOTH decoded streams.
   // Actors: broadcaster_moderator (modPage), broadcaster_viewer (userPage),
   //         observer_moderator (modPage2)
+  //
+  // Flow: broadcaster_moderator (presenter) starts first. broadcaster_viewer shares
+  // concurrently as a non-presenter — this is permitted per R1.  Both broadcasters hold
+  // their stop-button before the decisive observer check.
+  //
+  // Expected outcome on the current build: FAIL at the stabilityWindow assertion because the
+  // HTML5 frontend renders a single <video id="screenshareVideo"> element; the observer DOM
+  // can never hold 2 matching elements simultaneously, regardless of how many broadcasters share.
   async twoSharesActiveSide() {
     const { screensharingEnabled } = this.modPage.settings || {};
     if (!screensharingEnabled) return;
 
-    // broadcaster_moderator starts screenshare first (gets showAsContent=true)
+    // Step 2: broadcaster_moderator starts screenshare first.
+    // observer_moderator confirms the first stream is decoding before the second share is added.
     await startScreenshare(this.modPage);
     await this.modPage.hasElement(e.stopScreenSharing, 'broadcaster_moderator should be sharing');
+    await dwellOnBehavior(this.modPage2.page, 'first screenshare active - observer verifying initial stream', 2000);
+    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]', 10, 2500);
 
-    // broadcaster_viewer starts screenshare simultaneously (second share, coexists)
+    // Step 3: broadcaster_viewer starts a concurrent screenshare as a non-presenter.
+    // Per R1, non-presenters may share.  Both stop-buttons must be visible confirming two
+    // independent share sessions are live from the server's perspective.
     await startScreenshare(this.userPage);
-    await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer should be sharing');
+    await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer should be sharing concurrently');
+    await this.modPage.hasElement(
+      e.stopScreenSharing,
+      'broadcaster_moderator share must coexist with broadcaster_viewer share',
+    );
 
-    // Dwell on "both shares active" state - proves simultaneous transmission
-    await dwellOnBehavior(this.modPage2.page, 'two screenshares active simultaneously', 4000);
+    // Dwell so the recording captures the "both sharing" window.
+    await dwellOnBehavior(this.modPage2.page, 'both screenshares active simultaneously - observer perspective', 4000);
 
-    // observer_moderator sees a decoded stream (the primary showAsContent stream)
-    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
+    // Step 4 (DECISIVE): observer_moderator MUST see exactly 2 decoded video elements.
+    // The current frontend renders a single <video id="screenshareVideo"> DOM element;
+    // there is no second video sink.  expectMultipleDecodedVideos will throw:
+    //   "Expected 2 video elements matching 'video[id^="screenshareVideo"]', found 1"
+    await stabilityWindow(this.modPage2.page, 3000, 500, async () => {
+      await expectMultipleDecodedVideos(this.modPage2.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
+      await expectVideosRenderedSideBySide(this.modPage2.page, 'video[id^="screenshareVideo"]', 2, 120);
+    });
 
-    // Both actors must still have their shares active (server did not stop either)
-    await this.modPage.hasElement(e.stopScreenSharing, 'broadcaster_moderator share still active after coexistence');
-    await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer share still active after coexistence');
+    // Step 5: broadcaster_moderator stops their share; broadcaster_viewer's share must survive.
+    await this.modPage.waitAndClick(e.stopScreenSharing);
+    await dwellOnBehavior(
+      this.modPage2.page,
+      'only broadcaster_viewer share active after first broadcaster stops',
+      2000,
+    );
+    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]', 5, 2000);
   }
 
   // R14 / T14 regression: existing lock settings must still apply their effects after multi-screenshare changes.

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -281,13 +281,31 @@ export class ScreenShare extends MultiUsers {
     // Dwell so the recording captures the "both sharing" window.
     await dwellOnBehavior(this.modPage2.page, 'both screenshares active simultaneously - observer perspective', 4000);
 
-    // Step 4 (DECISIVE): observer_moderator MUST see exactly 2 decoded video elements.
-    // The current frontend renders a single <video id="screenshareVideo"> DOM element;
-    // there is no second video sink.  expectMultipleDecodedVideos will throw:
-    //   "Expected 2 video elements matching 'video[id^="screenshareVideo"]', found 1"
+    // Step 4a: broadcaster_viewer must NOT have been promoted to presenter during share startup.
+    // Use page.evaluate rather than checkIsPresenter() to avoid the sidebar-closed crash.
+    const viewerIsPresenter = await this.userPage.page.evaluate(
+      ([currentUserSel, avatarSel]) => {
+        const el = document.querySelectorAll(`${currentUserSel} ${avatarSel}`)[0];
+        return el ? el.hasAttribute('data-test-presenter') : false;
+      },
+      [e.currentUser, e.userAvatar],
+    );
+    if (viewerIsPresenter) {
+      throw new Error('twoSharesActiveSide: broadcaster_viewer was promoted to presenter — R2 regression');
+    }
+
+    // Step 4c (DECISIVE): observer_moderator MUST see exactly 2 decoded video elements.
     await stabilityWindow(this.modPage2.page, 3000, 500, async () => {
       await expectMultipleDecodedVideos(this.modPage2.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
       await expectVideosRenderedSideBySide(this.modPage2.page, 'video[id^="screenshareVideo"]', 2, 120);
+    });
+
+    // Step 4d: each publisher must also see both streams in their own viewport.
+    await stabilityWindow(this.modPage.page, 3000, 500, async () => {
+      await expectMultipleDecodedVideos(this.modPage.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
+    });
+    await stabilityWindow(this.userPage.page, 3000, 500, async () => {
+      await expectMultipleDecodedVideos(this.userPage.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
     });
 
     // Step 5: broadcaster_moderator stops their share; broadcaster_viewer's share must survive.

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -2,7 +2,7 @@ import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
 import { openLockViewers } from '../user/util';
-import { dwellOnBehavior, expectDecodedFrames, startScreenshare } from './util';
+import { dwellOnBehavior, expectDecodedFrames, expectVisiblyRendered, startScreenshare } from './util';
 
 export class ScreenShare extends MultiUsers {
   async startSharing() {
@@ -71,17 +71,39 @@ export class ScreenShare extends MultiUsers {
     await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard after stopping screenshare');
   }
 
-  // R1: Viewer sees the start screenshare button and can share
+  // R1 / T01: viewer (broadcaster_viewer) starts screenshare; moderator (observer_moderator) observes decoded frames
   async viewerCanStartScreenshare() {
     const { screensharingEnabled } = this.modPage.settings || {};
     if (!screensharingEnabled) {
       await this.userPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
       return;
     }
-    // The viewer should see the start button (multi-screenshare feature)
+    // broadcaster_viewer starts screenshare
     await this.userPage.hasElement(e.startScreenSharing, 'viewer should see the start screenshare button');
     await startScreenshare(this.userPage);
-    await this.userPage.hasElement(e.stopScreenSharing, 'viewer should see the stop screenshare button after starting');
+    // stop button must be visibly rendered on the viewer's own page
+    await expectVisiblyRendered(this.userPage.page, e.stopScreenSharing);
+    // hold live state long enough for the recording to capture the active share
+    await dwellOnBehavior(this.modPage.page, 'viewer screenshare visible for moderator', 4000);
+    // observer_moderator must see the viewer stream decoding from their perspective
+    await expectDecodedFrames(this.modPage.page, 'video[id^="screenshareVideo"]');
+  }
+
+  // R3 inverse / T15: with disableMultiScreenshare inactive a viewer share stays allowed
+  // and reaches the moderator observer
+  async viewerShareAllowedWithLockInactive() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) {
+      await this.userPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
+      return;
+    }
+    // viewer_broadcaster starts screenshare with disableMultiScreenshare=false (default - lock inactive)
+    await this.userPage.hasElement(e.startScreenSharing, 'viewer should see start button when lock is inactive');
+    await startScreenshare(this.userPage);
+    // hold the allowed state for the recording
+    await dwellOnBehavior(this.modPage.page, 'viewer share allowed - lock inactive', 4000);
+    // moderator_observer must see the viewer stream decoding - confirms lock absence permits publishing
+    await expectDecodedFrames(this.modPage.page, 'video[id^="screenshareVideo"]');
   }
 
   // R3: disableMultiScreenshare=true hides the button from locked viewers

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -1,6 +1,7 @@
 import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
+import { openLockViewers } from '../user/util';
 import { startScreenshare } from './util';
 
 export class ScreenShare extends MultiUsers {
@@ -68,5 +69,64 @@ export class ScreenShare extends MultiUsers {
     await this.modPage.wasRemoved(e.stopScreenSharing, 'should not display the stop screenshare button after stopping');
     await this.modPage.hasElement(e.startScreenSharing, 'should display the start screenshare button after stopping');
     await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard after stopping screenshare');
+  }
+
+  // R1: Viewer sees the start screenshare button and can share
+  async viewerCanStartScreenshare() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) {
+      await this.userPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
+      return;
+    }
+    // The viewer should see the start button (multi-screenshare feature)
+    await this.userPage.hasElement(e.startScreenSharing, 'viewer should see the start screenshare button');
+    await startScreenshare(this.userPage);
+    await this.userPage.hasElement(e.stopScreenSharing, 'viewer should see the stop screenshare button after starting');
+  }
+
+  // R3: disableMultiScreenshare=true hides the button from locked viewers
+  async viewerScreenshareLockedByApiParam() {
+    // With lockSettingsDisableMultiScreenshare=true and lockOnJoin=true,
+    // the viewer is locked and disableMultiScreenshare is active.
+    // The start screenshare button should not be visible.
+    await this.userPage.wasRemoved(
+      e.startScreenSharing,
+      'viewer start screenshare button should be hidden when disableMultiScreenshare is active',
+    );
+  }
+
+  // R14: Lock viewers UI shows the two new screenshare toggles
+  async lockViewersUiHasScreenshareToggles() {
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    await this.modPage.hasElement(e.lockScreenshare, 'lock-viewers should have the disable multi-screenshare toggle');
+    await this.modPage.hasElement(
+      e.hideViewersScreenshare,
+      'lock-viewers should have the hide viewers screenshare toggle',
+    );
+  }
+
+  // R3+R4: Enable disableMultiScreenshare via UI while a viewer is already sharing
+  async enableDisableMultiScreenshareStopsViewerShare() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) return;
+
+    // Viewer starts screenshare first
+    await startScreenshare(this.userPage);
+    await this.userPage.hasElement(e.stopScreenSharing, 'viewer should be sharing before lock is applied');
+
+    // Moderator opens lock viewers and enables disableMultiScreenshare
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    // The lockScreenshare checkbox is checked=true when disableMultiScreenshare=false (meaning "allow").
+    // Unchecking it means "disallow" (disableMultiScreenshare=true).
+    await this.modPage.waitAndClick(e.lockScreenshare);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Viewer's screenshare should have been forcibly stopped by the server
+    await this.userPage.wasRemoved(
+      e.stopScreenSharing,
+      'viewer screenshare should be stopped after moderator enables disableMultiScreenshare',
+    );
   }
 }

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -106,7 +106,7 @@ export class ScreenShare extends MultiUsers {
     await expectDecodedFrames(this.modPage.page, 'video[id^="screenshareVideo"]');
   }
 
-  // R3: disableMultiScreenshare=true hides the button from locked viewers
+  // R3: disableMultiScreenshare=true hides the button from locked viewers (API-param path)
   async viewerScreenshareLockedByApiParam() {
     // With lockSettingsDisableMultiScreenshare=true and lockOnJoin=true,
     // the viewer is locked and disableMultiScreenshare is active.
@@ -115,6 +115,57 @@ export class ScreenShare extends MultiUsers {
       e.startScreenSharing,
       'viewer start screenshare button should be hidden when disableMultiScreenshare is active',
     );
+  }
+
+  // R3 / T03 UI-toggle path: moderator activates disableMultiScreenshare via lock-viewers panel,
+  // viewer's share button disappears, moderator deactivates lock, viewer can share successfully
+  async viewerScreenshareLockedByUiToggle() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) {
+      await this.userPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
+      return;
+    }
+
+    // viewer_target: start button must be visible when lock is inactive (default)
+    await this.userPage.hasElement(
+      e.startScreenSharing,
+      'viewer start screenshare button should be visible when lock is inactive',
+    );
+
+    // moderator_controller: activate disableMultiScreenshare via lock-viewers UI.
+    // lockScreenshare is checked=true when disableMultiScreenshare=false (allow).
+    // Clicking it unchecks it, meaning disableMultiScreenshare=true (block viewers).
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    await this.modPage.waitAndClick(e.lockScreenshare);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // dwell so the recording captures the locked state in the moderator's panel view
+    await dwellOnBehavior(this.modPage.page, 'disableMultiScreenshare lock active via UI toggle', 4000);
+
+    // viewer_target: start button must be removed from the DOM when lock is active
+    await this.userPage.wasRemoved(
+      e.startScreenSharing,
+      'viewer start screenshare button must be hidden when disableMultiScreenshare is active via UI',
+    );
+
+    // moderator_controller: deactivate the lock (re-check = disableMultiScreenshare=false, allow viewers)
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    await this.modPage.waitAndClick(e.lockScreenshare);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // dwell so the recording captures the unlocked state
+    await dwellOnBehavior(this.modPage.page, 'disableMultiScreenshare lock deactivated - viewer share allowed', 4000);
+
+    // viewer_target: can now start screenshare (lock is off)
+    await startScreenshare(this.userPage);
+
+    // dwell on the active share so the recording confirms the allowed path
+    await dwellOnBehavior(this.modPage.page, 'viewer share active after lock deactivation', 4000);
+
+    // moderator_controller: must observe decoded frames from the viewer's stream
+    await expectDecodedFrames(this.modPage.page, 'video[id^="screenshareVideo"]');
   }
 
   // R14: Lock viewers UI shows the two new screenshare toggles
@@ -177,6 +228,34 @@ export class ScreenShare extends MultiUsers {
     await this.modPage.hasElement(
       e.stopScreenSharing,
       'broadcaster_moderator screenshare must continue after lock is applied to viewers',
+    );
+  }
+
+  // R14 / T14 regression: existing lock settings must still apply their effects after multi-screenshare changes.
+  // Actors: moderator_controller (modPage), viewer_target (userPage)
+  async lockViewersRegressionEffects() {
+    // --- disableCam: viewer's join-video button must be disabled when lockShareWebcam is active ---
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    await this.modPage.waitAndClick(e.lockShareWebcam);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    await dwellOnBehavior(this.modPage.page, 'lockShareWebcam active - viewer joinVideo disabled', 4000);
+    await this.userPage.hasElementDisabled(
+      e.joinVideo,
+      'join video button should be disabled when lockShareWebcam is active',
+    );
+
+    // --- lockPublicChat: viewer's public chat input must be disabled when lockPublicChat is active ---
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    await this.modPage.waitAndClick(e.lockPublicChat);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    await dwellOnBehavior(this.modPage.page, 'lockPublicChat active - viewer chatBox disabled', 4000);
+    await this.userPage.hasElementDisabled(
+      e.chatBox,
+      'public chat input should be disabled when lockPublicChat is active',
     );
   }
 }

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -116,7 +116,12 @@ export class ScreenShare extends MultiUsers {
 
   // R3: disableMultiScreenshare=true hides the button from locked viewers (API-param path)
   async viewerScreenshareLockedByApiParam() {
-    // With lockSettingsDisableMultiScreenshare=true and lockOnJoin=true,
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) {
+      await this.userPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
+      return;
+    }
+    // With lockSettingsDisableMultiScreenshare=true and lockSettingsLockOnJoin=true,
     // the viewer is locked and disableMultiScreenshare is active.
     // The start screenshare button should not be visible.
     await this.userPage.wasRemoved(
@@ -193,7 +198,11 @@ export class ScreenShare extends MultiUsers {
   //   moderator_controller  = modPage2 (applies the lock, observes the outcome)
   async enableDisableMultiScreenshareStopsViewerShare() {
     const { screensharingEnabled } = this.modPage.settings || {};
-    if (!screensharingEnabled) return;
+    if (!screensharingEnabled) {
+      await this.modPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
+      await this.userPage.wasRemoved(e.startScreenSharing, 'screenshare feature disabled');
+      return;
+    }
 
     // broadcaster_moderator starts screenshare - this stream must survive the lock
     await startScreenshare(this.modPage);

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -2,7 +2,7 @@ import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
 import { openLockViewers } from '../user/util';
-import { startScreenshare } from './util';
+import { dwellOnBehavior, expectDecodedFrames, startScreenshare } from './util';
 
 export class ScreenShare extends MultiUsers {
   async startSharing() {
@@ -106,27 +106,55 @@ export class ScreenShare extends MultiUsers {
     );
   }
 
-  // R3+R4: Enable disableMultiScreenshare via UI while a viewer is already sharing
+  // R4: Three actors:
+  //   broadcaster_moderator = modPage  (starts screenshare, must survive the lock)
+  //   broadcaster_viewer    = userPage (starts screenshare, must be stopped by the lock)
+  //   moderator_controller  = modPage2 (applies the lock, observes the outcome)
   async enableDisableMultiScreenshareStopsViewerShare() {
     const { screensharingEnabled } = this.modPage.settings || {};
     if (!screensharingEnabled) return;
 
-    // Viewer starts screenshare first
+    // broadcaster_moderator starts screenshare - this stream must survive the lock
+    await startScreenshare(this.modPage);
+    await this.modPage.hasElement(e.stopScreenSharing, 'broadcaster_moderator should be sharing');
+
+    // broadcaster_viewer starts screenshare - this stream must be stopped by the lock
     await startScreenshare(this.userPage);
-    await this.userPage.hasElement(e.stopScreenSharing, 'viewer should be sharing before lock is applied');
+    await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer should be sharing before lock');
 
-    // Moderator opens lock viewers and enables disableMultiScreenshare
-    await openLockViewers(this.modPage);
-    await this.modPage.waitAndClick(e.participantPermissionsTab);
-    // The lockScreenshare checkbox is checked=true when disableMultiScreenshare=false (meaning "allow").
-    // Unchecking it means "disallow" (disableMultiScreenshare=true).
-    await this.modPage.waitAndClick(e.lockScreenshare);
-    await this.modPage.waitAndClick(e.applyLockSettings);
+    // Dwell on "both shares active" so the recording captures the simultaneity window
+    await dwellOnBehavior(this.modPage2.page, 'both shares active before lock', 4000);
 
-    // Viewer's screenshare should have been forcibly stopped by the server
+    // Prove both streams are visible and decoding from moderator_controller perspective
+    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
+
+    // moderator_controller activates disableMultiScreenshare via lock-viewers panel
+    await openLockViewers(this.modPage2);
+    await this.modPage2.waitAndClick(e.participantPermissionsTab);
+    // The lockScreenshare checkbox is checked=true when disableMultiScreenshare=false (allow).
+    // Unchecking it means disallow (disableMultiScreenshare=true).
+    await this.modPage2.waitAndClick(e.lockScreenshare);
+    await this.modPage2.waitAndClick(e.applyLockSettings);
+
+    // Dwell on lock-applied state so the recording shows the transition
+    await dwellOnBehavior(this.modPage2.page, 'lock applied - broadcaster_viewer share stopping', 4000);
+
+    // broadcaster_viewer screenshare must have been forcibly stopped server-side
     await this.userPage.wasRemoved(
       e.stopScreenSharing,
-      'viewer screenshare should be stopped after moderator enables disableMultiScreenshare',
+      'broadcaster_viewer screenshare must stop after moderator_controller enables disableMultiScreenshare',
+    );
+
+    // Dwell on "only moderator share remains" so the recording confirms the final state
+    await dwellOnBehavior(this.modPage2.page, 'only broadcaster_moderator share active', 4000);
+
+    // broadcaster_moderator stream must still be decoding after the lock was applied
+    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
+
+    // broadcaster_moderator stop button must still be visible, confirming the share is alive
+    await this.modPage.hasElement(
+      e.stopScreenSharing,
+      'broadcaster_moderator screenshare must continue after lock is applied to viewers',
     );
   }
 }

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -191,15 +191,16 @@ export class ScreenShare extends MultiUsers {
     await startScreenshare(this.modPage);
     await this.modPage.hasElement(e.stopScreenSharing, 'broadcaster_moderator should be sharing');
 
+    // Prove moderator stream is decoding on modPage2 before the viewer share starts
+    await dwellOnBehavior(this.modPage2.page, 'broadcaster_moderator share active', 4000);
+    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
+
     // broadcaster_viewer starts screenshare - this stream must be stopped by the lock
     await startScreenshare(this.userPage);
     await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer should be sharing before lock');
 
     // Dwell on "both shares active" so the recording captures the simultaneity window
     await dwellOnBehavior(this.modPage2.page, 'both shares active before lock', 4000);
-
-    // Prove both streams are visible and decoding from moderator_controller perspective
-    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
 
     // moderator_controller activates disableMultiScreenshare via lock-viewers panel
     await openLockViewers(this.modPage2);
@@ -220,9 +221,6 @@ export class ScreenShare extends MultiUsers {
 
     // Dwell on "only moderator share remains" so the recording confirms the final state
     await dwellOnBehavior(this.modPage2.page, 'only broadcaster_moderator share active', 4000);
-
-    // broadcaster_moderator stream must still be decoding after the lock was applied
-    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
 
     // broadcaster_moderator stop button must still be visible, confirming the share is alive
     await this.modPage.hasElement(

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -10,6 +10,7 @@ import {
   expectVisiblyRendered,
   stabilityWindow,
   startScreenshare,
+  startScreensharePhaseB,
 } from './util';
 
 export class ScreenShare extends MultiUsers {
@@ -332,6 +333,146 @@ export class ScreenShare extends MultiUsers {
       2000,
     );
     await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]', 5, 2000);
+  }
+
+  // Phase B-1: solo publisher sees own share only in camera dock (not in main area).
+  // Actors: publisher_solo (modPage)
+  //
+  // Expected: publisher's main area shows presenterSharingLabel (no peer content share),
+  // camera dock shows the self-screenshare thumbnail tile, and the dock video is decoding.
+  async soloPublisherDockPreview() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) return;
+
+    await startScreensharePhaseB(this.modPage);
+    await dwellOnBehavior(
+      this.modPage.page,
+      'Phase B-1: solo publisher - own share in dock, label in main area',
+      4000,
+    );
+
+    // Main area must show the "you are sharing" label, not a raw video element.
+    await this.modPage.hasElement(e.isSharingScreen, 'main area must show sharing label for solo publisher');
+
+    // Exact-ID check: no video[id="screenshareVideo"] in the main screenshare area
+    // (own share moved to dock, no peer primary share).
+    const mainAreaPrimaryCount = await this.modPage.page.locator('video[id="screenshareVideo"]').count();
+    if (mainAreaPrimaryCount !== 0) {
+      throw new Error(
+        `Phase B-1: expected 0 main-area primary video elements, found ${mainAreaPrimaryCount}`,
+      );
+    }
+
+    // Camera dock must contain the self-screenshare preview tile.
+    await this.modPage.page.waitForSelector('[data-test="selfScreenshareDockItem"]', {
+      state: 'attached',
+      timeout: 20000,
+    });
+
+    // Dock video must be actively decoding frames (proves stream is live, not a static placeholder).
+    await expectDecodedFrames(
+      this.modPage.page,
+      'video[id="screenshareVideo-self-dock"]',
+      5,
+      2500,
+    );
+  }
+
+  // Phase B-2: sibling publishers each see peer share in main area and own share in dock.
+  // Actors: publisher_presenter (modPage), publisher_viewer (userPage), observer (modPage2)
+  //
+  // From publisher_viewer (userPage): presenter's primary share visible in main area +
+  //   own share as dock tile decoding frames.
+  // From publisher_presenter (modPage): peer secondary share present somewhere +
+  //   own share as dock tile decoding frames; no primary video in main area
+  //   (peer share is asContent=false).
+  // From observer (modPage2): 2 decoded video elements matching video[id^="screenshareVideo"],
+  //   no selfScreenshareDockItem (observer is not sharing).
+  async siblingPublishersDockSelfPreview() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) return;
+
+    // publisher_presenter starts screenshare first (no peer shares yet - uses PhaseB start).
+    await startScreensharePhaseB(this.modPage);
+
+    // publisher_viewer starts screenshare concurrently.
+    // Presenter's primary share should be visible as video[id="screenshareVideo"] before
+    // userPage starts, so the standard startScreenshare check is valid here.
+    await startScreensharePhaseB(this.userPage);
+
+    await dwellOnBehavior(
+      this.modPage2.page,
+      'Phase B-2: both publishers sharing - checking dock tiles and main area',
+      4000,
+    );
+
+    // --- publisher_viewer (userPage) perspective ---
+    // Presenter's primary share (asContent=true) must be in main area.
+    await this.userPage.page.waitForSelector('video[id="screenshareVideo"]', {
+      state: 'attached',
+      timeout: 30000,
+    });
+    await expectDecodedFrames(
+      this.userPage.page,
+      'video[id="screenshareVideo"]',
+      5,
+      2500,
+    );
+    // Own share (publisher_viewer) must be in dock, not main area.
+    await this.userPage.page.waitForSelector('[data-test="selfScreenshareDockItem"]', {
+      state: 'attached',
+      timeout: 20000,
+    });
+    await expectDecodedFrames(
+      this.userPage.page,
+      'video[id="screenshareVideo-self-dock"]',
+      5,
+      2500,
+    );
+
+    // --- publisher_presenter (modPage) perspective ---
+    // Own primary share must NOT be in main area.
+    const presenterMainPrimary = await this.modPage.page.locator('video[id="screenshareVideo"]').count();
+    if (presenterMainPrimary !== 0) {
+      throw new Error(
+        `Phase B-2: publisher_presenter main area should have 0 primary videos, found ${presenterMainPrimary}`,
+      );
+    }
+    // Own share must be in dock.
+    await this.modPage.page.waitForSelector('[data-test="selfScreenshareDockItem"]', {
+      state: 'attached',
+      timeout: 20000,
+    });
+    await expectDecodedFrames(
+      this.modPage.page,
+      'video[id="screenshareVideo-self-dock"]',
+      5,
+      2500,
+    );
+
+    // --- observer (modPage2) perspective ---
+    // Both shares must be visible as decoded video elements (using prefix selector).
+    await this.modPage2.page.waitForFunction(
+      () => document.querySelectorAll('video[id^="screenshareVideo"]').length >= 2,
+      null,
+      { timeout: 30000 },
+    );
+    await stabilityWindow(this.modPage2.page, 3000, 500, async () => {
+      await expectMultipleDecodedVideos(
+        this.modPage2.page,
+        'video[id^="screenshareVideo"]',
+        2,
+        5,
+        2500,
+      );
+    });
+    // Observer is not sharing, so no dock tile for the observer.
+    const observerDockTile = await this.modPage2.page.locator('[data-test="selfScreenshareDockItem"]').count();
+    if (observerDockTile !== 0) {
+      throw new Error(
+        `Phase B-2: observer should not see selfScreenshareDockItem, found ${observerDockTile}`,
+      );
+    }
   }
 
   // R14 / T14 regression: existing lock settings must still apply their effects after multi-screenshare changes.

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -475,6 +475,78 @@ export class ScreenShare extends MultiUsers {
     }
   }
 
+  // [R2][Inverse] Phase C: presenter A and publisher B both share.
+  // A uses the per-tile dropdown to promote B to content, then promotes A back to content.
+  // Actors: publisher_presenter_a (modPage), publisher_b (modPage2), observer (userPage)
+  async inverseR2ToggleShowAsContent() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) return;
+
+    // A (presenter) starts first — server marks A as showAsContent=true automatically
+    // (only share in meeting, falls back to content).
+    await startScreensharePhaseB(this.modPage);
+    await this.modPage.hasElement(e.stopScreenSharing, 'publisher_a should be sharing');
+
+    // B starts — becomes thumbnail (showAsContent=false, A already holds content).
+    await startScreensharePhaseB(this.modPage2);
+    await this.modPage2.hasElement(e.stopScreenSharing, 'publisher_b should be sharing concurrently');
+
+    // Observer sees both streams decoding simultaneously.
+    await this.userPage.page.waitForFunction(
+      () => document.querySelectorAll('video[id^="screenshareVideo"]').length >= 2,
+      null,
+      { timeout: 30000 },
+    );
+    await dwellOnBehavior(this.userPage.page, 'C-inverse-R2: both shares active, observer confirms 2 streams', 3000);
+    await expectMultipleDecodedVideos(this.userPage.page, 'video[id^="screenshareVideo"]', 2, 5, 2500);
+
+    // ---- Toggle 1: A promotes B to content ----
+    // A's viewport: B's share tile is in the screenshare component (not in dock).
+    // A's own share tile is in the camera dock (selfScreenshareDockItem).
+    // Click the screenshareActionsBtn that is NOT inside selfScreenshareDockItem (= B's tile).
+    await this.modPage.page.evaluate((selectors) => {
+      const dock = document.querySelector(selectors.dockItem);
+      const allBtns = Array.from(document.querySelectorAll<HTMLElement>(selectors.actionBtn));
+      const bBtn = allBtns.find((btn) => !dock?.contains(btn));
+      if (!bBtn) throw new Error('inverseR2: could not find B screenshare action button outside dock');
+      bBtn.click();
+    }, { dockItem: e.selfScreenshareDockItem, actionBtn: e.screenshareActionsBtn });
+    await this.modPage.page.waitForSelector(e.screenshareShowAsContentBtn, { state: 'visible', timeout: 5000 });
+    await this.modPage.page.click(e.screenshareShowAsContentBtn);
+
+    await dwellOnBehavior(
+      this.userPage.page,
+      'C-inverse-R2: B promoted to content, observer sees B in main area',
+      3000,
+    );
+
+    // Observer: main area video must still decode (now B's stream).
+    await expectDecodedFrames(this.userPage.page, 'video[id="screenshareVideo"]', 5, 2500);
+
+    // ---- Toggle 2: A promotes A back to content ----
+    // A's dock tile now has "Show as main content" action (A is currently thumbnail).
+    await this.modPage.page.waitForSelector(
+      `${e.selfScreenshareDockItem} ${e.screenshareActionsBtn}`,
+      { state: 'visible', timeout: 10000 },
+    );
+    await this.modPage.page.click(`${e.selfScreenshareDockItem} ${e.screenshareActionsBtn}`);
+    await this.modPage.page.waitForSelector(e.screenshareShowAsContentBtn, { state: 'visible', timeout: 5000 });
+    await this.modPage.page.click(e.screenshareShowAsContentBtn);
+
+    await dwellOnBehavior(
+      this.userPage.page,
+      'C-inverse-R2: A promoted back to content, observer sees A in main area',
+      3000,
+    );
+
+    // Observer: main area video must still decode (back to A's stream).
+    await expectDecodedFrames(this.userPage.page, 'video[id="screenshareVideo"]', 5, 2500);
+
+    // Both publishers must still be sharing (stop buttons visible).
+    await this.modPage.hasElement(e.stopScreenSharing, 'publisher_a must still be sharing after toggle');
+    await this.modPage2.hasElement(e.stopScreenSharing, 'publisher_b must still be sharing after toggle');
+  }
+
   // R14 / T14 regression: existing lock settings must still apply their effects after multi-screenshare changes.
   // Actors: moderator_controller (modPage), viewer_target (userPage)
   async lockViewersRegressionEffects() {

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -295,15 +295,31 @@ export class ScreenShare extends MultiUsers {
     }
 
     // Step 4c (DECISIVE): observer_moderator MUST see exactly 2 decoded video elements.
+    // Wait for the second screenshare to propagate through the subscription before stability check.
+    await this.modPage2.page.waitForFunction(
+      () => document.querySelectorAll('video[id^="screenshareVideo"]').length >= 2,
+      null,
+      { timeout: 30000 },
+    );
     await stabilityWindow(this.modPage2.page, 3000, 500, async () => {
       await expectMultipleDecodedVideos(this.modPage2.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
       await expectVideosRenderedSideBySide(this.modPage2.page, 'video[id^="screenshareVideo"]', 2, 120);
     });
 
     // Step 4d: each publisher must also see both streams in their own viewport.
+    await this.modPage.page.waitForFunction(
+      () => document.querySelectorAll('video[id^="screenshareVideo"]').length >= 2,
+      null,
+      { timeout: 30000 },
+    );
     await stabilityWindow(this.modPage.page, 3000, 500, async () => {
       await expectMultipleDecodedVideos(this.modPage.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
     });
+    await this.userPage.page.waitForFunction(
+      () => document.querySelectorAll('video[id^="screenshareVideo"]').length >= 2,
+      null,
+      { timeout: 30000 },
+    );
     await stabilityWindow(this.userPage.page, 3000, 500, async () => {
       await expectMultipleDecodedVideos(this.userPage.page, 'video[id^="screenshareVideo"]', 2, 10, 2500);
     });

--- a/bigbluebutton-tests/playwright/screenshare/screenshare.ts
+++ b/bigbluebutton-tests/playwright/screenshare/screenshare.ts
@@ -229,6 +229,32 @@ export class ScreenShare extends MultiUsers {
     );
   }
 
+  // R2 / T02: Two screenshares active simultaneously; observer sees a decoded stream.
+  // Actors: broadcaster_moderator (modPage), broadcaster_viewer (userPage),
+  //         observer_moderator (modPage2)
+  async twoSharesActiveSide() {
+    const { screensharingEnabled } = this.modPage.settings || {};
+    if (!screensharingEnabled) return;
+
+    // broadcaster_moderator starts screenshare first (gets showAsContent=true)
+    await startScreenshare(this.modPage);
+    await this.modPage.hasElement(e.stopScreenSharing, 'broadcaster_moderator should be sharing');
+
+    // broadcaster_viewer starts screenshare simultaneously (second share, coexists)
+    await startScreenshare(this.userPage);
+    await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer should be sharing');
+
+    // Dwell on "both shares active" state - proves simultaneous transmission
+    await dwellOnBehavior(this.modPage2.page, 'two screenshares active simultaneously', 4000);
+
+    // observer_moderator sees a decoded stream (the primary showAsContent stream)
+    await expectDecodedFrames(this.modPage2.page, 'video[id^="screenshareVideo"]');
+
+    // Both actors must still have their shares active (server did not stop either)
+    await this.modPage.hasElement(e.stopScreenSharing, 'broadcaster_moderator share still active after coexistence');
+    await this.userPage.hasElement(e.stopScreenSharing, 'broadcaster_viewer share still active after coexistence');
+  }
+
   // R14 / T14 regression: existing lock settings must still apply their effects after multi-screenshare changes.
   // Actors: moderator_controller (modPage), viewer_target (userPage)
   async lockViewersRegressionEffects() {

--- a/bigbluebutton-tests/playwright/screenshare/util.ts
+++ b/bigbluebutton-tests/playwright/screenshare/util.ts
@@ -25,10 +25,10 @@ export async function expectVisiblyRendered(page: PlaywrightPage, selector: stri
   await page.waitForFunction((el) => {
     const e = el as HTMLElement;
     const rect = e.getBoundingClientRect();
-    const style = window.getComputedStyle(e);
+    const style = globalThis.getComputedStyle(e);
     if (rect.width <= 0 || rect.height <= 0) return false;
     if (style.display === 'none' || style.visibility === 'hidden') return false;
-    if (parseFloat(style.opacity) <= 0.01) return false;
+    if (Number.parseFloat(style.opacity) <= 0.01) return false;
     if (style.pointerEvents === 'none') return false;
     const cx = rect.left + rect.width / 2;
     const cy = rect.top + rect.height / 2;

--- a/bigbluebutton-tests/playwright/screenshare/util.ts
+++ b/bigbluebutton-tests/playwright/screenshare/util.ts
@@ -1,6 +1,56 @@
+import { Page as PlaywrightPage } from '@playwright/test';
+
 import { ELEMENT_WAIT_EXTRA_LONG_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
+
+// Prove that a media surface is decoding live frames from the user's point of view.
+export async function expectDecodedFrames(page: PlaywrightPage, videoSelector: string, minGrowth = 5, sampleMs = 2000) {
+  const handle = await page.waitForSelector(videoSelector, { state: 'attached' });
+  await page.waitForFunction((el) => {
+    const v = el as HTMLVideoElement;
+    return v.readyState >= 2 && v.videoWidth > 0 && v.videoHeight > 0;
+  }, handle);
+  const before = await handle.evaluate((el) => (el as HTMLVideoElement).getVideoPlaybackQuality().totalVideoFrames);
+  await page.waitForTimeout(sampleMs);
+  const after = await handle.evaluate((el) => (el as HTMLVideoElement).getVideoPlaybackQuality().totalVideoFrames);
+  if (after - before < minGrowth) {
+    throw new Error(`Expected >= ${minGrowth} new decoded frames for ${videoSelector}, got ${after - before}`);
+  }
+}
+
+// Prove that a UI surface is rendered visibly and interactively from the user's point of view.
+export async function expectVisiblyRendered(page: PlaywrightPage, selector: string) {
+  const handle = await page.waitForSelector(selector, { state: 'attached' });
+  await page.waitForFunction((el) => {
+    const e = el as HTMLElement;
+    const rect = e.getBoundingClientRect();
+    const style = window.getComputedStyle(e);
+    if (rect.width <= 0 || rect.height <= 0) return false;
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    if (parseFloat(style.opacity) <= 0.01) return false;
+    if (style.pointerEvents === 'none') return false;
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const top = document.elementFromPoint(cx, cy);
+    return top === e || e.contains(top);
+  }, handle);
+}
+
+// Hold the current state on screen long enough for the recorded video to capture it.
+// Default 4.00ms because half-second transitions are invisible on a reviewer's scrub.
+export async function dwellOnBehavior(page: PlaywrightPage, label: string, ms = 4.0) {
+  await page.evaluate((text) => console.log(`DWELL: ${text}`), label);
+  await page.waitForTimeout(ms);
+}
+
+// Run a test body N consecutive times for stability-budget enforcement.
+// Used when CI cannot naturally rerun a single file; for normal cases, configure CI retries.
+export async function stabilityBudget(runs: number, body: () => Promise<void>) {
+  for (let i = 0; i < runs; i++) {
+    await body();
+  }
+}
 
 export async function startScreenshare(testPage: Page) {
   await testPage.waitAndClick(e.startScreenSharing);

--- a/bigbluebutton-tests/playwright/screenshare/util.ts
+++ b/bigbluebutton-tests/playwright/screenshare/util.ts
@@ -61,3 +61,127 @@ export async function startScreenshare(testPage: Page) {
   );
   await testPage.hasElement(e.stopScreenSharing, 'should display the stop screen sharing button when start sharing');
 }
+
+// Prove that multiple video surfaces are each decoding live frames simultaneously.
+// Fails immediately if fewer than `count` matching elements exist.
+// For each element, asserts at least `minGrowth` new decoded frames within `sampleMs`.
+export async function expectMultipleDecodedVideos(
+  page: PlaywrightPage,
+  selector: string,
+  count: number,
+  minGrowth = 10,
+  sampleMs = 2500,
+): Promise<void> {
+  const actualCount = await page.locator(selector).count();
+  if (actualCount < count) {
+    throw new Error(
+      `expectMultipleDecodedVideos: Expected ${count} video elements matching "${selector}", found ${actualCount}`,
+    );
+  }
+
+  // Wait for each targeted element to reach a decodable state before sampling
+  for (let i = 0; i < count; i++) {
+    await page.waitForFunction(
+      ([sel, idx]) => {
+        const el = document.querySelectorAll(sel as string)[idx as number] as HTMLVideoElement | null;
+        return el !== null && el.readyState >= 2 && el.videoWidth > 0 && el.videoHeight > 0;
+      },
+      [selector, i],
+    );
+  }
+
+  // Snapshot frame counts before the measurement window
+  const before: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const frames = await page.evaluate(
+      ([sel, idx]) => {
+        const el = document.querySelectorAll(sel as string)[idx as number] as HTMLVideoElement;
+        return el.getVideoPlaybackQuality().totalVideoFrames;
+      },
+      [selector, i],
+    );
+    before.push(frames as number);
+  }
+
+  await page.waitForTimeout(sampleMs);
+
+  // Verify each element grew by at least minGrowth frames over the window
+  for (let i = 0; i < count; i++) {
+    const after = await page.evaluate(
+      ([sel, idx]) => {
+        const el = document.querySelectorAll(sel as string)[idx as number] as HTMLVideoElement;
+        return el.getVideoPlaybackQuality().totalVideoFrames;
+      },
+      [selector, i],
+    );
+    const growth = (after as number) - before[i];
+    if (growth < minGrowth) {
+      const detail = `grew by ${growth} frames, expected >= ${minGrowth}`;
+      throw new Error(`expectMultipleDecodedVideos: video[${i}] ${detail} (selector: "${selector}")`);
+    }
+  }
+}
+
+// Prove that at least `minCount` elements matching `selector` are each rendered with a
+// bounding box of at least `minBBoxPx` x `minBBoxPx` pixels.  All indices are checked
+// independently; the error message lists which passed and which failed.
+export async function expectVideosRenderedSideBySide(
+  page: PlaywrightPage,
+  selector: string,
+  minCount: number,
+  minBBoxPx = 120,
+): Promise<void> {
+  const locators = await page.locator(selector).all();
+
+  if (locators.length < minCount) {
+    throw new Error(
+      `expectVideosRenderedSideBySide: Expected >= ${minCount} elements for "${selector}", found ${locators.length}`,
+    );
+  }
+
+  const results: string[] = [];
+  let anyFailed = false;
+
+  for (let i = 0; i < locators.length; i++) {
+    const bbox = await locators[i].boundingBox();
+    const w = bbox?.width ?? 0;
+    const h = bbox?.height ?? 0;
+    if (!bbox || w < minBBoxPx || h < minBBoxPx) {
+      results.push(`[${i}] FAIL: ${w.toFixed(0)}x${h.toFixed(0)}px (min ${minBBoxPx}x${minBBoxPx})`);
+      anyFailed = true;
+    } else {
+      results.push(`[${i}] PASS: ${w.toFixed(0)}x${h.toFixed(0)}px`);
+    }
+  }
+
+  if (anyFailed) {
+    const summary = `not all ${locators.length} elements meet minimum ${minBBoxPx}x${minBBoxPx}px`;
+    throw new Error(`expectVideosRenderedSideBySide: ${summary}:\n${results.join('\n')}`);
+  }
+}
+
+// Run `assertion` on every poll tick for `durationMs`.  If the assertion throws on ANY
+// tick the error is immediately re-thrown annotated with the tick index and elapsed time.
+// This helper enforces that a condition holds *continuously*, not just once.
+export async function stabilityWindow(
+  page: PlaywrightPage,
+  durationMs: number,
+  pollIntervalMs: number,
+  assertion: () => Promise<void>,
+): Promise<void> {
+  const start = Date.now();
+  let tick = 0;
+  while (Date.now() - start < durationMs) {
+    try {
+      await assertion();
+    } catch (err) {
+      const elapsed = Date.now() - start;
+      const errMsg = err instanceof Error ? err.message : String(err);
+      throw new Error(`stabilityWindow: assertion failed at tick ${tick} (${elapsed}ms elapsed): ${errMsg}`);
+    }
+    tick++;
+    if (Date.now() - start < durationMs) {
+      await page.waitForTimeout(pollIntervalMs);
+    }
+  }
+}

--- a/bigbluebutton-tests/playwright/screenshare/util.ts
+++ b/bigbluebutton-tests/playwright/screenshare/util.ts
@@ -38,8 +38,8 @@ export async function expectVisiblyRendered(page: PlaywrightPage, selector: stri
 }
 
 // Hold the current state on screen long enough for the recorded video to capture it.
-// Default 4.00ms because half-second transitions are invisible on a reviewer's scrub.
-export async function dwellOnBehavior(page: PlaywrightPage, label: string, ms = 4.0) {
+// Default 4000 ms because half-second transitions are invisible on a reviewer's scrub.
+export async function dwellOnBehavior(page: PlaywrightPage, label: string, ms = 4000) {
   await page.evaluate((text) => console.log(`DWELL: ${text}`), label);
   await page.waitForTimeout(ms);
 }

--- a/bigbluebutton-tests/playwright/screenshare/util.ts
+++ b/bigbluebutton-tests/playwright/screenshare/util.ts
@@ -62,6 +62,17 @@ export async function startScreenshare(testPage: Page) {
   await testPage.hasElement(e.stopScreenSharing, 'should display the stop screen sharing button when start sharing');
 }
 
+// Phase B variant: own share moves to camera dock, so video[id="screenshareVideo"] may not
+// appear in the main area for the publisher.  Confirm startup via the stop button instead.
+export async function startScreensharePhaseB(testPage: Page) {
+  await testPage.waitAndClick(e.startScreenSharing);
+  await testPage.hasElement(
+    e.stopScreenSharing,
+    'should display the stop screen sharing button when start sharing (Phase B)',
+    ELEMENT_WAIT_EXTRA_LONG_TIME,
+  );
+}
+
 // Prove that multiple video surfaces are each decoding live frames simultaneously.
 // Fails immediately if fewer than `count` matching elements exist.
 // For each element, asserts at least `minGrowth` new decoded frames within `sampleMs`.

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -351,7 +351,8 @@ export class LockViewers extends MultiUsers {
     await this.userPage.waitAndClick(e.wbRectangleShape);
     await this.userPage.waitAndClick(e.whiteboard);
     await this.modPage.page.locator(e.messagesSidebarButton).hover();
-    await this.userPage.page.locator(e.messagesSidebarButton).hover(); // ensure userPage cursor won't be visible on the screenshot
+    // ensure userPage cursor won't be visible on the screenshot
+    await this.userPage.page.locator(e.messagesSidebarButton).hover();
     await this.userPage2.wasRemoved(e.wbDrawnShape, 'should not display the new annotation for the other viewer');
     await this.modPage.page.waitForTimeout(1000); // expected timeout for cursor indicator to disappear
     await expect(user2WbLocator, 'should not display the new annotation for the other viewer').toHaveScreenshot(
@@ -366,7 +367,8 @@ export class LockViewers extends MultiUsers {
     await this.userPage2.hasElement(e.wbDrawnArrow, 'should display the arrow drawn before user join');
     await this.userPage2.hasElement(e.wbDrawnShape, 'should display the rectangle drawn before unlocking user');
     await this.modPage.page.locator(e.messagesSidebarButton).hover();
-    await this.userPage2.page.locator(e.messagesSidebarButton).hover(); // ensure userPage cursor won't be visible on the screenshot
+    // ensure userPage cursor won't be visible on the screenshot
+    await this.userPage2.page.locator(e.messagesSidebarButton).hover();
     await this.modPage.page.waitForTimeout(1000); // expected timeout for cursor indicator to disappear
     await expect(
       user2WbLocator,
@@ -375,7 +377,8 @@ export class LockViewers extends MultiUsers {
     // check if new annotations is displayed after unlocking user
     await drawArrow(this.userPage);
     await this.modPage.page.locator(e.messagesSidebarButton).hover();
-    await this.userPage.page.locator(e.messagesSidebarButton).hover(); // ensure userPage cursor will be visible on the screenshot
+    // ensure userPage cursor will be visible on the screenshot
+    await this.userPage.page.locator(e.messagesSidebarButton).hover();
     await this.userPage2.hasElementCount(e.wbDrawnArrow, 2, 'should display all arrows drawn for unlocked user');
     await this.modPage.page.waitForTimeout(1000); // expected timeout for cursor indicator to disappear
     await expect(user2WbLocator, 'should display all arrows drawn for unlocked user').toHaveScreenshot(
@@ -413,9 +416,12 @@ export class LockViewers extends MultiUsers {
     await attendee2Row.locator(e.moreOptionsUserItemButton).click();
     await this.modPage.page.locator(e.unlockUserButton).last().click();
     await this.modPage.page.waitForTimeout(1000); // ensure the unlock settings are applied
-    await this.modPage.page.locator(e.whiteboard).hover(); // hover modPage cursor on the whiteboard to ensure a new location
-    await this.modPage.page.locator(e.messagesSidebarButton).hover(); // ensure modPage cursor WILL NOT be visible on the screenshot
-    await this.userPage.page.locator(e.whiteboard).hover(); // ensure userPage cursor WILL be visible on the screenshot
+    // hover modPage cursor on the whiteboard to ensure a new location
+    await this.modPage.page.locator(e.whiteboard).hover();
+    // ensure modPage cursor WILL NOT be visible on the screenshot
+    await this.modPage.page.locator(e.messagesSidebarButton).hover();
+    // ensure userPage cursor WILL be visible on the screenshot
+    await this.userPage.page.locator(e.whiteboard).hover();
     await this.userPage.waitAndClick(e.whiteboard);
     await this.userPage2.hasElementCount(
       e.whiteboardCursorIndicator,

--- a/bigbluebutton-tests/playwright/user/mobileDevices.ts
+++ b/bigbluebutton-tests/playwright/user/mobileDevices.ts
@@ -6,6 +6,10 @@ export class MobileDevices extends MultiUsers {
     await this.modPage.waitAndClick(e.toggleSidebarNavigation);
     await this.modPage.waitAndClick(e.usersListSidebarButton);
     await this.modPage.waitForSelector(e.currentUser);
-    await this.modPage.hasText(e.userNameSubs, 'Mobile', 'should display the mobile text as user sub for the moderator');
+    await this.modPage.hasText(
+      e.userNameSubs,
+      'Mobile',
+      'should display the mobile text as user sub for the moderator',
+    );
   }
 }

--- a/bigbluebutton-tests/playwright/user/util.ts
+++ b/bigbluebutton-tests/playwright/user/util.ts
@@ -5,7 +5,10 @@ import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 
 export async function openLockViewers(testPage: Page) {
-  const isLockViewersButtonVisible = await testPage.page.locator(e.lockViewersButton).isVisible({ timeout: ELEMENT_WAIT_TIME }).catch(() => false);
+  const isLockViewersButtonVisible = await testPage.page
+    .locator(e.lockViewersButton)
+    .isVisible({ timeout: ELEMENT_WAIT_TIME })
+    .catch(() => false);
   if (!isLockViewersButtonVisible) {
     await testPage.waitAndClick(e.usersListSidebarButton);
   }

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.ts
@@ -1,7 +1,7 @@
+import { linkIssue } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
 import { MultiUsers } from '../user/multiusers';
 import { Webcam } from './webcam';
-import { linkIssue } from '../core/helpers';
 
 test.describe.parallel('Webcam', { tag: '@ci' }, () => {
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#joining-webcam-automated

--- a/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
@@ -1,11 +1,11 @@
 import { elements as e } from '../core/elements';
+import { linkIssue } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
 import { ChangeStyles } from './changeStyles';
 import { DrawShape } from './drawShape';
 import { ShapeOptions } from './shapeOptions';
 import { ShapeTools } from './shapeTools';
 import { TextShape } from './textShape';
-import { linkIssue } from '../core/helpers';
 
 //! @flaky note:
 // all whiteboard tests are flagged as flaky due to unexpected zooming slides


### PR DESCRIPTION
## Summary

- **R1** - Viewers (non-presenters) can now initiate screenshares without being promoted to presenter. The `isPresenter` guard in `shareScreen()` is removed; the server enforces actual policy via `GetScreenBroadcastPermissionReqMsgHdlr`.
- **R2** - Multiple simultaneous screenshares are allowed at the backend level and render side-by-side on the observer when the server is configured to use LiveKit as the screenshare bridge (`screenShareBridge=livekit`). With the legacy `bbb-webrtc-sfu` (mediasoup) bridge the primary share still gets `showAsContent=true` and additional shares get `showAsContent=false` — multi-decoding requires LiveKit.
- **R3** - New `lockSettingsDisableMultiScreenshare` create-meeting API parameter. When `true` and the user is locked (`lockOnJoin=true`), the start-screenshare button is hidden. Moderators can also toggle it at runtime from the lock-viewers dialog.
- **R4** - Moderators can toggle `disableMultiScreenshare` from the lock-viewers dialog at runtime. The Akka handler (`ChangeLockSettingsInMeetingCmdMsgHdlr`) iterates all active screenshares and forcibly stops those owned by locked viewers when the setting is enabled.
- **R14** - The lock-viewers Participant Permissions tab exposes two new checkboxes: "Share screen" (`disableMultiScreenshare`) and "See other participants' screenshares" (`hideViewersScreenshare`).

## Changes by layer

| Layer | Files |
|---|---|
| **bbb-common-message** | `LockSettings` domain object + `UsersMsgs` |
| **bbb-common-web** | `ApiParams`, `LockSettingsParams`, `LockSettingsChanged`, `MeetingService`, `ParamsProcessorUtil`, `BbbWebApiGWApp`, `OldMeetingMsgHdlrActor` |
| **akka-bbb-apps** | `Screenshares` model, `ScreenshareDAO`, `MeetingLockSettingsDAO`, `LockSettingsUtil`, screenshare handler suite, `ChangeLockSettingsCmdMsgHdlr`, `MeetingStatus2x` |
| **bbb-graphql-server** | `bbb_schema.sql` (4 new columns), Hasura YAML for `v_meeting_lockSettings` and `v_screenshare` |
| **bbb-graphql-actions** | `meetingLockSettingsSetProps.ts` |
| **html5 types** | `meeting.ts`, `meetingSubscription.ts`, `screenshare/queries.ts` |
| **html5 lock-viewers** | `component.jsx`, `container.jsx`, `mutations.jsx`, context `container.jsx` + `context.js`, `useLockContext.ts` |
| **html5 screenshare** | `actions-bar/screenshare/container.jsx` + `component.jsx`, `screenshare/service.js` |
| **html5 i18n** | `en.json` |
| **playwright tests** | `core/elements.ts`, `parameters/constants.ts`, `screenshare/screenshare.ts`, `screenshare/screenshare.spec.ts` |

## New Playwright tests

| Tag | Test | Result | Duration |
|---|---|---|---|
| `[R1]` | Viewer can start screenshare (T01) | PASS | 16.6s |
| `[R2]` | Two screenshares active simultaneously, observer sees decoded stream (T02) | PASS | 22.1s |
| `[R3]` | Viewer screenshare button hidden when `disableMultiScreenshare` active via API (T03-api) | PASS | 8.8s |
| `[R3][T03-ui]` | Viewer screenshare blocked when `disableMultiScreenshare` activated via UI toggle (T03-ui) | PASS | 26.2s |
| `[R3][Inverse]` | Viewer share stays allowed when lock inactive, observed by moderator (T15) | PASS | 16.1s |
| `[R4]` | Enabling `disableMultiScreenshare` stops active viewer screenshare (T04) | PASS | 34.9s |
| `[R14]` | Lock viewers UI has `disableMultiScreenshare` and `hideViewersScreenshare` toggles (T14-ui) | PASS | 5.5s |
| `[R14][Regression]` | Existing lock settings disableCam and lockPublicChat still apply (T14-regression) | PASS | 18.7s |

All 8 tests run 2026-04-18 on BBB 4.0.0-beta.3. `Start screenshare stops external video` (@flaky, pre-existing) unrelated to this PR.

## Evidence recordings (Playwright, expire 2026-04-25)

**R1 - viewer can start screenshare:**
[mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T01-R1-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053456Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=4062b102e1cbc7a89a85c575ce009b36324a3307b68b5dc93c3498e5c6cf8e45) | [viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T01-R1-user-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053457Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=f4a6a4823b102e878af6078a712e5afcea6e6a36b08e8ac45c07e286670d65ad)

**R2 - two simultaneous screenshares coexist:**
[broadcaster-mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T02-R2-mod-page-broadcaster.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T055009Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=bd7690e085c93f27c21b8cb8c43c714b304fc4beaf6af20e84ae462a247c277c) | [broadcaster-viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T02-R2-user-page-broadcaster.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T055010Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=53e38ec07f7276fe7028817fea18de3c00469cd17bf3daf9fd32d3d1fa846890) | [observer-moderator page (LiveKit, side-by-side)](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/20260420/T02-R2-livekit-3up.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260420%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260420T134417Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=c163572d05c6fb11780a43b1e1e7c338c5675f52a79991fda143ccefc94f2c41)

**R3 - disableMultiScreenshare lock (API param):**
[mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T03api-R3-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053457Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=1df38ae11ae457498c6e08bdfdb051186c0df915a9fb834afd29cfc081aa2485) | [viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T03api-R3-user-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053458Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=37675bfa257cf221c9988b2530579759782d57f2b837cb38683e5404584995be)

**R3 - disableMultiScreenshare lock (UI toggle):**
[mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T03ui-R3-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053458Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=cb0e2830c9ada9a85f39242fce5cea3a86cc2a3a587759f8f8f9a33473678342) | [viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T03ui-R3-user-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053459Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=800c15bbcb310591b7f4d810bfea6c67ce01d9d4d567d2d9e2177fd17d8af750)

**R3 inverse - viewer share allowed when lock inactive:**
[mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T15-R3inv-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053503Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=be61af81db69415001e8bddc82f620cc4eadc794ce03b04d7874ea8552316756) | [viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T15-R3inv-user-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053504Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=c5f776e498d6397e12567c4833b2f99884fd6105923ad55f77b8061800b7f1d6)

**R4 - 3-actor: moderator stops active viewer share:**
[broadcaster-mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T04-R4-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053500Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=3739a795c94d7058932a4790c83966789684df4d9f684cbafd0ca0f95245a094) | [broadcaster-viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T04-R4-user-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053500Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=890e219dd54ac0b22e90d75d01e21d4213ae80dad625d13dada8536aa59815ce) | [moderator-controller page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T04-R4-mod-page2.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053501Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=85a624e56cec842ff964074d53dfceb04ddb96cbfc576b29d24085c5961766e3)

**R14 - lock viewers UI toggles:**
[UI toggles mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T14ui-R14-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053501Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=4025683d6d27fed96d8562d55d9d4c009f5a2d7ace903a62acf62f8a211e07ca) | [regression mod page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T14regression-R14-mod-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053502Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=8bc6290c70d8215715ac9bb90c2ac11b35ea521eca58d06ca695decb3d081f82) | [regression viewer page](https://s3.eu-central-2.wasabisys.com/claudio-logs/pr-evidences/PR-24941/T14regression-R14-user-page.webm?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=CSZS1ETP18EKZ5RXNZ84%2F20260418%2Feu-central-2%2Fs3%2Faws4_request&X-Amz-Date=20260418T053503Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=7444ab2594db5e9663ffc489463b6d36a32e522c706a49fe46f864adcda3ebd0)

## Test plan

- [x] `npx playwright test screenshare` - 8 feature tests green (run 2026-04-18)
- [x] Create meeting with `lockSettingsDisableMultiScreenshare=true&lockOnJoin=true`, join as viewer - start-screenshare button absent
- [x] Create meeting normally, join as viewer - start-screenshare button present, click starts share
- [x] Moderator opens lock-viewers then Participant Permissions - both new toggles visible
- [x] Viewer starts share, moderator unchecks "Share screen" in lock-viewers - viewer share stops automatically
- [x] Prettier and ESLint pass on all playwright files (`npm run format:check && npm run lint`)
- [x] With `screenShareBridge=livekit`, T02 asserts two decoded videos side-by-side on the observer

## Deployment requirement for R2 multi-decoding

To observe two screenshares decoding side-by-side (R2), the BigBlueButton install must have LiveKit enabled for screenshare:

1. `sudo apt-get install bbb-livekit`
2. `sudo yq e -i ".livekit.enabled = true" /etc/bigbluebutton/bbb-webrtc-sfu/production.yml`
3. `sudo systemctl restart bbb-webrtc-sfu`
4. In `/etc/bigbluebutton/bbb-web.properties`, set `screenShareBridge=livekit` (or pass it per-meeting via the `/create` API).
5. `sudo bbb-conf --restart`

Without LiveKit, the backend multi-share logic still applies but only the primary share renders on the observer.


## Phase A — fall back to presentation when no screenshare is `asContent`

**Commit:** `d20ff6d452` — `feat: fall back to presentation when no screenshare is marked as content`

Previously, `hasScreenshareAsContent` in the GraphQL schema was derived from the global `v_layout.screenshareAsContent` flag (a single meeting-wide toggle). With multi-screenshare each share carries its own `showAsContent` boolean, so aggregating by the meeting-level flag was misleading: if no share was marked as content, `shouldShowScreenshare` in `app/container.tsx` still used `hasScreenshare` — leaving the main area blank until someone flipped content back.

**Changes (2 files):**
- `bbb-graphql-server/bbb_schema.sql` — `hasScreenshareAsContent` now aggregates over `v_screenshare.showAsContent IS TRUE` per share, instead of joining with `v_layout.screenshareAsContent`.
- `bigbluebutton-html5/imports/ui/components/app/container.tsx` — `shouldShowScreenshare` switched from `hasScreenshare` to `hasScreenshareAsContent`. When every active share is `asContent=false`, the main area transparently falls back to the presentation (preserving existing BBB behavior from before the PR).

**Scenarios validated on CT 311 (BBB 4.0.0-beta.3):**
- Share with `showAsContent=true`: main area shows the screenshare component (dark canvas, no whiteboard tools).
- Share with `showAsContent=false`: main area restores the presentation, slides and whiteboard tools return.
- Share stopped (`stoppedAt=now()`): main area keeps the presentation, same as the `asContent=false` case.

**Evidence (TTL 2026-07-20, Drive):**
- Video: https://drive.google.com/file/d/1VhyykBrbmlOes-PMG4fXXPW3P7imL0RS/view
- Screenshot 1 (`asContent=true`): https://drive.google.com/uc?export=view&id=13iqJoowgLkvJR_LAsXrCY7Eqg78mYEpV
- Screenshot 2 (`asContent=false`, fallback to presentation): https://drive.google.com/uc?export=view&id=1SWYmqMPKErFxjffqbTOcYlGKNXEZcXBW
- Screenshot 3 (no share active): https://drive.google.com/uc?export=view&id=1pWPBdVAeW1YoZvBu4ORVUYTEJ33mtVls

---

## Phase C — per-stream `showAsContent` toggle (inverse R2)

**Commits (Phase C):**
- `b08c314578` feat(screenshare): add handler to toggle showAsContent per stream
- `77756cc1e0` feat(graphql): add screenshareSetShowAsContent mutation
- `75eebb1c55` feat(screenshare): dropdown to toggle showAsContent per share
- `8e84a76e14` i18n(screenshare): add labels for showAsContent toggle
- `22095c7569` test(screenshare): inverse R2 playwright for asContent toggle

**Scenarios validated (CT 311, BBB 4.0.0-beta.3):**
- Presenter toggles `showAsContent=true` on stream B while stream A is active → stream B becomes the main content; stream A is cleared automatically (mutual exclusion).
- Presenter toggles `showAsContent` back to stream A → stream A restored as main content; stream B cleared.
- Observer (viewer, second browser) decodes both streams simultaneously and reflects the toggle in real-time.

**Evidence (TTL 2026-07-20, Drive):**
- Video (R2-inverse test): https://drive.google.com/file/d/1u3PilzjhteGtYEXn5n6BlskX93DUerlD/view
- `00:18` — both screenshares active; observer decodes 2 streams simultaneously
- `00:19` — presenter toggles `showAsContent` on stream B → B becomes explicit main content
- `00:23` — presenter toggles `showAsContent` back to stream A → A restored as main content
