### PR TITLE
feat(accessibility): add Esc shortcut to move focus in/out of the BlockNote shared notes editor

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -19,6 +19,7 @@ import {
   useComponentsContext,
   useCreateBlockNote,
 } from '@blocknote/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { Menu as MantineMenu } from '@mantine/core';
 
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
@@ -123,12 +124,12 @@ const AccessibleMenuRoot: React.FC<{
   children: React.ReactNode;
   onOpenChange?: (open: boolean) => void;
   position?: string;
-  sub?: boolean;
-// eslint-disable-next-line react/prop-types
 }> = ({ children, onOpenChange, position }) => (
   <MantineMenu
     withinPortal={false}
-    middlewares={{ flip: true, shift: true, inline: false, size: true }}
+    middlewares={{
+      flip: true, shift: true, inline: false, size: true,
+    }}
     trapFocus={false}
     onChange={onOpenChange}
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -454,6 +455,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           <ToolbarWithAccessibleMenus>
             <div
               ref={toolbarRef}
+              role="toolbar"
               className="bn-toolbar-row"
               onKeyDown={(e) => { if (e.key === 'Escape') editor.focus(); }}
             >

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -67,6 +67,18 @@ const createMaxDocumentCharsExtension = (
 // The left margin of the table Block as the first block is buggy when used with static toolbar;
 // ideally the fix would come from BlockNote
 // (wait for https://github.com/TypeCellOS/BlockNote/issues/2748 to be resolved)
+const escapeBlurExtension = Extension.create({
+  name: 'bbbEscapeBlur',
+  addKeyboardShortcuts() {
+    return {
+      Escape: () => {
+        this.editor.commands.blur();
+        return true;
+      },
+    };
+  },
+});
+
 // TODO: After the issue on BlockNote is resolved, update BlockNote and remove the
 // fixCursorAtOriginExtension and the fixCursorAtOriginPluginKey
 const fixCursorAtOriginPluginKey = new PluginKey('fixCursorAtOrigin');
@@ -197,7 +209,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
       },
     },
     _tiptapOptions: {
-      extensions: [maxDocumentCharsExtension, fixCursorAtOriginExtension],
+      extensions: [maxDocumentCharsExtension, fixCursorAtOriginExtension, escapeBlurExtension],
     },
     pasteHandler: ({ event, defaultPasteHandler }) => {
       try {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -12,11 +12,14 @@ import {
   BlockNoteViewEditor,
   BlockTypeSelect,
   ColorStyleButton,
+  ComponentsContext,
   FormattingToolbar,
   NestBlockButton,
   UnnestBlockButton,
+  useComponentsContext,
   useCreateBlockNote,
 } from '@blocknote/react';
+import { Menu as MantineMenu } from '@mantine/core';
 
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
@@ -113,6 +116,43 @@ const intlMessages = defineMessages({
     description: 'Error message for when number of typed characters exceeds the maximum',
   },
 });
+
+// Mantine's Menu defaults to trapFocus:true, trapping Tab inside open dropdowns.
+// Replace Generic.Menu.Root with this to let Tab exit the menu (WAI-ARIA pattern).
+const AccessibleMenuRoot: React.FC<{
+  children: React.ReactNode;
+  onOpenChange?: (open: boolean) => void;
+  position?: string;
+  sub?: boolean;
+// eslint-disable-next-line react/prop-types
+}> = ({ children, onOpenChange, position }) => (
+  <MantineMenu
+    withinPortal={false}
+    middlewares={{ flip: true, shift: true, inline: false, size: true }}
+    trapFocus={false}
+    onChange={onOpenChange}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    position={position as any}
+    returnFocus={false}
+  >
+    {children}
+  </MantineMenu>
+);
+
+// Patches ComponentsContext so every Generic.Menu.Root in the toolbar uses
+// AccessibleMenuRoot — fixes both ColorStyleButton and TextAlignSelect.
+function ToolbarWithAccessibleMenus({ children }: { children: React.ReactNode }) {
+  const components = useComponentsContext()!;
+  const patchedComponents = React.useMemo(() => ({
+    ...components,
+    Generic: {
+      ...components.Generic,
+      Menu: { ...components.Generic.Menu, Root: AccessibleMenuRoot },
+    },
+  }), [components]);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return <ComponentsContext.Provider value={patchedComponents as any}>{children}</ComponentsContext.Provider>;
+}
 
 interface BlockNoteAppProps {
   hocuspocusProvider: HocuspocusProvider;
@@ -411,21 +451,27 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
-          <div ref={toolbarRef} className="bn-toolbar-row">
-            <FormattingToolbar>
-              <BlockTypeSelect key="blockTypeSelect" />
-              <BasicTextStyleButton basicTextStyle="bold" key="boldStyleButton" />
-              <BasicTextStyleButton basicTextStyle="italic" key="italicStyleButton" />
-              <BasicTextStyleButton basicTextStyle="underline" key="underlineStyleButton" />
-              <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
-            </FormattingToolbar>
-            <FormattingToolbar>
-              <ColorStyleButton key="colorStyleButton" />
-              <TextAlignSelect key="textAlignSelect" />
-              <NestBlockButton key="nestBlockButton" />
-              <UnnestBlockButton key="unnestBlockButton" />
-            </FormattingToolbar>
-          </div>
+          <ToolbarWithAccessibleMenus>
+            <div
+              ref={toolbarRef}
+              className="bn-toolbar-row"
+              onKeyDown={(e) => { if (e.key === 'Escape') editor.focus(); }}
+            >
+              <FormattingToolbar>
+                <BlockTypeSelect key="blockTypeSelect" />
+                <BasicTextStyleButton basicTextStyle="bold" key="boldStyleButton" />
+                <BasicTextStyleButton basicTextStyle="italic" key="italicStyleButton" />
+                <BasicTextStyleButton basicTextStyle="underline" key="underlineStyleButton" />
+                <BasicTextStyleButton basicTextStyle="strike" key="strikeStyleButton" />
+              </FormattingToolbar>
+              <FormattingToolbar>
+                <ColorStyleButton key="colorStyleButton" />
+                <TextAlignSelect key="textAlignSelect" />
+                <NestBlockButton key="nestBlockButton" />
+                <UnnestBlockButton key="unnestBlockButton" />
+              </FormattingToolbar>
+            </div>
+          </ToolbarWithAccessibleMenus>
         )}
         <BlockNoteViewEditor />
       </BlockNoteView>


### PR DESCRIPTION
### What does this PR do?

Implements the following accessibility improvements in BlockNote shared notes:
- adds `Esc` keyboard shortcut to remove focus on the editor, matching the behavior of the Etherpad shared notes
- pressing `Esc` while focus is on block note toolbar calls editor.focus(), returning the user to the editor.

