### PR TITLE
docs: make navbar items version-aware so version selection sticks

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -163,12 +163,12 @@ const config = {
                 },
                 items: [
                     {to: 'https://bigbluebutton.org/teachers/tutorials/', label: 'Teaching', position: 'left'},
-                    {to: '/development/guide', label: 'Development', position: 'left'},
-                    {to: '/administration/install', label: 'Administration', position: 'left'},
-                    {to: '/greenlight/v3/install', label: 'Greenlight', position: 'left'},
-                    {to: '/new-features', label: 'New Features', position: 'left'},
-                    {to: '/plugins', label: 'Plugins', position: 'left'},
-                    {to: '/support/getting-help', label: 'Support', position: 'left'},
+                    {type: 'doc', docId: 'development/guide',      label: 'Development',    position: 'left'},
+                    {type: 'doc', docId: 'administration/install', label: 'Administration', position: 'left'},
+                    {type: 'doc', docId: 'greenlight/v3/install',  label: 'Greenlight',     position: 'left'},
+                    {type: 'doc', docId: 'new-features',           label: 'New Features',   position: 'left'},
+                    {type: 'doc', docId: 'plugins',                label: 'Plugins',        position: 'left'},
+                    {type: 'doc', docId: 'support/getting-help',   label: 'Support',        position: 'left'},
                     {
                         type: 'docsVersionDropdown',
                         position: 'right',


### PR DESCRIPTION
Navbar items used literal `to:` paths (e.g. `to: '/plugins'`), which always resolved to the default version. Clicking a navbar item while browsing 2.5/2.6/2.7 docs bounced the user back to 3.0.

Convert all six docs navbar items to `type: 'doc'` with `docId:`. Docusaurus then resolves each link to the current version's URL — e.g. `Development` becomes `/2.7/development/guide/` when the user is on a 2.7 page, and stays at `/development/guide/` (3.0 default) otherwise.

The Plugins item is the one exception: `plugins.md` only exists in 3.0, so on older versions it falls back to the 3.0 URL. Accepted as a minor wart — adding stubs to each archived branch would be more churn than it's worth for one nav item.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adjusts docs.bigbluebutton.org so the version selected via dropdown is sticky.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none (can't find one although I recall opening such)

### Motivation
<!-- What inspired you to submit this pull request? -->
Today if you are browsing a 2.7 docs page and you click on another part of the docs site, the next page will be showing the content from the current latest release (3.0 now). With this change you'll start browsing in the current release, but if you switch via the dropdown, clicking on links will _not_ change the version.