### PR TITLE
ref: decrease size of block-note toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -241,10 +241,10 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <style>
         {`
-          .mantine-Button-label {
+          .bn-toolbar-row .mantine-Button-label {
             display: none;
           }
-          .mantine-Button-inner > .mantine-Button-section:first-child {
+          .bn-toolbar-row .mantine-Button-inner > .mantine-Button-section:first-child {
             margin: 0;
           }
           .bn-collaboration-cursor__label {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -244,8 +244,11 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-toolbar-row .mantine-Button-label {
             display: none;
           }
-          .bn-toolbar-row .mantine-Button-inner > .mantine-Button-section:first-child {
+          .bn-toolbar-row .mantine-Button-inner > .mantine-Button-section {
             margin: 0;
+          }
+          .bn-toolbar-row [data-with-left-section] {
+            padding: 0 .25rem
           }
           .bn-collaboration-cursor__label {
             color: ${colorWhite} !important;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -263,6 +263,9 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             flex-direction: column;
             height: 100%;
           }
+          .bn-mantine button, .bn-mantine select {
+            height: 100%;
+          }
           .bn-toolbar-row {
             display: flex;
             flex-wrap: wrap;
@@ -331,8 +334,8 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
               <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
             </FormattingToolbar>
             <FormattingToolbar>
-              <TextAlignSelect key="textAlignSelect" />
               <ColorStyleButton key="colorStyleButton" />
+              <TextAlignSelect key="textAlignSelect" />
               <NestBlockButton key="nestBlockButton" />
               <UnnestBlockButton key="unnestBlockButton" />
             </FormattingToolbar>

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -14,11 +14,9 @@ import {
   ColorStyleButton,
   FormattingToolbar,
   NestBlockButton,
-  TextAlignButton,
   UnnestBlockButton,
   useCreateBlockNote,
 } from '@blocknote/react';
-
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
 import { defineMessages, useIntl } from 'react-intl';
@@ -31,6 +29,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import useCurrentUser from '../../core/hooks/useCurrentUser';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
+import TextAlignSelect from './text-align-select/component';
 
 // Force-retain `Awareness` against a webpack tree-shaking interaction that
 // otherwise drops this class while keeping its `extends Observable` expression,
@@ -242,6 +241,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <style>
         {`
+          .mantine-Button-label {
+            display: none;
+          }
+          .mantine-Button-inner > .mantine-Button-section:first-child {
+            margin: 0;
+          }
           .bn-collaboration-cursor__label {
             color: ${colorWhite} !important;
           }
@@ -326,9 +331,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
               <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
             </FormattingToolbar>
             <FormattingToolbar>
-              <TextAlignButton textAlignment="left" key="textAlignLeftButton" />
-              <TextAlignButton textAlignment="center" key="textAlignCenterButton" />
-              <TextAlignButton textAlignment="right" key="textAlignRightButton" />
+              <TextAlignSelect key="textAlignSelect" />
               <ColorStyleButton key="colorStyleButton" />
               <NestBlockButton key="nestBlockButton" />
               <UnnestBlockButton key="unnestBlockButton" />

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
+import { useCallback } from 'react';
 import {
   useBlockNoteEditor,
   useComponentsContext,
   useDictionary,
   useEditorState,
 } from '@blocknote/react';
+import {
+  blockHasType,
+  defaultProps,
+  editorHasBlockWithType,
+  mapTableCell,
+  TableContent,
+} from '@blocknote/core';
+import { TableHandlesExtension } from '@blocknote/core/extensions';
 import {
   RiAlignCenter,
   RiAlignJustify,
@@ -31,11 +40,63 @@ function TextAlignSelect(): React.ReactElement | null {
     selector: ({ editor: e }) => {
       if (!e.isEditable) return null;
       const blocks = e.getSelection()?.blocks ?? [e.getTextCursorPosition().block];
-      const alignment = (blocks[0].props as Record<string, unknown>)?.textAlignment;
-      if (typeof alignment !== 'string') return null;
-      return { alignment: alignment as TextAlignment, blocks };
+      const firstBlock = blocks[0];
+
+      if (blockHasType(firstBlock, e, firstBlock.type, { textAlignment: defaultProps.textAlignment })) {
+        return { alignment: firstBlock.props.textAlignment as TextAlignment, blocks };
+      }
+
+      if (blocks.length === 1 && blockHasType(firstBlock, e, 'table')) {
+        const cellSelection = e.getExtension(TableHandlesExtension)?.getCellSelection();
+        if (!cellSelection) return null;
+        const firstCell = mapTableCell(
+          (firstBlock.content as TableContent<never, never>).rows[0].cells[0],
+        );
+        return { alignment: firstCell.props.textAlignment as TextAlignment, blocks };
+      }
+
+      return null;
     },
   });
+
+  const setTextAlignment = useCallback(
+    (alignment: TextAlignment) => {
+      if (!state) return;
+      editor.focus();
+      state.blocks.forEach((block) => {
+        if (
+          blockHasType(block, editor, block.type, { textAlignment: defaultProps.textAlignment })
+          && editorHasBlockWithType(editor, block.type, { textAlignment: defaultProps.textAlignment })
+        ) {
+          editor.updateBlock(block, { props: { textAlignment: alignment } as never });
+        } else if (block.type === 'table') {
+          const cellSelection = editor.getExtension(TableHandlesExtension)?.getCellSelection();
+          if (!cellSelection) return;
+
+          const newTable = (block.content as TableContent<never, never>).rows.map((row) => ({
+            ...row,
+            cells: row.cells.map((cell) => mapTableCell(cell)),
+          }));
+
+          cellSelection.cells.forEach(({ row, col }) => {
+            newTable[row].cells[col].props.textAlignment = alignment;
+          });
+
+          editor.updateBlock(block, {
+            type: 'table',
+            content: {
+              ...(block.content as TableContent<never, never>),
+              type: 'tableContent',
+              rows: newTable,
+            } as never,
+          });
+
+          editor.setTextCursorPosition(block);
+        }
+      });
+    },
+    [editor, state],
+  );
 
   if (!state) return null;
 
@@ -46,12 +107,7 @@ function TextAlignSelect(): React.ReactElement | null {
         text: dict.formatting_toolbar[`align_${a.value}`].tooltip,
         icon: a.icon,
         isSelected: state.alignment === a.value,
-        onClick: () => {
-          editor.focus();
-          state.blocks.forEach((block) => {
-            editor.updateBlock(block, { props: { textAlignment: a.value } as never });
-          });
-        },
+        onClick: () => setTextAlignment(a.value),
       }))}
     />
   );

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import {
+  useBlockNoteEditor,
+  useComponentsContext,
+  useEditorState,
+} from '@blocknote/react';
+import {
+  RiAlignCenter,
+  RiAlignJustify,
+  RiAlignLeft,
+  RiAlignRight,
+} from 'react-icons/ri';
+
+type TextAlignment = 'left' | 'center' | 'right' | 'justify';
+
+const ALIGN_ITEMS: { value: TextAlignment; label: string; icon: React.ReactElement }[] = [
+  { value: 'left', label: 'Left', icon: <RiAlignLeft size={16} /> },
+  { value: 'center', label: 'Center', icon: <RiAlignCenter size={16} /> },
+  { value: 'right', label: 'Right', icon: <RiAlignRight size={16} /> },
+  { value: 'justify', label: 'Justify', icon: <RiAlignJustify size={16} /> },
+];
+
+function TextAlignSelect(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const editor = useBlockNoteEditor();
+
+  const state = useEditorState({
+    editor,
+    selector: ({ editor: e }) => {
+      if (!e.isEditable) return null;
+      const blocks = e.getSelection()?.blocks ?? [e.getTextCursorPosition().block];
+      const alignment = (blocks[0].props as Record<string, unknown>)?.textAlignment;
+      if (typeof alignment !== 'string') return null;
+      return { alignment: alignment as TextAlignment, blocks };
+    },
+  });
+
+  if (!state) return null;
+
+  return (
+    <Components.FormattingToolbar.Select
+      className="bn-select"
+      items={ALIGN_ITEMS.map((a) => ({
+        text: a.label,
+        icon: a.icon,
+        isSelected: state.alignment === a.value,
+        onClick: () => {
+          editor.focus();
+          state.blocks.forEach((block) => {
+            editor.updateBlock(block, { props: { textAlignment: a.value } as never });
+          });
+        },
+      }))}
+    />
+  );
+}
+
+export default TextAlignSelect;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   useBlockNoteEditor,
   useComponentsContext,
