### PR TITLE
fix(recording-button): allow reopening confirmation toast after cancel

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -142,6 +142,10 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
     }
   }, [openRecordingModal, closeRecordingModal]);
 
+  const closeRecordingConfirmation = useCallback(() => {
+    setIsRecordingModalOpen(false);
+  }, [setIsRecordingModalOpen]);
+
   const {
     isOpen: isRecordingNotifyModalOpen,
     open: openRecordingNotifyModal,
@@ -336,7 +340,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
       {isRecordingModalOpen ? (
         <RecordingContainer
           amIModerator={isModerator}
-          onRequestClose={() => setIsRecordingModalOpen(false)}
+          onRequestClose={closeRecordingConfirmation}
           priority="high"
           setIsOpen={setIsRecordingModalOpen}
           isOpen={isRecordingModalOpen}

--- a/bigbluebutton-html5/imports/ui/components/recording/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/component.tsx
@@ -53,27 +53,45 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
   recordingStatus, recordingTime, toggleRecording, onRequestClose,
 }) => {
   const intl = useIntl();
+  const [recordingToastId] = React.useState(() => `recording-confirmation-${uuid()}`);
 
-  const handleShowNotification = () => {
-    const isResuming = recordingTime > 0 && !recordingStatus;
-    let title;
+  const isResuming = recordingTime > 0 && !recordingStatus;
+  let notificationTitleMessage = intlMessages.startTitle;
 
-    if (recordingStatus) {
-      title = intl.formatMessage(intlMessages.stopTitle);
-    } else if (isResuming) {
-      title = intl.formatMessage(intlMessages.resumeTitle);
-    } else {
-      title = intl.formatMessage(intlMessages.startTitle);
-    }
+  if (recordingStatus) {
+    notificationTitleMessage = intlMessages.stopTitle;
+  } else if (isResuming) {
+    notificationTitleMessage = intlMessages.resumeTitle;
+  }
 
-    const description = recordingStatus
-      ? intl.formatMessage(intlMessages.stopDescription)
-      : intl.formatMessage(intlMessages.startDescription);
+  const notificationTitle = intl.formatMessage(notificationTitleMessage);
+  const notificationDescription = intl.formatMessage(
+    recordingStatus ? intlMessages.stopDescription : intlMessages.startDescription,
+  );
+  const cancelButtonLabel = intl.formatMessage(intlMessages.cancelButtonLabel);
+  const confirmationButtonLabel = intl.formatMessage(
+    recordingStatus ? intlMessages.stopButtonLabel : intlMessages.recordButtonLabel,
+  );
 
-    const toastId = notify(
+  const dismissRecordingToast = React.useCallback(() => {
+    toast.dismiss(recordingToastId);
+  }, [recordingToastId]);
+
+  const handleCancel = React.useCallback(() => {
+    dismissRecordingToast();
+    onRequestClose();
+  }, [dismissRecordingToast, onRequestClose]);
+
+  const handleConfirm = React.useCallback(() => {
+    dismissRecordingToast();
+    toggleRecording();
+  }, [dismissRecordingToast, toggleRecording]);
+
+  React.useEffect(() => {
+    notify(
       <div>
-        <Styled.TitleText>{title}</Styled.TitleText>
-        <Styled.DescriptionText>{description}</Styled.DescriptionText>
+        <Styled.TitleText>{notificationTitle}</Styled.TitleText>
+        <Styled.DescriptionText>{notificationDescription}</Styled.DescriptionText>
       </div>,
       'default',
       false,
@@ -82,30 +100,20 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
         closeButton: false,
         closeOnClick: false,
         disablePointer: true,
-        toastId: `recording-confirmation-${uuid()}`,
+        toastId: recordingToastId,
       },
       (
         <Styled.NotificationContent>
           <Styled.NotificationActions>
             <Styled.CancelButton
               data-test="cancelRecordingButton"
-              onClick={() => {
-                if (toastId != null) {
-                  toast.dismiss(toastId);
-                }
-                onRequestClose();
-              }}
+              onClick={handleCancel}
             >
-              {intl.formatMessage(intlMessages.cancelButtonLabel)}
+              {cancelButtonLabel}
             </Styled.CancelButton>
             <Styled.ConfirmationButton
               data-test="confirmRecordingButton"
-              onClick={() => {
-                if (toastId != null) {
-                  toast.dismiss(toastId);
-                }
-                toggleRecording();
-              }}
+              onClick={handleConfirm}
             >
               <Styled.SvgCapsule>
                 {recordingStatus ? (
@@ -114,9 +122,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
                   <SvgIcon iconName="recording" />
                 )}
               </Styled.SvgCapsule>
-              {recordingStatus
-                ? intl.formatMessage(intlMessages.stopButtonLabel)
-                : intl.formatMessage(intlMessages.recordButtonLabel)}
+              {confirmationButtonLabel}
             </Styled.ConfirmationButton>
           </Styled.NotificationActions>
         </Styled.NotificationContent>
@@ -124,19 +130,22 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
       false,
       false,
     );
-
-    return toastId;
-  };
+  }, [
+    cancelButtonLabel,
+    confirmationButtonLabel,
+    handleCancel,
+    handleConfirm,
+    notificationDescription,
+    notificationTitle,
+    recordingStatus,
+    recordingToastId,
+  ]);
 
   React.useEffect(() => {
-    const toastId = handleShowNotification();
-
     return () => {
-      if (toastId != null) {
-        toast.dismiss(toastId);
-      }
+      dismissRecordingToast();
     };
-  }, [recordingStatus]);
+  }, [dismissRecordingToast]);
 
   return null;
 };

