### PR TITLE
feat (html5): Implement static toolbar for BlockNote

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -579,6 +579,7 @@ export interface SharedNotes {
   serverHostname: string
   maxDocumentChars: number
   maxLengthForContentUpdate: number
+  staticFormattingToolbar: boolean
 }
 
 export interface Media {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -227,15 +227,14 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-mantine .bn-suggestion-menu {
             min-width: 300px;
           }
-          .bn-editor {
-            padding-inline: 35px 25px;
-            font-size: 1rem;
-          }
-          /* Static toolbar at top, editor fills remaining space */
+          /* Static toolbar at top, editor fills remaining space and scrolls internally.
+             Note: .bn-container and .bn-mantine are the same element; its direct flex
+             children are .bn-editor and .bn-toolbar-row. */
           .bn-container {
             display: flex;
             flex-direction: column-reverse;
             height: 100%;
+            min-height: 0;
           }
           .bn-toolbar-row {
             display: flex;
@@ -245,19 +244,19 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             padding-block: 4px;
             flex-shrink: 0;
             border-bottom: 1px solid #d4d9df;
+            background-color: ${colorWhite};
           }
           .bn-toolbar-row .bn-formatting-toolbar {
             box-shadow: none;
             border: none;
             padding: 0;
           }
-          /* Make the editor fill the available space so clicks below last line focus it */
-          .bn-mantine,
-          .bn-editor,
-          .bn-editor .ProseMirror {
-            height: 100%;
-          }
-          .bn-editor .ProseMirror {
+          .bn-editor {
+            padding-inline: 35px 25px;
+            font-size: 1rem;
+            flex: 1 1 0;
+            min-height: 0;
+            overflow-y: auto;
             box-sizing: border-box;
             cursor: text;
           }

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -12,7 +12,6 @@ import {
   BlockNoteViewEditor,
   BlockTypeSelect,
   ColorStyleButton,
-  CreateLinkButton,
   FormattingToolbar,
   NestBlockButton,
   TextAlignButton,
@@ -306,7 +305,6 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
               <BasicTextStyleButton basicTextStyle="italic" key="italicStyleButton" />
               <BasicTextStyleButton basicTextStyle="underline" key="underlineStyleButton" />
               <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
-              <BasicTextStyleButton basicTextStyle="code" key="codeStyleButton" />
             </FormattingToolbar>
             <FormattingToolbar>
               <TextAlignButton textAlignment="left" key="textAlignLeftButton" />
@@ -315,7 +313,6 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
               <ColorStyleButton key="colorStyleButton" />
               <NestBlockButton key="nestBlockButton" />
               <UnnestBlockButton key="unnestBlockButton" />
-              <CreateLinkButton key="createLinkButton" />
             </FormattingToolbar>
           </div>
         )}

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -9,6 +9,7 @@ import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Awareness } from 'y-protocols/awareness';
 import {
   BasicTextStyleButton,
+  BlockNoteViewEditor,
   BlockTypeSelect,
   ColorStyleButton,
   CreateLinkButton,
@@ -227,14 +228,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-mantine .bn-suggestion-menu {
             min-width: 300px;
           }
-          /* Static toolbar at top, editor fills remaining space and scrolls internally.
-             Note: .bn-container and .bn-mantine are the same element; its direct flex
-             children are .bn-editor and .bn-toolbar-row. */
+          /* Toolbar and editor are siblings inside .bn-container. DOM order matches
+             visual order (toolbar first, editor second), so tab order is correct. */
           .bn-container {
             display: flex;
-            flex-direction: column-reverse;
+            flex-direction: column;
             height: 100%;
-            min-height: 0;
           }
           .bn-toolbar-row {
             display: flex;
@@ -244,7 +243,6 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             padding-block: 4px;
             flex-shrink: 0;
             border-bottom: 1px solid #d4d9df;
-            background-color: ${colorWhite};
           }
           .bn-toolbar-row .bn-formatting-toolbar {
             box-shadow: none;
@@ -254,11 +252,11 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-editor {
             padding-inline: 35px 25px;
             font-size: 1rem;
+            box-sizing: border-box;
+            cursor: text;
             flex: 1 1 0;
             min-height: 0;
             overflow-y: auto;
-            box-sizing: border-box;
-            cursor: text;
           }
           /* Flip labels to below when near top of scroll container */
           .bn-block-group > .bn-block-outer:first-child
@@ -287,6 +285,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
           <div className="bn-toolbar-row">
@@ -309,6 +308,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             </FormattingToolbar>
           </div>
         )}
+        <BlockNoteViewEditor />
       </BlockNoteView>
     </div>
   );

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -229,6 +229,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           }
           .bn-editor {
             padding-inline: 35px 25px;
+            font-size: 1rem;
           }
           /* Static toolbar at top, editor fills remaining space */
           .bn-container {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -215,6 +215,17 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
 
   const editable = !disableNotes || !currentUserIsLocked || currentUserIsModerator;
 
+  // Keep the editor's focus/selection when tapping a toolbar button by
+  // cancelling the default focus move on mousedown.
+  const toolbarRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const el = toolbarRef.current;
+    if (!el) return undefined;
+    const handler = (e: MouseEvent) => e.preventDefault();
+    el.addEventListener('mousedown', handler);
+    return () => el.removeEventListener('mousedown', handler);
+  }, [editable]);
+
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <style>
@@ -288,7 +299,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
-          <div className="bn-toolbar-row">
+          <div ref={toolbarRef} className="bn-toolbar-row">
             <FormattingToolbar>
               <BlockTypeSelect key="blockTypeSelect" />
               <BasicTextStyleButton basicTextStyle="bold" key="boldStyleButton" />

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -7,7 +7,18 @@ import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Awareness } from 'y-protocols/awareness';
-import { useCreateBlockNote } from '@blocknote/react';
+import {
+  BasicTextStyleButton,
+  BlockTypeSelect,
+  ColorStyleButton,
+  CreateLinkButton,
+  FormattingToolbar,
+  NestBlockButton,
+  TextAlignButton,
+  UnnestBlockButton,
+  useCreateBlockNote,
+} from '@blocknote/react';
+
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
@@ -86,6 +97,9 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   const MAX_UPDATE_SHARED_NOTES = window.meetingClientSettings.public.sharedNotes.maxLengthForContentUpdate;
 
   const MAX_DOCUMENT_CHARS = window.meetingClientSettings?.public?.sharedNotes?.maxDocumentChars || 99999;
