### PR TITLE
Fix allowPromoteGuestToModerator

### DIFF
--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -52,6 +52,7 @@
                 allowModsToEjectCameras
                 allowModsToUnmuteUsers
                 authenticatedGuest
+                allowPromoteGuestToModerator
                 maxUserConcurrentAccesses
                 maxUsers
                 meetingLayout


### PR DESCRIPTION
Commit d4699d0492bcb57790113b8027a84ccce20a41cc introduced a new endpoint for static data.

However, even though allowPromoteGuestToModerator is present in public_v_meeting_usersPolicies.yaml, it's missing in query_collections.yaml.
Thus the variable was never sent to the client and promoting a guest user to moderator was not working.