### PR TITLE
ci: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/actions/check-artifact-exists/action.yml
+++ b/.github/actions/check-artifact-exists/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Check if artifact exists
       id: check
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const runId = context.payload.workflow_run?.id ?? context.runId;

--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -11,7 +11,7 @@ runs:
     - run: ./build/get_external_dependencies.sh
       shell: bash
     - name: Download all BBB artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: all-bbb-artifacts
         path: artifacts
@@ -27,7 +27,7 @@ runs:
         echo "BBB_LIBREOFFICE_IMAGE_NAME=$(head -n 1 bbb-libreoffice/docker/Dockerfile | cut -d ' ' -f 2)" >> $GITHUB_ENV
     - name: LIBREOFFICE CACHE - Restore bbb-libreoffice.tar from cache
       id: libreoffice-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: bbb-libreoffice.tar
         key: ${{ env.BBB_LIBREOFFICE_IMAGE_NAME }}
@@ -42,7 +42,7 @@ runs:
         sudo chown -R "$USER":"$USER" /var/cache/apt
         sudo chmod -R u+rwX /var/cache/apt
     - name: APT CACHE - Restore from cache (if exists)
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /var/cache/apt/archives
         key: ${{ runner.os }}-apt-${{ hashFiles('bigbluebutton-config/bigbluebutton-release') }}

--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -11,7 +11,7 @@ runs:
     - run: ./build/get_external_dependencies.sh
       shell: bash
     - name: Download all BBB artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v7
       with:
         name: all-bbb-artifacts
         path: artifacts

--- a/.github/actions/merge-and-upload-blob-reports/action.yml
+++ b/.github/actions/merge-and-upload-blob-reports/action.yml
@@ -3,7 +3,7 @@ description: Merge and upload the blob reports to GitHub Actions Artifacts
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: 22
     - name: Install dependencies
@@ -11,13 +11,13 @@ runs:
       working-directory: ./bigbluebutton-tests/playwright
       run: npm ci
     - name: Merge artifacts
-      uses: actions/upload-artifact/merge@v4
+      uses: actions/upload-artifact/merge@v5
       with:
         name: all-blob-reports
         pattern: blob-report-*
         delete-merged: true
     - name: Download all blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         name: all-blob-reports
         path: bigbluebutton-tests/playwright/all-blob-reports
@@ -26,7 +26,7 @@ runs:
       working-directory: ./bigbluebutton-tests/playwright
       run: npx playwright merge-reports --reporter html ./all-blob-reports -c playwright.config.ts
     - name: Upload HTML tests report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: tests-report
         overwrite: true

--- a/.github/actions/merge-and-upload-blob-reports/action.yml
+++ b/.github/actions/merge-and-upload-blob-reports/action.yml
@@ -17,7 +17,7 @@ runs:
         pattern: blob-report-*
         delete-merged: true
     - name: Download all blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v7
       with:
         name: all-blob-reports
         path: bigbluebutton-tests/playwright/all-blob-reports
@@ -26,7 +26,7 @@ runs:
       working-directory: ./bigbluebutton-tests/playwright
       run: npx playwright merge-reports --reporter html ./all-blob-reports -c playwright.config.ts
     - name: Upload HTML tests report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: tests-report
         overwrite: true

--- a/.github/actions/merge-and-upload-blob-reports/action.yml
+++ b/.github/actions/merge-and-upload-blob-reports/action.yml
@@ -11,7 +11,7 @@ runs:
       working-directory: ./bigbluebutton-tests/playwright
       run: npm ci
     - name: Merge artifacts
-      uses: actions/upload-artifact/merge@v5
+      uses: actions/upload-artifact/merge@v6
       with:
         name: all-blob-reports
         pattern: blob-report-*
@@ -32,7 +32,7 @@ runs:
         overwrite: true
         path: bigbluebutton-tests/playwright/playwright-report
     - name: Delete unnecessary merged blob reports artifact
-      uses: geekyeggo/delete-artifact@v5
+      uses: geekyeggo/delete-artifact@v6
       with:
         name: all-blob-reports
         failOnError: false

--- a/.github/actions/publish-playwright-report/action.yml
+++ b/.github/actions/publish-playwright-report/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Checkout reports repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         repository: ${{ inputs.reports-repo }}
         token: ${{ inputs.token }}

