### PR TITLE
[4.0] feat(chat): render emoji-only messages with larger font (jumbomoji)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/component.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Styled from './styles';
+import { isJumbomoji } from './jumbomoji';
 
 interface ChatMessageTextContentProps {
   text: string;
@@ -9,11 +10,13 @@ const ChatMessageTextContent: React.FC<ChatMessageTextContentProps> = ({
   text,
   dataTest = 'messageContent',
 }) => {
+  const jumbomoji = useMemo(() => isJumbomoji(text), [text]);
   return (
     <Styled.ChatMessage
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: text }}
       data-test={dataTest}
+      $jumbomoji={jumbomoji}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/jumbomoji.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/jumbomoji.ts
@@ -1,0 +1,36 @@
+// Up to this many emoji-only graphemes get the jumbomoji treatment.
+// Aligned with WhatsApp/Telegram/iMessage thresholds (1-3).
+export const MAX_JUMBOMOJI_COUNT = 3;
+
+// Matches a single emoji grapheme:
+//  - regional indicator pair (country flags)
+//  - keycap sequences (0-9, #, *)
+//  - extended_pictographic with optional VS16, optional Fitzpatrick skin-tone
+//    modifier, and ZWJ chains where each segment can carry its own modifier
+//    (e.g. 👨🏿‍💻 = man + dark skin + ZWJ + computer)
+// Unicode property escapes with the 'u' flag are ES2018, the compile target of
+// this codebase. \p{RGI_Emoji} would be stricter, but it requires the 'v' flag
+// (ES2024), beyond the current TS target and browser floor.
+const EMOJI_COMPONENT = '\\p{Extended_Pictographic}\\uFE0F?\\p{Emoji_Modifier}?';
+const EMOJI_GRAPHEME = `(?:\\p{RI}\\p{RI}|[0-9#*]\\uFE0F?\\u20E3|${EMOJI_COMPONENT}(?:\\u200D${EMOJI_COMPONENT})*)`;
+
+// The whole string must consist of 1..MAX_JUMBOMOJI_COUNT emoji graphemes and
+// nothing else.
+const JUMBOMOJI_PATTERN = new RegExp(
+  `^${EMOJI_GRAPHEME}{1,${MAX_JUMBOMOJI_COUNT}}$`,
+  'u',
+);
+
+// Message text arrives as sanitized HTML (server-side commonmark render).
+// Parsing it into a detached element both strips tags and decodes entities.
+const stripHtml = (html: string): string => {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  return tmp.textContent || '';
+};
+
+export const isJumbomoji = (htmlText: string): boolean => {
+  if (!htmlText) return false;
+  const condensed = stripHtml(htmlText).replace(/\s+/g, '');
+  return JUMBOMOJI_PATTERN.test(condensed);
+};

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/text-content/styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import {
   colorDangerDark,
   colorGrayLightest,
@@ -8,7 +8,17 @@ import {
 
 interface ChatMessageProps {
   systemMsg?: boolean;
+  $jumbomoji?: boolean;
 }
+
+const jumbomojiStyles = css`
+  font-size: 2.5em;
+  line-height: 1.2;
+
+  & p {
+    line-height: 1.2;
+  }
+`;
 
 export const ChatMessage = styled.div<ChatMessageProps>`
   flex: 1;
@@ -17,6 +27,8 @@ export const ChatMessage = styled.div<ChatMessageProps>`
   flex-direction: column;
   color: ${colorText};
   word-break: break-word;
+
+  ${({ $jumbomoji }) => $jumbomoji && jumbomojiStyles}
 
   & img {
     max-width: 100%;
@@ -28,7 +40,8 @@ export const ChatMessage = styled.div<ChatMessageProps>`
     white-space: pre-wrap;
   }
 
-  & pre:has(code), p code:not(pre > code) {
+  & pre:has(code),
+  p code:not(pre > code) {
     background-color: ${colorOffWhite};
     border: solid 1px ${colorGrayLightest};
     border-radius: 4px;

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '../core/setup/fixtures';
 import { Chat } from './chat';
+import { Jumbomoji } from './jumbomoji';
 import { MessageActions } from './messageActions';
 
 test.describe.parallel('Chat', { tag: '@ci' }, () => {
@@ -159,6 +160,12 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
     const chat = new Chat(browser, context);
     await chat.initPages(page, testInfo);
     await chat.chatDisabledUserLeaves();
+  });
+
+  test('Jumbomoji renders emoji-only messages with larger font', async ({ browser, context, page }, testInfo) => {
+    const jumbomoji = new Jumbomoji(browser, context);
+    await jumbomoji.initModPage(page, { testInfo });
+    await jumbomoji.verifyJumbomoji();
   });
 
   test.describe('Message actions', () => {

--- a/bigbluebutton-tests/playwright/chat/jumbomoji.ts
+++ b/bigbluebutton-tests/playwright/chat/jumbomoji.ts
@@ -1,0 +1,67 @@
+import { expect } from '@playwright/test';
+
+import { elements as e } from '../core/elements';
+import { MultiUsers } from '../user/multiusers';
+import { getLastMessageSent, openPublicChat } from './util';
+
+// Body font-size in BBB's chat is 14px, jumbomoji applies font-size: 2.5em → 35px.
+// Threshold of 24px sits comfortably between the two (regular ≤ 14, jumbo ≥ 35).
+const JUMBO_MIN_PX = 24;
+
+const JUMBO_CASES: ReadonlyArray<[label: string, text: string]> = [
+  ['single emoji', '😀'],
+  ['three emojis', '😀🎉🚀'],
+  ['country flag (regional indicators)', '🇧🇷'],
+  ['ZWJ family', '👨‍👩‍👧‍👦'],
+  ['heart with VS16', '❤️'],
+  ['keycap digit', '1️⃣'],
+  ['rainbow flag (ZWJ)', '🏳️‍🌈'],
+  ['Fitzpatrick skin tone modifier', '👋🏿'],
+  ['skin tone in ZWJ chain', '👨🏿‍💻'],
+  ['whitespace-separated emojis', '😀 🎉'],
+];
+
+const REGULAR_CASES: ReadonlyArray<[label: string, text: string]> = [
+  ['four emojis (above threshold)', '😀🎉🚀✨'],
+  ['mixed text + emoji', 'oi 😀'],
+  ['emoji followed by text', '😀 oi'],
+  ['plain text', 'mensagem normal sem emoji'],
+];
+
+export class Jumbomoji extends MultiUsers {
+  async sendAndMeasureFontSize(text: string): Promise<number> {
+    await this.modPage.fill(e.chatBox, text);
+    await this.modPage.waitAndClick(e.sendButton);
+    const lastMessage = await getLastMessageSent(this.modPage);
+    // .last() still resolves to the PREVIOUS message until the new one renders
+    // (toBeVisible passes instantly on it), so a slow round trip would measure
+    // the wrong message. Waiting for the text pins the measurement to the
+    // message just sent.
+    await expect(lastMessage, `last message should render text "${text}"`).toHaveText(text);
+    // The styled wrapper carrying the $jumbomoji prop is data-test="messageContent" (a div).
+    // We read its computed font-size and let the inner <p> inherit.
+    const container = lastMessage.locator('xpath=ancestor::div[@data-test="messageContent"][1]');
+    const fontSize = await container.evaluate((el) => parseFloat(window.getComputedStyle(el).fontSize));
+    return fontSize;
+  }
+
+  async verifyJumbomoji() {
+    await openPublicChat(this.modPage);
+
+    for (const [label, text] of JUMBO_CASES) {
+      const px = await this.sendAndMeasureFontSize(text);
+      expect(
+        px,
+        `"${label}" (${text}) should render jumbo (font-size > ${JUMBO_MIN_PX}px, got ${px}px)`,
+      ).toBeGreaterThan(JUMBO_MIN_PX);
+    }
+
+    for (const [label, text] of REGULAR_CASES) {
+      const px = await this.sendAndMeasureFontSize(text);
+      expect(
+        px,
+        `"${label}" (${text}) should render regular (font-size ≤ ${JUMBO_MIN_PX}px, got ${px}px)`,
+      ).toBeLessThanOrEqual(JUMBO_MIN_PX);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

When a chat message contains only emoji graphemes (up to 3, ignoring whitespace), render them at `2.5em`. Mirrors the long-standing pattern in Slack, WhatsApp, iMessage, Telegram, Discord and Signal: it makes emoji-only messages far more legible at a glance, and is what most users already expect.

## Implementation

Detection lives in a new helper `text-content/jumbomoji.ts`:

- strips HTML tags and decodes entities from the rendered message (the text arrives as sanitized HTML from the server-side commonmark render), then removes whitespace
- tests the result against a single anchored pattern, `^(emoji grapheme){1,3}$`, where one grapheme is: a regional indicator pair (country flags), a keycap sequence (`1️⃣`), or a `\p{Extended_Pictographic}` base with optional VS16, optional Fitzpatrick skin-tone modifier, and ZWJ chains (family, rainbow flag, `👨🏿‍💻`)

The styled component picks up a `$jumbomoji` transient prop (same pattern used across the codebase) and applies the font-size bump plus a tightened `line-height` so ZWJ sequences with extra vertical extent still fit.

Threshold of 3 graphemes aligns with WhatsApp / iMessage. Anything mixed with text, or 4+ emojis, renders at the regular size.

No new dependencies. Unicode property escapes with the `u` flag are ES2018, the compile target of this codebase. `\p{RGI_Emoji}` (stricter matching) was considered and rejected: it requires the regex `v` flag (ES2024), beyond the current TS target and browser floor, and a runtime-built `v` regex would throw at module load on older browsers. `Intl.Segmenter` was also considered: it would only replace the grapheme counting while still needing a hand-rolled "is this grapheme an emoji" classifier, so it adds a second mechanism without removing the first.

Known limitations (accepted as benign):

- tag-sequence flags (England, Scotland, Wales) render at the regular size (fail-safe direction)
- pictographs with default text presentation sent bare (for example a lone trademark sign) can trigger jumbo; they are rare in chat and render harmlessly

## Test coverage

E2E test in `bigbluebutton-tests/playwright/chat/jumbomoji.ts` (registered in the chat suite, `@ci` tag) sends each case below and asserts the computed `font-size` of the message container: jumbo cases at 35px (2.5 x 14px), regular cases at 14px. The suite ran green against a BBB 4.0 from-source environment.

| Input | Expected |
|---|---|
| `😀` | jumbo |
| `😀🎉🚀` | jumbo |
| `😀 🎉` (whitespace-separated) | jumbo |
| `🇧🇷` (flag) | jumbo |
| `👨‍👩‍👧‍👦` (family ZWJ) | jumbo |
| `❤️` (heart with VS16) | jumbo |
| `1️⃣` (keycap) | jumbo |
| `🏳️‍🌈` (rainbow flag ZWJ) | jumbo |
| `👋🏿` (skin tone) | jumbo |
| `👨🏿‍💻` (skin tone in ZWJ chain) | jumbo |
| `😀🎉🚀✨` (4 emojis) | regular |
| `oi 😀` (text then emoji) | regular |
| `😀 oi` (emoji then text) | regular |
| `mensagem normal sem emoji` | regular |

## Evidence

Animated preview below - click the GIF to open the MP4 (higher quality, with controls):

[![Jumbomoji demo](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-07/ed58da6b-5d5f-44f3-a320-389a61717dfe/jumbomoji-demo.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-07/e420af41-9497-4db0-9a4a-b2a753347fed/jumbomoji-demo.mp4)

Timestamps in the MP4 (recorded on a BBB 4.0 from-source environment):

- **0:08** - sending `😀🎉🚀✨` (4 emojis) - renders **regular** (above threshold)
- **0:10** - sending `oi 😀` - renders **regular** (mixed text + emoji)
- **0:12** - sending `😀` - renders **jumbo**
- **0:14** - sending `🇧🇷` - renders **jumbo** (flag)
- **0:16** - sending `👨‍👩‍👧‍👦` - renders **jumbo** (family ZWJ)
- **0:18** - sending `mensagem normal sem emoji` - renders **regular**