### PR TITLE
fix(recording): address ffmpeg high memory usage from video PTS gaps

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -396,18 +396,22 @@ module BigBlueButton
           }
         end
 
-        BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
-          edl,
-          audio_files,
-          process_dir,
-          stream_type: :audio,
+        source_handlers = {
           source_for_entry: lambda { |entry, filename|
             entry[:audios]&.find { |audio| audio[:filename] == filename }
           },
           split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
           remove_source: lambda { |entry, filename|
             entry[:audios]&.reject! { |audio| audio[:filename] == filename }
-          }
+          },
+        }
+
+        BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
+          edl,
+          audio_files,
+          process_dir,
+          stream_type: :audio,
+          source_handlers: source_handlers
         )
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -407,7 +407,7 @@ module BigBlueButton
           split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
           remove_source: lambda { |entry, filename|
             entry[:audios]&.reject! { |audio| audio[:filename] == filename }
-          },
+          }
         )
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -420,7 +420,7 @@ module BigBlueButton
           edl,
           entry_i,
           rec_time,
-          BigBlueButton::Events.edl_entry_offset_audio,
+          BigBlueButton::Events.edl_entry_offset_audio
         )
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -389,68 +389,35 @@ module BigBlueButton
       # which uses a lot of memory. To work around this issue, detect long gaps in the audio files
       # and remove the audio file from the mix for the duration of the gap.
       def self.remove_audio_gaps(edl, audioinfo, process_dir)
-        audioinfo.each do |filename, info|
-          gaps_array = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio, info[:duration])
-          next if gaps_array.empty?
-
-          BigBlueButton.logger.info("Audio file #{File.basename(filename)} has #{gaps_array.length} gap(s), adjusting EDL")
-
-          next_i = 0
-          gaps = gaps_array.each
-          gap_start, gap_end = gaps.next
-          while next_i < edl.length - 1
-            i = next_i
-            entry = edl[i]
-            next_i += 1
-
-            audio_data = entry[:audios]&.find { |a| a[:filename] == filename }
-            # Current EDL entry does not contain this file
-            next unless audio_data
-
-            audio_in = audio_data[:timestamp]
-            audio_out = audio_in + edl[next_i][:timestamp] - entry[:timestamp]
-
-            # Iterate forward through gaps until we find one that's not in the past
-            gap_start, gap_end = gaps.next while gap_end <= audio_in
-
-            # Nothing to do if the next gap is after the current entry ends
-            next if gap_start >= audio_out
-
-            BigBlueButton.logger.debug(
-              "Processing gap [#{gap_start}ms, #{gap_end}ms) " \
-              "in EDL entry #{i} (timestamp=#{entry[:timestamp]}ms)",
-            )
-
-            # If gap starts in this EDL entry, then it needs to be split
-            if gap_start > audio_in
-              split_edl_at(edl, i, gap_start - audio_in + entry[:timestamp])
-              # No audio to remove from the current entry
-              next
-            end
-
-            # If gap ends in this EDL entry, then it needs to be split
-            if gap_end < audio_out
-              split_edl_at(edl, i, gap_end - audio_in + entry[:timestamp])
-              # Audio needs to be removed from the current entry
-            end
-
-            # Only get here if the current EDL entry is completely contained within a gap.
-            # Remove the file from the entry.
-            entry[:audios].reject! { |a| a[:filename] == filename }
-          end
-        rescue StopIteration
-          # Reached the end of the gaps list for this file, go to the next file.
-          next
+        audio_files = audioinfo.each_with_object({}) do |(filename, info), files|
+          files[filename] = {
+            filename: filename,
+            duration: info[:duration],
+          }
         end
+
+        BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
+          edl,
+          audio_files,
+          process_dir,
+          stream_type: :audio,
+          source_for_entry: lambda { |entry, filename|
+            entry[:audios]&.find { |audio| audio[:filename] == filename }
+          },
+          split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
+          remove_source: lambda { |entry, filename|
+            entry[:audios]&.reject! { |audio| audio[:filename] == filename }
+          },
+        )
       end
 
       def self.split_edl_at(edl, entry_i, rec_time)
