### PR TITLE
Fix breakout webcams only for moderator lock

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -102,6 +102,13 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         else
           (false, false, false, false, false, false, false, false, false, false)
 
+      // webcamsOnlyForModerator ("See other viewers webcams") is not part of
+      // LockSettingsProps, so propagate it from the parent's live status too.
+      val webcamsOnlyForModerator =
+        if (msg.body.inheritLockSettings)
+          org.bigbluebutton.core2.MeetingStatus2x.webcamsOnlyForModeratorEnabled(liveMeeting.status)
+        else false
+
       val roomDetail = BreakoutRoomDetail(
         breakout.id,
         breakout.name,
@@ -140,7 +147,8 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
         lsLockOnJoin,
         lsLockOnJoinCfg,
         lsHideCursor,
-        lsHideAnnotation
+        lsHideAnnotation,
+        webcamsOnlyForModerator
       )
 
       val event = buildCreateBreakoutRoomSysCmdMsg(liveMeeting.props.meetingProp.intId, roomDetail)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/CreateBreakoutRoomsCmdMsgHdlr.scala
@@ -9,6 +9,7 @@ import org.bigbluebutton.core.models.PluginModel.getPlugins
 import org.bigbluebutton.core.models.{ Plugin, PresentationInPod }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.running.MeetingActor
+import org.bigbluebutton.core2.MeetingStatus2x
 
 import java.util
 import scala.jdk.CollectionConverters._
@@ -92,7 +93,7 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
       val roomSlides = if (breakout.allPages) -1 else presSlide;
 
       // get lock settings from parent meeting
-      val lockSettings = org.bigbluebutton.core2.MeetingStatus2x.getPermissions(liveMeeting.status)
+      val lockSettings = MeetingStatus2x.getPermissions(liveMeeting.status)
 
       val (lsPrivChat, lsCam, lsMic, lsPubChat, lsNotes, lsHideUsers, lsLockOnJoin, lsLockOnJoinCfg, lsHideCursor, lsHideAnnotation) =
         if (msg.body.inheritLockSettings)
