### PR TITLE
feat(recording): disable formats per meeting

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -380,7 +380,7 @@ This pattern can be repeated for additional recording formats. Note that it's ve
 
 After you edit the configuration file, you must restart the recording processing queue: `systemctl restart bbb-rap-resque-worker.service` in order to pick up the changes.
 
-To disable one or more enabled recording formats for a single meeting, pass `meta_disable-recording-formats` on the `create` API call with a comma-separated list of format names. For example, `meta_disable-recording-formats=video,presentation` (or `meta_disable-recording-formats=[video,presentation]`) skips the `video` and `presentation` recording formats for that meeting. The format names are case-insensitive and match the format part of the recording steps. Disabled formats are not processed or published, so they do not trigger recording-ready callbacks.
+To disable one or more enabled recording formats for a single meeting, pass `meta_bbb-disable-recording-formats` on the `create` API call with a comma-separated list of format names. For example, `meta_bbb-disable-recording-formats=video,presentation` (or `meta_bbb-disable-recording-formats=[video,presentation]`) skips the `video` and `presentation` recording formats for that meeting. The format names are case-insensitive and match the format part of the recording steps. Disabled formats are not processed or published, so they do not trigger recording-ready callbacks.
 
 The following script will enable the video recording format of a BigBlueButton 2.6+ server.
 

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -380,6 +380,8 @@ This pattern can be repeated for additional recording formats. Note that it's ve
 
 After you edit the configuration file, you must restart the recording processing queue: `systemctl restart bbb-rap-resque-worker.service` in order to pick up the changes.
 