-        BigBlueButton.logger.debug("Splitting EDL entry #{entry_i} at #{rec_time}ms")
-        entry = edl[entry_i]
-        offset = rec_time - entry[:timestamp]
-        new_entry = BigBlueButton::Events.edl_entry_offset_audio.call(entry, offset)
-        new_entry[:timestamp] = rec_time
-        edl.insert(entry_i + 1, new_entry)
+        BigBlueButton::EDL::MediaUtils.split_edl_entry(
+          edl,
+          entry_i,
+          rec_time,
+          BigBlueButton::Events.edl_entry_offset_audio,
+        )
       end
 
       def self.audio_info(filename)

--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -389,29 +389,14 @@ module BigBlueButton
       # which uses a lot of memory. To work around this issue, detect long gaps in the audio files
       # and remove the audio file from the mix for the duration of the gap.
       def self.remove_audio_gaps(edl, audioinfo, process_dir)
-        audio_files = audioinfo.each_with_object({}) do |(filename, info), files|
-          files[filename] = {
-            filename: filename,
-            duration: info[:duration],
-          }
+        audio_gaps = audioinfo.each_with_object({}) do |(filename, info), gaps|
+          gaps[filename] = BigBlueButton::EDL::MediaUtils.pts_gaps(process_dir, filename, :audio, info[:duration])
         end
-
-        source_handlers = {
-          source_for_entry: lambda { |entry, filename|
-            entry[:audios]&.find { |audio| audio[:filename] == filename }
-          },
-          split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
-          remove_source: lambda { |entry, filename|
-            entry[:audios]&.reject! { |audio| audio[:filename] == filename }
-          },
-        }
 
         BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
           edl,
-          audio_files,
-          process_dir,
-          stream_type: :audio,
-          source_handlers: source_handlers
+          audio_gaps,
+          stream_type: :audio
         )
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -161,7 +161,8 @@ module BigBlueButton
           next if gaps_array.empty?
 
           BigBlueButton.logger.info(
-            "#{stream_type.to_s.capitalize} file #{File.basename(source_id.to_s)} has #{gaps_array.length} gap(s), adjusting EDL",
+            "#{stream_type.to_s.capitalize} file #{File.basename(source_id.to_s)} " \
+            "has #{gaps_array.length} gap(s), adjusting EDL"
           )
 
           next_entry_i = 0
@@ -187,7 +188,7 @@ module BigBlueButton
 
             BigBlueButton.logger.debug(
               "Processing gap [#{gap_start}ms, #{gap_end}ms) " \
-              "in EDL entry #{entry_i} (timestamp=#{entry[:timestamp]}ms)",
+              "in EDL entry #{entry_i} (timestamp=#{entry[:timestamp]}ms)"
             )
 
             # If gap starts in this EDL entry, then it needs to be split

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -24,12 +24,30 @@ require 'tempfile'
 module BigBlueButton
   module EDL
     module MediaUtils
+      DEFAULT_PTS_GAP_MS = 60_000
+
+      # Split an EDL entry into two entries at a recording timestamp.
+      #
+      # @param edl [Array<Hash>] EDL to modify in place
+      # @param entry_i [Integer] index of the entry to split
+      # @param rec_time [Integer] recording timestamp to split at, in ms
+      # @param offset_entry [Proc] proc used to clone an EDL entry with timestamps offset
+      def self.split_edl_entry(edl, entry_i, rec_time, offset_entry)
+        BigBlueButton.logger.debug("Splitting EDL entry #{entry_i} at #{rec_time}ms")
+
+        entry = edl[entry_i]
+        offset = rec_time - entry[:timestamp]
+        new_entry = offset_entry.call(entry, offset)
+        new_entry[:timestamp] = rec_time
+        edl.insert(entry_i + 1, new_entry)
+      end
+
       # Get a list of gaps in PTS values.
       #
       # @param process_dir [String] path to directory for temporary processing files
       # @param filename [String] path to the media file
       # @param stream_type [:audio, :video] The type of media stream to inspect
-      # @param duration [Numeric] The expected duration of the media stream (ms)
+      # @param duration [Numeric, nil] The expected duration of the media stream (ms), if known
       # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
       #   Default is 60 seconds, long enough that it won't be hit for short dropouts, but short
       #   enough that it won't cause excessive memory use when ffmpeg fills the gap.
@@ -38,7 +56,7 @@ module BigBlueButton
       #   start of the gap (the moment when the last frame of media before the gap finishes) and
       #   the second element is the end of the gap (the moment when the next frame of media after
       #   the gap starts). All timestamps in ms.
