### PR TITLE
perf(html5): Enable json patch for GridUsers subscription (and reduce payload significantly)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -6,7 +6,6 @@ import {
 import {
   useReactiveVar,
   useMutation,
-  useSubscription,
 } from '@apollo/client';
 import Auth from '/imports/ui/services/auth';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
@@ -356,7 +355,7 @@ export const useGridUsers = (visibleStreamCount: number) => {
     data: gridData,
     error: gridError,
     loading: gridLoading,
-  } = useSubscription<GridUsersResponse>(
+  } = useDeduplicatedSubscription<GridUsersResponse>(
     GRID_USERS_SUBSCRIPTION,
     {
       // When the user can only see moderator cameras, drop non-moderators ([true]);
@@ -368,6 +367,7 @@ export const useGridUsers = (visibleStreamCount: number) => {
       },
       skip: !isGridEnabled,
     },
+    true,
   );
 
   if (gridLoading) return { gridUsers: gridItems.current, overflowCount: overflowCount.current };

--- a/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import GrahqlSubscriptionStore, { stringToHash, SubscriptionStructure } from '/imports/ui/core/singletons/subscriptionStore';
 import { DocumentNode, TypedQueryDocumentNode } from 'graphql';
 import {
   OperationVariables, SubscriptionHookOptions, makeVar, useReactiveVar, ReactiveVar,
 } from '@apollo/client';
+import { makePatchedQuery } from '/imports/ui/core/hooks/createUseSubscription';
 
 const initialEmptySub = makeVar<SubscriptionStructure<unknown>>({
   count: 0,
@@ -16,9 +17,16 @@ const initialEmptySub = makeVar<SubscriptionStructure<unknown>>({
 const useDeduplicatedSubscription = <T>(
   subscription: DocumentNode | TypedQueryDocumentNode,
   options?: SubscriptionHookOptions<NoInfer<T>, NoInfer<OperationVariables>>,
+  usePatchedSubscription = false,
 ) => {
+  // When patching is enabled, rename the operation to Patched_* so the middleware streams
+  // JSON patches instead of full datasets; the subscription store applies them automatically.
+  const query = useMemo(
+    () => (usePatchedSubscription ? makePatchedQuery(subscription) : subscription),
+    [subscription, usePatchedSubscription],
+  );
   const subscriptionHash = stringToHash(JSON.stringify({
-    subscription,
+    subscription: query,
     variables: options?.variables,
     skip: options?.skip,
   }));
@@ -38,11 +46,15 @@ const useDeduplicatedSubscription = <T>(
       return () => {};
     }
 
-    const newSubVar = GrahqlSubscriptionStore.makeSubscription<T>(subscription, options?.variables);
+    const newSubVar = GrahqlSubscriptionStore.makeSubscription<T>(
+      query,
+      options?.variables,
+      usePatchedSubscription ? 'no-cache' : undefined,
+    );
     setSubVar(() => newSubVar);
 
     return () => {
-      GrahqlSubscriptionStore.unsubscribe(subscription, options?.variables);
+      GrahqlSubscriptionStore.unsubscribe(query, options?.variables);
     };
   }, [subscriptionHash, options?.skip]);
 

--- a/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useDeduplicatedSubscription.ts
@@ -56,7 +56,7 @@ const useDeduplicatedSubscription = <T>(
     return () => {
       GrahqlSubscriptionStore.unsubscribe(query, options?.variables);
     };
-  }, [subscriptionHash, options?.skip]);
+  }, [subscriptionHash, options?.skip, usePatchedSubscription]);
 
   return useReactiveVar(subVar);
 };


### PR DESCRIPTION
This PR improves `GridUsers` data consumption by enabling JSON Patch support for this subscription.

Below is a comparison of the payload traffic when 20 users join the room:

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>

<img width="1737" height="1045" alt="before" src="https://github.com/user-attachments/assets/91e98e4b-dde9-4869-875b-a8ace00f837d" />

</td>
<td>

<img width="1735" height="1041" alt="after" src="https://github.com/user-attachments/assets/c11ea46f-af74-4e8e-a282-63736b97de01" />

</td>
</tr>
</table>

My first attempt was to use `createUseSubscription`, but it does not support skip, which is required by Grid.
Because of that, it was necessary to switch to `useDeduplicatedSubscription` and add JSON Patch support there instead.