### PR TITLE
Fix: hidden camera if audio-only tiles are displayed for viewers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -577,7 +577,7 @@ export const useVideoStreams = () => {
           (audioUser) => !streams.find((s) => s.userId === audioUser.userId),
         );
 
-        const availableSlots = myPageSize - pinnedAndLocalCount;
+        const availableSlots = Math.max(0, myPageSize - pinnedAndLocalCount);
         const audioOnlyToAdd = uniqueAudioOnly.slice(0, audioOnlySlotsUsedOnPage1);
 
         if (audioOnlyToAdd.length > 0 && paginatedStreams.length + audioOnlyToAdd.length > availableSlots) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -540,6 +540,7 @@ export const useVideoStreams = () => {
       );
 
       // This is needed to adjust pagination for displaced video streams
+      const pinnedAndLocalCount = pin.length + mine.length;
       let audioOnlySlotsUsedOnPage1 = 0;
       if (showAudioOnlyOnFirstPage && audioOnlyUsers.length > 0) {
         const uniqueAudioOnly = audioOnlyUsers.filter(
@@ -547,16 +548,23 @@ export const useVideoStreams = () => {
         );
 
         if (uniqueAudioOnly.length > 0) {
-          const pinnedAndLocalCount = pin.length + mine.length;
           const availableSlots = myPageSize - pinnedAndLocalCount;
           const maxAudioOnlySlots = Math.min(availableSlots, maxAudioOnlyUsers);
           audioOnlySlotsUsedOnPage1 = Math.min(uniqueAudioOnly.length, maxAudioOnlySlots);
         }
       }
-      totalNumberOfOtherStreams = others.length + audioOnlySlotsUsedOnPage1;
+      if (audioOnlySlotsUsedOnPage1 > 0 && pinnedAndLocalCount > 0) {
+        const othersOnPage0 = Math.max(0, myPageSize - pinnedAndLocalCount - audioOnlySlotsUsedOnPage1);
+        const remainingOthers = Math.max(0, others.length - othersOnPage0);
+        const additionalPages = remainingOthers > 0 ? Math.ceil(remainingOthers / myPageSize) : 0;
+        totalNumberOfOtherStreams = (1 + additionalPages) * myPageSize;
+      } else {
+        totalNumberOfOtherStreams = others.length + audioOnlySlotsUsedOnPage1;
+      }
 
-      const effectiveChunkIndex = currentVideoPageIndex > 0
-        ? chunkIndex - audioOnlySlotsUsedOnPage1
+      const effectiveChunkIndex = currentVideoPageIndex > 0 && audioOnlySlotsUsedOnPage1 > 0
+        ? Math.max(0, myPageSize - pinnedAndLocalCount - audioOnlySlotsUsedOnPage1)
+          + (currentVideoPageIndex - 1) * myPageSize
         : chunkIndex;
 
       let paginatedStreams = sortVideoStreams(others, sortingMethod)
@@ -568,7 +576,6 @@ export const useVideoStreams = () => {
           (audioUser) => !streams.find((s) => s.userId === audioUser.userId),
         );
 
-        const pinnedAndLocalCount = pin.length + mine.length;
         const availableSlots = myPageSize - pinnedAndLocalCount;
         const audioOnlyToAdd = uniqueAudioOnly.slice(0, audioOnlySlotsUsedOnPage1);
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -548,7 +548,7 @@ export const useVideoStreams = () => {
         );
 
         if (uniqueAudioOnly.length > 0) {
-          const availableSlots = myPageSize - pinnedAndLocalCount;
+          const availableSlots = Math.max(0, myPageSize - pinnedAndLocalCount);
           const maxAudioOnlySlots = Math.min(availableSlots, maxAudioOnlyUsers);
           audioOnlySlotsUsedOnPage1 = Math.min(uniqueAudioOnly.length, maxAudioOnlySlots);
         }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -571,6 +571,7 @@ export const useVideoStreams = () => {
         .slice(effectiveChunkIndex, (effectiveChunkIndex + myPageSize)) || [];
 
       // Add audio-only users only on page 1
+      let audioOnlyStreams: StreamItem[] = [];
       if (showAudioOnlyOnFirstPage && currentVideoPageIndex === 0 && audioOnlySlotsUsedOnPage1 > 0) {
         const uniqueAudioOnly = audioOnlyUsers.filter(
           (audioUser) => !streams.find((s) => s.userId === audioUser.userId),
@@ -584,13 +585,13 @@ export const useVideoStreams = () => {
           paginatedStreams = paginatedStreams.slice(0, Math.max(0, remoteStreamsToKeep));
         }
 
-        paginatedStreams = [...paginatedStreams, ...audioOnlyToAdd];
+        audioOnlyStreams = audioOnlyToAdd;
       }
 
       if (sortingConfig.localFirst) {
-        streams = [...pin, ...mine, ...paginatedStreams];
+        streams = [...pin, ...mine, ...paginatedStreams, ...audioOnlyStreams];
       } else {
-        streams = [...pin, ...paginatedStreams, ...mine];
+        streams = [...pin, ...paginatedStreams, ...mine, ...audioOnlyStreams];
       }
     }
   } else {


### PR DESCRIPTION
### What does this PR do?

Adjust camera pagination and audio-only tiles calculation to resolve an issue where a camera could be hidden from the first page without triggering pagination for viewers.

### How to test
Prerequisites
  - showAudioOnlyOnFirstPage: true (default)
  - maxAudioOnlyUsers: 2 (default)
  - Viewer desktop page size: 5 (default)
  - Unified layout enabled (required for audio-only tiles to appear)
  - Video pagination enabled
  - Presentation minimized

  Setup
  1. Create a meeting.
  2. Join as a moderator, minimize presentation.
  3. Join as Viewer A, share webcam. (this is the observer for the bug)
  4. Join as Viewer B, Viewer C, Viewer D. Each share their webcam. (At this point Viewer A sees 3 remote webcams + their own + presenter avatar = 5 tiles, no pagination yet.)
  5. Join as Viewer E and Viewer F - each join with microphone only (no webcam), and speak so their voice activity is set (Audio-only tiles for E and F now appear on Viewer A's first page, displacing one of the webcam tiles.)

#### Before:
  - Viewer A sees on first page: 3 video tiles, 2 audio-only, presenter avatar.
  - No pagination control appears. The displaced webcam stream is permanently hidden.

<img width="2356" height="1222" alt="before" src="https://github.com/user-attachments/assets/eb57301a-6cf6-451c-9a04-a19b6276781b" />

#### After:
  - Viewer A sees on first page: 3 video tiles, 2 audio-only, presenter avatar.
  - A pagination control is visible to navigate to page 2, which shows the displaced and the local webcam.

page 1
<img width="2356" height="1222" alt="after-page-1" src="https://github.com/user-attachments/assets/9f8b3c28-fdf6-4073-98c0-cfe33f172b48" />

page 2
<img width="2356" height="1222" alt="after-page-2" src="https://github.com/user-attachments/assets/25da7aaa-e527-4a8f-b8a9-9edab924f0eb" />
