### PR TITLE
fix: SVG support for notifications

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/component.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '/imports/ui/components/common/icon/component';
+import { PluginButtonIcon } from '/imports/ui/components/plugins/plugin-icon/styles';
 import Styled from './styles';
 
 const propTypes = {
-  icon: PropTypes.string,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   message: PropTypes.node.isRequired,
 };
 
@@ -14,6 +15,21 @@ const defaultIcons = {
   warning: 'warning',
   error: 'close',
   default: 'about',
+};
+
+const renderIcon = (icon, type) => {
+  if (icon && typeof icon === 'object' && 'svgContent' in icon) {
+    return (
+      <Styled.ToastCustomIcon>
+        <PluginButtonIcon>{icon.svgContent}</PluginButtonIcon>
+      </Styled.ToastCustomIcon>
+    );
+  }
+
+  let iconName = icon;
+  if (icon && typeof icon === 'object' && 'iconName' in icon) iconName = icon.iconName;
+
+  return <Icon iconName={iconName || defaultIcons[type]} />;
 };
 
 const Toast = ({
@@ -26,7 +42,7 @@ const Toast = ({
   <Styled.ToastContainer small={small} data-test="toastContainer">
     <Styled.Toast type={type}>
       <Styled.ToastIcon className="toastIcon" small={small}>
-        <Icon iconName={icon || defaultIcons[type]} />
+        {renderIcon(icon, type)}
       </Styled.ToastIcon>
       <Styled.ToastMessage data-test="toastSmallMsg">
         <span>{message}</span>

--- a/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/common/toast/styles.js
@@ -113,6 +113,14 @@ const ToastIcon = styled.div`
   `}
 `;
 
+const ToastCustomIcon = styled.span`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const ToastMessage = styled.div`
   margin-top: auto;
   margin-bottom: auto;
@@ -211,6 +219,7 @@ export default {
   CloseIcon,
   ToastContainer,
   ToastIcon,
+  ToastCustomIcon,
   ToastMessage,
   BackgroundColorInherit,
   Separator,


### PR DESCRIPTION
### What does this PR do:

Previously, even though passing an SVG content as the toast icon, the toast would be displayed with no icon at all.

Now this PR fix it.