@@ -104,9 +105,11 @@ trait CreateBreakoutRoomsCmdMsgHdlr extends RightsManagementTrait {
 
       // webcamsOnlyForModerator ("See other viewers webcams") is not part of
       // LockSettingsProps, so propagate it from the parent's live status too.
+      // When not inheriting we send `false` explicitly (mirroring the lock-settings
+      // tuple above), which overrides the bbb-web server-config default for the breakout.
       val webcamsOnlyForModerator =
         if (msg.body.inheritLockSettings)
-          org.bigbluebutton.core2.MeetingStatus2x.webcamsOnlyForModeratorEnabled(liveMeeting.status)
+          MeetingStatus2x.webcamsOnlyForModeratorEnabled(liveMeeting.status)
         else false
 
       val roomDetail = BreakoutRoomDetail(

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/BreakoutMsgs.scala
@@ -75,7 +75,8 @@ case class BreakoutRoomDetail(
     lockOnJoin:              Boolean,
     lockOnJoinConfigurable:  Boolean,
     hideViewersCursor:       Boolean,
-    hideViewersAnnotation:   Boolean
+    hideViewersAnnotation:   Boolean,
+    webcamsOnlyForModerator: Boolean
 )
 
 /**

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -920,6 +920,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.LOCK_SETTINGS_LOCK_ON_JOIN_CONFIGURABLE, message.lockOnJoinConfigurable.toString());
       params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_CURSOR, message.hideViewersCursor.toString());
       params.put(ApiParams.LOCK_SETTINGS_HIDE_VIEWERS_ANNOTATION, message.hideViewersAnnotation.toString());
+      params.put(ApiParams.WEBCAMS_ONLY_FOR_MODERATOR, message.webcamsOnlyForModerator.toString());
 
       Map<String, String> parentMeetingMetadata = parentMeeting.getMetadata();
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/messaging/messages/CreateBreakoutRoom.java
@@ -44,6 +44,7 @@ public class CreateBreakoutRoom implements IMessage {
     public final Boolean lockOnJoinConfigurable;
     public final Boolean hideViewersCursor;
     public final Boolean hideViewersAnnotation;
+    public final Boolean webcamsOnlyForModerator;
 
     public CreateBreakoutRoom(String meetingId,
                               String parentMeetingId,
@@ -82,7 +83,8 @@ public class CreateBreakoutRoom implements IMessage {
                               Boolean lockOnJoin,
                               Boolean lockOnJoinConfigurable,
                               Boolean hideViewersCursor,
-                              Boolean hideViewersAnnotation) {
+                              Boolean hideViewersAnnotation,
+                              Boolean webcamsOnlyForModerator) {
         this.meetingId = meetingId;
         this.parentMeetingId = parentMeetingId;
         this.name = name;
@@ -121,5 +123,6 @@ public class CreateBreakoutRoom implements IMessage {
         this.lockOnJoinConfigurable = lockOnJoinConfigurable;
         this.hideViewersCursor = hideViewersCursor;
         this.hideViewersAnnotation = hideViewersAnnotation;
+        this.webcamsOnlyForModerator = webcamsOnlyForModerator;
     }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/meeting/OldMeetingMsgHdlrActor.scala
@@ -144,7 +144,8 @@ class OldMeetingMsgHdlrActor(val olgMsgGW: OldMessageReceivedGW)
       msg.body.room.lockOnJoin,
       msg.body.room.lockOnJoinConfigurable,
       msg.body.room.hideViewersCursor,
-      msg.body.room.hideViewersAnnotation
+      msg.body.room.hideViewersAnnotation,
+      msg.body.room.webcamsOnlyForModerator
     ))
   }
 

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -88,6 +88,12 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await create.initPages(page, testInfo);
       await create.webcamsOnlyForModeratorPropagatedWhenChecked();
     });
+
+    test('See other viewers webcams (webcamsOnlyForModerator) is NOT propagated to breakout when checkbox is unchecked', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.webcamsOnlyForModeratorNotPropagatedByDefault();
+    });
   });
 
   test.describe.parallel('After creating', () => {

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -82,6 +82,12 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await create.initPages(page, testInfo);
       await create.lockSettingsPropagatedWhenChecked();
     });
+
+    test('See other viewers webcams (webcamsOnlyForModerator) IS propagated to breakout when checkbox is checked', async ({ browser, context, page }, testInfo) => {
+      const create = new Create(browser, context);
+      await create.initPages(page, testInfo);
+      await create.webcamsOnlyForModeratorPropagatedWhenChecked();
+    });
   });
 
   test.describe.parallel('After creating', () => {

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -505,6 +505,59 @@ export class Create extends MultiUsers {
     await breakoutTab.close();
   }
 
+  async webcamsOnlyForModeratorPropagatedWhenChecked() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Enable "See other viewers webcams" (webcamsOnlyForModerator) lock in main room
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.page.locator(e.lockSeeOtherViewersWebcam).locator('xpath=..').click();
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Create breakout WITH the "Propagate the current lock settings" checkbox checked
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.page.check(e.inheritLockSettingsCheckbox);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+    // The audio modal pops up a few seconds after the breakout tab loads and its
+    // overlay intercepts clicks; wait for it, close it, and wait for it to detach.
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: ELEMENT_WAIT_LONGER_TIME });
+      await breakoutTab.click(e.closeModal);
+      await breakoutTab.locator(e.audioModal).waitFor({ state: 'detached', timeout: ELEMENT_WAIT_LONGER_TIME });
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout and verify webcamsOnlyForModerator WAS propagated from parent
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'Lock Viewers should be visible in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+
+    await expect(
+      breakoutTab.locator(e.lockSeeOtherViewersWebcam),
+      'see other viewers webcams (webcamsOnlyForModerator) should be enforced in breakout when propagation is on',
+    ).toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
+  }
+
   async dragDropUserInRoom() {
     if (!this?.modPage) throw new Error('modPage not initialized');
     if (!this?.userPage) throw new Error('userPage not initialized');

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -558,6 +558,58 @@ export class Create extends MultiUsers {
     await breakoutTab.close();
   }
 
+  async webcamsOnlyForModeratorNotPropagatedByDefault() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+    if (!this?.userPage) throw new Error('userPage not initialized');
+
+    // Enable "See other viewers webcams" (webcamsOnlyForModerator) lock in main room
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.page.locator(e.lockSeeOtherViewersWebcam).locator('xpath=..').click();
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // Create breakout WITHOUT the "Propagate the current lock settings" checkbox (default: unchecked)
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.createBreakoutRooms);
+    await this.modPage.dragDropSelector(e.attendeeNotAssigned, e.breakoutBox1);
+    await this.modPage.waitAndClick(e.modalConfirmButton, ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.waitAndClick(e.modalDismissButton);
+    await this.modPage.hasElement(e.breakoutRoomsItem, 'should have the breakout rooms item');
+
+    // Mod joins breakout room
+    await this.modPage.waitAndClick(e.breakoutRoomsItem);
+    await this.modPage.waitAndClick(e.askJoinRoom1, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitForSelector(e.joinRoom1, ELEMENT_WAIT_EXTRA_LONG_TIME);
+
+    const newTabPromise = this.modPage.page.context().waitForEvent('page');
+    await this.modPage.waitAndClick(e.joinRoom1);
+    const breakoutTab = await newTabPromise;
+    await breakoutTab.waitForLoadState('domcontentloaded');
+    // The audio modal pops up a few seconds after the breakout tab loads and its
+    // overlay intercepts clicks; wait for it, close it, and wait for it to detach.
+    try {
+      await breakoutTab.waitForSelector(e.audioModal, { timeout: ELEMENT_WAIT_LONGER_TIME });
+      await breakoutTab.click(e.closeModal);
+      await breakoutTab.locator(e.audioModal).waitFor({ state: 'detached', timeout: ELEMENT_WAIT_LONGER_TIME });
+    } catch { /* audio modal not present */ }
+    await breakoutTab.locator(e.manageUsers).waitFor({ state: 'visible', timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+
+    // Open Lock Viewers in breakout and verify webcamsOnlyForModerator was NOT propagated
+    await breakoutTab.locator(e.manageUsers).click();
+    await expect(
+      breakoutTab.locator(e.lockViewersButton),
+      'Lock Viewers should be visible in breakout gear menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await breakoutTab.locator(e.lockViewersButton).click();
+
+    await expect(
+      breakoutTab.locator(e.lockSeeOtherViewersWebcam),
+      'see other viewers webcams (webcamsOnlyForModerator) should NOT be enforced in breakout when propagation is off',
+    ).not.toBeChecked({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    await breakoutTab.close();
+  }
+
   async dragDropUserInRoom() {
     if (!this?.modPage) throw new Error('modPage not initialized');
     if (!this?.userPage) throw new Error('userPage not initialized');


### PR DESCRIPTION
### What does this PR do?

When a moderator creates breakout rooms with **"Propagate the current lock settings"** checked, every lock setting is inherited from the parent meeting **except "See other viewers webcams"** — it stays unlocked in the breakout even when locked in the parent.

The reason is that the other ten toggles live in `LockSettingsProps`, which the breakout-creation path copies as a bundle, while "See other viewers webcams" (`webcamsOnlyForModerator`) lives in `UsersProp` and was simply never added to that path.

This PR carries `webcamsOnlyForModerator` through the same propagation chain as the rest of the lock settings, reading the parent's **live** value and respecting the same `inheritLockSettings` flag. So a moderator who toggles it mid-session still gets it propagated, and an unchecked "propagate" box still leaves the breakout at the default (unlocked) — exactly like the other settings.

### Closes Issue(s)
#25228

### How to test

1. As moderator, open **Manage users → Lock viewers**, enable **"See other viewers webcams"**, and apply.
2. Create breakout rooms with **"Propagate the current lock settings"** checked.
3. Join a breakout room → open **Lock viewers** there.
4. ✅ "See other viewers webcams" should be **locked** (before this fix it was unlocked).
5. Repeat with the propagate box **unchecked** → the breakout should keep it **unlocked**.
