### PR TITLE
Tests: add Unified Layout minimize regression tests

### DIFF
--- a/bigbluebutton-tests/playwright/core/helpers.ts
+++ b/bigbluebutton-tests/playwright/core/helpers.ts
@@ -36,6 +36,7 @@ interface InitOptions {
   createParameter?: string;
   joinParameter?: string;
   testInfo?: TestInfo;
+  recordVideo?: boolean;
 }
 
 interface GetJoinUrlProp {
@@ -305,8 +306,8 @@ export async function initializePages(
   browser: Browser,
   initOptions?: InitOptions,
 ): Promise<void> {
-  const { isMultiUser, createParameter, joinParameter, testInfo } = initOptions || {};
-  const context = await browser.newContext();
+  const { isMultiUser, createParameter, joinParameter, testInfo, recordVideo } = initOptions || {};
+  const context = await browser.newContext(recordVideo ? { recordVideo: { dir: 'test-results/' } } : {});
   const page = await context.newPage();
   await testInstance.initModPage(page, { createParameter, joinParameter, testInfo });
   if (isMultiUser) await testInstance.initUserPage(context, { createParameter, joinParameter, testInfo });

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -1,6 +1,95 @@
+import { elements as e } from '../core/elements';
 import { initializePages } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
 import { Layouts } from './layouts';
+
+test.describe.parallel('Unified Layout - meeting create param', () => {
+  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+    const layouts = new Layouts(browser, context);
+    await initializePages(layouts, browser, {
+      isMultiUser: true,
+      createParameter: 'meetingLayout=UNIFIED_LAYOUT',
+      testInfo,
+      recordVideo: true,
+    });
+    await layouts.unifiedLayoutMinimizeShowsTiles();
+  });
+});
+
+test.describe.parallel('Unified Layout - join param', () => {
+  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+    const layouts = new Layouts(browser, context);
+    await initializePages(layouts, browser, {
+      isMultiUser: true,
+      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
+      testInfo,
+      recordVideo: true,
+    });
+    await layouts.unifiedLayoutMinimizeShowsTiles();
+  });
+});
+
+test.describe.parallel('Unified Layout - concurrent user join', () => {
+  test('Minimize concurrent with user joining shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+    const layouts = new Layouts(browser, context);
+    // Only moderator joins initially — the user join happens inside the test method,
+    // overlapping with the minimize click to surface the race condition.
+    await initializePages(layouts, browser, {
+      isMultiUser: false,
+      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
+      testInfo,
+      recordVideo: true,
+    });
+    await layouts.unifiedLayoutMinimizeConcurrentWithUserJoin();
+  });
+});
+
+test.describe.parallel('Unified Layout - meeting create param - with audio', () => {
+  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+    const layouts = new Layouts(browser, context);
+    await initializePages(layouts, browser, {
+      isMultiUser: false,
+      createParameter: 'meetingLayout=UNIFIED_LAYOUT',
+      testInfo,
+      recordVideo: true,
+    });
+    await layouts.modPage.waitAndClick(e.joinAudio);
+    await layouts.modPage.joinMicrophone({ shouldUnmute: false });
+    await layouts.initUserPage();
+    await layouts.unifiedLayoutMinimizeShowsTiles();
+  });
+});
+
+test.describe.parallel('Unified Layout - join param - with audio', () => {
+  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+    const layouts = new Layouts(browser, context);
+    await initializePages(layouts, browser, {
+      isMultiUser: false,
+      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
+      testInfo,
+      recordVideo: true,
+    });
+    await layouts.modPage.waitAndClick(e.joinAudio);
+    await layouts.modPage.joinMicrophone({ shouldUnmute: false });
+    await layouts.initUserPage(undefined, { joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT' });
+    await layouts.unifiedLayoutMinimizeShowsTiles();
+  });
+});
+
+test.describe.parallel('Unified Layout - concurrent user join - with audio', () => {
+  test('Minimize concurrent with user joining shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+    const layouts = new Layouts(browser, context);
+    await initializePages(layouts, browser, {
+      isMultiUser: false,
+      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
+      testInfo,
+      recordVideo: true,
+    });
+    await layouts.modPage.waitAndClick(e.joinAudio);
+    await layouts.modPage.joinMicrophone({ shouldUnmute: false });
+    await layouts.unifiedLayoutMinimizeConcurrentWithUserJoin();
+  });
+});
 
 test.describe.parallel('Layout', { tag: '@ci' }, () => {
   let layouts: Layouts;

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -16,34 +16,6 @@ test.describe.parallel('Unified Layout - meeting create param', () => {
   });
 });
 