-      def self.pts_gaps(process_dir, filename, stream_type, duration, min_gap = 60_000)
+      def self.pts_gaps(process_dir, filename, stream_type, duration = nil, min_gap = DEFAULT_PTS_GAP_MS)
         stream_specifier =
           case stream_type
           when :audio then 'a:0'
@@ -93,7 +111,7 @@ module BigBlueButton
                 prev_end += (row[:duration_time] * 1000).round unless row[:duration_time] == 'N/A'
               end
 
-              if prev_end < duration
+              if duration && prev_end < duration
                 gap = duration - prev_end
                 BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and end of file at #{duration}ms (#{gap}ms long)")
                 # Using Infinity as end time to avoid rounding issues causing a tiny cut near the file end
@@ -114,6 +132,87 @@ module BigBlueButton
       rescue StandardError => e
         BigBlueButton.logger.warn("Failed to probe PTS: #{e}")
         []
+      end
+
+      # Remove sources from an EDL for time ranges where the underlying media stream has large PTS gaps.
+      #
+      # @param edl [Array<Hash>] EDL to modify in place
+      # @param sources [Hash{String => Hash}] mapping of logical source ids to probe metadata hashes with :filename
+      #   and optional :duration
+      # @param process_dir [String] path to directory for temporary processing files
+      # @param stream_type [:audio, :video] media stream type to inspect
+      # @param source_for_entry [Proc] returns the matching source hash from an EDL entry, or nil
+      # @param split_entry [Proc] splits an EDL entry at a recording timestamp
+      # @param remove_source [Proc] removes the matching source from an EDL entry
+      # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
+      def self.remove_pts_gaps_from_edl(
+        edl,
+        sources,
+        process_dir,
+        stream_type:,
+        source_for_entry:,
+        split_entry:,
+        remove_source:,
+        min_gap: DEFAULT_PTS_GAP_MS
+      )
+        sources.each do |source_id, probe_info|
+          probe_filename = probe_info.fetch(:filename)
+          gaps_array = pts_gaps(process_dir, probe_filename, stream_type, probe_info[:duration], min_gap)
+          next if gaps_array.empty?
+
+          BigBlueButton.logger.info(
+            "#{stream_type.to_s.capitalize} file #{File.basename(source_id.to_s)} has #{gaps_array.length} gap(s), adjusting EDL",
+          )
+
+          next_entry_i = 0
+          gaps = gaps_array.each
+          gap_start, gap_end = gaps.next
+          while next_entry_i < edl.length - 1
+            entry_i = next_entry_i
+            entry = edl[entry_i]
+            next_entry_i += 1
+
+            source = source_for_entry.call(entry, source_id)
+            # Current EDL entry does not contain this file
+            next unless source
+
+            source_in = source[:timestamp]
+            source_out = source_in + edl[next_entry_i][:timestamp] - entry[:timestamp]
+
+            # Iterate forward through gaps until we find one that's not in the past
+            gap_start, gap_end = gaps.next while gap_end <= source_in
+
+            # Nothing to do if the next gap is after the current entry ends
+            next if gap_start >= source_out
+
+            BigBlueButton.logger.debug(
+              "Processing gap [#{gap_start}ms, #{gap_end}ms) " \
+              "in EDL entry #{entry_i} (timestamp=#{entry[:timestamp]}ms)",
+            )
+
+            # If gap starts in this EDL entry, then it needs to be split
+            if gap_start > source_in
+              # Split before the gap; the new entry will be handled by the next loop.
+              split_entry.call(edl, entry_i, gap_start - source_in + entry[:timestamp])
+              next
+            end
+
+            # If gap ends in this EDL entry, then it needs to be split
+            if gap_end < source_out
+              split_entry.call(edl, entry_i, gap_end - source_in + entry[:timestamp])
+              # Source needs to be removed from the current entry
+            end
+
+            # Only get here if the current EDL entry is completely contained within a gap.
+            # Remove the file from the entry.
+            remove_source.call(entry, source_id)
+          end
+        rescue StopIteration
+          # Reached the end of the gaps list for this file, go to the next file.
+          next
+        end
+
+        nil
       end
     end
   end

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -24,9 +24,7 @@ require 'tempfile'
 module BigBlueButton
   module EDL
     module MediaUtils
