### PR TITLE
feat(core): allow moderators to manage lock settings inside breakout rooms and optionally inherit parent meeting lock settings on creation

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -94,6 +94,14 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       // get lock settings from parent meeting
       val lockSettings = org.bigbluebutton.core2.MeetingStatus2x.getPermissions(liveMeeting.status)
 
+      val (lsCam, lsMic, lsPubChat, lsNotes, lsHideUsers, lsLockOnJoin, lsLockOnJoinCfg, lsHideCursor, lsHideAnnotation) =
+        if (msg.body.inheritLockSettings)
+          (lockSettings.disableCam, lockSettings.disableMic, lockSettings.disablePubChat,
+            lockSettings.disableNotes, lockSettings.hideUserList, lockSettings.lockOnJoin,
+            lockSettings.lockOnJoinConfigurable, lockSettings.hideViewersCursor, lockSettings.hideViewersAnnotation)
+        else
+          (false, false, false, false, false, true, false, false, false)
+
       val roomDetail = BreakoutRoomDetail(
         breakout.id,
         breakout.name,
@@ -123,7 +131,16 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         liveMeeting.props.meetingProp.audioBridge,
         liveMeeting.props.meetingProp.cameraBridge,
         liveMeeting.props.meetingProp.screenShareBridge,
-        lockSettings.disablePrivChat
+        lockSettings.disablePrivChat,
+        lsCam,
+        lsMic,
+        lsPubChat,
+        lsNotes,
+        lsHideUsers,
+        lsLockOnJoin,
+        lsLockOnJoinCfg,
+        lsHideCursor,
+        lsHideAnnotation
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -94,13 +94,13 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       // get lock settings from parent meeting
       val lockSettings = org.bigbluebutton.core2.MeetingStatus2x.getPermissions(liveMeeting.status)
 
-      val (lsCam, lsMic, lsPubChat, lsNotes, lsHideUsers, lsLockOnJoin, lsLockOnJoinCfg, lsHideCursor, lsHideAnnotation) =
+      val (lsPrivChat, lsCam, lsMic, lsPubChat, lsNotes, lsHideUsers, lsLockOnJoin, lsLockOnJoinCfg, lsHideCursor, lsHideAnnotation) =
         if (msg.body.inheritLockSettings)
-          (lockSettings.disableCam, lockSettings.disableMic, lockSettings.disablePubChat,
+          (lockSettings.disablePrivChat, lockSettings.disableCam, lockSettings.disableMic, lockSettings.disablePubChat,
             lockSettings.disableNotes, lockSettings.hideUserList, lockSettings.lockOnJoin,
             lockSettings.lockOnJoinConfigurable, lockSettings.hideViewersCursor, lockSettings.hideViewersAnnotation)
         else
-          (false, false, false, false, false, true, false, false, false)
+          (false, false, false, false, false, false, false, false, false, false)
 
       val roomDetail = BreakoutRoomDetail(
         breakout.id,
@@ -131,7 +131,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         liveMeeting.props.meetingProp.audioBridge,
         liveMeeting.props.meetingProp.cameraBridge,
         liveMeeting.props.meetingProp.screenShareBridge,
-        lockSettings.disablePrivChat,
+        lsPrivChat,
         lsCam,
         lsMic,
         lsPubChat,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/ChangeLockSettingsInMeetingCmdMsgHdlr.scala
@@ -19,7 +19,7 @@ trait ChangeLockSettingsInMeetingCmdMsgHdlr extends RightsManagementTrait {
 
   def handleSetLockSettings(msg: ChangeLockSettingsInMeetingCmdMsg): Unit = {
 
-    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId) || liveMeeting.props.meetingProp.isBreakout) {
+    if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, msg.header.userId)) {
       val meetingId = liveMeeting.props.meetingProp.intId
       val reason = "No permission to change lock settings"
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, outGW, liveMeeting)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
@@ -81,7 +81,6 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
       liveMeeting: LiveMeeting,
       userId:      String
   ): Boolean = {
-    val isBreakout = liveMeeting.props.meetingProp.isBreakout
     val hasPermission = !permissionFailed(
       PermissionCheck.MOD_LEVEL,
       PermissionCheck.VIEWER_LEVEL,
@@ -89,7 +88,7 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
       userId
     )
 
-    (!isBreakout && hasPermission)
+    hasPermission
   }
 
   def updateWebcamsOnlyForModerator(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -66,7 +66,16 @@ case class BreakoutRoomDetail(
     audioBridge:             String,
     cameraBridge:            String,
     screenShareBridge:       String,
-    disablePrivChat:         Boolean
+    disablePrivChat:         Boolean,
+    disableCam:              Boolean,
+    disableMic:              Boolean,
+    disablePubChat:          Boolean,
+    disableNotes:            Boolean,
+    hideUserList:            Boolean,
+    lockOnJoin:              Boolean,
+    lockOnJoinConfigurable:  Boolean,
+    hideViewersCursor:       Boolean,
+    hideViewersAnnotation:   Boolean
 )
 
 /**
@@ -74,7 +83,7 @@ case class BreakoutRoomDetail(
  */
 object CreateBreakoutRoomsCmdMsg { val NAME = "CreateBreakoutRoomsCmdMsg" }
 case class CreateBreakoutRoomsCmdMsg(header: BbbClientMsgHeader, body: CreateBreakoutRoomsCmdMsgBody) extends StandardMsg
-case class CreateBreakoutRoomsCmdMsgBody(meetingId: String, durationInMinutes: Int, record: Boolean, captureNotes: Boolean, captureSlides: Boolean, rooms: Vector[BreakoutRoomMsgBody], sendInviteToModerators: Boolean)
+case class CreateBreakoutRoomsCmdMsgBody(meetingId: String, durationInMinutes: Int, record: Boolean, captureNotes: Boolean, captureSlides: Boolean, rooms: Vector[BreakoutRoomMsgBody], sendInviteToModerators: Boolean, inheritLockSettings: Boolean)
 case class BreakoutRoomMsgBody(name: String, sequence: Int, shortName: String, captureNotesFilename: String, captureSlidesFilename: String, isDefaultName: Boolean, freeJoin: Boolean, users: Vector[String], allPages: Boolean, presId: String)
 
 // Sent by user to request ending all the breakout rooms

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -902,8 +902,17 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.DISABLED_FEATURES,String.join(",", message.disabledFeatures));
       params.put(ApiParams.GUEST_POLICY, GuestPolicy.ALWAYS_ACCEPT);
 
-      // Apply private chat lock settings from parent meeting to breakout room
+      // Apply lock settings from parent meeting to breakout room
       params.put(ApiParams.LOCK_SETTINGS_DISABLE_PRIVATE_CHAT, message.disablePrivChat.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_CAM, message.disableCam.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_MIC, message.disableMic.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_PUBLIC_CHAT, message.disablePubChat.toString());
+      params.put(ApiParams.LOCK_SETTINGS_DISABLE_NOTES, message.disableNotes.toString());
+      params.put(ApiParams.LOCK_SETTINGS_HIDE_USER_LIST, message.hideUserList.toString());
+      params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN, message.lockOnJoin.toString());
+      params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE, message.lockOnJoinConfigurable.toString());
+      params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_CURSOR, message.hideViewersCursor.toString());
+      params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION, message.hideViewersAnnotation.toString());
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -35,36 +35,54 @@ public class CreateBreakoutRoom implements IMessage {
     public final String cameraBridge;
     public final String screenShareBridge;
     public final Boolean disablePrivChat;
+    public final Boolean disableCam;
+    public final Boolean disableMic;
+    public final Boolean disablePubChat;
+    public final Boolean disableNotes;
+    public final Boolean hideUserList;
+    public final Boolean lockOnJoin;
+    public final Boolean lockOnJoinConfigurable;
+    public final Boolean hideViewersCursor;
+    public final Boolean hideViewersAnnotation;
 
     public CreateBreakoutRoom(String meetingId,
-															String parentMeetingId,
-															String name,
-															Integer sequence,
-															String shortName,
-                                                            String sharedNotesEditor,
-															Boolean isDefaultName,
-															Boolean freeJoin,
-															String dialNumber,
-															String voiceConfId,
-															String viewerPassword,
-															String moderatorPassword,
-															Integer duration,
-															String sourcePresentationId,
-															Integer sourcePresentationSlide,
-															Boolean record,
-															Boolean autoStartRecording,
-															Boolean allowStartStopRecording,
-															Boolean privateChatEnabled,
-                                                            Boolean captureNotes,
-                                                            Boolean captureSlides,
-                                                            String captureNotesFilename,
-                                                            String captureSlidesFilename,
-                                                            Map<String, Object> pluginProp,
-                                                            ArrayList<String> disabledFeatures,
-                                                            String audioBridge,
-                                                            String cameraBridge,
-                                                            String screenShareBridge,
-                                                            Boolean disablePrivChat) {
+                              String parentMeetingId,
+                              String name,
+                              Integer sequence,
+                              String shortName,
+                              String sharedNotesEditor,
+                              Boolean isDefaultName,
+                              Boolean freeJoin,
+                              String dialNumber,
+                              String voiceConfId,
+                              String viewerPassword,
+                              String moderatorPassword,
+                              Integer duration,
+                              String sourcePresentationId,
+                              Integer sourcePresentationSlide,
+                              Boolean record,
+                              Boolean autoStartRecording,
+                              Boolean allowStartStopRecording,
+                              Boolean privateChatEnabled,
+                              Boolean captureNotes,
+                              Boolean captureSlides,
+                              String captureNotesFilename,
+                              String captureSlidesFilename,
+                              Map<String, Object> pluginProp,
+                              ArrayList<String> disabledFeatures,
+                              String audioBridge,
+                              String cameraBridge,
+                              String screenShareBridge,
+                              Boolean disablePrivChat,
+                              Boolean disableCam,
+                              Boolean disableMic,
+                              Boolean disablePubChat,
+                              Boolean disableNotes,
+                              Boolean hideUserList,
+                              Boolean lockOnJoin,
+                              Boolean lockOnJoinConfigurable,
+                              Boolean hideViewersCursor,
+                              Boolean hideViewersAnnotation) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -94,5 +112,14 @@ public class CreateBreakoutRoom implements IMessage {
         this.cameraBridge = cameraBridge;
         this.screenShareBridge = screenShareBridge;
         this.disablePrivChat = disablePrivChat;
+        this.disableCam = disableCam;
+        this.disableMic = disableMic;
+        this.disablePubChat = disablePubChat;
+        this.disableNotes = disableNotes;
+        this.hideUserList = hideUserList;
+        this.lockOnJoin = lockOnJoin;
+        this.lockOnJoinConfigurable = lockOnJoinConfigurable;
+        this.hideViewersCursor = hideViewersCursor;
+        this.hideViewersAnnotation = hideViewersAnnotation;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -135,7 +135,16 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.audioBridge,
       msg.body.room.cameraBridge,
       msg.body.room.screenShareBridge,
-      msg.body.room.disablePrivChat
+      msg.body.room.disablePrivChat,
+      msg.body.room.disableCam,
+      msg.body.room.disableMic,
+      msg.body.room.disablePubChat,
+      msg.body.room.disableNotes,
+      msg.body.room.hideUserList,
+      msg.body.room.lockOnJoin,
+      msg.body.room.lockOnJoinConfigurable,
+      msg.body.room.hideViewersCursor,
+      msg.body.room.hideViewersAnnotation
     ))
   }
 

