### PR TITLE
fix(chat): preserve text before links in reply message preview

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/service.ts
@@ -1,3 +1,42 @@
+const lineBreakingTags = new Set(['P', 'DIV', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI', 'BLOCKQUOTE', 'TABLE', 'TR', 'TD']);
+
+// Truncates the subtree at the first visual line break: a newline inside a
+// text node (rendered as a break by `white-space: pre-wrap`), a <br>, or the
+// end of the first nested line-breaking element. Returns true when the line
+// ended inside the given node, so callers must drop the siblings that follow.
+const truncateAtFirstLineBreak = (node: Node): boolean => {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent || '';
+    // whitespace-only nodes are markup formatting between elements, not a visual break
+    if (!text.trim()) return false;
+    const newlineIndex = text.indexOf('\n');
+    if (newlineIndex === -1) return false;
+    // eslint-disable-next-line no-param-reassign
+    node.textContent = text.slice(0, newlineIndex);
+    return true;
+  }
+
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
+
+  const element = node as Element;
+  if (element.tagName === 'BR') {
+    element.remove();
+    return true;
+  }
+
+  let lineEnded = false;
+  Array.from(element.childNodes).forEach((child) => {
+    if (lineEnded) {
+      child.remove();
+      return;
+    }
+    lineEnded = truncateAtFirstLineBreak(child)
+      || (child.nodeType === Node.ELEMENT_NODE && lineBreakingTags.has((child as Element).tagName));
+  });
+
+  return lineEnded;
+};
+
 export const getFirstVisibleLineHtml = (htmlContent: string): string => {
   if (!htmlContent.trim()) return '';
 
@@ -6,35 +45,7 @@ export const getFirstVisibleLineHtml = (htmlContent: string): string => {
   const root = doc.body.firstElementChild;
   if (!root) return '';
 
-  const displayBlockTags = new Set(['P', 'A', 'DIV', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI', 'BLOCKQUOTE', 'TABLE', 'TR', 'TD', 'CODE']);
-
-  const children = Array.from(root.childNodes);
-  let keptBlocks = 0;
-
-  for (let i = children.length - 1; i >= 0; i -= 1) {
-    const node = children[i];
-
-    if (node.nodeType === Node.ELEMENT_NODE) {
-      const tagName = (node as Element).tagName.toUpperCase();
-      if (displayBlockTags.has(tagName)) {
-        if (keptBlocks === 0) {
-          keptBlocks = 1;
-        } else {
-          node.remove();
-        }
-      } else if (keptBlocks > 0) {
-        node.remove();
-      }
-    } else if (node.nodeType === Node.TEXT_NODE) {
-      if (keptBlocks > 0) {
-        node.remove();
-      } else {
-        const text = node.textContent || '';
-        const firstLine = text.split(/\n/)[0];
-        node.textContent = firstLine;
-      }
-    }
-  }
+  truncateAtFirstLineBreak(root);
 
   return root.outerHTML;
 };

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -203,6 +203,12 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
         await message.replyMessage();
       });
 
+      test('Reply to a message with text followed by a link', async ({ browser, context, page }, testInfo) => {
+        const message = new MessageActions(browser, context);
+        await message.initModPage(page, { testInfo });
+        await message.replyMessageWithTextBeforeLink();
+      });
+
       test('Cancel a reply to a message', async ({ browser, context, page }, testInfo) => {
         const message = new MessageActions(browser, context);
         await message.initModPage(page, { testInfo });

--- a/bigbluebutton-tests/playwright/chat/messageActions.ts
+++ b/bigbluebutton-tests/playwright/chat/messageActions.ts
@@ -417,6 +417,51 @@ export class MessageActions extends Chat {
     await expect(messageReplied, 'should display the replied message content in the message sent').toBeVisible();
   }
 
+  async replyMessageWithTextBeforeLink() {
+    await openPublicChat(this.modPage);
+    // send a message containing text followed by a link
+    await this.modPage.fill(e.chatBox, e.messageWithTextBeforeLink);
+    await this.modPage.waitAndClick(e.sendButton);
+    await this.modPage.hasElement(
+      e.chatUserMessageText,
+      'should display the message sent by the moderator on the public chat',
+    );
+    await checkLastMessageSent(this.modPage, e.messageWithTextBeforeLink);
+    const initialMessagesCount = await this.modPage.getSelectorCount(e.chatUserMessageText);
+    // hover message and click to reply
+    const lastMessageItem = this.modPage.page.locator(e.chatMessageItem).last();
+    await lastMessageItem.hover();
+    await expect(
+      lastMessageItem.locator(e.messageToolbar),
+      'should display the message toolbar when hovering a message',
+    ).toBeVisible();
+    await this.modPage.waitAndClick(e.replyMessageButton);
+    // the reply intention preview must keep the whole first line: the text and the link
+    await this.modPage.hasElement(
+      e.chatReplyIntentionContainerContent,
+      'should display the chat reply intention container content',
+    );
+    await this.modPage.hasText(
+      e.chatReplyIntentionContainerContent,
+      e.messageWithTextBeforeLink,
+      'should display the full first line (text and link) in the reply intention preview',
+    );
+    // reply the message
+    await this.modPage.fill(e.chatBox, e.message2);
+    await this.modPage.waitAndClick(e.sendButton);
+    await this.modPage.hasElementCount(
+      e.chatUserMessageText,
+      initialMessagesCount + 1,
+      'should display the reply as a new message',
+    );
+    // the quote inside the sent reply must keep the whole first line as well
+    const messageReplied = this.modPage.page.locator(e.chatMessageItem).last().locator(e.chatMessageReplied);
+    await expect(
+      messageReplied,
+      'should display the full first line (text and link) in the replied message quote',
+    ).toContainText(e.messageWithTextBeforeLink);
+  }
+
   async cancelReplyMessage() {
     await openPublicChat(this.modPage);
     // send a message

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -188,6 +188,7 @@ export const elements = {
   testMessage: 'Just a test',
   message1: 'Hello User2',
   message2: 'Hello User1',
+  messageWithTextBeforeLink: 'Hello https://example.com',
   publicMessage1: 'This is a Public Message from User1',
   publicMessage2: 'This is a Public Message from User2',
   uniqueCharacterMessage: 'A',


### PR DESCRIPTION
### What does this PR do?

ports #25268 changes to BBB 3.0:

_Fixes the chat **reply preview** dropping text that comes before a link.)_

_When you reply to a message like `Hello https://example.com`, both previews — the "replying to" banner above the input and the quote inside the sent reply — showed only `https://example.com`, silently dropping the `Hello`._

_The culprit is `getFirstVisibleLineHtml` (`bigbluebutton-html5/.../chat/chat-graphql/service.ts`), which extracts the first line of the original message. It walked the message's nodes **in reverse** and treated the inline tags `<a>` and `<code>` as block-level, so it kept the *last* block (the link) and removed everything before it. This also affected text before inline code, text on both sides of a link, and lists (showed the last item instead of the first)._

_The fix rewrites the extraction to walk the DOM **in document order** and truncate at the first real line break (a `\n` in a text node, a `<br>`, or the end of the first block element), keeping all inline content of the first line intact._