+  useDictionary,
   useEditorState,
 } from '@blocknote/react';
 import {
@@ -13,16 +14,17 @@ import {
 
 type TextAlignment = 'left' | 'center' | 'right' | 'justify';
 
-const ALIGN_ITEMS: { value: TextAlignment; label: string; icon: React.ReactElement }[] = [
-  { value: 'left', label: 'Left', icon: <RiAlignLeft size={16} /> },
-  { value: 'center', label: 'Center', icon: <RiAlignCenter size={16} /> },
-  { value: 'right', label: 'Right', icon: <RiAlignRight size={16} /> },
-  { value: 'justify', label: 'Justify', icon: <RiAlignJustify size={16} /> },
+const ALIGN_ITEMS: { value: TextAlignment; icon: React.ReactElement }[] = [
+  { value: 'left', icon: <RiAlignLeft size={16} /> },
+  { value: 'center', icon: <RiAlignCenter size={16} /> },
+  { value: 'right', icon: <RiAlignRight size={16} /> },
+  { value: 'justify', icon: <RiAlignJustify size={16} /> },
 ];
 
 function TextAlignSelect(): React.ReactElement | null {
   const Components = useComponentsContext()!;
   const editor = useBlockNoteEditor();
+  const dict = useDictionary();
 
   const state = useEditorState({
     editor,
@@ -41,7 +43,7 @@ function TextAlignSelect(): React.ReactElement | null {
     <Components.FormattingToolbar.Select
       className="bn-select"
       items={ALIGN_ITEMS.map((a) => ({
-        text: a.label,
+        text: dict.formatting_toolbar[`align_${a.value}`].tooltip,
         icon: a.icon,
         isSelected: state.alignment === a.value,
         onClick: () => {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -48,11 +48,12 @@ function TextAlignSelect(): React.ReactElement | null {
 
       if (blocks.length === 1 && blockHasType(firstBlock, e, 'table')) {
         const cellSelection = e.getExtension(TableHandlesExtension)?.getCellSelection();
-        if (!cellSelection) return null;
-        const firstCell = mapTableCell(
-          (firstBlock.content as TableContent<never, never>).rows[0].cells[0],
-        );
-        return { alignment: firstCell.props.textAlignment as TextAlignment, blocks };
+        if (!cellSelection || cellSelection.cells.length === 0) return null;
+        const { row, col } = cellSelection.cells[0];
+        const tableContent = firstBlock.content as TableContent<never, never>;
+        const selectedCell = tableContent.rows[row]?.cells[col];
+        if (!selectedCell) return null;
+        return { alignment: mapTableCell(selectedCell).props.textAlignment as TextAlignment, blocks };
       }
 
       return null;
@@ -79,7 +80,13 @@ function TextAlignSelect(): React.ReactElement | null {
           }));
 
           cellSelection.cells.forEach(({ row, col }) => {
-            newTable[row].cells[col].props.textAlignment = alignment;
+            newTable[row].cells[col] = {
+              ...newTable[row].cells[col],
+              props: {
+                ...newTable[row].cells[col].props,
+                textAlignment: alignment,
+              },
+            };
           });
 
           editor.updateBlock(block, {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -30,6 +30,9 @@ const ALIGN_ITEMS: { value: TextAlignment; icon: React.ReactElement }[] = [
   { value: 'justify', icon: <RiAlignJustify size={16} /> },
 ];
 
+// TODO: PR https://github.com/TypeCellOS/BlockNote/pull/2728 has been sent to BlockNote
+// to have this implemented there - If it's merged, we need to remove this code and use
+// their native component.
 function TextAlignSelect(): React.ReactElement | null {
   const Components = useComponentsContext()!;
   const editor = useBlockNoteEditor();

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -64,6 +64,7 @@
         "react-dom": "^18.2.0",
         "react-draggable": "^4.4.6",
         "react-dropzone": "^7.0.1",
+        "react-icons": "^5.5.0",
         "react-intl": "^6.1.0",
         "react-loading-skeleton": "^3.0.3",
         "react-modal": "^3.15.1",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -105,6 +105,7 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.6",
     "react-dropzone": "^7.0.1",
+    "react-icons": "^5.5.0",
     "react-intl": "^6.1.0",
     "react-loading-skeleton": "^3.0.3",
     "react-modal": "^3.15.1",


### PR DESCRIPTION
### What does this PR do?

- It removes the label from the block type of the block-note toolbar;
- And it compiles the three types of alignments in one dropdown menu;

That is done so that the toolbar is smaller in order to render in one line for some monitors.

### How to test

Play around with the alignment and block-types making sure they don't break

### More
See screenshot ahead:
<img width="417" height="489" alt="image" src="https://github.com/user-attachments/assets/736ddcc3-5f1d-433b-b333-814944057fe7" />

