### PR TITLE
fix (ci/tests): Stabilize cross-page slide comparison

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -12,6 +12,7 @@ import { checkNotificationText } from '../notifications/util';
 import { MultiUsers } from '../user/multiusers';
 import {
   checkSvgIndex,
+  expectSlidesEqualBetweenPages,
   getCurrentPresentationHeight,
   getSlideOuterHtml,
   uploadMultiplePresentations,
@@ -344,16 +345,21 @@ export class Presentation extends MultiUsers {
     );
 
     const modSlides0 = await getSlideOuterHtml(this.modPage);
-    const userSlides0 = await getSlideOuterHtml(this.userPage);
-    await expect(modSlides0).toEqual(userSlides0);
+    await expectSlidesEqualBetweenPages(
+      this.modPage,
+      this.userPage,
+      'should the moderator slide and the attendee slide to be equal before upload',
+    );
 
     await uploadMultiplePresentations(this.modPage, [e.questionSlideFileName, e.uploadPresentationFileName]);
 
+    await expectSlidesEqualBetweenPages(
+      this.modPage,
+      this.userPage,
+      'moderator slide 1 should be equal to the user slide 1',
+    );
     const modSlides1 = await getSlideOuterHtml(this.modPage);
-    const userSlides1 = await getSlideOuterHtml(this.userPage);
-    await expect(modSlides1, 'moderator slide 1 should be equal to the user slide 1').toEqual(userSlides1);
     await expect(modSlides0, 'moderator slide 0 should not be equal to moderator slide 1').not.toEqual(modSlides1);
-    await expect(userSlides0, 'user slide 0 should not be equal to the user slide 1').not.toEqual(userSlides1);
   }
 
   async fitToWidthTest() {
@@ -484,11 +490,12 @@ export class Presentation extends MultiUsers {
   async uploadAndRemoveAllPresentations() {
     await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName);
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
-    await this.modPage.page.waitForTimeout(1000); // timeout to avoid trying to get the slide data before it's ready
 
-    const modSlides1 = await getSlideOuterHtml(this.modPage);
-    const userSlides1 = await getSlideOuterHtml(this.userPage);
-    await expect(modSlides1, 'should the moderator slide and the attendee slide to be equal').toEqual(userSlides1);
+    await expectSlidesEqualBetweenPages(
+      this.modPage,
+      this.userPage,
+      'should the moderator slide and the attendee slide to be equal',
+    );
 
     // Remove
     await this.modPage.waitAndClick(e.actions);
@@ -533,9 +540,11 @@ export class Presentation extends MultiUsers {
     await this.modPage.closeAllToastNotifications();
     await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName);
 
-    const modSlides1 = await getSlideOuterHtml(this.modPage);
-    const userSlides1 = await getSlideOuterHtml(this.userPage);
-    await expect(modSlides1, 'should the moderator slide and the attendee slide to be equal').toEqual(userSlides1);
+    await expectSlidesEqualBetweenPages(
+      this.modPage,
+      this.userPage,
+      'should the moderator slide and the attendee slide to be equal',
+    );
 
     await this.modPage.waitAndClick(e.userListItem);
     await this.modPage.waitAndClick(e.makePresenter);

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -22,14 +22,9 @@ export async function checkSvgIndex(testPage: Page, element: string) {
   await expect(check).toBeTruthy();
 }
 
-// Strip the URL query string from the returned HTML
 export async function getSlideOuterHtml(testPage: Page) {
   await testPage.waitForSelector(e.currentSlideImg);
-  const outerHtml = await testPage.page.evaluate(
-    ([slideImg]) => document.querySelector(slideImg)?.outerHTML,
-    [e.currentSlideImg],
-  );
-  return outerHtml?.replace(/\?[^"&]*(?:&amp;[^"]*)?/g, '');
+  return testPage.page.evaluate(([slideImg]) => document.querySelector(slideImg)?.outerHTML, [e.currentSlideImg]);
 }
 
 // Cross-page comparison can race against subscription propagation

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -1,7 +1,12 @@
 import { expect, Locator } from '@playwright/test';
 import path from 'path';
 
-import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_TIME, UPLOAD_PDF_WAIT_TIME } from '../core/constants';
+import {
+  ELEMENT_WAIT_EXTRA_LONG_TIME,
+  ELEMENT_WAIT_LONGER_TIME,
+  ELEMENT_WAIT_TIME,
+  UPLOAD_PDF_WAIT_TIME,
+} from '../core/constants';
 import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 
@@ -17,9 +22,26 @@ export async function checkSvgIndex(testPage: Page, element: string) {
   await expect(check).toBeTruthy();
 }
 
+// Strip the URL query string from the returned HTML
 export async function getSlideOuterHtml(testPage: Page) {
   await testPage.waitForSelector(e.currentSlideImg);
-  return testPage.page.evaluate(([slideImg]) => document.querySelector(slideImg)?.outerHTML, [e.currentSlideImg]);
+  const outerHtml = await testPage.page.evaluate(
+    ([slideImg]) => document.querySelector(slideImg)?.outerHTML,
+    [e.currentSlideImg],
+  );
+  return outerHtml?.replace(/\?[^"&]*(?:&amp;[^"]*)?/g, '');
+}
+
+// Cross-page comparison can race against subscription propagation
+// Poll the user page until it matches the (already-stable) moderator slide.
+export async function expectSlidesEqualBetweenPages(
+  modPage: Page,
+  userPage: Page,
+  description: string,
+  timeout = ELEMENT_WAIT_LONGER_TIME,
+) {
+  const modSlide = await getSlideOuterHtml(modPage);
+  await expect.poll(() => getSlideOuterHtml(userPage), { message: description, timeout }).toBe(modSlide);
 }
 
 export async function getCurrentPresentationHeight(locator: Locator) {
@@ -118,10 +140,11 @@ export async function uploadMultiplePresentations(
     );
 
     await testPage.hasNElements(
-    e.uploadDoneIcon,
-    fileNames.length,
-    'should display the upload done icon after all presentations are successfully uploaded',);
-    } catch {
+      e.uploadDoneIcon,
+      fileNames.length,
+      'should display the upload done icon after all presentations are successfully uploaded',
+    );
+  } catch {
     await testPage.hasNElements(
       e.uploadDoneIcon,
       fileNames.length,


### PR DESCRIPTION
Poll the user page until it matches the moderator side, fixing flaky uploads in CI.

Attempt to avoid this error that occurs often:

<img width="700" src="https://github.com/user-attachments/assets/f9afc0c5-323c-4a8a-b9c0-a788d1f51de6" />
