### PR TITLE
fix(bbb-web): Return Better Errors From Presentation Upload

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/DownloadResult.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/DownloadResult.java
@@ -1,0 +1,7 @@
+package org.bigbluebutton.api.service;
+
+public enum DownloadResult {
+    SUCCESS,
+    TOO_LARGE,
+    DOWNLOAD_ERROR
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/SecureUrlDownloader.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/SecureUrlDownloader.java
@@ -45,10 +45,12 @@ public class SecureUrlDownloader {
      * @param destination  The file to write the downloaded content to.
      * @param timeoutMs    Connect/socket timeout in milliseconds.
      * @param maxBytes     Maximum allowed payload size in bytes. Pass {@link Long#MAX_VALUE} for no limit.
-     * @return {@code true} if the file was created successfully and within the size limit.
+     * @return {@link DownloadResult#SUCCESS} if the file was written within the size limit,
+     *         {@link DownloadResult#TOO_LARGE} if the response exceeded {@code maxBytes},
+     *         or {@link DownloadResult#DOWNLOAD_ERROR} for any other failure.
      */
-    public boolean downloadToFile(String contextId, ValidatedUrl validatedUrl, File destination,
-                                  int timeoutMs, long maxBytes) {
+    public DownloadResult downloadToFile(String contextId, ValidatedUrl validatedUrl, File destination,
+                                         int timeoutMs, long maxBytes) {
         try (CloseableHttpClient httpClient = buildPinnedClient(validatedUrl, timeoutMs)) {
             HttpGet request = buildRequest(validatedUrl);
 
@@ -57,7 +59,8 @@ public class SecureUrlDownloader {
                     throw new ClientProtocolException("Download failed: " + response.getStatusLine());
                 }
                 if (response.getEntity() == null || response.getEntity().getContent() == null) {
-                    return destination.exists();
+                    log.warn("Empty response body from [{}] for context [{}]", validatedUrl.originalUrl(), contextId);
+                    return DownloadResult.DOWNLOAD_ERROR;
                 }
 
                 try (InputStream in = response.getEntity().getContent();
@@ -72,18 +75,18 @@ public class SecureUrlDownloader {
                                     validatedUrl.originalUrl(), maxBytes, contextId);
                             out.close();
                             destination.delete();
-                            return false;
+                            return DownloadResult.TOO_LARGE;
                         }
                         out.write(buf, 0, n);
                     }
                 }
             }
 
-            return destination.exists();
+            return DownloadResult.SUCCESS;
         } catch (IOException e) {
             log.error("IOException while downloading [{}] for context [{}]", validatedUrl.originalUrl(), contextId, e);
             destination.delete();
-            return false;
+            return DownloadResult.DOWNLOAD_ERROR;
         }
     }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/service/SecureUrlDownloader.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/service/SecureUrlDownloader.java
@@ -63,6 +63,12 @@ public class SecureUrlDownloader {
                     return DownloadResult.DOWNLOAD_ERROR;
                 }
 
+                File parent = destination.getParentFile();
+                if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+                    log.error("Cannot create parent directory [{}] for context [{}]", parent, contextId);
+                    return DownloadResult.DOWNLOAD_ERROR;
+                }
+
                 try (InputStream in = response.getEntity().getContent();
                      OutputStream out = new FileOutputStream(destination)) {
                     byte[] buf = new byte[8192];

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/PresentationUrlDownloadService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.bigbluebutton.api.Util;
+import org.bigbluebutton.api.service.DownloadResult;
 import org.bigbluebutton.api.service.RedirectFollowerService;
 import org.bigbluebutton.api.service.SecureUrlDownloader;
 import org.bigbluebutton.api.service.ValidatedUrl;
@@ -164,7 +165,7 @@ public class PresentationUrlDownloadService {
 
 
 
-    public boolean savePresentation(final String meetingId,
+    public DownloadResult savePresentation(final String meetingId,
             final String filename, final String urlString, final long maxBytes) {
 
         ValidatedUrl validatedUrl = redirectFollower.followRedirectSecure(
@@ -173,7 +174,7 @@ public class PresentationUrlDownloadService {
 
         if (validatedUrl == null) {
             log.error("Failed to validate and resolve URL [{}] for meeting [{}]", urlString, meetingId);
-            return false;
+            return DownloadResult.DOWNLOAD_ERROR;
         }
 
         if (!validatedUrl.originalUrl().equals(urlString)) {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -32,6 +32,7 @@ import org.bigbluebutton.api.*
 import org.bigbluebutton.api.domain.GuestPolicy
 import org.bigbluebutton.api.domain.Meeting
 import org.bigbluebutton.api.domain.UserSession
+import org.bigbluebutton.api.service.DownloadResult
 import org.bigbluebutton.api.service.ServiceUtils
 import org.bigbluebutton.api.service.ValidationService
 import org.bigbluebutton.api.util.ParamsUtil
@@ -1794,25 +1795,25 @@ class ApiController {
         def newFilename = Util.createNewFilename(presId, filenameExt)
         def newFilePath = uploadDir.absolutePath + File.separatorChar + newFilename
 
-        if(presDownloadService.savePresentation(meetingId, newFilePath, address, maxFileSize)) pres = new File(newFilePath)
-        else {
-          log.error("Failed to download presentation=[${address}], meeting=[${meetingId}], fileName=[${fileName}]")
-          uploadFailReasons.add("failed_to_download_file")
-          uploadFailed = true
-        }
-
-        if (pres != null && pres.length() > maxFileSize) {
-          log.warn("Upload failed. Downloaded file too large: ${pres.length()} bytes exceeds max ${maxFileSize} bytes for meeting=[${meetingId}], url=[${address}]")
-          long downloadedSize = pres.length()
-          pres.delete()
-          pres = null
-          uploadFailReasons.add("file_too_large")
-          uploadFailed = true
-          if (isFromInsertAPI) {
-            meetingService.sendPresentationUploadMaxFilesizeMessage(
-                    presId, "DEFAULT_PRESENTATION_POD", meetingId, presFilename,
-                    "preupload-download-authz-token", (int) downloadedSize, (int) maxFileSize)
-          }
+        def downloadResult = presDownloadService.savePresentation(meetingId, newFilePath, address, maxFileSize)
+        switch (downloadResult) {
+          case DownloadResult.SUCCESS:
+            pres = new File(newFilePath)
+            break
+          case DownloadResult.TOO_LARGE:
+            log.warn("Upload failed. Downloaded file exceeded max ${maxFileSize} bytes for meeting=[${meetingId}], url=[${address}]")
+            uploadFailReasons.add("file_too_large")
+            uploadFailed = true
+            if (isFromInsertAPI) {
+              meetingService.sendPresentationUploadMaxFilesizeMessage(
+                      presId, "DEFAULT_PRESENTATION_POD", meetingId, presFilename,
+                      "preupload-download-authz-token", (int) maxFileSize, (int) maxFileSize)
+            }
+            break
+          default:
+            log.error("Failed to download presentation=[${address}], meeting=[${meetingId}], fileName=[${fileName}]")
+            uploadFailReasons.add("failed_to_download_file")
+            uploadFailed = true
         }
 
         if (pres != null && isPreUploadedPresentationFromParameter && filenameExt.isEmpty()) {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1715,7 +1715,7 @@ class ApiController {
       if (isFromInsertAPI) {
         meetingService.sendPresentationUploadMaxFilesizeMessage(
                 presId, "DEFAULT_PRESENTATION_POD", meetingId, presFilename,
-                "preupload-raw-authz-token", bytes.length, (int) maxFileSize)
+                "preupload-raw-authz-token", bytes.length, (int) Math.min(maxFileSize, Integer.MAX_VALUE))
       }
     } else {
       String presentationDir = presentationService.getPresentationDir()
@@ -1807,7 +1807,7 @@ class ApiController {
             if (isFromInsertAPI) {
               meetingService.sendPresentationUploadMaxFilesizeMessage(
                       presId, "DEFAULT_PRESENTATION_POD", meetingId, presFilename,
-                      "preupload-download-authz-token", (int) maxFileSize, (int) maxFileSize)
+                      "preupload-download-authz-token", (int) Math.min(maxFileSize, Integer.MAX_VALUE), (int) Math.min(maxFileSize, Integer.MAX_VALUE))
             }
             break
           default:


### PR DESCRIPTION
### What does this PR do?

This is a follow-up PR to #25129 that improves the errors returned from API on the presentation upload paths and implements some minor fixes for how the maximum presentation size is handled.

### Motivation

AI code review tools suggested some improvements to the previous PR.