### PR TITLE
fix (gql-server): Set `typing=false` once user edited a message

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1325,9 +1325,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER "update_chatUser_clear_lastTypingAt_trigger" AFTER INSERT ON chat_message FOR EACH ROW
+CREATE TRIGGER "update_chatUser_clear_lastTypingAt_trigger" AFTER INSERT OR UPDATE ON chat_message FOR EACH ROW
 EXECUTE FUNCTION "update_chatUser_clear_lastTypingAt_trigger_func"();
-
 
 
 CREATE UNLOGGED TABLE "chat_message_history" (


### PR DESCRIPTION
When a user sends a message, the database automatically assumes they stopped typing.

That behavior was not applied when a message was edited, so after editing, the user could still appear as typing.

This PR fixes that by marking the user as having stopped typing as soon as they edit a message.