### PR TITLE
build(bbb-webrtc-sfu): v2.23.0 (up from v2.22.2)

### DIFF
--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.22.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.23.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-webrtc-sfu): v2.23.0 (up from v2.22.2)](https://github.com/bigbluebutton/bigbluebutton/commit/966f3712b492df898e45217fd330e48146b9a47e) 
  * feat(livekit): add option to capture mic on external Redis triggers
  * build(deps): bump uuid from 10.0.0 to 14.0.0
  * build(deps): bump qs from 6.14.2 to 6.15.2 (transitive)
  * build(deps): bump express from 4.22.1 to 4.22.2
  * build(deps): bump ws from 8.18.0 to 8.21.0
  * build: update publish-docker-image actions to latest and pin to SHAs

### Closes Issue(s)

None