### PR TITLE
perf (html5): Improve video stream queries for server performance

### DIFF
--- a/bbb-graphql-server/bbb-graphql-schema.md
+++ b/bbb-graphql-server/bbb-graphql-schema.md
@@ -89,9 +89,11 @@ Permission: Restricted to User Viewing Self-Related Data
 - `isDialIn`
 - `isModerator`
 - `isRunningEchoTest`
+- `isSharingCamera`
 - `joinErrorCode`
 - `joinErrorMessage`
 - `joined`
+- `lastFloorTime`
 - `lastName`
 - `lastNameSortable`
 - `locked`
@@ -211,7 +213,9 @@ Permission: Restricted by Lock Settings
 - `isDialIn`
 - `isModerator`
 - `isRunningEchoTest`
+- `isSharingCamera`
 - `joined`
+- `lastFloorTime`
 - `lastName`
 - `lastNameSortable`
 - `locked`

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -305,10 +305,12 @@ CREATE UNLOGGED TABLE "user" (
 	"inactivityWarningTimeoutSecs" numeric,
 	"whiteboardWriteAccess" bool default FALSE,
 	"echoTestRunningAt" timestamp with time zone,
+	"lastFloorTime" varchar(25), --replicated from user_voice via trigger
+	"camerasCount" integer default 0, --maintained from user_camera via trigger
 	CONSTRAINT "user_pkey" PRIMARY KEY ("meetingId","userId"),
 	FOREIGN KEY ("meetingId", "guestStatusSetByModerator") REFERENCES "user"("meetingId","userId") ON DELETE SET NULL
 );
-CREATE INDEX "idx_user_pk_reverse" on "user" ("userId", "meetingId");
+CREATE INDEX "idx_user_pk_reverse" on "user"("userId", "meetingId");
 CREATE INDEX "idx_user_meetingId_extId" ON "user"("meetingId", "extId");
 
 -- user (on update raiseHand or away: set new time)
@@ -389,6 +391,13 @@ ALTER TABLE "user" ADD COLUMN "currentlyInMeeting" boolean GENERATED ALWAYS AS (
         ELSE false
         END) STORED;
 
+ALTER TABLE "user" ADD COLUMN "isSharingCamera" boolean GENERATED ALWAYS AS (
+    CASE WHEN "user"."camerasCount" > 0
+        THEN true
+        ELSE false
+        END) STORED;
+
+
 CREATE OR REPLACE VIEW "v_user"
 AS SELECT "user"."userId",
     "user"."extId",
@@ -430,7 +439,9 @@ AS SELECT "user"."userId",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     "user"."whiteboardWriteAccess",
     "user"."isModerator",
-    "user"."currentlyInMeeting"
+    "user"."currentlyInMeeting",
+    "user"."lastFloorTime",
+    "user"."isSharingCamera"
   FROM "user"
   WHERE "user"."currentlyInMeeting" is true;
 
@@ -455,6 +466,15 @@ WHERE "currentlyInMeeting" IS TRUE;
 CREATE INDEX "idx_v_user_UsersBasicInfo" ON "user"(
     "meetingId",
     "nameSortable" ASC NULLS LAST,
+    "userId" ASC NULLS LAST
+)
+WHERE "currentlyInMeeting" IS TRUE;
+
+CREATE INDEX "idx_v_user_AudioOnlySubscription" ON "user"(
+    "meetingId",
+    "isSharingCamera",
+    "isModerator",
+    "lastFloorTime" DESC NULLS LAST,
     "userId" ASC NULLS LAST
 )
 WHERE "currentlyInMeeting" IS TRUE;
@@ -508,6 +528,8 @@ AS SELECT "user"."userId",
     CASE WHEN "user"."echoTestRunningAt" > current_timestamp - INTERVAL '3 seconds' THEN TRUE ELSE FALSE END "isRunningEchoTest",
     "user"."isModerator",
     "user"."currentlyInMeeting",
+    "user"."lastFloorTime",
+    "user"."isSharingCamera",
     "user"."inactivityWarningDisplay",
     "user"."inactivityWarningTimeoutSecs"
    FROM "user";
@@ -753,6 +775,23 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER "update_user_voice_voiceActivityAt_trigger" BEFORE INSERT OR UPDATE ON "user_voice" FOR EACH ROW
 EXECUTE FUNCTION "update_user_voice_voiceActivityAt_trigger_func"();
 
