### PR TITLE
fix(html5): correct recording timer when client clock is ahead of server

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/connection-status/component.jsx
@@ -94,8 +94,8 @@ const ConnectionStatus = ({
         connectionStatus.setMinRtt(networkRtt);
         const clientNowEpoch = Date.now();
         const oneWay = networkRtt / 2; // aproximation NTP
-        // Not allow negative skew
-        const skew = Math.max(0, ((serverEpochMsec * 1000) + oneWay) - clientNowEpoch);
+        // Allow negative skew to correct a client clock that is ahead of the server
+        const skew = ((serverEpochMsec * 1000) + oneWay) - clientNowEpoch;
         logger.debug({ logCode: 'latency_skew_calc' }, 'Latency between server and client (skew ms): %d (serverEpochMsec=%d, clientNowEpoch=%d, oneWay=%d)', skew, serverEpochMsec, clientNowEpoch, oneWay);
         setTimeSync(skew);
         timeSyncRef.current = skew;

--- a/bigbluebutton-tests/playwright/recording/recordingTimerClockSkew.spec.ts
+++ b/bigbluebutton-tests/playwright/recording/recordingTimerClockSkew.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { test } from '../core/setup/fixtures';
+import { constants as c } from '../parameters/constants';
+
+// Regression test for the recording-timer clock-skew bug (issue #25312).
+// When the moderator's system clock is ahead of the server, the recording timer used to
+// jump straight to the clock offset (e.g. "14:00") right after Start Recording, instead of
+// starting at "00:00". The recording itself was always correct - only the displayed timer
+// was wrong, because the timeSync skew was clamped to a non-negative value and could not
+// correct a client-ahead clock.
+const CLOCK_SKEW_MINUTES = 14;
+const CLOCK_SKEW_MS = CLOCK_SKEW_MINUTES * 60 * 1000;
+
+test.describe('Recording timer', { tag: '@ci' }, () => {
+  test('should start at zero when the moderator clock is ahead of the server', async ({ browser, page }) => {
+    // Simulate a moderator whose system clock is 14 minutes ahead of the server.
+    // This must run before any navigation so the client sees the skewed clock from the
+    // very first script it executes.
+    await page.addInitScript((skewMs) => {
+      const RealDate = Date;
+      const realNow = RealDate.now.bind(RealDate);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      class SkewedDate extends RealDate {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+          if (args.length === 0) {
+            super(realNow() + skewMs);
+          } else {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            super(...(args as []));
+          }
+        }
+
+        static now(): number {
+          return realNow() + skewMs;
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).Date = SkewedDate;
+    }, CLOCK_SKEW_MS);
+
+    const modPage = new Page(browser, page);
+    await modPage.init(true, { fullName: 'Moderator', createParameter: c.recordMeeting });
+
+    // Give the RTT worker time to send its first round-trip to /rtt-check.
+    // The timeSync skew is only set after the first RTT message arrives; without
+    // this wait the timer shows the raw client clock offset until the worker kicks in.
+    await modPage.page.waitForTimeout(5000);
+
+    // start recording
+    const recordingIndicatorButton = modPage.page.locator(`${e.recordingIndicator} button`);
+    await modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
+    await modPage.hasElement(e.recordingIndicator, 'should display the recording indicator once joined');
+    await modPage.waitAndClick(e.recordingIndicator);
+    await modPage.hasElement(e.simpleModal, 'should display the recording modal');
+    await modPage.hasElement(e.yesButton, 'should display the "Yes" button in the recording modal');
+    await modPage.waitAndClick(e.yesButton);
+    await expect(
+      recordingIndicatorButton,
+      'recording indicator button should have a red background color when recording',
+    ).toHaveCSS('background-color', 'rgb(174, 16, 16)');
+
+    // The timer must start near 0:00. With the clock-skew bug it shows ~14:00 instead,
+    // because the clamped (>= 0) skew leaves the client's clock offset baked into the
+    // elapsed time. The skew correction is applied asynchronously after the first RTT
+    // round-trip, so we poll until the timer reflects the corrected value.
+    await expect
+      .poll(
+        async () => {
+          const text = await recordingIndicatorButton.textContent();
+          const match = text?.match(/(\d{1,2}):(\d{2})/);
+          if (!match) return Infinity;
+          return Number(match[1]) * 60 + Number(match[2]);
+        },
+        {
+          timeout: 15000,
+          message: 'recording timer should start near 0:00 after skew correction',
+        },
+      )
+      .toBeLessThan(60);
+
+    // capture evidence of the displayed timer (named per run via EVIDENCE_TAG)
+    const evidenceTag = process.env.EVIDENCE_TAG || 'recording-timer';
+    await modPage.page.screenshot({ path: `/tmp/evidence/${evidenceTag}.png` });
+  });
+});


### PR DESCRIPTION
## What is happening

When a moderator presses Start Recording, the recording timer in the top bar can immediately show a non-zero value (e.g. "14:00") instead of "0:00". The recording itself is correct - only the displayed timer is wrong. This happens when the moderator's computer clock is ahead of the server's clock.

## Why it happens

The HTML5 client periodically asks the server for its time and compares it with the browser's own clock. The difference (called "skew") is used to correct all time-based displays (recording timer, meeting countdown, breakout timers).

The problem: the skew calculation clamped the result to never go below zero:

```js
const skew = Math.max(0, ((serverEpochMsec * 1000) + oneWay) - clientNowEpoch);
```

This means the correction only worked in one direction - when the server's clock was ahead of the client. When the client's clock was ahead (the common case for a moderator with an unsynced Windows laptop), the correction was silently set to zero, and the timer showed the client's clock offset as if it were elapsed recording time.

## The fix

Remove the clamp so the skew can be negative:

```js
const skew = ((serverEpochMsec * 1000) + oneWay) - clientNowEpoch;
```

This allows the correction to work in both directions. All counters that use `Date.now() + timeSync` (recording timer, meeting remaining-time, breakout countdown, external video sync) now display correctly regardless of whether the client clock is ahead or behind the server.

## Why not bound the skew to plus or minus 24 hours?

A two-sided bound (reject skew if its absolute value exceeds 24h) was considered but rejected. If a user's clock is set to, say, January 2001, the skew would be about 25 years - well over 24h. The bound would reject the correction, leaving timeSync at zero, and the timer would show an absurd value based on the raw client clock. Without the bound, the skew correction handles any clock offset, no matter how large, and the timer always shows the correct elapsed time.

The only scenario where a bound would help is if the server sends garbage data (e.g. a misconfigured proxy injects a bad timestamp). But the right place to guard against that is validating the server response, not clamping the calculated skew.

## Test

An e2e test (`recordingTimerClockSkew.spec.ts`) simulates a moderator whose clock is 14 minutes ahead by overriding `Date.now()` in the browser. The test starts a recording and verifies the timer shows near "0:00" (not "14:00").

## Evidence

**Before fix** - timer shows 14:00 right after pressing Start Recording:

[![Before fix: timer shows 14:00](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/a3586560-b766-4c50-b622-27ca9997cc25/before-fix.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/fd664fff-5060-47cc-95d5-9be581bf5aca/before-fix.mp4)

**After fix** - timer starts at 0:00 regardless of clock offset:

[![After fix: timer starts at 0:00](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/753b8a47-853c-40ed-acf9-90359b5d62ef/after-fix.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/56ea6d5a-cf62-4512-851c-cf3322ae0cc5/after-fix.mp4)

Closes #25312
