### PR TITLE
docs: incorrect forceRelay* removal indication

### DIFF
--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -248,8 +248,6 @@ These changes apply to the client configuration file (`/etc/bigbluebutton/bbb-ht
 
 - `public.layout.showPushLayoutButton`, `public.layout.showPushLayoutToggle`, and `public.layout.enableDeprecatedLayoutSelection`.
 - `public.stats.log` (replaced by `public.stats.logMediaStats`).
-- `public.media.livekit.forceRelay` and `public.media.livekit.forceRelayOnFirefox`.
-
 
 ## Development
 


### PR DESCRIPTION
### What does this PR do?

- [docs: incorrect forceRelay* removal indication](https://github.com/bigbluebutton/bigbluebutton/commit/f4ed6c9ac9aa2221cd2b50324b56127d636d8f29)
  - They weren't removed, just not pulled from v3.0.28 _yet_.

### Closes Issue(s)

None