### PR TITLE
fix(bbb-export-annotations): add viewBox to background slides missing one to prevent ODF export cropping

### DIFF
--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -296,6 +296,39 @@ async function overlayAnnotations(svg, slideAnnotations) {
 }
 
 /**
+ * Ensure a slide background SVG carries a viewBox.
+ *
+ * The background slide is loaded as an `<image>` sized to the slide, but
+ * CairoSVG only rescales the referenced SVG to that box when the file is
+ * resolution-independent (carries a viewBox). Slides converted without one
+ * keep their intrinsic size and render cropped into the top-left corner.
+ * When the attribute is missing, derive it from the SVG's own width and
+ * height so the background scales to fill the slide. See issue #25303.
+ * @param {string} file Path of the slide SVG.
+ * @param {number} page Page number (for logging).
+ */
+function ensureSlideViewBox(file, page) {
+  try {
+    const svg = fs.readFileSync(file, {encoding: 'utf-8'});
+    const svgTag = svg.match(/<svg[^>]*>/)?.[0];
+
+    if (!svgTag || /viewBox=/.test(svgTag)) return;
+
+    const width = svgTag.match(/width="([\d.]+)/)?.[1];
+    const height = svgTag.match(/height="([\d.]+)/)?.[1];
+
+    if (!width || !height) return;
+
+    const patchedTag = svgTag.replace(
+        '<svg', `<svg viewBox="0 0 ${width} ${height}"`);
+    fs.writeFileSync(file, svg.replace(svgTag, patchedTag));
+  } catch (error) {
+    logger.error(`Adding viewBox to slide ${page} ` +
+      `failed for job ${jobId}: ${error.message}`);
+  }
+}
+
+/**
  * Processes presentation slides and associated annotations into
  * a single PDF file.
  * @async
@@ -377,6 +410,16 @@ async function processPresentationAnnotations() {
           'xmlns': 'http://www.w3.org/2000/svg',
           'xmlns:xlink': 'http://www.w3.org/1999/xlink',
         });
+
+    // Guarantee the background slide scales to fill the canvas. CairoSVG only
+    // rescales a referenced SVG when it has a viewBox; converted slides that
+    // lack one would otherwise render cropped (issue #25303).
+    if (backgroundFormat === 'svg') {
+      ensureSlideViewBox(
+          `${dropbox}/slide${currentSlide.page}.${backgroundFormat}`,
+          currentSlide.page,
+      );
+    }
 
     // Add the image element
     canvas

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -314,8 +314,8 @@ function ensureSlideViewBox(file, page) {
 
     if (!svgTag || /viewBox=/.test(svgTag)) return;
 
-    const width = svgTag.match(/width="([\d.]+)/)?.[1];
-    const height = svgTag.match(/height="([\d.]+)/)?.[1];
+    const width = svgTag.match(/(?<![\w-])width\s*=\s*['"]([\d.]+)/i)?.[1];
+    const height = svgTag.match(/(?<![\w-])height\s*=\s*['"]([\d.]+)/i)?.[1];
 
     if (!width || !height) return;
 


### PR DESCRIPTION
## What's happening

When a presentation is exported with whiteboard annotations (PDF), slides that contain an image can render with that image **cropped** instead of filling the slide. This happens when the slide's background SVG was converted **without a `viewBox`** — older conversion output, as reported in #25303.

## Why it happens

`bbb-export-annotations` loads each slide background as an `<image>` sized to the slide canvas:

```js
canvas.image(`file://${dropbox}/slide${page}.${backgroundFormat}`)
     .size(scaledWidth, scaledHeight);
```

CairoSVG only rescales a referenced SVG to that box when the SVG is resolution-independent — i.e. when it carries a `viewBox`. Slides converted without one keep their intrinsic size, so a background larger than the slide is anchored at the top-left and clipped on the right/bottom.

## The fix

Add `ensureSlideViewBox(file, page)` in `bbb-export-annotations/workers/process.js`. When the background slide SVG lacks a `viewBox`, derive one (`viewBox="0 0 W H"`) from the SVG's own `width`/`height` so the background scales to fill the slide. It is a **no-op when a `viewBox` already exists**, so decks that already convert correctly are unaffected.

Re-introducing the previously-removed `resizeAssetIfBase64Image` is not the right fix — it regresses decks that already carry a `viewBox`, which is why it was removed in 62704de56f.

## Validation

The current build's converter always emits a `viewBox`, so the crop does not reproduce end-to-end on a live export in this environment. To validate the fix against the affected condition (a slide background SVG with **no** `viewBox`, as the decks in #25303 had), the real default "Welcome to BigBlueButton" slide — which contains a real image — was rendered through the actual export rendering path (`bbb-export-annotations` `svg.js` + CairoSVG 2.5.2, deployed `cairoSVGUnsafeFlag=false` config), with its `viewBox` stripped to reproduce the bug, toggling the fix off/on:

**Before** — real Welcome slide, viewBox stripped, fix OFF: the background renders at intrinsic size, larger than the slide, so it is clipped — anchored top-left, with the subtitle truncated ("...online l") and the right feature column / footer cut off.

![before-cropped](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-24/e8620006-4359-4044-a30a-78089b119dec/bbb25303-recap-before.png)

**After fix** — same slide, viewBox stripped, `ensureSlideViewBox` re-derives it: the image scales to fill the slide (all features, full subtitle and footer visible).

![after-fix-full](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-24/da9387b4-08bb-40aa-8e6b-1cdb00d40f64/bbb25303-recap-after.png)

**No regression** — a slide that already carries a `viewBox` renders identically with the fix deployed (the `ensureSlideViewBox` no-op path leaves it untouched):

![no-regression](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/63342c4a-15c6-40bf-85ad-0d576835a002/bbb25303-no-regression.png)

Closes #25303
