### PR TITLE
docs(administration): fix typos in lti.md

### DIFF
--- a/docs/docs/administration/lti.md
+++ b/docs/docs/administration/lti.md
@@ -30,6 +30,6 @@ When installing using [bbb-install.sh](https://github.com/bigbluebutton/bbb-inst
 -t <key>:<secret>      Install BigBlueButton LTI framework tools and add/update LTI consumer credentials <key>:<secret>
 ```
 
-After using the `-t` option, you can access the LTI launch URL by opening the URL `https://<hostname>/lti`.  With the LTI launch URL, key, and secret, you can test the LTI integration using the [TUSGI test](https://www.tsugi.org/lti-test/lms.php) page.
+After using the `-t` option, you can access the LTI launch URL by opening the URL `https://<hostname>/lti`.  With the LTI launch URL, key, and secret, you can test the LTI integration using the [TSUGI test](https://www.tsugi.org/lti-test/lms.php) page.
 
 For more details on the configuration of the LTI integration for BigBlueButton, see the README files for [bbb-lti-broker](https://github.com/bigbluebutton/bbb-lti-broker) and [bbb-apps-room](https://github.com/bigbluebutton/bbb-app-rooms).

--- a/docs/docs/administration/lti.md
+++ b/docs/docs/administration/lti.md
@@ -30,6 +30,6 @@ When installing using [bbb-install.sh](https://github.com/bigbluebutton/bbb-inst
 -t <key>:<secret>      Install BigBlueButton LTI framework tools and add/update LTI consumer credentials <key>:<secret>
 ```
 
-After using the `-t` option, you can access the LTI launch URL by opening the URL `https://<hostnam>/lti`.  With the LTI launchh URL, key, and secret, you can test the LTI integration using the [TUSGI test](https://www.tsugi.org/lti-test/lms.php) page.
+After using the `-t` option, you can access the LTI launch URL by opening the URL `https://<hostname>/lti`.  With the LTI launch URL, key, and secret, you can test the LTI integration using the [TUSGI test](https://www.tsugi.org/lti-test/lms.php) page.
 
 For more details on the configuration of the LTI integration for BigBlueButton, see the README files for [bbb-lti-broker](https://github.com/bigbluebutton/bbb-lti-broker) and [bbb-apps-room](https://github.com/bigbluebutton/bbb-app-rooms).


### PR DESCRIPTION
### What does this PR do?
Fixes typos in docs/administration/lti.md

### Closes Issue(s)
Closes #23392

### Motivation
I am annoyed by typo errors.

### How to test
- Open the `docs/docs/administration/lti.md` file and preview the document.
- Validate no other typos were forgotten.


### More
- [X] Added/updated documentation
