### PR TITLE
fix(html5): keep loading screen during graphql retries and show error screen on connection timeout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/loading-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/loading-screen/component.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Styled from './styles';
 
 const LoadingScreen = () => (
-  <Styled.Background>
+  <Styled.Background data-test="loadingScreen">
     <Styled.Spinner animations>
       <Styled.Bounce1 animations />
       <Styled.Bounce2 animations />

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -110,6 +110,8 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
   const [MeetingSettings] = useMeetingSettings();
   const enableDevTools = MeetingSettings.public.app.enableApolloDevTools;
   const terminateAndRetry = MeetingSettings.public.app.terminateAndRetryConnection ?? 30_000; // Default to 30 seconds
+  const hasEverConnectedRef = useRef(false);
+  const tsCurrentConnectingRef = useRef<number>(0);
 
   useEffect(() => {
     BBBWeb.index().then(({ data }) => {
@@ -130,6 +132,15 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
   useEffect(() => {
     const interval = setInterval(() => {
       const tsNow = Date.now();
+
+      // If the initial connection never succeeds within terminateAndRetry ms, give up and show error
+      if (!hasEverConnectedRef.current && tsCurrentConnectingRef.current !== 0) {
+        const elapsed = tsNow - tsCurrentConnectingRef.current;
+        if (elapsed > terminateAndRetry) {
+          setTerminalError(new Error('Unable to connect to server', { cause: 'connection_timeout' }));
+        }
+      }
+
       if (tsLastMessageRef.current !== 0 && tsLastPingMessageRef.current !== 0) {
         if ((tsNow - tsLastMessageRef.current > boundary.current) && connectionStatus.getServerIsResponding()) {
           connectionStatus.setServerIsResponding(false);
@@ -276,7 +287,11 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
                   errorMessage: JSON.stringify(error),
                 },
               }, 'Graphql Client Error occurred');
-              loadingContextInfo.setLoading(false);
+              if (!hasEverConnectedRef.current) {
+                loadingContextInfo.setLoading(true);
+              } else {
+                loadingContextInfo.setLoading(false);
+              }
               connectionStatus.setConnectedStatus(false);
               setErrorCounts((prev: number) => prev + 1);
             },
@@ -297,10 +312,13 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
               }
             },
             connected: (socket) => {
+              hasEverConnectedRef.current = true;
+              tsCurrentConnectingRef.current = 0;
               activeSocket.current = socket as WebSocket;
               connectionStatus.setConnectedStatus(true);
             },
             connecting: () => {
+              tsCurrentConnectingRef.current = Date.now();
               connectionStatus.setConnectedStatus(false);
             },
             message: (message) => {

--- a/bigbluebutton-tests/playwright/connectionFailure/graphqlFailure.spec.ts
+++ b/bigbluebutton-tests/playwright/connectionFailure/graphqlFailure.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '../core/setup/fixtures';
+import { expect } from '@playwright/test';
+import { createMeeting, getJoinURL } from '../core/helpers';
+
+test.describe('GraphQL connection failure', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    testInfo.setTimeout(120_000);
+
+    const meetingID = await createMeeting();
+    const joinURL = getJoinURL({ meetingID, fullName: 'Claude' });
+
+    // Block the GraphQL WebSocket so it never connects
+    await page.routeWebSocket('**/graphql', () => { /* never connect */ });
+    await page.goto(joinURL);
+  });
+
+  test('Loading screen stays visible while graphql is retrying', async ({ page }) => {
+    await expect(page.locator('[data-test="loadingScreen"]')).toBeVisible({ timeout: 15_000 });
+    await page.waitForTimeout(10_000);
+    await expect(page.locator('[data-test="loadingScreen"]')).toBeVisible();
+  });
+
+  test('Error screen appears after connection timeout', async ({ page }) => {
+    // terminateAndRetry defaults to 30s — error screen should appear shortly after
+    await expect(page.locator('[data-test="loadingScreen"]')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('h1[data-test="errorScreenMessage"]')).toBeVisible({ timeout: 60_000 });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

When the BigBlueButton client loses connection to the server during startup, it used to briefly flash a blank screen before retrying, which was confusing. Now it keeps the loading screen visible while it retries in the background, so users always know something is happening. If the connection can't be established after a timeout, the user is taken to a proper error screen instead of being left hanging.


### Closes Issue(s)
N/A

### Motivation



### How to test
-when join with a user blocks its graphql connection

