### PR TITLE
fix(html5): prevent pinch-to-zoom for viewers and WB users on touch devices

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -124,6 +124,9 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
     document.addEventListener('gesturestart', function (e) {
       e.preventDefault();
     });
+    document.addEventListener('gesturechange', function (e) {
+      e.preventDefault();
+    });
   </script>
   <script src="compatibility/sip.js?v=VERSION" language="javascript"></script>
   <script src="compatibility/tflite-simd.js?v=VERSION" language="javascript"></script>

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2343,6 +2343,16 @@ const Whiteboard = React.memo((props) => {
         tools={customTools}
         overrides={customUiOverrides}
       />
+      {!isPresenter && !hasWBAccess && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 300,
+            touchAction: 'none',
+          }}
+        />
+      )}
       <Styled.TldrawV2GlobalStyle
         {...{
           hasWBAccess,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2345,6 +2345,7 @@ const Whiteboard = React.memo((props) => {
       />
       {!isPresenter && !hasWBAccess && (
         <div
+          aria-hidden="true"
           style={{
             position: 'absolute',
             inset: 0,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -261,7 +261,7 @@ const useMouseEvents = ({
   });
 
   const handlePointerDown = (event) => {
-    if (!event.isPrimary && !isPresenterRef.current) {
+    if (!event.isPrimary && event.pointerType === 'touch' && !isPresenterRef.current) {
       event.stopPropagation();
       tlEditorRef.current?.cancel();
     }
@@ -394,10 +394,10 @@ const useMouseEvents = ({
         presentationWrapper.removeEventListener('mouseup', handleMouseUp);
         presentationWrapper.removeEventListener('mouseenter', handleMouseEnter);
         presentationWrapper.removeEventListener('mouseleave', handleMouseLeave);
-        presentationWrapper.removeEventListener('wheel', handleMouseWheel);
-        presentationWrapper.removeEventListener('pointerdown', handlePointerDown);
-        presentationWrapper.removeEventListener('touchstart', handleTouchStart);
-        presentationWrapper.removeEventListener('touchend', handleTouchEnd);
+        presentationWrapper.removeEventListener('wheel', handleMouseWheel, { capture: true });
+        presentationWrapper.removeEventListener('pointerdown', handlePointerDown, { capture: true });
+        presentationWrapper.removeEventListener('touchstart', handleTouchStart, { capture: true });
+        presentationWrapper.removeEventListener('touchend', handleTouchEnd, { capture: true });
         presentationWrapper.removeEventListener('touchmove', handleTouchMove);
       }
       window.removeEventListener('mousedown', handleMouseDownWindow);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -260,8 +260,19 @@ const useMouseEvents = ({
     setWheelZoomTimeout();
   });
 
+  const handlePointerDown = (event) => {
+    if (!event.isPrimary && !isPresenterRef.current) {
+      event.stopPropagation();
+      tlEditorRef.current?.cancel();
+    }
+  };
+
   const handleTouchStart = (event) => {
     if (event.touches.length === 2) {
+      if (!isPresenterRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       fingerCountRef.current = 2;
       isPinchingRef.current = false;
       const [t1, t2] = event.touches;
@@ -371,6 +382,7 @@ const useMouseEvents = ({
       presentationWrapper.addEventListener('mouseenter', handleMouseEnter);
       presentationWrapper.addEventListener('mouseleave', handleMouseLeave);
       presentationWrapper.addEventListener('wheel', handleMouseWheel, { passive: false, capture: true });
+      presentationWrapper.addEventListener('pointerdown', handlePointerDown, { capture: true });
       presentationWrapper.addEventListener('touchstart', handleTouchStart, { passive: false, capture: true });
       presentationWrapper.addEventListener('touchend', handleTouchEnd, { passive: false, capture: true });
       presentationWrapper.addEventListener('touchmove', handleTouchMove, { passive: false });
@@ -383,6 +395,7 @@ const useMouseEvents = ({
         presentationWrapper.removeEventListener('mouseenter', handleMouseEnter);
         presentationWrapper.removeEventListener('mouseleave', handleMouseLeave);
         presentationWrapper.removeEventListener('wheel', handleMouseWheel);
+        presentationWrapper.removeEventListener('pointerdown', handlePointerDown);
         presentationWrapper.removeEventListener('touchstart', handleTouchStart);
         presentationWrapper.removeEventListener('touchend', handleTouchEnd);
         presentationWrapper.removeEventListener('touchmove', handleTouchMove);


### PR DESCRIPTION
### What does this PR do?

On phones and tablets, participants could accidentally zoom the presentation by pinching the screen, which should only be allowed for the presenter. We now block pinch gestures for all non-presenter participants, keeping the presentation locked in place on touch devices. As a bonus, any accidental drawing stroke triggered while pinching is automatically cancelled for whiteboard users.

### Closes Issue(s)

Closes #24900

### How to test
- Create a Meeting
- Join a Meeting as Mod 
- Join a Meerting as viewer on mobile
- as viewer try to pinch screen 
- as Mod enable multi user whiteboard
- as viewer try again and test multi user wb
- mod makes viewer preseter
- viewer test wb as preseter






### More

https://github.com/user-attachments/assets/b49c671a-5a65-4b83-9ece-2c23574b676c