### PR TITLE
fix: drag button with ctrl+z problems

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -14,6 +14,7 @@ import {
   ColorStyleButton,
   FormattingToolbar,
   NestBlockButton,
+  SideMenuController,
   UnnestBlockButton,
   useCreateBlockNote,
 } from '@blocknote/react';
@@ -31,6 +32,7 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
+import FocusRestoredSideMenu from './side-menu-controller/component';
 
 // Force-retain `Awareness` against a webpack tree-shaking interaction that
 // otherwise drops this class while keeping its `extends Observable` expression,
@@ -354,7 +356,9 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
         renderEditor={false}
+        sideMenu={false}
       >
+        <SideMenuController sideMenu={FocusRestoredSideMenu} />
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
           <div ref={toolbarRef} className="bn-toolbar-row">
             <FormattingToolbar>

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -178,6 +178,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   );
 
   const editor = useCreateBlockNote({
+    tabBehavior: 'prefer-indent',
     collaboration: {
       provider: { awareness: hocuspocusProvider.awareness || undefined },
       fragment,

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/side-menu-controller/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/side-menu-controller/component.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable import/extensions */
+import * as React from 'react';
+import { SideMenuExtension } from '@blocknote/core/extensions';
+import '@blocknote/core/fonts/inter.css';
+import '@blocknote/mantine/style.css';
+import {
+  AddBlockButton,
+  DragHandleMenu,
+  SideMenu,
+  useBlockNoteEditor,
+  useComponentsContext,
+  useDictionary,
+  useExtension,
+  useExtensionState,
+} from '@blocknote/react';
+import { MdDragIndicator } from 'react-icons/md';
+
+function FocusingDragHandleButton({
+  children,
+  dragHandleMenu,
+}: { children?: React.ReactNode; dragHandleMenu?: React.FC }) {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const editor = useBlockNoteEditor();
+  const sideMenu = useExtension(SideMenuExtension);
+  const block = useExtensionState(SideMenuExtension, {
+    selector: (state) => state?.block,
+  });
+
+  if (block === undefined) return null;
+
+  const MenuComponent = dragHandleMenu || DragHandleMenu;
+
+  const handleDragEnd = () => {
+    sideMenu.blockDragEnd();
+    setTimeout(() => editor.focus(), 0);
+  };
+
+  return (
+    <Components.Generic.Menu.Root
+      onOpenChange={(open: boolean) => {
+        if (open) {
+          sideMenu.freezeMenu();
+        } else {
+          sideMenu.unfreezeMenu();
+          // Defer focus so the dropdown finishes closing before the editor receives it.
+          setTimeout(() => editor.focus(), 0);
+        }
+      }}
+      position="left"
+    >
+      <Components.Generic.Menu.Trigger>
+        <Components.SideMenu.Button
+          label={dict.side_menu.drag_handle_label}
+          draggable
+          onDragStart={(e) => sideMenu.blockDragStart(e, block)}
+          onDragEnd={handleDragEnd}
+          className="bn-button"
+          icon={<MdDragIndicator size={24} data-test="dragHandle" />}
+        />
+      </Components.Generic.Menu.Trigger>
+      <MenuComponent>{children}</MenuComponent>
+    </Components.Generic.Menu.Root>
+  );
+}
+
+export default function FocusRestoredSideMenu() {
+  return (
+    <SideMenu>
+      <AddBlockButton />
+      <FocusingDragHandleButton />
+    </SideMenu>
+  );
+}


### PR DESCRIPTION
### What does this PR do?

- Replaces BlockNote's default `SideMenu` with a custom `FocusRestoredSideMenu` component that restores editor focus after drag-handle interactions (both on drag end and on menu close). This also fixes Ctrl+Z (undo) breaking after a block is deleted via the drag handle button.
- Changes behavior of tab when multiple lines are selected at once, it prefers to indent the text;

### Motivation

Have better experience when using mostly keyboard.

### How to test

1. Open Shared Notes (BlockNote editor).
2. Hover over a block to reveal the side menu drag handle (⠿ icon).
3. Click the drag handle to open the context menu → select **Delete** → press **Ctrl+Z** → the block should be restored without needing to click back into the editor.
4. Select multiple lines across blocks → press **Tab** → all selected lines should indent.
5. Drag a block to a new position → press **Ctrl+Z** → undo should work without re-clicking the editor.

### More

See demo video ahead

https://github.com/user-attachments/assets/5e2f2221-8607-4205-8a76-e36f373e6dc8

