### PR TITLE
fix (shared-notes-server/cluster): Use `$bbb_cors_origin` for shared-notes-server Allow-Origin (CORS)

### DIFF
--- a/build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx
+++ b/build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx
@@ -1,3 +1,8 @@
+# For cluster-proxy setups it can be overridden in /etc/bigbluebutton/nginx/bbb-cluster.nginx
+if ($bbb_cors_origin = '') {
+        set $bbb_cors_origin '*';
+}
+
 location /hocuspocus/collaboration {
   # Extract sessionToken from query parameter for auth_request
   set $session_token $arg_sessionToken;
@@ -44,7 +49,7 @@ location /bigbluebutton/connection/checkHocuspocusAuthorization {
 
 location /hocuspocus/api/ {
   if ($request_method = 'OPTIONS') {
-    add_header 'Access-Control-Allow-Origin' $http_origin always;
+    add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
     add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type' always;
     add_header 'Access-Control-Allow-Credentials' 'true' always;
@@ -52,7 +57,7 @@ location /hocuspocus/api/ {
     return 204;
   }
 
-  add_header 'Access-Control-Allow-Origin' $http_origin always;
+  add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
   add_header 'Access-Control-Allow-Credentials' 'true' always;
 
   auth_request /bigbluebutton/connection/checkAuthorization;


### PR DESCRIPTION
Now Docs will recommend to set `$bbb_cors_origin` for cluster/proxy setups.
So `bbb-shared-notes-server` can benefit from it instead of allowing `$http_origin` always.

More info: #25108