### PR TITLE
fix: Recordings break on nfs

### DIFF
--- a/record-and-playback/notes/scripts/publish/notes.rb
+++ b/record-and-playback/notes/scripts/publish/notes.rb
@@ -129,10 +129,10 @@ begin
       end
 
       BigBlueButton.logger.info("Removing processed files.")
-      FileUtils.rm_r(process_dir)
+      FileUtils.rm_rf(process_dir)
 
       BigBlueButton.logger.info("Removing published files.")
-      FileUtils.rm_r(target_dir)
+      FileUtils.rm_rf(target_dir)
 
       publish_done = File.new("#{recording_dir}/status/published/#{meeting_id}-notes.done", "w")
       publish_done.write("Published #{meeting_id}")

--- a/record-and-playback/podcast/scripts/publish/podcast.rb
+++ b/record-and-playback/podcast/scripts/publish/podcast.rb
@@ -124,10 +124,10 @@ begin
       BigBlueButton.logger.info("Finished publishing script podcast.rb successfully.")
 
       BigBlueButton.logger.info("Removing processed files.")
-      FileUtils.rm_r(process_dir)
+      FileUtils.rm_rf(process_dir)
 
       BigBlueButton.logger.info("Removing published files.")
-      FileUtils.rm_r(target_dir)
+      FileUtils.rm_rf(target_dir)
 
       publish_done = File.new("#{recording_dir}/status/published/#{meeting_id}-podcast.done", "w")
       publish_done.write("Published #{meeting_id}")

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -1522,7 +1522,7 @@ begin
         BigBlueButton.logger.info('Finished publishing script presentation.rb successfully.')
 
         BigBlueButton.logger.info('Removing processed and published files.')
-        FileUtils.rm_r([Dir.glob("#{@process_dir}/*"), Dir.glob("#{target_dir}/*")])
+        FileUtils.rm_rf([Dir.glob("#{@process_dir}/*"), Dir.glob("#{target_dir}/*")])
       rescue StandardError => e
         BigBlueButton.logger.error(e.message)
         e.backtrace.each do |traceline|

--- a/record-and-playback/screenshare/scripts/publish/screenshare.rb
+++ b/record-and-playback/screenshare/scripts/publish/screenshare.rb
@@ -90,7 +90,7 @@ FileUtils.cp_r("#{process_dir}/js", publish_dir)
 FileUtils.cp_r("#{process_dir}/video-js", publish_dir)
 
 logger.info "Cleaning up processed files"
-FileUtils.rm_r(Dir.glob("#{process_dir}/*"))
+FileUtils.rm_rf(Dir.glob("#{process_dir}/*"))
 
 # Create the done file
 File.open(donefile, 'w') do |done|

--- a/record-and-playback/video/scripts/publish/video.rb
+++ b/record-and-playback/video/scripts/publish/video.rb
@@ -143,7 +143,7 @@ FileUtils.cp_r("#{process_dir}/js", publish_dir)
 FileUtils.cp_r("#{process_dir}/video-js", publish_dir)
 
 logger.info 'Cleaning up processed files'
-FileUtils.rm_r(Dir.glob("#{process_dir}/*"))
+FileUtils.rm_rf(Dir.glob("#{process_dir}/*"))
 
 # Create the done file
 File.open(donefile, 'w') do |done|


### PR DESCRIPTION
Some recording scripts use `FileUtils.rm_r` to delete temporary directories, which sometimes fails on NFS with a "Directory not empty" error. Replacing those calls with `FileUtils.rm_rf` fixes the issue.