--- a/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
+++ b/bbb-graphql-actions/src/actions/breakoutRoomCreate.ts
@@ -13,6 +13,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
         {name: 'captureSlides', type: 'boolean', required: true},
         {name: 'durationInMinutes', type: 'int', required: true},
         {name: 'sendInviteToModerators', type: 'boolean', required: true},
+        {name: 'inheritLockSettings', type: 'boolean', required: true},
         {name: 'rooms', type: 'objectArray', required: true},
       ]
   )
@@ -54,6 +55,7 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     captureSlides: input.captureSlides,
     durationInMinutes: input.durationInMinutes,
     sendInviteToModerators: input.sendInviteToModerators,
+    inheritLockSettings: input.inheritLockSettings,
     rooms: input.rooms,
   };
 

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -39,6 +39,7 @@ type Mutation {
     captureSlides: Boolean!
     durationInMinutes: Int!
     sendInviteToModerators: Boolean!
+    inheritLockSettings: Boolean!
     rooms: [BreakoutRoom]!
   ): Boolean
 }

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -218,6 +218,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.sendInvitationToMods',
     description: 'label for checkbox send invitation to moderators',
   },
+  inheritLockSettingsLabel: {
+    id: 'app.createBreakoutRoom.inheritLockSettings',
+    description: 'label for checkbox to propagate lock settings',
+  },
   timeCannotExceedMainRoom: {
     id: 'app.createBreakoutRoom.timeCannotExceedMainRoom',
     description: 'label for checkbox send invitation to moderators',
@@ -271,6 +275,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
   const [leastOneUserIsValid, setLeastOneUserIsValid] = React.useState(false);
   const [captureNotes, setCaptureNotes] = React.useState(captureSharedNotesByDefault);
   const [inviteMods, setInviteMods] = React.useState(inviteModsByDefault);
+  const [inheritLockSettings, setInheritLockSettings] = React.useState(false);
   const [numberOfRooms, setNumberOfRooms] = React.useState(initialNumberOfRooms);
   const [durationTime, setDurationTime] = React.useState(DEFAULT_BREAKOUT_TIME);
   const [roomPresentations, setRoomPresentations] = React.useState<RoomPresentations>([]);
@@ -377,6 +382,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
           captureSlides,
           durationInMinutes: durationTime,
           sendInviteToModerators: inviteMods,
+          inheritLockSettings,
           rooms: roomsArray,
         },
       },
