### PR TITLE
fix: Guests note missing / disappearing

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/UserDAO.scala
@@ -1,5 +1,5 @@
 package org.bigbluebutton.core.db
-import org.bigbluebutton.core.models.{ClientType, RegisteredUser, UserLockSettings, VoiceUserState}
+import org.bigbluebutton.core.models.{ClientType, IntIdPrefixType, RegisteredUser, UserLockSettings, VoiceUserState}
 import slick.jdbc.PostgresProfile.api._
 
 case class UserNameColumnsDbModel(
@@ -128,12 +128,21 @@ object UserDAO {
   }
 
   def updateVoiceUserJoined(voiceUserState: VoiceUserState) = {
+    val isDialIn = voiceUserState.intId.startsWith(IntIdPrefixType.DIAL_IN)
     DatabaseConnection.enqueue(
-      TableQuery[UserDbTableDef]
-        .filter(_.meetingId === voiceUserState.meetingId)
-        .filter(_.userId === voiceUserState.intId)
-        .map(u => (u.guest, u.guestStatus, u.authed, u.joined))
-        .update((false, "ALLOW", true, true))
+      if (isDialIn) {
+        TableQuery[UserDbTableDef]
+          .filter(_.meetingId === voiceUserState.meetingId)
+          .filter(_.userId === voiceUserState.intId)
+          .map(u => (u.guest, u.guestStatus, u.authed, u.joined))
+          .update((false, "ALLOW", true, true))
+      } else {
+        TableQuery[UserDbTableDef]
+          .filter(_.meetingId === voiceUserState.meetingId)
+          .filter(_.userId === voiceUserState.intId)
+          .map(u => (u.guestStatus, u.authed, u.joined))
+          .update(("ALLOW", true, true))
+      }
     )
   }
 


### PR DESCRIPTION
### What does this PR do?

Adjusts updateVoiceUserJoined to only update guest status on audio join for dial-in users


https://github.com/user-attachments/assets/c27c3191-07ff-48fa-a009-2ad138377bca



### Closes Issue(s)
Closes #24980

### How to test
1. Create new meeting
2. Join as moderator
3. Create new join url with guest=true and role=VIEWER and join in incognito window (but cancel audio dialog!)
4. See guest user in user list with "guest" label, click on user and see **no** promote to moderator button
5. Connect to audio in the guest window
6. Guest label and user dropdown options should remain the same for this user