### PR TITLE
Update Poll button label for better clarity

### DIFF
--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -463,7 +463,7 @@
     "app.poll.dragDropPollInstruction": "To fill the poll values, drag a text file with the poll values onto the highlighted field",
     "app.poll.customPollTextArea": "Fill poll values",
     "app.poll.publishLabel": "Publish results",
-    "app.poll.cancelPollLabel": "Cancel",
+    "app.poll.cancelPollLabel": "Stop poll",
     "app.poll.backLabel": "Start A Poll",
     "app.poll.ariaInputCount": "Custom poll option {currentOption} of {totalOptions}",
     "app.poll.closeLabel": "Close",


### PR DESCRIPTION
### What does this PR do?

update poll stop button label to better describe the action (from `Cancel` to `Stop poll`)

<img width="442" height="379" alt="Screenshot from 2026-05-14 09-10-01" src="https://github.com/user-attachments/assets/af363179-c37d-4e01-8484-5fe11ea17dd4" />


### Closes Issue(s)
Closes #23503