### PR TITLE
fix(tests): stabilize "Upload multiple presentations" against toast race

### DIFF
--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -353,13 +353,20 @@ export class Presentation extends MultiUsers {
 
     await uploadMultiplePresentations(this.modPage, [e.questionSlideFileName, e.uploadPresentationFileName]);
 
+    // The "current presentation" toast can appear before the slide image DOM swaps,
+    // so poll the moderator until the slide actually changes before comparing across pages.
+    await expect
+      .poll(async () => getSlideOuterHtml(this.modPage), {
+        message: 'moderator slide should change after uploading new presentations',
+        timeout: ELEMENT_WAIT_LONGER_TIME,
+      })
+      .not.toBe(modSlides0);
+
     await expectSlidesEqualBetweenPages(
       this.modPage,
       this.userPage,
       'moderator slide 1 should be equal to the user slide 1',
     );
-    const modSlides1 = await getSlideOuterHtml(this.modPage);
-    await expect(modSlides0, 'moderator slide 0 should not be equal to moderator slide 1').not.toEqual(modSlides1);
   }
 
   async fitToWidthTest() {

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -141,25 +141,15 @@ export async function uploadMultiplePresentations(
     e.presentationUploadProgressToast,
     'should display a toast presentation upload progress after confirming the presentation to be uploaded',
   );
-  try {
-    await testPage.hasNElements(
-      e.processingPresentationItem,
-      fileNames.length,
-      'should display the presentation status info element with converting label after confirmation to upload the new file',
-    );
-
-    await testPage.hasNElements(
-      e.uploadDoneIcon,
-      fileNames.length,
-      'should display the upload done icon after all presentations are successfully uploaded',
-    );
-  } catch {
-    await testPage.hasNElements(
-      e.uploadDoneIcon,
-      fileNames.length,
-      'should display the upload done icon after all presentations are successfully uploaded',
-    );
-  }
+  // Poll row count instead of asserting visibility on transient processing/done icons —
+  // the toast auto-dismisses ~2s after completion and the status span briefly renders 0-height.
+  const uploadItemsLocator = testPage.page.locator(`${e.processingPresentationItem}, ${e.uploadDoneIcon}`);
+  await expect
+    .poll(() => uploadItemsLocator.count(), {
+      message: 'should display one upload row per file in the upload progress toast after confirming the upload',
+      timeout: uploadTimeout,
+    })
+    .toBeGreaterThanOrEqual(fileNames.length);
   await hasCurrentPresentationToastElement(testPage, { timeout: uploadTimeout });
 }
 


### PR DESCRIPTION
- `Upload multiple presentations` flaked on CI: it asserted `toBeVisible` on `:nth-match()` of `processingPresentationItem` / `uploadDoneIcon`, but those rows are transient — the status span briefly renders 0-height between ticks, and the progress toast auto-dismisses ~2s after completion (`TIMEOUT_CLOSE_TOAST` in `presentation-uploader-toast`).
- Replaced the pair of `nth-match` visibility checks with a single `expect.poll` over the combined row count. Upload success is still verified by `hasCurrentPresentationToastElement` and the slide-content change in the caller.

Attempt to avoid:

<img width="2145" height="1535" alt="image" src="https://github.com/user-attachments/assets/01c5de7b-39d8-4fcd-aef3-debe1cd899b8" />
