### PR TITLE
fix: exclude audio-only tiles from SFU subscription and plugin buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
@@ -434,7 +434,7 @@ class VideoService {
 
   static getStreamsToConnectAndDisconnect(allStreams: VideoItem[], connectedStreamIds: string[]) {
     const cameraIds = allStreams
-      .filter((s) => s?.type !== VIDEO_TYPES.GRID)
+      .filter((s) => s?.type !== VIDEO_TYPES.GRID && s?.type !== VIDEO_TYPES.AUDIO_ONLY)
       .map((s) => (s as StreamItem).stream);
     const streamsToConnect = cameraIds.filter((stream) => {
       return !connectedStreamIds.includes(stream);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -507,7 +507,7 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
       )}
       {((isSelfViewDisabled && stream.userId === Auth.userID) || disabledCams.includes(cameraId))
       && renderWebcamConnecting()}
-      {renderCameraHelperButtons()}
+      {stream.type !== VIDEO_TYPES.AUDIO_ONLY && renderCameraHelperButtons()}
     </Styled.Content>
   );
 };


### PR DESCRIPTION
### What does this PR do?
Fixes two issues where audio-only tiles (introduced in #24574) were being treated as full camera containers:
- 2301 errors in bbb-webrtc-sfu console: `getStreamsToConnectAndDisconnect` in `service.ts` was not filtering out `AUDIO_ONLY` streams when building the list of camera IDs to subscribe.
- Popout plugin button shown on audio-only tiles `renderCameraHelperButtons()` in `video-list-item/component.tsx` was called unconditionally for all stream types. Plugin helper buttons (such as the media popout button from bbb-plugin-media-popout) were rendered on audio-only tiles even though there is no actual video stream to pop out.

### Closes Issue(s)
Closes None

### How to test
1. Join a meeting as moderator, minimize presentation (unified layout active)
2. Join as User A — share webcam
3. Join as User B and User C — join with microphone only and speak
   (audio-only tiles should appear for B and C)
4. Open browser DevTools console:
   - **Expected:** no 2301 errors from bbb-webrtc-sfu
5. Hover over User B or C audio-only tile:
   - **Expected:** no popout button is shown


### More
[Screencast from 22-04-2026 15:45:32.webm](https://github.com/user-attachments/assets/2c9c8b80-770b-4bb9-9c3d-8f01bfadae0b)