-      DEFAULT_PTS_GAP_MS = 60_000
-      # Ignore tiny EOF deltas caused by timestamp rounding, but still catch real EOF gaps.
-      EOF_GAP_TOLERANCE_MS = 100
+      DEFAULT_PTS_GAP_MS = 30_000
 
       # Split an EDL entry into two entries at a recording timestamp.
       #
@@ -51,7 +49,7 @@ module BigBlueButton
       # @param stream_type [:audio, :video] The type of media stream to inspect
       # @param duration [Numeric, nil] The expected duration of the media stream (ms), if known
       # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
-      #   Default is 60 seconds, long enough that it won't be hit for short dropouts, but short
+      #   Default is 30 seconds, long enough that it won't be hit for short dropouts, but short
       #   enough that it won't cause excessive memory use when ffmpeg fills the gap.
       #
       # @return [Array<Array<Numeric>>] A list of gaps. For each gap, the first element is the
@@ -115,14 +113,12 @@ module BigBlueButton
 
               if duration && prev_end < duration
                 gap = duration - prev_end
-                if gap > EOF_GAP_TOLERANCE_MS
-                  BigBlueButton.logger.info(
-                    "PTS gap detected between #{prev_end}ms and end of file at #{duration}ms " \
-                    "(#{gap}ms long)"
-                  )
-                  # Using Infinity as end time to avoid rounding issues causing a tiny cut near the file end
-                  pts_gaps << [prev_end, Float::INFINITY]
-                end
+                BigBlueButton.logger.info(
+                  "PTS gap detected between #{prev_end}ms and end of file at #{duration}ms " \
+                  "(#{gap}ms long)"
+                )
+                # Using Infinity as end time to avoid rounding issues causing a tiny cut near the file end
+                pts_gaps << [prev_end, Float::INFINITY]
               end
             ensure
               _pid, status = Process.wait2(pid)
@@ -144,28 +140,48 @@ module BigBlueButton
       # Remove sources from an EDL for time ranges where the underlying media stream has large PTS gaps.
       #
       # @param edl [Array<Hash>] EDL to modify in place
-      # @param sources [Hash{String => Hash}] mapping of logical source ids to probe metadata hashes with :filename
-      #   and optional :duration
-      # @param process_dir [String] path to directory for temporary processing files
-      # @param stream_type [:audio, :video] media stream type to inspect
-      # @param source_handlers [Hash{Symbol => Proc}] callbacks to find, split, and remove sources
-      # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
-      def self.remove_pts_gaps_from_edl(
-        edl,
-        sources,
-        process_dir,
-        stream_type:,
-        source_handlers:,
-        min_gap: DEFAULT_PTS_GAP_MS
-      )
-        source_for_entry = source_handlers.fetch(:source_for_entry)
-        split_entry = source_handlers.fetch(:split_entry)
-        remove_source = source_handlers.fetch(:remove_source)
+      # @param source_gaps [Hash{Object => Array<Array<Numeric>>}] mapping of logical source ids to PTS gaps
+      # @param stream_type [:audio, :video] media stream type to remove
+      def self.remove_pts_gaps_from_edl(edl, source_gaps, stream_type:)
+        source_for_entry, split_entry, remove_source =
+          case stream_type
+          when :audio
+            [
+              lambda { |entry, filename|
+                entry[:audios]&.find { |audio| audio[:filename] == filename }
+              },
+              lambda { |entries, entry_i, rec_time|
+                split_edl_entry(entries, entry_i, rec_time, BigBlueButton::Events.edl_entry_offset_audio)
+              },
+              lambda { |entry, filename|
+                entry[:audios]&.reject! { |audio| audio[:filename] == filename }
+              },
+            ]
+          when :video
+            [
+              lambda { |entry, filename|
+                source = nil
+                entry[:areas].each_value do |videos|
+                  source = videos.find { |video| video[:filename] == filename }
+                  break unless source.nil?
+                end
+                source
+              },
+              lambda { |entries, entry_i, rec_time|
+                split_edl_entry(entries, entry_i, rec_time, BigBlueButton::Events.edl_entry_offset_video)
+              },
+              lambda { |entry, filename|
+                entry[:areas].each_value do |videos|
+                  videos.reject! { |video| video[:filename] == filename }
+                end
+              },
+            ]
+          else
+            raise ArgumentError, "Unexpected stream_type #{stream_type.inspect}"
+          end
 
