### PR TITLE
fix (html5/bbb-web): Preloading of slides not working for proxy setups

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -207,7 +207,7 @@ const PresentationContainer = (props) => {
         .filter((s) => !fetchedpresentation[presentationId].fetchedSlide[s.svgUrl])
         .map(async (slide) => {
           if (presentation.canFetch) presentation.canFetch = false;
-          const image = await fetch(slide.svgUrl);
+          const image = await fetch(slide.svgUrl, { credentials: 'include' });
           if (image.ok) {
             presentation.fetchedSlide[slide.svgUrl] = true;
           }

--- a/bigbluebutton-web/nginx-confs/presentation-slides.nginx
+++ b/bigbluebutton-web/nginx-confs/presentation-slides.nginx
@@ -19,31 +19,40 @@
 # Have nginx serve the presentation slides instead of tomcat as large files
 # causes tomcat to OOM. (ralam sept 20, 2018)
 
+        # Default CORS origin for presentation assets.
+        # For cluster-proxy setups it can be overridden in /etc/bigbluebutton/nginx/bbb-cluster.nginx
+        if ($bbb_cors_origin = '') {
+                set $bbb_cors_origin '*';
+        }
+
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/svg\/(?<page_num>\d+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type image/svg+xml;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide$page_num.svg;
-                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/pdf\/(?<job_id>[A-Za-z0-9]+)\/annotated_slides.pdf$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type application/pdf;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/pdfs/$job_id/annotated_slides.pdf;
-                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/thumbnail\/(?<page_num>\d+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type image/png;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/thumbnails/thumb-$page_num.png;
-                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
 
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/textfiles\/(?<page_num>\d+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type text/plain;
                 alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/textfiles/slide-$page_num.txt;
-                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
-

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -140,8 +140,8 @@ public:
 ---
 
 Create a new file in `/etc/bigbluebutton/nginx/bbb-cluster.nginx`
-- raplace bbb-proxy.example.com with your proxy for $bbb_cors_origin
-- prepend the mount point of bbb-html5 in all location sections
+- replace `bbb-proxy.example.com` with your proxy origin in `$bbb_cors_origin`
+- prepend the `bbb-html5` mount point in all `location` sections
 
 
 ```

--- a/docs/docs/administration/cluster-proxy.md
+++ b/docs/docs/administration/cluster-proxy.md
@@ -140,9 +140,16 @@ public:
 ---
 
 Create a new file in `/etc/bigbluebutton/nginx/bbb-cluster.nginx`
-and prepend the mount point of bbb-html5 in all location sections:
+- raplace bbb-proxy.example.com with your proxy for $bbb_cors_origin
+- prepend the mount point of bbb-html5 in all location sections
+
 
 ```
+# Enable per-origin CORS
+# Required because the HTML5 client is served from the proxy origin while slides (and other requests)
+# are fetched directly from this BBB node with credentials
+set $bbb_cors_origin 'https://bbb-proxy.example.com';
+
 # running in production (static assets)
 location /bbb-01/html5client {
     gzip_static on;


### PR DESCRIPTION
In proxy setups, slide preloading is currently failing with `401 (Unauthorized)` because slides now require authentication to be fetched by nginx.

To fix this in HTML5, we need to include `{ credentials: 'include' }` in the `fetch()` call.

The second issue is that browsers do not allow credentials to be included when the request is made to a different origin. Because of that, we also need a CORS rule allowing the proxy domain.

I refactored the nginx file so the `Access-Control-Allow-Origin` value comes from a variable. This allows admins to define the value once and have it applied properly across all locations, instead of having to tweak each location individually.

Looking ahead, we will likely need CORS rules for other locations too, such as `shared-notes-server`. For that reason, I recommended in the documentation that admins set the CORS domain as an override in `/etc/bigbluebutton/nginx/bbb-cluster.nginx`. This way, the configuration will not be lost during BBB updates.

By setting the variable there, we can also reuse it in other nginx files. The admin only needs to configure it once, and BBB can take advantage of it wherever needed.