### PR TITLE
fix(generic-sidekick-content): open panel when content is injected with open: true

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
@@ -109,6 +109,15 @@ const GenericContentPluginStateContainer = ((
         },
       });
     });
+    // If multiple sidekick items are registered with open: true, only the last one is opened.
+    const lastOpenSidekick = genericContentSidekickArea.findLast((gci) => gci.open);
+    if (lastOpenSidekick) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+        value: genericContentSidekickId(lastOpenSidekick.id),
+      });
+      layoutContextDispatch({ type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN, value: true });
+    }
   }, [genericContentItems, setPluginsExtensibleAreasAggregatedState]);
 
   pluginApi.setGenericContentItems = (items: PluginSdk.GenericContentInterface[]) => {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/extensible-areas/components/generic-content/manager.tsx
@@ -110,7 +110,7 @@ const GenericContentPluginStateContainer = ((
       });
     });
     // If multiple sidekick items are registered with open: true, only the last one is opened.
-    const lastOpenSidekick = genericContentSidekickArea.findLast((gci) => gci.open);
+    const lastOpenSidekick = genericContentSidekickArea.slice().reverse().find((gci) => gci.open);
     if (lastOpenSidekick) {
       layoutContextDispatch({
         type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,


### PR DESCRIPTION
### What does this PR do?
The generic sidekick content is not opened when injected with `open: true`.

Dispatch the layout action to open the sidebar content when a generic sidekick content with `open: true` is detected. If a plugin injects multiple generic sidekick contents with `open: true` — which is possible but not recommended — only the last one will be opened.

If two plugins inject generic sidekick contents with `open: true` simultaneously, they will keep overwriting each other's open panel until the last one wins, so only that plugin's panel will be opened.

### Closes Issue(s)
Closes https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/issues/259