### PR TITLE
ref: change text align select button to remove previous selector

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -20,6 +20,7 @@ import {
   RiAlignLeft,
   RiAlignRight,
 } from 'react-icons/ri';
+import { HiChevronDown } from 'react-icons/hi';
 
 type TextAlignment = 'left' | 'center' | 'right' | 'justify';
 
@@ -110,16 +111,44 @@ function TextAlignSelect(): React.ReactElement | null {
 
   if (!state) return null;
 
+  const currentItem = ALIGN_ITEMS.find((a) => a.value === state.alignment)!;
+
+  type TriggerButtonProps = {
+    className?: string;
+    label?: string;
+    mainTooltip?: string;
+    leftSection?: React.ReactNode;
+    rightSection?: React.ReactNode;
+    children?: React.ReactNode;
+  };
+  const TriggerButton = Components.FormattingToolbar.Button as unknown as React.ComponentType<TriggerButtonProps>;
+
   return (
-    <Components.FormattingToolbar.Select
-      className="bn-select"
-      items={ALIGN_ITEMS.map((a) => ({
-        text: dict.formatting_toolbar[`align_${a.value}`].tooltip,
-        icon: a.icon,
-        isSelected: state.alignment === a.value,
-        onClick: () => setTextAlignment(a.value),
-      }))}
-    />
+    <Components.Generic.Menu.Root>
+      <Components.Generic.Menu.Trigger>
+        <TriggerButton
+          className="bn-button"
+          label={dict.formatting_toolbar[`align_${state.alignment}`].tooltip}
+          mainTooltip={dict.formatting_toolbar[`align_${state.alignment}`].tooltip}
+          leftSection={currentItem.icon}
+          rightSection={<HiChevronDown size={10} />}
+        >
+          <span />
+        </TriggerButton>
+      </Components.Generic.Menu.Trigger>
+      <Components.Generic.Menu.Dropdown className="bn-menu-dropdown">
+        {ALIGN_ITEMS.map((a) => (
+          <Components.Generic.Menu.Item
+            key={a.value}
+            icon={a.icon}
+            checked={state.alignment === a.value}
+            onClick={() => setTextAlignment(a.value)}
+          >
+            {dict.formatting_toolbar[`align_${a.value}`].tooltip}
+          </Components.Generic.Menu.Item>
+        ))}
+      </Components.Generic.Menu.Dropdown>
+    </Components.Generic.Menu.Root>
   );
 }
 


### PR DESCRIPTION
### What does this PR do?

It changes the strategy we used with the text align select button.

**Previous way**: We used a `Select` from BN components;
**Now**: We use a Button + Dropdown; 

Pros:
- Don't have to rely on `display: none` to the inline text of the select item;
- Native tool-tip indicating current text alignment; 

Cons:
- A bit more verbose;

### Motivation

 Main reason to do this is to have a native way to not include the inline text once a selection is done.

### How to test

Just play around with the text alignment, the overall behavior and look should remain unchanged.

### More

See sceenshots ahead:

Hovering the select button:
<img width="419" height="440" alt="image" src="https://github.com/user-attachments/assets/5c1edc11-8223-4bcf-832d-308c156b9161" />

Not hovering it (all stay the same):
<img width="412" height="455" alt="image" src="https://github.com/user-attachments/assets/87ee132b-3abd-4d6d-b12b-dfae5c974172" />