--- a/bigbluebutton-html5/imports/ui/components/recording/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/component.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { notify } from '/imports/ui/services/notification';
 import { toast } from 'react-toastify';
+import { v4 as uuid } from 'uuid';
 import SvgIcon from '/imports/ui/components/common/icon-svg/component';
 import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
-
-let recordingToastSequence = 0;
 
 const intlMessages = defineMessages({
   startTitle: {
@@ -57,7 +56,6 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
 
   const handleShowNotification = () => {
     const isResuming = recordingTime > 0 && !recordingStatus;
-    const recordingToastId = `recording-confirmation-${recordingToastSequence += 1}`;
     let title;
 
     if (recordingStatus) {
@@ -84,7 +82,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
         closeButton: false,
         closeOnClick: false,
         disablePointer: true,
-        toastId: recordingToastId,
+        toastId: `recording-confirmation-${uuid()}`,
       },
       (
         <Styled.NotificationContent>
@@ -92,7 +90,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
             <Styled.CancelButton
               data-test="cancelRecordingButton"
               onClick={() => {
-                if (toastId !== null && toastId !== undefined) {
+                if (toastId != null) {
                   toast.dismiss(toastId);
                 }
                 onRequestClose();
@@ -103,7 +101,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
             <Styled.ConfirmationButton
               data-test="confirmRecordingButton"
               onClick={() => {
-                if (toastId !== null && toastId !== undefined) {
+                if (toastId != null) {
                   toast.dismiss(toastId);
                 }
                 toggleRecording();
@@ -134,7 +132,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
     const toastId = handleShowNotification();
 
     return () => {
-      if (toastId !== null && toastId !== undefined) {
+      if (toastId != null) {
         toast.dismiss(toastId);
       }
     };

--- a/bigbluebutton-html5/imports/ui/components/recording/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/component.tsx
@@ -6,6 +6,8 @@ import SvgIcon from '/imports/ui/components/common/icon-svg/component';
 import Icon from '/imports/ui/components/common/icon/component';
 import Styled from './styles';
 
+let recordingToastSequence = 0;
+
 const intlMessages = defineMessages({
   startTitle: {
     id: 'app.recording.startTitle',
@@ -55,6 +57,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
 
   const handleShowNotification = () => {
     const isResuming = recordingTime > 0 && !recordingStatus;
+    const recordingToastId = `recording-confirmation-${recordingToastSequence += 1}`;
     let title;
 
     if (recordingStatus) {
@@ -81,6 +84,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
         closeButton: false,
         closeOnClick: false,
         disablePointer: true,
+        toastId: recordingToastId,
       },
       (
         <Styled.NotificationContent>
@@ -88,7 +92,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
             <Styled.CancelButton
               data-test="cancelRecordingButton"
               onClick={() => {
-                if (toastId !== null) {
+                if (toastId !== null && toastId !== undefined) {
                   toast.dismiss(toastId);
                 }
                 onRequestClose();
@@ -99,7 +103,7 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
             <Styled.ConfirmationButton
               data-test="confirmRecordingButton"
               onClick={() => {
-                if (toastId !== null) {
+                if (toastId !== null && toastId !== undefined) {
                   toast.dismiss(toastId);
                 }
                 toggleRecording();
@@ -122,10 +126,18 @@ const RecordingComponent: React.FC<RecordingComponentProps> = ({
       false,
       false,
     );
+
+    return toastId;
   };
 
   React.useEffect(() => {
-    handleShowNotification();
+    const toastId = handleShowNotification();
+
+    return () => {
+      if (toastId !== null && toastId !== undefined) {
+        toast.dismiss(toastId);
+      }
+    };
   }, [recordingStatus]);
 
   return null;

--- a/bigbluebutton-html5/imports/ui/components/recording/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/container.tsx
@@ -43,14 +43,14 @@ const RecordingContainer: React.FC<RecordingContainerProps> = (props) => {
   const time = recordingData?.meeting_recording[0]?.previousRecordedTimeInSeconds ?? 0;
   const allowStartStopRecording = currentMeetingData?.recordingPolicies?.allowStartStopRecording ?? false;
 
-  const toggleRecording = () => {
+  const toggleRecording = React.useCallback(() => {
     setRecordingStatus({
       variables: {
         recording: !recording,
       },
     });
     setIsOpen(false);
-  };
+  }, [recording, setIsOpen, setRecordingStatus]);
 
   const mayIRecord = Service.mayIRecord(amIModerator, allowStartStopRecording);
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
Fixes the recording confirmation prompt so it can be opened again after the user cancels it.

The recording confirmation toast now receives a unique toast id for each prompt instance, and the active toast is dismissed when the prompt component unmounts.


### Motivation
After cancelling the recording confirmation prompt once, clicking the recording button again did not show the prompt. The modal state was reopened, but react-toastify could still treat the previous toast id as active while its dismissal animation was finishing, so the new prompt was skipped as a duplicate.


### How to test

1. Join a meeting as a moderator with recording enabled.
2. Click the recording button in the navigation bar.
3. Click Cancel in the recording confirmation prompt.
4. Click the recording button again.
5. Confirm the recording confirmation prompt appears again.
6. Repeat the same flow quickly to verify the prompt can be reopened consistently.