### PR TITLE
fix: Fix performance issue with block-note dark mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/app/styles.js
@@ -91,7 +91,8 @@ const DtfCss = `
   .tl-note__container,
   .tl-text.tl-text-content,
   .tl-arrow-label,
-  .tl-arrow-label__inner
+  .tl-arrow-label__inner,
+  .bn-mantine *
 `;
 
 const DtfImages = `


### PR DESCRIPTION
### What does this PR do?

It fixes the performance issues (client freezes, for example) in the dark mode of client with block-note.

### How to test

Enter a meeting with block-note as the `sharedNotesEditor`, set your client to dark mode and play around with your client, make sure to open the shared-notes, use other features like chat messages, microphone, camera, etc. While doing all that, make sure to track CPU and memory usage. See if the usage profile is the same for light and dark theme, if so, we're good.