-        sources.each do |source_id, probe_info|
-          probe_filename = probe_info.fetch(:filename)
-          gaps_array = pts_gaps(process_dir, probe_filename, stream_type, probe_info[:duration], min_gap)
-          next if gaps_array.empty?
+        source_gaps.each do |source_id, gaps_array|
+          next if gaps_array.nil? || gaps_array.empty?
 
           BigBlueButton.logger.info(
             "#{stream_type.to_s.capitalize} file #{File.basename(source_id.to_s)} " \

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -25,6 +25,8 @@ module BigBlueButton
   module EDL
     module MediaUtils
       DEFAULT_PTS_GAP_MS = 60_000
+      # Ignore tiny EOF deltas caused by timestamp rounding, but still catch real EOF gaps.
+      EOF_GAP_TOLERANCE_MS = 100
 
       # Split an EDL entry into two entries at a recording timestamp.
       #
@@ -113,9 +115,14 @@ module BigBlueButton
 
               if duration && prev_end < duration
                 gap = duration - prev_end
-                BigBlueButton.logger.info("PTS gap detected between #{prev_end}ms and end of file at #{duration}ms (#{gap}ms long)")
-                # Using Infinity as end time to avoid rounding issues causing a tiny cut near the file end
-                pts_gaps << [prev_end, Float::INFINITY]
+                if gap > EOF_GAP_TOLERANCE_MS
+                  BigBlueButton.logger.info(
+                    "PTS gap detected between #{prev_end}ms and end of file at #{duration}ms " \
+                    "(#{gap}ms long)"
+                  )
+                  # Using Infinity as end time to avoid rounding issues causing a tiny cut near the file end
+                  pts_gaps << [prev_end, Float::INFINITY]
+                end
               end
             ensure
               _pid, status = Process.wait2(pid)
@@ -141,20 +148,20 @@ module BigBlueButton
       #   and optional :duration
       # @param process_dir [String] path to directory for temporary processing files
       # @param stream_type [:audio, :video] media stream type to inspect
-      # @param source_for_entry [Proc] returns the matching source hash from an EDL entry, or nil
-      # @param split_entry [Proc] splits an EDL entry at a recording timestamp
-      # @param remove_source [Proc] removes the matching source from an EDL entry
+      # @param source_handlers [Hash{Symbol => Proc}] callbacks to find, split, and remove sources
       # @param min_gap [Numeric] Only include gaps which are at least this long (ms)
       def self.remove_pts_gaps_from_edl(
         edl,
         sources,
         process_dir,
         stream_type:,
-        source_for_entry:,
-        split_entry:,
-        remove_source:,
+        source_handlers:,
         min_gap: DEFAULT_PTS_GAP_MS
       )
+        source_for_entry = source_handlers.fetch(:source_for_entry)
+        split_entry = source_handlers.fetch(:split_entry)
+        remove_source = source_handlers.fetch(:remove_source)
+
         sources.each do |source_id, probe_info|
           probe_filename = probe_info.fetch(:filename)
           gaps_array = pts_gaps(process_dir, probe_filename, stream_type, probe_info[:duration], min_gap)

--- a/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/media_utils.rb
@@ -143,42 +143,37 @@ module BigBlueButton
       # @param source_gaps [Hash{Object => Array<Array<Numeric>>}] mapping of logical source ids to PTS gaps
       # @param stream_type [:audio, :video] media stream type to remove
       def self.remove_pts_gaps_from_edl(edl, source_gaps, stream_type:)
-        source_for_entry, split_entry, remove_source =
-          case stream_type
-          when :audio
-            [
-              lambda { |entry, filename|
-                entry[:audios]&.find { |audio| audio[:filename] == filename }
-              },
-              lambda { |entries, entry_i, rec_time|
-                split_edl_entry(entries, entry_i, rec_time, BigBlueButton::Events.edl_entry_offset_audio)
-              },
-              lambda { |entry, filename|
-                entry[:audios]&.reject! { |audio| audio[:filename] == filename }
-              },
-            ]
-          when :video
-            [
-              lambda { |entry, filename|
-                source = nil
-                entry[:areas].each_value do |videos|
-                  source = videos.find { |video| video[:filename] == filename }
-                  break unless source.nil?
-                end
-                source
-              },
-              lambda { |entries, entry_i, rec_time|
-                split_edl_entry(entries, entry_i, rec_time, BigBlueButton::Events.edl_entry_offset_video)
-              },
-              lambda { |entry, filename|
-                entry[:areas].each_value do |videos|
-                  videos.reject! { |video| video[:filename] == filename }
-                end
-              },
-            ]
-          else
-            raise ArgumentError, "Unexpected stream_type #{stream_type.inspect}"
-          end
+        case stream_type
+        when :audio
+          source_for_entry = lambda { |entry, filename|
+            entry[:audios]&.find { |audio| audio[:filename] == filename }
+          }
+          split_entry = lambda { |entries, entry_i, rec_time|
+            split_edl_entry(entries, entry_i, rec_time, BigBlueButton::Events.edl_entry_offset_audio)
+          }
+          remove_source = lambda { |entry, filename|
+            entry[:audios]&.reject! { |audio| audio[:filename] == filename }
+          }
+        when :video
+          source_for_entry = lambda { |entry, filename|
+            source = nil
+            entry[:areas].each_value do |videos|
+              source = videos.find { |video| video[:filename] == filename }
+              break unless source.nil?
+            end
+            source
+          }
+          split_entry = lambda { |entries, entry_i, rec_time|
+            split_edl_entry(entries, entry_i, rec_time, BigBlueButton::Events.edl_entry_offset_video)
+          }
+          remove_source = lambda { |entry, filename|
+            entry[:areas].each_value do |videos|
+              videos.reject! { |video| video[:filename] == filename }
+            end
+          }
+        else
+          raise ArgumentError, "Unexpected stream_type #{stream_type.inspect}"
+        end
 
         source_gaps.each do |source_id, gaps_array|
           next if gaps_array.nil? || gaps_array.empty?

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -389,14 +389,18 @@ module BigBlueButton
 
       # Check video files for large gaps in timestamps and remove them from the EDL for the duration of the gap.
       def self.remove_video_gaps(edl, video_files, process_dir)
+        source_handlers = {
+          source_for_entry: ->(entry, filename) { find_video(entry, filename) },
+          split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
+          remove_source: ->(entry, filename) { remove_video(entry, filename) },
+        }
+
         BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
           edl,
           video_files,
           process_dir,
           stream_type: :video,
-          source_for_entry: ->(entry, filename) { find_video(entry, filename) },
-          split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
-          remove_source: ->(entry, filename) { remove_video(entry, filename) },
+          source_handlers: source_handlers,
           min_gap: 30_000
         )
       end

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -298,18 +298,10 @@ module BigBlueButton
           end
         end
 
