### PR TITLE
fix(profile): remove presence status dot from profile button in sidebar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/profile-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/profile-list-item/component.tsx
@@ -3,8 +3,6 @@ import { defineMessages, useIntl } from 'react-intl';
 import { PANELS } from '../../layout/enums';
 import { BaseSidebarButtonProps } from '../types';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
-import SidebarNavButtonStyled from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles';
-import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 
 const intlMessages = defineMessages({
   profileLabel: {
@@ -15,8 +13,6 @@ const intlMessages = defineMessages({
 
 const ProfileListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
   const intl = useIntl();
-  const { data: currentUserData } = useCurrentUser((user) => ({ away: user.away }));
-  const away = currentUserData?.away ?? false;
 
   const label = intl.formatMessage(intlMessages.profileLabel);
 
@@ -29,9 +25,7 @@ const ProfileListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
       id="profile-toggle-button"
       ariaDescribedBy="profile"
       dataTest="profileSidebarButton"
-    >
-      <SidebarNavButtonStyled.StatusDot away={away} />
-    </SidebarNavigationButton>
+    />
   );
 };
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
@@ -13,7 +13,6 @@ import {
   itemFocusBorder,
   colorGrayIcons,
   colorGrayLightest,
-  colorSuccess,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { ListItemProps } from './types';
 
@@ -100,19 +99,6 @@ export const ListItem = styled.div<ListItemProps>`
   }
 `;
 
-const StatusDot = styled.div<{ away?: boolean }>`
-  position: absolute;
-  bottom: -1px;
-  right: 2px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background-color: ${({ away }: { away?: boolean }) => (away ? colorGrayLight : colorSuccess)};
-  border: 1px solid ${colorWhite};
-  pointer-events: none;
-`;
-
 export default {
   ListItem,
-  StatusDot,
 };


### PR DESCRIPTION
### What does this PR do?
Removes the presence status dot from the profile button in the navigation sidebar.


### Closes Issue(s)
Closes None


### More
<img width="473" height="431" alt="image" src="https://github.com/user-attachments/assets/eae7502e-80b7-44fe-81a3-c51def68988c" />

