### PR TITLE
Fix(blocknote): shared notes unread indicator

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/SharedNotesRevDAO.scala
@@ -49,7 +49,7 @@ object SharedNotesRevDAO {
   def insertNextRev(meetingId: String, sharedNotesExtId: String, userId: String) = {
     DatabaseConnection.enqueue(
       sqlu"""
-          insert into "sharedNotes_rev"("meetingId", "sharedNotesExtId", "userId", "rev")
+          insert into "sharedNotes_rev"("meetingId", "sharedNotesExtId", "userId", "rev", "createdAt")
            select
              ${meetingId} as "meetingId",
              ${sharedNotesExtId} as "sharedNotesExtId",
@@ -58,7 +58,8 @@ object SharedNotesRevDAO {
                 from "sharedNotes_rev"
                 where "meetingId" = ${meetingId}
                 and "sharedNotesExtId" = ${sharedNotesExtId}
-             ),0) + 1 as "rev"
+             ),0) + 1 as "rev",
+             current_timestamp as "createdAt"
           """
     )
   }

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -32,6 +32,7 @@ import { colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
 import { useBlockNoteLocaleLanguage, useHocuspocusProvider } from './hooks';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import useCurrentUser from '../../core/hooks/useCurrentUser';
+import useNotesLastRead from '/imports/ui/components/notes/hooks/useNotesLastRead';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
@@ -482,10 +483,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   );
 }
 
