### PR TITLE
feat(plugins): stop screenshare and upload presentation 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/handler.tsx
@@ -3,6 +3,7 @@ import PluginSaveCaptionServerCommandsManager from './caption/save/manager';
 import PluginAddLocaleCaptionServerCommandsManager from './caption/add-locale/manager';
 import PluginSendMessageChatServerCommandsManager from './chat/send-message/manager';
 import PluginCreatePrivateChatServerCommandsManager from './chat/create-private-chat/manager';
+import PluginUploadPresentationServerCommandsManager from './presentation/upload/manager';
 
 const PluginServerCommandsHandler = () => (
   <>
@@ -10,6 +11,7 @@ const PluginServerCommandsHandler = () => (
     <PluginAddLocaleCaptionServerCommandsManager />
     <PluginSendMessageChatServerCommandsManager />
     <PluginCreatePrivateChatServerCommandsManager />
+    <PluginUploadPresentationServerCommandsManager />
   </>
 );
 

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/presentation/upload/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/presentation/upload/manager.tsx
@@ -9,6 +9,28 @@ import {
 import { uniqueId } from '/imports/utils/string-utils';
 import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
 import logger from '/imports/startup/client/logger';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+
+const getMaxBytes = (): number => window.meetingClientSettings?.public?.presentation
+  ?.mirroredFromBBBCore?.uploadSizeMax ?? 30_000_000;
+
+const assertSize = (bytes: number) => {
+  const maxBytes = getMaxBytes();
+  if (bytes > maxBytes) {
+    throw new Error(`Presentation payload exceeds the maximum allowed size of ${maxBytes} bytes.`);
+  }
+};
+
+const decodeBase64ToFile = (
+  rawBase64: string,
+  mimeType: string,
+  presentationName: string,
+): File => {
+  // base64 encodes 3 bytes as 4 chars; this gives the upper-bound decoded size.
+  assertSize(Math.ceil((rawBase64.length * 3) / 4));
+  const bytes = Uint8Array.from(atob(rawBase64), (c) => c.charCodeAt(0));
+  return new File([new Blob([bytes], { type: mimeType })], presentationName, { type: mimeType });
+};
 
 const toFile = async (
   content: UploadPresentationContent,
@@ -17,28 +39,50 @@ const toFile = async (
 ): Promise<File> => {
   const ext = mimeType.split('/')[1] || 'pdf';
   const presentationName = name || `Plugin_Presentation.${ext}`;
-  if ('base64' in content) {
-    const { base64 } = content;
-    const dataUrlMatch = base64.match(/^data:[^;]+;base64,(.+)$/);
-    const rawBase64 = dataUrlMatch ? dataUrlMatch[1] : base64;
-    const binaryStr = atob(rawBase64);
-    const bytes = Uint8Array.from(binaryStr, (c) => c.charCodeAt(0));
-    const blob = new Blob([bytes], { type: mimeType });
-    return new File([blob], presentationName, { type: mimeType });
+
+  if ('file' in content) {
+    assertSize(content.file.size);
+    return content.file;
   }
+
+  if ('blob' in content) {
+    assertSize(content.blob.size);
+    return new File([content.blob], presentationName, { type: mimeType });
+  }
+
+  if ('dataUrl' in content) {
+    const match = content.dataUrl.match(/^data:[^;]+;base64,(.+)$/);
+    if (!match) throw new Error('Invalid or non-base64 dataURL.');
+    return decodeBase64ToFile(match[1], mimeType, presentationName);
+  }
+
+  if ('base64' in content) {
+    return decodeBase64ToFile(content.base64, mimeType, presentationName);
+  }
+
   throw new Error('Object type not supported.');
 };
 
 const PluginUploadPresentationServerCommandsManager = () => {
+  const { data: currentUserData } = useCurrentUser((user) => ({
+    presenter: user.presenter,
+  }));
+
   const handleUploadPresentation = ((
     event: CustomEvent<UploadPresentationCommandArguments>,
   ) => {
+    if (!currentUserData?.presenter) {
+      logger.warn({
+        logCode: 'plugin_presentation_upload_not_allowed',
+      }, 'Plugin tried to upload a presentation but user is not a presenter');
+      return;
+    }
     toFile(event.detail.content, event.detail.mimeType, event.detail.filename).then((file) => {
       const id = uniqueId(file.name);
       PresentationUploaderService.handleSavePresentation([], false, {
         file,
         presentationId: id,
-        isDownloadable: false,
+        downloadable: false,
         isRemovable: true,
         name: file.name,
         current: true,
@@ -63,7 +107,7 @@ const PluginUploadPresentationServerCommandsManager = () => {
     return () => {
       window.removeEventListener(PresentationCommandsEnum.UPLOAD, handleUploadPresentation);
     };
-  }, []);
+  }, [currentUserData]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/presentation/upload/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/presentation/upload/manager.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import {
+  UploadPresentationCommandArguments,
+  UploadPresentationContent,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/server-commands/presentation/types';
+import {
+  PresentationCommandsEnum,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/server-commands/presentation/enum';
+import { uniqueId } from '/imports/utils/string-utils';
+import PresentationUploaderService from '/imports/ui/components/presentation/presentation-uploader/service';
+import logger from '/imports/startup/client/logger';
+
+const toFile = async (
+  content: UploadPresentationContent,
+  mimeType: string,
+  name?: string,
+): Promise<File> => {
+  const ext = mimeType.split('/')[1] || 'pdf';
+  const presentationName = name || `Plugin_Presentation.${ext}`;
+  if ('base64' in content) {
+    const { base64 } = content;
+    const dataUrlMatch = base64.match(/^data:[^;]+;base64,(.+)$/);
+    const rawBase64 = dataUrlMatch ? dataUrlMatch[1] : base64;
+    const binaryStr = atob(rawBase64);
+    const bytes = Uint8Array.from(binaryStr, (c) => c.charCodeAt(0));
+    const blob = new Blob([bytes], { type: mimeType });
+    return new File([blob], presentationName, { type: mimeType });
+  }
+  throw new Error('Object type not supported.');
+};
+
+const PluginUploadPresentationServerCommandsManager = () => {
+  const handleUploadPresentation = ((
+    event: CustomEvent<UploadPresentationCommandArguments>,
+  ) => {
+    toFile(event.detail.content, event.detail.mimeType, event.detail.filename).then((file) => {
+      const id = uniqueId(file.name);
+      PresentationUploaderService.handleSavePresentation([], false, {
+        file,
+        presentationId: id,
+        isDownloadable: false,
+        isRemovable: true,
+        name: file.name,
+        current: true,
+        conversion: { done: false, error: false },
+        upload: { done: false, error: false, progress: 0 },
+        exportation: { isRunning: false, error: false },
+        onConversion: () => {},
+        onUpload: () => {},
+        onProgress: () => {},
+        onDone: () => {},
+      }, undefined, () => {}, undefined, true);
+    }).catch((error) => {
+      logger.error({
+        logCode: 'plugin_presentation_upload',
+        extraInfo: { error },
+      }, 'Failed to upload presentation from plugin command');
+    });
+  }) as EventListener;
+
+  useEffect(() => {
+    window.addEventListener(PresentationCommandsEnum.UPLOAD, handleUploadPresentation);
+    return () => {
+      window.removeEventListener(PresentationCommandsEnum.UPLOAD, handleUploadPresentation);
+    };
+  }, []);
+
+  return null;
+};
+
+export default PluginUploadPresentationServerCommandsManager;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/presentation/upload/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/server-commands/presentation/upload/manager.tsx
@@ -63,6 +63,18 @@ const toFile = async (
   throw new Error('Object type not supported.');
 };
 
+const isValidUploadEvent = (event: CustomEvent<UploadPresentationCommandArguments>) => {
+  if (
+    !(event instanceof CustomEvent)
+      || event.detail == null
+      || typeof event.detail.mimeType !== 'string'
+      || event.detail.content == null
+  ) {
+    return false;
+  }
+  return true;
+};
+
 const PluginUploadPresentationServerCommandsManager = () => {
   const { data: currentUserData } = useCurrentUser((user) => ({
     presenter: user.presenter,
@@ -75,6 +87,12 @@ const PluginUploadPresentationServerCommandsManager = () => {
       logger.warn({
         logCode: 'plugin_presentation_upload_not_allowed',
       }, 'Plugin tried to upload a presentation but user is not a presenter');
+      return;
+    }
+    if (!isValidUploadEvent(event)) {
+      logger.error({
+        logCode: 'plugin_presentation_upload',
+      }, 'Failed to upload presentation from plugin command: malformed event detail');
       return;
     }
     toFile(event.detail.content, event.detail.mimeType, event.detail.filename).then((file) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -9,10 +9,12 @@ import { PluginLayoutUiCommandsHandler } from './layout/handler';
 import PluginNavBarUiCommandsHandler from './nav-bar/handler';
 import PluginActionsBarUiCommandsHandler from './actions-bar/handler';
 import PluginCameraUiCommandsHandler from './camera/handler';
+import PluginScreenshareUiCommandsHandler from './screenshare/handler';
 
 const PluginUiCommandsHandler = () => (
   <>
     <PluginActionsBarUiCommandsHandler />
+    <PluginScreenshareUiCommandsHandler />
     <PluginLayoutUiCommandsHandler />
     <PluginChatUiCommandsHandler />
     <PluginCameraUiCommandsHandler />

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/screenshare/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/screenshare/handler.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import { screenshareHasEnded, useIsScreenBroadcasting } from '/imports/ui/components/screenshare/service';
+
+const STOP_SCREENSHARE_COMMAND = 'STOP_SCREENSHARE_COMMAND';
+
+const PluginScreenshareUiCommandsHandler = () => {
+  const { data: currentUserData } = useCurrentUser((user) => ({
+    presenter: user.presenter,
+  }));
+  const isScreenBroadcasting = useIsScreenBroadcasting();
+
+  useEffect(() => {
+    const handleStopScreenshare = () => {
+      const amIBroadcasting = isScreenBroadcasting && currentUserData?.presenter;
+      if (!amIBroadcasting) return;
+      screenshareHasEnded();
+    };
+
+    window.addEventListener(STOP_SCREENSHARE_COMMAND, handleStopScreenshare);
+
+    return () => {
+      window.removeEventListener(STOP_SCREENSHARE_COMMAND, handleStopScreenshare);
+    };
+  }, [currentUserData, isScreenBroadcasting]);
+
+  return null;
+};
+
+export default PluginScreenshareUiCommandsHandler;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/screenshare/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/screenshare/handler.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { screenshareHasEnded, useIsScreenBroadcasting } from '/imports/ui/components/screenshare/service';
-
-const STOP_SCREENSHARE_COMMAND = 'STOP_SCREENSHARE_COMMAND';
+import { ScreenshareCommandsEnum } from 'bigbluebutton-html-plugin-sdk';
+import logger from '/imports/startup/client/logger';
 
 const PluginScreenshareUiCommandsHandler = () => {
   const { data: currentUserData } = useCurrentUser((user) => ({
@@ -13,14 +13,19 @@ const PluginScreenshareUiCommandsHandler = () => {
   useEffect(() => {
     const handleStopScreenshare = () => {
       const amIBroadcasting = isScreenBroadcasting && currentUserData?.presenter;
-      if (!amIBroadcasting) return;
+      if (!amIBroadcasting) {
+        logger.warn({
+          logCode: 'plugin_screenshare_stop_not_allowed',
+        }, 'Plugin tried to stop screenshare but user is not broadcasting');
+        return;
+      }
       screenshareHasEnded();
     };
 
-    window.addEventListener(STOP_SCREENSHARE_COMMAND, handleStopScreenshare);
+    window.addEventListener(ScreenshareCommandsEnum.STOP, handleStopScreenshare);
 
     return () => {
-      window.removeEventListener(STOP_SCREENSHARE_COMMAND, handleStopScreenshare);
+      window.removeEventListener(ScreenshareCommandsEnum.STOP, handleStopScreenshare);
     };
   }, [currentUserData, isScreenBroadcasting]);
 

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/4deff9ec6a91b240997ced26dc7d4bd2274587d0",
+        "bigbluebutton-html-plugin-sdk": "0.0.100",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6858,9 +6858,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.99",
-      "resolved": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/4deff9ec6a91b240997ced26dc7d4bd2274587d0",
-      "integrity": "sha512-iTOBJ2HL2gPBQKIVbUBG69FRTQi/CCxYX34g0kOaB6UsZmTx64E9V8NvEDBYhrrq5o6+gLPNkYFEcCIm2Ndf0A==",
+      "version": "0.0.100",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.100.tgz",
+      "integrity": "sha512-Ge/CXQBCMwdfR6qjx4VI4SuCmEoH7rMW0t4d01ENiYi+mxLHi2HW8hiZvsEnlaw1D8KTN7ETSjhiHzL6J5070A==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.99",
+        "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/69dfe9e495f228616a256dd451b9cc104df9078a",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6859,8 +6859,8 @@
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
       "version": "0.0.99",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.99.tgz",
-      "integrity": "sha512-v0Hfe+qz+YVgOkdtP1r5UPYxkWC9R4oZeqk2EjYrzXb+64GutNX9OUMN5dW06So/u/Gf5A8CtpQ1kc7gAseAng==",
+      "resolved": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/69dfe9e495f228616a256dd451b9cc104df9078a",
+      "integrity": "sha512-Y8QaC2iu/O06dHWpa1Stid6r6LTzrwDJozP37UeB+vFR1iQA9FPdbeNpY29UTsH899/6K2RtvsqVZh/xjaW3Lg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/69dfe9e495f228616a256dd451b9cc104df9078a",
+        "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/4deff9ec6a91b240997ced26dc7d4bd2274587d0",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6859,8 +6859,8 @@
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
       "version": "0.0.99",
-      "resolved": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/69dfe9e495f228616a256dd451b9cc104df9078a",
-      "integrity": "sha512-Y8QaC2iu/O06dHWpa1Stid6r6LTzrwDJozP37UeB+vFR1iQA9FPdbeNpY29UTsH899/6K2RtvsqVZh/xjaW3Lg==",
+      "resolved": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/4deff9ec6a91b240997ced26dc7d4bd2274587d0",
+      "integrity": "sha512-iTOBJ2HL2gPBQKIVbUBG69FRTQi/CCxYX34g0kOaB6UsZmTx64E9V8NvEDBYhrrq5o6+gLPNkYFEcCIm2Ndf0A==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -77,7 +77,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/69dfe9e495f228616a256dd451b9cc104df9078a",
+    "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/4deff9ec6a91b240997ced26dc7d4bd2274587d0",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -77,7 +77,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.99",
+    "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/69dfe9e495f228616a256dd451b9cc104df9078a",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -77,7 +77,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "https://codeload.github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/tar.gz/4deff9ec6a91b240997ced26dc7d4bd2274587d0",
+    "bigbluebutton-html-plugin-sdk": "0.0.100",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -574,4 +574,4 @@ pluginManifests=
 # List the parameters without including the 'userdata-' prefix
 getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools
 
-html5PluginSdkVersion=0.0.99
+html5PluginSdkVersion=0.0.100

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -1041,6 +1041,8 @@ As seen for the `useUiData`, the return type is well defined by the enum chosen 
 - presentation-area:
   - open: this function will open the presentation area content automatically;
   - close: this function will close the presentation area content automatically;
+- screenshare:
+  - stop: Stops broadcasting the screenshare if user is presenter and is sharing screen (it is ignored otherwise);
 - sidekick-options-container: **(deprecated - use [sidekickArea](#sidekickarea-ui-commands) instead)**
   - open: this function will open the sidekick options panel automatically;
   - close: this function will close the sidekick options panel automatically (and also the sidebar content if open, to avoid inconsistencies in ui);
@@ -1128,6 +1130,9 @@ For a complete working example, see the [sample-generic-content-sidekick-plugin]
   - caption:
     - save: this function saves the given text, locale and caption type
     - addLocale: this function sends a locale to be added to the available options
+  
+  - presentation:
+    - upload: uploads a new presentation to BigBlueButton;
 
 As these commands can change state in the back-end, "permission control" is available based on role for some of the Commands (in the manifest), those are:
   - chat:


### PR DESCRIPTION
### What does this PR do?

- Adds a new UI command to stop broadcasting screenshare, exposing it via `ui-commands/screenshare` 
- Adds a new server command to upload a new presentation, introducing the `server-commands/presentation`;

### Motivation

Recent development in plugins has seen great value in these 2 features (they were implemented manually from the plugin side - having them as official APIs for the developer to call will help a lot).

### More

Closely related to the PR from SDK: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/256;
- [x] Added/updated documentation
