### PR TITLE
feat(plugins): support configurable button styles

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -47,11 +47,13 @@ class ActionsBar extends PureComponent {
                 buttonProps = {
                   key: `${plugin.type}-${plugin.id}`,
                   onClick: plugin.onClick,
-                  hideLabel: true,
+                  hideLabel: plugin.hideLabel !== false,
                   color: plugin.color || 'primary',
-                  size: 'lg',
-                  circle: true,
+                  size: plugin.size || 'lg',
+                  circle: plugin.circle !== false,
+                  style: plugin.style,
                   label: plugin.tooltip,
+                  tooltipLabel: plugin.tooltip,
                   dataTest: plugin.dataTest,
                 };
                 if (typeof plugin?.icon === 'string') {

--- a/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/component.jsx
@@ -52,7 +52,7 @@ class ActionsBar extends PureComponent {
                   size: plugin.size || 'lg',
                   circle: plugin.circle !== false,
                   style: plugin.style,
-                  label: plugin.tooltip,
+                  label: plugin.label || plugin.tooltip,
                   tooltipLabel: plugin.tooltip,
                   dataTest: plugin.dataTest,
                 };

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -102,9 +102,9 @@ const renderPluginItems = (pluginItems) => {
                       label={pluginItem.label}
                       aria-label={pluginItem.tooltip}
                       color={pluginItem.color || 'primary'}
-                      circle={pluginItem.circle !== false}
-                      hideLabel={pluginItem.hideLabel !== false}
-                      size={pluginItem.size || 'sm'}
+                      circle={pluginItem.circle === true}
+                      hideLabel={pluginItem.hideLabel === true}
+                      size={pluginItem.size || 'md'}
                       style={pluginItem.style}
                       tooltipLabel={pluginItem.tooltip}
                       onClick={pluginItem.onClick}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -101,8 +101,12 @@ const renderPluginItems = (pluginItems) => {
                       disabled={pluginItem.disabled}
                       label={pluginItem.label}
                       aria-label={pluginItem.tooltip}
-                      color="primary"
-                      tooltip={pluginItem.tooltip}
+                      color={pluginItem.color || 'primary'}
+                      circle={pluginItem.circle !== false}
+                      hideLabel={pluginItem.hideLabel !== false}
+                      size={pluginItem.size || 'sm'}
+                      style={pluginItem.style}
+                      tooltipLabel={pluginItem.tooltip}
                       onClick={pluginItem.onClick}
                       dataTest={pluginItem.dataTest}
                       {...navBarIconProps}

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -252,6 +252,10 @@ class PresentationToolbar extends PureComponent {
               key={ppbId}
               style={{ marginLeft: '2px', ...ppb.style }}
               label={ppb.label}
+              color={ppb.color || 'default'}
+              circle={ppb.circle === true}
+              hideLabel={ppb.hideLabel === true}
+              size={ppb.size || 'md'}
               onClick={ppb.onClick}
               tooltipLabel={ppb.tooltip}
               dataTest={ppb.dataTest}
@@ -343,9 +347,6 @@ class PresentationToolbar extends PureComponent {
       allowInfiniteWhiteboard,
       allowInfiniteWhiteboardInBreakouts,
       infiniteWhiteboardIcon,
-      resetSlide,
-      zoomChanger,
-      tldrawAPI,
       maxNumberOfActiveUsers,
       numberOfJoinedUsers,
     } = this.props;


### PR DESCRIPTION
### What does this PR do?

Adds support for configurable styling on plugin-provided buttons in the HTML5 client.

- Reads optional `color`, `circle`, `hideLabel`, `size`, and `style` props from plugin nav bar buttons.
- Reads the same optional props from plugin actions bar buttons.
- Reads the same optional props from plugin presentation toolbar buttons.
- Preserves the previous defaults when older SDK/plugin objects do not provide these props.
- Also fixes a bug where the tooltip for navbar inject buttons was not working.

SDK related code: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/266

### Motivation

The plugin SDK can expose button styling options for plugin authors, but the HTML5 client also needs to consume those optional fields when rendering plugin-provided buttons. This lets plugins control button appearance while keeping existing plugins backward-compatible.

### How to test

- Build/run the HTML5 client with a plugin that injects nav bar, actions bar, and presentation toolbar buttons.
- Confirm existing plugins without the new props still render with the previous defaults.
- Confirm plugin buttons using `color`, `circle`, `hideLabel`, `size`, and `style` render with the expected appearance.