### PR TITLE
Fix(html5): improve accessibility of app item controls

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactNode } from 'react';
+import React, { memo, ReactNode, useCallback } from 'react';
 import Icon from '/imports/ui/components/common/icon/component';
 import { layoutDispatch } from '/imports/ui/components/layout/context';
 import { defineMessages, useIntl } from 'react-intl';
@@ -6,6 +6,7 @@ import { ACTIONS } from '/imports/ui/components/layout/enums';
 import { PluginIconType } from 'bigbluebutton-html-plugin-sdk';
 import Styled from '../styles';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
+import KEYS from '/imports/utils/keys';
 
 interface AppItemProps {
   appKey: string;
@@ -76,19 +77,19 @@ const AppItem: React.FC<AppItemProps> = ({
 
   const functionToBeCalled = typeof onClick === 'function' ? onClick : openAppPanel;
 
-  const handleClickableAreaKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+  const handleClickableAreaKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === KEYS.ENTER || e.key === KEYS.SPACE) {
       e.preventDefault();
       functionToBeCalled();
     }
-  };
+  }, [functionToBeCalled]);
 
-  const handlePinKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Enter' || e.key === ' ') {
+  const handlePinKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === KEYS.ENTER || e.key === KEYS.SPACE) {
       e.preventDefault();
       togglePinApp(e);
     }
-  };
+  }, [togglePinApp]);
 
   return (
     <Styled.RegisteredAppContent key={`${appKey}${isPinned}`} data-test={dataTest}>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
@@ -31,6 +31,13 @@ const intlMessages = defineMessages({
   },
 });
 
