### PR TITLE
fix(notes): adjust padding to not stay out of sidebar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -318,7 +318,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             color: #2f80ed;
           }
           .bn-editor {
-            padding-inline: 35px 25px;
+            padding-inline: 50px 25px;
             font-size: 1rem;
             box-sizing: border-box;
             cursor: text;


### PR DESCRIPTION

### What does this PR do?
Increase padding so the block note controlos don't stay out of sidebar in the left.

Before
https://github.com/user-attachments/assets/4f37eb61-5b3d-49e8-815b-0f7990fd4258

After
https://github.com/user-attachments/assets/b8804467-1803-40be-ab68-eaa776022015


