### PR TITLE
[fix-bn-table-crash] Fix BlockNote table crash (#25076)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -17,7 +17,8 @@ import {
   UnnestBlockButton,
   useCreateBlockNote,
 } from '@blocknote/react';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
@@ -57,6 +58,33 @@ const createMaxDocumentCharsExtension = (
             onExceed(charCount);
           }
           return charCount <= maxChars;
+        },
+      }),
+    ];
+  },
+});
+
+// The left margin of the table Block as the first block is buggy when used with static toolbar;
+// ideally the fix would come from BlockNote
+// (wait for https://github.com/TypeCellOS/BlockNote/issues/2748 to be resolved)
+// TODO: After the issue on BlockNote is resolved, update BlockNote and remove the
+// fixCursorAtOriginExtension and the fixCursorAtOriginPluginKey
+const fixCursorAtOriginPluginKey = new PluginKey('fixCursorAtOrigin');
+const fixCursorAtOriginExtension = Extension.create({
+  name: 'bbbFixCursorAtOrigin',
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: fixCursorAtOriginPluginKey,
+        appendTransaction(_transactions, _oldState, newState) {
+          const { selection } = newState;
+          if (selection.$from.pos > 2 || selection.$to.pos > 2) return null;
+          const firstBlockContent = newState.doc.firstChild?.firstChild?.firstChild;
+          if (!firstBlockContent || firstBlockContent.type.name !== 'table') return null;
+          if (newState.doc.content.size < 1) return null;
+          const safeSelection = TextSelection.near(newState.doc.resolve(1), 1);
+          if (safeSelection.from === 0) return null;
+          return newState.tr.setSelection(safeSelection);
         },
       }),
     ];
@@ -168,7 +196,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
       },
     },
     _tiptapOptions: {
-      extensions: [maxDocumentCharsExtension],
+      extensions: [maxDocumentCharsExtension, fixCursorAtOriginExtension],
     },
     pasteHandler: ({ event, defaultPasteHandler }) => {
       try {


### PR DESCRIPTION
Porting #25076 to `v3.0.x-release` so it lands in 3.0.27