### PR TITLE
refactor (akka-apps / LAD): Improve session grouping after disconnect

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -53,6 +53,8 @@ case class User(
                  totalOfMessages:                 Long = 0,
                  totalOfSharedNotes:              Long = 0,
                  totalOfWhiteboardAnnotations:    Long = 0,
+                 registeredInLadOn:               Long = System.currentTimeMillis(),
+                 lastUserDisconnectionOn:         java.lang.Long = null,
                )
 
 case class UserId(
@@ -175,6 +177,7 @@ class LearningDashboardActor(
       case m: UserJoinedMeetingEvtMsg               => handleUserJoinedMeetingEvtMsg(m)
       case m: UserJoinMeetingReqMsg                 => handleUserJoinMeetingReqMsg(m)
       case m: UserLeaveReqMsg                       => handleUserLeaveReqMsg(m)
+      case m: UserLeftFlagUpdatedEvtMsg             => handleUserLeftFlagUpdatedEvtMsg(m)
       case m: UserLeftMeetingEvtMsg                 => handleUserLeftMeetingEvtMsg(m)
       case m: UserAwayChangedEvtMsg                 => handleUserAwayChangedEvtMsg(m)
       case m: UserRaiseHandChangedEvtMsg            => handleUserRaiseHandChangedEvtMsg(m)
@@ -349,14 +352,47 @@ class LearningDashboardActor(
     meeting.users.values.find(u => u.currentIntId == intId ||  (u.currentIntId == null && u.intIds.exists(uId => uId._2.intId == intId && uId._2.sessions.last.leftOn == 0)))
   }
 
+  private def findUserByAnyIntId(meeting: Meeting, intId: String): Option[User] = {
+    meeting.users.values.find(u => u.intIds.contains(intId))
+  }
+
+  private def userHasActiveSession(user: User): Boolean = {
+    user.intIds.values.exists(userId => userId.sessions.last.leftOn == 0 && userId.userLeftFlag == false)
+  }
+
   private def findUserByExtId(meeting: Meeting, extId: String, filterUserLeft: Boolean = false): Option[User] = {
-    meeting.users.values.find(u => {
-      u.extId == extId && (filterUserLeft == false || !u.intIds.exists(uId => uId._2.sessions.last.leftOn == 0 && uId._2.userLeftFlag == false))
-    })
+    val latestUserWithExtId = meeting.users.values
+      .filter(u => u.extId == extId)
+      .toVector
+      .sortBy(_.registeredInLadOn)
+      .lastOption
+
+    if(filterUserLeft) {
+      latestUserWithExtId.filterNot(userHasActiveSession)
+    } else {
+      latestUserWithExtId
+    }
   }
 
   private def getNextKey(meeting: Meeting, extId: String): String = {
-    extId + "-" + (meeting.users.values.filter(u => u.extId == extId).toVector.size + 1).toString
+    val keyPrefix = extId + "-"
+    val lastUsedIndex = meeting.users.values
+      .filter(u => u.extId == extId)
+      .flatMap(u => {
+        if(u.userKey.startsWith(keyPrefix)) {
+          u.userKey.stripPrefix(keyPrefix).toIntOption
+        } else {
+          None
+        }
+      })
+      .foldLeft(0)(math.max)
+
+    var nextIndex = lastUsedIndex + 1
+    while(meeting.users.contains(extId + "-" + nextIndex.toString)) {
+      nextIndex += 1
+    }
+
+    extId + "-" + nextIndex.toString
   }
 
   private def handleUserJoinMeetingReqMsg(msg: UserJoinMeetingReqMsg): Unit = {
@@ -375,7 +411,8 @@ class LearningDashboardActor(
           )
           val updatedUser = user.copy(
             currentIntId = userId.intId,
-            intIds = user.intIds + (userId.intId -> updatedUserId)
+            intIds = user.intIds + (userId.intId -> updatedUserId),
+            lastUserDisconnectionOn = null,
           )
           val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
 
@@ -419,9 +456,22 @@ class LearningDashboardActor(
     for {
       meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
       user <- findUserByIntId(meeting, msg.body.userId)
-      userId <- user.intIds.get(msg.body.userId)
     } yield {
-      val updatedUser = user.copy(currentIntId = null, intIds = user.intIds + (userId.intId -> userId.copy(userLeftFlag = true)))
+      val updatedUser = user.copy(currentIntId = null)
+      val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
+
+      meetings += (updatedMeeting.intId -> updatedMeeting)
+    }
+  }
+
+  private def handleUserLeftFlagUpdatedEvtMsg(msg: UserLeftFlagUpdatedEvtMsg): Unit = {
+    for {
+      meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
+      user <- findUserByAnyIntId(meeting, msg.body.intId)
+    } yield {
+      val updatedUser = user.copy(
+        lastUserDisconnectionOn = if(msg.body.userLeftFlag) System.currentTimeMillis() else null,
+      )
       val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
 
       meetings += (updatedMeeting.intId -> updatedMeeting)
@@ -444,8 +494,9 @@ class LearningDashboardActor(
         intIds = user.intIds + (userId.intId -> updatedUserId)
       )
       val updatedMeeting = meeting.copy(users = meeting.users + (updatedUser.userKey -> updatedUser))
+      val mergedMeeting = mergeNextRegisteredUserAfterDisconnection(updatedMeeting, updatedUser.userKey)
 
-      meetings += (updatedMeeting.intId -> updatedMeeting)
+      meetings += (mergedMeeting.intId -> mergedMeeting)
     }
   }
 
@@ -913,13 +964,93 @@ class LearningDashboardActor(
     }
   }
 
+  private def mergeVectorMap[T](first: Map[String, Vector[T]], second: Map[String, Vector[T]]): Map[String, Vector[T]] = {
+    second.foldLeft(first) {
+      case (acc, (key, values)) => acc + (key -> (acc.getOrElse(key, Vector()) ++ values))
+    }
+  }
+
+  private def mergeUserId(first: UserId, second: UserId): UserId = {
+    val firstLastRegisteredOn = first.sessions.lastOption.map(_.registeredOn).getOrElse(0L)
+    val secondLastRegisteredOn = second.sessions.lastOption.map(_.registeredOn).getOrElse(0L)
+
+    first.copy(
+      sessions = (first.sessions ++ second.sessions).sortBy(_.registeredOn),
+      userLeftFlag = if(secondLastRegisteredOn >= firstLastRegisteredOn) second.userLeftFlag else first.userLeftFlag,
+    )
+  }
+
+  private def mergeIntIds(first: Map[String, UserId], second: Map[String, UserId]): Map[String, UserId] = {
+    second.foldLeft(first) {
+      case (acc, (intId, userId)) =>
+        acc + (intId -> acc.get(intId).map(mergeUserId(_, userId)).getOrElse(userId))
+    }
+  }
+
+  private def mergeUsers(first: User, second: User): User = {
+    first.copy(
+      currentIntId = if(second.currentIntId != null) second.currentIntId else first.currentIntId,
+      intIds = mergeIntIds(first.intIds, second.intIds),
+      isModerator = first.isModerator || second.isModerator,
+      isDialIn = first.isDialIn || second.isDialIn,
+      avatar = if(first.avatar == null || first.avatar.isEmpty) second.avatar else first.avatar,
+      answers = mergeVectorMap(first.answers, second.answers),
+      pluginUserData = mergeVectorMap(first.pluginUserData, second.pluginUserData),
+      talk = Talk(
+        totalTime = first.talk.totalTime + second.talk.totalTime,
+        lastTalkStartedOn = if(second.talk.lastTalkStartedOn > 0) second.talk.lastTalkStartedOn else first.talk.lastTalkStartedOn,
+      ),
+      reactions = first.reactions ++ second.reactions,
+      raiseHand = first.raiseHand ++ second.raiseHand,
+      away = first.away ++ second.away,
+      webcams = first.webcams ++ second.webcams,
+      totalOfMessages = first.totalOfMessages + second.totalOfMessages,
+      totalOfSharedNotes = first.totalOfSharedNotes + second.totalOfSharedNotes,
+      totalOfWhiteboardAnnotations = first.totalOfWhiteboardAnnotations + second.totalOfWhiteboardAnnotations,
+      lastUserDisconnectionOn = second.lastUserDisconnectionOn,
+    )
+  }
+
+  private def findNextRegisteredUserAfterDisconnection(meeting: Meeting, user: User): Option[User] = {
+    if(user.lastUserDisconnectionOn == null || userHasActiveSession(user)) {
+      None
+    } else {
+      meeting.users.values.filter(candidate => {
+        candidate.userKey != user.userKey &&
+          candidate.extId == user.extId &&
+          candidate.registeredInLadOn > user.lastUserDisconnectionOn
+      }).toVector.sortBy(_.registeredInLadOn).headOption
+    }
+  }
+
+  private def mergeNextRegisteredUserAfterDisconnection(meeting: Meeting, userKey: String): Meeting = {
+    (for {
+      user <- meeting.users.get(userKey)
+      userToMerge <- findNextRegisteredUserAfterDisconnection(meeting, user)
+    } yield {
+      val mergedUser = mergeUsers(user, userToMerge)
+      meeting.copy(users = (meeting.users - userToMerge.userKey) + (mergedUser.userKey -> mergedUser))
+    }).getOrElse(meeting)
+  }
+
+  private def mergeAllRegisteredUsersAfterDisconnection(meeting: Meeting): Meeting = {
+    val mergeableUser = meeting.users.values.toVector
+      .sortBy(_.registeredInLadOn)
+      .find(user => findNextRegisteredUserAfterDisconnection(meeting, user).nonEmpty)
+
+    mergeableUser match {
+      case Some(user) => mergeAllRegisteredUsersAfterDisconnection(mergeNextRegisteredUserAfterDisconnection(meeting, user.userKey))
+      case None       => meeting
+    }
+  }
+
   private def handleMeetingEndingEvtMsg(msg: MeetingEndingEvtMsg): Unit = {
     for {
       meeting <- meetings.values.find(m => m.intId == msg.body.meetingId)
     } yield {
       //Update endedOn and screenshares.stoppedOn, user.totalTime talks, webcams.stoppedOn
       val endedOn : Long = System.currentTimeMillis()
-      val updatedMeeting = meeting.copy(
+      val meetingWithLeftProps = meeting.copy(
         endedOn = endedOn,
         screenshares = meeting.screenshares.map(screenshare => {
           if(screenshare.stoppedOn > 0) screenshare;
@@ -929,6 +1060,7 @@ class LearningDashboardActor(
           (user._1 -> userWithLeftProps(user._2, endedOn))
         })
       )
+      val updatedMeeting = mergeAllRegisteredUsersAfterDisconnection(meetingWithLeftProps)
 
       meetings += (updatedMeeting.intId -> updatedMeeting)
 
@@ -1014,6 +1146,7 @@ class LearningDashboardActor(
               })))
           }) + (user.userKey -> user.copy(
             currentIntId = intId,
+            lastUserDisconnectionOn = null,
             intIds = user.intIds + (intId -> currentUserId.copy(
               sessions = currentUserId.sessions :+ UserSession(currentTime),
               userLeftFlag = false

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -991,7 +991,7 @@ class LearningDashboardActor(
     first.copy(
       currentIntId = if(second.currentIntId != null) second.currentIntId else first.currentIntId,
       intIds = mergeIntIds(first.intIds, second.intIds),
-      isModerator = first.isModerator || second.isModerator,
+      isModerator = second.isModerator,
       isDialIn = first.isDialIn || second.isDialIn,
       avatar = if(first.avatar == null || first.avatar.isEmpty) second.avatar else first.avatar,
       answers = mergeVectorMap(first.answers, second.answers),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -1011,15 +1011,29 @@ class LearningDashboardActor(
     )
   }
 
+  private def firstSessionStartedAfter(user: User, timestamp: Long): Option[Long] = {
+    user.intIds.valuesIterator
+      .flatMap(_.sessions.iterator)
+      .filter(_.registeredOn > timestamp)
+      .map(_.registeredOn)
+      .toVector
+      .sorted
+      .headOption
+  }
+
   private def findNextRegisteredUserAfterDisconnection(meeting: Meeting, user: User): Option[User] = {
     if(user.lastUserDisconnectionOn == null || userHasActiveSession(user)) {
       None
     } else {
-      meeting.users.values.filter(candidate => {
-        candidate.userKey != user.userKey &&
-          candidate.extId == user.extId &&
-          candidate.registeredInLadOn > user.lastUserDisconnectionOn
-      }).toVector.sortBy(_.registeredInLadOn).headOption
+      val disconnectionOn = user.lastUserDisconnectionOn.longValue()
+
+      meeting.users.values.flatMap(candidate => {
+        firstSessionStartedAfter(candidate, disconnectionOn)
+          .filter(_ => candidate.userKey != user.userKey && candidate.extId == user.extId)
+          .map(sessionStartedOn => (candidate, sessionStartedOn))
+      }).toVector.sortBy {
+        case (candidate, sessionStartedOn) => (sessionStartedOn, candidate.registeredInLadOn)
+      }.headOption.map(_._1)
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -1011,29 +1011,15 @@ class LearningDashboardActor(
     )
   }
 
-  private def firstSessionStartedAfter(user: User, timestamp: Long): Option[Long] = {
-    user.intIds.valuesIterator
-      .flatMap(_.sessions.iterator)
-      .filter(_.registeredOn > timestamp)
-      .map(_.registeredOn)
-      .toVector
-      .sorted
-      .headOption
-  }
-
   private def findNextRegisteredUserAfterDisconnection(meeting: Meeting, user: User): Option[User] = {
     if(user.lastUserDisconnectionOn == null || userHasActiveSession(user)) {
       None
     } else {
-      val disconnectionOn = user.lastUserDisconnectionOn.longValue()
-
-      meeting.users.values.flatMap(candidate => {
-        firstSessionStartedAfter(candidate, disconnectionOn)
-          .filter(_ => candidate.userKey != user.userKey && candidate.extId == user.extId)
-          .map(sessionStartedOn => (candidate, sessionStartedOn))
-      }).toVector.sortBy {
-        case (candidate, sessionStartedOn) => (sessionStartedOn, candidate.registeredInLadOn)
-      }.headOption.map(_._1)
+      meeting.users.values.filter(candidate => {
+        candidate.userKey != user.userKey &&
+          candidate.extId == user.extId &&
+          candidate.registeredInLadOn > user.lastUserDisconnectionOn
+      }).toVector.sortBy(_.registeredInLadOn).headOption
     }
   }
 


### PR DESCRIPTION
As reported in #24802.

When a user leaves a meeting and another user with the same `externalId` joins shortly after, they are not grouped in the Learning Dashboard because the first session is not yet confirmed as ended. This delay exists to avoid treating temporary disconnects or reloads as a leave. At the same time, merging sessions too early could incorrectly combine different users who share the same `externalId`.

This PR introduces a safer merge strategy: once BBB confirms that a user did not reconnect within a short period, the Learning Dashboard checks for a new session with the same `externalId` that started after the disconnection. If found, both sessions are merged into a single entry.

This ensures continuity for quick reconnects while avoiding incorrect merges, and reduces clutter in the dashboard.