-function BlockNoteContainer(): React.ReactElement {
+interface BlockNoteContainerProps {
+  isVisible: boolean;
+}
+
+function BlockNoteContainer({ isVisible }: BlockNoteContainerProps): React.ReactElement {
   const {
     error, isAuthenticating, hocuspocusProvider, connectionClosed, handleRetry, isSynced,
   } = useHocuspocusProvider();
+  const { markNotesAsRead } = useNotesLastRead();
 
   const { data: currentUser } = useCurrentUser((user) => ({
     color: user.color,
@@ -506,6 +512,18 @@ function BlockNoteContainer(): React.ReactElement {
 
   const renderBlockNote = !error && !isAuthenticating
     && hocuspocusProvider && !connectionClosed && isSynced && !!currentUser;
+
+  // The notes are read when the synced editor is on screen. Mirror the
+  // etherpad pad (pads-graphql/component.tsx): mark as read on show and on
+  // hide - the panel stays mounted for NOTES_UNMOUNT_DELAY after closing,
+  // and edits arriving in that window must stay unread.
+  React.useEffect(() => {
+    if (!renderBlockNote) return () => {};
+    if (isVisible) markNotesAsRead();
+    return () => {
+      if (isVisible) markNotesAsRead();
+    };
+  }, [renderBlockNote, isVisible, markNotesAsRead]);
   return (
     <Styled.Notes id="bn-notes-scroll-container">
       {(hasError) && (

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -182,7 +182,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
             amIPresenter={amIPresenter}
             isVisible={isVisible}
           />
-        ) : <BlockNoteContainer />}
+        ) : <BlockNoteContainer isVisible={isVisible} />}
     </Styled.PanelContent>
   );
 };

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -64,4 +64,10 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
     await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
+
+  test('Unread indicator notifies users of new notes content', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.unreadNotesIndicator();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -3,7 +3,13 @@ import { expect, Response } from '@playwright/test';
 import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
-import { getBlockNoteEditorLocator, getBlockNoteReadOnlyLocator, startSharedNotesBlockNote } from './util';
+import {
+  getBlockNoteEditorLocator,
+  getBlockNoteReadOnlyLocator,
+  hasNoUnreadNotesIndicator,
+  startSharedNotesBlockNote,
+  unreadNotesIndicatorStaysHidden,
+} from './util';
 
 export class BlockNoteSharedNotes extends MultiUsers {
   async openSharedNotes() {
@@ -404,5 +410,43 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.up('Shift');
     await this.modPage.press('Control+I');
     await this.modPage.press('ArrowLeft');
+  }
+
+  async unreadNotesIndicator() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.messagesSidebarButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    // viewer starts without the unread indicator
+    await this.userPage.hasElement(e.sharedNotesSidebarButton, 'should display the shared notes button');
+    await hasNoUnreadNotesIndicator(this.userPage, 'should not display the unread indicator before any edit');
+
+    // moderator opens the notes and types
+    await startSharedNotesBlockNote(this.modPage);
+    const notesEditor = getBlockNoteEditorLocator(this.modPage);
+    await notesEditor.click();
+    await this.modPage.page.keyboard.type('Hello attendees');
+
+    // viewer (notes panel closed) must see the unread indicator
+    await this.userPage.hasNotificationIcon(e.sharedNotesSidebarButton, 'should display the unread indicator for the viewer');
+
+    // opening the notes clears the indicator
+    await startSharedNotesBlockNote(this.userPage);
+    await hasNoUnreadNotesIndicator(this.userPage, 'should clear the unread indicator when the notes panel is open');
+
+    // closing the panel must not bring the indicator back (notes were read)
+    await this.userPage.waitAndClick(e.hideNotesLabel);
+    await this.userPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+    await unreadNotesIndicatorStaysHidden(this.userPage, 'should keep the indicator hidden after reading the notes');
+
+    // new edits after the viewer read the notes must light the indicator again
+    const modNotesEditor = getBlockNoteEditorLocator(this.modPage);
+    await modNotesEditor.click();
+    await this.modPage.page.keyboard.type('New content');
+    await this.userPage.hasNotificationIcon(e.sharedNotesSidebarButton, 'should display the unread indicator again after new edits');
   }
 }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -1,4 +1,6 @@
-import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { Page } from '../../core/page';
 
@@ -14,4 +16,31 @@ export function getBlockNoteEditorLocator(testPage: Page) {
 
 export function getBlockNoteReadOnlyLocator(testPage: Page) {
   return testPage.page.locator(e.blockNoteReadOnly);
+}
+
+function checkUnreadNotesIndicator(testPage: Page) {
+  return testPage.page.evaluate((selector) => {
+    const element = document.querySelector(selector);
+    if (!element) return false;
+    const afterElement = getComputedStyle(element, 'after');
+    return !!afterElement && afterElement.content !== 'none';
+  }, e.sharedNotesSidebarButton);
+}
+
+export async function hasNoUnreadNotesIndicator(testPage: Page, description: string, timeout = ELEMENT_WAIT_TIME) {
+  await expect(async () => {
+    expect(await checkUnreadNotesIndicator(testPage)).toBeFalsy();
+  }, description).toPass({ timeout });
+}
+
+// The indicator must not (re)appear: poll for the whole duration instead of
+// passing on the first falsy check.
+export async function unreadNotesIndicatorStaysHidden(testPage: Page, description: string, durationMs = 3000) {
+  const deadline = Date.now() + durationMs;
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    expect(await checkUnreadNotesIndicator(testPage), description).toBeFalsy();
+    // eslint-disable-next-line no-await-in-loop
+    await testPage.page.waitForTimeout(250);
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the sidebar unread indicator (red dot) for shared notes when the meeting uses the BlockNote editor (`sharedNotesEditor=blockNote`). Today, anyone with the notes panel closed gets no hint that someone is writing — the dot never lights. It works fine with the etherpad editor.

Two causes, both specific to the BlockNote path:

- **Server:** BlockNote revisions were inserted without a `createdAt`, so `v_sharedNotes.lastUpdatedAt` (a `max(createdAt)` aggregate) stayed `NULL` and the client never saw an update. Now `insertNextRev` fills `createdAt`, like the etherpad path already does.
- **Client:** the BlockNote panel never marked the notes as read, so the dot wouldn't clear/relight correctly. It now marks as read when the editor is shown and when it's hidden — mirroring the etherpad pad.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/25250

### How to test

Create a meeting with `sharedNotesEditor=blockNote`, join as a moderator and a viewer.

1. Viewer keeps the notes panel **closed**; moderator opens notes and types → red dot appears on the viewer's notes button.
2. Viewer opens the notes → dot clears.
3. Viewer closes the panel → dot stays hidden (content was read).
4. Moderator types again → dot reappears.

Covered end to end by the new `Shared Notes - BlockNote > Unread indicator notifies users of new notes content` Playwright spec.