-        video_gaps = {}
-        (0...(edl.length - 1)).each do |i|
-          edl[i][:areas].each_value do |videos|
-            videos.each do |video|
-              next if video_gaps.key?(video[:filename])
+        video_gaps = video_sources.each_with_object({}) do |(filename, source), gaps|
+          next if source.corrupt?
 
-              source = video[:source]
-              next if source.nil? || source.corrupt?
-
-              video_gaps[video[:filename]] = source.pts_gaps
-            end
-          end
+          gaps[filename] = source.pts_gaps
         end
         remove_video_gaps(edl, video_gaps)
         # Gap removal can add cuts, so enforce the minimum length on the final EDL.

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -298,15 +298,20 @@ module BigBlueButton
           end
         end
 
-        gap_probe_files = video_sources.each_with_object({}) do |(filename, video_source), files|
-          next if corrupt_videos.include?(filename)
+        video_gaps = {}
+        (0...(edl.length - 1)).each do |i|
+          edl[i][:areas].each_value do |videos|
+            videos.each do |video|
+              next if video_gaps.key?(video[:filename])
 
-          files[filename] = {
-            filename: video_source.filename,
-            duration: video_source.duration,
-          }
+              source = video[:source]
+              next if source.nil? || source.corrupt?
+
+              video_gaps[video[:filename]] = source.pts_gaps
+            end
+          end
         end
-        remove_video_gaps(edl, gap_probe_files, process_dir)
+        remove_video_gaps(edl, video_gaps)
         # Gap removal can add cuts, so enforce the minimum length on the final EDL.
         enforce_cut_lengths(edl, layout[:framerate])
 
