### PR TITLE
fix(bbb-graphql-server): lower connection_lifetime to limit Postgres memory growth

### DIFF
--- a/bbb-graphql-server/metadata/databases/databases.yaml
+++ b/bbb-graphql-server/metadata/databases/databases.yaml
@@ -19,7 +19,7 @@
       database_url: postgres://bbb_hasura:bbb_hasura@127.0.0.1:5432/bbb_graphql
       isolation_level: read-committed
       pool_settings:
-        connection_lifetime: 3600
+        connection_lifetime: 300
         max_connections: 100
       use_prepared_statements: true
   tables: "!include BigBlueButton/tables/tables.yaml"


### PR DESCRIPTION
## Summary

The `BigBlueButton` source in `bbb-graphql-server/metadata/databases/databases.yaml` keeps each Postgres connection alive for 1 hour (`connection_lifetime: 3600`). This lowers it to `300` (5 minutes) - the value tested in the investigation.

It is a one-line change, but it fixes a real memory problem, shown in the charts below.

## The problem

On busy BBB 3.x servers, Postgres memory grows through the day and never comes back down, even when load drops. Over a workday this pushes servers into swap, and the visible result is audio joins timing out during the busiest hours.

A snapshot of 5 production hosts:

| Host | Connections | Postgres memory | idle (graphql pool) | Per-connection memory | idle-in-transaction |
|------|------------:|----------------:|--------------------:|----------------------:|--------------------:|
| A | 72 | 6.74 GB | 59 | 100-200 MB | 0 |
| B | 78 | 8.06 GB | 64 | 100-200 MB | 0 |
| C | 79 | 7.95 GB | 65 | 100-200 MB | 0 |
| D | 108 | 7.87 GB | 94 | 60-100 MB | 0 |
| E | 84 | 5.17 GB | 72 | 60-100 MB | 0 |

Almost every connection belongs to the BBB graphql server's pool, sits idle, and was used less than a minute ago. The last column matters: `idle-in-transaction` is 0 on every host, which rules out the most common fix people try first.

## Why it happens

The BBB graphql server keeps a pool of Postgres connections and reuses them. While a connection stays open, Postgres holds onto the memory it used to run queries and does not give it back to the system. The only thing that frees that memory is closing the connection.

The pool closes a connection after it has been idle for 180 seconds, or after it has lived for `connection_lifetime`. During a busy day the pool is never idle for 180 seconds (the graphql server queries it constantly), so the only thing recycling connections is `connection_lifetime: 3600` - one full hour. With up to 100 connections each holding memory for an hour, several GB pile up and never get returned.

Each line below is one connection. Its memory only goes up, never down, for as long as it lives:

![Per-connection memory over time, stock config - it only goes up](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-22/85ee6e40-6834-4653-b049-85df732463f4/chart-2.png)

## Why the usual fixes don't work

- `idle_in_transaction_session_timeout` - there are no idle-in-transaction connections (the pool is plain idle), so there is nothing for it to act on.
- `idle_session_timeout` - Postgres resets this timer on every query. The graphql server queries the pool constantly, so no connection is ever idle long enough for it to fire. Tested at 300s: no effect.

There is also a trap that hides the bug in tests: if a test pauses longer than 180 seconds between bursts of activity, the pool drains on its own and memory snaps back, so the server looks healthy. Production never pauses that long, so the problem only shows up there.

## The fix

Lower `connection_lifetime` from `3600` to `300`. Connections now close and reopen every 5 minutes while still under load, so the memory they held is freed before it can pile up.

Same workload, stock config vs the fix:

![Total Postgres memory over time: stock (3600s) vs fix (300s)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-22/fad18c5b-2b7b-4337-b000-ae8e0c1cca37/chart-1.png)

- **Stock (3600s):** the memory held between bursts only climbs (750 -> 882 MB) until the 1-hour lifetime finally starts closing the oldest connections.
- **Fix (300s):** the memory held between bursts falls (761 -> 676 MB) under the same load.

The effect is clearest here - each dot is one connection sampled every 20 seconds, age vs memory:

![Each connection's age vs memory: stock vs fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-22/4cf23635-4dc3-460b-8374-7593d0fd400a/chart-3.png)

Stock drifts to the top-right (older connections holding more memory); the fix keeps both age and memory small.

## Cost

One reconnect per connection every 5 minutes. The graphql server already queries each connection constantly, so this is negligible.

## Rollout

Test on one host first with `connection_lifetime: 300` and confirm: Postgres memory stays bounded across a full workday, the `bbb-graphql-server` logs show no connection errors, and client `graphql_client_error` rates are unchanged.

Draft - opening for early review.
