### PR TITLE
Fix: disable virtual background toggle on unsupported devices (iOS/Safari)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/profile-settings/component.tsx
@@ -56,6 +56,10 @@ const intlMessages: { [key: string]: { id: string; description?: string } } = de
     id: 'app.videoPreview.webcamVirtualBackgroundLabel',
     description: 'Title for the virtual background modal',
   },
+  webcamVirtualBackgroundDisabledLabel: {
+    id: 'app.videoPreview.webcamVirtualBackgroundDisabledLabel',
+    description: 'Label for the virtual background toggle when not supported on this device',
+  },
   cameraLabel: {
     id: 'app.videoPreview.cameraLabel',
     description: 'Camera dropdown label',
@@ -699,20 +703,31 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = () => {
       sectionIndex, type, name, customParams,
     );
 
+    const switchTitle = (
+      <Styled.SwitchTitle
+        sx={{ margin: 0 }}
+        control={(
+          <Styled.MaterialSwitch
+            sx={{ marginRight: '1rem' }}
+            checked={section.virtualBackgroundChecked}
+            onChange={(_, checked) => handleVirtualBgChange(sectionIndex, checked)}
+            disabled={!isVirtualBackgroundsEnabled || !isVirtualBackgroundSupported() || isCameraLoading}
+            inputProps={{ 'data-test': 'virtualBackgroundToggle' } as React.InputHTMLAttributes<HTMLInputElement>}
+          />
+        )}
+        label={formatMessage(intlMessages.webcamVirtualBackgroundTitle)}
+      />
+    );
+
     return (
       <>
-        <Styled.SwitchTitle
-          sx={{ margin: 0 }}
-          control={(
-            <Styled.MaterialSwitch
-              sx={{ marginRight: '1rem' }}
-              checked={section.virtualBackgroundChecked}
-              onChange={(_, checked) => handleVirtualBgChange(sectionIndex, checked)}
-              disabled={!isVirtualBackgroundsEnabled || isCameraLoading}
-            />
-          )}
-          label={formatMessage(intlMessages.webcamVirtualBackgroundTitle)}
-        />
+        {!isVirtualBackgroundSupported() ? (
+          <Tooltip title={formatMessage(intlMessages.webcamVirtualBackgroundDisabledLabel)}>
+            {switchTitle}
+          </Tooltip>
+        ) : (
+          switchTitle
+        )}
         {section.virtualBackgroundChecked
           && (
             <Styled.VirtualBgSelectorBorder>

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -243,6 +243,7 @@ export const elements = {
   usersList: 'div[data-test="userList"]',
   selectCameraQualityId: 'select[id="setQuality"]',
   virtualBackgrounds: 'div[data-test="virtualBackground"]',
+  virtualBackgroundToggle: 'input[data-test="virtualBackgroundToggle"]',
 
   // Timer
   timerContainer: 'div[data-test="timerContainer"]',

--- a/bigbluebutton-tests/playwright/webcam/webcam.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/webcam.spec.ts
@@ -1,3 +1,4 @@
+import { devices } from '@playwright/test';
 import { test } from '../core/setup/fixtures';
 import { MultiUsers } from '../user/multiusers';
 import { Webcam } from './webcam';
@@ -96,6 +97,17 @@ test.describe.parallel('Webcam', { tag: '@ci' }, () => {
       const webcam = new Webcam(browser, page);
       await webcam.init(true, { testInfo });
       await webcam.keepBackgroundWhenRejoin(context);
+    });
+
+    test('Virtual background toggle is disabled on unsupported devices (iPhone)', async ({ browser }, testInfo) => {
+      linkIssue(23756);
+      const iPhone11 = devices['iPhone 11'];
+      const context = await browser.newContext({ ...iPhone11 });
+      const mobilePage = await context.newPage();
+      const webcam = new Webcam(browser, mobilePage);
+      await webcam.init(true, { testInfo });
+      await webcam.virtualBackgroundToggleDisabledOnUnsupportedDevice();
+      await context.close();
     });
   });
 });

--- a/bigbluebutton-tests/playwright/webcam/webcam.ts
+++ b/bigbluebutton-tests/playwright/webcam/webcam.ts
@@ -352,4 +352,13 @@ export class Webcam extends Page {
       mask: [this.page.locator(e.currentUserLocalStreamVideo)],
     });
   }
+
+  async virtualBackgroundToggleDisabledOnUnsupportedDevice() {
+    // On mobile viewports the sidebar navigation is collapsed — open it first
+    await this.page.locator(e.toggleSidebarNavigation).click({ force: true });
+    await this.waitAndClick(e.profileSidebarButton);
+    await this.hasElement(e.virtualBackgroundToggle, 'should display the virtual background toggle in profile settings');
+    const toggle = this.page.locator(e.virtualBackgroundToggle);
+    await expect(toggle, 'virtual background toggle should be disabled on unsupported device').toBeDisabled();
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Disable virtual background on webcams for safari/ios 


### Closes Issue(s)
Closes #23756 