@@ -459,6 +465,15 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
         onChange: checkboxCallbackFactory(setInviteMods),
         label: intl.formatMessage(intlMessages.sendInvitationToMods),
       },
+      {
+        allowed: true,
+        checked: inheritLockSettings,
+        htmlFor: 'inheritLockSettingsCheckbox',
+        key: 'inherit-lock-settings-breakouts',
+        id: 'inheritLockSettingsCheckbox',
+        onChange: checkboxCallbackFactory(setInheritLockSettings),
+        label: intl.formatMessage(intlMessages.inheritLockSettingsLabel),
+      },
     ];
   }, [
     isBreakoutRecordable,
@@ -470,6 +485,7 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
     captureNotes,
     inviteMods,
     forceRecord,
+    inheritLockSettings,
   ]);
 
   const form = useMemo(() => {

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/mutations.ts
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/mutations.ts
@@ -7,6 +7,7 @@ export const BREAKOUT_ROOM_CREATE = gql`
     $captureSlides: Boolean!,
     $durationInMinutes: Int!,
     $sendInviteToModerators: Boolean!,
+    $inheritLockSettings: Boolean!,
     $rooms: [BreakoutRoom]!,
   ) {
     breakoutRoomCreate(
@@ -15,6 +16,7 @@ export const BREAKOUT_ROOM_CREATE = gql`
       captureSlides: $captureSlides,
       durationInMinutes: $durationInMinutes,
       sendInviteToModerators: $sendInviteToModerators,
+      inheritLockSettings: $inheritLockSettings,
       rooms: $rooms,
     )
   }

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-graphql/user-participants-title/user-options-dropdown/component.tsx
@@ -270,7 +270,7 @@ const UserTitleOptions: React.FC<UserTitleOptionsProps> = ({
         dataTest: 'muteAllExceptPresenter',
       },
       {
-        allow: !isBreakout,
+        allow: true,
         key: uuids.current[2],
         label: intl.formatMessage(intlMessages.lockViewersLabel),
         description: intl.formatMessage(intlMessages.lockViewersDesc),

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1386,6 +1386,7 @@
     "app.createBreakoutRoom.captureNotes": "Save shared notes",
     "app.createBreakoutRoom.captureSlides": "Save whiteboard",
     "app.createBreakoutRoom.sendInvitationToMods": "Send invitation to assigned moderators",
+    "app.createBreakoutRoom.inheritLockSettings": "Propagate the current lock settings",
     "app.createBreakoutRoom.leastOneWarnBreakout": "You must place at least one user in a breakout room.",
     "app.createBreakoutRoom.minimumDurationWarnBreakout": "Minimum duration for a breakout room is {timeInMinutes} minutes.",
     "app.createBreakoutRoom.timeCannotExceedMainRoom": "The breakout room duration cannot exceed the session remaining time.",

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -39,6 +39,24 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await create.initPages(page, testInfo);
       await create.dragDropUserInRoom();
     });
