### PR TITLE
fix: lockSettingsHideUserList leaks usernames in the chat if a viewer was (temp) set to presenter

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -126,12 +126,13 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
       )
 
       if (announcePresenterChangeInChat) {
-        val assignedByUser = Users2x.findWithIntId(liveMeeting.users2x, assignedBy)
-        val assignedByName = assignedByUser.map(_.name).getOrElse("")
+        val assignedByName = Users2x.findWithIntId(liveMeeting.users2x, assignedBy).get match {
+          case u: UserState => u.name
+          case _            => ""
+        }
 
         val hideUserList = MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList
-        val assignedByIsViewer = assignedByUser.exists(_.role == Roles.VIEWER_ROLE)
-        val shouldSkip = hideUserList && (newPres.role == Roles.VIEWER_ROLE || assignedByIsViewer)
+        val shouldSkip = hideUserList && newPres.role == Roles.VIEWER_ROLE
 
         if (!shouldSkip) {
           val msgMeta = Map("assignedBy" -> assignedByName)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/AssignPresenterReqMsgHdlr.scala
@@ -5,7 +5,8 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.presentationpod.SetPresenterInPodActionHandler
 import org.bigbluebutton.core.apps.ExternalVideoModel
 import org.bigbluebutton.core.apps.groupchats.GroupChatApp
-import org.bigbluebutton.core.models.{ PresentationPod, RegisteredUsers, UserState, Users2x }
+import org.bigbluebutton.core.models.{ PresentationPod, RegisteredUsers, Roles, UserState, Users2x }
+import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.domain.MeetingState2x
@@ -125,16 +126,17 @@ object AssignPresenterActionHandler extends RightsManagementTrait {
       )
 
       if (announcePresenterChangeInChat) {
-        val assignedByName = Users2x.findWithIntId(liveMeeting.users2x, assignedBy).get match {
-          case u: UserState => u.name
-          case _            => ""
-        }
+        val assignedByUser = Users2x.findWithIntId(liveMeeting.users2x, assignedBy)
+        val assignedByName = assignedByUser.map(_.name).getOrElse("")
 
-        //System message
-        val msgMeta = Map(
-          "assignedBy" -> assignedByName
-        )
-        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "", GroupChatMessageType.USER_IS_PRESENTER_MSG, msgMeta, newPres.name)
+        val hideUserList = MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList
+        val assignedByIsViewer = assignedByUser.exists(_.role == Roles.VIEWER_ROLE)
+        val shouldSkip = hideUserList && (newPres.role == Roles.VIEWER_ROLE || assignedByIsViewer)
+
+        if (!shouldSkip) {
+          val msgMeta = Map("assignedBy" -> assignedByName)
+          ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "", GroupChatMessageType.USER_IS_PRESENTER_MSG, msgMeta, newPres.name)
+        }
       }
     }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeUserAwayReqMsgHdlr.scala
@@ -44,6 +44,7 @@ trait ChangeUserAwayReqMsgHdlr extends RightsManagementTrait {
 
       if (!(user.role == Roles.VIEWER_ROLE && user.locked && permissions.disablePubChat)
         && (!user.userLockSettings.disablePublicChat || user.role == Roles.MODERATOR_ROLE)
+        && !(permissions.hideUserList && user.role == Roles.VIEWER_ROLE)
         && ((user.away && !msg.body.away) || (!user.away && msg.body.away))) {
         ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "", GroupChatMessageType.USER_AWAY_STATUS_MSG, msgMeta, user.name)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -14,6 +14,7 @@ import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
 import org.bigbluebutton.core2.message.senders.{MsgBuilder, Sender}
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
 import org.bigbluebutton.core.db.{ChatMessageDAO, UserDAO, UserStateDAO}
+import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.graphql.GraphqlMiddleware
 
 object UsersApp {
@@ -177,8 +178,12 @@ object UsersApp {
     )
 
     if (announcePresenterChangeInChat) {
-      //System message
-      ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "", GroupChatMessageType.USER_IS_PRESENTER_MSG, Map(), newPresenter.name)
+      val hideUserList = MeetingStatus2x.getPermissions(liveMeeting.status).hideUserList
+      val shouldSkip = hideUserList && newPresenter.role == Roles.VIEWER_ROLE
+
+      if (!shouldSkip) {
+        ChatMessageDAO.insertSystemMsg(liveMeeting.props.meetingProp.intId, GroupChatApp.MAIN_PUBLIC_CHAT, "", "", GroupChatMessageType.USER_IS_PRESENTER_MSG, Map(), newPresenter.name)
+      }
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

- do not send presenter change chat message if `lockSettingsHideUserList` is active and a user mentioned in the message is a viewer
- do not send "user is away/back" messages if `lockSettingsHideUserList` is active and user is a viewer

### Closes Issue(s)
Closes #24984

