### PR TITLE
feat(livekit): add forceRelay/forceRelayOnFirefox settings, +

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -655,6 +655,8 @@ export interface LiveKitSettings {
   logLevel?: LogLevel
   roomOptions?: Partial<InternalRoomOptions>
   reconnectOnFatalFailures?: boolean
+  forceRelay?: boolean
+  forceRelayOnFirefox?: boolean
   audio?: LiveKitAudioSettings
   camera?: LiveKitCameraSettings
   screenshare?: LiveKitScreenShareSettings

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -37,6 +37,7 @@ import {
   USER_SET_TALKING,
 } from '/imports/ui/components/livekit/mutations';
 import { useIceServers } from '/imports/ui/components/livekit/hooks';
+import shouldForceRelay from '/imports/ui/components/livekit/utils';
 import LKAutoplayModalContainer from '/imports/ui/components/livekit/autoplay-modal/container';
 import { ForcedReconnectionError } from '/imports/ui/components/livekit/errors';
 import connectionStatus, { MetricStatus } from '/imports/ui/core/graphql/singletons/connectionStatus';
@@ -181,7 +182,11 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
   const [lkRoomOptionsAvailable, setLkRoomOptionsAvailable] = useState(false);
   const [connectOptions, setConnectOptions] = useState<RoomConnectOptions | undefined>(undefined);
   const isClientConnected = useReactiveVar(connectionStatus.getConnectedStatusVar());
-  const { iceServers, isLoading: iceServersLoading } = useIceServers(bbbSessionToken);
+  const {
+    iceServers,
+    isLoading: iceServersLoading,
+    hasTurnServer,
+  } = useIceServers(bbbSessionToken);
   const speakerLevel = useSpeakerLevel();
   const intl = useIntl();
   const isReconnectingRef = useRef(false);
@@ -298,10 +303,12 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       return;
     }
 
+    const forceRelay = shouldForceRelay(hasTurnServer);
     const connOpts: RoomConnectOptions = {
       autoSubscribe: !withSelectiveSubscription,
       rtcConfig: {
         iceServers,
+        iceTransportPolicy: forceRelay ? 'relay' : undefined,
       },
     };
 
@@ -314,9 +321,10 @@ const BBBLiveKitRoom: React.FC<BBBLiveKitRoomProps> = ({
       extraInfo: {
         url,
         iceServers,
+        forceRelay,
       },
     }, 'LiveKit room will connect');
