### PR TITLE
[3.0 port]fix: exclude audio-only tiles from SFU subscription and plugin buttons

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
@@ -431,7 +431,7 @@ class VideoService {
 
   static getStreamsToConnectAndDisconnect(allStreams: VideoItem[], connectedStreamIds: string[]) {
     const cameraIds = allStreams
-      .filter((s) => s?.type !== VIDEO_TYPES.GRID)
+      .filter((s) => s?.type !== VIDEO_TYPES.GRID && s?.type !== VIDEO_TYPES.AUDIO_ONLY)
       .map((s) => (s as StreamItem).stream);
     const streamsToConnect = cameraIds.filter((stream) => {
       return !connectedStreamIds.includes(stream);

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -538,7 +538,7 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
       )}
       {((isSelfViewDisabled && stream.userId === Auth.userID) || disabledCams.includes(cameraId))
       && renderWebcamConnecting()}
-      {renderCameraHelperButtons()}
+      {stream.type !== VIDEO_TYPES.AUDIO_ONLY && renderCameraHelperButtons()}
     </Styled.Content>
   );
 };


### PR DESCRIPTION
### What does this PR do?

backports #24957 changes to BBB 3.0.x:

_Fixes two issues where audio-only tiles (introduced in https://github.com/bigbluebutton/bigbluebutton/pull/24574) were being treated as full camera containers:_

_- 2301 errors in bbb-webrtc-sfu console: getStreamsToConnectAndDisconnect in service.ts was not filtering out AUDIO_ONLY streams when building the list of camera IDs to subscribe._
_- Popout plugin button shown on audio-only tiles renderCameraHelperButtons() in video-list-item/component.tsx was called unconditionally for all stream types. Plugin helper buttons (such as the media popout button from bbb-plugin-media-popout) were rendered on audio-only tiles even though there is no actual video stream to pop out._