### PR TITLE
webpack: ignore .yalc/ from file watching and exclude tldraw from man…

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const CopyPlugin = require('copy-webpack-plugin');
@@ -30,6 +31,14 @@ const config = {
     type: 'filesystem',
     allowCollectingMemory: true,
     maxAge: 86400000,
+    // Only active during local yalc-based tldraw development. When the file exists,
+    // webpack discards its cache on each rebuild so stale ENOENT errors can't persist.
+    // Absent in production / CI (package comes from npm), so no effect there.
+    ...(fs.existsSync(path.join(__dirname, '.tldraw-build-id')) && {
+      buildDependencies: {
+        tldraw: [path.join(__dirname, '.tldraw-build-id')],
+      },
+    }),
   },
   snapshot: {
     // Exclude tldraw from version-based managed-path caching so webpack uses

--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -12,7 +12,7 @@ const detailedLogs = process.env.DETAILED_LOGS || false;
 const hotReload = String(process.env.HOT_RELOAD).toLowerCase() === 'true';
 const prodEnv = 'production';
 const devEnv = 'development';
-const isDev = env === devEnv;
+const isDev = env === devEnv && false;
 const isSafariTarget = process.env.TARGET === 'safari';
 
 process.stdout.write(`Building: ${process.env.TARGET}\n`);
@@ -30,6 +30,19 @@ const config = {
     type: 'filesystem',
     allowCollectingMemory: true,
     maxAge: 86400000,
+  },
+  snapshot: {
+    // Exclude tldraw from version-based managed-path caching so webpack uses
+    // content hashing instead. Without this, webpack treats the package as
+    // unchanged because yalc never bumps the version (2.0.0-alpha.33 forever).
+    managedPaths: [/^(.+?[\\/]node_modules[\\/])(?!@bigbluebutton[\\/]tldraw[\\/])/],
+  },
+  watchOptions: {
+    // Ignore .yalc/ so that yalc remove+add operations don't trigger webpack
+    // rebuilds mid-flight (which would ENOENT on partially-deleted files and
+    // cache that failure). Only our explicit triggerWebpackRebuild touch
+    // (component.jsx) should start a tldraw rebuild.
+    ignored: /node_modules|\.yalc/,
   },
   devtool: 'source-map',
   plugins: [

--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -13,7 +13,7 @@ const detailedLogs = process.env.DETAILED_LOGS || false;
 const hotReload = String(process.env.HOT_RELOAD).toLowerCase() === 'true';
 const prodEnv = 'production';
 const devEnv = 'development';
-const isDev = env === devEnv && false;
+const isDev = env === devEnv;
 const isSafariTarget = process.env.TARGET === 'safari';
 
 process.stdout.write(`Building: ${process.env.TARGET}\n`);


### PR DESCRIPTION
### What does this PR do?
**Problem**: When developing tldraw locally via yalc, webpack watches .yalc/@bigbluebutton/tldraw/ (the real path behind the symlink) and triggers mid-flight rebuilds during yalc
  remove/yalc add, causing ENOENT failures that get persisted in webpack's filesystem cache; additionally, webpack's managed-path cache treats the package as unchanged because yalc
   never bumps its version.

  **Solution**: Exclude .yalc/ from webpack's file watcher so only an explicit source-file touch triggers rebuilds, and exclude @bigbluebutton/tldraw from snapshot.managedPaths so
  webpack uses content hashing instead of version comparison to detect changes.

