### PR TITLE
fix(akka, bbb-web): clientSettingsOverride fails silently

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -1,6 +1,6 @@
 package org.bigbluebutton
 
-import org.bigbluebutton.common2.util.YamlUtil
+import org.bigbluebutton.common2.util.{ ConfigOverrideIssue, YamlUtil }
 import org.slf4j.LoggerFactory
 
 import java.io.{ ByteArrayInputStream, File }
@@ -9,45 +9,82 @@ import scala.util.{ Failure, Success }
 
 object ClientSettings extends SystemConfiguration {
   var clientSettingsFromFile: Map[String, Object] = Map("" -> "")
+  // The pristine settings.yml catalog (with `private` still present, before any override-file
+  // merge). Used as the schema that overrides are validated against - see diffOverrideAgainstBase.
+  var clientSettingsCatalog: Map[String, Object] = Map.empty
   val logger = LoggerFactory.getLogger(this.getClass)
 
+  private def readAndClose(source: scala.io.Source): String =
+    try source.mkString finally source.close()
+
   def loadClientSettingsFromFile() = {
-    val clientSettingsFile = scala.io.Source.fromFile(clientSettingsPath, "UTF-8")
+    val baseText = readAndClose(scala.io.Source.fromFile(clientSettingsPath, "UTF-8"))
 
     val clientSettingsFileOverrideToCheck = new File(clientSettingsPathOverride)
+    val hasOverrideFile = clientSettingsFileOverrideToCheck.exists()
 
-    val clientSettingsFileOverride = if (clientSettingsFileOverrideToCheck.exists())
-      scala.io.Source.fromFile(
-        clientSettingsPathOverride,
-        "UTF-8"
-      )
-    else new BufferedSource(new ByteArrayInputStream(Array[Byte]()))
+    val overrideText = readAndClose(
+      if (hasOverrideFile) scala.io.Source.fromFile(clientSettingsPathOverride, "UTF-8")
+      else new BufferedSource(new ByteArrayInputStream(Array[Byte]()))
+    )
 
-    clientSettingsFromFile =
-      common2.util.YamlUtil.mergeImmutableMaps(
-        common2.util.YamlUtil.toMap[Object](clientSettingsFile.mkString) match {
-          case Success(value) => value
-          case Failure(exception) =>
-            println("Error while fetching client Settings: ", exception)
-            Map[String, Object]()
-        },
-        common2.util.YamlUtil.toMap[Object](clientSettingsFileOverride.mkString) match {
-          case Success(value) => value
-          case Failure(exception) =>
-            println("Error while fetching client override Settings: ", exception)
-            Map[String, Object]()
-        }
+    val baseSettings = common2.util.YamlUtil.toMap[Object](baseText) match {
+      case Success(value) => value
+      case Failure(exception) =>
+        logger.error("Error parsing client settings file [{}]; falling back to empty settings", clientSettingsPath, exception)
+        Map[String, Object]()
+    }
+
+    val overrideSettings = common2.util.YamlUtil.toMap[Object](overrideText) match {
+      case Success(value) => value
+      case Failure(exception) =>
+        logger.error("Error parsing client settings override file [{}]; falling back to empty settings", clientSettingsPathOverride, exception)
+        Map[String, Object]()
+    }
+
+    // Keep the pristine catalog (settings.yml, with `private`) to validate overrides against, so a
+    // malformed override file can never extend the schema and `private.*` keys stay recognized.
+    clientSettingsCatalog = baseSettings
+
+    // Validate the override file against the catalog before merging, while it still contains the
+    // `private` section so overrides to `private.*` are checked too. Skip when the catalog failed
+    // to load (empty) - otherwise every override key would be flagged unknown, hiding the real error.
+    if (hasOverrideFile && clientSettingsCatalog.nonEmpty) {
+      logOverrideIssues(
+        YamlUtil.diffOverrideAgainstBase(clientSettingsCatalog, overrideSettings),
+        s"file [$clientSettingsPathOverride]"
       )
+    }
+
+    clientSettingsFromFile = common2.util.YamlUtil.mergeImmutableMaps(baseSettings, overrideSettings)
 
     //Remove `:private` once it's used only by HTML5 client's internal configs
     clientSettingsFromFile -= "private"
   }
 
-  def getClientSettingsWithOverride(clientSettingsOverrideJson: String): Map[String, Object] = {
+  private def logOverrideIssues(issues: List[ConfigOverrideIssue], source: String): Unit = {
+    issues.foreach { issue =>
+      logger.warn(
+        "Client settings override {}: {} '{}' - {}; value is still applied.",
+        source, issue.kind, issue.path, issue.detail
+      )
+    }
+  }
+
+  def getClientSettingsWithOverride(clientSettingsOverrideJson: String, meetingId: String = ""): Map[String, Object] = {
     if (clientSettingsOverrideJson.nonEmpty) {
       val scalaMapClientOverride = common2.util.JsonUtil.toMap[Object](clientSettingsOverrideJson)
       scalaMapClientOverride match {
-        case Success(clientSettingsOverrideAsMap) => YamlUtil.mergeImmutableMaps(clientSettingsFromFile, clientSettingsOverrideAsMap)
+        case Success(clientSettingsOverrideAsMap) =>
+          val meetingSuffix = if (meetingId.nonEmpty) s" (meeting $meetingId)" else ""
+          // Only diagnose when the catalog loaded; an empty catalog would flag every key as unknown.
+          if (clientSettingsCatalog.nonEmpty) {
+            logOverrideIssues(
+              YamlUtil.diffOverrideAgainstBase(clientSettingsCatalog, clientSettingsOverrideAsMap),
+              s"on create call$meetingSuffix"
+            )
+          }
+          YamlUtil.mergeImmutableMaps(clientSettingsFromFile, clientSettingsOverrideAsMap)
         case Failure(msg) =>
           logger.debug("No valid JSON override of client configuration in create call: {}", msg)
           clientSettingsFromFile

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -50,10 +50,20 @@ object ClientSettings extends SystemConfiguration {
     // `private` section so overrides to `private.*` are checked too. Skip when the catalog failed
     // to load (empty) - otherwise every override key would be flagged unknown, hiding the real error.
     if (hasOverrideFile && clientSettingsCatalog.nonEmpty) {
-      logOverrideIssues(
-        YamlUtil.diffOverrideAgainstBase(clientSettingsCatalog, overrideSettings),
-        s"file [$clientSettingsPathOverride]"
-      )
+      val issues = YamlUtil.diffOverrideAgainstBase(clientSettingsCatalog, overrideSettings)
+      val source = s"file [$clientSettingsPathOverride]"
+      if (issues.nonEmpty && clientSettingsOverrideStrictValidation) {
+        // Strict mode (test/staging): refuse to boot so a bad config fails the deploy loudly,
+        // instead of silently applying an override the client will ignore.
+        logger.error(
+          "Refusing to start: client settings override {} has {} issue(s) and " +
+            "clientSettingsOverrideStrictValidation is enabled:", source, issues.size.toString
+        )
+        issues.foreach(issue => logger.error("  - {} '{}' - {}", issue.kind, issue.path, issue.detail))
+        System.exit(1)
+      } else {
+        logOverrideIssues(issues, source)
+      }
     }
 
     clientSettingsFromFile = common2.util.YamlUtil.mergeImmutableMaps(baseSettings, overrideSettings)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/ClientSettings.scala
@@ -35,7 +35,8 @@ object ClientSettings extends SystemConfiguration {
         Map[String, Object]()
     }
 
-    val overrideSettings = common2.util.YamlUtil.toMap[Object](overrideText) match {
+    val overrideParseResult = common2.util.YamlUtil.toMap[Object](overrideText)
+    val overrideSettings = overrideParseResult match {
       case Success(value) => value
       case Failure(exception) =>
         logger.error("Error parsing client settings override file [{}]; falling back to empty settings", clientSettingsPathOverride, exception)
@@ -50,7 +51,12 @@ object ClientSettings extends SystemConfiguration {
     // `private` section so overrides to `private.*` are checked too. Skip when the catalog failed
     // to load (empty) - otherwise every override key would be flagged unknown, hiding the real error.
     if (hasOverrideFile && clientSettingsCatalog.nonEmpty) {
-      val issues = YamlUtil.diffOverrideAgainstBase(clientSettingsCatalog, overrideSettings)
+      // A malformed override file parses to an empty map above; treat that parse failure as an
+      // issue too, so strict mode refuses to boot instead of silently ignoring the whole file.
+      val parseIssues = overrideParseResult.failed.toOption.toList.map { ex =>
+        ConfigOverrideIssue(clientSettingsPathOverride, "invalid-yaml", Option(ex.getMessage).getOrElse(ex.toString))
+      }
+      val issues = parseIssues ++ YamlUtil.diffOverrideAgainstBase(clientSettingsCatalog, overrideSettings)
       val source = s"file [$clientSettingsPathOverride]"
       if (issues.nonEmpty && clientSettingsOverrideStrictValidation) {
         // Strict mode (test/staging): refuse to boot so a bad config fails the deploy loudly,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -106,6 +106,20 @@ trait SystemConfiguration {
   lazy val clientSettingsPathOverride = Try(config.getString("client.clientSettingsOverrideFilePath")).getOrElse(
     "/etc/bigbluebutton/bbb-html5.yml"
   )
+  // Strict validation flag - single source of truth, shared with bbb-web. Read directly from
+  // bbb-web's properties so one setting controls both the bbb-web create rejection and this
+  // akka-apps boot refusal (no separate akka flag to drift out of sync). Defaults to false.
+  lazy val clientSettingsOverrideStrictValidation: Boolean = Try {
+    val propsFile = new java.io.File("/etc/bigbluebutton/bbb-web.properties")
+    if (!propsFile.exists()) false
+    else {
+      val props = new java.util.Properties()
+      val in = new java.io.FileInputStream(propsFile)
+      try props.load(in) finally in.close()
+      "true".equalsIgnoreCase(props.getProperty("clientSettingsOverrideStrictValidation", "false").trim)
+    }
+    // A read failure must never take down boot - default to lenient (false).
+  }.getOrElse(false)
 
   // Grab the "interface" parameter from the http config
   val httpHost = config.getString("http.interface")

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/RunningMeeting.scala
@@ -34,7 +34,7 @@ class RunningMeeting(val props: DefaultProps, outGW: OutMessageGateway,
   private val deskshareModel = new ScreenshareModel
   private val audioCaptions = new AudioCaptions
   private val timerModel = new TimerModel
-  private val clientSettingsBeforePluginValidation: Map[String, Object] = ClientSettings.getClientSettingsWithOverride(props.overrideClientSettings)
+  private val clientSettingsBeforePluginValidation: Map[String, Object] = ClientSettings.getClientSettingsWithOverride(props.overrideClientSettings, props.meetingProp.intId)
   private val (plugins, pluginSettings) = PluginModel.createPluginModelFromJson(props.pluginProp, props.systemProps.html5PluginSdkVersion, clientSettingsBeforePluginValidation)
   val clientSettings: Map[String, Object] = {
     val merged = ClientSettings.mergePluginSettingsIntoClientSettings(

--- a/akka-bbb-apps/src/universal/conf/application.conf
+++ b/akka-bbb-apps/src/universal/conf/application.conf
@@ -30,6 +30,9 @@ pekko {
 client {
     clientSettingsFilePath = "/usr/share/bigbluebutton/html5-client/private/config/settings.yml"
     clientSettingsOverrideFilePath = "/etc/bigbluebutton/bbb-html5.yml"
+    # Note: strict validation (refuse boot on a bad override file) is controlled by the single
+    # `clientSettingsOverrideStrictValidation` property in /etc/bigbluebutton/bbb-web.properties,
+    # shared with bbb-web - see SystemConfiguration.
 }
 
 redis {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/util/YamlUtil.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/util/YamlUtil.scala
@@ -6,9 +6,68 @@ import com.fasterxml.jackson.module.scala.{ DefaultScalaModule, ScalaObjectMappe
 
 import scala.util.Try
 
+case class ConfigOverrideIssue(path: String, kind: String, detail: String)
+
 object YamlUtil {
   val mapper = new ObjectMapper(new YAMLFactory()) with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)
+
+  // Coarse type classification so equivalent numeric values compare as equal regardless of how
+  // they were written: an integer literal deserializes to Int/Long while a decimal literal
+  // deserializes to Double, but both are reported as "Number" so we don't false-positive on them.
+  private def typeClass(value: Object): String = value match {
+    case null                 => "Null"
+    case _: Map[_, _]         => "Map"
+    case _: Seq[_]            => "List"
+    case _: java.lang.Boolean => "Boolean"
+    case _: Number            => "Number"
+    case _: String            => "String"
+    case _                    => "Other"
+  }
+
+  /**
+   * Walks `overrides` against `base`, treating `base` (the catalog from settings.yml) as the
+   * schema, and reports keys/shapes in the override that don't line up: unknown keys (likely
+   * typos), and shape/type mismatches. Behavior is purely diagnostic - the caller decides how to
+   * surface the returned issues. `ignoredPrefixes` skips dynamic subtrees (e.g. "public.plugins",
+   * whose contents are plugin-defined and not present in settings.yml).
+   */
+  def diffOverrideAgainstBase(
+      base:            Map[String, Object],
+      overrides:       Map[String, Object],
+      pathPrefix:      String              = "",
+      ignoredPrefixes: Set[String]         = Set("public.plugins")
+  ): List[ConfigOverrideIssue] = {
+    // Sort keys at each level so the reported issues (and the WARN log lines) are deterministic,
+    // independent of Map iteration order.
+    overrides.toList.sortBy(_._1).flatMap {
+      case (key, overrideValue) =>
+        val path = if (pathPrefix.isEmpty) key else s"$pathPrefix.$key"
+        if (ignoredPrefixes.exists(p => path == p || path.startsWith(p + "."))) {
+          List.empty
+        } else {
+          base.get(key) match {
+            case None =>
+              List(ConfigOverrideIssue(path, "unknown-key", "not present in settings.yml (possible typo)"))
+            case Some(baseValue) =>
+              (baseValue, overrideValue) match {
+                case (baseMap: Map[String, Object] @unchecked, overrideMap: Map[String, Object] @unchecked) =>
+                  diffOverrideAgainstBase(baseMap, overrideMap, path, ignoredPrefixes)
+                case (_: Map[_, _], _) =>
+                  List(ConfigOverrideIssue(path, "shape-mismatch", "expected an object/section, got a value"))
+                case (_, _: Map[_, _]) =>
+                  List(ConfigOverrideIssue(path, "shape-mismatch", "expected a value, got an object/section"))
+                case (b, o) =>
+                  val (bt, ot) = (typeClass(b), typeClass(o))
+                  if (bt != ot)
+                    List(ConfigOverrideIssue(path, "type-mismatch", s"expected $bt, got $ot"))
+                  else
+                    List.empty
+              }
+          }
+        }
+    }
+  }
 
   def mergeImmutableMaps(target: Map[String, Object], source: Map[String, Object]): Map[String, Object] = {
     source.foldLeft(target) {

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/util/YamlUtil.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/util/YamlUtil.scala
@@ -49,6 +49,10 @@ object YamlUtil {
           base.get(key) match {
             case None =>
               List(ConfigOverrideIssue(path, "unknown-key", "not present in settings.yml (possible typo)"))
+            case Some(null) =>
+              // A null default in settings.yml (e.g. customStyleUrl, overrideLocale) means "no
+              // declared type / admin-supplied", so any override value is acceptable.
+              List.empty
             case Some(baseValue) =>
               (baseValue, overrideValue) match {
                 case (baseMap: Map[String, Object] @unchecked, overrideMap: Map[String, Object] @unchecked) =>

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/util/YamlUtilTest.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/util/YamlUtilTest.scala
@@ -190,4 +190,24 @@ class YamlUtilTest extends UnitSpec2 {
     assert(issues.head.kind == "type-mismatch")
     assert(issues.head.detail == "expected Number, got List")
   }
+
+  it should "not flag an override of a null-default key (e.g. customStyleUrl)" in {
+    // settings.yml declares some keys with a null default (customStyleUrl, overrideLocale),
+    // meaning "no declared type / admin-supplied" - any override value must be accepted.
+    val baseWithNull = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "customStyleUrl" -> null
+        )
+      )
+    )
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "customStyleUrl" -> "https://example.com/style.css"
+        )
+      )
+    )
+    assert(YamlUtil.diffOverrideAgainstBase(baseWithNull, overrides).isEmpty)
+  }
 }

--- a/bbb-common-message/src/test/scala/org/bigbluebutton/common2/util/YamlUtilTest.scala
+++ b/bbb-common-message/src/test/scala/org/bigbluebutton/common2/util/YamlUtilTest.scala
@@ -1,0 +1,193 @@
+package org.bigbluebutton.common2.util
+
+import org.bigbluebutton.common2.UnitSpec2
+
+import scala.util.Success
+
+class YamlUtilTest extends UnitSpec2 {
+
+  // A small stand-in for settings.yml acting as the schema/catalog.
+  val base: Map[String, Object] = Map(
+    "public" -> Map[String, Object](
+      "app" -> Map[String, Object](
+        "breakouts" -> Map[String, Object](
+          "captureWhiteboardByDefault" -> Boolean.box(false),
+          "recordRoomByDefault" -> Boolean.box(true)
+        ),
+        "preloadNextSlides" -> Int.box(2)
+      ),
+      "layout" -> Map[String, Object](
+        "showScreenshareQuickSwapButton" -> Boolean.box(true)
+      )
+    )
+  )
+
+  "diffOverrideAgainstBase" should "report no issues for a valid nested override" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "breakouts" -> Map[String, Object](
+            "recordRoomByDefault" -> Boolean.box(false)
+          )
+        )
+      )
+    )
+    assert(YamlUtil.diffOverrideAgainstBase(base, overrides).isEmpty)
+  }
+
+  it should "flag a typo'd leaf key as unknown-key at the right path" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "breakouts" -> Map[String, Object](
+            "captureWhitebordByDefault" -> Boolean.box(true) // typo
+          )
+        )
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "unknown-key")
+    assert(issues.head.path == "public.app.breakouts.captureWhitebordByDefault")
+  }
+
+  it should "flag a typo'd nested section key as unknown-key" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "ap" -> Map[String, Object]( // typo for "app"
+          "preloadNextSlides" -> Int.box(0)
+        )
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "unknown-key")
+    assert(issues.head.path == "public.ap")
+  }
+
+  it should "flag a shape-mismatch when an object is given where base has a scalar" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "preloadNextSlides" -> Map[String, Object]("nested" -> Int.box(1))
+        )
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "shape-mismatch")
+    assert(issues.head.path == "public.app.preloadNextSlides")
+  }
+
+  it should "flag a shape-mismatch when a scalar is given where base has an object" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "layout" -> "true" // base.public.layout is an object
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "shape-mismatch")
+    assert(issues.head.path == "public.layout")
+  }
+
+  it should "flag a bool-vs-string type-mismatch at a leaf" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "breakouts" -> Map[String, Object](
+            "recordRoomByDefault" -> "false" // string instead of boolean
+          )
+        )
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "type-mismatch")
+    assert(issues.head.path == "public.app.breakouts.recordRoomByDefault")
+  }
+
+  it should "not flag Int-vs-Double (integer vs decimal literal, same Number type class)" in {
+    // base has an integer literal (parses to Int); override writes the same setting as a decimal
+    // literal (parses to Double). The two leaves are genuinely different concrete numeric types,
+    // and coarse Number classification must not false-positive on that.
+    val Success(yamlBase) = YamlUtil.toMap[Object]("public:\n  app:\n    preloadNextSlides: 2\n")
+    val Success(jsonOverride) = JsonUtil.toMap[Object]("""{"public":{"app":{"preloadNextSlides":5.0}}}""")
+    def leaf(m: Map[String, Object]): Object =
+      m("public").asInstanceOf[Map[String, Object]]("app")
+        .asInstanceOf[Map[String, Object]]("preloadNextSlides")
+    assert(leaf(yamlBase).getClass != leaf(jsonOverride).getClass)
+    assert(YamlUtil.diffOverrideAgainstBase(yamlBase, jsonOverride).isEmpty)
+  }
+
+  it should "ignore the public.plugins subtree" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "plugins" -> List(
+          Map[String, Object]("name" -> "my-plugin", "anyArbitraryKey" -> Boolean.box(true))
+        )
+      )
+    )
+    assert(YamlUtil.diffOverrideAgainstBase(base, overrides).isEmpty)
+  }
+
+  it should "report issues in a deterministic (sorted) order regardless of map order" in {
+    val overrides = Map[String, Object](
+      "zKey" -> Boolean.box(true),
+      "aKey" -> Boolean.box(true),
+      "mKey" -> Boolean.box(true)
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.map(_.path) == List("aKey", "mKey", "zKey"))
+  }
+
+  it should "flag every top-level key as unknown when the base catalog is empty" in {
+    // documents why callers should guard against an empty catalog (e.g. settings.yml parse failure)
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](),
+      "private" -> Map[String, Object]()
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(Map.empty, overrides)
+    assert(issues.map(_.path) == List("private", "public"))
+    assert(issues.forall(_.kind == "unknown-key"))
+  }
+
+  it should "ignore a nested section under public.plugins" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "plugins" -> Map[String, Object](
+          "somePlugin" -> Map[String, Object]("anyArbitraryKey" -> Boolean.box(true))
+        )
+      )
+    )
+    assert(YamlUtil.diffOverrideAgainstBase(base, overrides).isEmpty)
+  }
+
+  it should "classify a null override leaf as a type-mismatch (no crash)" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "preloadNextSlides" -> null
+        )
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "type-mismatch")
+    assert(issues.head.detail.contains("Null"))
+  }
+
+  it should "flag a List override where the catalog has a scalar as a type-mismatch" in {
+    val overrides = Map[String, Object](
+      "public" -> Map[String, Object](
+        "app" -> Map[String, Object](
+          "preloadNextSlides" -> List(Int.box(1), Int.box(2))
+        )
+      )
+    )
+    val issues = YamlUtil.diffOverrideAgainstBase(base, overrides)
+    assert(issues.size == 1)
+    assert(issues.head.kind == "type-mismatch")
+    assert(issues.head.detail == "expected Number, got List")
+  }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
@@ -77,7 +77,7 @@ public class ApiErrors {
 	}
 
 	public void clientSettingsOverrideError(String detail) {
-		errors.add(new String[] {"clientSettingsOverrideValidationError", "The client settings override contains invalid keys: " + detail});
+		errors.add(new String[] {"clientSettingsOverrideValidationError", "The client settings override has the following issue(s): " + detail});
 	}
 
 	public void addError(String[] error) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiErrors.java