+To disable one or more enabled recording formats for a single meeting, pass `meta_disable-recording-formats` on the `create` API call with a comma-separated list of format names. For example, `meta_disable-recording-formats=video,presentation` (or `meta_disable-recording-formats=[video,presentation]`) skips the `video` and `presentation` recording formats for that meeting. The format names are case-insensitive and match the format part of the recording steps. Disabled formats are not processed or published, so they do not trigger recording-ready callbacks.
+
 The following script will enable the video recording format of a BigBlueButton 2.6+ server.
 
 ```

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -133,6 +133,12 @@ const createEndpointTableData = [
     "description": (<>This is a special parameter type (there is no parameter named just <code className="language-plaintext highlighter-rouge">meta</code>).<br /><br /> You can pass one or more metadata values when creating a meeting. These will be stored by BigBlueButton can be retrieved later via the getMeetingInfo and getRecordings calls.<br /><br /> Examples of the use of the meta parameters are <code className="language-plaintext highlighter-rouge">meta_Presenter=Jane%20Doe</code>, <code className="language-plaintext highlighter-rouge">meta_category=FINANCE</code>, and <code className="language-plaintext highlighter-rouge">meta_TERM=Fall2016</code>.</>)
   },
   {
+    "name": "meta_disable-recording-formats",
+    "required": false,
+    "type": "String",
+    "description": (<>Comma-separated list of recording format names to skip for this meeting, such as <code className="language-plaintext highlighter-rouge">video,presentation</code> or <code className="language-plaintext highlighter-rouge">[video,presentation]</code>. Format names are case-insensitive and match the format part of recording steps such as <code className="language-plaintext highlighter-rouge">process:video</code>. Disabled formats are not processed or published.</>)
+  },
+  {
     "name": "meta_bbb-anonymize-chat",
     "required": false,
     "type": "Boolean",

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -133,7 +133,7 @@ const createEndpointTableData = [
     "description": (<>This is a special parameter type (there is no parameter named just <code className="language-plaintext highlighter-rouge">meta</code>).<br /><br /> You can pass one or more metadata values when creating a meeting. These will be stored by BigBlueButton can be retrieved later via the getMeetingInfo and getRecordings calls.<br /><br /> Examples of the use of the meta parameters are <code className="language-plaintext highlighter-rouge">meta_Presenter=Jane%20Doe</code>, <code className="language-plaintext highlighter-rouge">meta_category=FINANCE</code>, and <code className="language-plaintext highlighter-rouge">meta_TERM=Fall2016</code>.</>)
   },
   {
-    "name": "meta_disable-recording-formats",
+    "name": "meta_bbb-disable-recording-formats",
     "required": false,
     "type": "String",
     "description": (<>Comma-separated list of recording format names to skip for this meeting, such as <code className="language-plaintext highlighter-rouge">video,presentation</code> or <code className="language-plaintext highlighter-rouge">[video,presentation]</code>. Format names are case-insensitive and match the format part of recording steps such as <code className="language-plaintext highlighter-rouge">process:video</code>. Disabled formats are not processed or published.</>)

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -182,6 +182,10 @@ Following the license change of Akka back in September 2022, we considered sever
 
 Administrators will appreciate that we now allow the passing of custom client settings through the meeting create API call. You no longer need separate servers to accommodate sessions requiring vastly different `settings.yml` configurations.
 
+#### Disable recording formats per meeting
+
+Integrations can now skip one or more enabled recording formats for a specific meeting by passing `meta_disable-recording-formats` on the `/create` call, for example `meta_disable-recording-formats=video,presentation`. Disabled formats are not processed or published. See the [Create API parameters](/development/api/#get-post-create) and [recording format customization](/administration/customize#install-additional-recording-processing-formats) docs for details.
+
 #### Removal of Meteor and MongoDB
 
 For years, we have discussed internally the topic of replacing Meteor.js with other technologies in order to improve scalability, performance, etc. Over the last year, we have introduced several different new components to replace Meteor. These new components are: `bbb-graphql-server`, `bbb-graphql-middleware`, `bbb-graphql-actions`, PostgreSQL database, and the GraphQL server Hasura. As of BigBlueButton 3.0.0-beta.1, we are no longer using Meteor or MongoDB.

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -184,7 +184,7 @@ Administrators will appreciate that we now allow the passing of custom client se
 
 #### Disable recording formats per meeting
 
-Integrations can now skip one or more enabled recording formats for a specific meeting by passing `meta_disable-recording-formats` on the `/create` call, for example `meta_disable-recording-formats=video,presentation`. Disabled formats are not processed or published. See the [Create API parameters](/development/api/#get-post-create) and [recording format customization](/administration/customize#install-additional-recording-processing-formats) docs for details.
+Integrations can now skip one or more enabled recording formats for a specific meeting by passing `meta_bbb-disable-recording-formats` on the `/create` call, for example `meta_bbb-disable-recording-formats=video,presentation`. Disabled formats are not processed or published. See the [Create API parameters](/development/api/#get-post-create) and [recording format customization](/administration/customize#install-additional-recording-processing-formats) docs for details.
 
 #### Removal of Meteor and MongoDB
 

--- a/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
@@ -126,14 +126,14 @@ module BigBlueButton
         return @disabled_recording_formats unless File.exist?(events_xml)
 
         metadata = BigBlueButton::Events.get_meeting_metadata(events_xml)
-        value = metadata['disable-recording-formats']
+        value = metadata['bbb-disable-recording-formats']
         value = value.nil? ? '' : value.value.to_s
         @disabled_recording_formats = value.delete('[]')
                                            .split(',')
                                            .map { |format| format.strip.downcase }
                                            .reject(&:empty?)
       rescue StandardError => e
-        @logger.warn("Failed to read disable-recording-formats metadata: #{e.message}")
+        @logger.warn("Failed to read bbb-disable-recording-formats metadata: #{e.message}")
         @disabled_recording_formats = []
       end
 
@@ -161,7 +161,7 @@ module BigBlueButton
             step_name, step_format = step.split(':') # e.g. 'process:presentation'
 
             if !step_format.nil? && disabled_recording_formats.include?(step_format.downcase)
-              @logger.info("Skipping #{step}: disabled by meta_disable-recording-formats")
+              @logger.info("Skipping #{step}: disabled by meta_bbb-disable-recording-formats")
               next
             end
 

--- a/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
@@ -118,6 +118,25 @@ module BigBlueButton
         end
       end
 
+      def disabled_recording_formats
+        return @disabled_recording_formats unless @disabled_recording_formats.nil?
+
+        @disabled_recording_formats = []
+        events_xml = File.join(@recording_dir, 'raw', @meeting_id, 'events.xml')
+        return @disabled_recording_formats unless File.exist?(events_xml)
+
+        metadata = BigBlueButton::Events.get_meeting_metadata(events_xml)
+        value = metadata['disable-recording-formats']
+        value = value.nil? ? '' : value.value.to_s
+        @disabled_recording_formats = value.delete('[]')
+                                           .split(',')
+                                           .map { |format| format.strip.downcase }
+                                           .reject(&:empty?)
+      rescue StandardError => e
+        @logger.warn("Failed to read disable-recording-formats metadata: #{e.message}")
+        @disabled_recording_formats = []
+      end
+
       def schedule_next_step
         @logger.info("Scheduling next step for #{@step_name}")
 
@@ -140,6 +159,12 @@ module BigBlueButton
         else
           next_step.each do |step|
             step_name, step_format = step.split(':') # e.g. 'process:presentation'
+
+            if !step_format.nil? && disabled_recording_formats.include?(step_format.downcase)
+              @logger.info("Skipping #{step}: disabled by meta_disable-recording-formats")
+              next
+            end
+
             opts['format_name'] = step_format unless step_format.nil?
 
             @logger.info("Enqueueing #{step_name} worker with #{opts.inspect}")


### PR DESCRIPTION
### What does this PR do?
Adds support for disabling selected recording formats for a single meeting using the create API metadata parameter `meta_bbb-disable-recording-formats`.

When a meeting is created with a value such as `meta_bbb-disable-recording-formats=video,presentation`, the recording worker skips matching format-specific recording steps such as `process:video`, `publish:video`, `process:presentation`, and `publish:presentation`. Disabled formats are not processed or published.

Also updates the API/admin/new-features docs and adds focused worker tests for metadata parsing and scheduling behavior.

### Closes Issue(s)
Closes #25257

### Motivation
Some integrations enable multiple recording formats globally, but need to suppress one or more formats for specific meetings. This allows the integration to choose which enabled formats should be produced per meeting without changing the server-wide recording workflow.

### More
<!-- Anything else we should know when reviewing? -->
- [x] Added/updated documentation