### PR TITLE
fix(presentation): prevent restore-on-upload logic from disabling itself

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -20,6 +20,11 @@ import { useIsChatEnabled, useIsPresentationEnabled, useIsScreenSharingEnabled }
 import useUserChangedLocalSettings from '/imports/ui/services/settings/hooks/useUserChangedLocalSettings';
 import Session from '/imports/ui/services/storage/in-memory';
 import deviceInfo from '/imports/utils/deviceInfo';
+import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import {
+  CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
+  CurrentPresentationPageSubscriptionResponse,
+} from '/imports/ui/components/whiteboard/queries';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
 
@@ -39,10 +44,50 @@ const LayoutObserver: React.FC = () => {
   const { selectedLayout } = layoutSettings;
   const {
     data: currentMeeting,
+    loading: loadingMeeting,
   } = useMeeting((m) => ({
     layout: m.layout,
     componentsFlags: m.componentsFlags,
+    isBreakout: m.isBreakout,
   }));
+
+  const {
+    data: presentationPageData,
+    loading: loadingPresentationPageData,
+  } = useDeduplicatedSubscription<CurrentPresentationPageSubscriptionResponse>(
+    CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
+  );
+
+  const presentationPageArray = presentationPageData?.pres_page_curr ?? [];
+  const currentPresentationPage = presentationPageArray[0];
+  const currentPageId = currentPresentationPage?.pageId;
+
+  // Track whether the presentation was closed by this effect (no page available),
+  // so it can be re-opened when a page becomes available again (e.g. after a
+  // pre-uploaded presentation finishes converting on slow CI machines).
+  const closedDueToAbsentPresentation = useRef(false);
+
+  useEffect(() => {
+    // close presentation if there isn't any
+    // case when the presentation has been manually removed in the media area drop up
+    // or when defaultUploadedPresentation is null in bigbluebutton.properties
+    if (loadingPresentationPageData || loadingMeeting) return;
+    if (!currentPageId && !currentMeeting?.isBreakout) {
+      closedDueToAbsentPresentation.current = true;
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: false,
+      });
+    } else if (currentPageId && closedDueToAbsentPresentation.current) {
+      // restore presentation when a page becomes available after having been absent
+      // (e.g. preUploadedPresentationOverrideDefault=true on a slow server)
+      closedDueToAbsentPresentation.current = false;
+      layoutContextDispatch({
+        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
+        value: true,
+      });
+    }
+  }, [currentPageId, loadingPresentationPageData, loadingMeeting, currentMeeting?.isBreakout]);
 
   const isThereWebcam = useVideoStreamsCount() > 0;
   const { streams: videoStream } = useVideoStreams();

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -61,6 +61,11 @@ const LayoutObserver: React.FC = () => {
   const presentationPageArray = presentationPageData?.pres_page_curr ?? [];
   const currentPresentationPage = presentationPageArray[0];
   const currentPageId = currentPresentationPage?.pageId;
+  const LAYOUT_CONFIG = window.meetingClientSettings.public.layout;
+  const hidePresentationOnJoin = getFromUserSettings(
+    'bbb_hide_presentation_on_join',
+    LAYOUT_CONFIG.hidePresentationOnJoin,
+  );
 
   // Track whether the presentation was closed by this effect (no page available),
   // so it can be re-opened when a page becomes available again (e.g. after a
@@ -68,6 +73,7 @@ const LayoutObserver: React.FC = () => {
   const closedDueToAbsentPresentation = useRef(false);
 
   useEffect(() => {
+    if (hidePresentationOnJoin) return;
     // close presentation if there isn't any
     // case when the presentation has been manually removed in the media area drop up
     // or when defaultUploadedPresentation is null in bigbluebutton.properties

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -1,7 +1,5 @@
 import React, {
-  useEffect,
   useMemo,
-  useRef,
   useState,
   useCallback,
   memo,
@@ -20,7 +18,7 @@ import {
   layoutSelectOutput,
   layoutDispatch,
 } from '../layout/context';
-import { DEVICE_TYPE, ACTIONS } from '/imports/ui/components/layout/enums';
+import { DEVICE_TYPE } from '/imports/ui/components/layout/enums';
 import MediaService from '../media/service';
 import {
   CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
@@ -50,7 +48,6 @@ const PresentationContainer = ({
 
   const {
     data: presentationPageData,
-    loading: loadingPresentationPageData,
   } = useDeduplicatedSubscription(
     CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
   );
@@ -65,39 +62,10 @@ const PresentationContainer = ({
 
   const {
     data: currentMeeting,
-    loading: loadingMeeting,
   } = useMeeting((m) => ({
     createdTime: m.createdTime,
-    isBreakout: m.isBreakout,
     usersPolicies: m.usersPolicies,
   }));
-
-  // Track whether the presentation was closed by this effect (no page available),
-  // so it can be re-opened when a page becomes available again (e.g. after a
-  // pre-uploaded presentation finishes converting on slow CI machines).
-  const closedDueToAbsentPresentation = useRef(false);
-
-  useEffect(() => {
-    // close presentation if there isn't any
-    // case when the presentation has been manually removed in the media area drop up
-    // or when defaultUploadedPresentation is null in bigbluebutton.properties
-    if (loadingPresentationPageData || loadingMeeting) return;
-    if (!currentPageId && !currentMeeting?.isBreakout) {
-      closedDueToAbsentPresentation.current = true;
-      layoutContextDispatch({
-        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-        value: false,
-      });
-    } else if (currentPageId && closedDueToAbsentPresentation.current) {
-      // restore presentation when a page becomes available after having been absent
-      // (e.g. preUploadedPresentationOverrideDefault=true on a slow server)
-      closedDueToAbsentPresentation.current = false;
-      layoutContextDispatch({
-        type: ACTIONS.SET_PRESENTATION_IS_OPEN,
-        value: true,
-      });
-    }
-  }, [currentPageId, loadingPresentationPageData, loadingMeeting, currentMeeting?.isBreakout]);
 
   const { data: whiteboardWritersData } = useDeduplicatedSubscription(
     CURRENT_PAGE_WRITERS_SUBSCRIPTION,

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -27,7 +27,7 @@ export const constants = {
   preUploadedPresentation:
     'preUploadedPresentation=https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v3.0.x-develop/bigbluebutton-tests/playwright/core/media/sample.pdf',
   preUploadedHeavyPresentation:
-    'preUploadedPresentation=https://raw.githubusercontent.com/py-pdf/sample-files/947bdc1682fb4cb6b245a6080a5aedfa71032fea/009-pdflatex-geotopo/GeoTopo.pdf',
+    'preUploadedPresentation=https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v4.0.x-develop/bigbluebutton-tests/playwright/core/media/GeoTopo.pdf',
   preUploadedPresentationOverrideDefault: 'preUploadedPresentationOverrideDefault=true',
   preUploadedPresentationName: 'preUploadedPresentationName=ScientificPaper.pdf',
   customLayout: 'meetingLayout=CUSTOM_LAYOUT',

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -26,6 +26,8 @@ export const constants = {
   notifyRecordingIsOn: 'notifyRecordingIsOn=true&notifyRecordingIsOn=true',
   preUploadedPresentation:
     'preUploadedPresentation=https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v3.0.x-develop/bigbluebutton-tests/playwright/core/media/sample.pdf',
+  preUploadedHeavyPresentation:
+    'preUploadedPresentation=https://raw.githubusercontent.com/py-pdf/sample-files/947bdc1682fb4cb6b245a6080a5aedfa71032fea/009-pdflatex-geotopo/GeoTopo.pdf',
   preUploadedPresentationOverrideDefault: 'preUploadedPresentationOverrideDefault=true',
   preUploadedPresentationName: 'preUploadedPresentationName=ScientificPaper.pdf',
   customLayout: 'meetingLayout=CUSTOM_LAYOUT',
@@ -70,6 +72,7 @@ export const constants = {
   outsideToggleRecording: 'userdata-bbb_outside_toggle_recording=true',
   showPublicChatOnLogin: 'userdata-bbb_show_public_chat_on_login=false',
   forceRestorePresentationOnNewEvents: 'userdata-bbb_force_restore_presentation_on_new_events=true',
+  noRestorePresentationOnNewEvents: 'userdata-bbb_force_restore_presentation_on_new_events=false',
   recordMeeting: 'record=true',
   skipVideoPreview: 'userdata-bbb_skip_video_preview=true',
   skipVideoPreviewOnFirstJoin: 'userdata-bbb_skip_video_preview_on_first_join=true',

--- a/bigbluebutton-tests/playwright/parameters/customparameters.ts
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.ts
@@ -456,17 +456,17 @@ export class CustomParameters extends MultiUsers {
 
     await Promise.all([
       // Very high timeout because the presentation is heavy and might take time on slow machines
-      // - 29 multiplier is a empiric value that works on my machine
+      // - 7 multiplier is a empirical value that works on my machine
       // The upload is assumed to be finished when the toast vanishes
       this.modPage.wasRemoved(
         e.presentationUploadProgressToast,
         'the upload should complete sometime',
-        UPLOAD_PDF_WAIT_TIME * 29,
+        UPLOAD_PDF_WAIT_TIME * 7,
       ),
       this.userPage.wasRemoved(
         e.presentationUploadProgressToast,
         'the upload should complete sometime',
-        UPLOAD_PDF_WAIT_TIME * 29,
+        UPLOAD_PDF_WAIT_TIME * 7,
       ),
     ]);
 
@@ -615,9 +615,9 @@ export class CustomParameters extends MultiUsers {
 
     await Promise.all([
       // Very high timeout because the presentation is heavy and might take time on slow machines
-      // - 29 multiplier is a empiric value that works on my machine
-      this.modPage.waitForSelector(e.whiteboard, UPLOAD_PDF_WAIT_TIME * 29),
-      this.userPage.waitForSelector(e.whiteboard, UPLOAD_PDF_WAIT_TIME * 29),
+      // - 7 multiplier is a empirical value that works on my machine
+      this.modPage.waitForSelector(e.whiteboard, UPLOAD_PDF_WAIT_TIME * 7),
+      this.userPage.waitForSelector(e.whiteboard, UPLOAD_PDF_WAIT_TIME * 7),
     ]);
 
     await Promise.all([

--- a/bigbluebutton-tests/playwright/parameters/customparameters.ts
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.ts
@@ -422,6 +422,76 @@ export class CustomParameters extends MultiUsers {
     await this.userPage.hasElement(e.whiteboard, 'should display the whiteboard for the attendee');
   }
 
+  async hidePresentationOnJoinWhenHeavyPresentationUploadAndNoRestoreOnUpdate() {
+    await this.modPage.hasElement(
+      e.presentationUploadProgressToast,
+      'should display the presentation upload progress toast',
+      ELEMENT_WAIT_TIME,
+    );
+
+    await Promise.all([
+      this.modPage.wasRemoved(
+        e.restorePresentation,
+        'should not display the restore presentation button for the moderator while upload is in progress',
+      ),
+      this.modPage.wasRemoved(
+        e.whiteboard,
+        'should keep the whiteboard minimized for the moderator while upload is in progress',
+      ),
+      this.userPage.wasRemoved(
+        e.restorePresentation,
+        'should not display the restore presentation button for the attendee while upload is in progress',
+      ),
+      this.userPage.wasRemoved(
+        e.whiteboard,
+        'should keep the whiteboard minimized for the attendee while upload is in progress',
+      ),
+    ]);
+
+    await this.modPage.hasElement(
+      e.presentationUploadProgressToast,
+      'should keep displaying the presentation upload progress toast while upload is in progress',
+      ELEMENT_WAIT_TIME,
+    );
+
+    await Promise.all([
+      // Very high timeout because the presentation is heavy and might take time on slow machines
+      // - 29 multiplier is a empiric value that works on my machine
+      // The upload is assumed to be finished when the toast vanishes
+      this.modPage.wasRemoved(
+        e.presentationUploadProgressToast,
+        'the upload should complete sometime',
+        UPLOAD_PDF_WAIT_TIME * 29,
+      ),
+      this.userPage.wasRemoved(
+        e.presentationUploadProgressToast,
+        'the upload should complete sometime',
+        UPLOAD_PDF_WAIT_TIME * 29,
+      ),
+    ]);
+
+    await Promise.all([
+      this.modPage.wasRemoved(
+        e.whiteboard,
+        'should be no presentation opened for the moderator after upload completes since restore on update is false and presentation hide on join is true',
+        ELEMENT_WAIT_TIME,
+      ),
+      this.userPage.wasRemoved(
+        e.whiteboard,
+        'should be no presentation opened for the attendee after upload completes since restore on update is false and presentation hide on join is true',
+        ELEMENT_WAIT_TIME,
+      ),
+      this.modPage.hasElement(
+        e.restorePresentation,
+        'should display the restore presentation button because the presentation is minimized',
+      ),
+      this.userPage.hasElement(
+        e.restorePresentation,
+        'should display the restore presentation button because the presentation is minimized',
+      ),
+    ]);
+  }
+
   async forceRestorePresentationOnNewEvents() {
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
     const { presentationHidden, pollEnabled } = this.modPage.settings || {};
@@ -509,6 +579,57 @@ export class CustomParameters extends MultiUsers {
       e.minimizePresentation,
       'should display the minimize presentation button when the presentation is restored',
     );
+  }
+
+  async restorePresentationAfterUpload() {
+    await this.modPage.hasElement(
+      e.presentationUploadProgressToast,
+      'should display the presentation upload progress toast',
+      ELEMENT_WAIT_TIME,
+    );
+
+    await Promise.all([
+      this.modPage.wasRemoved(
+        e.restorePresentation,
+        'should not display the restore presentation button for the moderator while upload is in progress',
+      ),
+      this.modPage.wasRemoved(
+        e.whiteboard,
+        'should keep the whiteboard minimized for the moderator while upload is in progress',
+      ),
+      this.userPage.wasRemoved(
+        e.restorePresentation,
+        'should not display the restore presentation button for the attendee while upload is in progress',
+      ),
+      this.userPage.wasRemoved(
+        e.whiteboard,
+        'should keep the whiteboard minimized for the attendee while upload is in progress',
+      ),
+    ]);
+
+    await this.modPage.hasElement(
+      e.presentationUploadProgressToast,
+      'should keep displaying the presentation upload progress toast while upload is in progress',
+      ELEMENT_WAIT_TIME,
+    );
+
+    await Promise.all([
+      // Very high timeout because the presentation is heavy and might take time on slow machines
+      // - 29 multiplier is a empiric value that works on my machine
+      this.modPage.waitForSelector(e.whiteboard, UPLOAD_PDF_WAIT_TIME * 29),
+      this.userPage.waitForSelector(e.whiteboard, UPLOAD_PDF_WAIT_TIME * 29),
+    ]);
+
+    await Promise.all([
+      this.modPage.hasElement(
+        e.minimizePresentation,
+        'should display the minimize presentation button when the presentation is restored',
+      ),
+      this.userPage.hasElement(
+        e.minimizePresentation,
+        'should display the minimize presentation button when the presentation is restored',
+      ),
+    ]);
   }
 
   async enableVideo() {

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -711,6 +711,7 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
       context,
       page,
     }, testInfo) => {
+      testInfo.setTimeout(4 * 60 * 1000); // 4 minutes, because of uploading heavy presentation on CI
       const customParam = new CustomParameters(browser, context);
       await customParam.initModPage(page, {
         testInfo,
@@ -742,6 +743,7 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
       context,
       page,
     }, testInfo) => {
+      testInfo.setTimeout(4 * 60 * 1000); // 4 minutes, because of uploading heavy presentation on CI
       const customParam = new CustomParameters(browser, context);
       await customParam.initModPage(page, {
         testInfo,

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -706,6 +706,24 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
       });
       await customParam.hidePresentationOnJoinUploadLargePresentation();
     });
+    test('Ensure presentation is not restored after pre-uploading heavy presentation and restore on update is false', async ({
+      browser,
+      context,
+      page,
+    }, testInfo) => {
+      const customParam = new CustomParameters(browser, context);
+      await customParam.initModPage(page, {
+        testInfo,
+        createParameter: c.preUploadedHeavyPresentation,
+        joinParameter: [c.noRestorePresentationOnNewEvents, c.hidePresentationOnJoin].join('&'),
+      });
+      await customParam.initUserPage(context, {
+        useModMeetingId: true,
+        joinParameter: [c.noRestorePresentationOnNewEvents, c.hidePresentationOnJoin].join('&'),
+        testInfo,
+      });
+      await customParam.hidePresentationOnJoinWhenHeavyPresentationUploadAndNoRestoreOnUpdate();
+    });
   });
 
   test.describe.parallel('Presentation', () => {
@@ -718,6 +736,24 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
         testInfo,
       });
       await customParam.forceRestorePresentationOnNewEvents();
+    });
+    test('Ensure presentation is restored after upload completes when restore on update is false', async ({
+      browser,
+      context,
+      page,
+    }, testInfo) => {
+      const customParam = new CustomParameters(browser, context);
+      await customParam.initModPage(page, {
+        testInfo,
+        createParameter: c.preUploadedHeavyPresentation,
+        joinParameter: c.noRestorePresentationOnNewEvents,
+      });
+      await customParam.initUserPage(context, {
+        useModMeetingId: true,
+        joinParameter: c.noRestorePresentationOnNewEvents,
+        testInfo,
+      });
+      await customParam.restorePresentationAfterUpload();
     });
   });
 

--- a/bigbluebutton-tests/playwright/playwright.config.ts
+++ b/bigbluebutton-tests/playwright/playwright.config.ts
@@ -8,7 +8,7 @@ dotenv.config();
 
 export default defineConfig({
   workers: CI ? 1 : 2,
-  timeout: 4 * 60 * 1000,
+  timeout: 3 * 60 * 1000,
   reporter: CI ? [['blob'], ['./core/setup/customReporter.ts']] : [['list'], ['html', { open: 'never' }]],
   reportSlowTests: null,
   forbidOnly: CI,

--- a/bigbluebutton-tests/playwright/playwright.config.ts
+++ b/bigbluebutton-tests/playwright/playwright.config.ts
@@ -8,7 +8,7 @@ dotenv.config();
 
 export default defineConfig({
   workers: CI ? 1 : 2,
-  timeout: 3 * 60 * 1000,
+  timeout: 4 * 60 * 1000,
   reporter: CI ? [['blob'], ['./core/setup/customReporter.ts']] : [['list'], ['html', { open: 'never' }]],
   reportSlowTests: null,
   forbidOnly: CI,

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -39,6 +39,27 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
     await presentation.hideAndRestorePresentation();
   });
 
+  // The presentation should always be restored when a new one is shared. It follows the same behavior as
+  // when the presentar starts sharing screen or sharing camera as content - the presentation area is always restored.
+  test('Presentation is restored when a new one is shared', async ({ browser, context, page }, testInfo) => {
+    const presentation = new Presentation(browser, context);
+    await presentation.initPages(page, testInfo);
+    await presentation.hideAndShareNewPresentation();
+  });
+
+  // The presentation should always be restored when a new one is shared. It follows the same behavior as
+  // when the presentar starts sharing screen or sharing camera as content - the presentation area is always restored.
+  test('Presentation is restored when deleted and a new one is shared', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const presentation = new Presentation(browser, context);
+    await presentation.initPages(page, testInfo);
+    await presentation.hidePresentation();
+    await presentation.shareNewPresentationAfterDelete();
+  });
+
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#fit-to-width-option
   test('Presentation fit to width', async ({ browser, context, page }, testInfo) => {
     const presentation = new Presentation(browser, context);

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -73,7 +73,7 @@ export class Presentation extends MultiUsers {
     await expect(viewerScreenShareVideo).toHaveScreenshot('viewer-share-camera-as-content.png');
   }
 
-  async hideAndRestorePresentation() {
+  async hidePresentation() {
     const { presentationHidden } = this.modPage.settings || {};
 
     if (!presentationHidden) {
@@ -88,11 +88,49 @@ export class Presentation extends MultiUsers {
       e.presentationContainer,
       'should not display the presentation container since the presentation is minimized',
     );
+  }
+
+  async hideAndRestorePresentation() {
+    await this.hidePresentation();
 
     await this.modPage.waitAndClick(e.restorePresentation);
     await this.modPage.hasElement(
       e.presentationContainer,
       'should display the presentation container since the presentation was restored',
+    );
+  }
+
+  async hideAndShareNewPresentation() {
+    await this.hidePresentation();
+
+    await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName, UPLOAD_PDF_WAIT_TIME);
+
+    await this.modPage.hasElement(
+      e.presentationContainer,
+      'should display the presentation container after a new presentation is shared',
+    );
+  }
+
+  async shareNewPresentationAfterDelete() {
+    await this.modPage.waitAndClick(e.mediaAreaButton);
+    await this.modPage.waitAndClick(e.managePresentations);
+    await this.modPage.waitAndClick(e.removePresentation);
+    await this.modPage.wasRemoved(
+      e.presentationContainer,
+      'should not display the presentation container after the default presentation is removed',
+    );
+    await this.modPage.press('Escape');
+
+    // because the previous presentation was removed, the one to be uploaded is expected to be the only one (index 0)
+    await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName, UPLOAD_PDF_WAIT_TIME, 0);
+
+    await this.modPage.hasElement(
+      e.presentationContainer,
+      'should display the presentation container for the moderator after the new presentation is shared',
+    );
+    await this.userPage.hasElement(
+      e.presentationContainer,
+      'should display the presentation container for the attendee after the new presentation is shared',
     );
   }
 
@@ -110,7 +148,7 @@ export class Presentation extends MultiUsers {
         e.shareExternalVideoBtn,
         'should not display the option to share an external video, since is deactivated',
       );
-      return
+      return;
     }
     await this.modPage.waitAndClick(e.shareExternalVideoBtn);
     await this.modPage.hasElement(
@@ -423,7 +461,7 @@ export class Presentation extends MultiUsers {
     //! await this.modPage.handleDownload(this.modPage.page.locator(e.presentationDownloadBtn), testInfo);
     //! await this.userPage.handleDownload(this.userPage.page.locator(e.presentationDownloadBtn), testInfo);
     // disable original presentation download
-    
+
     await this.modPage.waitAndClick(e.managePresentations);
     await this.modPage.waitAndClick(e.presentationOptionsDownloadBtn);
     await this.modPage.waitAndClick(e.disableOriginalPresentationDownloadBtn);
@@ -458,7 +496,7 @@ export class Presentation extends MultiUsers {
     }
     await this.modPage.waitAndClick(e.sendPresentationInCurrentStateBtn);
     await this.modPage.hasElement(e.downloadPresentationToast, 'should display the download presentation toast');
-     await this.userPage.hasElement(
+    await this.userPage.hasElement(
       e.downloadPresentation,
       'should display the download presentation button for the attendee',
       ELEMENT_WAIT_EXTRA_LONG_TIME,

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -72,7 +72,12 @@ export async function hasCurrentPresentationToastElement(
   ).toBeVisible({ timeout });
 }
 
-export async function uploadSinglePresentation(testPage: Page, fileName: string, uploadTimeout = UPLOAD_PDF_WAIT_TIME) {
+export async function uploadSinglePresentation(
+  testPage: Page,
+  fileName: string,
+  uploadTimeout = UPLOAD_PDF_WAIT_TIME,
+  thumbnailIndex = 1,
+) {
   const firstSlideSrc = await testPage.page.evaluate(
     ([selector]) => {
       const el = document.querySelector(selector) as HTMLElement | null;
@@ -99,7 +104,7 @@ export async function uploadSinglePresentation(testPage: Page, fileName: string,
   await testPage.waitUntilHaveCountSelector(e.presentationThumbnails, numPresentationsBefore + 1, uploadTimeout);
 
   // select and share the uploaded presentation
-  const newPDFThumbnail = await testPage.getLocatorByIndex(e.presentationThumbnails, 1);
+  const newPDFThumbnail = await testPage.getLocatorByIndex(e.presentationThumbnails, thumbnailIndex);
   await newPDFThumbnail.click();
   await testPage.waitAndClick(e.sharePresentationButton);
   await testPage.press('Escape'); // close the media sharing menu


### PR DESCRIPTION
### What does this PR do?
There is a mechanism to hide the presentation area while the default presentation file is still uploading, to prevent displaying
an empty area during that time. 
This mechanism lives inside the presentation component itself, which gets unmounted when the presentation is hidden. As a result, the mechanism disables itself and is no longer active to reopen the presentation when the upload finishes. This only occurs when `public.presentation.restoreOnUpdate` is set to false — when true, the presentation is kept visible regardless, which masks the issue.
Move the restore-on-upload logic to the layout observer, in order to prevent it from disabling itself.


Also, adds tests for such cases: ad14b9c2d3175aaf82ff1f8b849229f8eb396326.

### Closes Issue(s)
Closes #25190 