### PR TITLE
fix(tests): install BlockNote shared notes in v4 CI on Noble

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -269,8 +269,8 @@ jobs:
           PKGS="bbb-apps-akka bbb-config bbb-etherpad bbb-export-annotations
                 bbb-freeswitch-core bbb-freeswitch-sounds bbb-fsesl-akka bbb-html5
                 bbb-learning-dashboard bbb-libreoffice-docker bbb-mkclean bbb-pads
-                bbb-playback bbb-playback-presentation bbb-record-core bbb-web
-                bbb-webrtc-sfu bbb-webrtc-recorder"
+                bbb-shared-notes-server bbb-playback bbb-playback-presentation
+                bbb-record-core bbb-web bbb-webrtc-sfu bbb-webrtc-recorder"
 
           # Use the version from the first .deb we find as the meta-package version
           FIRST_DEB=$(ls "$DEBS_DIR"/*.deb | head -1)

--- a/build/packages-template/bbb-shared-notes-server/opts-noble.sh
+++ b/build/packages-template/bbb-shared-notes-server/opts-noble.sh
@@ -2,4 +2,4 @@
 
 . ./opts-global.sh
 
-OPTS="$OPTS -t deb -d npm,wkhtmltopdf,postgresql-14"
+OPTS="$OPTS -t deb -d npm,wkhtmltopdf,postgresql-16"


### PR DESCRIPTION
### What does this PR do?

Fixes the v4 CI setup for BlockNote shared notes.

Changes include:
- Add `bbb-shared-notes-server` to the v4 automated test meta-package dependency list.
- Update the Noble package options for `bbb-shared-notes-server` to depend on `postgresql-16` instead of `postgresql-14`.

### Motivation

The v4 automated test workflow already builds and downloads the `bbb-shared-notes-server` artifact, but the temporary BigBlueButton meta-package used by CI did not depend on it. As a result, `bbb-install` skipped the service, BlockNote shared notes were not created, and Playwright tests could miss the shared notes sidebar button.

After adding the service to the v4 install, CI exposed another issue: the Noble package options still depended on `postgresql-14`, which is not installable on Ubuntu Noble. Noble should use PostgreSQL 16.

### More

This keeps the v4 CI install aligned with the package template and Noble package requirements.