### PR TITLE
refactor (graphql/html5): Always show most recently pinned user first, followed by the others

### DIFF
--- a/bbb-graphql-server/bbb-graphql-schema.md
+++ b/bbb-graphql-server/bbb-graphql-schema.md
@@ -103,6 +103,7 @@ Permission: Restricted to User Viewing Self-Related Data
 - `name`
 - `nameSortable`
 - `pinned`
+- `pinnedTime`
 - `presenter`
 - `raiseHand`
 - `reactionEmoji`
@@ -224,6 +225,7 @@ Permission: Restricted by Lock Settings
 - `name`
 - `nameSortable`
 - `pinned`
+- `pinnedTime`
 - `presenter`
 - `raiseHand`
 - `raiseHandTime`

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -298,6 +298,7 @@ CREATE UNLOGGED TABLE "user" (
 	"ejectedByModerator" varchar(50),
 	"presenter" bool,
 	"pinned" bool,
+	"pinnedTime" timestamp with time zone,
 	"locked" bool,
 	"speechLocale" varchar(255),
 	"captionLocale" varchar(255),
@@ -313,8 +314,8 @@ CREATE UNLOGGED TABLE "user" (
 CREATE INDEX "idx_user_pk_reverse" on "user"("userId", "meetingId");
 CREATE INDEX "idx_user_meetingId_extId" ON "user"("meetingId", "extId");
 
--- user (on update raiseHand or away: set new time)
-CREATE OR REPLACE FUNCTION update_user_raiseHand_away_time_trigger_func()
+-- user (on update raiseHand, away or pinned: set new time)
+CREATE OR REPLACE FUNCTION update_user_raiseHand_away_pinned_time_trigger_func()
 RETURNS TRIGGER AS $$
 BEGIN
     IF NEW."raiseHand" IS DISTINCT FROM OLD."raiseHand" THEN
@@ -331,12 +332,19 @@ BEGIN
             NEW."awayTime" := NOW();
         END IF;
     END IF;
+    IF NEW."pinned" IS DISTINCT FROM OLD."pinned" THEN
+        IF NEW."pinned" is true THEN
+            NEW."pinnedTime" := NOW();
+        ELSE
+            NEW."pinnedTime" := NULL;
+        END IF;
+    END IF;
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER update_user_raiseHand_away_time_trigger BEFORE UPDATE OF "raiseHand", "away" ON "user"
-    FOR EACH ROW EXECUTE FUNCTION update_user_raiseHand_away_time_trigger_func();
+CREATE TRIGGER update_user_raiseHand_away_pinned_time_trigger BEFORE UPDATE OF "raiseHand", "away", "pinned" ON "user"
+    FOR EACH ROW EXECUTE FUNCTION update_user_raiseHand_away_pinned_time_trigger_func();
 
 
 COMMENT ON COLUMN "user"."disconnected" IS 'This column is set true when the user closes the window or his with the server is over';
@@ -433,6 +441,7 @@ AS SELECT "user"."userId",
     "user"."registeredAt",
     "user"."presenter",
     "user"."pinned",
+    "user"."pinnedTime",
     CASE WHEN "user"."role" = 'MODERATOR' THEN false ELSE "user"."locked" END "locked",
     "user"."speechLocale",
     "user"."captionLocale",
@@ -520,6 +529,7 @@ AS SELECT "user"."userId",
     "user"."registeredAt",
     "user"."presenter",
     "user"."pinned",
+    "user"."pinnedTime",
     CASE WHEN "user"."role" = 'MODERATOR' THEN false ELSE "user"."locked" END "locked",
     "user"."speechLocale",
     "user"."captionLocale",
@@ -591,6 +601,7 @@ AS SELECT
     "user"."registeredAt",
     "user"."presenter",
     "user"."pinned",
+    "user"."pinnedTime",
     CASE WHEN "user"."role" = 'MODERATOR' THEN false ELSE "user"."locked" END "locked",
     "user"."speechLocale",
     "user"."captionLocale",

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user.yaml
@@ -113,6 +113,7 @@ select_permissions:
         - lastName
         - lastNameSortable
         - pinned
+        - pinnedTime
         - presenter
         - raiseHand
         - raiseHandTime

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_current.yaml
@@ -290,6 +290,7 @@ select_permissions:
         - name
         - nameSortable
         - pinned
+        - pinnedTime
         - presenter
         - raiseHand
         - reactionEmoji

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_user_ref.yaml
@@ -37,6 +37,7 @@ select_permissions:
         - lastName
         - lastNameSortable
         - pinned
+        - pinnedTime
         - presenter
         - raiseHand
         - reactionEmoji

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -618,6 +618,10 @@ const useVideoSenders = () => {
 export const useVideoStreams = () => {
   const { viewParticipantsWebcams } = useSettings(SETTINGS.DATA_SAVING) as { viewParticipantsWebcams?: boolean };
   const { currentVideoPageIndex, numberOfPages } = useVideoState();
+  const { data: currentUser } = useCurrentUser((u) => ({ isModerator: u.isModerator }));
+  // Viewers should see pinned moderators ahead of pinned non-moderators; moderators keep
+  // a purely pinnedTime-based order.
+  const moderatorFirst = !currentUser?.isModerator;
   const videoStreams = useStreams();
   const connectingStream = useConnectingStream(videoStreams);
   const audioOnlyUsers = useAudioOnlyUsers();
@@ -661,7 +665,7 @@ export const useVideoStreams = () => {
     if (!partitionPrivilegedStreams) {
       // When partitionPrivilegedStreams is false, paginate all streams equally
       // This means local/pinned cameras will only appear on their page (where they belong in sort order)
-      const sortedStreams = sortVideoStreams(streams, sortingMethod);
+      const sortedStreams = sortVideoStreams(streams, sortingMethod, moderatorFirst);
 
       totalNumberOfOtherStreams = sortedStreams.length;
       const paginatedStreams = sortedStreams.slice(chunkIndex, chunkIndex + myPageSize) || [];
@@ -689,8 +693,9 @@ export const useVideoStreams = () => {
         filtered,
         (vs: StreamItem) => vs.type === VIDEO_TYPES.STREAM && vs.user?.pinned,
       );
-      // partition keeps subscription order (userId asc); reorder so the most recently pinned is first.
-      pin.sort(sortPin);
+      // partition keeps subscription order (userId asc); reorder pinned tiles (moderators first
+      // for viewers, then most recently pinned).
+      pin.sort((a, b) => sortPin(a, b, moderatorFirst));
 
       // This is needed to adjust pagination for displaced video streams
       let audioOnlySlotsUsedOnPage1 = 0;
@@ -712,7 +717,7 @@ export const useVideoStreams = () => {
         ? chunkIndex - audioOnlySlotsUsedOnPage1
         : chunkIndex;
 
-      let paginatedStreams = sortVideoStreams(others, sortingMethod)
+      let paginatedStreams = sortVideoStreams(others, sortingMethod, moderatorFirst)
         .slice(effectiveChunkIndex, (effectiveChunkIndex + myPageSize)) || [];
 
       // Add audio-only users only on page 1
@@ -740,7 +745,7 @@ export const useVideoStreams = () => {
       }
     }
   } else {
-    streams = sortVideoStreams(streams, DEFAULT_SORTING);
+    streams = sortVideoStreams(streams, DEFAULT_SORTING, moderatorFirst);
 
     // Add up to maxAudioOnlyUsers when pagination is disabled
     if (showAudioOnlyOnFirstPage && audioOnlyUsers.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -16,6 +16,7 @@ import { USER_AGGREGATE_COUNT_SUBSCRIPTION, UsersCountSubscriptionResponse } fro
 import {
   getSortingMethod,
   sortVideoStreams,
+  sortPin,
 } from '/imports/ui/components/video-provider/stream-sorting';
 import {
   useVideoState,
@@ -408,6 +409,7 @@ export const useGridUsers = (visibleStreamCount: number) => {
         name: currentUser.name ?? '',
         nameSortable: currentUser.nameSortable ?? '',
         pinned: currentUser.pinned ?? false,
+        pinnedTime: null,
         away: currentUser.away ?? false,
         disconnected: false,
         role: currentUser.role ?? '',
@@ -687,6 +689,8 @@ export const useVideoStreams = () => {
         filtered,
         (vs: StreamItem) => vs.type === VIDEO_TYPES.STREAM && vs.user?.pinned,
       );
+      // partition keeps subscription order (userId asc); reorder so the most recently pinned is first.
+      pin.sort(sortPin);
 
       // This is needed to adjust pagination for displaced video streams
       let audioOnlySlotsUsedOnPage1 = 0;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -28,6 +28,7 @@ export const VIDEO_STREAMS_SUBSCRIPTION = gql`
         userId
         nameSortable
         pinned
+        pinnedTime
         away
         disconnected
         role
@@ -77,6 +78,7 @@ export const GRID_USERS_SUBSCRIPTION = gql`
       userId
       nameSortable
       pinned
+      pinnedTime
       away
       disconnected
       role
@@ -116,6 +118,7 @@ export const AUDIO_ONLY_USERS_SUBSCRIPTION = gql`
       userId
       nameSortable
       pinned
+      pinnedTime
       away
       disconnected
       role

--- a/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.ts
@@ -7,7 +7,7 @@ import { VIDEO_TYPES } from './enums';
 const DEFAULT_SORTING_MODE = 'LOCAL_ALPHABETICAL';
 
 export interface SortingMethodConfig {
-  sortingMethod: (s1: StreamItem, s2: StreamItem) => number;
+  sortingMethod: (s1: StreamItem, s2: StreamItem, moderatorFirst?: boolean) => number;
   localFirst: boolean;
 }
 
@@ -16,11 +16,24 @@ const getPinnedTime = (item: StreamItem): number => {
   return item.user?.pinnedTime ? new Date(item.user.pinnedTime).getTime() : 0;
 };
 
-// Most recently pinned first.
-const sortByPinnedTime = (s1: StreamItem, s2: StreamItem) => getPinnedTime(s2) - getPinnedTime(s1);
+const isStreamModerator = (item: StreamItem): boolean => {
+  if (item.type === VIDEO_TYPES.CONNECTING) return false;
+  return !!item.user?.isModerator;
+};
+
+// Orders two pinned streams. When moderatorFirst (viewers), moderators come ahead of
+// non-moderators; otherwise — and as a tiebreak — the most recently pinned comes first.
+const sortPinnedStreams = (s1: StreamItem, s2: StreamItem, moderatorFirst: boolean) => {
+  if (moderatorFirst) {
+    const m1 = isStreamModerator(s1);
+    const m2 = isStreamModerator(s2);
+    if (m1 !== m2) return m1 ? -1 : 1;
+  }
+  return getPinnedTime(s2) - getPinnedTime(s1);
+};
 
 // pin first (most recently pinned ahead), ignore connecting streams
-export const sortPin = (s1: StreamItem, s2: StreamItem) => {
+export const sortPin = (s1: StreamItem, s2: StreamItem, moderatorFirst = false) => {
   if (s1.type === VIDEO_TYPES.CONNECTING) {
     return 0;
   }
@@ -28,7 +41,7 @@ export const sortPin = (s1: StreamItem, s2: StreamItem) => {
     return 0;
   }
   if (s1.user?.pinned && s2.user?.pinned) {
-    return sortByPinnedTime(s1, s2);
+    return sortPinnedStreams(s1, s2, moderatorFirst);
   }
   if (s1.user?.pinned) {
     return -1;
@@ -38,7 +51,11 @@ export const sortPin = (s1: StreamItem, s2: StreamItem) => {
   return 0;
 };
 
-export const mandatorySorting = (s1: StreamItem, s2: StreamItem) => sortPin(s1, s2);
+export const mandatorySorting = (
+  s1: StreamItem,
+  s2: StreamItem,
+  moderatorFirst = false,
+) => sortPin(s1, s2, moderatorFirst);
 
 // lastFloorTime (descending), ignore connecting streams
 export const sortVoiceActivity = (s1: StreamItem, s2: StreamItem) => {
@@ -58,14 +75,14 @@ export const sortVoiceActivity = (s1: StreamItem, s2: StreamItem) => {
 };
 
 // pin -> lastFloorTime (descending) -> alphabetical -> local
-export const sortVoiceActivityLocal = (s1: StreamItem, s2: StreamItem) => {
+export const sortVoiceActivityLocal = (s1: StreamItem, s2: StreamItem, moderatorFirst = false) => {
   if (s1.userId === Auth.userID) {
     return 1;
   } if (s2.userId === Auth.userID) {
     return -1;
   }
 
-  return mandatorySorting(s1, s2)
+  return mandatorySorting(s1, s2, moderatorFirst)
     || sortVoiceActivity(s1, s2)
     || UserListService.sortUsersByName(s1, s2);
 };
@@ -81,13 +98,21 @@ export const sortByLocal = (s1: StreamItem, s2: StreamItem) => {
 };
 
 // pin -> local -> lastFloorTime (descending) -> alphabetical
-export const sortLocalVoiceActivity = (s1: StreamItem, s2: StreamItem) => mandatorySorting(s1, s2)
+export const sortLocalVoiceActivity = (
+  s1: StreamItem,
+  s2: StreamItem,
+  moderatorFirst = false,
+) => mandatorySorting(s1, s2, moderatorFirst)
     || sortByLocal(s1, s2)
     || sortVoiceActivity(s1, s2)
     || UserListService.sortUsersByName(s1, s2);
 
 // pin -> local -> alphabetic
-export const sortLocalAlphabetical = (s1: StreamItem, s2: StreamItem) => mandatorySorting(s1, s2)
+export const sortLocalAlphabetical = (
+  s1: StreamItem,
+  s2: StreamItem,
+  moderatorFirst = false,
+) => mandatorySorting(s1, s2, moderatorFirst)
     || sortByLocal(s1, s2)
     || UserListService.sortUsersByName(s1, s2);
 
@@ -102,16 +127,20 @@ export const sortPresenter = (s1: StreamItem, s2: StreamItem) => {
 };
 
 // pin -> local -> presenter -> alphabetical
-export const sortLocalPresenterAlphabetical = (s1: StreamItem, s2: StreamItem) => mandatorySorting(s1, s2)
+export const sortLocalPresenterAlphabetical = (
+  s1: StreamItem,
+  s2: StreamItem,
+  moderatorFirst = false,
+) => mandatorySorting(s1, s2, moderatorFirst)
     || sortByLocal(s1, s2)
     || sortPresenter(s1, s2)
     || UserListService.sortUsersByName(s1, s2);
 
-export const sortByPinned = (s1: StreamItem, s2: StreamItem) => {
+export const sortByPinned = (s1: StreamItem, s2: StreamItem, moderatorFirst = false) => {
   const s1Pinned = s1.type === VIDEO_TYPES.STREAM && s1.user?.pinned;
   const s2Pinned = s2.type === VIDEO_TYPES.STREAM && s2.user?.pinned;
   if (s1Pinned && s2Pinned) {
-    return sortByPinnedTime(s1, s2);
+    return sortPinnedStreams(s1, s2, moderatorFirst);
   }
   if (s1Pinned) {
     return -1;
@@ -123,7 +152,7 @@ export const sortByPinned = (s1: StreamItem, s2: StreamItem) => {
 };
 
 // presenter -> local -> pinned -> alphabetical
-export const sortPresenterLocalPinned = (s1: StreamItem, s2: StreamItem) => {
+export const sortPresenterLocalPinned = (s1: StreamItem, s2: StreamItem, moderatorFirst = false) => {
   // First, check if either is presenter
   const presenterSort = sortPresenter(s1, s2);
   if (presenterSort !== 0) return presenterSort;
@@ -136,7 +165,7 @@ export const sortPresenterLocalPinned = (s1: StreamItem, s2: StreamItem) => {
   if (!isS1Local && isS2Local) return 1;
 
   // If both are local or both are not local, check pinned status
-  const pinnedSort = sortByPinned(s1, s2);
+  const pinnedSort = sortByPinned(s1, s2, moderatorFirst);
   if (pinnedSort !== 0) return pinnedSort;
 
   // Finally, sort alphabetically
@@ -171,8 +200,8 @@ export const getSortingMethod = (identifier: string): SortingMethodConfig => {
   return SORTING_METHODS[identifier as keyof typeof SORTING_METHODS] || SORTING_METHODS[DEFAULT_SORTING_MODE];
 };
 
-export const sortVideoStreams = (streams: StreamItem[], mode: string) => {
+export const sortVideoStreams = (streams: StreamItem[], mode: string, moderatorFirst = false) => {
   const { sortingMethod } = getSortingMethod(mode);
-  const sorted = streams.sort(sortingMethod);
+  const sorted = streams.sort((s1, s2) => sortingMethod(s1, s2, moderatorFirst));
   return sorted;
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/stream-sorting.ts
@@ -11,13 +11,24 @@ export interface SortingMethodConfig {
   localFirst: boolean;
 }
 
-// pin first, ignore connecting streams
+const getPinnedTime = (item: StreamItem): number => {
+  if (item.type === VIDEO_TYPES.CONNECTING) return 0;
+  return item.user?.pinnedTime ? new Date(item.user.pinnedTime).getTime() : 0;
+};
+
+// Most recently pinned first.
+const sortByPinnedTime = (s1: StreamItem, s2: StreamItem) => getPinnedTime(s2) - getPinnedTime(s1);
+
+// pin first (most recently pinned ahead), ignore connecting streams
 export const sortPin = (s1: StreamItem, s2: StreamItem) => {
   if (s1.type === VIDEO_TYPES.CONNECTING) {
     return 0;
   }
   if (s2.type === VIDEO_TYPES.CONNECTING) {
     return 0;
+  }
+  if (s1.user?.pinned && s2.user?.pinned) {
+    return sortByPinnedTime(s1, s2);
   }
   if (s1.user?.pinned) {
     return -1;
@@ -97,10 +108,15 @@ export const sortLocalPresenterAlphabetical = (s1: StreamItem, s2: StreamItem) =
     || UserListService.sortUsersByName(s1, s2);
 
 export const sortByPinned = (s1: StreamItem, s2: StreamItem) => {
-  if (s1.type === VIDEO_TYPES.STREAM && s1.user?.pinned) {
+  const s1Pinned = s1.type === VIDEO_TYPES.STREAM && s1.user?.pinned;
+  const s2Pinned = s2.type === VIDEO_TYPES.STREAM && s2.user?.pinned;
+  if (s1Pinned && s2Pinned) {
+    return sortByPinnedTime(s1, s2);
+  }
+  if (s1Pinned) {
     return -1;
   }
-  if (s2.type === VIDEO_TYPES.STREAM && s2.user?.pinned) {
+  if (s2Pinned) {
     return 1;
   }
   return 0;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/types.ts
@@ -3,6 +3,7 @@ import { VIDEO_TYPES } from './enums';
 export type User = {
   userId: string;
   pinned: boolean;
+  pinnedTime: string | null;
   nameSortable: string;
   name: string;
   away: boolean;


### PR DESCRIPTION
Currently, the sorting order of pinned users is not clear.
As a result, tests may eventually fail because they expect one order while the UI displays another.

This PR introduces the `pinnedTime` column, which stores the timestamp of when a user was pinned. 
Users are now consistently sorted by pin time, with the most recently pinned user shown first, followed by the others.

This behavior is consistent with how `raiseHand` currently works.


Attempt to fix:

<img width="600" src="https://github.com/user-attachments/assets/f22d098d-9931-43b6-84e9-39e95fa08ed9" />
