### PR TITLE
Fix(html5): don't pre-select listen-only device when switching to microphone from listen-only mode

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -22,7 +22,7 @@ import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockCon
 import deviceInfo from '/imports/utils/deviceInfo';
 import { useIsAudioTranscriptionEnabled } from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
 import useIsAudioConnected from '/imports/ui/components/audio/audio-graphql/hooks/useIsAudioConnected';
-import { getStoredAudioInputDeviceId, DEFAULT_INPUT_DEVICE_ID } from '/imports/api/audio/client/bridge/service';
+import { getStoredAudioInputDeviceId } from '/imports/api/audio/client/bridge/service';
 
 const invalidDialNumbers = ['0', '613-555-1212', '613-555-1234', '0000'];
 
@@ -78,10 +78,7 @@ const AudioModalContainer = (props) => {
   } = window.meetingClientSettings.public.media.localEchoTest;
 
   const forceListenOnlyAttendee = forceListenOnly && !isModerator;
-  const rawInputDeviceId = useReactiveVar(AudioManager._inputDeviceId.value);
-  const inputDeviceId = rawInputDeviceId === 'listen-only'
-    ? (getStoredAudioInputDeviceId() || DEFAULT_INPUT_DEVICE_ID)
-    : rawInputDeviceId;
+  const inputDeviceId = useReactiveVar(AudioManager._inputDeviceId.value);
   const outputDeviceId = useReactiveVar(AudioManager._outputDeviceId.value);
   const showPermissionsOvelay = useReactiveVar(AudioManager._isWaitingPermissions.value);
   const isConnecting = useReactiveVar(AudioManager._isConnecting.value);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -22,7 +22,7 @@ import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockCon
 import deviceInfo from '/imports/utils/deviceInfo';
 import { useIsAudioTranscriptionEnabled } from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
 import useIsAudioConnected from '/imports/ui/components/audio/audio-graphql/hooks/useIsAudioConnected';
-import { getStoredAudioInputDeviceId } from '/imports/api/audio/client/bridge/service';
+import { getStoredAudioInputDeviceId, DEFAULT_INPUT_DEVICE_ID } from '/imports/api/audio/client/bridge/service';
 
 const invalidDialNumbers = ['0', '613-555-1212', '613-555-1234', '0000'];
 
@@ -78,7 +78,10 @@ const AudioModalContainer = (props) => {
   } = window.meetingClientSettings.public.media.localEchoTest;
 
   const forceListenOnlyAttendee = forceListenOnly && !isModerator;
-  const inputDeviceId = useReactiveVar(AudioManager._inputDeviceId.value);
+  const rawInputDeviceId = useReactiveVar(AudioManager._inputDeviceId.value);
+  const inputDeviceId = rawInputDeviceId === 'listen-only'
+    ? (getStoredAudioInputDeviceId() || DEFAULT_INPUT_DEVICE_ID)
+    : rawInputDeviceId;
   const outputDeviceId = useReactiveVar(AudioManager._outputDeviceId.value);
   const showPermissionsOvelay = useReactiveVar(AudioManager._isWaitingPermissions.value);
   const isConnecting = useReactiveVar(AudioManager._isConnecting.value);

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-settings/component.jsx
@@ -12,6 +12,7 @@ import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import { hasMediaDevicesEventTarget } from '/imports/ui/services/webrtc-base/utils';
 import AudioManager from '/imports/ui/services/audio-manager';
 import Session from '/imports/ui/services/storage/in-memory';
+import { getStoredAudioInputDeviceId, DEFAULT_INPUT_DEVICE_ID } from '/imports/api/audio/client/bridge/service';
 import AudioCaptionsSelectContainer from '../audio-graphql/audio-captions/captions/component';
 
 const propTypes = {
@@ -174,7 +175,14 @@ class AudioSettings extends React.Component {
           );
         }
         this.setState({ findingDevices: false });
-        this.setInputDevice(inputDeviceId);
+        if (inputDeviceId === 'listen-only') {
+          this.setState({
+            inputDeviceId: getStoredAudioInputDeviceId() || DEFAULT_INPUT_DEVICE_ID,
+            producingStreams: false,
+          });
+        } else {
+          this.setInputDevice(inputDeviceId);
+        }
         this.setOutputDevice(outputDeviceId);
       });
 


### PR DESCRIPTION
### What does this PR do?
Fix pre-selection of "No Microphone (listen only)" when switching from listen-only to microphone in the audio modal. When the current input device is the 'listen-only' sentinel, the modal now falls back to the last-stored device or the browser default instead of passing the sentinel through to the device selector.


### Closes Issue(s)
Closes #22950 


### How to test
- Join as listen only
- open audio Modal
- Speaker selector should show a valid device.

### More
[Screencast from 06-05-2026 22:24:35.webm](https://github.com/user-attachments/assets/ecef2c6e-85b9-4b87-a1b5-1d0839965829)

