### PR TITLE
feat(LAD): add standalone build mode for LAD

### DIFF
--- a/bbb-learning-dashboard/package.json
+++ b/bbb-learning-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-analytics-dashboard",
-  "homepage": "/learning-analytics-dashboard/",
+  "homepage": ".",
   "version": "0.1.0",
   "private": true,
   "overrides": {

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -107,6 +107,19 @@ class App extends React.Component {
   }
 
   setDashboardParams(callback) {
+    if (process.env.REACT_APP_PLAYBACK_MODE === 'true') {
+      const pathParts = window.location.pathname.replace(/\/$/, '').split('/');
+      const meetingId = pathParts[pathParts.length - 1] || '';
+      if (!meetingId) {
+        // eslint-disable-next-line no-console
+        console.warn('Learning Dashboard is running in playback mode but no meetingId could be identified from the URL:', window.location.pathname);
+      }
+      this.setState({ meetingId, learningDashboardAccessToken: '', sessionToken: '' }, () => {
+        if (typeof callback === 'function') callback();
+      });
+      return;
+    }
+
     let learningDashboardAccessToken = '';
     let meetingId = '';
     let sessionToken = '';
@@ -204,9 +217,12 @@ class App extends React.Component {
   }
 
   getErrorMessage() {
-    const { activitiesJson, learningDashboardAccessToken, sessionToken } = this.state;
+    const {
+      activitiesJson, learningDashboardAccessToken, sessionToken,
+    } = this.state;
     const { intl } = this.props;
-    if (learningDashboardAccessToken === '' && sessionToken === '') {
+    if (process.env.REACT_APP_PLAYBACK_MODE !== 'true'
+        && learningDashboardAccessToken === '' && sessionToken === '') {
       return intl.formatMessage({ id: 'app.learningDashboard.errors.invalidToken', defaultMessage: 'Invalid session token' });
     }
 
@@ -278,20 +294,38 @@ class App extends React.Component {
       return newActivivies;
     };
 
-    if (learningDashboardAccessToken !== '') {
+    const handleSuccess = (json) => {
+      this.setState({
+        activitiesJson: convertUserUsessionsFormat(json),
+        loading: false,
+        invalidSessionCount: 0,
+        lastUpdated: Date.now(),
+      });
+      this.updateModalUser();
+    };
+
+    const handleFailure = () => {
+      this.setState({ loading: false, invalidSessionCount: invalidSessionCount + 1 });
+    };
+
+    const isPlaybackMode = process.env.REACT_APP_PLAYBACK_MODE === 'true';
+
+    if (isPlaybackMode) {
+      const basePath = window.location.pathname.endsWith('/')
+        ? window.location.pathname
+        : `${window.location.pathname}/`;
+      fetch(`${basePath}learning_dashboard_data.json`)
+        .then((response) => {
+          if (!response.ok) throw new Error('not found');
+          return response.json();
+        })
+        .then(handleSuccess)
+        .catch(handleFailure);
+    } else if (learningDashboardAccessToken !== '') {
       fetch(`${meetingId}/${learningDashboardAccessToken}/learning_dashboard_data.json`)
         .then((response) => response.json())
-        .then((json) => {
-          this.setState({
-            activitiesJson: convertUserUsessionsFormat(json),
-            loading: false,
-            invalidSessionCount: 0,
-            lastUpdated: Date.now(),
-          });
-          this.updateModalUser();
-        }).catch(() => {
-          this.setState({ loading: false, invalidSessionCount: invalidSessionCount + 1 });
-        });
+        .then(handleSuccess)
+        .catch(handleFailure);
     } else if (sessionToken !== '') {
       const url = new URL('/bigbluebutton/api/learningDashboard', window.location);
       fetch(`${url}?sessionToken=${sessionToken}`, { credentials: 'include' })
@@ -299,29 +333,23 @@ class App extends React.Component {
         .then((json) => {
           if (json.response.returncode === 'SUCCESS') {
             const jsonData = JSON.parse(json.response.data);
-            this.setState({
-              activitiesJson: jsonData,
-              loading: false,
-              invalidSessionCount: 0,
-              lastUpdated: Date.now(),
-            });
-            this.updateModalUser();
+            handleSuccess(jsonData);
           } else {
             // When meeting is ended the sessionToken stop working, check for new cookies
             this.setDashboardParams();
-            this.setState({ loading: false, invalidSessionCount: invalidSessionCount + 1 });
+            handleFailure();
           }
         })
-        .catch(() => {
-          this.setState({ loading: false, invalidSessionCount: invalidSessionCount + 1 });
-        });
+        .catch(handleFailure);
     } else {
-      this.setState({ loading: false });
+      handleFailure();
     }
 
-    setTimeout(() => {
-      this.fetchActivitiesJson();
-    }, 10000 * (2 ** invalidSessionCount));
+    if (process.env.REACT_APP_PLAYBACK_MODE !== 'true') {
+      setTimeout(() => {
+        this.fetchActivitiesJson();
+      }, 10000 * (2 ** invalidSessionCount));
+    }
   }
 
   totalOfReactions() {
@@ -361,8 +389,13 @@ class App extends React.Component {
 
   render() {
     const {
-      activitiesJson, tab, loading, lastUpdated, ldAccessTokenCopied, sessionToken, modalOpen,
+      activitiesJson, tab, loading, lastUpdated, ldAccessTokenCopied, sessionToken,
+      modalOpen,
     } = this.state;
+
+    const presentationBase = process.env.REACT_APP_PLAYBACK_MODE === 'true'
+      ? `${window.location.pathname.replace(/\/?$/, '/')}presentation`
+      : null;
     const { intl } = this.props;
 
     const pluginUserDataCardTitle = activitiesJson?.pluginUserDataCardTitles?.[0];
@@ -678,6 +711,7 @@ class App extends React.Component {
                   slides={activitiesJson.presentationSlides}
                   meetingId={activitiesJson.intId}
                   sessionToken={sessionToken}
+                  presentationBase={presentationBase}
                 />
               </div>
             </div>

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -107,12 +107,12 @@ class App extends React.Component {
   }
 
   setDashboardParams(callback) {
-    if (process.env.REACT_APP_PLAYBACK_MODE === 'true') {
+    if (process.env.REACT_APP_STANDALONE_MODE === 'true') {
       const pathParts = window.location.pathname.replace(/\/$/, '').split('/');
       const meetingId = pathParts[pathParts.length - 1] || '';
       if (!meetingId) {
         // eslint-disable-next-line no-console
-        console.warn('Learning Dashboard is running in playback mode but no meetingId could be identified from the URL:', window.location.pathname);
+        console.warn('Learning Dashboard is running in standalone mode but no meetingId could be identified from the URL:', window.location.pathname);
       }
       this.setState({ meetingId, learningDashboardAccessToken: '', sessionToken: '' }, () => {
         if (typeof callback === 'function') callback();
@@ -221,7 +221,7 @@ class App extends React.Component {
       activitiesJson, learningDashboardAccessToken, sessionToken,
     } = this.state;
     const { intl } = this.props;
-    if (process.env.REACT_APP_PLAYBACK_MODE !== 'true'
+    if (process.env.REACT_APP_STANDALONE_MODE !== 'true'
         && learningDashboardAccessToken === '' && sessionToken === '') {
       return intl.formatMessage({ id: 'app.learningDashboard.errors.invalidToken', defaultMessage: 'Invalid session token' });
     }
@@ -308,9 +308,9 @@ class App extends React.Component {
       this.setState({ loading: false, invalidSessionCount: invalidSessionCount + 1 });
     };
 
-    const isPlaybackMode = process.env.REACT_APP_PLAYBACK_MODE === 'true';
+    const isStandaloneMode = process.env.REACT_APP_STANDALONE_MODE === 'true';
 
-    if (isPlaybackMode) {
+    if (isStandaloneMode) {
       const basePath = window.location.pathname.endsWith('/')
         ? window.location.pathname
         : `${window.location.pathname}/`;
@@ -345,7 +345,7 @@ class App extends React.Component {
       handleFailure();
     }
 
-    if (process.env.REACT_APP_PLAYBACK_MODE !== 'true') {
+    if (process.env.REACT_APP_STANDALONE_MODE !== 'true') {
       setTimeout(() => {
         this.fetchActivitiesJson();
       }, 10000 * (2 ** invalidSessionCount));
@@ -393,7 +393,7 @@ class App extends React.Component {
       modalOpen,
     } = this.state;
 
-    const presentationBase = process.env.REACT_APP_PLAYBACK_MODE === 'true'
+    const presentationBase = process.env.REACT_APP_STANDALONE_MODE === 'true'
       ? `${window.location.pathname.replace(/\/?$/, '/')}presentation`
       : null;
     const { intl } = this.props;

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -108,15 +108,7 @@ class App extends React.Component {
 
   setDashboardParams(callback) {
     if (process.env.REACT_APP_STANDALONE_MODE === 'true') {
-      const pathParts = window.location.pathname.replace(/\/$/, '').split('/');
-      const meetingId = pathParts[pathParts.length - 1] || '';
-      if (!meetingId) {
-        // eslint-disable-next-line no-console
-        console.warn('Learning Dashboard is running in standalone mode but no meetingId could be identified from the URL:', window.location.pathname);
-      }
-      this.setState({ meetingId, learningDashboardAccessToken: '', sessionToken: '' }, () => {
-        if (typeof callback === 'function') callback();
-      });
+      if (typeof callback === 'function') callback();
       return;
     }
 
@@ -311,10 +303,7 @@ class App extends React.Component {
     const isStandaloneMode = process.env.REACT_APP_STANDALONE_MODE === 'true';
 
     if (isStandaloneMode) {
-      const basePath = window.location.pathname.endsWith('/')
-        ? window.location.pathname
-        : `${window.location.pathname}/`;
-      fetch(`${basePath}learning_dashboard_data.json`)
+      fetch('learning_dashboard_data.json')
         .then((response) => {
           if (!response.ok) throw new Error('not found');
           return response.json();
@@ -394,7 +383,7 @@ class App extends React.Component {
     } = this.state;
 
     const presentationBase = process.env.REACT_APP_STANDALONE_MODE === 'true'
-      ? `${window.location.pathname.replace(/\/?$/, '/')}presentation`
+      ? 'presentation'
       : null;
     const { intl } = this.props;
 

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -115,7 +115,7 @@ class StatusTable extends React.Component {
 
   render() {
     const {
-      allUsers, slides, meetingId, sessionToken, intl,
+      allUsers, slides, meetingId, sessionToken, presentationBase, intl,
     } = this.props;
 
     const usersPeriods = {};
@@ -226,6 +226,12 @@ class StatusTable extends React.Component {
                 const tokenParams = pageToken && sessionToken
                   ? `?${new URLSearchParams({ pageToken, sessionToken })}`
                   : '';
+                const slideUrl = presentationBase
+                  ? `${presentationBase}/${presentationId}/svgs/slide${pageNum}.svg`
+                  : `${URLPrefix}/${presentationId}/svg/${pageNum}${tokenParams}`;
+                const thumbUrl = presentationBase
+                  ? `${presentationBase}/${presentationId}/thumbnails/thumb-${pageNum}.png`
+                  : `${URLPrefix}/${presentationId}/thumbnail/${pageNum}${tokenParams}`;
                 return (
                   <td
                     style={{
@@ -236,14 +242,14 @@ class StatusTable extends React.Component {
                       <div className="flex">
                         <div className="my-4">
                           <a
-                            href={`${URLPrefix}/${presentationId}/svg/${pageNum}${tokenParams}`}
+                            href={slideUrl}
                             className="block border-2 border-gray-300"
                             target="_blank"
                             rel="noreferrer"
                             aria-describedby={`thumb-desc-${presentationId}`}
                           >
                             <img
-                              src={`${URLPrefix}/${presentationId}/thumbnail/${pageNum}${tokenParams}`}
+                              src={thumbUrl}
                               alt={`${intl.formatMessage(intlMessages.thumbnail)} - ${intl.formatMessage(intlMessages.presentation)} ${presentationName} - ${intl.formatMessage(intlMessages.pageNumber)} ${pageNum}`}
                               style={{
                                 maxWidth: '150px',

--- a/bbb-learning-dashboard/src/index.js
+++ b/bbb-learning-dashboard/src/index.js
@@ -52,7 +52,7 @@ class Dashboard extends React.Component {
 
   setMessages() {
     const fetchMessages = (lang) => new Promise((resolve, reject) => {
-      const localesBase = process.env.REACT_APP_PLAYBACK_MODE === 'true' ? '.' : '/html5client';
+      const localesBase = process.env.REACT_APP_STANDALONE_MODE === 'true' ? '.' : '/html5client';
       const url = `${localesBase}/locales/${normalizeLocale(lang)}.json`;
       fetch(url).then((response) => {
         if (!response.ok) return reject();

--- a/bbb-learning-dashboard/src/index.js
+++ b/bbb-learning-dashboard/src/index.js
@@ -52,7 +52,8 @@ class Dashboard extends React.Component {
 
   setMessages() {
     const fetchMessages = (lang) => new Promise((resolve, reject) => {
-      const url = `/html5client/locales/${normalizeLocale(lang)}.json`;
+      const localesBase = process.env.REACT_APP_PLAYBACK_MODE === 'true' ? '.' : '/html5client';
+      const url = `${localesBase}/locales/${normalizeLocale(lang)}.json`;
       fetch(url).then((response) => {
         if (!response.ok) return reject();
         return resolve(response.json());


### PR DESCRIPTION
### What does this PR do?

Introduces support for a standalone build mode, enabled at build time via the `REACT_APP_STANDALONE_MODE=true` environment variable. When not set, the dashboard behaves exactly as before.

In standalone mode:

- Asset paths are relative (homepage: ".") so the bundle is location-independent.
- The meeting ID is extracted from the URL path rather than query parameters.
- Session data is fetched from a relative learning_dashboard_data.json next to the app, instead of the token-based BBB endpoint.
- Token validation is skipped and polling is disabled, since it's not relative to a live session anymore.
- Locale files are resolved relative to the app root instead of /html5client/locales/;
- Presentation asset paths are derived from the current URL rather than the BBB presentation API.

### Motivation

Some other services might set location to use the same LAD front-end as we currently have, but pointing to different `data.json` - relative to that different location.

### How to test

Just test a normal flow with learning-dashboard, the behavior should remain the exact same