@@ -76,6 +76,10 @@ public class ApiErrors {
 		errors.add(new String[] {"guestDeniedAccess", "You have been denied access to this meeting based on the meeting's guest policy"});
 	}
 
+	public void clientSettingsOverrideError(String detail) {
+		errors.add(new String[] {"clientSettingsOverrideValidationError", "The client settings override contains invalid keys: " + detail});
+	}
+
 	public void addError(String[] error) {
 		errors.add(error);
 	}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1221,7 +1221,9 @@ public class ParamsProcessorUtil {
             java.nio.charset.StandardCharsets.UTF_8);
       } catch (Exception e) {
         log.error("Could not read client settings catalog [{}] for override validation; skipping strict check.", clientSettingsFilePath, e);
-        cachedClientSettingsCatalog = "";
+        // Do not cache the failure - a transient read error must not disable strict validation for
+        // the rest of the process lifetime; retry on the next call.
+        return "";
       }
     }
     return cachedClientSettingsCatalog;
@@ -1934,6 +1936,8 @@ public class ParamsProcessorUtil {
 
 	public void setClientSettingsFilePath(String clientSettingsFilePath) {
 		this.clientSettingsFilePath = clientSettingsFilePath;
+		// Invalidate any cached catalog so the new path is read on the next validation.
+		this.cachedClientSettingsCatalog = null;
 	}
 
 	public void setMaxNumPages(Integer maxNumPages) { this.defaultMaxNumPages = maxNumPages; }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -160,6 +160,9 @@ public class ParamsProcessorUtil {
     private Boolean allowOverrideClientSettingsOnCreateCall = false;
     private Integer clientSettingsOverrideJsonUrlResponseTimeout;
     private Integer maxClientSettingsOverrideJsonUrlPayloadSize;
+    private Boolean clientSettingsOverrideStrictValidation = false;
+    private String clientSettingsFilePath = "/usr/share/bigbluebutton/html5-client/private/config/settings.yml";
+    private volatile String cachedClientSettingsCatalog = null;
 
     private Integer defaultMaxNumPages;
     private String getJoinUrlUserdataBlocklist;
@@ -1206,6 +1209,34 @@ public class ParamsProcessorUtil {
     return allowOverrideClientSettingsOnCreateCall;
   }
 
+  public Boolean getClientSettingsOverrideStrictValidation() {
+    return clientSettingsOverrideStrictValidation;
+  }
+
+  private String loadClientSettingsCatalog() {
+    if (cachedClientSettingsCatalog == null) {
+      try {
+        cachedClientSettingsCatalog = new String(
+            java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(clientSettingsFilePath)),
+            java.nio.charset.StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        log.error("Could not read client settings catalog [{}] for override validation; skipping strict check.", clientSettingsFilePath, e);
+        cachedClientSettingsCatalog = "";
+      }
+    }
+    return cachedClientSettingsCatalog;
+  }
+
+  /**
+   * Validates a client-settings override (the create-call JSON) against the settings.yml catalog,
+   * reusing the same logic as akka-apps. Returns the list of human-readable issues (empty if valid
+   * or if the check could not run). Does not block on its own - the caller decides.
+   */
+  public java.util.List<String> validateClientSettingsOverride(String overrideJson) {
+    if (StringUtils.isEmpty(overrideJson)) return java.util.Collections.emptyList();
+    return org.bigbluebutton.api2.util.ClientSettingsValidator.validateOverride(loadClientSettingsCatalog(), overrideJson);
+  }
+
     public String processWelcomeMessage(String message, Boolean isBreakout) {
         String welcomeMessage = message;
         if (StringUtils.isEmpty(message)) {
@@ -1895,6 +1926,14 @@ public class ParamsProcessorUtil {
 
 	public void setAllowOverrideClientSettingsOnCreateCall(Boolean allowOverrideClientSettingsOnCreateCall) {
 		this.allowOverrideClientSettingsOnCreateCall = allowOverrideClientSettingsOnCreateCall;
+	}
+
+	public void setClientSettingsOverrideStrictValidation(Boolean clientSettingsOverrideStrictValidation) {
+		this.clientSettingsOverrideStrictValidation = clientSettingsOverrideStrictValidation;
+	}
+
+	public void setClientSettingsFilePath(String clientSettingsFilePath) {
+		this.clientSettingsFilePath = clientSettingsFilePath;
 	}
 
 	public void setMaxNumPages(Integer maxNumPages) { this.defaultMaxNumPages = maxNumPages; }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/ClientSettingsValidator.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/ClientSettingsValidator.scala
@@ -27,14 +27,16 @@ object ClientSettingsValidator {
     // No catalog -> don't block (mirrors the akka-apps empty-catalog guard).
     if (catalog.isEmpty) return java.util.Collections.emptyList()
 
-    val overrides = JsonUtil.toMap[Object](overrideJson) match {
-      case Success(value) => value
-      case Failure(_)     => Map.empty[String, Object]
+    JsonUtil.toMap[Object](overrideJson) match {
+      case Failure(ex) =>
+        // Unparseable override JSON would otherwise be silently dropped by akka-apps; in strict
+        // mode the caller must fail fast, so report it as an issue rather than an empty result.
+        java.util.Collections.singletonList(s"invalid-json - override is not valid JSON: ${ex.getMessage}")
+      case Success(overrides) =>
+        YamlUtil
+          .diffOverrideAgainstBase(catalog, overrides)
+          .map(issue => s"${issue.kind} '${issue.path}' - ${issue.detail}")
+          .asJava
     }
-
-    YamlUtil
-      .diffOverrideAgainstBase(catalog, overrides)
-      .map(issue => s"${issue.kind} '${issue.path}' - ${issue.detail}")
-      .asJava
   }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/ClientSettingsValidator.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/util/ClientSettingsValidator.scala
@@ -1,0 +1,40 @@
+package org.bigbluebutton.api2.util
+
+import org.bigbluebutton.common2.util.{ JsonUtil, YamlUtil }
+
+import scala.jdk.CollectionConverters._
+import scala.util.{ Failure, Success }
+
+/**
+ * Java-friendly bridge over `YamlUtil.diffOverrideAgainstBase` so bbb-web (Java/Grails) can validate
+ * a client-settings override (the create-call JSON) against the `settings.yml` catalog using the same
+ * logic as akka-apps - no duplicated rules.
+ */
+object ClientSettingsValidator {
+
+  /**
+   * Validates `overrideJson` against the `settings.yml` catalog `catalogYaml`. Returns a list of
+   * human-readable issue messages; an empty list means the override is valid (or could not be
+   * checked, e.g. the catalog failed to load - in which case we never block).
+   */
+  def validateOverride(catalogYaml: String, overrideJson: String): java.util.List[String] = {
+    if (catalogYaml == null || overrideJson == null) return java.util.Collections.emptyList()
+
+    val catalog = YamlUtil.toMap[Object](catalogYaml) match {
+      case Success(value) => value
+      case Failure(_)     => Map.empty[String, Object]
+    }
+    // No catalog -> don't block (mirrors the akka-apps empty-catalog guard).
+    if (catalog.isEmpty) return java.util.Collections.emptyList()
+
+    val overrides = JsonUtil.toMap[Object](overrideJson) match {
+      case Success(value) => value
+      case Failure(_)     => Map.empty[String, Object]
+    }
+
+    YamlUtil
+      .diffOverrideAgainstBase(catalog, overrides)
+      .map(issue => s"${issue.kind} '${issue.path}' - ${issue.detail}")
+      .asJava
+  }
+}

--- a/bbb-common-web/src/test/scala/org/bigbluebutton/api2/util/ClientSettingsValidatorTest.scala
+++ b/bbb-common-web/src/test/scala/org/bigbluebutton/api2/util/ClientSettingsValidatorTest.scala
@@ -1,0 +1,51 @@
+package org.bigbluebutton.api2.util
+
+import org.bigbluebutton.api.util.UnitSpec
+
+/**
+ * Covers the bbb-web side of strict client-settings override validation - the logic that decides
+ * whether a /create call carrying an override is rejected when strictValidation is enabled.
+ */
+class ClientSettingsValidatorTest extends UnitSpec {
+
+  // A small stand-in for settings.yml acting as the catalog (YAML).
+  val catalog: String =
+    "public:\n" +
+      "  app:\n" +
+      "    breakouts:\n" +
+      "      recordRoomByDefault: true\n" +
+      "    preloadNextSlides: 2\n" +
+      "  layout:\n" +
+      "    showScreenshareQuickSwapButton: true\n"
+
+  it should "return no issues for a valid override" in {
+    val overrideJson = "{\"public\":{\"app\":{\"breakouts\":{\"recordRoomByDefault\":false}}}}"
+    assert(ClientSettingsValidator.validateOverride(catalog, overrideJson).isEmpty)
+  }
+
+  it should "report an unknown key placed at the wrong path" in {
+    val overrideJson = "{\"public\":{\"breakouts\":{\"recordRoomByDefault\":true}}}"
+    val issues = ClientSettingsValidator.validateOverride(catalog, overrideJson)
+    assert(issues.size == 1)
+    assert(issues.get(0).contains("unknown-key"))
+    assert(issues.get(0).contains("public.breakouts"))
+  }
+
+  it should "report a type mismatch" in {
+    val overrideJson = "{\"public\":{\"app\":{\"preloadNextSlides\":\"two\"}}}"
+    val issues = ClientSettingsValidator.validateOverride(catalog, overrideJson)
+    assert(issues.size == 1)
+    assert(issues.get(0).contains("type-mismatch"))
+  }
+
+  it should "report unparseable override JSON as an issue so strict mode fails fast" in {
+    val issues = ClientSettingsValidator.validateOverride(catalog, "{ this is not valid json")
+    assert(issues.size == 1)
+    assert(issues.get(0).contains("invalid-json"))
+  }
+
+  it should "not block when the catalog could not be loaded (empty)" in {
+    val overrideJson = "{\"public\":{\"anythingGoes\":true}}"
+    assert(ClientSettingsValidator.validateOverride("", overrideJson).isEmpty)
+  }
+}

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -453,6 +453,17 @@ configDir=/var/bigbluebutton/configs
 # Enable this option to allow overriding client settings through /create call
 allowOverrideClientSettingsOnCreateCall=false
 
+# Single switch for strict client-settings override validation, read by BOTH bbb-web and
+# bbb-apps-akka (akka reads this same file at boot). When true:
+#  - bbb-web rejects the /create call (returncode=FAILED) if a client settings override
+#    (clientSettingsOverride or clientSettingsOverrideJsonUrl) has unknown/malformed keys, and
+#  - bbb-apps-akka refuses to boot if /etc/bigbluebutton/bbb-html5.yml has unknown/malformed keys.
+# Both are checked against the settings.yml catalog below. Intended for test/staging; keep false in production.
+clientSettingsOverrideStrictValidation=false
+
+# Path to the client settings catalog (settings.yml) used as the schema for the strict validation above.
+clientSettingsFilePath=/usr/share/bigbluebutton/html5-client/private/config/settings.yml
+
 # The directory to export Json with Meeting activities (used in Learning Dashboard)
 learningDashboardFilesDir=/var/bigbluebutton/learning-dashboard
 

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -263,6 +263,8 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="defaultKeepEvents" value="${defaultKeepEvents}"/>
         <property name="allowRevealOfBBBVersion" value="${allowRevealOfBBBVersion}"/>
         <property name="allowOverrideClientSettingsOnCreateCall" value="${allowOverrideClientSettingsOnCreateCall}"/>
+        <property name="clientSettingsOverrideStrictValidation" value="${clientSettingsOverrideStrictValidation}"/>
+        <property name="clientSettingsFilePath" value="${clientSettingsFilePath}"/>
         <property name="pluginManifests" value="${pluginManifests}"/>
         <property name="pluginManifestsFetchUrlResponseTimeout" value="${pluginManifestsFetchUrlResponseTimeout}"/>
         <property name="maxPluginManifestsFetchUrlPayloadSize" value="${maxPluginManifestsFetchUrlPayloadSize}"/>

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -228,6 +228,20 @@ class ApiController {
 
     ApiErrors errors = new ApiErrors()
 
+    // Strict client-settings override validation (test/staging only, off by default): reject the
+    // create call when the override (POST body or clientSettingsOverrideJsonUrl) contains
+    // unknown/malformed keys. The meeting is not created and nothing is passed to akka-apps.
+    if (paramsProcessorUtil.getClientSettingsOverrideStrictValidation()
+        && StringUtils.isNotEmpty(newMeeting.getOverrideClientSettings())) {
+      List<String> overrideIssues = paramsProcessorUtil.validateClientSettingsOverride(newMeeting.getOverrideClientSettings())
+      if (!overrideIssues.isEmpty()) {
+        log.warn("Rejecting create for meetingID [{}]: client settings override has issues {}", params.meetingID, overrideIssues)
+        errors.clientSettingsOverrideError(overrideIssues.join("; "))
+        respondWithErrors(errors)
+        return
+      }
+    }
+
     if (meetingService.createMeeting(newMeeting)) {
       respondWithConference(newMeeting, null, null)
       // See if the request came with pre-uploading of presentation.

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1555,6 +1555,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `disabledFeatures` | Comma-separated list of features to disable (see [`/create` docs](/development/api/#create) for the full list of feature names) | csv | _(empty)_ _`overwritable`_ |
 | `sharedNotesEditor` | Type of shared notes editor to use | etherpad, blockNote | etherpad _`overwritable`_ |
 | `allowOverrideClientSettingsOnCreateCall` | Allow `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` to be passed on `/create` | true/false | false |
+| `clientSettingsOverrideStrictValidation` | When true, reject the `/create` call (`bbb-web`) and refuse `bbb-apps-akka` boot if a client settings override has unknown or malformed keys. Intended for test/staging (see [Validating client settings overrides](#validating-client-settings-overrides)) | true/false | false |
 | `pluginManifests` | List of plugin manifests as a JSON array, e.g. `[{"url": "https://example.com/manifest.json"}]` | JSON array | _(empty)_ _`overwritable`_ |
 | `pluginManifestCacheEnabled` | Cache plugin manifests on disk to speed up `/create` calls | true/false | false |
 | `pluginManifestCacheDirectory` | Base directory for cached plugin manifest files. The directory is wiped every time bbb-web starts; entries idle for over a week are also evicted automatically by the periodic refresh task | path | `/var/bigbluebutton/plugin-manifests-cache/` |

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -470,6 +470,19 @@ If you have sessions that like to share lots of webcams, such as ten or more, th
 
 To ensure that your modifications are not lost when a new version of the packages is installed, you can [create the file and] write your changes to `/etc/bigbluebutton/bbb-html5.yml`.
 
+#### Validating client settings overrides
+
+When you override the HTML5 client settings - via `/etc/bigbluebutton/bbb-html5.yml`, or per meeting via the `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` create parameters - keys that do not exist in the base `settings.yml` (typos, obsolete parameters, or values placed at the wrong level in the structure) are merged in but never read by the client, so they are silently ignored.
+
+BigBlueButton logs a `WARN` in `bbb-apps-akka` for each such key so the problem is visible. The warning is non-blocking: the value is still applied.
+
+For test and staging environments you can additionally enable **strict validation**, which turns those warnings into hard failures. It is **disabled by default** and controlled by a single setting, `clientSettingsOverrideStrictValidation`, in `/etc/bigbluebutton/bbb-web.properties`. Both `bbb-web` and `bbb-apps-akka` read this same property (akka reads the file directly at boot), so there is one switch and no risk of the two processes disagreeing. When set to `true`:
+
+- **Filesystem override (`/etc/bigbluebutton/bbb-html5.yml`), enforced by `bbb-apps-akka` at boot.** If the override file has issues, `bbb-apps-akka` logs an explicit error listing each offending key and exits (the service fails to start), so a bad config breaks the deploy instead of running silently wrong.
+- **API override (`clientSettingsOverride` / `clientSettingsOverrideJsonUrl`), enforced by `bbb-web` at create.** If a `/create` call carries an override with issues, the call is rejected with `returncode=FAILED` and `messageKey=clientSettingsOverrideValidationError`, with the offending keys listed in the message; the meeting is not created.
+
+Keep it `false` in production unless you specifically want such overrides to be rejected.
+
 #### Disable webcams
 
 You can disable webcams by setting `enableVideo` to `false` in the `/etc/bigbluebutton/bbb-html5.yml` file for the HTML5 client.


### PR DESCRIPTION
### What does this PR do?

**Problem:** Client settings overrides — whether from `/etc/bigbluebutton/bbb-html5.yml` or the `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` create parameters — are deep-merged onto `settings.yml` blindly. A typo, an obsolete key, or a key at the wrong level (e.g. `public.breakouts` instead of `public.app.breakouts`) gets merged in but is never read by the client, so the setting is **silently ignored** — no error, no warning, nothing to debug from.

**Solution:** Before merging, the override is validated against the `settings.yml` catalog and `bbb-apps-akka` logs a `WARN` for each key that doesn't line up:
- `unknown-key` — not present in `settings.yml` (likely a typo or obsolete)
- `shape-mismatch` — a section was expected but a value was given, or vice-versa
- `type-mismatch` — e.g. a boolean setting overridden with a string

It's **non-blocking**: the value is still applied exactly as before; the warning only adds visibility. A clean override stays silent (no log spam), and it runs on both override paths.

Optionally, it also adds an **opt-in strict mode** (off by default) for test/staging that turns those warnings into hard failures — a single setting, `clientSettingsOverrideStrictValidation` in `/etc/bigbluebutton/bbb-web.properties`, read by both `bbb-web` and `bbb-apps-akka`. When enabled, akka refuses to boot on a bad `bbb-html5.yml` and `bbb-web` rejects the bad `/create` call. **Production behavior is unchanged.**

### Closes Issue(s)

Closes #25224

### How to test

1. Put a bad key in an override — e.g. add `public.breakouts` (instead of `public.app.breakouts`) to `/etc/bigbluebutton/bbb-html5.yml`, or pass it via `clientSettingsOverride` on a `/create` call.
2. Create a meeting → it still succeeds and the value is applied just as before.
3. Check the `bbb-apps-akka` log: you now get a `WARN` naming the offending key and why (`unknown-key` / `shape-mismatch` / `type-mismatch`). A correct override — or a `private.*` one — logs nothing.
4. **Strict mode (optional):** set `clientSettingsOverrideStrictValidation=true` in `/etc/bigbluebutton/bbb-web.properties`. A bad `bbb-html5.yml` now makes `bbb-apps-akka` fail to start; a bad `/create` override is rejected with `returncode=FAILED` and `messageKey=clientSettingsOverrideValidationError`. Default (`false`) keeps current behavior.

### More

- Validation logic lives in the shared `YamlUtil.diffOverrideAgainstBase` and is reused by both akka and bbb-web (via `ClientSettingsValidator`), so there's a single set of rules.
- [x] Added/updated documentation (`docs/docs/administration/customize.md`)
