### PR TITLE
fix(user-list): removes "Blocked" label until new design

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
@@ -76,6 +76,18 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
 
   const subs = [];
 
+  const hasActiveLockSettingExcludingPresenterPolicy = !!(lockSettings && (
+    lockSettings.disableCam
+    || lockSettings.disableMic
+    || lockSettings.disablePrivateChat
+    || lockSettings.disablePublicChat
+    || lockSettings.disableNotes
+    || lockSettings.hideUserList
+    || lockSettings.hideViewersCursor
+    || lockSettings.hideViewersAnnotation
+    || lockSettings.webcamsOnlyForModerator
+  ));
+
   if (subjectUser.presenter && LABEL.presenter) {
     subs.push(intl.formatMessage(intlMessages.presenter));
   }
@@ -92,7 +104,7 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
     subs.push(intl.formatMessage(intlMessages.bot));
   }
   if ((subjectUser.locked || subjectUser.userLockSettings?.disablePublicChat)
-      && (subjectUser.userLockSettings?.disablePublicChat || lockSettings?.hasActiveLockSetting)
+      && (subjectUser.userLockSettings?.disablePublicChat || hasActiveLockSettingExcludingPresenterPolicy)
       && !subjectUser.isModerator
   ) {
     subs.push(


### PR DESCRIPTION
### What does this PR do?
Removes the "Blocked" label under the username in the user list for when the user does not have permission to be a presenter. It's a preliminary decision until the design team finds a better solution to show this without confusing it with the lock settings.

### Closes Issue(s)
Closes None

