### PR TITLE
feat(recording): add playback type to recording ready callback

### DIFF
--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -636,12 +636,15 @@ to pass this to BigBlueButton add the following parameter to the `create` API ca
 
 Later, when the recording is ready, the BigBlueButton server will make an HTTPS POST request to this URL (https is supported and recommended).
 
+If BigBlueButton publishes multiple playback formats for the recording, it will make one callback for each playback format. Each callback URL includes a `type` query parameter with the playback format name, such as `presentation` or `video`, so the callback URL would look like `https://example.com/api/v1/recording_status?type=presentation`.
+
 The POST request body will be in the standard `application/x-www-form-urlencoded` format. The body will contain one parameter, named `signed_parameters`. The value of this parameter is a JWT (JSON Web Tokens) encoded string.
 
-The JWT will be encoded using the "HS256" method. (i.e. the header should be `{ "typ": "JWT", "alg": "HS256" }` ). The payload will contain a the following JSON keys:
+The JWT will be encoded using the "HS256" method. (i.e. the header should be `{ "typ": "JWT", "alg": "HS256" }` ). The payload will contain the following JSON keys:
 
 - `meeting_id` - The value will be the meeting_id (as provided on the BigBlueButton create API call).
 - `record_id` - The identifier of the specific recording to which the notification applies. This corresponds to the IDs returned in the getRecordings api, and the `internalMeetingId` field on the getMeetingInfo request.
+- `type` - The playback format name for this callback, when available. This corresponds to playback format types returned by the getRecordings API, such as `presentation` or `video`.
 
 The secret used to sign the JWT message will be the shared secret of the BigBlueButton API endpoint that was used to create the original meeting.
 

--- a/record-and-playback/core/scripts/post_publish/post_publish_recording_ready_callback.rb
+++ b/record-and-playback/core/scripts/post_publish/post_publish_recording_ready_callback.rb
@@ -35,6 +35,7 @@ opts = Optimist::options do
   opt :format, "Playback format name", :type => String
 end
 meeting_id = opts[:meeting_id]
+playback_format = opts[:format]
 
 bbb_web_properties = "/etc/bigbluebutton/bbb-web.properties"
 events_xml = "/var/bigbluebutton/recording/raw/#{meeting_id}/events.xml"
@@ -78,9 +79,16 @@ begin
     external_meeting_id = BigBlueButton::Events.get_external_meeting_id(events_xml)
 
     payload = { meeting_id: external_meeting_id, record_id: meeting_id }
+    payload[:type] = playback_format unless playback_format.nil? || playback_format.empty?
     payload_encoded = JWT.encode(payload, secret)
 
     uri = URI.parse(callback_url)
+    unless playback_format.nil? || playback_format.empty?
+      params = URI.decode_www_form(uri.query || '')
+      params << ['type', playback_format]
+      uri.query = URI.encode_www_form(params)
+    end
+
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = (uri.scheme == 'https')
 


### PR DESCRIPTION
### What does this PR do?

Adds the playback format type to recording-ready callbacks.

When `post_publish_recording_ready_callback.rb` is run with a playback format, the callback now includes:

- `type=<playback_format>` in the callback URL query string
- `type` in the signed JWT payload

The API docs were updated to describe the per-format callback behavior.

### Closes Issue(s)

Closes #25256

### Motivation

When multiple recording formats are published for the same meeting, integrations currently receive one recording-ready callback per format but cannot tell which playback format each callback refers to.

Adding the playback format type lets external applications distinguish callbacks for formats such as `presentation` and `video`.

### More
<!-- Anything else we should know when reviewing? -->
- [x] Added/updated documentation