### PR TITLE
fix: Poll/quiz publishing does not show notification to viewers

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1238,7 +1238,7 @@ BEGIN
      AND u."userId"    = cu."userId"
     WHERE cm."meetingId" = cu."meetingId"
       AND cm."chatId"    = cu."chatId"
-      AND cm."senderId" <> cu."userId"
+      AND cm."senderId" IS DISTINCT FROM cu."userId"
       AND cm."createdAt" > COALESCE(cu."lastSeenAt", u."registeredAt")
   )
   WHERE cu."meetingId" = _meetingId
@@ -1252,7 +1252,7 @@ BEGIN
        AND u."userId"    = cu."userId"
       WHERE cm."meetingId" = cu."meetingId"
         AND cm."chatId"    = cu."chatId"
-        AND cm."senderId" <> cu."userId"
+        AND cm."senderId" IS DISTINCT FROM cu."userId"
         AND cm."createdAt" > COALESCE(cu."lastSeenAt", u."registeredAt")
     );
 END;
@@ -1303,7 +1303,7 @@ BEGIN
   SET "totalUnreadMessages" = coalesce("totalUnreadMessages",0) + 1
   WHERE cu."meetingId" = NEW."meetingId"
     AND cu."chatId"    = NEW."chatId"
-    AND cu."userId"    != NEW."senderId";
+    AND cu."userId" IS DISTINCT FROM NEW."senderId";
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -380,7 +380,7 @@ export const elements = {
   multiWhiteboardTool: 'span[data-test="multiWhiteboardTool"]',
   manageUsers: 'button[data-test="manageUsers"]',
   presenterClassName: 'presenter--',
-  userListToggleBtn: 'button[data-test="toggleUserList"]',
+  userListToggleBtn: 'button[data-test="toggleUserList"], button[data-test="hasUnreadMessages"]',
   mobileUser: 'span[data-test="mobileUser"]',
   connectionStatusBtn: 'button[data-test="connectionStatusButton"]',
   connectionStatusModal: 'div[data-test="connectionStatusModal"]',


### PR DESCRIPTION
### What does this PR do?

Adjusts unread messages comparison so system messages count as a message for the unread indicator.

### Closes Issue(s)
Closes #24710

### How to test
1. Join a session with two users
2. the viewer sends a private chat message to the presenter and keeps viewing this conversation
3. The presenter initiates a poll
4. The viewer votes
5. The presenter publishes the poll results
6. Check if viewer unread message indicator appears
