### PR TITLE
fix(recording): reduce mem usage when audio cut extends into gap

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -328,6 +328,8 @@ module BigBlueButton
               track_label = "t#{i}_#{idx}"
               line = "[#{input_index}]"
               line << "atempo=#{speed},atrim=start=#{ms_to_s(audio_data[:timestamp])}," if speed != 1.0
+              # Ensure the aresample filter doesn't see the next audio packet after a long pts gap
+              line << "atrim=end=#{ms_to_s(entry[:next_timestamp] - entry[:timestamp])},"
               line << "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT},apad"
               line << "[#{track_label}];"
               filter_lines << line


### PR DESCRIPTION
### What does this PR do?

Fixes an audio processing crash that can happen when an EDL cut extends slightly into a large audio PTS gap.

Some recordings contain audio files with long timestamp gaps. The gap removal step detects those gaps and adds EDL cuts so the audio source is removed while the gap is active. However, if another cut is very close to the gap boundary, `enforce_cut_lengths` can remove the gap-start cut because the resulting segment is shorter than the minimum cut length.

That can leave a short segment starting just before the gap. When ffmpeg processes that segment, `aresample` may see the next packet after the gap and try to generate silence for the entire missing timestamp range. For very large gaps, this can spike memory usage and crash the worker.

This PR trims each input audio stream to the EDL segment duration before `aresample`. That prevents `aresample` from seeing packets outside the segment, including packets after a long PTS gap. Any silence still needed at the end of the segment is handled by the existing `apad` filter.

### Motivation

A recording was crashing due to high memory usage while processing a short audio segment near a large PTS gap. In the affected case, the segment started just before the gap, and `enforce_cut_lengths` had removed a nearby gap boundary cut. This allowed `aresample` to see across the gap and allocate a large silent fill.