### PR TITLE
fix(presentation): snapshot of current slide is blank under cluster-proxy

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -182,6 +182,47 @@ const PresentationMenu = (props) => {
       svgElem.appendChild(pollShapeImage);
     }
 
+    // Embed the slide background as a credentialed data URL before rasterizing.
+    // tldraw's getSvg fetches image assets WITHOUT credentials, so under a
+    // cluster-proxy (client on the proxy origin, slide served by the BBB node
+    // origin) the slide request is answered with 401 and tldraw inlines the
+    // error page instead of the slide - the exported snapshot then shows a
+    // broken image. We re-fetch the slide from its asset src WITH credentials
+    // and replace the broken reference so the export matches what is on screen,
+    // on same-origin and cluster-proxy setups alike.
+    try {
+      const bgAssetId = backgroundShape?.props?.assetId;
+      const asset = bgAssetId
+        ? (tldrawAPI.getAsset?.(bgAssetId) || tldrawAPI.store?.get?.(bgAssetId))
+        : null;
+      const slideSrc = asset?.props?.src;
+      if (slideSrc) {
+        const response = await fetch(slideSrc, { credentials: 'include' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const blob = await response.blob();
+        const slideDataUrl = await new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => resolve(reader.result);
+          reader.onerror = reject;
+          reader.readAsDataURL(blob);
+        });
+        svgElem.querySelectorAll('image').forEach((imageEl) => {
+          const href = imageEl.getAttribute('href') || imageEl.getAttribute('xlink:href');
+          // Annotations and polls are already valid data:image URIs; only the
+          // slide background fails to inline, so replace anything that is not.
+          if (!href || !href.startsWith('data:image')) {
+            imageEl.removeAttribute('xlink:href');
+            imageEl.setAttribute('href', slideDataUrl);
+          }
+        });
+      }
+    } catch (error) {
+      logger.warn({
+        logCode: 'presentation_snapshot_inline_image_error',
+        extraInfo: { error: error?.message || String(error) },
+      }, `Snapshot: failed to embed slide image for export: ${error?.message || error}`);
+    }
+
     if (isIos || isSafari) {
       const svgString = new XMLSerializer().serializeToString(svgElem);
       const blob = new Blob([svgString], { type: 'image/svg+xml' });


### PR DESCRIPTION
## Summary

The presentation **Options → "Snapshot of current slide"** export produces a broken-image placeholder instead of the slide when BigBlueButton is deployed behind a [cluster proxy](https://docs.bigbluebutton.org/administration/cluster-proxy/) (HTML5 client served from the proxy origin, slides served from the BBB node origin). Annotations are exported correctly; only the slide background is lost.

## Root cause

`extractSlideContentToImage` (presentation-menu) builds the export via `tldrawAPI.getSvg(...)` and then `html-to-image`'s `toPng`. tldraw's `getSvg` inlines image assets by fetching them **without credentials**. The slide SVG requires an authenticated request (nginx `auth_request`), so under a cluster proxy the cross-origin fetch is answered with **HTTP 401**, and the 401 HTML page gets embedded (`data:text/html;base64,...`) in place of the slide. The on-screen render is unaffected because its fetch is credentialed.

## Fix

Before rasterizing, re-fetch the slide from its asset `src` **with credentials** and embed it inline as a data URL, replacing the broken reference. It only runs when `getSvg` failed to inline the asset (the `<image>` href is not a `data:image`), so same-origin deployments are unaffected; on failure it logs a warning and falls back to the previous behavior.

## Before / after (cluster-proxy)

![before and after the fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-02/9cb1c3b3-5239-41be-bdcf-2faec35ccaf7/snapshot-fix-before-after.jpg)

Left: broken placeholder (before). Right: slide background + annotation rendered (after), matching the on-screen slide.

## How to test

1. Deploy 3.0 in a cluster-proxy setup.
2. Start a meeting and keep the default presentation (or upload a PDF).
3. Draw an annotation on the slide.
4. Options → "Snapshot of current slide".
5. The exported PNG should match the displayed slide (background + annotation).

Verified from source on `v3.0.x-develop` in a cluster-proxy environment.
