### PR TITLE
feat(core): recording parameter passthrough to breakouts

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -111,6 +111,8 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         breakout.presId,
         roomSlides,
         msg.body.record,
+        liveMeeting.props.recordProp.autoStartRecording,
+        liveMeeting.props.recordProp.allowStartStopRecording,
         liveMeeting.props.breakoutProps.privateChatEnabled,
         breakout.captureNotes,
         breakout.captureSlides,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -54,6 +54,8 @@ case class BreakoutRoomDetail(
     sourcePresentationId:    String,
     sourcePresentationSlide: Int,
     record:                  Boolean,
+    autoStartRecording:      Boolean,
+    allowStartStopRecording: Boolean,
     privateChatEnabled:      Boolean,
     captureNotes:            Boolean,
     captureSlides:           Boolean,

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -892,6 +892,8 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.VOICE_BRIDGE, message.voiceConfId);
       params.put(ApiParams.DURATION, message.durationInMinutes.toString());
       params.put(ApiParams.RECORD, message.record.toString());
+      params.put(ApiParams.AUTO_START_RECORDING, message.autoStartRecording.toString());
+      params.put(ApiParams.ALLOW_START_STOP_RECORDING, message.allowStartStopRecording.toString());
       params.put(ApiParams.WELCOME, getMeeting(message.parentMeetingId).getWelcomeMessageTemplate());
       params.put(ApiParams.AUDIO_BRIDGE, message.audioBridge);
       params.put(ApiParams.CAMERA_BRIDGE, message.cameraBridge);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -22,6 +22,8 @@ public class CreateBreakoutRoom implements IMessage {
     public final String sourcePresentationId;
     public final Integer sourcePresentationSlide;
     public final Boolean record;
+    public final Boolean autoStartRecording;
+    public final Boolean allowStartStopRecording;
     public final Boolean privateChatEnabled;
     public final Boolean captureNotes; // Upload shared notes to main room after breakout room end
     public final Boolean captureSlides; // Upload annotated breakout slides to main room after breakout room end
@@ -50,6 +52,8 @@ public class CreateBreakoutRoom implements IMessage {
 															String sourcePresentationId,
 															Integer sourcePresentationSlide,
 															Boolean record,
+															Boolean autoStartRecording,
+															Boolean allowStartStopRecording,
 															Boolean privateChatEnabled,
                                                             Boolean captureNotes,
                                                             Boolean captureSlides,
@@ -77,6 +81,8 @@ public class CreateBreakoutRoom implements IMessage {
         this.sourcePresentationId = sourcePresentationId;
         this.sourcePresentationSlide = sourcePresentationSlide;
         this.record = record;
+        this.autoStartRecording = autoStartRecording;
+        this.allowStartStopRecording = allowStartStopRecording;
         this.privateChatEnabled = privateChatEnabled;
         this.captureNotes = captureNotes;
         this.captureSlides = captureSlides;

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -123,6 +123,8 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.sourcePresentationId,
       msg.body.room.sourcePresentationSlide,
       msg.body.room.record,
+      msg.body.room.autoStartRecording,
+      msg.body.room.allowStartStopRecording,
       msg.body.room.privateChatEnabled,
       msg.body.room.captureNotes,
       msg.body.room.captureSlides,

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -148,6 +148,7 @@ export interface Breakouts {
   sendInvitationToAssignedModeratorsByDefault: boolean
   breakoutRoomLimit: number
   allowPresentationManagementInBreakouts: boolean
+  lockBreakoutRecording: boolean
 }
 
 export interface RaiseHandActionButton {

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -148,7 +148,7 @@ export interface Breakouts {
   sendInvitationToAssignedModeratorsByDefault: boolean
   breakoutRoomLimit: number
   allowPresentationManagementInBreakouts: boolean
-  lockBreakoutRecording: boolean
+  lockBreakoutRecordingSetting: boolean
 }
 
 export interface RaiseHandActionButton {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -250,7 +250,12 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   // @ts-ignore
   const BREAKOUT_SETTINGS = window.meetingClientSettings.public.app.breakouts;
 
-  const { allowUserChooseRoomByDefault, recordRoomByDefault, offerRecordingForBreakouts } = BREAKOUT_SETTINGS;
+  const {
+    allowUserChooseRoomByDefault,
+    recordRoomByDefault,
+    offerRecordingForBreakouts,
+    lockBreakoutRecording,
+  } = BREAKOUT_SETTINGS;
   const captureWhiteboardByDefault = BREAKOUT_SETTINGS.captureWhiteboardByDefault
                                     && isImportPresentationWithAnnotationsEnabled;
   const captureSharedNotesByDefault = BREAKOUT_SETTINGS.captureSharedNotesByDefault
@@ -259,8 +264,9 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
 
   const [numberOfRoomsIsValid, setNumberOfRoomsIsValid] = React.useState(true);
   const [durationIsValid, setDurationIsValid] = React.useState(true);
+  const forceRecord = lockBreakoutRecording && isBreakoutRecordable;
   const [freeJoin, setFreeJoin] = React.useState(allowUserChooseRoomByDefault);
-  const [record, setRecord] = React.useState(recordRoomByDefault);
+  const [record, setRecord] = React.useState(forceRecord || recordRoomByDefault);
   const [captureSlides, setCaptureSlides] = React.useState(captureWhiteboardByDefault);
   const [leastOneUserIsValid, setLeastOneUserIsValid] = React.useState(false);
   const [captureNotes, setCaptureNotes] = React.useState(captureSharedNotesByDefault);
@@ -419,6 +425,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
       {
         allowed: isBreakoutRecordable && offerRecordingForBreakouts,
         checked: record,
+        disabled: forceRecord,
         htmlFor: 'recordBreakoutCheckbox',
         key: 'record-breakouts',
         id: 'recordBreakoutCheckbox',
@@ -462,6 +469,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
     captureSlides,
     captureNotes,
     inviteMods,
+    forceRecord,
   ]);
 
   const form = useMemo(() => {
@@ -564,6 +572,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
                     onChange={item.onChange}
                     aria-label={item.label}
                     checked={item.checked}
+                    disabled={item.disabled ?? false}
                   />
                   <span aria-hidden>{item.label}</span>
                 </Styled.FreeJoinLabel>

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -254,7 +254,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
     allowUserChooseRoomByDefault,
     recordRoomByDefault,
     offerRecordingForBreakouts,
-    lockBreakoutRecording,
+    lockBreakoutRecordingSetting,
   } = BREAKOUT_SETTINGS;
   const captureWhiteboardByDefault = BREAKOUT_SETTINGS.captureWhiteboardByDefault
                                     && isImportPresentationWithAnnotationsEnabled;
@@ -264,7 +264,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
 
   const [numberOfRoomsIsValid, setNumberOfRoomsIsValid] = React.useState(true);
   const [durationIsValid, setDurationIsValid] = React.useState(true);
-  const forceRecord = lockBreakoutRecording && isBreakoutRecordable;
+  const forceRecord = lockBreakoutRecordingSetting && isBreakoutRecordable;
   const [freeJoin, setFreeJoin] = React.useState(allowUserChooseRoomByDefault);
   const [record, setRecord] = React.useState(forceRecord || recordRoomByDefault);
   const [captureSlides, setCaptureSlides] = React.useState(captureWhiteboardByDefault);

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -94,7 +94,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         sendInvitationToAssignedModeratorsByDefault: false,
         breakoutRoomLimit: 16,
         allowPresentationManagementInBreakouts: true,
-        lockBreakoutRecording: false,
+        lockBreakoutRecordingSetting: false,
       },
       showAllAvailableLocales: true,
       showAudioFilters: true,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -94,6 +94,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         sendInvitationToAssignedModeratorsByDefault: false,
         breakoutRoomLimit: 16,
         allowPresentationManagementInBreakouts: true,
+        lockBreakoutRecording: false,
       },
       showAllAvailableLocales: true,
       showAudioFilters: true,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -133,14 +133,23 @@ public:
     # can generate excessive overhead to the server. We recommend
     # this value to be kept under 16.
     breakouts:
+      # Allow participants to pick their own breakout room instead of being assigned
       allowUserChooseRoomByDefault: false
+      # Show the recording option (if breakout recording is enabled) when creating breakout rooms
       offerRecordingForBreakouts: false
+      # Pre-check the "record breakout room" option
       recordRoomByDefault: false
+      # Pre-check the "capture whiteboard when ending breakouts" option 
       captureWhiteboardByDefault: false
+      # Pre-check the "save shared notes when ending breakouts" option
       captureSharedNotesByDefault: false
+      # Pre-check the "send invitation to assigned moderators" option
       sendInvitationToAssignedModeratorsByDefault: false
+      # Maximum number of breakout rooms that can be created
       breakoutRoomLimit: 16
+      # Allow the presenter role to manage presentations inside breakout rooms
       allowPresentationManagementInBreakouts: true
+      # Set to true to remove the ability to disable recording when setting up breakout rooms
       lockBreakoutRecording: false
     showAllAvailableLocales: true
     # Show "Audio Filters for Microphone" option in settings menu.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -149,7 +149,7 @@ public:
       breakoutRoomLimit: 16
       # Allow the presenter role to manage presentations inside breakout rooms
       allowPresentationManagementInBreakouts: true
-      # Set to true to remove the ability to disable recording when setting up breakout rooms
+      # Set to true to remove the ability for the breakout recording policy to be changed by the moderator at breakout creation time
       lockBreakoutRecording: false
     showAllAvailableLocales: true
     # Show "Audio Filters for Microphone" option in settings menu.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -150,7 +150,7 @@ public:
       # Allow the presenter role to manage presentations inside breakout rooms
       allowPresentationManagementInBreakouts: true
       # Set to true to remove the ability for the breakout recording policy to be changed by the moderator at breakout creation time
-      lockBreakoutRecording: false
+      lockBreakoutRecordingSetting: false
     showAllAvailableLocales: true
     # Show "Audio Filters for Microphone" option in settings menu.
     # When set to true, users are able to enable/disable microphone constraints,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -141,6 +141,7 @@ public:
       sendInvitationToAssignedModeratorsByDefault: false
       breakoutRoomLimit: 16
       allowPresentationManagementInBreakouts: true
+      lockBreakoutRecording: false
     showAllAvailableLocales: true
     # Show "Audio Filters for Microphone" option in settings menu.
     # When set to true, users are able to enable/disable microphone constraints,


### PR DESCRIPTION
### What does this PR do?

Applies the following changes to breakout room creation:
- Pass through `autoStartRecording` from parent room to breakout room
- Pass through `allowStartStopRecording` from parent room to breakout room
- Introduces new option in settings.yml `lockBreakoutRecordingSetting` (default: `false`) to remove the ability for a moderator to disable breakout room recording when setting up breakout rooms