-test.describe.parallel('Unified Layout - join param', () => {
-  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
-    const layouts = new Layouts(browser, context);
-    await initializePages(layouts, browser, {
-      isMultiUser: true,
-      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
-      testInfo,
-      recordVideo: true,
-    });
-    await layouts.unifiedLayoutMinimizeShowsTiles();
-  });
-});
-
-test.describe.parallel('Unified Layout - concurrent user join', () => {
-  test('Minimize concurrent with user joining shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
-    const layouts = new Layouts(browser, context);
-    // Only moderator joins initially — the user join happens inside the test method,
-    // overlapping with the minimize click to surface the race condition.
-    await initializePages(layouts, browser, {
-      isMultiUser: false,
-      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
-      testInfo,
-      recordVideo: true,
-    });
-    await layouts.unifiedLayoutMinimizeConcurrentWithUserJoin();
-  });
-});
-
 test.describe.parallel('Unified Layout - meeting create param - with audio', () => {
   test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
     const layouts = new Layouts(browser, context);
@@ -57,37 +29,6 @@ test.describe.parallel('Unified Layout - meeting create param - with audio', () 
     await layouts.modPage.joinMicrophone({ shouldUnmute: false });
     await layouts.initUserPage();
     await layouts.unifiedLayoutMinimizeShowsTiles();
-  });
-});
-
-test.describe.parallel('Unified Layout - join param - with audio', () => {
-  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
-    const layouts = new Layouts(browser, context);
-    await initializePages(layouts, browser, {
-      isMultiUser: false,
-      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
-      testInfo,
-      recordVideo: true,
-    });
-    await layouts.modPage.waitAndClick(e.joinAudio);
-    await layouts.modPage.joinMicrophone({ shouldUnmute: false });
-    await layouts.initUserPage(undefined, { joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT' });
-    await layouts.unifiedLayoutMinimizeShowsTiles();
-  });
-});
-
-test.describe.parallel('Unified Layout - concurrent user join - with audio', () => {
-  test('Minimize concurrent with user joining shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
-    const layouts = new Layouts(browser, context);
-    await initializePages(layouts, browser, {
-      isMultiUser: false,
-      joinParameter: 'userdata-bbb_change_layout=UNIFIED_LAYOUT',
-      testInfo,
-      recordVideo: true,
-    });
-    await layouts.modPage.waitAndClick(e.joinAudio);
-    await layouts.modPage.joinMicrophone({ shouldUnmute: false });
-    await layouts.unifiedLayoutMinimizeConcurrentWithUserJoin();
   });
 });
 

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -251,4 +251,81 @@ export class Layouts extends MultiUsers {
     await this.userPage.hasElementCount(e.webcamVideoItem, 2, 'should display 2 webcams for the attendee');
     await checkScreenshots(this, 'pagination should work for the attendees', 'video', 'pagination-second-page');
   }
