### PR TITLE
fix: bn- table crash with static toolbar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -17,7 +17,8 @@ import {
   UnnestBlockButton,
   useCreateBlockNote,
 } from '@blocknote/react';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
@@ -57,6 +58,33 @@ const createMaxDocumentCharsExtension = (
             onExceed(charCount);
           }
           return charCount <= maxChars;
+        },
+      }),
+    ];
+  },
+});
+
+// The left margin of the table Block as the first block is buggy when used with static toolbar;
+// ideally the fix would come from BlockNote
+// (wait for https://github.com/TypeCellOS/BlockNote/issues/2748 to be resolved)
+// TODO: After the issue on BlockNote is resolved, update BlockNote and remove the
+// fixCursorAtOriginExtension and the fixCursorAtOriginPluginKey
+const fixCursorAtOriginPluginKey = new PluginKey('fixCursorAtOrigin');
+const fixCursorAtOriginExtension = Extension.create({
+  name: 'bbbFixCursorAtOrigin',
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: fixCursorAtOriginPluginKey,
+        appendTransaction(_transactions, _oldState, newState) {
+          const { selection } = newState;
+          if (selection.$from.pos > 2 || selection.$to.pos > 2) return null;
+          const firstBlockContent = newState.doc.firstChild?.firstChild?.firstChild;
+          if (!firstBlockContent || firstBlockContent.type.name !== 'table') return null;
+          if (newState.doc.content.size < 1) return null;
+          const safeSelection = TextSelection.near(newState.doc.resolve(1), 1);
+          if (safeSelection.from === 0) return null;
+          return newState.tr.setSelection(safeSelection);
         },
       }),
     ];
@@ -168,7 +196,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
       },
     },
     _tiptapOptions: {
-      extensions: [maxDocumentCharsExtension],
+      extensions: [maxDocumentCharsExtension, fixCursorAtOriginExtension],
     },
     pasteHandler: ({ event, defaultPasteHandler }) => {
       try {


### PR DESCRIPTION
### What does this PR do?

The issue that generated this problem in BBB is described in BlockNote, see issue [here](https://github.com/TypeCellOS/BlockNote/issues/2748).

This PR is just a temporary, but robust fix. (we'd still need to wait for the correct approach from BN).

### Motivation

The error crashes the entire client.

### How to test

See steps in the issue from BN

### More
See video of the reproduction of the bug down here:

Bug:

https://github.com/user-attachments/assets/4748668c-5b6e-45d4-8b3f-3760ed74f975



Fixed:

https://github.com/user-attachments/assets/e17bc6ed-2ea5-4d02-9354-82d3dbd96737



