### PR TITLE
fix: Talking indicator some letters are cut off

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/talking-indicator/styles.ts
@@ -59,6 +59,7 @@ const TalkingIndicatorButton = styled(Button)`
     text-overflow: ellipsis;
     white-space: nowrap;
     margin: 0 0 0 0 !important;
+    padding-bottom: 1em;
     max-width: ${talkerMaxWidth};
 
     @media ${phoneLandscape} {


### PR DESCRIPTION
### What does this PR do?

Adjusts talking indicator styles so it does not cut letters with descenders

#### before
<img width="206" height="43" alt="Screenshot from 2026-05-19 09-23-24" src="https://github.com/user-attachments/assets/2ee959ed-8608-4315-b1fd-41a02149b9d6" />

#### after
<img width="206" height="43" alt="Screenshot from 2026-05-19 09-21-07" src="https://github.com/user-attachments/assets/23124103-2993-4ceb-909e-2614f606de01" />


### Closes Issue(s)
Closes #25094
