### PR TITLE
fix: BBB 3.0.27 breaks downloading presentations in cluster proxy setup

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -162,11 +162,59 @@ const PresentationMenu = (props) => {
     const backgroundShape = tldrawAPI.getCurrentPageShapes().find((s) => s.id === `shape:BG-${slideNum}`);
     const shapes = tldrawAPI.getCurrentPageShapes();
     const pollShape = shapes.find((shape) => shape.type === 'poll');
-    const svgElem = await tldrawAPI.getSvg(
-      shapes
-        .filter((shape) => shape.type !== 'poll')
-        .map((shape) => shape.id),
-    );
+
+    // In a cluster proxy setup the slide URL is cross-origin.  tldraw's
+    // ImageShapeUtil.toSvg() calls fetch(url) without credentials, so the
+    // nginx auth_request check fails with 401.  Pre-fetch the background asset
+    // with credentials and temporarily swap the store record to a data URL so
+    // tldraw skips its own unauthenticated fetch during getSvg().
+    let originalAsset = null;
+    const assetId = backgroundShape?.props?.assetId;
+    if (assetId) {
+      const asset = tldrawAPI.getAsset(assetId);
+      const src = asset?.props?.src;
+      if (src && !src.startsWith('data:')) {
+        try {
+          const res = await fetch(src, { credentials: 'include' });
+          if (res.ok) {
+            const blob = await res.blob();
+            const dataUrl = await new Promise((resolve, reject) => {
+              const reader = new FileReader();
+              reader.onloadend = () => resolve(reader.result);
+              reader.onerror = reject;
+              reader.readAsDataURL(blob);
+            });
+            originalAsset = asset;
+            tldrawAPI.store.mergeRemoteChanges(() => {
+              tldrawAPI.store.put([{ ...asset, props: { ...asset.props, src: dataUrl } }]);
+            });
+          }
+        } catch (e) {
+          // CORS rejection is expected in cluster setups where $bbb_cors_origin
+          // is not overridden from the wildcard default; getSvg() will attempt
+          // its own fetch via the browser's same-site cookie rules.
+          logger.debug({
+            logCode: 'presentation_snapshot_prefetch_error',
+          }, `Slide asset pre-fetch for snapshot skipped: ${e}`);
+        }
+      }
+    }
+
+    let svgElem;
+    try {
+      svgElem = await tldrawAPI.getSvg(
+        shapes
+          .filter((shape) => shape.type !== 'poll')
+          .map((shape) => shape.id),
+      );
+    } finally {
+      if (originalAsset) {
+        tldrawAPI.store.mergeRemoteChanges(() => {
+          tldrawAPI.store.put([originalAsset]);
+        });
+      }
+    }
+
     svgElem.setAttribute('width', backgroundShape.props.w);
     svgElem.setAttribute('height', backgroundShape.props.h);
     svgElem.setAttribute('viewBox', `1 1 ${backgroundShape.props.w} ${backgroundShape.props.h}`);


### PR DESCRIPTION
### What does this PR do?

#### Problem

In a cluster proxy setup, the "snapshot of current slide" feature was broken. When `tldrawAPI.getSvg()` is called to generate the snapshot, tldraw's `ImageShapeUtil.toSvg()` internally calls `fetch(url)` without credentials to convert the slide asset URL to a data URI. In a cluster setup the slide URL is cross-origin (e.g. bbb-proxy.example.com → bbb-01.example.com), and since no JSESSIONID cookie is sent, the nginx auth_request check fails, causing the slide background to be missing from the snapshot.

#### Fix

Before calling `getSvg()`, the background asset URL is pre-fetched with `credentials: 'include'` (the same approach used in container.jsx for slide preloading). If the response is successful, the slide data is converted to a data URL and temporarily swapped into the tldraw store. Because the URL now starts with data:, tldraw's `ImageShapeUtil.toSvg()` skips its own unauthenticated fetch entirely and uses the embedded data directly. The original asset URL is restored in a finally block after `getSvg()` completes. If the pre-fetch fails (e.g. CORS wildcard is not overridden in `bbb-cluster.nginx`), the code falls through to `getSvg()`'s own fetch, which works for same-site clusters via SameSite=Lax cookies.

### Closes Issue(s)
Closes #25132

### How to test
1. Upload a PDF
2. Click on "Snapshot of current slide"