### PR TITLE
fix(presentation): authenticate thumbnail URL in manage presentations

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/presentation/component.jsx
@@ -10,6 +10,7 @@ import Styled from './styles';
 import PresentationDownloadDropdown from './presentation-download-dropdown/component';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Session from '/imports/ui/services/storage/in-memory';
+import Auth from '/imports/ui/services/auth';
 import ModalStyled from '../styles';
 
 const { isMobile } = deviceInfo;
@@ -578,7 +579,7 @@ class PresentationUploader extends Component {
           }}
           aria-label={`${item.name}`}
         >
-          <img src={firstPageThumbnailUrl} alt={item.name} />
+          <img src={Auth.authenticateURL(firstPageThumbnailUrl)} alt={item.name} />
         </Styled.PresentationThumbnail>
         <Styled.PresentationItemBottomContainer>
           <Styled.PresentationItemName data-test="presentationName">

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -174,6 +174,13 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
       await presentation.removeAllPresentation();
     });
 
+    test('Presentation thumbnail loads', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25163);
+      const presentation = new Presentation(browser, context);
+      await presentation.initModPage(page, { testInfo });
+      await presentation.presentationThumbnailLoads();
+    });
+
     test('Upload and remove all presentations', { tag: '@flaky' }, async ({ browser, context, page }, testInfo) => {
       // duplicate toast notification displayed
       linkIssue(24056);

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -543,6 +543,38 @@ export class Presentation extends MultiUsers {
     );
   }
 
+  async presentationThumbnailLoads() {
+    await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitAndClick(e.mediaAreaButton);
+    await this.modPage.waitAndClick(e.managePresentations);
+    await this.modPage.hasElement(
+      e.presentationItem,
+      'should display the presentation item in the manage presentations list',
+    );
+
+    const thumbnail = this.modPage.page.locator(e.presentationThumbnails).first().locator('img');
+
+    // The thumbnail request is authorized only when the client appends the session
+    // token to the URL (the server returns 401 otherwise). Without the token the
+    // image fails to load and naturalWidth stays 0.
+    await expect(thumbnail, 'should append the session token to the thumbnail URL').toHaveAttribute(
+      'src',
+      /sessionToken=/,
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+
+    await expect
+      .poll(
+        async () =>
+          thumbnail.evaluate((img) => (img as HTMLImageElement).complete && (img as HTMLImageElement).naturalWidth > 0),
+        {
+          message: 'should load the presentation thumbnail image (no 401 Unauthorized)',
+          timeout: ELEMENT_WAIT_LONGER_TIME,
+        },
+      )
+      .toBe(true);
+  }
+
   async uploadAndRemoveAllPresentations() {
     await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName);
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);


### PR DESCRIPTION
### What does this PR do?

Presentation thumbnails in the **Manage presentations** panel fail to load on 4.0 — they render as broken images and the console logs `401 (Unauthorized)` for the thumbnail requests.

Since #25020, presentation resource URLs (svg/png/thumbnail) require a `sessionToken` in the query string. The client adds it via `Auth.authenticateURL()`, which is why slides render fine — but the Manage-presentations thumbnail was the one spot still using the raw URL straight from GraphQL, so its request got rejected.

The fix authenticates the thumbnail URL the same way the slide path already does:

```jsx
<img src={Auth.authenticateURL(firstPageThumbnailUrl)} alt={item.name} />
```

One client-side line, no backend change. `authenticateURL` is idempotent (won't duplicate an existing token) and the surrounding guard guarantees the URL is non-empty.

### Closes Issue(s)

Closes bigbluebutton/bigbluebutton#25163

### How to test

1. Join a meeting as a presenter.
2. Open the media area → **Manage presentations**.
3. The thumbnail should render (not a broken image), the network/console should show **no 401** for `/bigbluebutton/presentation/.../thumbnail/...`, and the thumbnail URL should carry `&sessionToken=...`.

Covered by a new Playwright test (`Presentation thumbnail loads`) that opens the panel and asserts the thumbnail URL has the session token and the image actually loads (`naturalWidth > 0`).

Validated on BBB 4.0.0-beta.3 (only this one-line client change between runs):

| | Before | After |
|---|---|---|
| Thumbnail request | 401 Unauthorized | 200 OK |
| Thumbnail URL | `?pageToken=...` | `?pageToken=...&sessionToken=...` |
| Rendered image | broken (`naturalWidth = 0`) | loads (`naturalWidth = 150`) |

**Before** (401, broken):

[![Before](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/0d37c33c-6155-4488-b9c3-a50fa4b691b3/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/13991253-7ed0-4726-95a3-c584c8a2be92/before.mp4)

**After** (200, loads):

[![After](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/3cd48fbf-a93d-422f-a35b-c0d369237b7f/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-04/4344a48a-dab5-4dbf-9832-e95f51ee4c2c/after.mp4)

### More
- [ ] Added/updated documentation