+
+    test('Inherit lock settings checkbox is visible and unchecked by default', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.inheritLockSettingsCheckboxIsVisible();
+    });
+
+    test('Lock Viewers option is visible in gear menu inside breakout room', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.lockViewersVisibleInBreakoutGearMenu();
+    });
+
+    test('Moderator can disable inherited lock settings in breakout room', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.modCanDisableInheritedLockInBreakout();
+    });
   });
 
   test.describe.parallel('After creating', () => {

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -69,6 +69,18 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await create.initPages(page, testInfo);
       await create.modCanApplyLockSettingsInBreakoutWithInheritance();
     });
+
+    test('Lock settings are NOT propagated to breakout when checkbox is unchecked', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.lockSettingsNotPropagatedByDefault();
+    });
+
+    test('Lock settings ARE propagated to breakout when checkbox is checked', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.lockSettingsPropagatedWhenChecked();
+    });
   });
 
   test.describe.parallel('After creating', () => {

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -57,6 +57,18 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await create.initPages(page, testInfo);
       await create.modCanDisableInheritedLockInBreakout();
     });
+
+    test('Moderator can apply lock settings in breakout room without inheritance', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.modCanApplyLockSettingsInBreakout();
+    });
+
+    test('Moderator can apply lock settings in breakout room with inheritance', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.modCanApplyLockSettingsInBreakoutWithInheritance();
+    });
   });
 
   test.describe.parallel('After creating', () => {

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -172,6 +172,11 @@ export class Create extends MultiUsers {
     await this.modPage.waitAndClick(e.joinRoom1);
     const breakoutTab = await newTabPromise;
     await breakoutTab.waitForLoadState('domcontentloaded');
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: 5000 });
+      await breakoutTab.click(e.closeModal);
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
 
     await breakoutTab.locator(e.manageUsers).click();
     await expect(

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -210,6 +210,10 @@ export class Create extends MultiUsers {
     await this.modPage.waitAndClick(e.joinRoom1);
     const breakoutTab = await newTabPromise;
     await breakoutTab.waitForLoadState('domcontentloaded');
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: 5000 });
+      await breakoutTab.click(e.closeModal);
+    } catch { /* audio modal not present */ }
 
     // Wait for the React app to be ready in the breakout tab
     await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
