### PR TITLE
fix(core): breakout: propagate parent client settings override

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -914,6 +914,9 @@ public class MeetingService implements MessageListener {
 
       Meeting breakout = paramsProcessorUtil.processCreateParams(params);
 
+      // breakout rooms inherit client settings override from the parent
+      breakout.setOverrideClientSettings(parentMeeting.getOverrideClientSettings());
+
       createMeeting(breakout, message.pluginProp);
 
       presDownloadService.extractPresentationPage(message.parentMeetingId,

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -1,4 +1,5 @@
 import { test } from '../core/setup/fixtures';
+import { ClientSettingsOverride } from './clientSettingsOverride';
 import { Create } from './create';
 import { Join } from './join';
 
@@ -160,6 +161,12 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       const join = new Join(browser, context);
       await join.initPages(page, testInfo);
       await join.breakoutWithDifferentPresentations();
+    });
+
+    // https://github.com/bigbluebutton/bigbluebutton/issues/25138
+    test('Breakout room inherits client settings override from parent meeting', async ({ browser, context, page }, testInfo) => {
+      const override = new ClientSettingsOverride(browser, context);
+      await override.testClientSettingsOverrideInheritedByBreakout(page, testInfo);
     });
   });
 });

--- a/bigbluebutton-tests/playwright/breakout/clientSettingsOverride.ts
+++ b/bigbluebutton-tests/playwright/breakout/clientSettingsOverride.ts
@@ -1,0 +1,23 @@
+import { expect, Page as PlaywrightPage, TestInfo } from '@playwright/test';
+
+import { Join } from './join';
+
+const CLIENT_SETTINGS_OVERRIDE_URL =
+  'https://gist.githubusercontent.com/antobinary/2fc6f52dbcfa5bb39e5461ca59170c51/raw/94679aa21f1653476e49c1152a1ba768e5c4839b/gistfile1.txt';
+
+export class ClientSettingsOverride extends Join {
+  async testClientSettingsOverrideInheritedByBreakout(page: PlaywrightPage, testInfo: TestInfo): Promise<void> {
+    const createParameter = `clientSettingsOverrideJsonUrl=${encodeURIComponent(CLIENT_SETTINGS_OVERRIDE_URL)}`;
+    await this.initModPage(page, { createParameter, testInfo });
+    await this.initUserPage(this.context, { testInfo });
+
+    await this.create();
+    const breakoutPage = await this.joinRoom();
+
+    const showScreenshareQuickSwapButton = await breakoutPage.page.evaluate(
+      () => (window as unknown as { meetingClientSettings: { public: { layout: { showScreenshareQuickSwapButton: boolean } } } })
+        .meetingClientSettings?.public?.layout?.showScreenshareQuickSwapButton,
+    );
+    expect(showScreenshareQuickSwapButton, 'breakout room should inherit the parent meeting clientSettingsOverride').toBe(true);
+  }
+}


### PR DESCRIPTION
### What does this PR do?

propagates parent client settings override to breakout rooms

### Closes Issue(s)
Closes #25138