### PR TITLE
docs: fix searchbox spinning forever after Docusaurus upgrade

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -31,9 +31,21 @@ const config = {
         locales: ['en'],
     },
 
-    scripts: [
+    headTags: [
         // Cookie consent control required for GDPR. Token is not required to be renewed. Update hN querystring to match domain.
-        'https://cdn.baycloud.com/cl.js?cid=9be233bfe3004dc49e742fd0fa98642c&hN=docs.bigbluebutton.org'
+        {
+            tagName: 'script',
+            attributes: {
+                src: 'https://cdn.baycloud.com/cl.js?cid=9be233bfe3004dc49e742fd0fa98642c&hN=docs.bigbluebutton.org',
+            },
+        },
+        // baycloud's cl.js monkey-patches window.Worker and assumes a string URL (calls .includes/.replace).
+        // docusaurus-search-local 0.52+ passes a URL object — coerce it back to a string here so search works.
+        {
+            tagName: 'script',
+            attributes: {},
+            innerHTML: "(function(){if(typeof window==='undefined'||typeof window.Worker!=='function')return;var P=window.Worker;window.Worker=new Proxy(P,{construct:function(t,a){var u=a[0];if(u&&typeof u!=='string'&&typeof u.toString==='function')a=[u.toString()].concat(a.slice(1));return Reflect.construct(t,a)}})})();",
+        },
     ],
     
     presets: [


### PR DESCRIPTION




<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
tl;dr: The searchbox of docs.bigbluebutton.org was not producing results.

The baycloud cookie-consent script (cl.js) monkey-patches window.Worker and calls .includes() / .replace() on the URL argument assuming it is always a string. @easyops-cn/docusaurus-search-local 0.52 instantiates its worker with `new Worker(new URL("./worker.js", import.meta.url))`, passing a URL object — which makes baycloud throw "TypeError: t.includes is not a function" and leaves the search dropdown spinning forever.

Move the baycloud tag from scripts[] into headTags[] so we control ordering, then add an inline Proxy on window.Worker right after it that coerces non-string URL args via .toString() before delegating to baycloud's wrapper. The consent script still loads sitewide as before; only the URL/string incompatibility is neutralized, so search works without downgrading the plugin.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #25009 