### PR TITLE
fix(shared-notes): prevent collaboration cursor name from leaking into links

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -107,6 +107,9 @@ const fixCursorAtOriginExtension = Extension.create({
   },
 });
 
+// TODO: remove this workaround once y-prosemirror's cursor decoration can set `marks: []`
+// (the upstream-correct fix is `marks: []` on the cursor `Decoration.widget` in
+// y-prosemirror/src/plugins/cursor-plugin.js; related: https://github.com/yjs/y-prosemirror/issues/174).
 // The remote collaboration cursor is a ProseMirror *widget decoration*. y-prosemirror
 // renders it with `side: 10` and no `marks`, so ProseMirror wraps the widget in the
 // marks of the node that follows the caret. When a remote user's caret sits inside (or

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -107,6 +107,37 @@ const fixCursorAtOriginExtension = Extension.create({
   },
 });
 
+// The remote collaboration cursor is a ProseMirror *widget decoration*. y-prosemirror
+// renders it with `side: 10` and no `marks`, so ProseMirror wraps the widget in the
+// marks of the node that follows the caret. When a remote user's caret sits inside (or
+// at the edge of) a link, that following node carries the `link` mark, so the cursor
+// widget — and therefore the user's name and the U+2060 word-joiner separators around
+// it — is rendered *inside* the <a>, polluting the link's visible text (issue #25225).
+//
+// y-prosemirror hardcodes the decoration spec and BlockNote exposes no hook for it, so
+// we use BlockNote's supported `renderCursor` hook to render a cursor that carries no
+// document text: the name lives in a `data-cursor-name` attribute shown via the CSS
+// `::after` rule below (pseudo-content is never part of `textContent`), and the U+2060
+// separators are omitted. The widget may still be positioned inside the link mark, but
+// it no longer leaks the name (or any separator characters) into the link's text/href.
+const renderCollaborationCursor = (user: { name: string; color: string }) => {
+  const cursorElement = document.createElement('span');
+  cursorElement.classList.add('bn-collaboration-cursor__base');
+
+  const caret = document.createElement('span');
+  caret.classList.add('bn-collaboration-cursor__caret');
+  caret.setAttribute('style', `background-color: ${user.color}`);
+
+  const label = document.createElement('span');
+  label.classList.add('bn-collaboration-cursor__label');
+  label.setAttribute('style', `background-color: ${user.color}`);
+  label.setAttribute('data-cursor-name', user.name ?? '');
+
+  caret.appendChild(label);
+  cursorElement.appendChild(caret);
+  return cursorElement;
+};
+
 const intlMessages = defineMessages({
   payloadSizeError: {
     id: 'app.notes.blocknote.payloadSizeError',
@@ -237,6 +268,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         name: userName || '',
         color: userColor || '',
       },
+      renderCursor: renderCollaborationCursor,
     },
     schema,
     dictionary: {
@@ -376,6 +408,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           }
           .bn-collaboration-cursor__label {
             color: ${colorWhite} !important;
+          }
+          /* The collaborator's name is held in a data attribute (see
+             renderCollaborationCursor) and rendered as pseudo-content so it never
+             becomes part of a surrounding link's text/href — issue #25225. */
+          .bn-collaboration-cursor__label::after {
+            content: attr(data-cursor-name);
           }
           .bn-collaboration-cursor__caret {
             overflow: visible !important;

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -1,0 +1,22 @@
+import { initializePages } from '../../core/helpers';
+import { test } from '../../core/setup/fixtures';
+import { BlockNoteSharedNotes } from './blocknote';
+
+test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
+  let blockNoteSharedNotes: BlockNoteSharedNotes;
+
+  test.beforeEach(async ({ browser, context }, testInfo) => {
+    blockNoteSharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(blockNoteSharedNotes, browser, {
+      isMultiUser: true,
+      createParameter: 'sharedNotesEditor=blocknote',
+      testInfo,
+    });
+  });
+
+  // Regression test for #25225 — BlockNote: a remote user's collaboration-cursor
+  // name must not be embedded in a link when their caret is positioned inside it.
+  test("Collaboration cursor must not embed a user's name in a link", async () => {
+    await blockNoteSharedNotes.collaborationCursorMustNotEmbedInLink();
+  });
+});

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -39,32 +39,30 @@ export class BlockNoteSharedNotes extends MultiUsers {
       timeout: ELEMENT_WAIT_LONGER_TIME,
     });
 
