### PR TITLE
fix(recording): Avoid leaking file handles in ruby scripts.

### DIFF
--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -244,9 +244,9 @@ module BigBlueButton
     hasOverride = File.file?(filepathRecOverride)
     
     filepath = File.join(BigBlueButton.rap_scripts_path, 'bigbluebutton.yml')
-    @props = YAML::load(File.open(filepath))
+    @props = YAML::load(File.read(filepath))
     if (hasOverride)
-      recOverrideProps = YAML::load(File.open(filepathRecOverride))
+      recOverrideProps = YAML::load(File.read(filepathRecOverride))
       @props = @props.merge(recOverrideProps)
     end
     @props

--- a/record-and-playback/core/lib/recordandplayback/events_archiver.rb
+++ b/record-and-playback/core/lib/recordandplayback/events_archiver.rb
@@ -24,7 +24,7 @@ require 'yaml'
 require 'fileutils'
 
 module BigBlueButton
-  $bbb_props = YAML::load(File.open(File.expand_path('../../../scripts/bigbluebutton.yml', __FILE__)))
+  $bbb_props = YAML::load(File.read(File.expand_path('../../../scripts/bigbluebutton.yml', __FILE__)))
   $recording_dir = $bbb_props['recording_dir']
   $raw_recording_dir = "#{$recording_dir}/raw"
   $store_recording_status = $bbb_props['store_recording_status']
@@ -252,9 +252,7 @@ module BigBlueButton
       version = BigBlueButton.read_props["bbb_version"]
 
       if File.exist?(events_file)
-        io = File.open(events_file, 'rb')
-        events_doc = Nokogiri::XML::Document.parse(io)
-        io.close
+        events_doc = Nokogiri::XML(File.read(events_file))
         recording = events_doc.at_xpath('/recording')
         if recording.nil?
           raise "recording is nil"

--- a/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/audio_processor.rb
@@ -37,7 +37,7 @@ module BigBlueButton
       BigBlueButton.logger.info("AudioProcessor.process: Processing audio...")
 
       events_xml = "#{archive_dir}/events.xml"
-      events = Nokogiri::XML(File.open(events_xml))
+      events = Nokogiri::XML(File.read(events_xml))
 
       audio_edl = BigBlueButton::AudioEvents.create_audio_edl(events, archive_dir)
       BigBlueButton::EDL::Audio.dump(audio_edl)

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -47,7 +47,7 @@ module BigBlueButton
     # Get the meeting metadata
     def self.get_meeting_metadata(events_xml)
       BigBlueButton.logger.info("Task: Getting meeting metadata")
-      doc = Nokogiri::XML(File.open(events_xml))
+      doc = Nokogiri::XML(File.read(events_xml))
       metadata = {}
       doc.xpath("recording/metadata").each do |e|
         e.keys.each do |k|

--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -29,7 +29,7 @@ module BigBlueButton
     def self.get_presentations(events_xml)
       BigBlueButton.logger.info("Task: Getting presentations from events")      
       presentations = []
-      doc = Nokogiri::XML(File.open(events_xml))
+      doc = Nokogiri::XML(File.read(events_xml))
       doc.xpath("//event[@eventname='SharePresentationEvent']").each do |presentation_event|
         presentations << presentation_event.xpath("presentationName").text
       end
@@ -114,7 +114,7 @@ module BigBlueButton
       events_xml = "#{process_dir}/events.xml"
       BigBlueButton.logger.info("Task: Getting from events the presentation to be used for preview")
       presentation = {}
-      doc = Nokogiri::XML(File.open(events_xml))
+      doc = Nokogiri::XML(File.read(events_xml))
       presentation_filenames = {}
       doc.xpath("//event[@eventname='ConversionCompletedEvent']").each do |conversion_event|
         presentation_filenames[conversion_event.xpath("presentationName").text] = conversion_event.xpath("originalFilename").text

--- a/record-and-playback/core/lib/recordandplayback/generators/video.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/video.rb
@@ -32,7 +32,7 @@ module BigBlueButton
     BigBlueButton.logger.info("Processing webcam videos")
 
     # raw_archive_dir already contains meeting_id
