### PR TITLE
fix(livekit): dial-in unable to be heard by web users, +

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -2,7 +2,9 @@ package org.bigbluebutton.core.apps.voice
 
 import org.bigbluebutton.SystemConfiguration
 import org.bigbluebutton.common2.msgs._
+import org.bigbluebutton.core.apps.mediagroups.MediaGroupApp
 import org.bigbluebutton.core.db.NotificationDAO
+import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.running.{ LiveMeeting, MeetingActor, OutMsgRouter, HandlerHelpers }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 import org.bigbluebutton.core.models._
@@ -15,7 +17,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
   val liveMeeting: LiveMeeting
   val outGW: OutMsgRouter
 
-  def handleUserJoinedVoiceConfEvtMsg(msg: UserJoinedVoiceConfEvtMsg): Unit = {
+  def handleUserJoinedVoiceConfEvtMsg(msg: UserJoinedVoiceConfEvtMsg, state: MeetingState2x): MeetingState2x = {
 
     val guestPolicy = GuestsWaiting.getGuestPolicy(liveMeeting.guestsWaiting)
     val isDialInUser = msg.body.intId.startsWith(IntIdPrefixType.DIAL_IN)
@@ -106,7 +108,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
       }
     }
 
-    def letUserEnter() = {
+    def letUserEnter(state: MeetingState2x): MeetingState2x = {
       val speechLocale = Users2x.findWithIntId(liveMeeting.users2x, msg.body.intId) match {
         case Some(u) => u.speechLocale
         case None    => ""
@@ -132,6 +134,17 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
         msg.body.hold,
         msg.body.uuid
       )
+
+      // Dial-in users need to be enrolled in public media groups to be heard
+      // by clients that use selective subscription. Regular web users do this
+      // in UserJoinMeetingReqMsgHdlr
+      if (isDialInUser) {
+        state.update(
+          MediaGroupApp.enrollUserInPublicGroups(liveMeeting, msg.body.intId, state.mediaGroups)
+        )
+      } else {
+        state
+      }
     }
 
     //Firs of all we check whether the user is banned from the meeting
@@ -143,6 +156,7 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
         msg.body.voiceUserId
       )
       outGW.send(event)
+      state
     } else {
       if (isDialInUser) {
         // Guest lobby is always disabled for dial-in users joining via LiveKit
@@ -156,20 +170,24 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
           guestPolicy match {
             case GuestPolicy(policy, setBy) => {
               policy match {
-                case GuestPolicyType.ALWAYS_ACCEPT => letUserEnter()
-                case GuestPolicyType.ALWAYS_DENY   => VoiceApp.removeUserFromVoiceConf(liveMeeting, outGW, msg.body.voiceUserId)
-                case GuestPolicyType.ASK_MODERATOR => registerUserAsGuest()
+                case GuestPolicyType.ALWAYS_ACCEPT => letUserEnter(state)
+                case GuestPolicyType.ALWAYS_DENY =>
+                  VoiceApp.removeUserFromVoiceConf(liveMeeting, outGW, msg.body.voiceUserId)
+                  state
+                case GuestPolicyType.ASK_MODERATOR =>
+                  registerUserAsGuest()
+                  state
               }
             }
           }
         } else {
-          letUserEnter()
+          letUserEnter(state)
         }
       } else {
-        // Regular users reach this point after beeing
-        // allowed to join
-        letUserEnter()
+        // Regular users reach this point after being allowed to join
+        letUserEnter(state)
       }
     }
   }
+
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -478,7 +478,7 @@ class MeetingActor(
         updateModeratorsPresence()
 
       case m: UserJoinedVoiceConfEvtMsg =>
-        handleUserJoinedVoiceConfEvtMsg(m)
+        state = handleUserJoinedVoiceConfEvtMsg(m, state)
         updateVoiceUserLastActivity(m.body.voiceUserId)
       case m: LogoutAndEndMeetingCmdMsg => usersApp.handleLogoutAndEndMeetingCmdMsg(m, state)
       case m: SetRecordingStatusCmdMsg =>

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -305,8 +305,10 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
       publication: RemoteTrackPublication;
       participantId: string;
     }> = [];
