### PR TITLE
fix(polls): corrects download/copy date to chat post time

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/component.tsx
@@ -586,7 +586,7 @@ const ChatMessage = React.forwardRef<ChatMessageRef, ChatMessageProps>(({
           color: '#3B48A9',
           isModerator: true,
           component: (
-            <ChatPollContent ref={pollActionsRef} metadata={message.messageMetadata} />
+            <ChatPollContent ref={pollActionsRef} metadata={message.messageMetadata} createdAt={message.createdAt} />
           ),
           avatarIcon: 'icon-bbb-polling',
           showAvatar: true,

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/poll-content/component.tsx
@@ -23,6 +23,7 @@ import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 interface ChatPollContentProps {
   metadata: string;
   height?: number;
+  createdAt?: string;
 }
 
 export interface ChatPollContentHandle {
@@ -107,7 +108,7 @@ function assertAsMetadata(metadata: unknown): asserts metadata is Metadata {
 }
 
 const ChatPollContent = forwardRef<ChatPollContentHandle, ChatPollContentProps>((
-  { metadata, height },
+  { metadata, height, createdAt },
   ref,
 ) => {
   const intl = useIntl();
@@ -130,10 +131,10 @@ const ChatPollContent = forwardRef<ChatPollContentHandle, ChatPollContentProps>(
   });
 
   const handleCopy = useCallback((onDone: () => void) => {
-    const now = new Date();
+    const pollDate = createdAt ? new Date(createdAt) : new Date();
     const pad = (n: number) => n.toString().padStart(2, '0');
-    const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
-      + ` ${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+    const dateStr = `${pollDate.getFullYear()}-${pad(pollDate.getMonth() + 1)}-${pad(pollDate.getDate())}`
+      + ` ${pad(pollDate.getHours())}:${pad(pollDate.getMinutes())}:${pad(pollDate.getSeconds())}`;
     const lines = [
       `[${dateStr}]`,
       pollData.questionText,
@@ -167,10 +168,10 @@ const ChatPollContent = forwardRef<ChatPollContentHandle, ChatPollContentProps>(
   const handleDownload = useCallback(() => {
     if (!chartRef.current) return;
     const chartNode = chartRef.current;
-    const now = new Date();
+    const pollDate = createdAt ? new Date(createdAt) : new Date();
     const pad = (n: number) => n.toString().padStart(2, '0');
-    const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
-      + `_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+    const dateStr = `${pollDate.getFullYear()}-${pad(pollDate.getMonth() + 1)}-${pad(pollDate.getDate())}`
+      + `_${pad(pollDate.getHours())}-${pad(pollDate.getMinutes())}-${pad(pollDate.getSeconds())}`;
     const fileName = `poll-result_${dateStr}.png`;
     toPng(chartNode, { backgroundColor: '#fff' }).then((dataUrl) => {
       const anchor = document.createElement('a');


### PR DESCRIPTION
### What does this PR do?
Changes the copy/download time reference to when the poll was published in the chat. Before this commit it was showing the moment when the copy/download occurs.

### Closes Issue(s)
Closes None

### More
<img width="379" height="311" alt="image" src="https://github.com/user-attachments/assets/d1f24ada-d4c1-4245-8090-8c4653ac7b32" />

#### Copy
[2026-05-18 10:18:36]
this is a test

A: 0 votos
B: 0 votos
C: 0 votos
D: 1 voto

#### Download
poll-result_2026-05-18_10-18-36.png
<img width="301" height="239" alt="poll-result_2026-05-18_10-18-36" src="https://github.com/user-attachments/assets/636ab95c-3f19-4c89-87db-b9d52f60f2c5" />