+--Replicate user_voice.lastFloorTime into user.lastFloorTime
+CREATE OR REPLACE FUNCTION "update_user_lastFloorTime_trigger_func"() RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE "user"
+    SET "lastFloorTime" = NEW."lastFloorTime"
+    WHERE "meetingId" = NEW."meetingId" AND "userId" = NEW."userId";
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "insert_user_lastFloorTime_trigger" AFTER INSERT ON "user_voice"
+    FOR EACH ROW EXECUTE FUNCTION "update_user_lastFloorTime_trigger_func"();
+
+CREATE TRIGGER "update_user_lastFloorTime_trigger" AFTER UPDATE OF "lastFloorTime" ON "user_voice"
+    FOR EACH ROW WHEN (NEW."lastFloorTime" IS DISTINCT FROM OLD."lastFloorTime")
+    EXECUTE FUNCTION "update_user_lastFloorTime_trigger_func"();
+
 CREATE OR REPLACE VIEW "v_user_voice_activity" AS
 select
 	"user_voice"."meetingId",
@@ -792,6 +831,35 @@ SELECT * FROM "user_camera";
 -- this view will be used specifically for the join with user_current
 CREATE OR REPLACE VIEW "v_user_current_camera" AS
 SELECT * FROM "user_camera";
+
+--Maintain user.camerasCount with the count of rows in user_camera for the same (meetingId, userId)
+CREATE OR REPLACE FUNCTION "update_user_camerasCount_trigger_func"() RETURNS TRIGGER AS $$
+DECLARE
+    _meetingId varchar(100);
+    _userId varchar(50);
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        _meetingId := OLD."meetingId";
+        _userId := OLD."userId";
+    ELSE
+        _meetingId := NEW."meetingId";
+        _userId := NEW."userId";
+    END IF;
+
+    UPDATE "user"
+    SET "camerasCount" = (
+        SELECT count(*) FROM "user_camera"
+        WHERE "meetingId" = _meetingId AND "userId" = _userId
+    )
+    WHERE "meetingId" = _meetingId AND "userId" = _userId;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_user_camerasCount_trigger"
+AFTER INSERT OR DELETE ON "user_camera"
+FOR EACH ROW EXECUTE FUNCTION "update_user_camerasCount_trigger_func"();
 
 CREATE UNLOGGED TABLE "user_connectionStatus" (
 	"meetingId" varchar(100),

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -100,6 +100,7 @@ select_permissions:
         - isModerator
         - currentlyInMeeting
         - isRunningEchoTest
+        - isSharingCamera
         - joined
         - locked
         - loggedOut
@@ -108,6 +109,7 @@ select_permissions:
         - nameSortable
         - firstName
         - firstNameSortable
+        - lastFloorTime
         - lastName
         - lastNameSortable
         - pinned

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -217,6 +217,7 @@ select_permissions:
         - isModerator
         - currentlyInMeeting
         - isRunningEchoTest
+        - isSharingCamera
         - joinErrorCode
         - joinErrorMessage
         - joined
@@ -227,6 +228,7 @@ select_permissions:
         - nameSortable
         - firstName
         - firstNameSortable
+        - lastFloorTime
         - lastName
         - lastNameSortable
         - pinned
@@ -274,9 +276,11 @@ select_permissions:
         - isDialIn
         - isModerator
         - isRunningEchoTest
+        - isSharingCamera
         - joinErrorCode
         - joinErrorMessage
         - joined
+        - lastFloorTime
         - lastName
         - lastNameSortable
         - locked

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/mediaGroupStateStream.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/mediaGroupStateStream.ts
@@ -1,0 +1,21 @@
+import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import { MEDIA_GROUP_STREAMS_SUBSCRIPTION } from '/imports/ui/components/livekit/selective-subscription/queries';
+import { MediaGroupParticipant } from '/imports/ui/components/livekit/selective-subscription/types';
+
+interface MediaGroupStreamsResponse {
+  user_mediaGroup: MediaGroupParticipant[];
+}
+
+/**
+ * Shared, deduplicated subscription to the user_mediaGroup state. Consumers
+ * receive the raw participant rows and filter/process them by media type.
+ */
+const useUserMediaGroupStateStream = () => {
+  const { data, error } = useDeduplicatedSubscription<MediaGroupStreamsResponse>(
+    MEDIA_GROUP_STREAMS_SUBSCRIPTION,
+  );
+
+  return { data: data?.user_mediaGroup, error };
+};
+
+export default useUserMediaGroupStateStream;

--- a/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
@@ -8,7 +8,7 @@ import logger from '/imports/startup/client/logger';
 import { SCREENSHARING_ERRORS } from '/imports/api/screenshare/client/bridge/errors';
 import { EXTERNAL_VIDEO_STOP } from '../external-video-player/mutations';
 import {
-  useSharedDevices, useHasVideoStream, useHasCapReached, useIsUserLocked, useStreams,
+  useSharedDevices, useHasVideoStream, useHasCapReached, useIsCamSharingLocked, useStreams,
   useExitVideo,
   useStopVideo,
 } from '/imports/ui/components/video-provider/hooks';
@@ -33,7 +33,7 @@ const VideoPreviewContainer = (props) => {
   const sharedDevices = useSharedDevices();
   const hasVideoStream = useHasVideoStream();
   const camCapReached = useHasCapReached();
-  const isCamLocked = useIsUserLocked();
+  const isCamLocked = useIsCamSharingLocked();
   const settingsStorage = window.meetingClientSettings.public.app.userSettingsStorage;
   const webcamDeviceId = useStorageKey('WebcamDeviceId', settingsStorage);
   const isVirtualBackgroundsEnabled = useIsVirtualBackgroundsEnabled();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
@@ -8,7 +8,7 @@ import {
   useExitVideo,
   useInfo,
   useIsPaginationEnabled,
-  useIsUserLocked,
+  useIsCamSharingLocked,
   useLockUser,
   useMyPageSize,
   useStopVideo,
@@ -119,7 +119,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
     );
   }
 
-  const isUserLocked = useIsUserLocked();
+  const isUserLocked = useIsCamSharingLocked();
   const currentVideoPageIndex = useCurrentVideoPageIndex();
   const exitVideo = useExitVideo();
   const lockUser = useLockUser();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -55,11 +55,9 @@ import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { Layout } from '/imports/ui/components/layout/layoutTypes';
 import { LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
-import createUseSubscription from '/imports/ui/core/hooks/createUseSubscription';
+import createUseSubscription, { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
-import {
-  MEDIA_GROUP_STREAMS_SUBSCRIPTION,
-} from '/imports/ui/components/livekit/selective-subscription/queries';
+import useUserMediaGroupStateStream from '/imports/ui/components/livekit/selective-subscription/mediaGroupStateStream';
 import {
   MediaGroupParticipant,
   MediaType,
@@ -320,6 +318,7 @@ export const useGridUsers = (visibleStreamCount: number) => {
   const gridSize = useGridSize();
   const userCount = getCountData();
   const isGridEnabled = useStorageKey('isGridEnabled');
+  const isUserLocked = useIsUserLocked();
   const gridItems = useRef<GridItem[]>([]);
   const overflowCount = useRef<number>(0);
 
@@ -334,7 +333,13 @@ export const useGridUsers = (visibleStreamCount: number) => {
   } = useSubscription<GridUsersResponse>(
     GRID_USERS_SUBSCRIPTION,
     {
-      variables: { limit: Math.max(gridSize - visibleStreamCount, 0) },
+      // Locked viewers can't see non-moderator cameras in the video streams, so only
+      // exclude moderator camera-sharers ([true]); otherwise exclude every
+      // camera-sharer ([true, false]).
+      variables: {
+        limit: Math.max(gridSize - visibleStreamCount, 0),
+        excludedModeratorValues: isUserLocked ? [true] : [true, false],
+      },
       skip: !isGridEnabled,
     },
   );
@@ -422,20 +427,17 @@ export const useGridSize = () => {
   return size;
 };
 
-const useAudioOnlySubscription = createUseSubscription(
-  AUDIO_ONLY_USERS_SUBSCRIPTION,
-  {},
-  true,
-);
-
-const useMediaGroupStreamsSubscription = createUseSubscription(
-  MEDIA_GROUP_STREAMS_SUBSCRIPTION,
-  {},
-  true,
-);
-
 export const useAudioOnlyUsers = (): AudioOnlyStream[] => {
   const { data: meeting } = useMeeting((m) => ({ meetingId: m.meetingId }));
+  const isUserLocked = useIsUserLocked();
+  // Locked viewers can't see non-moderator cameras in the video streams, so only
+  // exclude moderator camera-sharers ([true]); otherwise exclude every camera-sharer
+  // ([true, false]).
+  const useAudioOnlySubscription = useCreateUseSubscription(
+    AUDIO_ONLY_USERS_SUBSCRIPTION,
+    { excludedModeratorValues: isUserLocked ? [true] : [true, false] },
+    true,
+  );
   const { data, loading, errors } = useAudioOnlySubscription();
   const layoutType = layoutSelect((i: Layout) => i.layoutType);
   const {
@@ -485,18 +487,16 @@ export const useAudioOnlyUsers = (): AudioOnlyStream[] => {
 };
 
 const useVideoSenders = () => {
-  const { data, errors } = useMediaGroupStreamsSubscription();
+  const { data, error } = useUserMediaGroupStateStream();
 
-  if (errors) {
-    errors.forEach((error) => {
-      logger.error({
-        logCode: 'video_provider_media_group_sub_error',
-        extraInfo: {
-          errorMessage: error.message,
-          mediaType: MediaType.CAMERA,
-        },
-      }, `VideoProvider: ${MediaType.CAMERA} group participants subscription failed.`);
-    });
+  if (error) {
+    logger.error({
+      logCode: 'video_provider_media_group_sub_error',
+      extraInfo: {
+        errorMessage: error.message,
+        mediaType: MediaType.CAMERA,
+      },
+    }, `VideoProvider: ${MediaType.CAMERA} group participants subscription failed.`);
   }
 
   const mediaGroupParticipants = (data as MediaGroupParticipant[] || []).filter(

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -131,7 +131,7 @@ export const useStatus = () => {
 };
 
 export const useDisableReason = () => {
-  const videoLocked = useIsUserLocked();
+  const videoLocked = useIsCamSharingLocked();
   const hasCapReached = useHasCapReached();
   const hasVideoStream = useHasVideoStream();
   const connected = useReactiveVar(ConnectionStatus.getConnectedStatusVar());
@@ -147,13 +147,24 @@ export const useDisableReason = () => {
   return disableReason;
 };
 
-export const useIsUserLocked = () => {
+export const useIsCamSharingLocked = () => {
   const disableCam = useDisableCam();
   const { data: currentUser } = useCurrentUser((u) => ({
     locked: u.locked,
     isModerator: u.isModerator,
   }));
   return !!currentUser?.locked && !currentUser.isModerator && disableCam;
+};
+
+// Mirrors the webcam visibility lock enforced in video-provider/container.tsx: when
+// webcamsOnlyForModerator is on and the user is locked, only moderator cameras (and the
+// user's own) are visible. Used to drop non-moderators from the grid/audio-only queries.
+export const useCanOnlySeeModeratorCameras = () => {
+  const { data: meeting } = useMeeting((m) => ({
+    usersPolicies: m.usersPolicies,
+  }));
+  const { data: currentUser } = useCurrentUser((u) => ({ locked: u.locked }));
+  return !!meeting?.usersPolicies?.webcamsOnlyForModerator && !!currentUser?.locked;
 };
 
 export const useVideoStreamsCount = () => {
@@ -316,12 +327,32 @@ export const useGridUsers = (visibleStreamCount: number) => {
   const gridSize = useGridSize();
   const userCount = getCountData();
   const isGridEnabled = useStorageKey('isGridEnabled');
-  const isUserLocked = useIsUserLocked();
+  const canOnlySeeModeratorCameras = useCanOnlySeeModeratorCameras();
   const gridItems = useRef<GridItem[]>([]);
   const overflowCount = useRef<number>(0);
 
   const { data: meeting } = useMeeting((m) => ({
     meetingId: m.meetingId,
+  }));
+
+  // Used to re-inject the current user into the grid when the moderator-only filter drops
+  // them (see below). Their own record is already subscribed, so this is free.
+  const { data: currentUser } = useCurrentUser((u) => ({
+    userId: u.userId,
+    name: u.name,
+    nameSortable: u.nameSortable,
+    pinned: u.pinned,
+    away: u.away,
+    role: u.role,
+    avatar: u.avatar,
+    color: u.color,
+    presenter: u.presenter,
+    clientType: u.clientType,
+    raiseHand: u.raiseHand,
+    isModerator: u.isModerator,
+    reactionEmoji: u.reactionEmoji,
+    cameras: u.cameras,
+    voice: u.voice,
   }));
 
   const {
@@ -331,12 +362,12 @@ export const useGridUsers = (visibleStreamCount: number) => {
   } = useSubscription<GridUsersResponse>(
     GRID_USERS_SUBSCRIPTION,
     {
-      // Locked viewers can't see non-moderator cameras in the video streams, so only
-      // exclude moderator camera-sharers ([true]); otherwise exclude every
-      // camera-sharer ([true, false]).
+      // When the user can only see moderator cameras, drop non-moderators ([true]);
+      // otherwise keep everyone ([true, false]). The current user is re-added client-side
+      // below (the query can't reference it without breaking Hasura multiplexing).
       variables: {
         limit: Math.max(gridSize - visibleStreamCount, 0),
-        excludedModeratorValues: isUserLocked ? [true] : [true, false],
+        moderatorValues: canOnlySeeModeratorCameras ? [true] : [true, false],
       },
       skip: !isGridEnabled,
     },
@@ -365,6 +396,53 @@ export const useGridUsers = (visibleStreamCount: number) => {
       ...user,
       type: VIDEO_TYPES.GRID,
     }));
+
+    // The moderator-only grid filter (webcamsOnlyForModerator + locked) drops the current
+    // user too, since they're a non-moderator. We will re-add current user.
+    if (
+      canOnlySeeModeratorCameras
+      && currentUser?.userId
+      && !currentUser.isModerator
+      && (currentUser.cameras?.length ?? 0) === 0
+      && !newGridUsers.some((u) => u.userId === currentUser.userId)
+    ) {
+      const selfGridUser: GridItem = {
+        userId: currentUser.userId,
+        name: currentUser.name ?? '',
+        nameSortable: currentUser.nameSortable ?? '',
+        pinned: currentUser.pinned ?? false,
+        away: currentUser.away ?? false,
+        disconnected: false,
+        role: currentUser.role ?? '',
+        avatar: currentUser.avatar ?? '',
+        color: currentUser.color ?? '',
+        presenter: currentUser.presenter ?? false,
+        clientType: currentUser.clientType ?? '',
+        raiseHand: currentUser.raiseHand ?? false,
+        isModerator: currentUser.isModerator ?? false,
+        reactionEmoji: currentUser.reactionEmoji ?? '',
+        voice: {
+          joined: currentUser.voice?.joined ?? false,
+          listenOnly: currentUser.voice?.listenOnly ?? false,
+          userId: currentUser.userId,
+        },
+        type: VIDEO_TYPES.GRID,
+      };
+
+      // Insert the current user at the position the query's ordering (nameSortable, then
+      // userId) would have placed them, instead of appending last.
+      const insertAt = newGridUsers.findIndex((u) => (
+        u.nameSortable.localeCompare(selfGridUser.nameSortable) > 0
+        || (u.nameSortable === selfGridUser.nameSortable
+          && u.userId.localeCompare(selfGridUser.userId) > 0)
+      ));
+      if (insertAt === -1) {
+        newGridUsers.push(selfGridUser);
+      } else {
+        newGridUsers.splice(insertAt, 0, selfGridUser);
+      }
+    }
+
     gridItems.current = newGridUsers;
 
     const overflow = Math.max(userCount - gridSize, 0);
@@ -427,13 +505,12 @@ export const useGridSize = () => {
 
 export const useAudioOnlyUsers = (): AudioOnlyStream[] => {
   const { data: meeting } = useMeeting((m) => ({ meetingId: m.meetingId }));
-  const isUserLocked = useIsUserLocked();
-  // Locked viewers can't see non-moderator cameras in the video streams, so only
-  // exclude moderator camera-sharers ([true]); otherwise exclude every camera-sharer
-  // ([true, false]).
+  const canOnlySeeModeratorCameras = useCanOnlySeeModeratorCameras();
+  // When the user can only see moderator cameras, drop non-moderators ([true]); otherwise
+  // keep everyone ([true, false]).
   const useAudioOnlySubscription = useCreateUseSubscription(
     AUDIO_ONLY_USERS_SUBSCRIPTION,
-    { excludedModeratorValues: isUserLocked ? [true] : [true, false] },
+    { moderatorValues: canOnlySeeModeratorCameras ? [true] : [true, false] },
     true,
   );
   const { data, loading, errors } = useAudioOnlySubscription();

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -5,7 +5,6 @@ import {
 } from 'react';
 import {
   useReactiveVar,
-  useLazyQuery,
   useMutation,
   useSubscription,
 } from '@apollo/client';
@@ -26,7 +25,6 @@ import {
   getVideoState,
 } from '/imports/ui/components/video-provider/state';
 import {
-  OWN_VIDEO_STREAMS_QUERY,
   GRID_USERS_SUBSCRIPTION,
   VIDEO_STREAMS_SUBSCRIPTION,
   AUDIO_ONLY_USERS_SUBSCRIPTION,
@@ -39,7 +37,6 @@ import {
   StreamItem,
   AudioOnlyStream,
   GridUsersResponse,
-  OwnVideoStreamsResponse,
   StreamSubscriptionData,
 } from '/imports/ui/components/video-provider/types';
 import { DesktopPageSizes, MobilePageSizes } from '/imports/ui/Types/meetingClientSettings';
@@ -771,24 +768,23 @@ export const useHasVideoStream = () => {
   return !!connectingStream || streams.some((s) => videoService.isLocalStream(s.stream));
 };
 
-const useOwnVideoStreamsQuery = () => useLazyQuery<OwnVideoStreamsResponse>(
-  OWN_VIDEO_STREAMS_QUERY,
-  {
-    variables: {
-      userId: Auth.userID,
-      streamIdPrefix: `${videoService.getPrefix()}%`,
-    },
-    // UID and prefix are stable, so for now we need to bust the cache. If we don't,
-    // users will hit issues where cannot unshare their webcam or unsharing deals
-    // with unexpected behavior. E.g.: a camera was first ejected server side (empty
-    // stream list), or multiple cameras were shared (just the first one is cached).
-    fetchPolicy: 'no-cache',
-  },
-);
+// Returns the current user's own camera streams from the live VIDEO_STREAMS_SUBSCRIPTION.
+// streamId is prefixed with `${userId}_${sessionUUID}`, so isLocalStream reproduces the
+// old OWN_VIDEO_STREAMS_QUERY filter (userId _eq + streamId _like prefix). The streams are
+// kept in a ref so the exit/stop callbacks stay stable while always reading the freshest
+// list at call time — the subscription is live, so there is no cache staleness to bust.
+const useOwnStreamsRef = () => {
+  const streams = useStreams();
+  const ownStreamsRef = useRef<string[]>([]);
+  ownStreamsRef.current = streams
+    .filter((s) => videoService.isLocalStream(s.stream))
+    .map((s) => s.stream);
+  return ownStreamsRef;
+};
 
 export const useExitVideo = (forceExit = false) => {
   const [cameraBroadcastStop] = useMutation(CAMERA_BROADCAST_STOP);
-  const [getOwnVideoStreams] = useOwnVideoStreamsQuery();
+  const ownStreamsRef = useOwnStreamsRef();
 
   const exitVideo = useCallback(async () => {
     const { isConnected } = getVideoState();
@@ -798,26 +794,20 @@ export const useExitVideo = (forceExit = false) => {
         return cameraBroadcastStop({ variables: { cameraId } });
       };
 
-      return getOwnVideoStreams().then(async ({ data }) => {
-        if (data) {
-          const streams = data.user_camera || [];
-          const results = streams.map((s) => sendUserUnshareWebcam(s.streamId));
+      const results = ownStreamsRef.current.map((streamId) => sendUserUnshareWebcam(streamId));
 
-          return Promise.all(results).then(() => {
-            videoService.exitedVideo();
-            return true;
-          }).catch((e) => {
-            logger.warn({
-              logCode: 'exit_video_error',
-              extraInfo: {
-                errorMessage: e.message,
-                errorStack: e.stack,
-              },
-            }, `Failed to exit video: ${e.message}`);
-            return false;
-          });
-        }
+      return Promise.all(results).then(() => {
+        videoService.exitedVideo();
         return true;
+      }).catch((e) => {
+        logger.warn({
+          logCode: 'exit_video_error',
+          extraInfo: {
+            errorMessage: e.message,
+            errorStack: e.stack,
+          },
+        }, `Failed to exit video: ${e.message}`);
+        return false;
       });
     }
     return true;
@@ -849,14 +839,13 @@ export const useLockUser = () => {
 
 export const useStopVideo = () => {
   const [cameraBroadcastStop] = useMutation(CAMERA_BROADCAST_STOP);
-  const [getOwnVideoStreams] = useOwnVideoStreamsQuery();
+  const ownStreamsRef = useOwnStreamsRef();
 
   return useCallback(async (cameraId?: string) => {
-    const { data } = await getOwnVideoStreams();
-    const streams = data?.user_camera ?? [];
+    const streams = ownStreamsRef.current;
     const connectingStream = getConnectingStream();
-    const hasTargetStream = streams.some((s) => s.streamId === cameraId);
-    const hasOtherStream = streams.some((s) => s.streamId !== cameraId);
+    const hasTargetStream = streams.some((streamId) => streamId === cameraId);
+    const hasOtherStream = streams.some((streamId) => streamId !== cameraId);
 
     if (hasTargetStream) {
       cameraBroadcastStop({ variables: { cameraId } });

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -28,10 +28,8 @@ import {
 import {
   OWN_VIDEO_STREAMS_QUERY,
   GRID_USERS_SUBSCRIPTION,
-  VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION,
   VIDEO_STREAMS_SUBSCRIPTION,
   AUDIO_ONLY_USERS_SUBSCRIPTION,
-  ViewerVideoStreamsSubscriptionResponse,
   AudioOnlyUsersResponse,
 } from '/imports/ui/components/video-provider/queries';
 import videoService from '/imports/ui/components/video-provider/service';
@@ -752,10 +750,14 @@ export const useExitVideo = (forceExit = false) => {
 };
 
 export const useViewersInWebcamCount = (): number => {
-  const { data } = useDeduplicatedSubscription<ViewerVideoStreamsSubscriptionResponse>(
-    VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION,
-  );
-  return data?.user_camera_aggregate?.aggregate?.count || 0;
+  const streams = useStreams();
+  const ROLE_VIEWER = videoService.getRoleViewer();
+
+  // Mirror the VIEWERS_IN_WEBCAM_COUNT aggregate: count camera streams whose
+  // owner is a non-presenter viewer. Each stream maps to one user_camera row.
+  return streams.filter(
+    (s) => s.user?.role === ROLE_VIEWER && s.user?.presenter === false,
+  ).length;
 };
 
 export const useLockUser = () => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -51,19 +51,6 @@ export const VIDEO_STREAMS_SUBSCRIPTION = gql`
   }
 `;
 
-export const OWN_VIDEO_STREAMS_QUERY = gql`
-  query OwnVideoStreams($userId: String!, $streamIdPrefix: String!) {
-    user_camera(
-      where: {
-        userId: { _eq: $userId },
-        streamId: { _like: $streamIdPrefix }
-      },
-    ) {
-      streamId
-    }
-  }
-`;
-
 // Grid shows users who aren't displayed as a video tile for the current user.
 // Camera-sharers are excluded (isSharingCamera = camerasCount > 0). When the user can
 // only see moderator cameras (webcamsOnlyForModerator + locked), non-moderators are
@@ -152,7 +139,6 @@ export const AUDIO_ONLY_USERS_SUBSCRIPTION = gql`
 `;
 
 export default {
-  OWN_VIDEO_STREAMS_QUERY,
   VIDEO_STREAMS_SUBSCRIPTION,
   GRID_USERS_SUBSCRIPTION,
   AUDIO_ONLY_USERS_SUBSCRIPTION,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -1,14 +1,6 @@
 import { gql } from '@apollo/client';
 import { User } from '/imports/ui/components/video-provider/types';
 
-export interface ViewerVideoStreamsSubscriptionResponse {
-  user_camera_aggregate: {
-    aggregate: {
-      count: number;
-    };
-  };
-}
-
 export interface AudioOnlyUsersResponse {
   user: Array<User & {
     voice: {
@@ -68,18 +60,6 @@ export const OWN_VIDEO_STREAMS_QUERY = gql`
       },
     ) {
       streamId
-    }
-  }
-`;
-
-export const VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION = gql`
-  subscription ViewerVideoStreams {
-    user_camera_aggregate(where: {
-      user: { role: { _eq: "VIEWER" }, presenter: { _eq: false } }
-    }) {
-      aggregate {
-        count
-      }
     }
   }
 `;
@@ -173,7 +153,6 @@ export const AUDIO_ONLY_USERS_SUBSCRIPTION = gql`
 export default {
   OWN_VIDEO_STREAMS_QUERY,
   VIDEO_STREAMS_SUBSCRIPTION,
-  VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION,
   GRID_USERS_SUBSCRIPTION,
   AUDIO_ONLY_USERS_SUBSCRIPTION,
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -65,17 +65,19 @@ export const OWN_VIDEO_STREAMS_QUERY = gql`
 `;
 
 // Grid shows users who aren't displayed as a video tile for the current user.
-// We exclude camera-sharers whose isModerator is in $excludedModeratorValues:
-// [true, false] excludes every camera-sharer, while locked viewers pass [true] so
-// non-moderator camera-sharers they can't see in the video streams still surface here.
+// Camera-sharers are excluded (isSharingCamera = camerasCount > 0). When the user can
+// only see moderator cameras (webcamsOnlyForModerator + locked), non-moderators are
+// dropped too via $moderatorValues = [true]; otherwise [true, false] keeps everyone.
+// NOTE: isSharingCamera is global and ignores per-viewer locks, so it is trusted only for
+// moderators (their cameras reach everyone); non-moderator visibility is handled by role.
+// The current user is intentionally NOT special-cased here (no per-user variable, so
+// Hasura can still multiplex this subscription); self is re-added client-side instead.
 export const GRID_USERS_SUBSCRIPTION = gql`
-  subscription GridUsers($limit: Int!, $excludedModeratorValues: [Boolean!]) {
+  subscription GridUsers($limit: Int!, $moderatorValues: [Boolean!]) {
     user(
       where: {
-        _not: {
-          isSharingCamera: { _eq: true },
-          isModerator: { _in: $excludedModeratorValues },
-        },
+        isSharingCamera: { _eq: false },
+        isModerator: { _in: $moderatorValues },
       },
       limit: $limit,
       order_by: {
@@ -108,14 +110,13 @@ export const GRID_USERS_SUBSCRIPTION = gql`
 `;
 
 // Audio-only shows users with floor time who aren't displayed as a video tile for the current user.
+// Same camera-sharer/role filtering as GRID_USERS_SUBSCRIPTION (see note there).
 export const AUDIO_ONLY_USERS_SUBSCRIPTION = gql`
-  subscription AudioOnlyUsers($excludedModeratorValues: [Boolean!]) {
+  subscription AudioOnlyUsers($moderatorValues: [Boolean!]) {
     user(
       where: {
-        _not: {
-          isSharingCamera: { _eq: true },
-          isModerator: { _in: $excludedModeratorValues },
-        },
+        isSharingCamera: { _eq: false },
+        isModerator: { _in: $moderatorValues },
         lastFloorTime: { _neq: "0" },
       },
       order_by: {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -24,7 +24,11 @@ export interface AudioOnlyUsersResponse {
 
 export const VIDEO_STREAMS_SUBSCRIPTION = gql`
   subscription VideoStreams {
-    user_camera {
+    user_camera(
+      order_by: {
+        userId: asc,
+      }
+    ) {
       meetingId
       streamId
       user {
@@ -80,14 +84,17 @@ export const VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION = gql`
   }
 `;
 
+// Grid shows users who aren't displayed as a video tile for the current user.
+// We exclude camera-sharers whose isModerator is in $excludedModeratorValues:
+// [true, false] excludes every camera-sharer, while locked viewers pass [true] so
+// non-moderator camera-sharers they can't see in the video streams still surface here.
 export const GRID_USERS_SUBSCRIPTION = gql`
-  subscription GridUsers($limit: Int!) {
+  subscription GridUsers($limit: Int!, $excludedModeratorValues: [Boolean!]) {
     user(
       where: {
-        cameras_aggregate: {
-          count: {
-            predicate: { _eq: 0 },
-          },
+        _not: {
+          isSharingCamera: { _eq: true },
+          isModerator: { _in: $excludedModeratorValues },
         },
       },
       limit: $limit,
@@ -120,25 +127,20 @@ export const GRID_USERS_SUBSCRIPTION = gql`
   }
 `;
 
+// Audio-only shows users with floor time who aren't displayed as a video tile for the current user.
 export const AUDIO_ONLY_USERS_SUBSCRIPTION = gql`
-  subscription AudioOnlyUsers {
+  subscription AudioOnlyUsers($excludedModeratorValues: [Boolean!]) {
     user(
       where: {
-        cameras_aggregate: {
-          count: {
-            predicate: { _eq: 0 },
-          },
+        _not: {
+          isSharingCamera: { _eq: true },
+          isModerator: { _in: $excludedModeratorValues },
         },
-        voice: {
-          lastFloorTime: {
-            _gt: "0",
-          },
-        },
+        lastFloorTime: { _neq: "0" },
       },
       order_by: {
-        voice: {
-          lastFloorTime: desc,
-        },
+        lastFloorTime: desc,
+        userId: asc,
       },
     ) {
       meetingId

--- a/bigbluebutton-html5/imports/ui/components/video-provider/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/types.ts
@@ -45,12 +45,6 @@ export interface GridUsersResponse {
   user: GridUser[];
 }
 
-export interface OwnVideoStreamsResponse {
-  user_camera: {
-    streamId: string;
-  }[];
-}
-
 export type ConnectingStream = {
   userId: string;
   stream: string;


### PR DESCRIPTION
This PR reduces the number of GraphQL subscriptions/queries the client opens for video, and makes the two remaining user subscriptions cheaper for the database to evaluate.

**Reuse `VIDEO_STREAMS_SUBSCRIPTION` instead of redundant subscriptions/queries**

The client already receives every camera stream via `VIDEO_STREAMS_SUBSCRIPTION`, so two other data sources were redundant and have been removed:

- Removed `VIEWERS_IN_WEBCAM_COUNT_SUBSCRIPTION`. `useViewersInWebcamCount` now derives the count from the streams already in memory, counting streams whose owner is a non-presenter viewer (one user_camera row per stream, mirroring the old aggregate).
- Removed `OWN_VIDEO_STREAMS_QUERY`. `useExitVideo`/`useStopVideo` now read the current user's own streams from the live subscription (filtered via `isLocalStream`) kept in a ref. Because the subscription is always live, this drops the no cache lazy query and the cache-busting workaround it required.

**Cheaper where clauses on `GRID_USERS_SUBSCRIPTION` and `AUDIO_ONLY_USERS_SUBSCRIPTION`**

These two subscriptions previously filtered on a cameras_aggregate count predicate and joined into user_voice, which is expensive for Postgres to evaluate per row. Two denormalized columns are now maintained on the user table via triggers:

- `camerasCount` (kept in sync from `user_camera`), exposed as a generated `isSharingCamera` boolean.
- `lastFloorTime` (replicated from `user_voice`).

The where/order_by clauses now hit these plain columns instead of aggregates and joins, backed by a new `idx_v_user_AudioOnlySubscription` index.

**Filter non-moderator cameras server-side when visibility is locked**

When `webcamsOnlyForModerator` is enabled and the viewer is locked, they can't see non-moderator cameras. 
Instead of fetching everyone and filtering client-side, the grid/audio-only subscriptions now exclude non-moderators directly via a `$moderatorValues` variable (`[true]` when restricted, `[true, false]` otherwise). 
The new `useCanOnlySeeModeratorCameras` hook drives this; `useIsUserLocked` was renamed to `useIsCamSharingLocked` to disambiguate it from this new check.

**Re-inject the current user into the grid**

The moderator-only filter above also drops the current user (a non-moderator), so they're re-added to the `GRID_USERS_SUBSCRIPTION` result client-side, inserted at the position the query's `nameSortable`/`userId` ordering would have placed them. 
This is intentionally done on the client rather than in the query: special-casing the current user in the where clause would give each user a unique subscription and break Hasura's subscription multiplexing. 
Their own record is already subscribed, so the re-injection is free.