### PR TITLE
fix: improve click target for chat input and user search

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -641,7 +641,13 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
           </Styled.EmojiPickerWrapper>
         ) : null}
         <Styled.Wrapper>
-          <Styled.InputWrapper>
+          <Styled.InputWrapper
+            onClick={(e) => {
+              if (e.target === e.currentTarget) {
+                textAreaRef.current?.textarea.focus();
+              }
+            }}
+          >
             <Styled.Input
               id="message-input"
               ref={textAreaRef}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -188,6 +188,7 @@ const InputWrapper = styled.div`
   border: 1px solid ${colorBorder};
   background-color: ${colorWhite};
   gap: 3px;
+  cursor: text;
 
   &:focus-within {
     box-shadow: 0 0 0 ${xsPadding} ${colorBorder};

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-search/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-search/component.tsx
@@ -28,6 +28,7 @@ const UserSearch: React.FC<UserSearchProps> = ({
 }) => {
   const intl = useIntl();
   const [internalValue, setInternalValue] = useState('');
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
@@ -50,9 +51,16 @@ const UserSearch: React.FC<UserSearchProps> = ({
   }, [onSearchChange]);
 
   return (
-    <Styled.SearchContainer>
+    <Styled.SearchContainer
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          inputRef.current?.focus();
+        }
+      }}
+    >
       <Icon iconName="search" />
       <Styled.SearchInput
+        ref={inputRef}
         type="text"
         placeholder={intl.formatMessage(intlMessages.searchUsers)}
         value={internalValue}

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-search/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-search/styles.ts
@@ -27,7 +27,8 @@ const SearchContainer = styled.div`
   height: 40px;
   overflow: hidden;
   box-shadow: none;
-  
+  cursor: text;
+
   &:focus-within {
     box-shadow: 0 0 0 ${xsPadding} ${colorBorder};
   }


### PR DESCRIPTION
### What does this PR do?

The bordered wrappers for the chat message input and the userlist search input were larger than their inner input elements, making it awkward to focus them by clicking on the padding area.

- Added cursor: text to both wrapper containers so the clickable zone is visually communicated                                                                                
- Added onClick handlers that forward clicks on the wrapper (padding/border area) to the inner input/textarea

#### before
only clicking the middle of the input (where the placeholder text is) triggers focus

<img width="215" height="131" alt="Screenshot from 2026-04-29 16-14-26" src="https://github.com/user-attachments/assets/82efe160-eddc-4788-84f9-ee9582f83ef2" />

<img width="390" height="112" alt="Screenshot from 2026-04-29 16-14-02" src="https://github.com/user-attachments/assets/8ab4e83a-ae41-42f4-b4fb-fa9c85ba6341" />

#### after

clicking anywhere inside the input wrapper borders triggers input focus

<img width="316" height="148" alt="Screenshot from 2026-04-29 16-11-59" src="https://github.com/user-attachments/assets/8c23a582-f3f0-47d7-a3a6-8bbc5d8e26b5" />
<img width="390" height="112" alt="Screenshot from 2026-04-29 16-12-22" src="https://github.com/user-attachments/assets/c0d3cd9a-cb36-41b3-86a5-9fb5566904c9" />