--- a/.github/workflows/automated-tests-publish-results.yml
+++ b/.github/workflows/automated-tests-publish-results.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Find associated pull request
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // PR resolution strategy:
@@ -79,7 +79,7 @@ jobs:
             return
       - name: Download PR artifact
         if: ${{ fromJson(env.isCompleted) }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -137,9 +137,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Download tests report artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -200,7 +200,7 @@ jobs:
     if: ${{ needs.get-pr-data.outputs.pr-number && needs.get-pr-data.outputs.workflow-id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check if test reports exist
         if: ${{ github.event.workflow_run.conclusion != 'success' && fromJson(env.isCompleted) }}
         id: check-reports
@@ -208,7 +208,7 @@ jobs:
         with:
           artifact-name: tests-report
       - name: Cleanup previous comments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: fc
         with:
           script: |

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -84,12 +84,12 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: Set cache-key vars
@@ -107,7 +107,7 @@ jobs:
       - name: Handle cache
         if: matrix.cache-files-list != ''
         id: cache-action
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: artifacts/
           key: ${{ runner.os }}-${{ matrix.package }}-${{ env.BIGBLUEBUTTON_RELEASE }}-commits-${{ env.CACHE_KEY_FILES }}-urls-${{ env.CACHE_KEY_URLS }}
@@ -132,7 +132,7 @@ jobs:
             ls -la artifacts/
           fi
       - name: Archive packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: artifacts_${{ matrix.package }}
           path: artifacts/
@@ -141,12 +141,12 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: LIBREOFFICE CACHE - Set cache-key vars
@@ -154,7 +154,7 @@ jobs:
           echo "BBB_LIBREOFFICE_IMAGE_NAME=$(head -n 1 bbb-libreoffice/docker/Dockerfile | cut -d ' ' -f 2)" >> $GITHUB_ENV
       - name: LIBREOFFICE CACHE - Restore docker image from cache
         id: libreoffice-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: bbb-libreoffice.tar
           key: ${{ env.BBB_LIBREOFFICE_IMAGE_NAME }}
@@ -170,72 +170,72 @@ jobs:
       - name: Create all-artifacts directory
         run: mkdir -p all-artifacts
       - name: Download artifacts_bbb-apps-akka
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-apps-akka
           path: all-artifacts
       - name: Download artifacts_bbb-config
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-config
           path: all-artifacts
       - name: Download artifacts_bbb-export-annotations
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-export-annotations
           path: all-artifacts
       - name: Download artifacts_bbb-learning-dashboard
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-learning-dashboard
           path: all-artifacts
       - name: Download artifacts_bbb-playback-record
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-playback-record
           path: all-artifacts
       - name: Download artifacts_bbb-graphql-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-graphql-server
           path: all-artifacts
       - name: Download artifacts_bbb-etherpad
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-etherpad
           path: all-artifacts
       - name: Download artifacts_bbb-shared-notes-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-shared-notes-server
           path: all-artifacts
       - name: Download artifacts_bbb-freeswitch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-freeswitch
           path: all-artifacts
       - name: Download artifacts_bbb-webrtc
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-webrtc
           path: all-artifacts
       - name: Download artifacts_bbb-web
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-web
           path: all-artifacts
       - name: Download artifacts_bbb-fsesl-akka
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-fsesl-akka
           path: all-artifacts
       - name: Download artifacts_bbb-html5
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_bbb-html5
           path: all-artifacts
       - name: Download artifacts_others
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: artifacts_others
           path: all-artifacts
@@ -244,7 +244,7 @@ jobs:
           echo "Final contents of all-artifacts:"
           ls -la all-artifacts/
       - name: Upload unified all-artifacts directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: all-bbb-artifacts
           path: all-artifacts/
@@ -282,25 +282,25 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: Install BBB
         timeout-minutes: 60
         uses: ./.github/actions/install-bbb
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         name: PLAYWRIGHT CACHE - Restore Playwright node modules from cache
         with:
           cache: "npm"
           cache-dependency-path: bigbluebutton-tests/playwright/package-lock.json
       - name: PLAYWRIGHT CACHE - Restore Playwright binaries from cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /home/runner/.cache/ms-playwright/
           key: ${{ runner.os }}-playwright-bins-${{ hashFiles('bigbluebutton-tests/playwright/package-lock.json') }}
@@ -336,7 +336,7 @@ jobs:
           npm run test-firefox-ci -- --shard=${{ env.shard }}
       - if: failure()
         name: Upload blob report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: blob-report-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/blob-report
@@ -353,13 +353,13 @@ jobs:
           fi
       - if: failure()
         name: Upload shard HTML report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-report_shard-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/playwright-report
       - if: always()
         name: Upload logs folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: browser-logs-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/logs
@@ -368,13 +368,13 @@ jobs:
         uses: ./.github/actions/prepare-artifacts
       - if: failure()
         name: Upload bbb-configs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bbb-configs-${{ env.MATRIX_SHARD_UNDERSCORED }}
           path: configs
       - if: failure()
         name: Upload bbb-logs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bbb-logs-${{ env.MATRIX_SHARD_UNDERSCORED }}
           path: ./bbb-logs.tar.gz
@@ -392,7 +392,7 @@ jobs:
           echo "hash=$hash" >> $GITHUB_OUTPUT
       - name: APT CACHE - Upload new packages (if changed)
         if: success() && matrix.shard == 1 && github.event_name != 'pull_request'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /var/cache/apt/archives
           key: ${{ runner.os }}-apt-${{ hashFiles('bigbluebutton-config/bigbluebutton-release') }}-${{ steps.apt-manifest.outputs.hash }}
@@ -408,12 +408,12 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: Install BBB
@@ -436,7 +436,7 @@ jobs:
           mkdir -p bigbluebutton-html-plugin-sdk
           tar -xzf bigbluebutton-html-plugin-sdk.tar.gz -C bigbluebutton-html-plugin-sdk --strip-components=1
       - name: PLAYWRIGHT CACHE (Plugins SDK) - Restore Playwright node modules from cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           cache: "npm"
           cache-dependency-path: |
@@ -444,7 +444,7 @@ jobs:
             bigbluebutton-tests/bigbluebutton-html-plugin-sdk/samples/**/package-lock.json
       - name: PLAYWRIGHT CACHE - Restore Playwright binaries from cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /home/runner/.cache/ms-playwright/
           key: ${{ runner.os }}-playwright-bins-${{ hashFiles('bigbluebutton-tests/bigbluebutton-html-plugin-sdk/package-lock.json') }}
@@ -550,7 +550,7 @@ jobs:
           fi
       - if: failure()
         name: Upload blob report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: blob-report-plugins
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/blob-report
@@ -567,13 +567,13 @@ jobs:
           fi
       - if: failure()
         name: Upload shard HTML report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-report_plugins
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/playwright-report
       - if: always()
         name: Upload logs folder
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: browser-logs-plugin
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/logs
@@ -583,13 +583,13 @@ jobs:
         uses: ./.github/actions/prepare-artifacts
       - if: failure()
         name: Upload bbb-configs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bbb-configs-plugins
           path: configs
       - if: failure()
         name: Upload bbb-logs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bbb-logs-plugins
           path: ./bbb-logs.tar.gz
@@ -602,8 +602,8 @@ jobs:
     env:
       hasFailure: ${{ needs.install-and-run-bbb-tests.result == 'failure' || needs.install-and-run-plugin-tests.result == 'failure' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - name: Check if blob reports exist
@@ -624,7 +624,7 @@ jobs:
           echo ${{ github.run_id }} > ./pr-comment-data/workflow_id
       - name: Upload PR data for auto-comment
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: pr-comment-data
           path: pr-comment-data

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -132,7 +132,7 @@ jobs:
             ls -la artifacts/
           fi
       - name: Archive packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: artifacts_${{ matrix.package }}
           path: artifacts/
@@ -170,72 +170,72 @@ jobs:
       - name: Create all-artifacts directory
         run: mkdir -p all-artifacts
       - name: Download artifacts_bbb-apps-akka
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-apps-akka
           path: all-artifacts
       - name: Download artifacts_bbb-config
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-config
           path: all-artifacts
       - name: Download artifacts_bbb-export-annotations
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-export-annotations
           path: all-artifacts
       - name: Download artifacts_bbb-learning-dashboard
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-learning-dashboard
           path: all-artifacts
       - name: Download artifacts_bbb-playback-record
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-playback-record
           path: all-artifacts
       - name: Download artifacts_bbb-graphql-server
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-graphql-server
           path: all-artifacts
       - name: Download artifacts_bbb-etherpad
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-etherpad
           path: all-artifacts
       - name: Download artifacts_bbb-shared-notes-server
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-shared-notes-server
           path: all-artifacts
       - name: Download artifacts_bbb-freeswitch
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-freeswitch
           path: all-artifacts
       - name: Download artifacts_bbb-webrtc
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-webrtc
           path: all-artifacts
       - name: Download artifacts_bbb-web
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-web
           path: all-artifacts
       - name: Download artifacts_bbb-fsesl-akka
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-fsesl-akka
           path: all-artifacts
       - name: Download artifacts_bbb-html5
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_bbb-html5
           path: all-artifacts
       - name: Download artifacts_others
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: artifacts_others
           path: all-artifacts
@@ -244,7 +244,7 @@ jobs:
           echo "Final contents of all-artifacts:"
           ls -la all-artifacts/
       - name: Upload unified all-artifacts directory
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: all-bbb-artifacts
           path: all-artifacts/
@@ -336,7 +336,7 @@ jobs:
           npm run test-firefox-ci -- --shard=${{ env.shard }}
       - if: failure()
         name: Upload blob report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: blob-report-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/blob-report
@@ -353,13 +353,13 @@ jobs:
           fi
       - if: failure()
         name: Upload shard HTML report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-report_shard-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/playwright-report
       - if: always()
         name: Upload logs folder
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: browser-logs-${{ matrix.shard }}
           path: bigbluebutton-tests/playwright/logs
@@ -368,13 +368,13 @@ jobs:
         uses: ./.github/actions/prepare-artifacts
       - if: failure()
         name: Upload bbb-configs artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: bbb-configs-${{ env.MATRIX_SHARD_UNDERSCORED }}
           path: configs
       - if: failure()
         name: Upload bbb-logs artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: bbb-logs-${{ env.MATRIX_SHARD_UNDERSCORED }}
           path: ./bbb-logs.tar.gz
@@ -550,7 +550,7 @@ jobs:
           fi
       - if: failure()
         name: Upload blob report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: blob-report-plugins
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/blob-report
@@ -567,13 +567,13 @@ jobs:
           fi
       - if: failure()
         name: Upload shard HTML report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: test-report_plugins
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/playwright-report
       - if: always()
         name: Upload logs folder
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: browser-logs-plugin
           path: bigbluebutton-tests/bigbluebutton-html-plugin-sdk/logs
@@ -583,13 +583,13 @@ jobs:
         uses: ./.github/actions/prepare-artifacts
       - if: failure()
         name: Upload bbb-configs artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: bbb-configs-plugins
           path: configs
       - if: failure()
         name: Upload bbb-logs artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: bbb-logs-plugins
           path: ./bbb-logs.tar.gz
@@ -624,7 +624,7 @@ jobs:
           echo ${{ github.run_id }} > ./pr-comment-data/workflow_id
       - name: Upload PR data for auto-comment
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: pr-comment-data
           path: pr-comment-data

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -249,7 +249,7 @@ jobs:
           name: all-bbb-artifacts
           path: all-artifacts/
       - name: Remove individual artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             artifacts_bbb-apps-akka

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,8 +22,8 @@ jobs:
         working-directory: ./docs
     steps:
       # Setup
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: yarn
@@ -37,9 +37,10 @@ jobs:
       - name: Build website
         run: yarn build
       - name: upload build artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs/build
+          include-hidden-files: true
 
   deploy:
     name: Deploy docs to gh-pages
@@ -57,4 +58,4 @@ jobs:
     steps:
       - name: deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/playwright-reports-cleanup.yml
+++ b/.github/workflows/playwright-reports-cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     if: ${{ github.repository_owner == 'bigbluebutton' }}
     steps:
       - name: Checkout reports repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/bbb-ci-playwright-reports
           token: ${{ secrets.PLAYWRIGHT_REPORTS_REPO_TOKEN }}

--- a/.github/workflows/plugin-sdk-version-check.yml
+++ b/.github/workflows/plugin-sdk-version-check.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -6,7 +6,7 @@ jobs:
   publiccode_yml_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: italia/publiccode-parser-action@v1
         with:
           publiccode: 'publiccode.yml'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
             fetch-depth: 1
       - uses: ludeeus/action-shellcheck@master   # runs ShellCheck on **/*.sh by default

--- a/.github/workflows/ts-code-compilation.yml
+++ b/.github/workflows/ts-code-compilation.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: run npm ci

--- a/.github/workflows/ts-code-validation.yml
+++ b/.github/workflows/ts-code-validation.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: refs/pull/${{ github.event.number }}/merge
       - name: Checkout commit/branch
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
       - name: install npm dependencies


### PR DESCRIPTION
Attempt to fix deprecation warnings in Automated Tests:

<img width="800" src="https://github.com/user-attachments/assets/ecdb9d1c-62d2-4edc-8d33-24abb89ac4e0" />