@@ -388,48 +393,15 @@ module BigBlueButton
       end
 
       # Check video files for large gaps in timestamps and remove them from the EDL for the duration of the gap.
-      def self.remove_video_gaps(edl, video_files, process_dir)
-        source_handlers = {
-          source_for_entry: ->(entry, filename) { find_video(entry, filename) },
-          split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
-          remove_source: ->(entry, filename) { remove_video(entry, filename) },
-        }
-
+      def self.remove_video_gaps(edl, video_gaps)
         BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
           edl,
-          video_files,
-          process_dir,
-          stream_type: :video,
-          source_handlers: source_handlers,
-          min_gap: 30_000
+          video_gaps,
+          stream_type: :video
         )
       end
 
       # The methods below are for private use
-
-      def self.find_video(entry, filename)
-        entry[:areas].each_value do |videos|
-          video = videos.find { |candidate| candidate[:filename] == filename }
-          return video unless video.nil?
-        end
-
-        nil
-      end
-
-      def self.remove_video(entry, filename)
-        entry[:areas].each_value do |videos|
-          videos.reject! { |video| video[:filename] == filename }
-        end
-      end
-
-      def self.split_edl_at(edl, entry_i, rec_time)
-        BigBlueButton::EDL::MediaUtils.split_edl_entry(
-          edl,
-          entry_i,
-          rec_time,
-          BigBlueButton::Events.edl_entry_offset_video
-        )
-      end
 
       def self.ms_to_s(timestamp)
         s = timestamp / 1000

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -427,7 +427,7 @@ module BigBlueButton
           edl,
           entry_i,
           rec_time,
-          BigBlueButton::Events.edl_entry_offset_video,
+          BigBlueButton::Events.edl_entry_offset_video
         )
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -397,7 +397,7 @@ module BigBlueButton
           source_for_entry: ->(entry, filename) { find_video(entry, filename) },
           split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
           remove_source: ->(entry, filename) { remove_video(entry, filename) },
-          min_gap: 30_000,
+          min_gap: 30_000
         )
       end
 

--- a/record-and-playback/core/lib/recordandplayback/edl/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video.rb
@@ -21,6 +21,7 @@ require 'json'
 require 'set'
 require 'shellwords'
 
+require_relative 'media_utils'
 require_relative 'video/presentation_video_source'
 require_relative 'video/video_source_reader'
 require_relative 'video/video_source'
@@ -250,6 +251,7 @@ module BigBlueButton
       # @param layouts [Array<Hash>] Additional layouts to select between automatically
       def self.render(edl, layout, output_basename, threads = 2, layouts: nil)
         video_sources = {}
+        process_dir = File.dirname(output_basename)
 
         corrupt_videos = Set.new
 
@@ -257,8 +259,6 @@ module BigBlueButton
         enforce_cut_lengths(edl, layout[:framerate])
 
         (0...(edl.length - 1)).each do |i|
-          # The render scripts need this to calculate cut lengths
-          edl[i][:next_timestamp] = edl[i + 1][:timestamp]
           # Have to fetch information about all the input video files,
           # so collect them.
           edl[i][:areas].each_value do |videos|
@@ -277,7 +277,7 @@ module BigBlueButton
               # Create a new file video source from the filename
               video_source = VideoSource.new(
                 video[:filename],
-                File.dirname(output_basename),
+                process_dir,
                 original_duration: video[:original_duration]
               )
               if video_source.corrupt?
@@ -296,6 +296,23 @@ module BigBlueButton
               videos.delete_if { |video| corrupt_videos.include?(video[:filename]) }
             end
           end
+        end
+
+        gap_probe_files = video_sources.each_with_object({}) do |(filename, video_source), files|
+          next if corrupt_videos.include?(filename)
+
+          files[filename] = {
+            filename: video_source.filename,
+            duration: video_source.duration,
+          }
+        end
+        remove_video_gaps(edl, gap_probe_files, process_dir)
+        # Gap removal can add cuts, so enforce the minimum length on the final EDL.
+        enforce_cut_lengths(edl, layout[:framerate])
+
+        (0...(edl.length - 1)).each do |i|
+          # The render scripts need this to calculate cut lengths.
+          edl[i][:next_timestamp] = edl[i + 1][:timestamp]
         end
 
         dump(edl)
@@ -370,7 +387,45 @@ module BigBlueButton
         render
       end
 
