### PR TITLE
fix(html5): escape emoticon auto-conversion with a leading backslash

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -304,6 +304,23 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
   const customCheckText = (input: string): string => {
     const placeholderMap: Record<string, string> = {};
 
+    // Escaped emoticons: a leading backslash prevents the conversion of an
+    // emoticon. Consume the backslash and keep the literal text, e.g. "\D:"
+    // is sent as "D:" instead of being turned into an emoji. See issue #23344.
+    let escapeIndex = 0;
+    // eslint-disable-next-line no-param-reassign
+    input = input.split(' ').map((word) => {
+      if (!word.startsWith('\\')) return word;
+      const unescaped = word.slice(1);
+      // Only treat the backslash as an escape when it precedes something
+      // smile2emoji would actually convert; otherwise leave the text as-is.
+      if (checkText(unescaped) === unescaped) return word;
+      const placeholder = `__ESCAPED_EMOJI_${escapeIndex}__`;
+      escapeIndex += 1;
+      placeholderMap[placeholder] = unescaped;
+      return placeholder;
+    }).join(' ');
+
     emojisToExclude.forEach((shortcode, index) => {
       const placeholder = `__EXCLUDE_${index}__`;
       const target = `:${shortcode}:`;

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -109,6 +109,16 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
   );
 
   test(
+    'Escape auto converted emoji with a backslash on public chat',
+    { tag: '@setting-required:chat.autoConvertEmoji' },
+    async ({ browser, context, page }, testInfo) => {
+      const chat = new Chat(browser, context);
+      await chat.initPages(page, testInfo);
+      await chat.autoConvertEmojiEscapePublicChat();
+    },
+  );
+
+  test(
     'Copy chat with auto converted emoji',
     { tag: '@setting-required:chat.autoConvertEmoji' },
     async ({ browser, context, page, browserName }, testInfo) => {

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -395,6 +395,40 @@ export class Chat extends MultiUsers {
     await this.modPage.hasElementCount(e.chatUserMessageText, 1, 'should display only one message on the public chat');
   }
 
+  async autoConvertEmojiEscapePublicChat() {
+    const { autoConvertEmojiEnabled } = this.modPage.settings || {};
+
+    try {
+      await this.modPage.hasElement(
+        e.hidePrivateChat,
+        'should display the hide private chat element for the moderator when private chat is open',
+      );
+      await this.modPage.waitAndClick(e.chatButton);
+    } catch {
+      await this.modPage.hasElement(
+        e.hidePublicChat,
+        'should display the hide public chat element for the moderator when public chat is open',
+      );
+    }
+
+    await this.modPage.waitAndClick(e.chatOptions);
+    await this.modPage.waitAndClick(e.chatClear);
+    await this.modPage.hasElementCount(e.chatUserMessageText, 0, 'should not display any messages on the public chat');
+
+    // a backslash before an emoticon escapes the auto conversion (issue #23344)
+    await this.modPage.fill(e.chatBox, e.escapedEmojiMessage);
+    await this.modPage.waitAndClick(e.sendButton);
+
+    if (!autoConvertEmojiEnabled) {
+      // with auto conversion disabled nothing is converted and the backslash is kept as typed
+      await checkLastMessageSent(this.modPage, e.escapedEmojiMessage);
+      return;
+    }
+
+    // the emoticon is not converted to an emoji and the escaping backslash is consumed
+    await checkLastMessageSent(this.modPage, e.autoConvertEmojiMessage);
+  }
+
   async autoConvertEmojiCopyChat() {
     const { autoConvertEmojiEnabled } = this.modPage.settings || {};
 

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -181,6 +181,8 @@ export const elements = {
   // Auto Convert Emoji
   autoConvertEmojiMessage: ':)',
   convertedEmojiMessage: '😊',
+  // a leading backslash escapes the conversion: "\:)" should stay ":)" (issue #23344)
+  escapedEmojiMessage: '\\:)',
   // Messages
   message: 'Hello World!',
   testMessage: 'Just a test',


### PR DESCRIPTION
Typing "\D:" in chat used to send the literal "\D:" — the backslash was never consumed. smile2emoji converts emoticons as the user types but has no escape mechanism, so a backslash before an emoticon was passed through verbatim.

customCheckText now detects a leading backslash before any token that smile2emoji would convert, consumes the backslash, and shields the token from conversion via the existing placeholder mechanism. Backslashes that do not precede an emoticon are left untouched, so "\D:" renders as "D:" while "D:" still converts to an emoji.

Adds a Playwright chat test (autoConvertEmojiEscapePublicChat) that sends "\:)" and asserts the message renders as exactly ":)".

Closes #23344

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Adds support for emojis that are typed up like "\D:"
Adds a test too.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #23344 

### Motivation
<!-- What inspired you to submit this pull request? -->
We were not converting to emoji

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
See #23344 