### PR TITLE
Set MALLOC_ARENA_MAX=2 for bbb-web and bbb-apps-akka

### DIFF
--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -59,6 +59,12 @@ for unit in freeswitch nginx redis-server postgresql; do
   cp bigbluebutton.conf "staging/usr/lib/systemd/system/${unit}.service.d/"
 done
 
+# MALLOC_ARENA_MAX=2 for JVM services - reduces glibc malloc arena overhead
+for svc in bbb-web bbb-apps-akka; do
+  mkdir -p "staging/usr/lib/systemd/system/${svc}.service.d"
+  cp malloc-arena.conf "staging/usr/lib/systemd/system/${svc}.service.d/"
+done
+
 . ./opts-$DISTRO.sh
 
 #

--- a/build/packages-template/bbb-config/malloc-arena.conf
+++ b/build/packages-template/bbb-config/malloc-arena.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="MALLOC_ARENA_MAX=2"


### PR DESCRIPTION
### What does this PR do?

Ships `MALLOC_ARENA_MAX=2` as a systemd drop-in via the `bbb-config` package for the two JVM services: `bbb-web` and `bbb-apps-akka`.

The drop-in files are installed to:
- `/usr/lib/systemd/system/bbb-web.service.d/malloc-arena.conf`
- `/usr/lib/systemd/system/bbb-apps-akka.service.d/malloc-arena.conf`

Each contains:

```ini
[Service]
Environment="MALLOC_ARENA_MAX=2"
```

The `build.sh` change follows the existing pattern already used for freeswitch, nginx, redis-server, and postgresql drop-ins in the same file.

### Motivation

glibc's malloc allocates a pool of independent arenas (default: `8 x vCPU` on 64-bit Linux). Each arena can hold up to 64 MB of virtual address space. Once pages are faulted in, glibc rarely returns them to the OS, so a long-running multi-threaded process accumulates elevated RSS that doesn't correspond to any live working set.

JVM services like `bbb-web` and `bbb-apps-akka` are not malloc-hot (almost all allocations are JVM-heap-managed via G1), so clamping the arena pool to 2 trades zero measurable latency for substantial RSS reduction.

**Measured results (bbb-web, 36 h A/B with three-host controls, BBB 3.0.29, 8 vCPU / 32 GB):**

| Host | Treatment | RSS p95 pre | RSS p95 post | Delta RSS p95 |
|---|---|---:|---:|---:|
| 230001 | none (control) | 1450 MB | 1387 MB | -63 MB |
| 230002 | NMT only (control) | 1625 MB | 1588 MB | -37 MB |
| 230004 | **MALLOC_ARENA_MAX=2** | **1730 MB** | **1098 MB** | **-632 MB** |

The 30-60 MB shift on the two control hosts is natural day-to-day load variation. The treatment host shifted by ~10x the baseline, net **-569 MB** vs control 1, **-595 MB** vs control 2.

Heap, metaspace, GC behavior, and thread count were unchanged across the cutover. The full 632 MB delta is glibc-arena off-heap overhead.

**Projected for bbb-apps-akka:** ~150-250 MB off-heap savings (projected from its lower thread count of ~140 vs ~230 on bbb-web; not yet directly measured).

**Industry precedent:** Cassandra ships `MALLOC_ARENA_MAX=4`, Elasticsearch ships `MALLOC_ARENA_MAX=4`. This is standard practice for multi-threaded JVM workloads on glibc.

**Non-JVM services are not affected:** `bbb-graphql-server` (Haskell), `bbb-graphql-middleware` (Go), `bbb-html5` (Node), `bbb-pads` (Node), and `bbb-livekit` (Go) all use their own allocators, so glibc arenas are not the dominant off-heap source for these.

### How to test

1. Build the `bbb-config` package from this branch.
2. Install it on a BBB server.
3. Verify the drop-in files exist:
   ```
   cat /usr/lib/systemd/system/bbb-web.service.d/malloc-arena.conf
   cat /usr/lib/systemd/system/bbb-apps-akka.service.d/malloc-arena.conf
   ```
4. Reload systemd and restart the services:
   ```
   systemctl daemon-reload
   systemctl restart bbb-web bbb-apps-akka
   ```
5. Verify the env var is set in the process:
   ```
   systemctl show bbb-web -p Environment
   ```
   Expected output includes `MALLOC_ARENA_MAX=2`.
6. (Optional) Monitor RSS over 24 h and compare against a control host without the change.

**Override:** Operators who need to restore stock behavior can drop a higher-priority file in `/etc/systemd/system/bbb-web.service.d/00-override.conf` with `Environment="MALLOC_ARENA_MAX=0"` (0 = unlimited, glibc default).

### More

- [ ] Added/updated documentation — not applicable (package-level default, documented in commit message and PR body)

**Spec-independent:** The absolute MB saved scales with vCPU count (default arena pool = `8 x vCPU`), but the direction and risk profile are the same on every BBB host. The clamp helps everyone; it helps bigger boxes more.

**Risk profile:** `MALLOC_ARENA_MAX` is a glibc knob, silently ignored under musl (Alpine). BBB officially ships on Ubuntu (glibc), so this is moot for the upstream default. No JNI hotpaths exist in `bbb-web` or `bbb-apps-akka`. 36 h of production data shows zero latency impact.