+
+  const STATIC_FORMATTING_TOOLBAR_ENABLED = window.meetingClientSettings
+    ?.public?.sharedNotes?.staticFormattingToolbar ?? true;
 
   const MAX_PASTE_SIZE = MAX_UPDATE_SHARED_NOTES * 1024;
 
@@ -216,6 +230,26 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-editor {
             padding-inline: 35px 25px;
           }
+          /* Static toolbar at top, editor fills remaining space */
+          .bn-container {
+            display: flex;
+            flex-direction: column-reverse;
+            height: 100%;
+          }
+          .bn-toolbar-row {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 4px;
+            padding-block: 4px;
+            flex-shrink: 0;
+            border-bottom: 1px solid #d4d9df;
+          }
+          .bn-toolbar-row .bn-formatting-toolbar {
+            box-shadow: none;
+            border: none;
+            padding: 0;
+          }
           /* Make the editor fill the available space so clicks below last line focus it */
           .bn-mantine,
           .bn-editor,
@@ -252,7 +286,30 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editable={editable}
         editor={editor}
         theme="light"
-      />
+        formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+      >
+        {STATIC_FORMATTING_TOOLBAR_ENABLED && (
+          <div className="bn-toolbar-row">
+            <FormattingToolbar>
+              <BlockTypeSelect key="blockTypeSelect" />
+              <BasicTextStyleButton basicTextStyle="bold" key="boldStyleButton" />
+              <BasicTextStyleButton basicTextStyle="italic" key="italicStyleButton" />
+              <BasicTextStyleButton basicTextStyle="underline" key="underlineStyleButton" />
+              <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
+              <BasicTextStyleButton basicTextStyle="code" key="codeStyleButton" />
+            </FormattingToolbar>
+            <FormattingToolbar>
+              <TextAlignButton textAlignment="left" key="textAlignLeftButton" />
+              <TextAlignButton textAlignment="center" key="textAlignCenterButton" />
+              <TextAlignButton textAlignment="right" key="textAlignRightButton" />
+              <ColorStyleButton key="colorStyleButton" />
+              <NestBlockButton key="nestBlockButton" />
+              <UnnestBlockButton key="unnestBlockButton" />
+              <CreateLinkButton key="createLinkButton" />
+            </FormattingToolbar>
+          </div>
+        )}
+      </BlockNoteView>
     </div>
   );
 }

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -259,6 +259,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             border: none;
             padding: 0;
           }
+          .bn-toolbar-row [data-test="colors"] .bn-color-icon {
+            font-weight: 700;
+          }
+          .bn-toolbar-row [data-test="colors"] .bn-color-icon[data-text-color="default"] {
+            color: #2f80ed;
+          }
           .bn-editor {
             padding-inline: 35px 25px;
             font-size: 1rem;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -288,7 +288,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
       >
-        {STATIC_FORMATTING_TOOLBAR_ENABLED && (
+        {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
           <div className="bn-toolbar-row">
             <FormattingToolbar>
               <BlockTypeSelect key="blockTypeSelect" />

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -209,6 +209,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       serverHostname: '',
       maxDocumentChars: 99999,
       maxLengthForContentUpdate: 512,
+      staticFormattingToolbar: true,
     },
     externalVideoPlayer: {
       enabled: true,

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -86,6 +86,7 @@
         "validator": "^13.15.22",
         "wasm-feature-detect": "^1.5.1",
         "webrtc-adapter": "^8.1.1",
+        "y-protocols": "^1.0.7",
         "yaml": "^2.8.3"
       },
       "devDependencies": {

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -813,6 +813,10 @@ public:
     serverHostname:
     maxDocumentChars: 99999
     maxLengthForContentUpdate: 1500
+    # When enabled, the formatting toolbar is rendered statically above the
+    # editor and always visible. When disabled, BlockNote's default floating
+    # toolbar appears only when text is selected.
+    staticFormattingToolbar: true
   media:
     audio:
       # defaultFullAudioBridge: bridge to be used by full audio mechanism.


### PR DESCRIPTION
Configurable via `settings.yml`: `public.sharedNotes.staticFormattingToolbar` (`true` by default)

<img width="600" src="https://github.com/user-attachments/assets/b7cd075f-5062-4c18-9968-2c91c0b04717" />

<img width="600" src="https://github.com/user-attachments/assets/70403f0f-390d-4b80-921c-01ea2cc066a1" />


---

I also reduce the font-size slightly to be on pair with Etherpad:

<img width="600" src="https://github.com/user-attachments/assets/4022b968-ff29-40a3-8323-6fa42fb897a9" />
