### PR TITLE
fix (html5): Export of Block Notes broken for cluster setup

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -576,7 +576,7 @@ export interface Pads {
 }
 
 export interface SharedNotes {
-  serverUrl: string
+  serverHostname: string
   maxDocumentChars: number
   maxLengthForContentUpdate: number
 }

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/hooks.ts
@@ -61,9 +61,9 @@ const useHocuspocusProvider = () => {
         extraInfo: { documentId: documentName },
       }, 'Creating new HocuspocusProvider instance');
 
-      const hocuspocusServer = window.meetingClientSettings.public.sharedNotes.serverHostname
+      const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
         || window.location.hostname;
-      const hocuspocusServerUrl = `wss://${hocuspocusServer}/hocuspocus/collaboration`;
+      const hocuspocusServerUrl = `wss://${hocuspocusServerHostname}/hocuspocus/collaboration`;
 
       const wsProvider = new HocuspocusProviderWebsocket({
         url: `${hocuspocusServerUrl}?sessionToken=${sessionToken}`,

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/hooks.ts
@@ -61,8 +61,9 @@ const useHocuspocusProvider = () => {
         extraInfo: { documentId: documentName },
       }, 'Creating new HocuspocusProvider instance');
 
-      const hocuspocusServerUrl = window.meetingClientSettings.public.sharedNotes.serverUrl
-        || `wss://${window.location.hostname}/hocuspocus/collaboration`;
+      const hocuspocusServer = window.meetingClientSettings.public.sharedNotes.serverHostname
+        || window.location.hostname;
+      const hocuspocusServerUrl = `wss://${hocuspocusServer}/hocuspocus/collaboration`;
 
       const wsProvider = new HocuspocusProviderWebsocket({
         url: `${hocuspocusServerUrl}?sessionToken=${sessionToken}`,

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -83,7 +83,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
     if (!isEtherpadSharedNotes) {
       const urlParams = new URLSearchParams(window.location.search);
       const sessionToken = urlParams.get('sessionToken');
-      const hocuspocusServer = window.meetingClientSettings.public.sharedNotes.serverHostname
+      const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
         || window.location.hostname;
 
       menuItems.push(
@@ -93,7 +93,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
           dataTest: 'exportNotesAsPDF',
           label: intl.formatMessage(intlMessages.exportAsPDFLabel),
           onClick: () => {
-            window.open(`https://${hocuspocusServer}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}`);
+            window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}`);
           },
         },
       );

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -83,6 +83,8 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
     if (!isEtherpadSharedNotes) {
       const urlParams = new URLSearchParams(window.location.search);
       const sessionToken = urlParams.get('sessionToken');
+      const hocuspocusServer = window.meetingClientSettings.public.sharedNotes.serverHostname
+        || window.location.hostname;
 
       menuItems.push(
         {
@@ -91,7 +93,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
           dataTest: 'exportNotesAsPDF',
           label: intl.formatMessage(intlMessages.exportAsPDFLabel),
           onClick: () => {
-            window.open(`/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}`);
+            window.open(`https://${hocuspocusServer}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}`);
           },
         },
       );

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.ts
@@ -22,7 +22,7 @@ async function convertAndUpload(
   filename = `${filename}.${extension}`;
 
   const PADS_CONFIG = window.meetingClientSettings.public.pads;
-  const hocuspocusServer = window.meetingClientSettings.public.sharedNotes.serverHostname
+  const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
     || window.location.hostname;
 
   let exportUrlString;
@@ -30,7 +30,7 @@ async function convertAndUpload(
   if (isEtherpadEditor) {
     exportUrlString = Auth.authenticateURL(`${PADS_CONFIG.url}/p/${padId}/export/${extension}?${params}`);
   } else {
-    exportUrlString = Auth.authenticateURL(`https://${hocuspocusServer}/hocuspocus/api/documents/${padId}/export/${extension}?${params}`);
+    exportUrlString = Auth.authenticateURL(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/${extension}?${params}`);
   }
   const exportUrl = Auth.authenticateURL(exportUrlString);
 

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/service.ts
@@ -22,13 +22,15 @@ async function convertAndUpload(
   filename = `${filename}.${extension}`;
 
   const PADS_CONFIG = window.meetingClientSettings.public.pads;
+  const hocuspocusServer = window.meetingClientSettings.public.sharedNotes.serverHostname
+    || window.location.hostname;
 
   let exportUrlString;
   const params = PadsService.getParams();
   if (isEtherpadEditor) {
     exportUrlString = Auth.authenticateURL(`${PADS_CONFIG.url}/p/${padId}/export/${extension}?${params}`);
   } else {
-    exportUrlString = Auth.authenticateURL(`/hocuspocus/api/documents/${padId}/export/${extension}?${params}`);
+    exportUrlString = Auth.authenticateURL(`https://${hocuspocusServer}/hocuspocus/api/documents/${padId}/export/${extension}?${params}`);
   }
   const exportUrl = Auth.authenticateURL(exportUrlString);
 

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -206,7 +206,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       showConnectionErrors: [3001, 3002, 3003, 3004, 3005, 3006],
     },
     sharedNotes: {
-      serverUrl: '',
+      serverHostname: '',
       maxDocumentChars: 99999,
       maxLengthForContentUpdate: 512,
     },

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -808,9 +808,9 @@ public:
   pads:
     url: ETHERPAD_HOST
   sharedNotes:
-    # Hocuspocus server url for BlockNote (it will use the client's domain when empty)
-    # e.g: `wss://bbb-host/hocuspocus/collaboration`
-    serverUrl:
+    # Hocuspocus server hostname for BlockNote (it will use the client's hostname when empty)
+    # e.g: `bbb-host` (only the domain without protocol and path)
+    serverHostname:
     maxDocumentChars: 99999
     maxLengthForContentUpdate: 1500
   media:

--- a/build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx
+++ b/build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx
@@ -41,6 +41,18 @@ location /bigbluebutton/connection/checkHocuspocusAuthorization {
 }
 
 location /hocuspocus/api/ {
+  if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin' $http_origin always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
+    add_header 'Content-Length' 0;
+    return 204;
+  }
+
+  add_header 'Access-Control-Allow-Origin' $http_origin always;
+  add_header 'Access-Control-Allow-Credentials' 'true' always;
+
   auth_request /bigbluebutton/connection/checkAuthorization;
   auth_request_set $auth_status $upstream_status;
   auth_request_set $meeting_id $sent_http_meeting_id;
@@ -62,4 +74,3 @@ location /hocuspocus/sample {
   proxy_http_version 1.1;
   proxy_set_header Host $host;
 }
-

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -128,7 +128,7 @@ public:
   presentation:
     uploadEndpoint: 'https://bbb-01.example.com/bigbluebutton/presentation/upload'
   sharedNotes:
-    serverUrl: wss://bbb-01.example.com/hocuspocus/collaboration
+    serverHostname: bbb-01.example.com
   # for BBB 2.4:
   note:
     url: 'https://bbb-01.example.com/pad'


### PR DESCRIPTION
Previously, only the WebSocket endpoint for BlockNote was configurable, while the document export URL relied on the browser domain.

Using the proxy URL for exports is not viable because download access is validated based on meeting participation, which depends on cookies from the BBB host domain. For this reason, exports must use the BBB host domain.

This PR updates the configuration to use a hostname instead of a full URL:

* Removed: `sharedNotes.serverUrl`
* Added: `sharedNotes.serverHostname`

With this change, the same config can be used for both `wss` and `https`, deriving the protocol-specific parts while keeping the domain centralized.

Additionally, this PR enables CORS in the nginx config, allowing the browser to download files via `fetch` for the "Convert notes to presentation" feature, including in cross-domain (cluster) setups.

The documentation has also been updated to reflect the new configuration.

Closes: #24944