### PR TITLE
[3.0 port] fix(bbb-web): respond to /create before downloading pre-uploaded presentations

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -228,9 +228,9 @@ class ApiController {
     ApiErrors errors = new ApiErrors()
 
     if (meetingService.createMeeting(newMeeting)) {
+      respondWithConference(newMeeting, null, null)
       // See if the request came with pre-uploading of presentation.
       uploadDocuments(xmlModules, newMeeting, false);  //
-      respondWithConference(newMeeting, null, null)
     } else {
       // Translate the external meeting id into an internal meeting id.
       String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);


### PR DESCRIPTION
### What does this PR do?

backports #24931 changes to BBB 3.0.x:


_Previously, uploadDocuments() was called before respondWithConference() inside the /create handler. When the request includes a pre-uploaded presentation URL (the common case for Moodle and LTI integrations), uploadDocuments() synchronously downloads the file via PresentationUrlDownloadService.savePresentation() before returning. This download blocks the HTTP thread, delaying the XML response to the LMS by however long the download takes._

_The fix swaps the call order: respondWithConference() is called first, then uploadDocuments() continues on the same thread. The meeting is already fully created and running at this point (createMeeting() has returned successfully), so the LMS receives a valid SUCCESS response immediately._

_This does not break error handling because:_

_- The return value of uploadDocuments() was already ignored at the call site before this change.
respondWithConference() always responds with SUCCESS (null msgKey/msg); upload failures are never surfaced to the LMS HTTP response — they are communicated only as internal events to meeting room clients._
_- The only invalid() call inside downloadAndProcessDocument() is inside a catch (UnsupportedEncodingException) block for URLDecoder.decode(..., "UTF-8"), which is unreachable on any JVM since UTF-8 is always available._

_After this change, the /create API response time is determined solely by meeting creation and plugin manifest fetching, regardless of the size or download speed of the pre-uploaded presentation._