### PR TITLE
feat(html5): Hide sessionToken from address bar

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/hooks.ts
@@ -5,6 +5,7 @@ import * as BlockNoteLocales from '@blocknote/core/locales';
 import { useEffect, useState, useRef } from 'react';
 import { GET_PAD_ID, GetPadIdQueryResponse } from '../notes/queries';
 import logger from '/imports/startup/client/logger';
+import Auth from '/imports/ui/services/auth';
 
 const hasSessionToken = (sessionToken?: string | null) => sessionToken != null && sessionToken !== '';
 const checkLockReason = (reason: string): boolean => reason === 'Lock rules changed.' || reason === 'Role changed.';
@@ -27,8 +28,7 @@ const useHocuspocusProvider = () => {
   );
   const padId = padIdData?.sharedNotes?.[0]?.padId;
 
-  const urlParams = new URLSearchParams(window.location.search);
-  const sessionToken = urlParams.get('sessionToken');
+  const sessionToken = Auth.sessionToken as string | null;
 
   const handleRetry = () => {
     if (hocuspocusProviderRef.current) {

--- a/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-manager/component.tsx
@@ -13,6 +13,7 @@ import connectionStatus from '../../core/graphql/singletons/connectionStatus';
 import deviceInfo from '/imports/utils/deviceInfo';
 import BBBWeb from '/imports/api/bbb-web-api';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
+import Auth from '/imports/ui/services/auth';
 
 interface ConnectionManagerProps {
   children: React.ReactNode;
@@ -200,8 +201,7 @@ const ConnectionManager: React.FC<ConnectionManagerProps> = ({ children }): Reac
     );
     loadingContextInfo.setLoading(true);
     if (graphqlUrl) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const sessionToken = urlParams.get('sessionToken');
+      const sessionToken = Auth.sessionToken as string | null;
       if (!sessionToken) {
         loadingContextInfo.setLoading(false);
         throw new Error('Missing session token');

--- a/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
@@ -3,6 +3,7 @@ import { setUserSettings } from '/imports/ui/core/local-states/useUserSettings';
 import { setUseCurrentLocale } from '/imports/ui/core/local-states/useCurrentLocale';
 import BBBWeb from '/imports/api/bbb-web-api';
 import Session from '/imports/ui/services/storage/in-memory';
+import Auth from '/imports/ui/services/auth';
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 
@@ -37,8 +38,7 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
       setLoading(false);
     }, CONNECTION_TIMEOUT);
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const sessionToken = urlParams.get('sessionToken');
+    const sessionToken = Auth.sessionToken as string | null;
 
     if (!sessionToken) {
       setLoading(false);

--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -8,6 +8,7 @@ import React, {
 import { defineMessages, useIntl } from 'react-intl';
 import { LoadingContext } from '../../common/loading-screen/loading-screen-HOC/component';
 import Styled from './styles';
+import Auth from '/imports/ui/services/auth';
 
 const REDIRECT_TIMEOUT = 15000;
 
@@ -66,18 +67,6 @@ const intlMessages = defineMessages({
   },
 });
 
-function getSearchParam(name: string) {
-  const params = new URLSearchParams(window.location.search);
-
-  if (params && params.has(name)) {
-    const param = params.get(name);
-
-    return param;
-  }
-
-  return null;
-}
-
 interface GuestWaitProps {
   guestStatus: string | null;
   guestLobbyMessage: string | null;
@@ -132,7 +121,7 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
   }, []);
 
   useEffect(() => {
-    const sessionToken = getSearchParam('sessionToken');
+    const { sessionToken } = Auth;
 
     if (loadingContextInfo.isLoading) {
       loadingContextInfo.setLoading(false);

--- a/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/presenceManager/component.tsx
@@ -17,6 +17,7 @@ import GuestWaitContainer, { GUEST_STATUSES } from '../guest-wait/component';
 import PluginTopLevelManager from '/imports/ui/components/plugin-top-level-manager/component';
 import meetingStaticData from '/imports/ui/core/singletons/meetingStaticData';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import Auth from '/imports/ui/services/auth';
 
 const connectionTimeout = 60000;
 const MESSAGE_TIMEOUT = 3000;
@@ -93,8 +94,7 @@ const PresenceManager: React.FC<PresenceManagerProps> = ({
   }, [guestStatus]);
 
   useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const sessionToken = urlParams.get('sessionToken') as string;
+    const sessionToken = Auth.sessionToken as string;
     setAuthData({
       meetingId,
       userId,

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -11,6 +11,7 @@ import {
 } from '/imports/ui/components/whiteboard/queries';
 import Service from './service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
+import Auth from '/imports/ui/services/auth';
 
 const DEBOUNCE_TIMEOUT = 15000;
 
@@ -81,8 +82,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
     }
 
     if (!isEtherpadSharedNotes) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const sessionToken = urlParams.get('sessionToken');
+      const { sessionToken } = Auth;
       const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
         || window.location.hostname;
 

--- a/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
@@ -5,6 +5,7 @@ import MeetingClientSettings from '/imports/ui/Types/meetingClientSettings';
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 import Session from '/imports/ui/services/storage/in-memory';
+import Auth from '/imports/ui/services/auth';
 import BBBWeb from '/imports/api/bbb-web-api';
 import MeetingStaticDataStore from '/imports/ui/core/singletons/meetingStaticData';
 import { MeetingStaticData } from '/imports/ui/Types/meetingStaticData';
@@ -50,8 +51,7 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
     const clientSessionUUID = uuid();
     sessionStorage.setItem('clientSessionUUID', clientSessionUUID);
 
-    const urlParams = new URLSearchParams(window.location.search);
-    const sessionToken = urlParams.get('sessionToken');
+    const sessionToken = Auth.sessionToken as string | null;
 
     if (!sessionToken) {
       setLoading(false);

--- a/bigbluebutton-html5/imports/ui/services/auth/index.js
+++ b/bigbluebutton-html5/imports/ui/services/auth/index.js
@@ -1,15 +1,36 @@
 /* eslint prefer-promise-reject-errors: 0 */
 import { makeVar, useReactiveVar } from '@apollo/client';
 import Storage from '/imports/ui/services/storage/session';
-import Session from '/imports/ui/services/storage/in-memory';
+
+function getAndRemoveSessionTokenFromUrl() {
+  const url = new URL(window.location.href);
+  const tokenFromUrl = url.searchParams.get('sessionToken');
+
+  if (!tokenFromUrl) {
+    return null;
+  }
+
+  url.searchParams.delete('sessionToken');
+  window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
+  return tokenFromUrl;
+}
 
 class Auth {
   constructor() {
     this._loggedIn = makeVar(false);
 
-    const queryParams = new URLSearchParams(document.location.search);
-    if (queryParams.has('sessionToken')
-      && queryParams.get('sessionToken') !== Session.getItem('sessionToken')) {
+    const storedSessionToken = Storage.getItem('sessionToken');
+    const tokenFromUrl = getAndRemoveSessionTokenFromUrl();
+
+    if (tokenFromUrl) {
+      this.sessionToken = tokenFromUrl;
+    }
+
+    if (
+      tokenFromUrl
+      && storedSessionToken
+      && tokenFromUrl !== storedSessionToken
+    ) {
       return;
     }
 
@@ -33,9 +54,9 @@ class Auth {
     Storage.setItem('meetingID', this._meetingID);
   }
 
-  set _connectionID(connectionId) {
+  set connectionID(connectionId) {
     this._connectionID = connectionId;
-    Storage.setItem('sessionToken', this._connectionID);
+    Storage.setItem('connectionID', this._connectionID);
   }
 
   get sessionToken() {
@@ -182,14 +203,14 @@ class Auth {
 
   logout() {
     if (!this.loggedIn) {
-      if (allowRedirectToLogoutURL()) {
+      if (this.allowRedirectToLogoutURL()) {
         return Promise.resolve(this._logoutURL);
       }
       return Promise.resolve();
     }
 
     return new Promise((resolve) => {
-      if (allowRedirectToLogoutURL()) {
+      if (this.allowRedirectToLogoutURL()) {
         resolve(this._logoutURL);
       }
 


### PR DESCRIPTION
### What does this PR do?

The Auth service now removes the sessionToken query parameter from the address bar and stores it into session storage, or recovers it from session storage if the user reloaded the page after the query parameter was removed. This avoids presenters accidentally leaking their token when sharing their screen, and may also help some people to not confuse the client url with a share-able meeting join url.

Since the query parameter is no longer present, all components that fetch it from there were updated to use Auth.sessionToken instead.

This patch also includes a bunch of bugfixes:

* Setting Auth._connectionID would overwrite Auth.sessionToken (copy&paste error). I could not find any code path that actually sets it though. It is never not null.
* A remembered sessionToken was read from in-memory storage, but never written to it. It is now stored in sessionStorage along with all the other auth information.
* Auth.logout() would always fail because allowRedirectToLogoutURL is a method, not a function.

### Closes Issue(s)
Closes #

### Motivation
This drastically reduces the impact of `allowRequestsWithoutSession=true` which is required as a workaround in certain circumstances. It is a workaround, yes, but it's also best practice to not show *any* sensitive information as part of the address bar, especially in a video conferencing client where the window is likely to be shared with others.

### Tested:
- [x] The sessionToken query parameter quickly disappears during client initialization
- [x] Reloading the browser tab works, the same session is resumed even if it is no longer present in the URL
- [x] Services that need the sessionToken are still working
- [x] The back-button still brings the user back to the room page (e.g. Greenlight)
