### PR TITLE
refactor(core): create public media groups groups lazily, + 

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/mediagroups/CreateMediaGroupReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/mediagroups/CreateMediaGroupReqMsgHdlr.scala
@@ -82,6 +82,9 @@ trait CreateMediaGroupReqMsgHdlr extends RightsManagementTrait {
           MediaGroupApp.handleMediaGroupUpdated(mg.id, updatedGroups, liveMeeting, bus.outGW)
           newState
         case None =>
+          // Lazily create public groups (and enroll all current users)
+          // before creating the first scoped group. No-op once public groups already exist.
+          val baseGroups = MediaGroupApp.ensurePublicGroupsCreated(liveMeeting, state.mediaGroups)
           val mg = MediaGroupApp.createMediaGroup(
             groupId,
             msg.header.userId,
@@ -90,9 +93,9 @@ trait CreateMediaGroupReqMsgHdlr extends RightsManagementTrait {
             msg.body.record,
             senders,
             receivers,
-            state.mediaGroups
+            baseGroups
           )
-          val updatedGroups = MediaGroupApp.addMediaGroup(mg, state.mediaGroups)
+          val updatedGroups = MediaGroupApp.addMediaGroup(mg, baseGroups)
           broadcastEvent(mg)
           MediaGroupDAO.insert(liveMeeting.props.meetingProp.intId, mg)
           insertParticipants(senders, receivers, mg.id)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/mediagroups/MediaGroupApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/mediagroups/MediaGroupApp.scala
@@ -178,23 +178,13 @@ object MediaGroupApp {
       active = true
     )
 
-    val newMgState = PublicMediaGroupIds.All.foldLeft(mediaGroups) { (acc, groupId) =>
+    // Enroll the user in each public group they are not already in.
+    // Public groups are created lazily (only once a scoped group
+    // exists), so a missing group here means there is nothing to enroll into.
+    PublicMediaGroupIds.All.foldLeft(mediaGroups) { (acc, groupId) =>
       acc.find(groupId) match {
         // Only enroll if not already in the group (e.g.: reconns, multiple sessions)
         case Some(mg) if !mg.isUserSending(userId) && !mg.isUserReceiving(userId) =>
-          addMediaGroupParticipant(groupId, participant, acc)
-        case _ => acc
-      }
-    }
-
-    // Only persist memberships for public groups that actually exist. Public
-    // groups are created lazily (once a scoped group exists), so a
-    // missing group here means there is nothing to enroll into.
-    PublicMediaGroupIds.All.foreach { groupId =>
-      mediaGroups.find(groupId).foreach { mg =>
-        val userAlreadyInGroup = mg.isUserSending(userId) || mg.isUserReceiving(userId)
-
-        if (!userAlreadyInGroup) {
           MediaGroupUserDAO.insertUser(
             liveMeeting.props.meetingProp.intId,
             groupId,
@@ -203,11 +193,10 @@ object MediaGroupApp {
             receiver = true,
             active = true
           )
-        }
+          addMediaGroupParticipant(groupId, participant, acc)
+        case _ => acc
       }
     }
-
-    newMgState
   }
 
   def publicGroupsExist(mediaGroups: MediaGroups): Boolean =

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/mediagroups/MediaGroupApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/mediagroups/MediaGroupApp.scala
@@ -3,7 +3,7 @@ package org.bigbluebutton.core.apps.mediagroups
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.db.MediaGroupUserDAO
+import org.bigbluebutton.core.db.{ MediaGroupDAO, MediaGroupUserDAO }
 
 // Reserved group IDs for the explicit public space per media type
 object PublicMediaGroupIds {
@@ -187,23 +187,53 @@ object MediaGroupApp {
       }
     }
 
+    // Only persist memberships for public groups that actually exist. Public
+    // groups are created lazily (once a scoped group exists), so a
+    // missing group here means there is nothing to enroll into.
     PublicMediaGroupIds.All.foreach { groupId =>
-      val userAlreadyInGroup = mediaGroups.find(groupId).exists(
-        mg => mg.isUserSending(userId) || mg.isUserReceiving(userId)
-      )
-      if (!userAlreadyInGroup) {
-        MediaGroupUserDAO.insertUser(
-          liveMeeting.props.meetingProp.intId,
-          groupId,
-          userId,
-          sender = true,
-          receiver = true,
-          active = true
-        )
+      mediaGroups.find(groupId).foreach { mg =>
+        val userAlreadyInGroup = mg.isUserSending(userId) || mg.isUserReceiving(userId)
+
+        if (!userAlreadyInGroup) {
+          MediaGroupUserDAO.insertUser(
+            liveMeeting.props.meetingProp.intId,
+            groupId,
+            userId,
+            sender = true,
+            receiver = true,
+            active = true
+          )
+        }
       }
     }
 
     newMgState
+  }
+
+  def publicGroupsExist(mediaGroups: MediaGroups): Boolean =
+    PublicMediaGroupIds.All.exists(groupId => mediaGroups.find(groupId).isDefined)
+
+  // Create three public group containers (model and DB ) and enrolls every
+  // current user as sender+receiver.
+  // Call this before creating the first scoped group in a meeting.
+  def ensurePublicGroupsCreated(
+      liveMeeting: LiveMeeting,
+      mediaGroups: MediaGroups
+  ): MediaGroups = {
+    if (publicGroupsExist(mediaGroups)) {
+      mediaGroups
+    } else {
+      val meetingId = liveMeeting.props.meetingProp.intId
+      val withGroups = createPublicMediaGroups(mediaGroups)
+
+      withGroups.findAllMediaGroups()
+        .filter(mg => PublicMediaGroupIds.isPublicGroup(mg.id))
+        .foreach(mg => MediaGroupDAO.insert(meetingId, mg))
+
+      Users2x.findAll(liveMeeting.users2x).foldLeft(withGroups) { (acc, user) =>
+        enrollUserInPublicGroups(liveMeeting, user.intId, acc)
+      }
+    }
   }
 
   def handleMediaGroupUpdated(
@@ -361,11 +391,13 @@ object MediaGroupApp {
 
         if (!userStillInType) {
           PublicMediaGroupIds.publicGroupIdForMediaType(mediaType).foreach { publicGroupId =>
-            val participant = MediaGroupParticipant(userId, sender = true, receiver = true, active = true)
+            if (updatedMediaGroups.find(publicGroupId).isDefined) {
+              val participant = MediaGroupParticipant(userId, sender = true, receiver = true, active = true)
 
-            updatedMediaGroups = addMediaGroupParticipant(publicGroupId, participant, updatedMediaGroups)
-            MediaGroupUserDAO.insertUser(meetingId, publicGroupId, userId, sender = true, receiver = true, active = true)
-            affectedGroupIds += publicGroupId
+              updatedMediaGroups = addMediaGroupParticipant(publicGroupId, participant, updatedMediaGroups)
+              MediaGroupUserDAO.insertUser(meetingId, publicGroupId, userId, sender = true, receiver = true, active = true)
+              affectedGroupIds += publicGroupId
+            }
           }
         }
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -51,10 +51,12 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
   private def handleSuccessfulUserJoin(msg: UserJoinMeetingReqMsg, regUser: RegisteredUser, state: MeetingState2x) = {
     var newState = userJoinMeeting(outGW, msg.body.authToken, msg.body.clientType, msg.body.clientIsMobile, liveMeeting, state)
 
-    // Enroll user in public media groups
-    newState = newState.update(
-      MediaGroupApp.enrollUserInPublicGroups(liveMeeting, regUser.id, newState.mediaGroups)
-    )
+    // Enroll user in the public media groups if they exist.
+    if (MediaGroupApp.publicGroupsExist(newState.mediaGroups)) {
+      newState = newState.update(
+        MediaGroupApp.enrollUserInPublicGroups(liveMeeting, regUser.id, newState.mediaGroups)
+      )
+    }
     updateParentMeetingWithNewListOfUsers()
     notifyPreviousUsersWithSameExtId(regUser)
     clearCachedVoiceUser(regUser)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -137,8 +137,9 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
 
       // Dial-in users need to be enrolled in public media groups to be heard
       // by clients that use selective subscription. Regular web users do this
-      // in UserJoinMeetingReqMsgHdlr
-      if (isDialInUser) {
+      // in UserJoinMeetingReqMsgHdlr. Only enroll when the public groups have
+      // been created (i.e. the meeting already has a scoped group).
+      if (isDialInUser && MediaGroupApp.publicGroupsExist(state.mediaGroups)) {
         state.update(
           MediaGroupApp.enrollUserInPublicGroups(liveMeeting, msg.body.intId, state.mediaGroups)
         )

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MediaGroupDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MediaGroupDAO.scala
@@ -25,7 +25,7 @@ class MediaGroupDbTableDef(tag: Tag) extends Table[MediaGroupDbModel](tag, None,
 object MediaGroupDAO {
   def insert(meetingId: String, mediaGroup: MediaGroup) = {
     DatabaseConnection.enqueue(
-      TableQuery[MediaGroupDbTableDef].forceInsert(
+      TableQuery[MediaGroupDbTableDef].insertOrUpdate(
         MediaGroupDbModel(
           meetingId = meetingId,
           groupId = mediaGroup.id,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -12,7 +12,7 @@ import org.bigbluebutton.core.util.TimeUtil
 import org.bigbluebutton.common2.domain.{ DefaultProps, LockSettingsProps }
 import org.bigbluebutton.core.api._
 import org.bigbluebutton.core.apps._
-import org.bigbluebutton.core.apps.mediagroups.{ MediaGroupApp, MediaGroupHdlrs, PublicMediaGroupIds }
+import org.bigbluebutton.core.apps.mediagroups.MediaGroupHdlrs
 import org.bigbluebutton.core.apps.caption.CaptionApp2x
 import org.bigbluebutton.core.apps.chat.ChatApp2x
 import org.bigbluebutton.core.apps.externalvideo.ExternalVideoApp2x
@@ -48,9 +48,7 @@ import org.bigbluebutton.core.db.{
   NotificationDAO,
   TimerDAO,
   UserDAO,
-  UserStateDAO,
-  MediaGroupDAO,
-  MediaGroupUserDAO
+  UserStateDAO
 }
 import org.bigbluebutton.core.graphql.GraphqlMiddleware
 import org.bigbluebutton.core.models.VoiceUsers.{ findAllFreeswitchCallers, findAllListenOnlyVoiceUsers }
@@ -193,13 +191,6 @@ class MeetingActor(
 
   // Create a default public group chat
   state = groupChatApp.handleCreateDefaultPublicGroupChat(state, liveMeeting, msgBus)
-
-  // Create explicit public media groups. See media groups apps and models and
-  // associated commit history for those.
-  state = state.update(MediaGroupApp.createPublicMediaGroups(state.mediaGroups))
-  state.mediaGroups.findAllMediaGroups().filter(mg => PublicMediaGroupIds.isPublicGroup(mg.id)).foreach { mg =>
-    MediaGroupDAO.insert(liveMeeting.props.meetingProp.intId, mg)
-  }
 
   //state = GroupChatApp.genTestChatMsgHistory(GroupChatApp.MAIN_PUBLIC_CHAT, state, BbbSystemConst.SYSTEM_USER, liveMeeting)
   // Create a default public group chat **DEPRECATED, NOT GOING TO WORK ANYMORE**

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -2527,6 +2527,7 @@ CREATE UNLOGGED TABLE "user_mediaGroup" (
 	"sender"						boolean NOT NULL DEFAULT false,
 	"receiver"					boolean NOT NULL DEFAULT false,
 	"active"						boolean NOT NULL DEFAULT false,
+	"createdAt"					timestamp with time zone NOT NULL DEFAULT current_timestamp,
 	CONSTRAINT "user_mediaGroup_pkey" PRIMARY KEY ("meetingId", "userId", "groupId"),
 	FOREIGN KEY ("meetingId", "groupId") REFERENCES "mediaGroup"("meetingId", "groupId") ON DELETE CASCADE,
 	FOREIGN KEY ("meetingId", "userId") REFERENCES "user"("meetingId", "userId") ON DELETE CASCADE
@@ -2534,6 +2535,8 @@ CREATE UNLOGGED TABLE "user_mediaGroup" (
 
 CREATE INDEX "idx_user_mediaGroup_userId_reverse" ON "user_mediaGroup"("userId", "meetingId");
 CREATE INDEX "idx_user_mediaGroup_groupId_sender_receiver" ON "user_mediaGroup"("meetingId", "groupId", "sender", "receiver");
+CREATE INDEX "idx_user_mediaGroup_createdAt" ON "user_mediaGroup"("meetingId", "createdAt", "userId", "groupId");
+
 CREATE OR REPLACE VIEW "v_user_mediaGroup" AS SELECT umg.*, mg."mediaType"
 FROM "user_mediaGroup" umg
 JOIN "mediaGroup" mg ON mg."meetingId" = umg."meetingId" AND mg."groupId" = umg."groupId";

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_mediaGroup.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_mediaGroup.yaml
@@ -35,6 +35,7 @@ select_permissions:
         - receiver
         - active
         - mediaType
+        - createdAt
       filter:
         _and:
           - meetingId:

--- a/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/selective-subscription/queries.ts
@@ -2,7 +2,13 @@ import { gql } from '@apollo/client';
 
 export const MEDIA_GROUP_STREAMS_SUBSCRIPTION = gql`
   subscription MediaGroupStreams {
-    user_mediaGroup {
+    user_mediaGroup(
+      order_by: [
+        { createdAt: asc }
+        { userId: asc }
+        { groupId: asc }
+      ]
+    ) {
       userId
       groupId
       mediaType


### PR DESCRIPTION
### What does this PR do?

- [x] ~Draft until E2E playwright testing of two media groups-based plugins is done on my side~

- [refactor(core): create public media groups groups lazily](https://github.com/bigbluebutton/bigbluebutton/commit/4c58cfa1216bcbb20c19bdb7e7f7e6af8494e02b) 
  - Public media groups are created at meeting start and every user is
enrolled in all three. Explicit public groups are only ever needed in
case scoped media groups exist. In case no scope nor public groups are
present, client-side selective subscription routines treat all users
as public by specification. With that in mind, the majority of use case
scenarios do not need explicit public group info to be propagated down to
clients.
  - Create public groups - enrolling all current users - only when a meeting
gets its first scoped group, and keep them until it ends. FWIW, tearing
down on the last scoped group would churn data and have implication on
dependent plugins, so it's out of the scope of this commit.
Additionally, condition user-join group enrollment and the public
re-enrollment paths on the existence of public groups.
- [fix: order user_mediaGroup subscription by createdAt, userId and groupId](https://github.com/bigbluebutton/bigbluebutton/commit/3fb51294e44d142b652d9ef08e96dd156076fbd2) 
  - The user_mediaGroup subscription has no defined order, so the DB might
returns rows in an unstable order. This may cause subscription data
churn even when nothing changes semantically due to the lack of ordering
throwing a wrench in the JSON patching system.
  - Add a createdAt column and order the media group subscription by
[createdAt, userId, groupId]. (userId, groupId) serves as tie-breakers in
case the lazy creation of media groups generates duplicate timestamps if
they share a transaction.


### Closes Issue(s)

None