### PR TITLE
test: add BlockNote shared notes e2e tests (backport #25165 to 3.0)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -457,6 +457,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
               ref={toolbarRef}
               role="toolbar"
               className="bn-toolbar-row"
+              data-test="blockNoteToolbar"
               onKeyDown={(e) => { if (e.key === 'Escape') editor.focus(); }}
             >
               <FormattingToolbar>

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -232,7 +232,7 @@ export const elements = {
   sharedNotesViewingMode: 'iframe[title="shared notes viewing mode"]',
   currentSlideText: 'span[id="currentSlideText"]',
   notesOptions: 'button[data-test="notesOptionsMenu"]',
-  exportNotesAsPDF: '[data-test="exportNotesAsPDF"]',
+  exportNotesAsPDF: 'li[data-test="exportNotesAsPDF"]',
   showMoreSharedNotesButton: 'span[class="show-more-icon-btn"]',
   exportSharedNotesButton: 'li[data-key="import_export"] button',
   exportPlainButton: 'a[id="exportplaina"] span',
@@ -240,6 +240,17 @@ export const elements = {
   unpinNotes: 'button[data-test="unpinNotes"]',
   exportetherpad: 'span[id="exportetherpad"]',
   exporthtml: 'span[id="exporthtml"]',
+
+  // BlockNote specific
+  blockNoteContainer: '#bn-notes-scroll-container',
+  blockNoteEditor: '#bn-notes-scroll-container .bn-editor',
+  blockNoteEditable: '#bn-notes-scroll-container .bn-editor[contenteditable="true"]',
+  blockNoteReadOnly: '#bn-notes-scroll-container .bn-editor[contenteditable="false"]',
+  blockNoteToolbar: 'div[data-test="blockNoteToolbar"]',
+  blockNoteUnderlineButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Underline"]',
+  notesConnectionError: '[data-test="notesError"]',
+  notesRetryButton: 'button[data-test="notesRetryButton"]',
+
   // Notifications
   smallToastMsg: 'div[data-test="toastSmallMsg"]',
   closeToastBtn: 'i[data-test="closeToastBtn"]',

--- a/bigbluebutton-tests/playwright/core/helpers.ts
+++ b/bigbluebutton-tests/playwright/core/helpers.ts
@@ -36,7 +36,7 @@ interface InitOptions {
   createParameter?: string;
   joinParameter?: string;
   testInfo?: TestInfo;
-  recordVideo?: boolean;
+
 }
 
 interface GetJoinUrlProp {
@@ -306,8 +306,10 @@ export async function initializePages(
   browser: Browser,
   initOptions?: InitOptions,
 ): Promise<void> {
-  const { isMultiUser, createParameter, joinParameter, testInfo, recordVideo } = initOptions || {};
-  const context = await browser.newContext(recordVideo ? { recordVideo: { dir: 'test-results/' } } : {});
+  const { isMultiUser, createParameter, joinParameter, testInfo } = initOptions || {};
+  const context = await browser.newContext({
+    ...(testInfo && { recordVideo: { dir: testInfo.outputDir } }),
+  });
   const page = await context.newPage();
   await testInstance.initModPage(page, { createParameter, joinParameter, testInfo });
   if (isMultiUser) await testInstance.initUserPage(context, { createParameter, joinParameter, testInfo });

--- a/bigbluebutton-tests/playwright/core/setup/fixtures.ts
+++ b/bigbluebutton-tests/playwright/core/setup/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test';
+import { test as base, type Video } from '@playwright/test';
 
 interface TestFixtures {
   sharedBeforeEachTestHook: void;
@@ -6,12 +6,27 @@ interface TestFixtures {
 
 const testWithValidation = base.extend<TestFixtures>({
   sharedBeforeEachTestHook: [
-    async ({ browser }, use) => {
+    async ({ browser }, use, testInfo) => {
       // Before test
       await use();
-      // After test
+      // After test — collect video refs before closing (videos finalize on context close)
       const contexts = browser.contexts();
+      const videos: Video[] = [];
+      for (const ctx of contexts) {
+        for (const pg of ctx.pages()) {
+          const v = pg.video();
+          if (v) videos.push(v);
+        }
+      }
       await Promise.all(contexts.map((context) => context.close()));
+      for (let i = 0; i < videos.length; i++) {
+        try {
+          const videoPath = await videos[i].path();
+          await testInfo.attach(`video-${i + 1}`, { path: videoPath, contentType: 'video/webm' });
+        } catch {
+          // skip if video file unavailable
+        }
+      }
     },
     { scope: 'test', auto: true },
   ],

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -1,20 +1,60 @@
-import { initializePages, linkIssue } from '../../core/helpers';
+import { initializePages } from '../../core/helpers';
 import { test } from '../../core/setup/fixtures';
-import { BlockNoteSharedNotes } from './sharednotes';
+import { SharedNotesBlockNote } from './sharednotes';
 
-test.describe('Shared Notes - BlockNote', { tag: '@ci' }, () => {
-  let sharedNotes: BlockNoteSharedNotes;
+const CREATE_PARAMETER = 'sharedNotesEditor=blockNote';
 
-  test.beforeEach(async ({ browser, context }, testInfo) => {
-    sharedNotes = new BlockNoteSharedNotes(browser, context);
-    await initializePages(sharedNotes, browser, {
-      createParameter: 'sharedNotesEditor=blockNote',
-      testInfo,
-    });
+test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
+  test('Open shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.openSharedNotes();
   });
 
-  test('Export empty shared notes as PDF returns a PDF, not an error', async () => {
-    linkIssue(25122);
-    await sharedNotes.exportEmptyNotesAsPDF();
+  test('Type in shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.typeInSharedNotes();
+  });
+
+  test('Format text in shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.formatTextInSharedNotes();
+  });
+
+  test('Export shared notes as PDF', async ({ browser, context, browserName }, testInfo) => {
+    test.skip(browserName === 'firefox', 'window.open popup handling differs on Firefox');
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.exportSharedNotesAsPDF();
+  });
+
+  test('Convert notes to presentation', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.convertNotesToWhiteboard();
+  });
+
+  test('Multiusers edit', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.editSharedNotesWithMoreThanOneUser();
+  });
+
+  test('See notes without edit permission', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.seeNotesWithoutEditPermission();
+  });
+
+  // different failures in CI and local
+  // local: not able to click on "unpin" button
+  // CI: not restoring presentation for viewer after unpinning notes
+  test('Pin and unpin notes onto whiteboard', async ({ browser, context, browserName }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Webcams does not work properly, due to heavy firefox for testing');
+    const sharedNotes = new SharedNotesBlockNote(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -1,14 +1,16 @@
-import { expect, Response } from '@playwright/test';
+import { expect } from '@playwright/test';
 
-import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
+import { ELEMENT_WAIT_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
+import {
+  startSharedNotesBlockNote,
+  getBlockNoteEditorLocator,
+  getBlockNoteReadOnlyLocator,
+} from './util';
 
-export class BlockNoteSharedNotes extends MultiUsers {
-  // Regression for https://github.com/bigbluebutton/bigbluebutton/issues/25122:
-  // exporting an empty BlockNote shared note must return a file, not an error
-  // page ("Export failed: Document is empty...").
-  async exportEmptyNotesAsPDF() {
+export class SharedNotesBlockNote extends MultiUsers {
+  async openSharedNotes() {
     const { sharedNotesEnabled } = this.modPage.settings || {};
 
     if (!sharedNotesEnabled) {
@@ -16,64 +18,318 @@ export class BlockNoteSharedNotes extends MultiUsers {
       await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
       return;
     }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await expect(editorLocator, 'should display the BlockNote editor in editable mode').toBeVisible({
+      timeout: ELEMENT_WAIT_TIME,
+    });
 
-    const { page } = this.modPage;
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
 
-    // Open the (empty) BlockNote shared notes panel. Nothing is typed, so the
-    // document stays empty.
-    await this.modPage.waitAndClick(e.sharedNotes, ELEMENT_WAIT_LONGER_TIME);
-    await this.modPage.hasElement(
-      e.sharedNotesBackground,
-      'should display the shared notes panel',
-      ELEMENT_WAIT_LONGER_TIME,
+  async typeInSharedNotes() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially(e.message);
+    await expect(editorLocator, 'should contain the typed text on shared notes').toContainText(e.message, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
+  async formatTextInSharedNotes() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially(e.message);
+
+    await editorLocator.press('Control+Z');
+    await expect(editorLocator, 'should not contain any text after undoing').not.toContainText(e.message, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+    // Re-type so we have content to format (Y.js collaborative redo is not reliable in tests)
+    await editorLocator.pressSequentially(e.message);
+    await expect(editorLocator, 'should contain the message again after re-typing').toContainText(e.message, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+
+    await this.formatBlockNoteMessage();
+    const html = await editorLocator.innerHTML();
+
+    await expect(html.includes('<u>'), 'should include underline formatting').toBeTruthy();
+    await expect(html.includes('<strong>'), 'should include bold formatting').toBeTruthy();
+    await expect(html.includes('<em>'), 'should include italic formatting').toBeTruthy();
+
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
+  async exportSharedNotesAsPDF() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially(e.message);
+
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.hasElement(e.exportNotesAsPDF, 'should display the export as PDF option');
+
+    // Intercept the outgoing request — the server responds with Content-Disposition: attachment
+    // so the popup tab never navigates; checking the request URL is the reliable approach.
+    const [request] = await Promise.all([
+      this.modPage.page.context().waitForEvent('request', {
+        predicate: (req) => req.url().includes('/hocuspocus/api/documents/'),
+        timeout: 15000,
+      }),
+      this.modPage.waitAndClick(e.exportNotesAsPDF),
+    ]);
+    await expect(request.url(), 'should request the PDF export endpoint').toContain('/export/pdf');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
+  async convertNotesToWhiteboard() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially('test');
+    await this.modPage.page.waitForTimeout(1000);
+
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.sendNotesToWhiteboard);
+
+    await this.modPage.hasText(
+      e.currentSlideText,
+      /test/,
+      'should the slide contain the text "test" for the moderator',
+      30000,
+    );
+    await this.userPage.hasText(
+      e.currentSlideText,
+      /test/,
+      'should the slide contain the text "test" for the attendee',
+      20000,
     );
 
-    // Open the notes options menu and export as PDF. "Export as PDF" is a
-    // window.open navigation that returns the file; capture its response.
-    // Promise.all keeps a single, handled rejection path and lets
-    // waitForEvent own the timeout / listener cleanup.
-    await this.modPage.waitAndClick(e.notesOptions, ELEMENT_WAIT_TIME);
-    const [pdfResponse] = await Promise.all([
-      page.context().waitForEvent('response', {
-        predicate: (response: Response) => response.url().includes('/export/pdf'),
-        timeout: ELEMENT_WAIT_LONGER_TIME,
-      }),
-      this.modPage.waitAndClick(e.exportNotesAsPDF, ELEMENT_WAIT_TIME),
-    ]);
+    await editorLocator.press('Control+Z');
 
-    expect(pdfResponse.status(), 'empty shared notes PDF export should return 200, not an error').toBe(200);
-    expect(
-      pdfResponse.headers()['content-type'] || '',
-      'empty shared notes PDF export should return a PDF document',
-    ).toContain('application/pdf');
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label button');
+  }
 
-    // Issue #25122 is general ("empty page should not be an error"), so every
-    // export format must treat an empty document as a valid empty file. Reuse
-    // the authenticated export URL and assert via API requests, which are
-    // browser-independent (no download-navigation semantics).
-    const exportUrl = pdfResponse.url();
-    const formats: Array<{ format: string; contentType: string; body?: (text: string) => void }> = [
-      { format: 'html', contentType: 'text/html' },
-      { format: 'txt', contentType: 'text/plain' },
-      { format: 'md', contentType: 'text/plain' },
-      {
-        format: 'json',
-        contentType: 'application/json',
-        body: (text) => expect(text.trim(), 'empty JSON export should be []').toBe('[]'),
-      },
-      { format: 'yjs', contentType: 'text/plain' },
-    ];
+  async editSharedNotesWithMoreThanOneUser() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
 
-    for (const { format, contentType, body } of formats) {
-      // eslint-disable-next-line no-await-in-loop
-      const response = await page.request.get(exportUrl.replace('/export/pdf', `/export/${format}`));
-      expect(response.status(), `empty shared notes ${format} export should return 200`).toBe(200);
-      expect(
-        response.headers()['content-type'] || '',
-        `empty shared notes ${format} export should return ${contentType}`,
-      ).toContain(contentType);
-      // eslint-disable-next-line no-await-in-loop
-      if (body) body(await response.text());
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
     }
+    // Open notes for both users before any typing so Hocuspocus registers both sessions
+    await startSharedNotesBlockNote(this.userPage);
+    const userEditorLocator = getBlockNoteEditorLocator(this.userPage);
+
+    await startSharedNotesBlockNote(this.modPage);
+    const modEditorLocator = getBlockNoteEditorLocator(this.modPage);
+    await modEditorLocator.click();
+    await modEditorLocator.pressSequentially('Hello');
+
+    // user waits for mod's text to sync, then selects all and replaces
+    await expect(userEditorLocator, 'should sync mod content to user before editing').toContainText(
+      'Hello',
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+    await userEditorLocator.click();
+    await userEditorLocator.press('Control+A');
+    await userEditorLocator.pressSequentially('Jello');
+
+    await expect(modEditorLocator, 'should the shared notes contain the text "Jello" for the moderator').toContainText(
+      /Jello/,
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+    await expect(userEditorLocator, 'should the shared notes contain the text "Jello" for the attendee').toContainText(
+      /Jello/,
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes button for the moderator');
+    await this.userPage.waitAndClick(e.hideNotesLabel);
+    await this.userPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes button for the attendee');
+  }
+
+  async seeNotesWithoutEditPermission() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    // type on shared notes as moderator
+    await startSharedNotesBlockNote(this.modPage);
+    const modEditorLocator = getBlockNoteEditorLocator(this.modPage);
+    await modEditorLocator.click();
+    await modEditorLocator.pressSequentially('Hello');
+
+    // open user notes to join the Hocuspocus session
+    await startSharedNotesBlockNote(this.userPage);
+
+    // lock shared notes editing for viewers (3.0 flow: manageUsers → lockViewersButton → lockEditSharedNotes → applyLockSettings)
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.waitAndClickElement(e.lockEditSharedNotes);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // attendee's editor should become read-only and still show content
+    const userReadOnlyLocator = getBlockNoteReadOnlyLocator(this.userPage);
+    await expect(userReadOnlyLocator, 'should display the text "Hello" in read-only mode for the attendee').toContainText(
+      /Hello/,
+      { timeout: 20000 },
+    );
+    await this.userPage.wasRemoved(
+      e.blockNoteToolbar,
+      'should not display the BlockNote toolbar when shared notes are locked for editing',
+    );
+  }
+
+  async pinAndUnpinNotesOntoWhiteboard() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitForSelector(e.whiteboard);
+    // user minimize presentation
+    await this.userPage.waitAndClick(e.minimizePresentation);
+    await this.userPage.hasElement(
+      e.restorePresentation,
+      'should display the restore presentation button for the attendee',
+    );
+    // type on shared notes as moderator
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially('Hello');
+    await this.modPage.page.waitForTimeout(1000); // avoid pinning notes before the text is fully synced
+    // pin notes
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.pinNotes);
+    await this.modPage.hasElement(e.unpinNotes, 'should display the unpin notes button');
+    await this.userPage.hasElement(
+      e.minimizePresentation,
+      'should display the minimize presentation button for the attendee',
+    );
+    // check text content on pinned shared notes
+    const userEditorLocator = getBlockNoteEditorLocator(this.userPage);
+    await expect(editorLocator, 'should display the text "Hello" on the shared notes for the moderator').toContainText(
+      /Hello/,
+      { timeout: 20000 },
+    );
+    await expect(
+      userEditorLocator,
+      'should display the text "Hello" on the shared notes for the attendee',
+    ).toContainText(/Hello/);
+    // unpin notes
+    await this.modPage.closeAllToastNotifications();
+    await this.modPage.waitAndClick(e.unpinNotes);
+    await this.modPage.hasElement(e.whiteboard, 'should restore the presentation for the moderator (previous state)');
+    await this.userPage.hasElement(
+      e.whiteboard,
+      'should restore the presentation for the attendee as it syncs to presenter state',
+    );
+    // pin notes again as moderator
+    await startSharedNotesBlockNote(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.pinNotes);
+    await this.modPage.hasElement(
+      e.unpinNotes,
+      'should display the unpin notes button for the moderator after pinning the notes again',
+    );
+    // make viewer as presenter and unpin notes (3.0 flow: manageUsers → userListItem → makePresenter)
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.userListItem);
+    await this.modPage.waitAndClick(e.makePresenter);
+    await this.userPage.closeAllToastNotifications();
+    await this.userPage.waitAndClick(e.unpinNotes);
+    await this.userPage.hasElement(e.whiteboard, 'should restore the presentation for the attendee (previous state)');
+    await this.modPage.hasElement(e.whiteboard, 'should restore the presentation for the moderator (previous state)');
+  }
+
+  async formatBlockNoteMessage() {
+    // U for '!' — BlockNote has no Ctrl+U shortcut; click the toolbar button instead.
+    // The static toolbar uses e.preventDefault() on mousedown to preserve selection.
+    await this.modPage.down('Shift');
+    await this.modPage.press('ArrowLeft');
+    await this.modPage.up('Shift');
+    await this.modPage.page.locator(e.blockNoteUnderlineButton).click();
+    await this.modPage.press('ArrowLeft');
+
+    // B for 'World'
+    await this.modPage.down('Shift');
+    let i = 5;
+    while (i > 0) {
+      await this.modPage.press('ArrowLeft');
+      i--;
+    }
+    await this.modPage.up('Shift');
+    await this.modPage.press('Control+B');
+    await this.modPage.press('ArrowLeft');
+
+    await this.modPage.press('ArrowLeft');
+
+    // I for 'Hello'
+    await this.modPage.down('Shift');
+    i = 5;
+    while (i > 0) {
+      await this.modPage.press('ArrowLeft');
+      i--;
+    }
+    await this.modPage.up('Shift');
+    await this.modPage.press('Control+I');
+    await this.modPage.press('ArrowLeft');
   }
 }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -1,0 +1,17 @@
+import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
+import { elements as e } from '../../core/elements';
+import { Page } from '../../core/page';
+
+export async function startSharedNotesBlockNote(testPage: Page) {
+  await testPage.waitAndClick(e.sharedNotes);
+  await testPage.waitForSelector(e.hideNotesLabel, ELEMENT_WAIT_LONGER_TIME);
+  await testPage.hasElement(e.blockNoteEditable, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+}
+
+export function getBlockNoteEditorLocator(testPage: Page) {
+  return testPage.page.locator(e.blockNoteEditor);
+}
+
+export function getBlockNoteReadOnlyLocator(testPage: Page) {
+  return testPage.page.locator(e.blockNoteReadOnly);
+}

--- a/bigbluebutton-tests/playwright/sharednotes/etherpad/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/etherpad/sharednotes.spec.ts
@@ -2,52 +2,59 @@ import { initializePages } from '../../core/helpers';
 import { test } from '../../core/setup/fixtures';
 import { SharedNotes } from './sharednotes';
 
+const CREATE_PARAMETER = 'sharedNotesEditor=etherpad';
+
 test.describe.parallel('Shared Notes - Etherpad', { tag: '@ci' }, () => {
-  let sharedNotes: SharedNotes;
-
-  test.beforeEach(async ({ browser, context }, testInfo) => {
-    sharedNotes = new SharedNotes(browser, context);
-    await initializePages(sharedNotes, browser, {
-      isMultiUser: true,
-      createParameter: 'sharedNotesEditor=etherpad',
-      testInfo,
-    });
-  });
-
-  test('Open shared notes', async () => {
+  test('Open shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.openSharedNotes();
   });
 
-  test('Type in shared notes', async ({ browserName }) => {
+  test('Type in shared notes', async ({ browser, context, browserName }, testInfo) => {
     test.skip(browserName === 'firefox', 'Firefox has different fonts on local and ci');
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.typeInSharedNotes();
   });
 
-  test('Formate text in shared notes', async () => {
+  test('Formate text in shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.formatTextInSharedNotes();
   });
 
-  test('Export shared notes', async () => {
+  test('Export shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.exportSharedNotes();
   });
 
-  test('Convert notes to presentation', async () => {
+  test('Convert notes to presentation', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.convertNotesToWhiteboard();
   });
 
-  test('Multiusers edit', async () => {
+  test('Multiusers edit', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.editSharedNotesWithMoreThanOneUSer();
   });
 
-  test('See notes without edit permission', async () => {
+  test('See notes without edit permission', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.seeNotesWithoutEditPermission();
   });
 
   // different failures in CI and local
   // local: not able to click on "unpin" button
   // CI: not restoring presentation for viewer after unpinning notes
-  test('Pin and unpin notes onto whiteboard', async ({ browserName }) => {
+  test('Pin and unpin notes onto whiteboard', async ({ browser, context, browserName }, testInfo) => {
     test.skip(browserName === 'firefox', 'Webcams does not work properly, due to heavy firefox for testing');
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });


### PR DESCRIPTION
Backport of PR #25165 to the 3.0 line.

## What changed

Adds 8 e2e tests for BlockNote shared notes (open, type, format, export PDF, convert to presentation, multi-user edit, edit permission, pin/unpin on whiteboard), plus test infra improvements (video recording via testInfo, attach in fixtures).

## 3.0 adaptations

The 3.0 UI differs from 4.0 in sidebar and user-list flows:
- Sidebar selectors: `sharedNotesSidebarButton` → `sharedNotes`, `messagesSidebarButton` → `chatButton`, `usersListSidebarButton` → `manageUsers`
- Lock edit flow: 3.0 has no `participantPermissionsTab` — goes directly `manageUsers` → `lockViewersButton` → checkbox → `applyLockSettings`
- makePresenter flow: 3.0 uses `manageUsers` → `userListItem` → `makePresenter` (4.0 uses `moreOptionsUserItemButton`)

## Commits

1. **helpers + fixtures:** video recording via `testInfo.outputDir`, attach in fixtures
2. **elements.ts:** 8 BlockNote selectors + refines `exportNotesAsPDF` to `li[data-test=...]`
3. **component.tsx:** adds `data-test="blockNoteToolbar"` to toolbar
4. **etherpad spec:** refactor to inline `initializePages` (no `beforeEach`)
5. **blocknote/:** full spec (8 tests) + `sharednotes.ts` (336 lines, adapted) + `util.ts`

Closes #25125 (backport)