-    events = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+    events = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
 
     # Process user video (camera)
     start_time = BigBlueButton::Events.first_event_timestamp(events)
@@ -96,7 +96,7 @@ module BigBlueButton
     BigBlueButton.logger.info("Processing deskshare videos")
 
     # raw_archive_dir already contains meeting_id
-    events = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+    events = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
 
     start_time = BigBlueButton::Events.first_event_timestamp(events)
     end_time = BigBlueButton::Events.last_event_timestamp(events)

--- a/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/events_worker.rb
@@ -39,7 +39,7 @@ module BigBlueButton
         return unless File.exist?("#{target_dir}/events.xml")
 
         @logger.info("Keeping etherpad events for #{@meeting_id}")
-        events = Nokogiri::XML(File.open("#{target_dir}/events.xml"))
+        events = Nokogiri::XML(File.read("#{target_dir}/events.xml"))
         notes_id = BigBlueButton::Events.get_notes_id(events)
         notes_editor = BigBlueButton::Events.get_notes_editor(events)
         if notes_id.nil? || notes_id.empty? || notes_id == 'undefined'

--- a/record-and-playback/core/scripts/archive/archive.rb
+++ b/record-and-playback/core/scripts/archive/archive.rb
@@ -47,7 +47,7 @@ end
 
 def archive_notes(meeting_id, etherpad_notes_endpoint, bn_notes_endpoint, notes_formats, raw_archive_dir)
   BigBlueButton.logger.info("Archiving notes for #{meeting_id}")
-  events = Nokogiri::XML(File.open("#{raw_archive_dir}/#{meeting_id}/events.xml"))
+  events = Nokogiri::XML(File.read("#{raw_archive_dir}/#{meeting_id}/events.xml"))
   notes_id = BigBlueButton::Events.get_notes_id(events)
   notes_editor = BigBlueButton::Events.get_notes_editor(events)
 
