### PR TITLE
docs: Add some missing properties of manifest.json in the docs

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -188,6 +188,7 @@ Here is a complete `manifest.json` example with all possible configurations:
   "javascriptEntrypointUrl": "MyPlugin.js",
   "javascriptEntrypointIntegrity": "sha384-Bwsz2rxm...", // Optional
   "localesBaseUrl": "https://cdn.domain.com/my-plugin/", // Optional
+  "enabledForBreakoutRooms": false, // Optional, defaults to false
   "loggerSettings": {                                    // Optional
     "console": {
       "enableRuntimeErrorLogging": false,
@@ -282,6 +283,44 @@ public:
           abc: my123
           def: 3234
 ```
+
+**enabledForBreakoutRooms:**
+
+By default, plugins are **not** loaded in breakout rooms. Setting `enabledForBreakoutRooms` to `true` makes the plugin available inside breakout rooms as well as the main room.
+
+```json
+{
+  "enabledForBreakoutRooms": true
+}
+```
+
+When this property is `false` (or omitted), the server filters the plugin out before creating any breakout room, so it never loads for breakout participants.
+
+**javascriptEntrypointIntegrity:**
+
+An optional [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash for the plugin's JavaScript bundle. When present, the browser verifies the fetched file matches the hash before executing it, protecting against tampered or malicious substitutions of the plugin file.
+
+The value must follow the SRI format `<algorithm>-<base64-hash>` (e.g. `sha384-Bwsz2rxm...`).
+
+```json
+{
+  "javascriptEntrypointIntegrity": "sha384-Bwsz2rxm..."
+}
+```
+
+If omitted, no integrity check is performed.
+
+**localesBaseUrl:**
+
+An optional base URL from which the plugin SDK loads locale (i18n) message files for the plugin. This enables internationalization support — the SDK fetches locale files relative to this URL when the client switches languages.
+
+```json
+{
+  "localesBaseUrl": "https://cdn.domain.com/my-plugin/"
+}
+```
+
+If the URL is relative, the server automatically resolves it relative to the manifest's own URL, the same way `javascriptEntrypointUrl` is resolved. If omitted, locale files will not be loaded for the plugin.
 
 ## Examples
 

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -308,6 +308,8 @@ The value must follow the SRI format `<algorithm>-<base64-hash>` (e.g. `sha384-B
 }
 ```
 
+> **Cross-origin limitation:** The plugin loader sets the `integrity` attribute on the `<script>` tag but does **not** set the `crossorigin` attribute. Browsers require both `integrity` and `crossorigin="anonymous"` (plus CORS headers from the server) for SRI checks on cross-origin scripts. Without `crossorigin`, the integrity check will fail for plugins hosted on a different domain (e.g. a CDN). SRI integrity verification therefore only works reliably when the plugin file is served from the **same origin** as the BigBlueButton client. Avoid setting this field for CDN-hosted plugins until cross-origin support is added to the loader.
+
 If omitted, no integrity check is performed.
 
 **localesBaseUrl:**
@@ -320,7 +322,15 @@ An optional base URL from which the plugin SDK loads locale (i18n) message files
 }
 ```
 
-If the URL is relative, the server automatically resolves it relative to the manifest's own URL, the same way `javascriptEntrypointUrl` is resolved. If omitted, locale files will not be loaded for the plugin.
+If the URL is relative (does not start with `http://` or `https://`), the server resolves it by appending it to the directory portion of the manifest URL using plain string concatenation. This means a leading `/` is **not** treated as the site root — it will be concatenated literally, producing a broken URL. Use either an absolute URL or a relative path without a leading `/`:
+
+```json
+{ "localesBaseUrl": "locales/" }       // OK — appended to manifest directory
+{ "localesBaseUrl": "https://cdn.example.com/my-plugin/locales/" } // OK — absolute
+{ "localesBaseUrl": "/locales/" }      // BAD — leading slash breaks the URL
+```
+
+If omitted, locale files will not be loaded for the plugin.
 
 ## Examples
 


### PR DESCRIPTION
### What does this PR do?

Added documentation for the following manifest.json properties:

- enabledForBreakoutRooms;
- localesBaseUrl;
- javascriptEntrypointIntegrity;

### Motivation

There were some properties that weren't documented anywhere, as if they didn't even exist, which caused a bit of a headache to find how they would work, if the would work and even the proper property's name.
