### PR TITLE
fix(breakouts): user id handling

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
@@ -22,22 +22,22 @@ trait BreakoutRoomUsersUpdateMsgHdlr extends HandlerHelpers {
       //Update user lastActivityTime in parent room (to avoid be ejected while is in Breakout room)
       for {
         breakoutRoomUser <- updatedRoom.users
-        user <- matchByBreakoutRoomId(liveMeeting.users2x, breakoutRoomUser.extId)
-      } yield Users2x.updateLastUserActivity(liveMeeting.users2x, user)
+        parentMeetingUser <- findUserInMainRoom(liveMeeting.users2x, breakoutRoomUser.extId)
+      } yield Users2x.updateLastUserActivity(liveMeeting.users2x, parentMeetingUser)
 
       //Update lastBreakout in registeredUsers to avoid lose this info when the user leaves
       for {
         breakoutRoomUser <- updatedRoom.users
-        user <- matchByBreakoutRoomId(liveMeeting.registeredUsers, breakoutRoomUser.extId)
+        parentMeetingUser <- findUserInMainRoom(liveMeeting.registeredUsers, breakoutRoomUser.extId)
       } yield {
-        if (room != null && (user.lastBreakoutRoom == null || user.lastBreakoutRoom.id != room.id)) {
-          RegisteredUsers.updateUserLastBreakoutRoom(liveMeeting.registeredUsers, user, room)
+        if (room != null && (parentMeetingUser.lastBreakoutRoom == null || parentMeetingUser.lastBreakoutRoom.id != room.id)) {
+          RegisteredUsers.updateUserLastBreakoutRoom(liveMeeting.registeredUsers, parentMeetingUser, room)
         }
       }
 
       for {
         breakoutRoomUser <- updatedRoom.users
-        parentMeetingUser <- matchByBreakoutRoomId(liveMeeting.registeredUsers, breakoutRoomUser.extId)
+        parentMeetingUser <- findUserInMainRoom(liveMeeting.registeredUsers, breakoutRoomUser.extId)
       } yield {
         BreakoutRoomUserDAO.updateUserJoined(breakoutRoomUser, parentMeetingUser, updatedRoom)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
@@ -4,9 +4,9 @@ import org.bigbluebutton.core.api.BreakoutRoomUsersUpdateInternalMsg
 import org.bigbluebutton.core.db.BreakoutRoomUserDAO
 import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.{ RegisteredUsers, Users2x }
-import org.bigbluebutton.core.running.{ MeetingActor, OutMsgRouter }
+import org.bigbluebutton.core.running.{ HandlerHelpers, MeetingActor, OutMsgRouter }
 
-trait BreakoutRoomUsersUpdateMsgHdlr {
+trait BreakoutRoomUsersUpdateMsgHdlr extends HandlerHelpers {
   this: MeetingActor =>
 
   val outGW: OutMsgRouter
@@ -22,26 +22,25 @@ trait BreakoutRoomUsersUpdateMsgHdlr {
       //Update user lastActivityTime in parent room (to avoid be ejected while is in Breakout room)
       for {
         breakoutRoomUser <- updatedRoom.users
-        user <- Users2x.findWithBreakoutRoomId(liveMeeting.users2x, breakoutRoomUser.extId)
+        user <- matchByBreakoutRoomId(liveMeeting.users2x, breakoutRoomUser.extId)
       } yield Users2x.updateLastUserActivity(liveMeeting.users2x, user)
 
       //Update lastBreakout in registeredUsers to avoid lose this info when the user leaves
       for {
         breakoutRoomUser <- updatedRoom.users
-        u <- RegisteredUsers.findWithBreakoutRoomId(breakoutRoomUser.extId, liveMeeting.registeredUsers)
+        user <- matchByBreakoutRoomId(liveMeeting.registeredUsers, breakoutRoomUser.extId)
       } yield {
-        if (room != null && (u.lastBreakoutRoom == null || u.lastBreakoutRoom.id != room.id)) {
-          RegisteredUsers.updateUserLastBreakoutRoom(liveMeeting.registeredUsers, u, room)
+        if (room != null && (user.lastBreakoutRoom == null || user.lastBreakoutRoom.id != room.id)) {
+          RegisteredUsers.updateUserLastBreakoutRoom(liveMeeting.registeredUsers, user, room)
         }
       }
 
       for {
         breakoutRoomUser <- updatedRoom.users
-        parentMeetingUser <- RegisteredUsers.findWithBreakoutRoomId(breakoutRoomUser.extId, liveMeeting.registeredUsers)
+        parentMeetingUser <- matchByBreakoutRoomId(liveMeeting.registeredUsers, breakoutRoomUser.extId)
       } yield {
         BreakoutRoomUserDAO.updateUserJoined(breakoutRoomUser, parentMeetingUser, updatedRoom)
       }
-
       model.update(updatedRoom)
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -72,18 +72,6 @@ object RegisteredUsers {
     users.toVector.filter(ru => id == ru.externId)
   }
 
-  def findWithBreakoutRoomId(breakoutRoomId: String, users: RegisteredUsers): Vector[RegisteredUser] = {
-    //userId + "-" + roomSequence
-    val lastHyphenIdx = breakoutRoomId.lastIndexOf('-')
-    val userExtId = if (lastHyphenIdx != -1) {
-      breakoutRoomId.substring(0, lastHyphenIdx)
-    } else {
-      breakoutRoomId
-    }
-
-    users.toVector.filter(ru => userExtId == ru.externId)
-  }
-
   def getRegisteredUserWithToken(token: String, userId: String, regUsers: RegisteredUsers): Option[RegisteredUser] = {
     def isSameUserId(ru: RegisteredUser, userId: String): Option[RegisteredUser] = {
       if (userId.startsWith(ru.id)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/RegisteredUsers.scala
@@ -74,9 +74,14 @@ object RegisteredUsers {
 
   def findWithBreakoutRoomId(breakoutRoomId: String, users: RegisteredUsers): Vector[RegisteredUser] = {
     //userId + "-" + roomSequence
-    val userIdParts = breakoutRoomId.split("-")
-    val userExtId = userIdParts(0)
-    users.toVector.filter(ru => userExtId == ru.id)
+    val lastHyphenIdx = breakoutRoomId.lastIndexOf('-')
+    val userExtId = if (lastHyphenIdx != -1) {
+      breakoutRoomId.substring(0, lastHyphenIdx)
+    } else {
+      breakoutRoomId
+    }
+
+    users.toVector.filter(ru => userExtId == ru.externId)
   }
 
   def getRegisteredUserWithToken(token: String, userId: String, regUsers: RegisteredUsers): Option[RegisteredUser] = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -8,18 +8,6 @@ object Users2x {
     users.toVector find (u => u.intId == intId)
   }
 
-  def findWithBreakoutRoomId(users: Users2x, breakoutRoomId: String): Option[UserState] = {
-    //userId + "-" + roomSequence
-    val lastHyphenIdx = breakoutRoomId.lastIndexOf('-')
-    val userExtId = if (lastHyphenIdx != -1) {
-      breakoutRoomId.substring(0, lastHyphenIdx)
-    } else {
-      breakoutRoomId
-    }
-
-    users.toVector find (u => u.extId == userExtId)
-  }
-
   def findAll(users: Users2x): Vector[UserState] = users.toVector
 
   def add(users: Users2x, user: UserState): Option[UserState] = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Users2x.scala
@@ -10,8 +10,12 @@ object Users2x {
 
   def findWithBreakoutRoomId(users: Users2x, breakoutRoomId: String): Option[UserState] = {
     //userId + "-" + roomSequence
-    val userIdParts = breakoutRoomId.split("-")
-    val userExtId = userIdParts(0)
+    val lastHyphenIdx = breakoutRoomId.lastIndexOf('-')
+    val userExtId = if (lastHyphenIdx != -1) {
+      breakoutRoomId.substring(0, lastHyphenIdx)
+    } else {
+      breakoutRoomId
+    }
 
     users.toVector find (u => u.extId == userExtId)
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -17,22 +17,23 @@ import org.bigbluebutton.core.util.TimeUtil
 
 trait HandlerHelpers extends SystemConfiguration {
 
-  def breakoutRoomExtId(breakoutRoomId: String): String = {
-    val lastHyphenIdx = breakoutRoomId.lastIndexOf('-')
-    if (lastHyphenIdx == -1) breakoutRoomId else breakoutRoomId.substring(0, lastHyphenIdx)
+  def extractMainRoomInternalUserId(breakoutRoomUserId: String): String = {
+    val lastHyphenIdx = breakoutRoomUserId.lastIndexOf('-')
+    if (lastHyphenIdx == -1) breakoutRoomUserId else breakoutRoomUserId.substring(0, lastHyphenIdx)
   }
 
-  def matchByBreakoutRoomId[T](users: Vector[T], breakoutRoomId: String)(extractExternId: T => String): T = {
-    val userExtId = breakoutRoomExtId(breakoutRoomId)
-    users.find(user => extractExternId(user) == userExtId)
+  def matchByBreakoutRoomExtUserId[T](users: Vector[T], breakoutRoomExtUserId: String)(extractInternalUserId: T => String): Option[T] = {
+    // The external id of the user in the breakout is the internal id of the user in the main room appended by the room sequence
+    val mainRoomInternalUserId = extractMainRoomInternalUserId(breakoutRoomExtUserId)
+    users.find(user => extractInternalUserId(user) == mainRoomInternalUserId)
   }
 
-  def matchByBreakoutRoomId(users: Users2x, breakoutRoomId: String): UserState = {
-    matchByBreakoutRoomId(Users2x.findAll(users), breakoutRoomId)(_.extId)
+  def findUserInMainRoom(users: Users2x, breakoutRoomExtUserId: String): Option[UserState] = {
+    matchByBreakoutRoomExtUserId(Users2x.findAll(users), breakoutRoomExtUserId)(_.intId)
   }
 
-  def matchByBreakoutRoomId(users: RegisteredUsers, breakoutRoomId: String): RegisteredUser = {
-    matchByBreakoutRoomId(RegisteredUsers.findAll(users), breakoutRoomId)(_.externId)
+  def findUserInMainRoom(users: RegisteredUsers, breakoutRoomExtUserId: String): Option[RegisteredUser] = {
+    matchByBreakoutRoomExtUserId(RegisteredUsers.findAll(users), breakoutRoomExtUserId)(_.id)
   }
 
   def sendUserLeftFlagUpdatedEvtMsg(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -17,6 +17,24 @@ import org.bigbluebutton.core.util.TimeUtil
 
 trait HandlerHelpers extends SystemConfiguration {
 
+  def breakoutRoomExtId(breakoutRoomId: String): String = {
+    val lastHyphenIdx = breakoutRoomId.lastIndexOf('-')
+    if (lastHyphenIdx == -1) breakoutRoomId else breakoutRoomId.substring(0, lastHyphenIdx)
+  }
+
+  def matchByBreakoutRoomId[T](users: Vector[T], breakoutRoomId: String)(extractExternId: T => String): T = {
+    val userExtId = breakoutRoomExtId(breakoutRoomId)
+    users.find(user => extractExternId(user) == userExtId)
+  }
+
+  def matchByBreakoutRoomId(users: Users2x, breakoutRoomId: String): UserState = {
+    matchByBreakoutRoomId(Users2x.findAll(users), breakoutRoomId)(_.extId)
+  }
+
+  def matchByBreakoutRoomId(users: RegisteredUsers, breakoutRoomId: String): RegisteredUser = {
+    matchByBreakoutRoomId(RegisteredUsers.findAll(users), breakoutRoomId)(_.externId)
+  }
+
   def sendUserLeftFlagUpdatedEvtMsg(
       outGW:       OutMsgRouter,
       liveMeeting: LiveMeeting,


### PR DESCRIPTION
### What does this PR do?

- [fix(breakouts): correct external user ID extraction](https://github.com/bigbluebutton/bigbluebutton/pull/24986/changes/a06c1e0e3e3bb82f2c0bf6b357b403b2a58c029f)
Breakout rooms build the user ID by appending `-<roomNumber>` to the external user ID. The previous extraction logic retrieved the original external ID by taking the first chunk of the hyphen-separated string.
This caused issues in edge cases where users joined with prefixed external IDs. For example, `myprefix-w_r12ch33-1` was incorrectly extracted as `myprefix`.
The extraction logic now removes only the last hyphen-separated segment, ensuring the original external user ID is preserved.
- [refactor(akka): reduce duplicate code by extracting to helper function](https://github.com/bigbluebutton/bigbluebutton/pull/24986/changes/81e480404a8a9b97d64f7bb4f9b10a53c77a9f8a)
Extracts the duplicate code from RegisteredUsers and Users2x to a helper function declared in HandlerHelpers as suggested by @prlanzarin in the PR's review.
- [fix(breakouts): find user in main room matching internal user id](https://github.com/bigbluebutton/bigbluebutton/pull/24986/changes/248d11b481d6710571169823de205c77308f2017)
- Reverts the breakout room join url creation to use the user's internal id in the main room as the user's external id in the breakout room.
- Adjusts the user matching logic to compare the correct fields and make the code more readable.



### Closes Issue(s)
Closes #24398