+    const participantsById = new Map<string, RemoteParticipant>();
 
     remoteParticipants.forEach((participant) => {
+      participantsById.set(participant.identity, participant);
       participant.audioTrackPublications.forEach((publication: RemoteTrackPublication) => {
         if (isAudioSource(publication.source)) {
           if (publication.isSubscribed) {
@@ -344,7 +346,7 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
     desiredSubscriptions.forEach((participantId) => {
       Object.entries(currentSubscriptions).forEach(([source, subscriptions]) => {
         if (!subscriptions.has(participantId)) {
-          const participant = remoteParticipants.find((p) => p.identity === participantId);
+          const participant = participantsById.get(participantId);
           if (participant) {
             participant.audioTrackPublications.forEach((publication) => {
               const { trackSid } = publication;
@@ -370,7 +372,7 @@ export const useMediaSubscriptions = (liveKitRoom: Room) => {
     Object.values(currentSubscriptions).forEach((subscriptions) => {
       subscriptions.forEach((participantId) => {
         if (!desiredSubscriptions.has(participantId)) {
-          const participant = remoteParticipants.find((p) => p.identity === participantId);
+          const participant = participantsById.get(participantId);
           if (participant) {
             participant.audioTrackPublications.forEach((publication) => {
               // Screen share audio is always subscribed regardless of group membership

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -25,6 +25,7 @@ import {
   PUBLIC_GROUP_IDS,
 } from '/imports/ui/components/livekit/selective-subscription/types';
 import {
+  getBbbUserIdForParticipant,
   isAudioSource,
   selectParticipantsToSubscribe,
 } from '/imports/ui/components/livekit/selective-subscription/service';
@@ -224,8 +225,13 @@ export const useMediaSenders = (
     const senderIdsOnlyInNonPublic = new Set(
       [...senderIdsInNonPublicGroups].filter((id) => !senderIdsInPublicGroup.has(id)),
     );
+    // Media groups use BBB intIds, which differ from LiveKit participant.identity
+    // for dial-in/VO participants (see getBbbUserIdForParticipant).
+    // Map pID to BBB intId when comparing against the non-public-sender set,
+    // but keep senders keyed by participant.identity so downstream code that
+    // looks up participants in the LiveKit room still matches.
     const senders = remoteParticipants
-      .filter((participant) => !senderIdsOnlyInNonPublic.has(participant.identity))
+      .filter((participant) => !senderIdsOnlyInNonPublic.has(getBbbUserIdForParticipant(participant)))
       .map((participant) => ({
         userId: participant.identity,
         groupId: 'default',
@@ -238,17 +244,31 @@ export const useMediaSenders = (
     return { senders, inAnyGroup: false };
   }
 
-  // Union of senders from all groups where I am a receiver
-  const senderStreams = groups
-    .filter((group) => myInboundGroupIds.includes(group.groupId))
-    .filter((stream) => stream.sender === true && stream.active);
-  // Dedupe by userId, keeping first occurrence
-  const seenUserIds = new Set<string>();
-  const senders = senderStreams.filter((stream) => {
-    if (seenUserIds.has(stream.userId)) return false;
-    seenUserIds.add(stream.userId);
-    return true;
+  // Union of senders from all groups where I am a receiver.
+  // Dedupe by userId (first occurrence wins) and rewrite BBB intId to LK
+  // identity as they are not 1:1 compatible for dial-in/VO users (see getBbbUserIdForParticipant).
+  const bbbIdToIdentity = new Map<string, string>();
+  remoteParticipants.forEach((p) => {
+    bbbIdToIdentity.set(getBbbUserIdForParticipant(p), p.identity);
   });
+  const myInboundGroupSet = new Set(myInboundGroupIds);
+  const seenUserIds = new Set<string>();
+  const senders = groups.reduce<MediaGroupStream[]>((acc, stream) => {
+    if (!myInboundGroupSet.has(stream.groupId)) return acc;
+
+    if (!stream.sender || !stream.active) return acc;
+
+    if (seenUserIds.has(stream.userId)) return acc;
+
+    const identity = bbbIdToIdentity.get(stream.userId);
+
+    if (!identity) return acc;
+
+    seenUserIds.add(stream.userId);
+    acc.push({ ...stream, userId: identity });
+
+    return acc;
+  }, []);
 
   return { senders, inAnyGroup };
 };

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/hooks.ts
@@ -135,7 +135,12 @@ const useDebouncedMuteState = (
   useEffect(() => {
     participants.forEach((participant) => {
       const userId = participant.identity;
-      const currUnmuted = unmutedUsers[userId] ?? false;
+      // useWhoIsUnmuted stores keys by LK identity when LK is connected and
+      // by BBB intId when it falls back to the graphql source on LK
+      // disconnect. Check if either variants exist (userId or getBbbUserIdForParticipant(participant))
+      const currUnmuted = unmutedUsers[userId]
+        ?? unmutedUsers[getBbbUserIdForParticipant(participant)]
+        ?? false;
       const prevUnmuted = debouncedStateRef.current[userId] ?? false;
 
       if (currUnmuted === prevUnmuted && !debounceTimers.current.has(userId)) return;

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/service.ts
@@ -14,6 +14,21 @@ export const isAudioSource = (source: Track.Source): boolean => (
 );
 
 /**
+ * Maps a LiveKit participant to the BBB user intId.
+ * Mirrors bbb-webrtc-sfu's lkIdToBbbId: web participants are keyed by their
+ * LiveKit identity, which WE specify and have control over; dial-in/voice-only
+ * participants are keyed by "v_<sid>" since their identities are not controlled
+ * by us and sid guarantees a stable-formatted and unique id.
+ */
+export const getBbbUserIdForParticipant = (participant: RemoteParticipant): string => {
+  const { identity, sid } = participant;
+
+  if (identity.startsWith('w_') || identity.startsWith('v_')) return identity;
+
+  return `v_${sid}`;
+};
+
+/**
  * Calculate audio track subscription priorities.
  * Sorts by:
  *   1) active speakers


### PR DESCRIPTION
### What does this PR do?

- [fix(livekit): dial-in unable to be heard by web users](https://github.com/bigbluebutton/bigbluebutton/commit/c6360749c9f6e0d0a2237acc902ebe3eb069c7b1)
  - After PR #24427 introduced public media groups, LiveKit SIP
    dial-in participants are inaudible to browser users. Two causes:
    - Dial-in users bypass UserJoinMeetingReqMsgHdlr and so are
    never enrolled in public:audio, meaning they are ignored by selective
    subscription
    - The client matches LK participants by identity (sip_<hash>
    for SIP) while media-group records use BBB intIds (v_<sid>).
    These coincide only for web users.
  - Make dial-in users audible again via:
    - Enroll dial-in users in the public media groups via
    UserJoinedVoiceConfEvtMsgHdlr's letUserEnter
    - Add intId-to-identity mapping in selective subscription's hooks,
    mirroring bbb-webrtc-sfu's strategy to properly add dial-in/voice only
    streams to the subscription pool.
- [refactor(livekit): index remoteParticipants by identity (selective sub)](https://github.com/bigbluebutton/bigbluebutton/pull/24963/changes/10ae740e99ed805edca95c85125d4dc11fb7352a)
  - Selective subscription's handleSubscriptionChanges does two participant
array lookups per iteration over subscription pools - while we already
iterate over the participants array earlier and could build a static map
beforehand. Not a big thing, but since these ops _may_ be bursty in
nature, there's no reason not to do this more efficiently.
- [fix(livekit): cover BBB intId in debounced mute fallback lookup](https://github.com/bigbluebutton/bigbluebutton/pull/24963/changes/961e48986d4da61e9ca70a7422c7b1843dce611d)
  - useWhoIsUnmutedLiveKit stores its state-var keyed by LK
participant.identity when LK is connected and by BBB intId when it
falls back to the graphql source on LK disconnect. For web users
those keys coincide; for SIP / voice-only participants (identity
sip_<hash>, intId v_<sid>) they don't.

### Closes Issue(s)

None