### PR TITLE
build(bbb-webhooks): v3.6.1 (up from v3.6.0)

### DIFF
--- a/bbb-webhooks.placeholder.sh
+++ b/bbb-webhooks.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v3.6.0 --depth 1 https://github.com/bigbluebutton/bbb-webhooks bbb-webhooks
+git clone --branch v3.6.1 --depth 1 https://github.com/bigbluebutton/bbb-webhooks bbb-webhooks


### PR DESCRIPTION
### What does this PR do?

* [build(bbb-webhooks): v3.6.1 (up from v3.6.0)](https://github.com/bigbluebutton/bigbluebutton/commit/1cd98e8045ab99bf68b9e76d284e2bc533a9104b) 
  * fix: re-enable test and hadolint workflows
  * fix: better specify webhook failure in logs and Prometheus metrics
  * build(deps): uuid@14.0.0 (up from v9.0.1)
  * build(deps): node-config@3.3.12 (up from 3.3.9)
  * build(deps): express@4.22.2 (up from 4.22.1)
  * build(deps): luxon@3.7.2 (up from 3.4.4)
  * build(deps): pino@10.3.1 (up from 9.14.0)
  * build(deps): prom-client@15.1.3 (up from 14.2.0)
  * build(deps): redis@4.7.1 (up from 4.6.8)
  * build(deps): bump dev dependencies
  * build(deps): npm audit fix
  
### Closes Issue(s)

None