### PR TITLE
fix(video-list-item): prevent overlapping icons in webcam containers

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -364,11 +364,11 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
   const renderDefaultButtons = () => (
     <>
       <Styled.TopBar>
-        {renderRaiseHandElement()}
         <PinArea
           stream={stream}
           amIModerator={amIModerator}
         />
+        {renderRaiseHandElement()}
       </Styled.TopBar>
       <Styled.BottomBar>
         <UserActions

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/pin-area/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/pin-area/component.tsx
@@ -35,7 +35,7 @@ const PinArea: React.FC<PinAreaProps> = (props) => {
 
   const [setCameraPinned] = useMutation(SET_CAMERA_PINNED);
 
-  if (!pinned && !presenter) return <Styled.PinButtonWrapper />;
+  if (!pinned && !presenter) return null;
 
   return (
     <Styled.PinButtonWrapper>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/styles.ts
@@ -189,7 +189,7 @@ const VideoDisabled = styled.div`
   top: 50%;
   left: 50%;
   padding: 20px;
-  backdrop-filter: blur(10px); 
+  backdrop-filter: blur(10px);
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 `;
 
@@ -200,7 +200,8 @@ const TopBar = styled.div`
   z-index: 1;
   top: 0;
   padding: 5px;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 4px;
 `;
 
 const BottomBar = styled.div`


### PR DESCRIPTION
### What does this PR do?
Moves the Presenter Icon in the video tile for the left to avoid overlay with the plugin of pop out video when raised hand is active.
Example of the issue:
<img width="361" height="132" alt="image" src="https://github.com/user-attachments/assets/e0ad33d7-fddd-41a3-9ad6-d6adfe2da458" />


### Closes Issue(s)
Closes None

### More
Temporary solution until design refactors tile icons:
<img width="732" height="246" alt="Screenshot from 2026-05-13 09-59-59" src="https://github.com/user-attachments/assets/28b2df8a-8978-444c-8e58-2cb4bbbc0aec" />

