### PR TITLE
Add client setting to not display guest lobby position

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -63,6 +63,7 @@ export interface App {
   skipMeetingEnded: boolean
   dynamicGuestPolicy: boolean
   enableGuestLobbyMessage: boolean
+  showGuestLobbyWaitingQueuePosition: boolean
   guestPolicyExtraAllowOptions: boolean
   alwaysShowWaitingRoomUI: boolean
   enableLimitOfViewersInWebcam: boolean

--- a/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/guest-wait/component.tsx
@@ -93,6 +93,8 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
   const lobbyMessageRef = useRef('');
   const positionInWaitingQueueRef = useRef('');
   const loadingContextInfo = useContext(LoadingContext);
+  const showPositionInWaitingQueue = window.meetingClientSettings
+    .public.app.showGuestLobbyWaitingQueuePosition !== false;
 
   const updateLobbyMessage = useCallback((message: string | null) => {
     if (!message) {
@@ -168,7 +170,7 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
 
     // WAIT
     updateLobbyMessage(guestLobbyMessage || '');
-    if (positionInWaitingQueue) {
+    if (showPositionInWaitingQueue && positionInWaitingQueue) {
       updatePositionInWaitingQueue(positionInWaitingQueue);
     }
   }, [
@@ -177,6 +179,7 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
     logoutUrl,
     positionInWaitingQueue,
     intl,
+    showPositionInWaitingQueue,
     updateLobbyMessage,
     updatePositionInWaitingQueue,
   ]);
@@ -187,9 +190,11 @@ const GuestWait: React.FC<GuestWaitProps> = (props) => {
     <Styled.Container>
       <Styled.Content id="content">
         <Styled.Heading id="heading">{intl.formatMessage(intlMessages.windowTitle)}</Styled.Heading>
-        <Styled.Position id="positionInWaitingQueue">
-          <p aria-live="polite">{positionMessage}</p>
-        </Styled.Position>
+        {showPositionInWaitingQueue && (
+          <Styled.Position id="positionInWaitingQueue">
+            <p aria-live="polite">{positionMessage}</p>
+          </Styled.Position>
+        )}
         {hasCustomMessage && (
           <Styled.MessageContainer>
             <Styled.MessageLabel>

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -42,6 +42,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       skipMeetingEnded: false,
       dynamicGuestPolicy: true,
       enableGuestLobbyMessage: true,
+      showGuestLobbyWaitingQueuePosition: true,
       guestPolicyExtraAllowOptions: false,
       alwaysShowWaitingRoomUI: true,
       enableLimitOfViewersInWebcam: false,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -62,6 +62,8 @@ public:
     skipMeetingEnded: false
     dynamicGuestPolicy: true
     enableGuestLobbyMessage: true
+    # Show the guest user's position in the lobby waiting queue.
+    # Set to false when users should not see their place in line.
     showGuestLobbyWaitingQueuePosition: true
     guestPolicyExtraAllowOptions: false
     alwaysShowWaitingRoomUI: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -62,6 +62,7 @@ public:
     skipMeetingEnded: false
     dynamicGuestPolicy: true
     enableGuestLobbyMessage: true
+    showGuestLobbyWaitingQueuePosition: true
     guestPolicyExtraAllowOptions: false
     alwaysShowWaitingRoomUI: true
     enableLimitOfViewersInWebcam: false

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1490,6 +1490,19 @@ You can overwrite the default guest policy in `/etc/bigbluebutton/bbb-web.proper
 #
 defaultGuestPolicy=ALWAYS_ACCEPT
 ```
+
+#### Configure guest lobby queue position
+
+When the guest policy makes users wait for moderator approval, the HTML5 client shows each guest their position in the waiting queue by default. To hide this position, set `public.app.showGuestLobbyWaitingQueuePosition` to `false` in `/etc/bigbluebutton/bbb-html5.yml`.
+
+```yaml
+public:
+  app:
+    showGuestLobbyWaitingQueuePosition: false
+```
+
+Restart BigBlueButton with `sudo bbb-conf --restart` for the change to take effect.
+
 #### Show a custom logo on the client
 
 Ensure that the parameter `displayBrandingArea` is set to `true` in bbb-html5's configuration, restart BigBlueButton server with `sudo bbb-conf --restart` and pass `logo=<image-url>` in Custom parameters when creating the meeting.

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -394,6 +394,10 @@ In BigBlueButton 2.6.17/2.7.5/3.0.0-alpha.5 we added a new configuration propert
 
 In BigBlueButton 3.0.0-alpha.5 we replaced the JOIN parameter `defaultLayout` with the JOIN parameter `userdata-bbb_default_layout`. If none provided the `meetingLayout` (passed on CREATE) will be used. If none passed, and if none passed there, the `defaultMeetingLayout` from bbb-web will be used.
 
+#### Added new setting to control guest lobby waiting queue position
+
+- Client settings.yml: `showGuestLobbyWaitingQueuePosition`. Defaults to `true`
+
 #### Added new setting and userdata to allow skipping echo test if session has valid input/output devices stored
 
 - Client settings.yml: `skipEchoTestIfPreviousDevice`. Defaults to `false`


### PR DESCRIPTION
### What does this PR do?

Introduces new client setting `public.app.showGuestLobbyWaitingQueuePosition` (default: true) to control the displaying of the user position in guest lobby list

#### showGuestLobbyWaitingQueuePosition = true (default value)

<img width="884" height="386" alt="Screenshot from 2026-06-19 08-33-12" src="https://github.com/user-attachments/assets/a15b8ef8-cb86-4e42-8a72-42f2235cf7fb" />


#### showGuestLobbyWaitingQueuePosition = false

<img width="884" height="386" alt="Screenshot from 2026-06-19 08-21-41" src="https://github.com/user-attachments/assets/419fa17a-5d05-4882-9b61-2b75e675becc" />


### Closes Issue(s)
Closes #25291