+      # Check video files for large gaps in timestamps and remove them from the EDL for the duration of the gap.
+      def self.remove_video_gaps(edl, video_files, process_dir)
+        BigBlueButton::EDL::MediaUtils.remove_pts_gaps_from_edl(
+          edl,
+          video_files,
+          process_dir,
+          stream_type: :video,
+          source_for_entry: ->(entry, filename) { find_video(entry, filename) },
+          split_entry: ->(entries, entry_i, rec_time) { split_edl_at(entries, entry_i, rec_time) },
+          remove_source: ->(entry, filename) { remove_video(entry, filename) },
+          min_gap: 30_000,
+        )
+      end
+
       # The methods below are for private use
+
+      def self.find_video(entry, filename)
+        entry[:areas].each_value do |videos|
+          video = videos.find { |candidate| candidate[:filename] == filename }
+          return video unless video.nil?
+        end
+
+        nil
+      end
+
+      def self.remove_video(entry, filename)
+        entry[:areas].each_value do |videos|
+          videos.reject! { |video| video[:filename] == filename }
+        end
+      end
+
+      def self.split_edl_at(edl, entry_i, rec_time)
+        BigBlueButton::EDL::MediaUtils.split_edl_entry(
+          edl,
+          entry_i,
+          rec_time,
+          BigBlueButton::Events.edl_entry_offset_video,
+        )
+      end
 
       def self.ms_to_s(timestamp)
         s = timestamp / 1000

--- a/record-and-playback/core/lib/recordandplayback/edl/video/presentation_video_source.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video/presentation_video_source.rb
@@ -27,6 +27,13 @@ module BigBlueButton
           false
         end
 
+        # Presentation video is generated on demand, so it cannot have input file PTS gaps.
+        #
+        # @return [Array] Always empty
+        def pts_gaps
+          []
+        end
+
         # Generate a cut of presentation area video using the bbb-presentation-video tool
         #
         # @param width [Integer] width of the presentation area

--- a/record-and-playback/core/lib/recordandplayback/edl/video/video_source.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video/video_source.rb
@@ -7,15 +7,6 @@ module BigBlueButton
       class VideoSource
         READ_VIDEO_INFO_FLAGS = ['-select_streams', 'v:0', '-count_frames', '-read_intervals', '%+#10'].freeze
 
-        # The filename currently used to read this source. This can differ from
-        # the original filename if the source was remuxed.
-        attr_reader :filename
-
-        # Duration of the current video source in milliseconds.
-        def duration
-          @info&.dig(:duration)
-        end
-
         # Initialize a video source from a video file
         #
         # @param filename [String] path to the video file
@@ -54,6 +45,15 @@ module BigBlueButton
             needs_remux = true
           end
           try_remux_video if needs_remux
+        end
+
+        # Check this video source for large gaps in timestamps.
+        #
+        # @return [Array<Array<Numeric>>] PTS gaps in the current source file
+        def pts_gaps
+          return [] if corrupt?
+
+          BigBlueButton::EDL::MediaUtils.pts_gaps(@process_dir, @filename, :video, @info[:duration])
         end
 
         # The native aspect ratio of the video source.

--- a/record-and-playback/core/lib/recordandplayback/edl/video/video_source.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/video/video_source.rb
@@ -7,6 +7,15 @@ module BigBlueButton
       class VideoSource
         READ_VIDEO_INFO_FLAGS = ['-select_streams', 'v:0', '-count_frames', '-read_intervals', '%+#10'].freeze
 
+        # The filename currently used to read this source. This can differ from
+        # the original filename if the source was remuxed.
+        attr_reader :filename
+
+        # Duration of the current video source in milliseconds.
+        def duration
+          @info&.dig(:duration)
+        end
+
         # Initialize a video source from a video file
         #
         # @param filename [String] path to the video file


### PR DESCRIPTION
### What does this PR do?
Remove video sources from the EDL during long PTS gaps so ffmpeg does not process/fill those ranges while rendering. This avoids excessive memory usage for recordings with large timestamp gaps in video streams.

It uses the same code as audio (added in https://github.com/bigbluebutton/bigbluebutton/pull/24776).

The min gap for removal used for video is set as 30 seconds instead because with 60 we still saw ffmpeg memory going over 2GB+ of usage in some recordings.

