### PR TITLE
fix(screenshare): keep startScreensharing name in minifier for tablet app

### DIFF
--- a/bigbluebutton-html5/webpack.config.js
+++ b/bigbluebutton-html5/webpack.config.js
@@ -139,7 +139,18 @@ if (env === prodEnv) {
   config.mode = prodEnv;
   config.optimization = {
     minimize: true,
-    minimizer: isSafariTarget ? [] : [new TerserPlugin()],
+    minimizer: isSafariTarget ? [] : [new TerserPlugin({
+      // Preserve the `startScreensharing` function name in the minified
+      // bundle. The tablet app (imports/ui/services/mobile-app/index.js)
+      // inspects the JS stack trace for this name to route screen sharing
+      // to the native broadcast upload extension; if the minifier strips
+      // it, the call is misclassified and screen sharing silently fails on
+      // the tablet app. Scoped via regex so the global bundle-size cost of
+      // a blanket keep_fnames is avoided.
+      terserOptions: {
+        keep_fnames: /startScreensharing/,
+      },
+    })],
   };
   config.performance = {
     hints: 'warning',


### PR DESCRIPTION
## Problem

On the BigBlueButton tablet app (iOS/iPadOS), starting a screen share is reported as *started* in the client, but no media is ever shared. Standard browsers are unaffected; audio and webcam keep working.

## Root cause

The tablet app decides how to route a WebRTC call (native ReplayKit screen broadcast vs. webview WebRTC) by inspecting the JS stack trace at peer-connection setup time and looking for the `startScreensharing` function name - a clever way to identify where the call originated:

```js
// imports/ui/services/mobile-app/index.js
if (caller === 'addEventListener'
    && stackTrace.indexOf('startScreensharing') !== -1) {
  // route to the native broadcast upload extension
}
```

The production webpack build minifies with the default `TerserPlugin`, which drops inferred function names. `ScreenshareBroker.startScreensharing` is emitted by Babel as `value: function startScreensharing(){...}` and then has its name stripped to `value: function(){...}`. At runtime its stack frame reads `value` instead of `startScreensharing`, so the lookup fails: the call is classified as a standard webview call, the native broadcast path is never engaged, and offer generation fails.

This regressed in b8c24faa24 (Revert "Build(html5): Change webpack minifier to preserve class and function names"), which removed `keep_classnames`/`keep_fnames` from the minifier. Builds before that revert keep the name and screen sharing works on the tablet app.

## Fix

Re-enable function-name preservation in the minifier, but scoped via regex to only the name the tablet app relies on, so the global bundle-size cost that motivated the original revert is avoided:

```js
minimizer: isSafariTarget ? [] : [new TerserPlugin({
  terserOptions: {
    keep_fnames: /startScreensharing/,
  },
})],
```

## Testing

Built from source on a 3.0 server and verified end to end on the tablet app:

- The rebuilt bundle keeps `function startScreensharing(){...}` (no longer the anonymous `value: function(){...}`).
- The tablet app classifies the call as a screen share again, the native broadcast path engages, and screen sharing works.
- No source changes are required - Babel already names the function; only the minifier was dropping it.
