### PR TITLE
fix(recording): Fix events archiving on servers with blocknote

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
@@ -41,9 +41,13 @@ module BigBlueButton
         @logger.info("Keeping etherpad events for #{@meeting_id}")
         events = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
         notes_id = BigBlueButton::Events.get_notes_id(events)
-
+        notes_editor = BigBlueButton::Events.get_notes_editor(events)
         if notes_id.nil? || notes_id.empty? || notes_id == 'undefined'
           @logger.warn("No notes_id found for #{@meeting_id}, skipping etherpad events")
+          return
+        end
+        unless notes_editor == 'etherpad'
+          @logger.debug('Notes are not using etherpad, no etherpad events to store')
           return
         end
 


### PR DESCRIPTION
The main archive script was updated to handle blocknote, but the separate events archiving script for the `defaultKeepEvents=true` configuration was not updated.

The script was therefore trying to pull the etherpad events from blocknote notes, which triggered a separate bug in bbb-pad where it did not return a response to the http connection, leading to a 2 minute hang, which backed up the recording queue.

The simple fix is to skip pulling the etherpad events if the notes implementation is not etherpad.