@@ -226,21 +230,159 @@ export class Create extends MultiUsers {
       'webcam lock should be enabled in breakout room (inherited from main room)',
     ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
 
-    // Mod disables webcam lock — force-click the hidden ScreenreaderInput
+    // Mod disables webcam lock and enables webcamsOnlyForModerator — force-click the hidden ScreenreaderInputs
     await breakoutTab.locator(e.lockShareWebcam).click({ force: true });
+    await breakoutTab.locator(e.lockSeeOtherViewersWebcam).click({ force: true });
 
-    // Verify toggle flipped to unchecked within the same modal (input.checked is native, not subscription-driven)
+    // Verify toggles flipped within the same modal (native input.checked, not subscription-driven)
     await expect(
       breakoutTab.locator(e.lockShareWebcam),
-      'webcam lock toggle should reflect the click before Apply is sent',
+      'webcam lock toggle should be unchecked after click',
     ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await expect(
+      breakoutTab.locator(e.lockSeeOtherViewersWebcam),
+      'webcamsOnlyForModerator toggle should be checked after click',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
 
-    // Apply — with the fix deployed the mod must NOT be ejected; ejection navigates away
+    // Apply — mod must NOT be ejected by either the lockSettings or webcamsOnlyForModerator mutation
     await breakoutTab.locator(e.applyLockSettings).click();
 
     await expect(
       breakoutTab.locator(e.manageUsers),
       'moderator should still be in the breakout room (not ejected by the server after changing lock settings)',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
+  }
+
+  async modCanApplyLockSettingsInBreakout() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Create breakout without inheriting lock settings (default: all locks off)
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: 5000 });
+      await breakoutTab.click(e.closeModal);
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'should display Lock Viewers in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+
+    // Enable webcam lock and webcamsOnlyForModerator (both start unchecked)
+    await expect(
+      breakoutTab.locator(e.lockShareWebcam),
+      'webcam lock should be off by default (no inheritance)',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockShareWebcam).click({ force: true });
+    await breakoutTab.locator(e.lockSeeOtherViewersWebcam).click({ force: true });
+
+    await expect(
+      breakoutTab.locator(e.lockShareWebcam),
+      'webcam lock toggle should be checked after click',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await expect(
+      breakoutTab.locator(e.lockSeeOtherViewersWebcam),
+      'webcamsOnlyForModerator toggle should be checked after click',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Apply — mod must NOT be ejected by either mutation
+    await breakoutTab.locator(e.applyLockSettings).click();
+
+    await expect(
+      breakoutTab.locator(e.manageUsers),
+      'moderator should still be in the breakout room after applying lock settings without inheritance',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
+  }
+
+  async modCanApplyLockSettingsInBreakoutWithInheritance() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Enable mic lock in main room (different from webcam to distinguish from modCanDisableInheritedLockInBreakout)
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.page.locator(e.lockShareMicrophone).locator('xpath=..').click();
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Create breakout with inherited lock settings
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.page.check(e.inheritLockSettingsCheckbox);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: 5000 });
+      await breakoutTab.click(e.closeModal);
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout and verify mic lock was inherited
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'should display Lock Viewers in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+    await expect(
+      breakoutTab.locator(e.lockShareMicrophone),
+      'mic lock should be enabled in breakout room (inherited from main room)',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Disable mic lock and enable webcamsOnlyForModerator
+    await breakoutTab.locator(e.lockShareMicrophone).click({ force: true });
+    await breakoutTab.locator(e.lockSeeOtherViewersWebcam).click({ force: true });
+
+    await expect(
+      breakoutTab.locator(e.lockShareMicrophone),
+      'mic lock toggle should be unchecked after click',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await expect(
+      breakoutTab.locator(e.lockSeeOtherViewersWebcam),
+      'webcamsOnlyForModerator toggle should be checked after click',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Apply — mod must NOT be ejected by either mutation
+    await breakoutTab.locator(e.applyLockSettings).click();
+
+    await expect(
+      breakoutTab.locator(e.manageUsers),
+      'moderator should still be in the breakout room after changing inherited lock settings',
     ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
 
     await breakoutTab.close();

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { MultiUsers } from '../user/multiusers';
 
@@ -134,6 +134,116 @@ export class Create extends MultiUsers {
     await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
     await this.modPage.waitAndClick(`${e.breakoutBox1} span[role="button"]`);
     await this.modPage.hasText(e.breakoutBox0, /Attendee/, 'should have and attendee on first breakout room box');
+  }
+
+  async inheritLockSettingsCheckboxIsVisible() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+
+    await this.modPage.hasElement(
+      e.inheritLockSettingsCheckbox,
+      'should display the "Propagate the current lock settings" checkbox in the create breakout modal',
+    );
+    const checkbox = this.modPage.page.locator(e.inheritLockSettingsCheckbox);
+    await expect(checkbox, 'checkbox should be unchecked by default').not.toBeChecked();
+    await this.modPage.press('Escape');
+  }
+
+  async lockViewersVisibleInBreakoutGearMenu() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    // Mod is not assigned — button is "Ask to join"; click it to request a URL
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    // Wait for URL to be generated (button changes to "Join Room 1")
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'should display the Lock Viewers option in the gear menu inside a breakout room',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.close();
+  }
+
+  async modCanDisableInheritedLockInBreakout() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Enable webcam lock in main room
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    // The checkbox is visually hidden (ScreenreaderInput); click its parent Switch container
+    await this.modPage.page.locator(e.lockShareWebcam).locator('xpath=..').click();
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Create breakout with inherited lock settings
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.page.check(e.inheritLockSettingsCheckbox);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+
+    // Wait for the React app to be ready in the breakout tab
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout and verify webcam is locked (inherited)
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'should display Lock Viewers in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+    await expect(
+      breakoutTab.locator(e.lockShareWebcam),
+      'webcam lock should be enabled in breakout room (inherited from main room)',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Mod disables webcam lock — force-click the hidden ScreenreaderInput
+    await breakoutTab.locator(e.lockShareWebcam).click({ force: true });
+
+    // Verify toggle flipped to unchecked within the same modal (input.checked is native, not subscription-driven)
+    await expect(
+      breakoutTab.locator(e.lockShareWebcam),
+      'webcam lock toggle should reflect the click before Apply is sent',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Apply — with the fix deployed the mod must NOT be ejected; ejection navigates away
+    await breakoutTab.locator(e.applyLockSettings).click();
+
+    await expect(
+      breakoutTab.locator(e.manageUsers),
+      'moderator should still be in the breakout room (not ejected by the server after changing lock settings)',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
   }
 
   async dragDropUserInRoom() {

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -388,6 +388,118 @@ export class Create extends MultiUsers {
     await breakoutTab.close();
   }
 
+  async lockSettingsNotPropagatedByDefault() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Enable private chat lock in main room
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.page.locator(e.lockPrivateChat).locator('xpath=..').click();
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Create breakout WITHOUT the "Propagate" checkbox (default: unchecked)
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: 5000 });
+      await breakoutTab.click(e.closeModal);
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout and verify NO lock settings were propagated
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'Lock Viewers should be visible in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+
+    await expect(
+      breakoutTab.locator(e.lockPrivateChat),
+      'private chat lock should NOT be enforced in breakout when propagation is off',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await expect(
+      breakoutTab.locator(e.lockShareWebcam),
+      'webcam lock should NOT be enforced in breakout when propagation is off',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await expect(
+      breakoutTab.locator(e.lockShareMicrophone),
+      'microphone lock should NOT be enforced in breakout when propagation is off',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
+  }
+
+  async lockSettingsPropagatedWhenChecked() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Enable private chat lock and webcam lock in main room
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.page.locator(e.lockPrivateChat).locator('xpath=..').click();
+    await this.modPage.page.locator(e.lockShareWebcam).locator('xpath=..').click();
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Create breakout WITH the "Propagate" checkbox checked
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.page.check(e.inheritLockSettingsCheckbox);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: 5000 });
+      await breakoutTab.click(e.closeModal);
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout and verify lock settings WERE propagated
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'Lock Viewers should be visible in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+
+    await expect(
+      breakoutTab.locator(e.lockPrivateChat),
+      'private chat lock should be enforced in breakout when propagation is on',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await expect(
+      breakoutTab.locator(e.lockShareWebcam),
+      'webcam lock should be enforced in breakout when propagation is on',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
+  }
+
   async dragDropUserInRoom() {
     if (!this?.modPage) throw new Error('modPage not initialized');
     if (!this?.userPage) throw new Error('userPage not initialized');

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -115,6 +115,7 @@ export const elements = {
   timeRemaining: 'span[data-test="timeRemaining"]',
   captureBreakoutSharedNotes: 'input[id="captureNotesBreakoutCheckbox"]',
   captureBreakoutWhiteboard: 'input[id="captureSlidesBreakoutCheckbox"]',
+  inheritLockSettingsCheckbox: 'input[id="inheritLockSettingsCheckbox"]',
   selectBreakoutRoomBtn: 'select[data-test="selectBreakoutRoomBtn"]',
   roomOption: 'option[data-test="roomOption"]',
   changeSlideBreakoutRoom1: 'select[data-test="changeSlideBreakoutRoom1"]',


### PR DESCRIPTION
### What does this PR do?
Moderators can now change lock settings inside breakout rooms (previously ejected), and a new "Propagate the current lock settings" checkbox on the create modal lets breakout rooms inherit all parent meeting lock settings.


### Closes Issue(s)
N/A

### How to test
- Join ModA and viewerA
- enable a lock settings
- Open "Breakout Rooms" creation modal
- check "Propagate the current lock settings"
- Move viewerA to A room
- Create breakout
- Join with both users
- See lock being applied 
- on gear button 
- see option to edit lock settings


### More

[Screencast from 27-05-2026 13:01:59.webm](https://github.com/user-attachments/assets/eefb2c76-ebaa-45c5-af61-bfe767fb88cb)