-    // The moderator clicks the link and nudges the caret a few characters inward, so
-    // the node following the caret is link-marked (the condition that makes
-    // y-prosemirror wrap the cursor widget in the link mark).
-    await getBlockNoteLinkLocator(this.modPage).first().click();
-    await this.modPage.page.keyboard.press('ArrowLeft');
-    await this.modPage.page.keyboard.press('ArrowLeft');
-    await this.modPage.page.keyboard.press('ArrowLeft');
+    // Place the moderator's caret a few characters inside the link — keyboard only.
+    // (Clicking the link opens BlockNote's link toolbar, which steals editor focus and
+    // stops y-prosemirror from broadcasting the cursor.) After typing, the caret sits
+    // after the trailing space; stepping left past the space and into the URL makes the
+    // node *after* the caret link-marked, which is what makes y-prosemirror wrap the
+    // remote cursor widget in the link mark — the #25225 trigger.
+    for (let i = 0; i < 9; i += 1) {
+      await this.modPage.page.keyboard.press('ArrowLeft');
+    }
 
-    // Poll until the attendee renders the moderator's remote cursor. The read runs
-    // inside readLinkAndCursorState via page.evaluate, which never focuses/activates
-    // the attendee page, so the moderator editor keeps focus and keeps broadcasting
-    // its cursor. This presence guard also prevents a clean-but-cursorless link from
-    // being a false pass.
+    // Wait until the attendee actually renders the moderator's cursor *inside* the link.
+    // This single poll is the presence guard + the bug precondition + a sync wait: a
+    // remote cursor exists and sits within the <a> (the exact #25225 condition), so a
+    // clean link cannot be a false pass. Reading via page.evaluate never focuses the
+    // attendee page, so the moderator editor keeps focus and keeps broadcasting.
+    // (A future upstream `marks: []` fix would render the widget *outside* the <a>;
+    // this precondition would then need relaxing.)
     await expect
