### PR TITLE
feat: Added patched flag to users basic info subscription

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/hooks/useUsersBasicInfo.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useUsersBasicInfo.ts
@@ -7,6 +7,8 @@ import { filterByMeetingId } from '../utils/subscriptionFilters';
 
 const useUsersBasicInfoSubscription = createUseSubscription<UserBasicInfo>(
   USERS_BASIC_INFO_SUBSCRIPTION,
+  {},
+  true,
 );
 
 const useUsersBasicInfo = (fn: (c: Partial<UserBasicInfo>) => Partial<UserBasicInfo>) => {


### PR DESCRIPTION
### What does this PR do?

This adds the patched flag to the users basic info subscription used by some plugins.

### Motivation

This will likely improve performance in some plugins that use this subscription (e.g.: pick-random-user).

### How to test

- Run the html5 from the code;
- Create a meeting with a plugin that uses this subscription (e.g.: pick-random-user);
- See in the network tab that the subscription has `Patched_` prepend to the subscription's name;
- See the incoming messages from the graphql WS connection are data patches;

