### PR TITLE
fix: Allow to select text in About section

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/about/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/about/component.jsx
@@ -75,7 +75,7 @@ class About extends Component {
     } = settings;
 
     return (
-      <div>
+      <div tabIndex="-1">
         <Styled.Form>
           <Styled.Content>
             <Styled.Title>{intl.formatMessage(intlMessages.title)}</Styled.Title>


### PR DESCRIPTION
### What does this PR do?

Fix text selection in the About settings tab.

### More

When clicking on a non-focusable element (like a `<p>`), focus-trap moves focus to the nearest focusable ancestor. In this case, that ancestor was `ReactModal__Content` (set to `tabIndex="-1"` by react-modal), which sits outside the focus-trap container. The library detected focus as "escaped" and redirected it back inside the trap, canceling the text selection in the process.

The fix adds `tabIndex="-1"` to the About section outer `<div>`, making it the nearest focusable ancestor. 
Since it lives inside the focus trap container, the library no longer redirects focus on click, and text selection works as expected.

### Closes Issue(s)
Closes #25031