-  }, [token, url, iceServersLoading, iceServers, withSelectiveSubscription]);
+  }, [token, url, iceServersLoading, iceServers, hasTurnServer, withSelectiveSubscription]);
 
   useEffect(() => {
     if (!url) return;

--- a/bigbluebutton-html5/imports/ui/components/livekit/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/hooks.ts
@@ -1,4 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import {
+  useState, useEffect, useCallback, useRef,
+} from 'react';
 import logger from '/imports/startup/client/logger';
 
 interface StunServer {
@@ -34,19 +36,25 @@ interface UseIceServersResult {
 }
 
 const FETCH_TIMEOUT = 5000;
+const MIN_CACHE_TTL_MS = 1_800_000;
+const MAX_CACHE_TTL_MS = 86_400_000;
+// Refresh prior to expiry
+const REFRESH_BUFFER_MS = 60_000;
 
 export const useIceServers = (sessionToken: string): UseIceServersResult => {
   const [iceServers, setIceServers] = useState<RTCIceServer[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
-  const [hasSeenTurnServer, setHasSeenTurnServer] = useState<boolean>(false);
-  const [cacheValidUntil, setCacheValidUntil] = useState<number | null>(null);
-  const [cachedServers, setCachedServers] = useState<RTCIceServer[] | null>(null);
+  const [hasTurnServer, setHasTurnServer] = useState<boolean>(false);
 
-  const getMappedFallbackStun = (): RTCIceServer[] => {
+  const cachedServersRef = useRef<RTCIceServer[] | null>(null);
+  const cacheExpiresAtRef = useRef<number | null>(null);
+  const currFetchRef = useRef<Promise<RTCIceServer[]> | null>(null);
+
+  const getMappedFallbackStun = useCallback((): RTCIceServer[] => {
     const FALLBACK_STUN_SERVER = window.meetingClientSettings.public.media.fallbackStunServer;
     return FALLBACK_STUN_SERVER ? [{ urls: FALLBACK_STUN_SERVER }] : [];
-  };
+  }, []);
 
   const mapIceServers = (dictionary: IceServersDictionary): RTCIceServer[] => {
     const rtcStuns = dictionary.stun.map((url) => ({ urls: url }));
@@ -58,9 +66,13 @@ export const useIceServers = (sessionToken: string): UseIceServersResult => {
     return rtcStuns.concat(rtcTurns);
   };
 
-  const fetchIceServers = useCallback(async (): Promise<IceServersDictionary> => {
+  const fetchIceServers = useCallback(async (): Promise<{
+    dictionary: IceServersDictionary;
+    ttlMs: number | null;
+  }> => {
     let stunServers: StunServer[] = [];
     let turnServers: TurnServerResponse[] = [];
+    let serverDateMs: number | null = null;
     const MEDIA = window.meetingClientSettings.public.media;
     const STUN_TURN_FETCH_URL = MEDIA.stunTurnServersFetchAddress;
     const url = `${STUN_TURN_FETCH_URL}?sessionToken=${sessionToken}`;
@@ -77,9 +89,17 @@ export const useIceServers = (sessionToken: string): UseIceServersResult => {
         throw new Error(`Failed to fetch ICE servers: ${response.status} ${response.statusText}`);
       }
 
+      const dateHeader = response.headers.get('Date');
+
+      if (dateHeader) {
+        const parsed = Date.parse(dateHeader);
+
+        if (!Number.isNaN(parsed)) serverDateMs = parsed;
+      }
+
       ({ stunServers, turnServers } = await response.json());
-    } catch (error) {
-      throw error instanceof Error ? error : new Error('Request timed out');
+    } catch (e) {
+      throw e instanceof Error ? e : new Error('Request timed out');
     } finally {
       clearTimeout(abort);
     }
@@ -89,14 +109,16 @@ export const useIceServers = (sessionToken: string): UseIceServersResult => {
     }
 
     const turnReply: TurnServer[] = [];
-    let maxTtl: number | null = null;
+    let earliestExpirySec: number | null = null;
 
     turnServers.forEach((turnEntry) => {
       const { password, url, username } = turnEntry;
       const validUntil = parseInt(username.split(':')[0], 10);
 
-      if (!maxTtl || (validUntil && validUntil < maxTtl)) {
-        maxTtl = validUntil;
+      if (Number.isFinite(validUntil) && validUntil > 0) {
+        if (earliestExpirySec == null || validUntil < earliestExpirySec) {
+          earliestExpirySec = validUntil;
+        }
       }
 
       turnReply.push({
@@ -106,62 +128,94 @@ export const useIceServers = (sessionToken: string): UseIceServersResult => {
       });
     });
 
-    setHasSeenTurnServer(turnServers.length > 0);
+    setHasTurnServer(turnServers.length > 0);
 
-    if (maxTtl) setCacheValidUntil(maxTtl);
+    // Figure out cache TTL from server-side deltas (cred expiry minus
+    // the response's Date header) so that any client skew can't produce a
+    // nonsensical cache window. If either is missing, leave
+    // ttlMs null and presume our min TTL floor (see constants).
+    let ttlMs: number | null = null;
+
+    if (earliestExpirySec != null && serverDateMs != null) {
+      ttlMs = (earliestExpirySec * 1000) - serverDateMs - REFRESH_BUFFER_MS;
+      if (ttlMs < MIN_CACHE_TTL_MS) {
+        logger.warn({
+          logCode: 'ice_servers_unusual_ttl',
+          extraInfo: {
+            ttlMs,
+            earliestExpirySec,
+            serverDateMs,
+          },
+        }, `STUN/TURN credentials TTL below floor: ${ttlMs}ms (clamped to ${MIN_CACHE_TTL_MS}ms)`);
+      }
+    }
 
     return {
-      stun: stunServers.map((server: StunServer) => server.url),
-      turn: turnReply,
+      dictionary: {
+        stun: stunServers.map((server: StunServer) => server.url),
+        turn: turnReply,
+      },
+      ttlMs,
     };
   }, [sessionToken]);
 
-  const fetchServers = useCallback(async () => {
-    try {
-      const now = Math.floor(Date.now() / 1000);
+  const fetchServers = useCallback(async (): Promise<RTCIceServer[]> => {
+    const cached = cachedServersRef.current;
+    const expiresAt = cacheExpiresAtRef.current;
 
-      setIsLoading(true);
-      setError(null);
-
-      if (cachedServers && (
-        // If no TTL is set, we assume the cache is valid indefinitely
-        cacheValidUntil == null || now < cacheValidUntil
-      )) {
-        setIceServers(cachedServers);
-        setIsLoading(false);
-
-        return cachedServers;
-      }
-
-      const stDictionary = await fetchIceServers();
-      const mapped = mapIceServers(stDictionary);
-
-      if (mapped?.length > 0) {
-        setCachedServers(mapped);
-        setIceServers(mapped);
-      }
-
-      return mapped;
-    } catch (error) {
-      const fallbackStun = getMappedFallbackStun();
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-
-      setError(error as Error);
-      setIceServers(fallbackStun);
-
-      logger.error({
-        logCode: 'ice_servers_fetch_failed',
-        extraInfo: {
-          errorMessage,
-          errorStack: (error as Error)?.stack,
-        },
-      }, `Failed to fetch STUN/TURN servers: ${errorMessage}`);
-
-      return fallbackStun;
-    } finally {
+    if (cached && expiresAt != null && performance.now() < expiresAt) {
+      setIceServers(cached);
       setIsLoading(false);
+      return cached;
     }
-  }, [fetchIceServers, cacheValidUntil, cachedServers]);
+
+    if (currFetchRef.current) return currFetchRef.current;
+
+    setIsLoading(true);
+    setError(null);
+
+    const promise = (async (): Promise<RTCIceServer[]> => {
+      try {
+        const { dictionary, ttlMs } = await fetchIceServers();
+        const mapped = mapIceServers(dictionary);
+
+        if (mapped.length > 0) {
+          const clampedTtl = Math.min(
+            MAX_CACHE_TTL_MS,
+            Math.max(MIN_CACHE_TTL_MS, ttlMs ?? MIN_CACHE_TTL_MS),
+          );
+          cachedServersRef.current = mapped;
+          cacheExpiresAtRef.current = performance.now() + clampedTtl;
+          setIceServers(mapped);
+        }
+
+        return mapped;
+      } catch (e) {
+        const fallbackStun = getMappedFallbackStun();
+        const errorMessage = e instanceof Error ? e.message : 'Unknown error occurred';
+
+        setHasTurnServer(false);
+        setError(e as Error);
+        setIceServers(fallbackStun);
+
+        logger.error({
+          logCode: 'ice_servers_fetch_failed',
+          extraInfo: {
+            errorMessage,
+            errorStack: (e as Error)?.stack,
+          },
+        }, `Failed to fetch STUN/TURN servers: ${errorMessage}`);
+
+        return fallbackStun;
+      } finally {
+        currFetchRef.current = null;
+        setIsLoading(false);
+      }
+    })();
+
+    currFetchRef.current = promise;
+    return promise;
+  }, [fetchIceServers, getMappedFallbackStun]);
 
   useEffect(() => {
     fetchServers();
@@ -171,7 +225,7 @@ export const useIceServers = (sessionToken: string): UseIceServersResult => {
     iceServers,
     isLoading,
     error,
-    hasTurnServer: hasSeenTurnServer,
+    hasTurnServer,
     refetch: fetchServers,
   };
 };

--- a/bigbluebutton-html5/imports/ui/components/livekit/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/utils.ts
@@ -1,0 +1,27 @@
+import browserInfo from '/imports/utils/browserInfo';
+import deviceInfo from '/imports/utils/deviceInfo';
+
+/*
+ * Whether TURN/relay usage should be forced for the LiveKit room. Mirrors the
+ * SFU bridge logic but reads from public.media.livekit so it can be tuned
+ * independently.
+ *
+ * The Firefox trigger is a testing measure to debug specific connectivity issues
+ * (unrelated to ICE lite) between Pion/LK and Firefox.
+ */
+const shouldForceRelay = (hasTurnServer: boolean): boolean => {
+  const { isFirefox } = browserInfo;
+  const { isIos } = deviceInfo;
+  const livekitSettings = window.meetingClientSettings.public.media.livekit;
+  const FORCE_RELAY = livekitSettings?.forceRelay ?? false;
+  const FORCE_RELAY_ON_FF = livekitSettings?.forceRelayOnFirefox ?? false;
+
+  // FORCE_RELAY is a hard policy ("force all media via TURN") and is intentionally
+  // not mandated by hasTurnServer: if TURN is unreachable, ICE failure is the
+  // desired outcome rather than a silent downgrade.
+  // The Firefox auto-trigger, in contrast, is a workaround that only makes sense
+  // when TURN is actually present.
+  return FORCE_RELAY || ((isFirefox && !isIos) && FORCE_RELAY_ON_FF && hasTurnServer);
+};
+
+export default shouldForceRelay;

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -960,6 +960,10 @@ public:
       # reconnectOnFatalFailures: whether to trigger LK room reconnections when
       # fatal errors occur (e.g.: unrecoverable publish timeouts).
       reconnectOnFatalFailures: true
+      # livekit.forceRelay: forces TURN/relay usage on all UAs when using LK.
+      forceRelay: false
+      # livekit.forceRelayOnFirefox: forces TURN/relay usage on Firefox when using LK.
+      forceRelayOnFirefox: false
       roomOptions:
         adaptiveStream: true
         dynacast: true


### PR DESCRIPTION
### What does this PR do?

- [feat(livekit): add forceRelay/forceRelayOnFirefox settings](https://github.com/bigbluebutton/bigbluebutton/commit/458069e7b0765d2a745f050d38f15e8a814d8c73)
  - Add LiveKit-scoped forceRelay and forceRelayOnFirefox flags under
public.media.livekit, independent from the SFU bridge's equivalents.
When triggered, set iceTransportPolicy=relay on the RoomConnectOptions
rtcConfig.
- [fix(livekit): break /stuns refetch loop on client clock skew](https://github.com/bigbluebutton/bigbluebutton/commit/525c0cbd35d0ab948c87a7004fde3f8612820d29) 
  - useIceServers validates its cache via Math.floor(Date.now()/1000)
< cacheValidUntil, where cacheValidUntil is a server-issued
absolute Unix ts. A client clock ahead of that expiry permanently
invalidates the cache. Combined with the very bad implementation of
useIceServers, the gathering useEffect re-fires after every fetch and
pings /stuns more than necessary.
  - Move cache state to refs so fetchServers's identity is stable.
  - Track the cache deadline as performance.now() + ttlMs, with ttlMs
derived from server-side deltas (credential expiry - response Date
header - an expiry buffer) and clamped to [30m, 24h].
  - Add a log to track when the TTL floor is hit.
  - Dedup in-flight fetches via a ref.
  
### Closes Issue(s)

None
