### PR TITLE
fix(presentation-toolbar): fix arrow keys not triggering slide navigation

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -203,17 +203,17 @@ class PresentationToolbar extends PureComponent {
   }
 
   switchSlide(event) {
-    const { target, which } = event;
+    const { target, key } = event;
     const isBody = target.nodeName === 'BODY';
     const isWhiteboard = target.classList.contains('tl-container');
 
-    if (which === KEYS.ENTER && (isWhiteboard || isBody)) {
+    if (key === KEYS.ENTER && (isWhiteboard || isBody)) {
       this.fullscreenToggleHandler();
       return;
     }
 
     if (isBody) {
-      switch (which) {
+      switch (key) {
         case KEYS.ARROW_LEFT:
         case KEYS.PAGE_UP:
           this.previousSlideHandler();

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -13,6 +13,12 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.skipSlide();
   });
 
+  test('Navigate slides with arrow keys', async ({ browser, context, page }, testInfo) => {
+    const presentation = new Presentation(browser, context);
+    await presentation.initModPage(page, { testInfo });
+    await presentation.navigateSlidesWithArrowKeys();
+  });
+
   test('Share Camera As Content', async ({ browser }, testInfo) => {
     const staticVideoBrowser = await browser.browserType().launch({
       args: [

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -16,7 +16,7 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
   test('Navigate slides with arrow keys', async ({ browser, context, page }, testInfo) => {
     const presentation = new Presentation(browser, context);
     await presentation.initModPage(page, { testInfo });
-    await presentation.navigateSlidesWithArrowKeys();
+    await presentation.navigateSlidesWithKeys();
   });
 
   test('Share Camera As Content', async ({ browser }, testInfo) => {

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -43,7 +43,7 @@ export class Presentation extends MultiUsers {
     await checkSvgIndex(this.modPage, '/svg/1');
   }
 
-  async navigateSlidesWithArrowKeys() {
+  async navigateSlidesWithKeys() {
     await this.modPage.hasElement(
       e.whiteboard,
       'should display the whiteboard when the moderator joins the meeting',
@@ -57,27 +57,47 @@ export class Presentation extends MultiUsers {
 
     await blurActive();
     await this.modPage.press('ArrowRight');
-    await this.modPage.hasElement(e.whiteboard, 'should display the next slide after pressing ArrowRight');
-    await this.modPage.page.waitForTimeout(1000);
-    await checkSvgIndex(this.modPage, '/svg/2');
+    await this.modPage.page.waitForFunction(
+       ([whiteboardSelector, expectedSvg]) => {
+         const whiteboard = document.querySelector(whiteboardSelector);
+         return whiteboard?.innerHTML.includes(expectedSvg) ?? false;
+       },
+       [e.whiteboard, '/svg/2'],
+       { timeout: ELEMENT_WAIT_LONGER_TIME },
+     );
 
     await blurActive();
     await this.modPage.press('ArrowLeft');
-    await this.modPage.hasElement(e.whiteboard, 'should display the previous slide after pressing ArrowLeft');
-    await this.modPage.page.waitForTimeout(1000);
-    await checkSvgIndex(this.modPage, '/svg/1');
+    await this.modPage.page.waitForFunction(
+       ([whiteboardSelector, expectedSvg]) => {
+         const whiteboard = document.querySelector(whiteboardSelector);
+         return whiteboard?.innerHTML.includes(expectedSvg) ?? false;
+       },
+       [e.whiteboard, '/svg/1'],
+       { timeout: ELEMENT_WAIT_LONGER_TIME },
+     );
 
     await blurActive();
     await this.modPage.press('PageDown');
-    await this.modPage.hasElement(e.whiteboard, 'should display the next slide after pressing PageDown');
-    await this.modPage.page.waitForTimeout(1000);
-    await checkSvgIndex(this.modPage, '/svg/2');
+    await this.modPage.page.waitForFunction(
+       ([whiteboardSelector, expectedSvg]) => {
+         const whiteboard = document.querySelector(whiteboardSelector);
+         return whiteboard?.innerHTML.includes(expectedSvg) ?? false;
+       },
+       [e.whiteboard, '/svg/2'],
+       { timeout: ELEMENT_WAIT_LONGER_TIME },
+     );
 
     await blurActive();
     await this.modPage.press('PageUp');
-    await this.modPage.hasElement(e.whiteboard, 'should display the previous slide after pressing PageUp');
-    await this.modPage.page.waitForTimeout(1000);
-    await checkSvgIndex(this.modPage, '/svg/1');
+    await this.modPage.page.waitForFunction(
+       ([whiteboardSelector, expectedSvg]) => {
+         const whiteboard = document.querySelector(whiteboardSelector);
+         return whiteboard?.innerHTML.includes(expectedSvg) ?? false;
+       },
+       [e.whiteboard, '/svg/1'],
+       { timeout: ELEMENT_WAIT_LONGER_TIME },
+     );
   }
 
   async shareCameraAsContent() {

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -43,6 +43,43 @@ export class Presentation extends MultiUsers {
     await checkSvgIndex(this.modPage, '/svg/1');
   }
 
+  async navigateSlidesWithArrowKeys() {
+    await this.modPage.hasElement(
+      e.whiteboard,
+      'should display the whiteboard when the moderator joins the meeting',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    await checkSvgIndex(this.modPage, '/svg/1');
+
+    // Blur any focused element so keydown events target document.body
+    const blurActive = () => this.modPage.page.evaluate(() => (document.activeElement as HTMLElement)?.blur());
+
+    await blurActive();
+    await this.modPage.press('ArrowRight');
+    await this.modPage.hasElement(e.whiteboard, 'should display the next slide after pressing ArrowRight');
+    await this.modPage.page.waitForTimeout(1000);
+    await checkSvgIndex(this.modPage, '/svg/2');
+
+    await blurActive();
+    await this.modPage.press('ArrowLeft');
+    await this.modPage.hasElement(e.whiteboard, 'should display the previous slide after pressing ArrowLeft');
+    await this.modPage.page.waitForTimeout(1000);
+    await checkSvgIndex(this.modPage, '/svg/1');
+
+    await blurActive();
+    await this.modPage.press('PageDown');
+    await this.modPage.hasElement(e.whiteboard, 'should display the next slide after pressing PageDown');
+    await this.modPage.page.waitForTimeout(1000);
+    await checkSvgIndex(this.modPage, '/svg/2');
+
+    await blurActive();
+    await this.modPage.press('PageUp');
+    await this.modPage.hasElement(e.whiteboard, 'should display the previous slide after pressing PageUp');
+    await this.modPage.page.waitForTimeout(1000);
+    await checkSvgIndex(this.modPage, '/svg/1');
+  }
+
   async shareCameraAsContent() {
     await this.modPage.hasElement(
       e.whiteboard,


### PR DESCRIPTION
### What does this PR do?
The code compares values from `event.which` against values from `event.key`, mixing two incompatible properties. `event.which` is also deprecated in favor of `event.key`.
Replace `event.which` with `event.key` for keyboard event handling.

Additonaly, adds E2E test for this case: 7a4339f070e0b4b4c3216b8de3ec046348442f47

### Closes Issue(s)
Closes --


### How to test
1. Join meeting
2. Try switching the slides with the arrow keys <-, -> or pageup and pagedown
3. Check that the slide changes