### PR TITLE
fix(chat): prevent false unread banner on first join in a fresh meeting

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/component.tsx
@@ -207,6 +207,9 @@ const ChatMessageList: React.FC<ChatListProps> = ({
   const [userLoadedBackUntilPage, setUserLoadedBackUntilPage] = useState<number | null>(null);
   const [lastMessageCreatedAt, setLastMessageCreatedAt] = useState<string>('');
   const [followingTail, setFollowingTail] = React.useState(true);
+  // Guards against the IntersectionObserver firing false during initial DOM layout
+  // before the sentinel has ever been painted, which would incorrectly flip followingTail.
+  const hasEndSentinelBeenVisible = React.useRef(false);
   const [showStartSentinel, setShowStartSentinel] = React.useState(false);
   const [focusedMessageElement, setFocusedMessageElement] = React.useState<HTMLElement | null>();
   const [loadingPages, setLoadingPages] = useState(new Set<number>());
@@ -298,11 +301,15 @@ const ChatMessageList: React.FC<ChatListProps> = ({
 
   useEffect(() => {
     if (isEndSentinelVisible) {
+      hasEndSentinelBeenVisible.current = true;
       startObservingStickyScroll();
+      toggleFollowingTail(true);
     } else {
       stopObservingStickyScroll();
+      if (hasEndSentinelBeenVisible.current) {
+        toggleFollowingTail(false);
+      }
     }
-    toggleFollowingTail(isEndSentinelVisible);
   }, [isEndSentinelVisible]);
 
   useEffect(() => {


### PR DESCRIPTION
### What does this PR do?
When the first user joins a fresh meeting, the unread notification banner appears at the bottom of the chat even though there are no unread messages. This happens because `followingTail` is set to false before the end sentinel has been painted, incorrectly signaling that the user is not at the bottom of the chat.

Add a guard to prevent `followingTail` from being toggled until the end sentinel has been seen for the first time.

### Closes Issue(s)
Closes #24982