### PR TITLE
feat(lock-viewers): reorder tabs to show participant permissions first

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/component.jsx
@@ -579,14 +579,14 @@ class LockViewersComponent extends Component {
 
     const tabs = [
       {
-        label: intlMessages.guestPolicyTab,
-        icon: 'guest_policy',
-        dataTest: 'guestPolicyTab',
-      },
-      {
         label: intlMessages.participantPermissionsTab,
         icon: 'lock_viewers',
         dataTest: 'participantPermissionsTab',
+      },
+      {
+        label: intlMessages.guestPolicyTab,
+        icon: 'guest_policy',
+        dataTest: 'guestPolicyTab',
       },
       {
         label: intlMessages.presentationPermissionsTab,
@@ -623,10 +623,10 @@ class LockViewersComponent extends Component {
             ))}
           </Styled.SettingsTabList>
           <Styled.SettingsTabPanel selectedClassName="is-selected">
-            {this.renderGuestPolicyTab()}
+            {this.renderParticipantPermissionsTab()}
           </Styled.SettingsTabPanel>
           <Styled.SettingsTabPanel selectedClassName="is-selected">
-            {this.renderParticipantPermissionsTab()}
+            {this.renderGuestPolicyTab()}
           </Styled.SettingsTabPanel>
           <Styled.SettingsTabPanel selectedClassName="is-selected">
             {this.renderPresentationPermissionsTab()}


### PR DESCRIPTION
### What does this PR do?

Reorders the tabs in the "Permissions and Policies" modal so that **Participant Permissions** appears first, followed by **Guest Policy** and **Presentation Policy**.

### Closes Issue(s)

Closes #25290

### Motivation

Participant Permissions is the most frequently accessed section in the modal. Placing it first reduces the number of clicks needed to reach it.

### How to test

1. Join a meeting as moderator
2. Open the **Permissions and Policies** modal
3. Verify the tab order is: **Participant Permissions** → **Guest Policy** → **Presentation Policy**
4. Verify that **Participant Permissions** is selected by default when the modal opens
5. Confirm all three tabs still work correctly