+
+  private async attachPageVideos() {
+    const testInfo = this.modPage.testInfo;
+    if (!testInfo) return;
+
+    // Register future video paths without closing anything — Playwright's fixture
+    // teardown closes the context, which writes the .webm files, and the reporter
+    // then finds them via these registered paths.
+    const modVideoPath = await this.modPage.page.video()?.path();
+    if (modVideoPath) {
+      testInfo.attachments.push({ name: 'Moderator screen recording', contentType: 'video/webm', path: modVideoPath });
+    }
+
+    const userVideoPath = this.userPage ? await this.userPage.page.video()?.path() : undefined;
+    if (userVideoPath) {
+      testInfo.attachments.push({ name: 'Attendee screen recording', contentType: 'video/webm', path: userVideoPath });
+    }
+  }
+
+  async unifiedLayoutMinimizeConcurrentWithUserJoin() {
+    await this.modPage.waitForSelector(e.whiteboard);
+
+    // Start the user join without awaiting — this fires the join request in the background
+    // while the moderator clicks minimize, overlapping the user-joined GraphQL event with
+    // the layout push that sets currentLayoutType=UNIFIED_LAYOUT and presentationMinimized=true.
+    const userJoinPromise = this.initUserPage(this.modPage.context);
+
+    // Click minimize immediately, concurrent with the user join in progress
+    await this.modPage.waitAndClick(e.minimizePresentation);
+
+    // Wait for user to fully join, then let any race condition settle
+    await userJoinPromise;
+    await this.modPage.page.waitForTimeout(3000);
+
+    await this.modPage.wasRemoved(
+      e.presentationContainer,
+      'presentation should remain hidden for moderator after minimize concurrent with user join in unified layout',
+    );
+    await this.modPage.hasElement(
+      e.restorePresentation,
+      'restore presentation button should be visible for moderator after minimize concurrent with user join in unified layout',
+    );
+    await this.modPage.hasElement(
+      e.cameraDock,
+      'camera dock with participant tiles should be visible for moderator after minimizing concurrent with user join in unified layout',
+    );
+
+    await this.attachPageVideos();
+  }
+
+  async unifiedLayoutMinimizeShowsTiles() {
+    // Wait for the whiteboard canvas to confirm the presentation is fully loaded and
+    // the minimize button is in an enabled/clickable state (isThereCurrentPresentation = true).
+    await this.modPage.waitForSelector(e.whiteboard);
+
+    await this.modPage.waitAndClick(e.minimizePresentation);
+    // Allow the server round-trip that triggers the race condition (layout push → GraphQL
+    // subscription → hasMeetingLayout: false→true → first useEffect re-fires) to settle.
+    await this.modPage.page.waitForTimeout(3000);
+
+    // Regression: the race condition reset presentationIsOpen=true for the presenter,
+    // hiding the camera dock. The moderator must see the camera dock after minimize.
+    await this.modPage.wasRemoved(
+      e.presentationContainer,
+      'presentation should remain hidden for moderator after the layout push settles in unified layout',
+    );
+    await this.modPage.hasElement(
+      e.restorePresentation,
+      'restore presentation button should be visible for moderator in unified layout after minimize',
+    );
+    await this.modPage.hasElement(
+      e.cameraDock,
+      'camera dock with participant tiles should be visible for moderator after minimizing in unified layout',
+    );
+
+    await this.attachPageVideos();
+  }
 }

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -270,37 +270,6 @@ export class Layouts extends MultiUsers {
     }
   }
 
-  async unifiedLayoutMinimizeConcurrentWithUserJoin() {
-    await this.modPage.waitForSelector(e.whiteboard);
-
-    // Start the user join without awaiting — this fires the join request in the background
-    // while the moderator clicks minimize, overlapping the user-joined GraphQL event with
-    // the layout push that sets currentLayoutType=UNIFIED_LAYOUT and presentationMinimized=true.
-    const userJoinPromise = this.initUserPage(this.modPage.context);
-
-    // Click minimize immediately, concurrent with the user join in progress
-    await this.modPage.waitAndClick(e.minimizePresentation);
-
-    // Wait for user to fully join, then let any race condition settle
-    await userJoinPromise;
-    await this.modPage.page.waitForTimeout(3000);
-
-    await this.modPage.wasRemoved(
-      e.presentationContainer,
-      'presentation should remain hidden for moderator after minimize concurrent with user join in unified layout',
-    );
-    await this.modPage.hasElement(
-      e.restorePresentation,
-      'restore presentation button should be visible for moderator after minimize concurrent with user join in unified layout',
-    );
-    await this.modPage.hasElement(
-      e.cameraDock,
-      'camera dock with participant tiles should be visible for moderator after minimizing concurrent with user join in unified layout',
-    );
-
-    await this.attachPageVideos();
-  }
-
   async unifiedLayoutMinimizeShowsTiles() {
     // Wait for the whiteboard canvas to confirm the presentation is fully loaded and
     // the minimize button is in an enabled/clickable state (isThereCurrentPresentation = true).


### PR DESCRIPTION
### What does this PR do?
Adds Playwright regression tests for the UNIFIED_LAYOUT minimize race condition, covering all entry points: meetingLayout=UNIFIED_LAYOUT create param.
  Each variant is duplicated with the moderator joining audio muted before the attendee, to match the described reproduction steps.


### Closes Issue(s)
Related to #25095

### More
Mod View:

[Moderator screen recording.webm](https://github.com/user-attachments/assets/581575d8-d84f-4a27-800b-d80d39516cf4)

Viewer View:

[Attendee screen recording.webm](https://github.com/user-attachments/assets/1ba0dae2-35b7-4ad5-8f3e-209d6549b959)