-      .poll(async () => (await readLinkAndCursorState(this.userPage)).remoteCursorCount, {
-        message: 'attendee should render the moderator collaboration cursor',
+      .poll(async () => (await readLinkAndCursorState(this.userPage)).cursorWidgetInsideLink, {
+        message: 'attendee should render the moderator cursor inside the link',
         timeout: ELEMENT_WAIT_LONGER_TIME,
       })
-      .toBeGreaterThan(0);
+      .toBe(true);
     const state = await readLinkAndCursorState(this.userPage);
-
-    // Precondition: the cursor widget is actually positioned inside the link — the exact
-    // condition that triggers #25225. The fix neutralises the text leak without
-    // relocating the widget, so this stays true; a future upstream `marks: []` fix would
-    // move the widget out of the <a> and this guard should then be relaxed.
-    expect(state.cursorWidgetInsideLink, 'precondition: the remote cursor must sit inside the link').toBe(true);
 
     // The bug: the cursor name and U+2060 separators must not pollute the link text.
     expect(state.linkTextHasWordJoiner, 'link text must not contain U+2060 word-joiner separator characters').toBe(

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -8,11 +8,11 @@ import {
   getBlockNoteLinkLocator,
   readLinkAndCursorState,
   startBlockNoteSharedNotes,
+  WORD_JOINER,
 } from './util';
 
 // URL mirrors the link shown in the original #25225 report (it referenced issue 25175).
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
-const WORD_JOINER = '⁠';
 
 export class BlockNoteSharedNotes extends MultiUsers {
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -1,0 +1,74 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
+import { elements as e } from '../../core/elements';
+import { MultiUsers } from '../../user/multiusers';
+import {
+  getBlockNoteEditorLocator,
+  getBlockNoteLinkLocator,
+  readLinkAndCursorState,
+  startBlockNoteSharedNotes,
+} from './util';
+
+const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
+const WORD_JOINER = '⁠';
+
+export class BlockNoteSharedNotes extends MultiUsers {
+  // Reproduces issue #25225: when a remote user's caret sits inside a link, that
+  // user's collaboration-cursor name (and the U+2060 word-joiner separators around
+  // it) must NOT be embedded in the link's text or href as seen by other users.
+  async collaborationCursorMustNotEmbedInLink() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    await startBlockNoteSharedNotes(this.userPage);
+
+    // The moderator creates a link by typing a URL followed by a space (autolink).
+    const modEditor = getBlockNoteEditorLocator(this.modPage);
+    await modEditor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    // The link must sync to the attendee's editor.
+    await expect(getBlockNoteLinkLocator(this.userPage), 'should sync the pasted link to the attendee').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+
+    // The moderator clicks the link and nudges the caret a few characters inward, so
+    // the node following the caret is link-marked (the condition that makes
+    // y-prosemirror wrap the cursor widget in the link mark).
+    await getBlockNoteLinkLocator(this.modPage).first().click();
+    await this.modPage.page.keyboard.press('ArrowLeft');
+    await this.modPage.page.keyboard.press('ArrowLeft');
+    await this.modPage.page.keyboard.press('ArrowLeft');
+
+    // Allow awareness to broadcast and the attendee to render the remote cursor.
+    // Read via evaluate so the attendee page is not focused/activated (which would
+    // blur the moderator editor and stop its cursor from broadcasting).
+    await this.userPage.page.waitForTimeout(ELEMENT_WAIT_TIME);
+    const state = await readLinkAndCursorState(this.userPage);
+
+    // Presence guard: the moderator's remote cursor must actually be rendered for the
+    // attendee — otherwise a clean link would be a false pass.
+    expect(state.remoteCursorCount, 'attendee should render the moderator collaboration cursor').toBeGreaterThan(0);
+
+    // The bug: the cursor name and U+2060 separators must not pollute the link text.
+    expect(state.linkTextHasWordJoiner, 'link text must not contain U+2060 word-joiner separator characters').toBe(
+      false,
+    );
+    expect(state.linkText, "link text must not contain the other user's name").not.toContain(this.modPage.username);
+    expect(state.linkText, 'link text should equal the original URL').toBe(LINK_URL);
+
+    // ...nor the href / navigation target.
+    expect(state.linkHref, "link href must not contain the other user's name").not.toContain(this.modPage.username);
+    expect(state.linkHref, 'link href must not contain U+2060').not.toContain(WORD_JOINER);
+    expect(state.linkHref, 'link href should equal the original URL').toBe(LINK_URL);
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+}

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 import {
@@ -10,6 +10,7 @@ import {
   startBlockNoteSharedNotes,
 } from './util';
 
+// URL mirrors the link shown in the original #25225 report (it referenced issue 25175).
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 const WORD_JOINER = '⁠';
 
@@ -46,15 +47,24 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.page.keyboard.press('ArrowLeft');
     await this.modPage.page.keyboard.press('ArrowLeft');
 
-    // Allow awareness to broadcast and the attendee to render the remote cursor.
-    // Read via evaluate so the attendee page is not focused/activated (which would
-    // blur the moderator editor and stop its cursor from broadcasting).
-    await this.userPage.page.waitForTimeout(ELEMENT_WAIT_TIME);
+    // Poll until the attendee renders the moderator's remote cursor. The read runs
+    // inside readLinkAndCursorState via page.evaluate, which never focuses/activates
+    // the attendee page, so the moderator editor keeps focus and keeps broadcasting
+    // its cursor. This presence guard also prevents a clean-but-cursorless link from
+    // being a false pass.
+    await expect
+      .poll(async () => (await readLinkAndCursorState(this.userPage)).remoteCursorCount, {
+        message: 'attendee should render the moderator collaboration cursor',
+        timeout: ELEMENT_WAIT_LONGER_TIME,
+      })
+      .toBeGreaterThan(0);
     const state = await readLinkAndCursorState(this.userPage);
 
-    // Presence guard: the moderator's remote cursor must actually be rendered for the
-    // attendee — otherwise a clean link would be a false pass.
-    expect(state.remoteCursorCount, 'attendee should render the moderator collaboration cursor').toBeGreaterThan(0);
+    // Precondition: the cursor widget is actually positioned inside the link — the exact
+    // condition that triggers #25225. The fix neutralises the text leak without
+    // relocating the widget, so this stays true; a future upstream `marks: []` fix would
+    // move the widget out of the <a> and this guard should then be relaxed.
+    expect(state.cursorWidgetInsideLink, 'precondition: the remote cursor must sit inside the link').toBe(true);
 
     // The bug: the cursor name and U+2060 separators must not pollute the link text.
     expect(state.linkTextHasWordJoiner, 'link text must not contain U+2060 word-joiner separator characters').toBe(

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -8,6 +8,10 @@ import { Page } from '../../core/page';
 // is the ProseMirror root `.bn-editor` inside the shared-notes panel.
 export const BLOCKNOTE_EDITOR = '[data-test="notes"] .bn-editor';
 
+// U+2060 word-joiner: y-prosemirror wraps the remote collaboration-cursor name
+// in these invisible separators, which is what #25225 leaked into the link.
+export const WORD_JOINER = '⁠';
+
 export async function startBlockNoteSharedNotes(testPage: Page): Promise<void> {
   await testPage.waitAndClick(e.sharedNotes);
   await testPage.waitForSelector(e.hideNotesLabel, ELEMENT_WAIT_LONGER_TIME);
@@ -29,21 +33,23 @@ export function getBlockNoteLinkLocator(testPage: Page): Locator {
  * cursor owner's editor and stop their awareness cursor from broadcasting).
  */
 export function readLinkAndCursorState(testPage: Page) {
-  return testPage.page.evaluate((sel: string) => {
-    const WORD_JOINER = '⁠';
-    const anchor = document.querySelector(`${sel} a`) as HTMLAnchorElement | null;
-    // One `__base` element per remote cursor — count bases only for an accurate count.
-    const cursorBases = document.querySelectorAll(`${sel} .bn-collaboration-cursor__base`);
-    return {
-      linkText: anchor ? (anchor.textContent ?? '') : '',
-      linkHref: anchor ? (anchor.getAttribute('href') ?? '') : '',
-      linkTextHasWordJoiner: anchor ? (anchor.textContent ?? '').includes(WORD_JOINER) : false,
-      cursorWidgetInsideLink: anchor
-        ? !!anchor.querySelector(
-            '.bn-collaboration-cursor__base, .bn-collaboration-cursor__caret, .bn-collaboration-cursor__label',
-          )
-        : false,
-      remoteCursorCount: cursorBases.length,
-    };
-  }, BLOCKNOTE_EDITOR);
+  return testPage.page.evaluate(
+    ({ sel, wordJoiner }: { sel: string; wordJoiner: string }) => {
+      const anchor = document.querySelector(`${sel} a`) as HTMLAnchorElement | null;
+      // One `__base` element per remote cursor — count bases only for an accurate count.
+      const cursorBases = document.querySelectorAll(`${sel} .bn-collaboration-cursor__base`);
+      return {
+        linkText: anchor ? (anchor.textContent ?? '') : '',
+        linkHref: anchor ? (anchor.getAttribute('href') ?? '') : '',
+        linkTextHasWordJoiner: anchor ? (anchor.textContent ?? '').includes(wordJoiner) : false,
+        cursorWidgetInsideLink: anchor
+          ? !!anchor.querySelector(
+              '.bn-collaboration-cursor__base, .bn-collaboration-cursor__caret, .bn-collaboration-cursor__label',
+            )
+          : false,
+        remoteCursorCount: cursorBases.length,
+      };
+    },
+    { sel: BLOCKNOTE_EDITOR, wordJoiner: WORD_JOINER },
+  );
 }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -1,0 +1,51 @@
+import { Locator } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
+import { elements as e } from '../../core/elements';
+import { Page } from '../../core/page';
+
+// The BlockNote editor renders inline (no Etherpad iframes); its editable area
+// is the ProseMirror root `.bn-editor` inside the shared-notes panel.
+export const BLOCKNOTE_EDITOR = '[data-test="notes"] .bn-editor';
+
+export async function startBlockNoteSharedNotes(testPage: Page): Promise<void> {
+  await testPage.waitAndClick(e.sharedNotes);
+  await testPage.waitForSelector(e.hideNotesLabel, ELEMENT_WAIT_LONGER_TIME);
+  await testPage.waitForSelector(BLOCKNOTE_EDITOR, ELEMENT_WAIT_LONGER_TIME);
+}
+
+export function getBlockNoteEditorLocator(testPage: Page): Locator {
+  return testPage.page.locator(BLOCKNOTE_EDITOR);
+}
+
+export function getBlockNoteLinkLocator(testPage: Page): Locator {
+  return testPage.page.locator(`${BLOCKNOTE_EDITOR} a`);
+}
+
+/**
+ * Reads the rendered state of the first <a> link in another user's BlockNote
+ * editor, plus whether a remote collaboration cursor is present. Runs via
+ * `evaluate` so it never focuses/activates the page (which would blur the
+ * cursor owner's editor and stop their awareness cursor from broadcasting).
+ */
+export function readLinkAndCursorState(testPage: Page) {
+  return testPage.page.evaluate((sel: string) => {
+    const WORD_JOINER = '⁠';
+    const anchor = document.querySelector(`${sel} a`) as HTMLAnchorElement | null;
+    const cursorBases = document.querySelectorAll(
+      `${sel} .bn-collaboration-cursor__base, ${sel} .bn-collaboration-cursor__caret`,
+    );
+    return {
+      hasAnchor: !!anchor,
+      linkText: anchor ? (anchor.textContent ?? '') : '',
+      linkHref: anchor ? (anchor.getAttribute('href') ?? '') : '',
+      linkTextHasWordJoiner: anchor ? (anchor.textContent ?? '').includes(WORD_JOINER) : false,
+      cursorWidgetInsideLink: anchor
+        ? !!anchor.querySelector(
+            '.bn-collaboration-cursor__base, .bn-collaboration-cursor__caret, .bn-collaboration-cursor__label',
+          )
+        : false,
+      remoteCursorCount: cursorBases.length,
+    };
+  }, BLOCKNOTE_EDITOR);
+}

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -32,11 +32,9 @@ export function readLinkAndCursorState(testPage: Page) {
   return testPage.page.evaluate((sel: string) => {
     const WORD_JOINER = '⁠';
     const anchor = document.querySelector(`${sel} a`) as HTMLAnchorElement | null;
-    const cursorBases = document.querySelectorAll(
-      `${sel} .bn-collaboration-cursor__base, ${sel} .bn-collaboration-cursor__caret`,
-    );
+    // One `__base` element per remote cursor — count bases only for an accurate count.
+    const cursorBases = document.querySelectorAll(`${sel} .bn-collaboration-cursor__base`);
     return {
-      hasAnchor: !!anchor,
       linkText: anchor ? (anchor.textContent ?? '') : '',
       linkHref: anchor ? (anchor.getAttribute('href') ?? '') : '',
       linkTextHasWordJoiner: anchor ? (anchor.textContent ?? '').includes(WORD_JOINER) : false,


### PR DESCRIPTION
### What does this PR do?

In the BlockNote shared notes editor, when one user puts their text cursor inside a link, their collaboration‑cursor **name** was rendered *inside* the `<a>` for everyone else — wrapped in invisible `U+2060` word‑joiner characters. Copying or reading the link then gave a broken URL with the name spliced into it (e.g. `…/issues/` + `Firstname Lastname` + `25175`).

The remote cursor is a ProseMirror widget that y‑prosemirror places without a `marks` override, so inside a link it inherits the link mark. y‑prosemirror exposes no hook for that, so the fix uses BlockNote's supported `renderCursor` hook: the name is now held in a `data-cursor-name` attribute and shown via CSS `::after` (never as document text), and the `U+2060` separators are dropped. The cursor still shows normally as a presence badge — only the leaked text is gone, so the link's text and href stay clean.

Also adds a two‑user Playwright regression test for BlockNote shared notes.

### Closes Issue(s)

Closes bigbluebutton/bigbluebutton#25225

### How to test

1. Two users (A and B) in a meeting with **shared notes** open (BlockNote editor).
2. B pastes/types a link; A places their caret inside that link.
3. **Before:** B sees A's name embedded in the link, and copying it yields the URL with A's name spliced in. **After:** the link text/href are clean and A's name shows only as a floating cursor badge.

Automated: `bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts` (2‑user) — fails on an unpatched build, passes with this fix.

### More

- Fixed in our integration layer (`renderCursor`) rather than patching y‑prosemirror; a future upstream `marks: []` fix could replace it.
- Render‑only change: no document/Yjs content or href is altered, and the name is a text node (not HTML), so this is not an XSS.