### PR TITLE
build(freeswitch): v1.11.1 (up from v1.10.12)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: bigbluebutton/bbb-build:v3.0.x-release--2026-03-20-151540
+  image: bigbluebutton/bbb-build:v3.0.x-release--2026-05-27-142334
 
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of

--- a/build/packages-template/bbb-freeswitch-core/audio.patch
+++ b/build/packages-template/bbb-freeswitch-core/audio.patch
@@ -1,14 +1,15 @@
+diff --git src/mod/applications/mod_conference/mod_conference.c src/mod/applications/mod_conference/mod_conference.c
+index 4f03742..3c1aa85 100644
 --- src/mod/applications/mod_conference/mod_conference.c
 +++ src/mod/applications/mod_conference/mod_conference.c
-@@ -2476,9 +2476,7 @@ SWITCH_STANDARD_APP(conference_function)
+@@ -2480,9 +2480,7 @@ SWITCH_STANDARD_APP(conference_function)
  
-  /* Run the conference loop */
-  do {
--   switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
--   
--   if (switch_channel_test_flag(channel, CF_AUDIO) && (audio_flow == SWITCH_MEDIA_FLOW_SENDRECV || audio_flow == SWITCH_MEDIA_FLOW_SENDONLY)) {
-+   if (switch_channel_test_flag(channel, CF_AUDIO)) {
-      conference_loop_output(&member);
-    } else {
-      if (!conference_utils_member_test_flag(&member, MFLAG_ITHREAD)) {
-
+ 	/* Run the conference loop */
+ 	do {
+-		switch_media_flow_t audio_flow = switch_core_session_media_flow(session, SWITCH_MEDIA_TYPE_AUDIO);
+-		
+-		if (switch_channel_test_flag(channel, CF_AUDIO) && (audio_flow == SWITCH_MEDIA_FLOW_SENDRECV || audio_flow == SWITCH_MEDIA_FLOW_SENDONLY)) {
++		if (switch_channel_test_flag(channel, CF_AUDIO)) {
+ 			conference_loop_output(&member);
+ 		} else {
+ 			if (!conference_utils_member_test_flag(&member, MFLAG_ITHREAD)) {

--- a/build/packages-template/bbb-freeswitch-core/floor.patch
+++ b/build/packages-template/bbb-freeswitch-core/floor.patch
@@ -1,6 +1,8 @@
---- src/mod/applications/mod_conference/conference_loop.c	2021-04-19 23:56:18.636116836 +0000
-+++ src/mod/applications/mod_conference/conference_loop-new.c	2021-04-20 00:23:16.700700282 +0000
-@@ -1193,7 +1193,7 @@
+diff --git src/mod/applications/mod_conference/conference_loop.c src/mod/applications/mod_conference/conference_loop.c
+index f9b7894..00fd775 100644
+--- src/mod/applications/mod_conference/conference_loop.c
++++ src/mod/applications/mod_conference/conference_loop.c
+@@ -1199,7 +1199,7 @@ void *SWITCH_THREAD_FUNC conference_loop_input(switch_thread_t *thread, void *ob
  
  			member->last_score = member->score;
  
@@ -9,4 +11,3 @@
  				if (member->id != member->conference->video_floor_holder &&
  					(member->floor_packets > member->conference->video_floor_packets || member->energy_level == 0)) {
  					conference_video_set_floor_holder(member->conference, member, SWITCH_FALSE);
-

--- a/build/packages-template/bbb-freeswitch-core/mod_audio_fork_build.patch
+++ b/build/packages-template/bbb-freeswitch-core/mod_audio_fork_build.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile.am b/Makefile.am
-index f869072ff7..b31807a6f8 100644
+index 7448ee1..5ce4986 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -166,6 +166,14 @@ if HAVE_FVAD
@@ -19,27 +19,27 @@ index f869072ff7..b31807a6f8 100644
  ##
 @@ -233,7 +241,7 @@ endif
  lib_LTLIBRARIES	         = libfreeswitch.la
- libfreeswitch_la_CFLAGS  = $(CORE_CFLAGS) $(SQLITE_CFLAGS) $(GUMBO_CFLAGS) $(FVAD_CFLAGS) $(FREETYPE_CFLAGS) $(CURL_CFLAGS) $(PCRE_CFLAGS) $(SPEEX_CFLAGS) $(LIBEDIT_CFLAGS) $(openssl_CFLAGS) $(SOFIA_SIP_CFLAGS) $(AM_CFLAGS) $(TPL_CFLAGS)
+ libfreeswitch_la_CFLAGS  = $(CORE_CFLAGS) $(SQLITE_CFLAGS) $(GUMBO_CFLAGS) $(FVAD_CFLAGS) $(FREETYPE_CFLAGS) $(CURL_CFLAGS) $(PCRE2_CFLAGS) $(SPEEX_CFLAGS) $(LIBEDIT_CFLAGS) $(openssl_CFLAGS) $(SOFIA_SIP_CFLAGS) $(AM_CFLAGS) $(TPL_CFLAGS)
  libfreeswitch_la_LDFLAGS = -version-info 1:0:0 $(AM_LDFLAGS) $(PLATFORM_CORE_LDFLAGS) -no-undefined
--libfreeswitch_la_LIBADD  = $(CORE_LIBS) $(APR_LIBS) $(SQLITE_LIBS) $(GUMBO_LIBS) $(FVAD_LIBS) $(FREETYPE_LIBS) $(CURL_LIBS) $(PCRE_LIBS) $(SPEEX_LIBS) $(LIBEDIT_LIBS) $(SYSTEMD_LIBS) $(openssl_LIBS) $(PLATFORM_CORE_LIBS) $(TPL_LIBS) $(SPANDSP_LIBS) $(SOFIA_SIP_LIBS)
-+libfreeswitch_la_LIBADD  = $(CORE_LIBS) $(APR_LIBS) $(SQLITE_LIBS) $(GUMBO_LIBS) $(FVAD_LIBS) $(FREETYPE_LIBS) $(CURL_LIBS) $(PCRE_LIBS) $(SPEEX_LIBS) $(LIBEDIT_LIBS) $(SYSTEMD_LIBS) $(openssl_LIBS) $(PLATFORM_CORE_LIBS) $(TPL_LIBS) $(SPANDSP_LIBS) $(SOFIA_SIP_LIBS) $(LWS_LIBS)
+-libfreeswitch_la_LIBADD  = $(CORE_LIBS) $(APR_LIBS) $(SQLITE_LIBS) $(GUMBO_LIBS) $(FVAD_LIBS) $(FREETYPE_LIBS) $(CURL_LIBS) $(PCRE2_LIBS) $(SPEEX_LIBS) $(LIBEDIT_LIBS) $(SYSTEMD_LIBS) $(openssl_LIBS) $(PLATFORM_CORE_LIBS) $(TPL_LIBS) $(SPANDSP_LIBS) $(SOFIA_SIP_LIBS)
++libfreeswitch_la_LIBADD  = $(CORE_LIBS) $(APR_LIBS) $(SQLITE_LIBS) $(GUMBO_LIBS) $(FVAD_LIBS) $(FREETYPE_LIBS) $(CURL_LIBS) $(PCRE2_LIBS) $(SPEEX_LIBS) $(LIBEDIT_LIBS) $(SYSTEMD_LIBS) $(openssl_LIBS) $(PLATFORM_CORE_LIBS) $(TPL_LIBS) $(SPANDSP_LIBS) $(SOFIA_SIP_LIBS) $(LWS_LIBS)
  libfreeswitch_la_DEPENDENCIES = $(BUILT_SOURCES)
  
  if HAVE_PNG
 diff --git a/build/modules.conf.in b/build/modules.conf.in
-index 7bf59e2acc..9cab2f6fdb 100644
+index 9b2e360..d81179b 100755
 --- a/build/modules.conf.in
 +++ b/build/modules.conf.in
 @@ -1,3 +1,4 @@
 +applications/mod_audio_fork
- #applications/mod_abstraction
  applications/mod_av
  #applications/mod_avmd
+ #applications/mod_bert
 diff --git a/configure.ac b/configure.ac
-index f09196bdfd..fba7b9d676 100644
+index b4938c8..3dbe7e6 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -1590,6 +1590,22 @@ AS_IF([test "x$enable_core_libedit_support" != "xno"],[
+@@ -1620,6 +1620,22 @@ AS_IF([test "x$enable_core_libedit_support" != "xno"],[
        AC_MSG_ERROR([You need to either install libedit-dev (>= 2.11) or configure with --disable-core-libedit-support])
        ])])])
  
@@ -62,11 +62,11 @@ index f09196bdfd..fba7b9d676 100644
  AC_ARG_ENABLE(systemd,
    [AS_HELP_STRING([--enable-systemd], [Compile with systemd notify support])])
  
-@@ -2081,6 +2097,7 @@ AC_CONFIG_FILES([Makefile
+@@ -1990,6 +2006,7 @@ AC_CONFIG_FILES([Makefile
  		tests/unit/Makefile
  		src/Makefile
  		src/mod/Makefile
 +		src/mod/applications/mod_audio_fork/Makefile
- 		src/mod/applications/mod_abstraction/Makefile
  		src/mod/applications/mod_avmd/Makefile
  		src/mod/applications/mod_bert/Makefile
+ 		src/mod/applications/mod_blacklist/Makefile

--- a/build/packages-template/bbb-freeswitch-core/modules.conf
+++ b/build/packages-template/bbb-freeswitch-core/modules.conf
@@ -93,7 +93,7 @@ endpoints/mod_rtc
 endpoints/mod_skinny
 #endpoints/mod_skypopen
 endpoints/mod_sofia
-endpoints/mod_verto
+#endpoints/mod_verto
 #event_handlers/mod_amqp
 event_handlers/mod_cdr_csv
 #event_handlers/mod_cdr_mongodb

--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -4,5 +4,5 @@ mkdir freeswitch
 cd freeswitch
 git init
 git remote add origin https://github.com/signalwire/freeswitch.git
-git fetch --depth 1 origin v1.10.12
+git fetch --depth 1 origin v1.11.1
 git checkout FETCH_HEAD


### PR DESCRIPTION
### What does this PR do?

- [build(freeswitch): v1.11.1 (up from v1.10.12)](https://github.com/bigbluebutton/bigbluebutton/pull/25157/changes/f614b54b72b433e79e42c58136b2a2bb7c52dba9)
  - Bump FreeSWITCH to v1.11.1.
  - See https://github.com/signalwire/freeswitch/releases/tag/v1.11.0
  - See https://github.com/signalwire/freeswitch/releases/tag/v1.11.1
  - Additional changes:
    - Adjust mod_audio_fork, audio floor and mod_conference patches to be
      up to date with v1.11.0
    - Update BBB build image to bigbluebutton/bbb-build:v3.0.x-release--2026-05-27-142334
      - FS@1.11.0 depends on libpcre2-dev (PCRE2)
- [build(freeswitch): disable mod_verto build](https://github.com/bigbluebutton/bigbluebutton/pull/25157/changes/50f8d9c0de92ae3d18904236115c5d7e0172aafd)
  - We do not enable mod_verto at runtime, nor require it.
  - Remove it from the module build list.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/25118

### More

Pending:
- [x] Update build image in bbb-docker-build-packages