@@ -68,7 +68,7 @@ def archive_notes(meeting_id, etherpad_notes_endpoint, bn_notes_endpoint, notes_
   if File.exist? tmp_note
     # If the notes are empty, do not archive them
     blank = false
-    content = File.open(tmp_note).read
+    content = File.read(tmp_note)
     if content.strip.empty?
       blank = true
     end
@@ -169,7 +169,7 @@ end
 def archive_has_recording_marks?(meeting_id, raw_archive_dir, break_timestamp)
   BigBlueButton.logger.info("Fetching the recording marks for #{meeting_id}.")
 
-  doc = Nokogiri::XML(File.open("#{raw_archive_dir}/#{meeting_id}/events.xml"))
+  doc = Nokogiri::XML(File.read("#{raw_archive_dir}/#{meeting_id}/events.xml"))
 
   # Find the start and stop timestamps for the current recording segment
   start_timestamp = BigBlueButton::Events.get_segment_start_timestamp(

--- a/record-and-playback/core/scripts/bbb-0.9-beta-recording-update
+++ b/record-and-playback/core/scripts/bbb-0.9-beta-recording-update
@@ -4,7 +4,7 @@ require File.expand_path('../../lib/recordandplayback', __FILE__)
 require 'nokogiri'
 require 'optimist'
 
-props = YAML::load(File.open(File.expand_path('../bigbluebutton.yml', __FILE__)))
+props = YAML::load(File.read(File.expand_path('../bigbluebutton.yml', __FILE__)))
 log_dir = props['log_dir']
 raw_recording_dir = "#{props['recording_dir']}/raw"
 published_dir = props['published_dir']
@@ -39,10 +39,7 @@ def do_recording_update(recording_dir, raw_recording_dir)
   BigBlueButton.logger.info("Processing recording #{meeting_id}")
 
   # Read the metadata.xml file to check if the URL needs update
-  metadata_xml = nil
-  File.open("#{recording_dir}/metadata.xml") do |io|
-    metadata_xml = Nokogiri::XML(io)
-  end
+  metadata_xml = Nokogiri::XML(File.read("#{recording_dir}/metadata.xml"))
 
   link_xml = metadata_xml.at_xpath('/recording/playback/link')
   link = link_xml.content
@@ -54,10 +51,7 @@ def do_recording_update(recording_dir, raw_recording_dir)
   end
 
   # Determine which version playback is appropriate for the recording
-  events_xml = nil
-  File.open("#{raw_recording_dir}/#{meeting_id}/events.xml") do |io|
-    events_xml = Nokogiri::XML(io)
-  end
+  events_xml = Nokogiri::XML(File.read("#{raw_recording_dir}/#{meeting_id}/events.xml"))
 
   recording_xml = events_xml.at_xpath('/recording')
   bbb_version = recording_xml['bbb_version']

--- a/record-and-playback/core/scripts/bbb-0.9-recording-size
+++ b/record-and-playback/core/scripts/bbb-0.9-recording-size
@@ -3,7 +3,7 @@
 require File.expand_path('../../lib/recordandplayback', __FILE__)
 require 'optimist'
 
-props = YAML::load(File.open(File.expand_path('../bigbluebutton.yml', __FILE__)))
+props = YAML::load(File.read(File.expand_path('../bigbluebutton.yml', __FILE__)))
 log_dir = props['log_dir']
 raw_recording_dir = "#{props['recording_dir']}/raw"
 published_dir = props['published_dir']

--- a/record-and-playback/core/scripts/bbb-1.1-meeting-tag
+++ b/record-and-playback/core/scripts/bbb-1.1-meeting-tag
@@ -3,7 +3,7 @@
 require File.expand_path('../../lib/recordandplayback', __FILE__)
 require 'optimist'
 
-props = YAML::load(File.open(File.expand_path('../bigbluebutton.yml', __FILE__)))
+props = YAML::load(File.read(File.expand_path('../bigbluebutton.yml', __FILE__)))
 log_dir = props['log_dir']
 published_dir = props['published_dir']
 unpublished_dir = "#{published_dir}/../unpublished"
@@ -40,7 +40,7 @@ def do_update(recording_dir, format_dir)
   BigBlueButton.logger.info("Processing #{format} recording #{meeting_id}")
   
   xml_filename = "#{recording_dir}/metadata.xml"
-  doc = Nokogiri::XML(File.open(xml_filename)) { |x| x.noblanks }
+  doc = Nokogiri::XML(File.read(xml_filename)) { |x| x.noblanks }
   return if ! doc.xpath("/recording/meeting").empty?
 
   node = Nokogiri::XML::Node.new "meeting", doc

--- a/record-and-playback/core/scripts/post_events/post_events.rb.example
+++ b/record-and-playback/core/scripts/post_events/post_events.rb.example
@@ -47,7 +47,7 @@ meeting_id = options[:meeting_id]
 
 # This script lives in scripts/post_events
 # while properties.yaml lives in scripts/
-props = YAML.safe_load(File.open('../../core/scripts/bigbluebutton.yml'))
+props = YAML.safe_load(File.read('../../core/scripts/bigbluebutton.yml'))
 
 recording_dir = props['recording_dir']
 events_dir = props['events_dir']

--- a/record-and-playback/core/scripts/post_events/post_events_analytics_callback.rb
+++ b/record-and-playback/core/scripts/post_events/post_events_analytics_callback.rb
@@ -59,7 +59,7 @@ meeting_id = options[:meeting_id]
 
 # This script lives in scripts/post_events
 # while properties.yaml lives in scripts/
-props = YAML.safe_load(File.open('../../core/scripts/bigbluebutton.yml'))
+props = YAML.safe_load(File.read('../../core/scripts/bigbluebutton.yml'))
 
 recording_dir = props['recording_dir']
 events_dir = props['events_dir']
@@ -145,7 +145,7 @@ begin
   data_json_path = "#{meeting_events_dir}/data.json"
 
   # Only process meetings that include analytics_callback_url
-  events_xml = File.open(events_xml_path, 'r') { |io| Nokogiri::XML(io) }
+  events_xml = Nokogiri::XML(File.read(events_xml_path))
   metadata = events_xml.at_xpath('/recording/metadata')
 
   analytics_callback_url = metadata.attributes['analytics-callback-url']&.content
@@ -176,9 +176,8 @@ begin
     File.open(data_json_path, 'w') do |f|
       f.write(events_data.to_json)
     end
-
-    json_file = File.open(data_json_path)
-    data = JSON.load(json_file)
+    
+    data = JSON.load(File.read(data_json_path))
 
     format_analytics_data!(data)
 

--- a/record-and-playback/core/scripts/rap-caption-inbox.rb
+++ b/record-and-playback/core/scripts/rap-caption-inbox.rb
@@ -30,9 +30,7 @@ require 'yaml'
 
 # Read configuration and set up logger
 
-props = File.open(File.expand_path('bigbluebutton.yml', __dir__)) do |bbb_yml|
-  YAML.safe_load(bbb_yml)
-end
+props = YAML.safe_load(File.read(File.expand_path('bigbluebutton.yml', __dir__)))
 
 logger = Journald::Logger.new('bbb-rap-caption-inbox')
 BigBlueButton.logger = logger
@@ -67,7 +65,7 @@ caption_file_notify = proc do |json_filename|
   # queue job (resque?) that does the actual work.
 
   captions_work_base = File.join(props['recording_dir'], 'caption', 'inbox')
-  new_caption_info = File.open(json_filename) { |file| JSON.parse(file.read) }
+  new_caption_info = JSON.parse(File.read(json_filename))
   record_id = new_caption_info['record_id']
   logger.tag(record_id: record_id) do
     begin
@@ -76,7 +74,7 @@ caption_file_notify = proc do |json_filename|
       index_filename = File.join(captions_dir, record_id, 'captions.json')
       captions_info =
         begin
-          File.open(index_filename) { |file| JSON.parse(file.read) }
+          JSON.parse(File.read(index_filename))
         rescue StandardError
           # No captions file or cannot be read, assume none present
           []

--- a/record-and-playback/core/scripts/rap-process-worker.rb
+++ b/record-and-playback/core/scripts/rap-process-worker.rb
@@ -137,7 +137,7 @@ def post_process(meeting_id)
 end
 
 begin
-  props = YAML::load(File.open('bigbluebutton.yml'))
+  props = YAML::load(File.read('bigbluebutton.yml'))
   redis_host = props['redis_host']
   redis_port = props['redis_port']
   redis_password = props['redis_password']

--- a/record-and-playback/core/scripts/sanity/sanity.rb
+++ b/record-and-playback/core/scripts/sanity/sanity.rb
@@ -51,7 +51,7 @@ logger = BigBlueButton.logger
 def check_events_xml(raw_dir,meeting_id)
   filepath = "#{raw_dir}/#{meeting_id}/events.xml"
   raise Exception,  "Events file doesn't exists." if not File.exists?(filepath)
-  bad_doc = Nokogiri::XML(File.open(filepath)) { |config| config.options = Nokogiri::XML::ParseOptions::STRICT }
+  bad_doc = Nokogiri::XML(File.read(filepath)) { |config| config.options = Nokogiri::XML::ParseOptions::STRICT }
 end
 
 # Determine the filenames for the done and fail files

--- a/record-and-playback/core/scripts/utils/captions.rb
+++ b/record-and-playback/core/scripts/utils/captions.rb
@@ -38,7 +38,7 @@ end
 meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
+props = YAML::load(File.read('../../core/scripts/bigbluebutton.yml'))
 
 recording_dir = props['recording_dir']
 raw_archive_dir = "#{recording_dir}/raw/#{meeting_id}"
@@ -54,7 +54,7 @@ target_dir = "#{recording_dir}/process/presentation/#{meeting_id}"
 def create_api_captions_file(captions_meeting_dir)
   BigBlueButton.logger.info("Generating closed captions for API")
 
-  captions = JSON.load(File.new("#{captions_meeting_dir}/captions_playback.json"))
+  captions = JSON.load(File.read("#{captions_meeting_dir}/captions_playback.json"))
   captions_json = []
   captions.each do |track|
     caption = {}

--- a/record-and-playback/core/test/recordandplayback/generators/test_events.rb
+++ b/record-and-playback/core/test/recordandplayback/generators/test_events.rb
@@ -7,18 +7,10 @@ require 'recordandplayback'
 
 class TestEvents < Minitest::Test
   def setup
-    @events_legacy = File.open('resources/raw/1b199e88-7df7-4842-a5f1-0e84b781c5c8/events.xml') do |io|
-      Nokogiri::XML(io)
-    end
-    @events_chat09 = File.open('resources/raw/chat_0_9.xml') do |io|
-      Nokogiri::XML(io)
-    end
-    @events_devcall = File.open('resources/raw/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/events.xml') do |io|
-      Nokogiri::XML(io)
-    end
-    @events_meta_edt = File.open('resources/raw/2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684/events.xml') do |io|
-      Nokogiri::XML(io)
-    end
+    @events_legacy = Nokogiri::XML(File.read('resources/raw/1b199e88-7df7-4842-a5f1-0e84b781c5c8/events.xml'))
+    @events_chat09 = Nokogiri::XML(File.read('resources/raw/chat_0_9.xml'))
+    @events_devcall = Nokogiri::XML(File.read('resources/raw/183f0bf3a0982a127bdb8161e0c44eb696b3e75c-1630430006889/events.xml'))
+    @events_meta_edt = Nokogiri::XML(File.read('resources/raw/2a1de53edf0543d950056bf3c0d4d357eba3383f-1630607370684/events.xml'))
   end
 
   def test_anonymous_user_map_legacy

--- a/record-and-playback/notes/scripts/process/notes.rb
+++ b/record-and-playback/notes/scripts/process/notes.rb
@@ -38,8 +38,8 @@ end
 meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
-notes_props = YAML::load(File.open('notes.yml'))
+props = YAML::load(File.read('../../core/scripts/bigbluebutton.yml'))
+notes_props = YAML::load(File.read('notes.yml'))
 format = notes_props['format']
 
 recording_dir = props['recording_dir']
@@ -85,7 +85,7 @@ if not FileTest.directory?(target_dir)
     FileUtils.cp(note_file, "#{target_dir}/notes.#{format}")
 
     # Get the real-time start and end timestamp
-    @doc = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+    @doc = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
 
     meeting_start = @doc.xpath("//event")[0][:timestamp]
     meeting_end = @doc.xpath("//event").last()[:timestamp]
@@ -96,7 +96,7 @@ if not FileTest.directory?(target_dir)
 
     # Add start_time, end_time and meta to metadata.xml
     ## Load metadata.xml
-    metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+    metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
     ## Add start_time and end_time
     recording = metadata.root
     ### Date Format for recordings: Thu Mar 04 14:05:56 UTC 2010

--- a/record-and-playback/notes/scripts/publish/notes.rb
+++ b/record-and-playback/notes/scripts/publish/notes.rb
@@ -30,8 +30,8 @@ require 'fastimage' # require fastimage to get the image size of the slides (gem
 
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-bbb_props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
-notes_props = YAML::load(File.open('notes.yml'))
+bbb_props = YAML::load(File.read('../../core/scripts/bigbluebutton.yml'))
+notes_props = YAML::load(File.read('notes.yml'))
 
 opts = Optimist::options do
   opt :meeting_id, "Meeting id to archive", :default => '58f4a6b3-cd07-444d-8564-59116cb53974', :type => String
@@ -73,7 +73,7 @@ begin
         BigBlueButton.logger.info("Copying: #{note_file} to -> #{target_dir}")
         FileUtils.cp(note_file, target_dir)
 
-        @doc = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+        @doc = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
         recording_time = BigBlueButton::Events.get_recording_length(@doc)
 
         BigBlueButton.logger.info("Creating metadata.xml")
@@ -85,7 +85,7 @@ begin
 
         # Update state and add playback to metadata.xml
         ## Load metadata.xml
-        metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+        metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
         ## Update state
         recording = metadata.root
         state = recording.at_xpath("state")

--- a/record-and-playback/podcast/scripts/process/podcast.rb
+++ b/record-and-playback/podcast/scripts/process/podcast.rb
@@ -38,8 +38,8 @@ end
 meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
-podcast_props = YAML::load(File.open('podcast.yml'))
+props = YAML::load(File.read('../../core/scripts/bigbluebutton.yml'))
+podcast_props = YAML::load(File.read('podcast.yml'))
 
 recording_dir = props['recording_dir']
 raw_archive_dir = "#{recording_dir}/raw/#{meeting_id}"
@@ -74,7 +74,7 @@ if not FileTest.directory?(target_dir)
     BigBlueButton::AudioProcessor.process("#{raw_archive_dir}", "#{target_dir}/audio")
 
     # Get the real-time start and end timestamp
-    @doc = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+    @doc = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
 
     meeting_start = @doc.xpath("//event")[0][:timestamp]
     meeting_end = @doc.xpath("//event").last()[:timestamp]
@@ -86,7 +86,7 @@ if not FileTest.directory?(target_dir)
 
     # Add start_time, end_time and meta to metadata.xml
     ## Load metadata.xml
-    metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+    metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
     ## Add start_time and end_time
     recording = metadata.root
     ### Date Format for recordings: Thu Mar 04 14:05:56 UTC 2010

--- a/record-and-playback/podcast/scripts/publish/podcast.rb
+++ b/record-and-playback/podcast/scripts/publish/podcast.rb
@@ -30,8 +30,8 @@ require 'fastimage' # require fastimage to get the image size of the slides (gem
 
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
-bbb_props = YAML::load(File.open('../../core/scripts/bigbluebutton.yml'))
-podcast_props = YAML::load(File.open('podcast.yml'))
+bbb_props = YAML::load(File.read('../../core/scripts/bigbluebutton.yml'))
+podcast_props = YAML::load(File.read('podcast.yml'))
 
 opts = Optimist::options do
   opt :meeting_id, "Meeting id to archive", :default => '58f4a6b3-cd07-444d-8564-59116cb53974', :type => String
@@ -70,7 +70,7 @@ begin
       BigBlueButton.logger.info("copying: #{process_dir}/audio.ogg to -> #{target_dir}")
       FileUtils.cp("#{process_dir}/audio.ogg", target_dir)
 
-      @doc = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+      @doc = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
       recording_time = BigBlueButton::Events.get_recording_length(@doc)
 
       BigBlueButton.logger.info("Creating metadata.xml")
@@ -82,7 +82,7 @@ begin
 
       # Update state and add playback to metadata.xml
       ## Load metadata.xml
-      metadata = Nokogiri::XML(File.open("#{target_dir}/metadata.xml"))
+      metadata = Nokogiri::XML(File.read("#{target_dir}/metadata.xml"))
       ## Update state
       recording = metadata.root
       state = recording.at_xpath("state")

--- a/record-and-playback/presentation/scripts/caption/presentation
+++ b/record-and-playback/presentation/scripts/caption/presentation
@@ -40,17 +40,13 @@ end
 
 # Read configuration and set up logger
 
-props = File.open(File.expand_path('../bigbluebutton.yml', __dir__)) do |bbb_yml|
-  YAML.safe_load(bbb_yml)
-end
-presentation_props = File.open(File.expand_path('../presentation.yml', __dir__)) do |pres_yml|
-  YAML.safe_load(pres_yml)
-end
+props = YAML.safe_load(File.read(File.expand_path('../bigbluebutton.yml', __dir__)))
+presentation_props = YAML.safe_load(File.read(File.expand_path('../presentation.yml', __dir__)))
 
 filepathPresOverride = "/etc/bigbluebutton/recording/presentation.yml"
 isThereOverride = File.file?(filepathPresOverride)
 if (isThereOverride)
-  presOverrideProps = YAML::load(File.open(filepathPresOverride))
+  presOverrideProps = YAML::load(File.read(filepathPresOverride))
   presentation_props = presentation_props.merge(presOverrideProps)
 end
 
@@ -75,9 +71,7 @@ end
 begin
   logger.info('Loading recording playback captions list')
   playback_captions_path = File.join(publish_dir, recording_id, 'captions.json')
-  playback_captions = File.open(playback_captions_path) do |json|
-    JSON.parse(json.read)
-  end
+  playback_captions = JSON.parse(File.read(playback_captions_path))
 rescue Errno::ENOENT
   logger.info("Playback doesn't have a captions.json - old playback format version?")
   logger.info('Triggering recording reprocessing.')
@@ -93,9 +87,7 @@ end
 begin
   logger.info('Loading captions index file')
   captions_path = File.join(captions_dir, recording_id, 'captions.json')
-  captions = File.open(captions_path) do |json|
-    JSON.parse(json.read)
-  end
+  captions = JSON.parse(File.read(captions_path))
 rescue Errno::ENOENT
   captions = []
 end

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -40,11 +40,11 @@ meeting_id = opts[:meeting_id]
 
 # This script lives in scripts/archive/steps while properties.yaml lives in scripts/
 props = BigBlueButton.read_props
-presentation_props = YAML.safe_load(File.open('presentation.yml'))
+presentation_props = YAML.safe_load(File.read('presentation.yml'))
 filepathPresOverride = "/etc/bigbluebutton/recording/presentation.yml"
 hasOverride = File.file?(filepathPresOverride)
 if (hasOverride)
-  presOverrideProps = YAML::load(File.open(filepathPresOverride))
+  presOverrideProps = YAML::load(File.read(filepathPresOverride))
   presentation_props = presentation_props.merge(presOverrideProps)
 end
 

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -39,7 +39,7 @@ bbb_props = BigBlueButton.read_props
 filepathPresOverride = "/etc/bigbluebutton/recording/presentation.yml"
 hasOverride = File.file?(filepathPresOverride)
 if (hasOverride)
-  presOverrideProps = YAML::load(File.open(filepathPresOverride))
+  presOverrideProps = YAML::load(File.read(filepathPresOverride))
   @presentation_props = @presentation_props.merge(presOverrideProps)
 end
 

--- a/record-and-playback/screenshare/scripts/process/screenshare.rb
+++ b/record-and-playback/screenshare/scripts/process/screenshare.rb
@@ -40,8 +40,8 @@ begin
 end
 
 # Load parameters and set up paths
-props = YAML::load(File.open(File.expand_path('../../bigbluebutton.yml', __FILE__)))
-screenshare_props = YAML::load(File.open(File.expand_path('../../screenshare.yml', __FILE__)))
+props = YAML::load(File.read(File.expand_path('../../bigbluebutton.yml', __FILE__)))
+screenshare_props = YAML::load(File.read(File.expand_path('../../screenshare.yml', __FILE__)))
 
 recording_dir = props['recording_dir']
 playback_dir = screenshare_props['playback_dir']
@@ -67,7 +67,7 @@ begin
 FileUtils.mkdir_p(process_dir)
 
 logger.info "Reading basic recording information"
-events = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+events = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
 initial_timestamp = nil
 final_timestamp = nil
 metadata = events.at_xpath('/recording/metadata')
@@ -164,7 +164,7 @@ ret = BigBlueButton.exec_ret('utils/gen_webvtt', '-i', raw_archive_dir, '-o', pr
 if ret != 0
   raise "Generating closed caption files failed"
 end
-captions = JSON.load(File.new("#{process_dir}/captions.json", 'r'))
+captions = JSON.load(File.read("#{process_dir}/captions.json"))
 
 # Publishing support files
 

--- a/record-and-playback/screenshare/scripts/publish/screenshare.rb
+++ b/record-and-playback/screenshare/scripts/publish/screenshare.rb
@@ -37,8 +37,8 @@ if playback != 'screenshare'
 end
 
 # Load parameters and set up paths
-props = YAML::load(File.open(File.expand_path('../../bigbluebutton.yml', __FILE__)))
-screenshare_props = YAML::load(File.open(File.expand_path('../../screenshare.yml', __FILE__)))
+props = YAML::load(File.read(File.expand_path('../../bigbluebutton.yml', __FILE__)))
+screenshare_props = YAML::load(File.read(File.expand_path('../../screenshare.yml', __FILE__)))
 
 process_dir = "#{props['recording_dir']}/process/screenshare/#{meeting_id}"
 publish_dir = "#{screenshare_props['publish_dir']}/#{meeting_id}"
@@ -74,7 +74,7 @@ screenshare_props['formats'].each_with_index do |format, i|
 end
 
 # Captions files
-captions = JSON.load(File.new("#{process_dir}/captions.json", 'r'))
+captions = JSON.load(File.read("#{process_dir}/captions.json"))
 FileUtils.cp("#{process_dir}/captions.json", "#{publish_dir}/captions.json")
 captions.each do |caption|
   FileUtils.cp("#{process_dir}/caption_#{caption['locale']}.vtt",

--- a/record-and-playback/video/scripts/process/video.rb
+++ b/record-and-playback/video/scripts/process/video.rb
@@ -42,13 +42,9 @@ end
 
 # Load parameters and set up paths
 props = BigBlueButton.read_props
-video_props = File.open(File.expand_path('../video.yml', __dir__)) do |video_props_file|
-  YAML.safe_load(video_props_file)
-end
+video_props = YAML.safe_load(File.read(File.expand_path('../video.yml', __dir__)))
 begin
-  video_props_override = File.open('/etc/bigbluebutton/recording/video.yml') do |video_props_override_file|
-    YAML.safe_load(video_props_override_file)
-  end
+  video_props_override = YAML.safe_load(File.read('/etc/bigbluebutton/recording/video.yml'))
   # Merge the presets separately, to allow someone to use the override file to add additional presets
   if video_props.include?('presets') && video_props_override.include?('presets')
     video_props['presets'].merge!(video_props_override.delete('presets'))
@@ -77,7 +73,7 @@ end
 FileUtils.mkdir_p process_dir
 
 logger.info 'Reading basic recording information'
-events = Nokogiri::XML(File.open("#{raw_archive_dir}/events.xml"))
+events = Nokogiri::XML(File.read("#{raw_archive_dir}/events.xml"))
 initial_timestamp = BigBlueButton::Events.first_event_timestamp(events)
 final_timestamp = BigBlueButton::Events.last_event_timestamp(events)
 duration = BigBlueButton::Events.get_recording_length(events)

--- a/record-and-playback/video/scripts/publish/video.rb
+++ b/record-and-playback/video/scripts/publish/video.rb
@@ -38,13 +38,9 @@ end
 
 # Load parameters and set up paths
 props = BigBlueButton.read_props
-video_props = File.open(File.expand_path('../video.yml', __dir__)) do |video_props_file|
-  YAML.safe_load(video_props_file)
-end
+video_props = YAML.safe_load(File.read(File.expand_path('../video.yml', __dir__)))
 begin
-  video_props_override = File.open('/etc/bigbluebutton/recording/video.yml') do |video_props_override_file|
-    YAML.safe_load(video_props_override_file)
-  end
+  video_props_override = YAML.safe_load(File.read('/etc/bigbluebutton/recording/video.yml'))
   # Merge the presets separately, to allow someone to use the override file to add additional presets
   if video_props.include?('presets') && video_props_override.include?('presets')
     video_props['presets'].merge!(video_props_override.delete('presets'))
@@ -70,9 +66,7 @@ unless File.exist?(process_donefile)
   exit 1
 end
 
-metadata_xml = File.open("#{process_dir}/metadata.xml") do |io|
-  Nokogiri::XML(io)
-end
+metadata_xml = Nokogiri::XML(File.read("#{process_dir}/metadata.xml"))
 meta = metadata_xml.at_xpath('/recording/meta')
 unless meta
   logger.error('Recording metadata.xml is missing <meta> element')


### PR DESCRIPTION
Second attempt at fixing recording processing on NFS file systems.

See #9857 and for an #10984 for context.

Work in progress and untested!

### What does this PR do?

When File.open() is used without a code block, the file handle stays open until closed explicitly. Leaked file handles can cause issues on some file systems (e.g. NFS) when cleanup logic tries to delete the parent directory.

This patch replaces all obvious read-only uses of `File.open()` with `File.read()`.

### Closes Issue(s)
Replaces #24772

