### PR TITLE
recording: Fix hang in audio processing

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/edl/audio.rb
+++ b/record-and-playback/core/lib/recordandplayback/edl/audio.rb
@@ -367,8 +367,8 @@ module BigBlueButton
               line = "[#{input_index}]"
               line << "atempo=#{speed},atrim=start=#{ms_to_s(audio_data[:timestamp])}," if speed != 1.0
               # Ensure the aresample filter doesn't see the next audio packet after a long pts gap
-              line << "atrim=end=#{ms_to_s(entry[:next_timestamp] - entry[:timestamp])},"
-              line << "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT},apad"
+              line << "atrim=end=#{ms_to_s(entry[:next_timestamp] - entry[:timestamp])},apad,"
+              line << "#{FFMPEG_ARESAMPLE},#{FFMPEG_AFORMAT}"
               line << "[#{track_label}];"
               filter_lines << line
               track_labels << "[#{track_label}]"


### PR DESCRIPTION
The changes made in bigbluebutton/bigbluebutton#25249 solved the immediate problem, but it turns out that cutting the input to the aresample filters could cause other issues which hang the ffmpeg process. To avoid these hangs, it's necessary for the input to the aresample filter to go up to (or potentially even slightly past) the end of the audio segment rather than be cut short. This can be done by moving the apad filter before the aresample filter.