### PR TITLE
fix(client): Fix Android being too greedy with Safari user agent (fixes #24295)

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -196,7 +196,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
           var miuiVersion = parseVersion(/MiuiBrowser\/(\d+)/);
 
           var tooOld =
-            (safariVersion && safariVersion < MIN_VERSIONS.safari) ||
+            (isSafari && safariVersion && safariVersion < MIN_VERSIONS.safari) ||
             (chromeVersion && chromeVersion < MIN_VERSIONS.chrome) ||
             (firefoxVersion && firefoxVersion < MIN_VERSIONS.firefox) ||
             (edgeVersion && edgeVersion < MIN_VERSIONS.edge)||


### PR DESCRIPTION
### What does this PR do?
The check for user agents on Android devices is too inaccurate. Specifically, the check for Safari also applies on Android's Chrome based WebView. This small change checks if the platform is actually a Safari before checking the necessary regular expression.


### Closes Issue(s)
Closes #24295

### Motivation
Embedding BBB in a WebView in Android is necessary for me.


### How to test
- check this UserAgent against the provided regular expressions in `index.html` and the `safariVersion` will be `4` although Safari was not the platform used by this agent. 
  - `Mozilla/5.0 (Linux; Android 16; sdk_gphone64_x86_64 Build/BE2A.250530.026.D1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/142.0.7444.102 Mobile Safari/537.36`
- UserAgent definition (still available through wayback machine): https://web.archive.org/web/20190312123827/developer.chrome.com/multidevice/user-agent#webview_user_agent


### More
- user agent checking is not optimal, there are numerous sources providing evidence (e.g. https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/User-agent_reduction#browser_detection)