### PR TITLE
chore: use Markdown headings in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/core-issue.md
+++ b/.github/ISSUE_TEMPLATE/core-issue.md
@@ -10,35 +10,38 @@ assignees: ''
 <!--PLEASE DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 This issue tracker is only for bbb development related issues.-->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### To Reproduce
+<!-- Steps to reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Actual behavior**
-A clear and concise description of what you expected to happen.
+### Actual behavior
+<!-- A clear and concise description of what actually happens. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
+### Environment
+<!-- Please complete the following information so we can reproduce the issue. -->
+
+#### Desktop
  - OS: [e.g. Windows, Mac]
- - Browser [e.g. Chrome, Safari]
- - Version [e.g. 22]
+ - Browser: [e.g. Chrome, Safari]
+ - Version: [e.g. 22]
 
-**Smartphone (please complete the following information):**
+#### Smartphone
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, Safari]
- - Version [e.g. 22]
+ - Browser: [e.g. stock browser, Safari]
+ - Version: [e.g. 22]
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/docs-issue.md
+++ b/.github/ISSUE_TEMPLATE/docs-issue.md
@@ -10,14 +10,14 @@ assignees: ''
 <!--PLEASE DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 This issue tracker is only for bbb development or docs related issues.-->
 
-**Link to the portion of the docs that is out of date**
-If applicable, link to the section of the docs that is out of date.
+### Link to the portion of the docs that is out of date
+<!-- If applicable, link to the section of the docs that is out of date. -->
 
-**Describe what you believe the correct version should be**
+### Describe what you believe the correct version should be
+<!-- A clear and concise description of the correct content. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your concern.
+### Screenshots
+<!-- If applicable, add screenshots to help explain your concern. -->
 
-**Additional context**
-Add any other context about the problem here.
-
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,14 +11,14 @@ assignees: ''
 This issue tracker is only for bbb development related issues.
 Search for existing feature requests to avoid creating duplicates.-->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+### Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+### Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Describe alternatives you've considered
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+### Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/html5-issue.md
+++ b/.github/ISSUE_TEMPLATE/html5-issue.md
@@ -10,41 +10,44 @@ assignees: ''
 <!--PLEASE DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 This issue tracker is only for bbb development related issues.-->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### To Reproduce
+<!-- Steps to reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Actual behavior**
-A clear and concise description of what you expected to happen.
+### Actual behavior
+<!-- A clear and concise description of what actually happens. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**BBB version:**
-BigBlueButton continually evolves. Providing the version/build helps us to pinpoint when an issue was introduced.
+### BBB version
+<!-- BigBlueButton continually evolves. Providing the version/build helps us to pinpoint when an issue was introduced.
 Example:
 $ sudo bbb-conf --check | grep BigBlueButton
-BigBlueButton Server 2.2.2 (1816)
+BigBlueButton Server 2.2.2 (1816) -->
 
-**Desktop (please complete the following information):**
+### Environment
+<!-- Please complete the following information so we can reproduce the issue. -->
+
+#### Desktop
  - OS: [e.g. Windows, Mac]
- - Browser [e.g. Chrome, Safari]
- - Version [e.g. 22]
+ - Browser: [e.g. Chrome, Safari]
+ - Version: [e.g. 22]
 
-**Smartphone (please complete the following information):**
+#### Smartphone
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, Safari]
- - Version [e.g. 22]
+ - Browser: [e.g. stock browser, Safari]
+ - Version: [e.g. 22]
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/installation-issue.md
@@ -12,17 +12,17 @@ This issue tracker is only for bbb development related issues.
 For support of BBB installation problems ask in the forum: 
 https://groups.google.com/forum/#!forum/bigbluebutton-setup -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**Installation type**
-Did you install manually or did you use the bbb-install script?
+### Installation type
+<!-- Did you install manually or did you use the bbb-install script? -->
 
-**Firewall and IP address type**
-Is your server behind a NAT or firewall? Does your BBB server have its own IPv4 addres?
+### Firewall and IP address type
+<!-- Is your server behind a NAT or firewall? Does your BBB server have its own IPv4 address? -->
 
-**Console output**
-Please include the full console output from the install.
+### Console output
+<!-- Please include the full console output from the install. -->
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/recording-issue.md
+++ b/.github/ISSUE_TEMPLATE/recording-issue.md
@@ -10,35 +10,38 @@ assignees: ''
 <!--PLEASE DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 This issue tracker is only for bbb development related issues.-->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+### To Reproduce
+<!-- Steps to reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Actual behavior**
-A clear and concise description of what you expected to happen.
+### Actual behavior
+<!-- A clear and concise description of what actually happens. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
+### Environment
+<!-- Please complete the following information so we can reproduce the issue. -->
+
+#### Desktop
  - OS: [e.g. Windows, Mac]
- - Browser [e.g. Chrome, Safari]
- - Version [e.g. 22]
+ - Browser: [e.g. Chrome, Safari]
+ - Version: [e.g. 22]
 
-**Smartphone (please complete the following information):**
+#### Smartphone
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, Safari]
- - Version [e.g. 22]
+ - Browser: [e.g. stock browser, Safari]
+ - Version: [e.g. 22]
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/test-scenario.md
+++ b/.github/ISSUE_TEMPLATE/test-scenario.md
@@ -10,17 +10,17 @@ assignees: ''
 <!--PLEASE DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 This issue tracker is only for bbb development related issues.-->
 
-**Describe the test scenario, be specific**
-A clear and concise description of what the test case is.
+### Describe the test scenario, be specific
+<!-- A clear and concise description of what the test case is. -->
 
-Steps to reproduce:
+#### Steps to reproduce
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Edge cases**
-Any specific edge cases to keep in mind?
+### Edge cases
+<!-- Any specific edge cases to keep in mind? -->
 
-**Additional context**
-Add any other context about the problem here.
+### Additional context
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
### What does this PR do?

- [chore: use Markdown headings in GitHub issue templates](https://github.com/bigbluebutton/bigbluebutton/commit/5c77aed6aee5ca3c0d6c6268700a15f0e3ce8b91) 
  - Bold-label section dividers produce no heading elements, so issue
templates have no anchors, no outline, and no way to nest steps or
subsections. 
  - Replace `**` with `###`/`####` headings, matching the PR template, 
and wrap inline examples in HTML comments so issues render clean like 
in PR templates.
  - Stems from writing https://github.com/bigbluebutton/bigbluebutton/issues/25203
  
### Closes Issue(s)

None