+const resolveIcon = (iconProp: PluginIconType): React.ReactNode => {
+  if (typeof iconProp === 'string') return <Icon iconName={iconProp} />;
+  if (iconProp && 'iconName' in iconProp) return <Icon iconName={iconProp.iconName} />;
+  if (iconProp && 'svgContent' in iconProp) return iconProp.svgContent as React.ReactNode;
+  return null;
+};
+
 const AppItem: React.FC<AppItemProps> = ({
   appKey,
   dataTest,
@@ -100,17 +107,9 @@ const AppItem: React.FC<AppItemProps> = ({
         onClick={functionToBeCalled}
         onKeyDown={handleClickableAreaKeyDown}
       >
-        <Styled.OpenButton
-          key={`OPEN${appKey}`}
-          color="primary"
-          type="button"
-          icon={icon}
-          $pinned={isPinned}
-          label=""
-          aria-hidden="true"
-          tabIndex={-1}
-          onClick={() => {}}
-        />
+        <Styled.OpenButton $pinned={isPinned} aria-hidden="true">
+          {resolveIcon(icon)}
+        </Styled.OpenButton>
         <Styled.AppTitle>{name}</Styled.AppTitle>
         {isNew && <Styled.NewLabel>{intl.formatMessage(intlMessages.newAppLabel)}</Styled.NewLabel>}
         {children}
@@ -119,6 +118,7 @@ const AppItem: React.FC<AppItemProps> = ({
         <Styled.PinApp
           role="button"
           aria-label={isPinned ? unpinTooltip : pinTooltip}
+          aria-pressed={isPinned}
           onClick={togglePinApp}
           onKeyDown={handlePinKeyDown}
           tabIndex={0}

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
@@ -76,9 +76,29 @@ const AppItem: React.FC<AppItemProps> = ({
 
   const functionToBeCalled = typeof onClick === 'function' ? onClick : openAppPanel;
 
+  const handleClickableAreaKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      functionToBeCalled();
+    }
+  };
+
+  const handlePinKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      togglePinApp(e);
+    }
+  };
+
   return (
     <Styled.RegisteredAppContent key={`${appKey}${isPinned}`} data-test={dataTest}>
-      <Styled.ClickableArea onClick={functionToBeCalled}>
+      <Styled.ClickableArea
+        role="button"
+        tabIndex={0}
+        aria-label={name}
+        onClick={functionToBeCalled}
+        onKeyDown={handleClickableAreaKeyDown}
+      >
         <Styled.OpenButton
           key={`OPEN${appKey}`}
           color="primary"
@@ -86,6 +106,8 @@ const AppItem: React.FC<AppItemProps> = ({
           icon={icon}
           $pinned={isPinned}
           label=""
+          aria-hidden="true"
+          tabIndex={-1}
           onClick={() => {}}
         />
         <Styled.AppTitle>{name}</Styled.AppTitle>
@@ -93,7 +115,14 @@ const AppItem: React.FC<AppItemProps> = ({
         {children}
       </Styled.ClickableArea>
       <TooltipContainer title={isPinned ? unpinTooltip : pinTooltip}>
-        <Styled.PinApp role="button" onClick={togglePinApp} tabIndex={0} pinned={isPinned}>
+        <Styled.PinApp
+          role="button"
+          aria-label={isPinned ? unpinTooltip : pinTooltip}
+          onClick={togglePinApp}
+          onKeyDown={handlePinKeyDown}
+          tabIndex={0}
+          pinned={isPinned}
+        >
           <Icon iconName={isPinned ? 'pin-video_on' : 'pin-video_off'} />
         </Styled.PinApp>
       </TooltipContainer>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -7,7 +7,6 @@ import {
   colorWhite,
   colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import Button from '/imports/ui/components/common/button/component';
 import { titlesFontWeight, headingsFontWeight, fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 import {
   $2xlPadding,
@@ -70,8 +69,10 @@ const RegisteredAppContent = styled.div`
   align-items: center;
 `;
 
-// @ts-expect-error -> Untyped component.
-const OpenButton = styled(Button)<{$pinned: boolean}>`
+const OpenButton = styled.span<{$pinned: boolean}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: ${$2xlPadding};
   border-radius: ${appsButtonsBorderRadius} 0px 0px ${appsButtonsBorderRadius};
 


### PR DESCRIPTION
### What does this PR do?
Issue #24564 reported several accessibility problems in BBB 3.1.0-beta.2 (now 4.0) affecting screen-reader users in the sidebar navigation and the Apps Gallery panel. This PR addresses the remaining unfixed items in the Apps Gallery panel.

#### Changes in this PR

- Added `role="button"`, `tabIndex={0}`, `aria-label={name}`, and `onKeyDown` (Enter/Space) to `ClickableArea`,  the clickable app row was a plain `div` with no accessible role or name, making it invisible to screen readers.
- Added `aria-hidden="true"` and `tabIndex={-1}` to `OpenButton`, the icon button inside `ClickableArea` is purely decorative (its `onClick` is a no-op); hiding it from the accessibility tree prevents screen readers from announcing a duplicate, unnamed control.
- Added `aria-label={isPinned ? unpinTooltip : pinTooltip}` and `onKeyDown` (Enter/Space) to `PinApp`, the pin/unpin control had `role="button"` but no accessible name; the tooltip strings were already available as props and are already translated at the call site.

#### Previously fixed items from the same report

The following items from issue #24564 were already addressed by earlier commits and are included here for traceability:

- **Three consecutive unlabeled buttons** (AudioCaptions, LearningDashboard, Settings) — fixed by [`6c7ff0ea41`](https://github.com/bigbluebutton/bigbluebutton/commit/6c7ff0ea4144491d8318dc89a5215c6c2cec0eae): introduced `SidebarNavigationButton`, a shared component that sets `aria-label={label}` on every sidebar navigation button, replacing the previous tooltip-only approach that screen readers could not reliably read.
- **Unnamed pinned-app buttons after the Apps Gallery** — fixed by the same commit [`6c7ff0ea41`](https://github.com/bigbluebutton/bigbluebutton/commit/6c7ff0ea4144491d8318dc89a5215c6c2cec0eae): `PinnedAppBase` was refactored to use `SidebarNavigationButton` with `label={name}`, giving each pinned app button a proper accessible name.
- **"Learning Analytics Dashboard" not translated** — fixed by [`3666850e0a`](https://github.com/bigbluebutton/bigbluebutton/commit/3666850e0a30c03bc0943cf4bdba6cf894362b72): the sidebar refactor created `LearningDashboardListItem` using `intl.formatMessage({ id: 'app.userList.learningDashboardLabel' })`, replacing the previously hardcoded English string.
- **"Settings" not translated** — fixed by the same commit [`3666850e0a`](https://github.com/bigbluebutton/bigbluebutton/commit/3666850e0a30c03bc0943cf4bdba6cf894362b72): `SettingsListItem` was created in the same refactor using `intl.formatMessage({ id: 'app.userList.settingsTitle' })`.

### Closes Issue(s)
Closes #24564

