### PR TITLE
fix(transcription): Properly test if a language is available

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/captions/component.tsx
@@ -3,7 +3,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import { useMutation } from '@apollo/client';
 
 import {
-  getSpeechVoices,
+  getAvailableTranscriptionLanguages,
   setUserLocaleProperty,
   useFixedLocale,
   isGladia,
@@ -148,7 +148,7 @@ const AudioCaptionsSelectContainer: React.FC<AudioCaptionsContainerProps> = ({
   showTitleLabel = true,
 }) => {
   const [voicesList, setVoicesList] = React.useState<string[]>([]);
-  const voices = getSpeechVoices();
+  const voices = getAvailableTranscriptionLanguages();
 
   useEffect(() => {
     if ((voices && voices.length > 0) && voicesList.length === 0) {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/service.ts
@@ -65,18 +65,47 @@ const getSpeechProvider = () => {
 export const isWebSpeechApi = () => getSpeechProvider() === 'webspeech';
 export const isGladia = () => getSpeechProvider() === 'gladia';
 
-export const getSpeechVoices = () => {
-  const LANGUAGES = window.meetingClientSettings.public.app.audioCaptions.language.available;
+// Module-level cache so language availability is only checked once
+let cachedTranscriptionLanguages: string[] | null = null;
+
+/**
+ * Checks whether a given language is supported for speech recognition
+ * using the SpeechRecognition.available() static method.
+ * Returns true if the API is unavailable (i.e. we cannot determine support).
+ */
+const isSpeechRecognitionLanguageSupported = (lang: string): boolean => {
+  try {
+    // @ts-ignore - SR types is not yet in the TS types
+    const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SR) return false;
+    if (typeof SR.available === 'function') {
+      return SR.available(lang);
+    }
+    // If SpeechRecognition.available() is not implemented in this browser,
+    // fall back to assuming all languages are supported.
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+/**
+ * Returns the list of languages available for speech recognition (transcription).
+ * For the webspeech provider, each configured language is validated using the
+ * SpeechRecognition.available() static method. The result is cached after the
+ * first call so that language checks are only performed once.
+ */
+export const getAvailableTranscriptionLanguages = (): string[] | null => {
+  const LANGUAGES: string[] = window.meetingClientSettings.public.app.audioCaptions.language.available;
+
   if (!isWebSpeechApi()) return LANGUAGES;
   if (!hasSpeechRecognitionSupport()) return null;
 
-  return unique(
-    window
-      .speechSynthesis
-      .getVoices()
-      .map((v) => v.lang)
-      .filter((v) => LANGUAGES.includes(v)),
-  );
+  if (cachedTranscriptionLanguages !== null) return cachedTranscriptionLanguages;
+
+  cachedTranscriptionLanguages = unique(LANGUAGES).filter(isSpeechRecognitionLanguageSupported);
+
+  return cachedTranscriptionLanguages;
 };
 
 export const setAudioCaptions = (value: boolean) => {
@@ -112,7 +141,7 @@ export const getLocaleName = (locale: string) => {
 };
 
 export default {
-  getSpeechVoices,
+  getAvailableTranscriptionLanguages,
   useIsAudioTranscriptionEnabled,
   setUserLocaleProperty,
   setSpeechLocale,


### PR DESCRIPTION
The old getSpeechVoices method was used for the purpose of filtering supported languages for the browser SpeechRecognition API. This was the wrong API to call and in some cases like for example Catalan it would result in the language being configured in the `app.audioCaptions.language.available` array but no actually showing in the dropdow list.

This new code attempts to call the correct API if it's present in the browser and now properly let's us configure and select all valid languages for a given SpeechRecognition API instance. 