### PR TITLE
docs: Fix layout naming inconsistency and missing MEDIA_ONLY

### DIFF
--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -231,7 +231,7 @@ defaultAllowPromoteGuestToModerator=false
 
 #---------------------------------------------------
 # Default Meeting Layout
-# Accepted values are: UNIFIED_LAYOUT (default), and the following options targeting hybrid or niche scenarios:  CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY
+# Accepted values are: UNIFIED_LAYOUT (default), and the following options targeting hybrid or niche scenarios:  CAMERAS_ONLY, PARTICIPANTS_AND_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY
 defaultMeetingLayout=UNIFIED_LAYOUT
 
 #

--- a/docs/docs/data/join.tsx
+++ b/docs/docs/data/join.tsx
@@ -118,7 +118,7 @@ const joinEndpointTableData = [
     "name": "enforceLayout",
     "required": false,
     "type": "String",
-    "description": (<>If passed it overrides the value of `meetingLayout` passed on CREATE or the value of `defaultMeetingLayout` read from configuration. Accepted values are: UNIFIED_LAYOUT, CAMERAS_ONLY, PARTICIPANTS_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY. Added in BBB 3.0</>)
+    "description": (<>If passed it overrides the value of `meetingLayout` passed on CREATE or the value of `defaultMeetingLayout` read from configuration. Accepted values are: UNIFIED_LAYOUT, CAMERAS_ONLY, PARTICIPANTS_AND_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY. Added in BBB 3.0</>)
   }
 ];
 

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -136,7 +136,7 @@ Updated in 4.0:
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**
-  - **Changed:** Parameter `enforceLayout` accepted values are now `UNIFIED_LAYOUT`, `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY` (the deprecated `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS` are no longer accepted).
+  - **Changed:** Parameter `enforceLayout` accepted values are now `UNIFIED_LAYOUT`, `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY` (the deprecated `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS` are no longer accepted).
 - **clientSettings** - The deprecated REST endpoint `/api/rest/clientSettings` was **removed**. Client settings are now served through the GraphQL stack.
 
 ## API Data Types

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -261,7 +261,7 @@ _None._
 
 #### Value changed
 
-- `defaultMeetingLayout` default changed from `CUSTOM_LAYOUT` to `UNIFIED_LAYOUT`. Accepted values are now `UNIFIED_LAYOUT` (default), plus the hybrid/niche options `CAMERAS_ONLY`, `PARTICIPANTS_CHAT_ONLY`, and `PRESENTATION_ONLY`. The previous values `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, and `VIDEO_FOCUS` are no longer accepted.
+- `defaultMeetingLayout` default changed from `CUSTOM_LAYOUT` to `UNIFIED_LAYOUT`. Accepted values are now `UNIFIED_LAYOUT` (default), plus the hybrid/niche options `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, and `MEDIA_ONLY`. The previous values `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, and `VIDEO_FOCUS` are no longer accepted.
 - `html5PluginSdkVersion` bumped from `0.1.17` to `0.1.20`.
 - `disabledFeatures` accepts a new value: `pinChatMessage` (alongside the existing chat-related options).
 


### PR DESCRIPTION
### What does this PR do?

Fixes a wrong layout name in the docs. Three files referenced `PARTICIPANTS_CHAT_ONLY`, but the real layout key is `PARTICIPANTS_AND_CHAT_ONLY` (the "AND" was missing). Because `bbb-web` stores the layout string verbatim without validating it, the misspelled name reaches the client, matches no layout, and silently falls back to `UNIFIED_LAYOUT` — so anyone copying the documented value would get the wrong layout.

Also adds the missing `MEDIA_ONLY` to the layout list in `new-features.md`, which was a valid 4.0 layout left out of that list.

### Closes Issue(s)

Closes #24958

### How to test

- `grep -rn 'PARTICIPANTS_CHAT_ONLY' docs/docs/` should return nothing.
- Build the docs (`npm ci` && `npx docusaurus build`) and check the Join API reference, the Development/API page, and the New Features page now list `PARTICIPANTS_AND_CHAT_ONLY` (and `MEDIA_ONLY` on the new-features list).

### More

- [x] Added/updated documentation
