### PR TITLE
recording: Fix hang when deskshare audio ends before video

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -235,7 +235,9 @@ module BigBlueButton
         end
 
         process_dir = File.dirname(output_basename)
-        remove_audio_gaps(edl, audioinfo.keys, process_dir)
+        BigBlueButton.logger.info("Removing audio PTS gaps from EDL")
+        remove_audio_gaps(edl, audioinfo, process_dir)
+        BigBlueButton.logger.info("Adjusting EDL to enforce minimum cut durations")
         enforce_cut_lengths(edl)
 
         dump(edl)
@@ -386,9 +388,9 @@ module BigBlueButton
       # fill the gap, but it enqueues the full length of the gap into the filter chain all at once,
       # which uses a lot of memory. To work around this issue, detect long gaps in the audio files
       # and remove the audio file from the mix for the duration of the gap.
-      def self.remove_audio_gaps(edl, audio_files, process_dir)
-        audio_files.each do |filename|
-          gaps_array = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio)
+      def self.remove_audio_gaps(edl, audioinfo, process_dir)
+        audioinfo.each do |filename, info|
+          gaps_array = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio, info[:duration])
           next if gaps_array.empty?
 
           BigBlueButton.logger.info("Audio file #{File.basename(filename)} has #{gaps_array.length} gap(s), adjusting EDL")

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -29,6 +29,7 @@ module BigBlueButton
       # @param process_dir [String] path to directory for temporary processing files
       # @param filename [String] path to the media file
       # @param stream_type [:audio, :video] The type of media stream to inspect
+      # @param duration [Numeric] The expected duration of the media stream (ms)
       # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
       #   Default is 60 seconds, long enough that it won't be hit for short dropouts, but short
       #   enough that it won't cause excessive memory use when ffmpeg fills the gap.
@@ -37,7 +38,7 @@ module BigBlueButton
       #   start of the gap (the moment when the last frame of media before the gap finishes) and
       #   the second element is the end of the gap (the moment when the next frame of media after
       #   the gap starts). All timestamps in ms.
-      def self.pts_gaps(process_dir, filename, stream_type, min_gap = 60_000)
+      def self.pts_gaps(process_dir, filename, stream_type, duration, min_gap = 60_000)
         stream_specifier =
           case stream_type
           when :audio then 'a:0'
@@ -90,6 +91,13 @@ module BigBlueButton
 
                 prev_end = pts
                 prev_end += (row[:duration_time] * 1000).round unless row[:duration_time] == 'N/A'
+              end
+
+              if prev_end < duration
+                gap = duration - prev_end
+                BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and end of file at #{duration}ms (#{gap}ms long)")
+                # Using Infinity as end time to avoid rounding issues causing a tiny cut near the file end
+                pts_gaps << [prev_end, Float::INFINITY]
               end
             ensure
               _pid, status = Process.wait2(pid)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
In deskshare audio specifically, it's fairly common for the audio stream to stop before the video stream does, leaving a "gap" between the end of the audio stream and the end of the media file as a whole. Seeking into this gap breaks the audio processing, resulting in a hanging ffmpeg process.

Since the audio file gap handling code is already inspecting all of the timestamps, it's easy for it to detect this sort of "gap" at the end of the file, and mark it as a gap to be removed from the EDL, which solves the seek problem.

### Closes Issue(s)
Issue was reported privately

### Motivation
Processing of some recordings with deskshare were hanging indefinitely, preventing other recordings from processing.


### How to test
Reproducing this issue requires a deskshare file where the audio is significantly shorter than the video, and also requires that there is another cut coincidentally during that gap caused by someone joining or leaving the audio on a server using livekit. It's very difficult to intentionally reproduce. I have several real recordings from Blindside Networks hosting which I have tested this change on, but which I am unfortunately not able to share.

Verifying that recordings without issues continue to process correctly is straightforwards.


### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
