### PR TITLE
fix(ui): align some modal and panel font sizes with design

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.js
@@ -90,7 +90,7 @@ const SettingsTabSelector = styled(Tab)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  font-size: 0.9rem;
+  font-size: 1.125rem;
   flex: none;
   padding: 0.85rem;
   color: ${colorGrayDark};

--- a/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/lock-viewers/styles.js
@@ -18,7 +18,11 @@ import {
   colorBorder,
   settingsModalTabSelected,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { fontSizeBase, fontSizeLarger } from '/imports/ui/stylesheets/styled-components/typography';
+import {
+  fontSizeBase,
+  fontSizeLarger,
+  fontSizeMedium,
+} from '/imports/ui/stylesheets/styled-components/typography';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 import Icon from '/imports/ui/components/common/icon/component';
@@ -90,7 +94,7 @@ const SettingsTabSelector = styled(Tab)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  font-size: 1.125rem;
+  font-size: ${fontSizeMedium};
   flex: none;
   padding: 0.85rem;
   color: ${colorGrayDark};
@@ -187,7 +191,7 @@ const TabContent = styled.div`
 const SectionTitle = styled.h3`
   color: ${colorGrayDark};
   margin: 0;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   font-weight: 600;
 `;
 
@@ -218,7 +222,7 @@ const ActionButton = styled.button`
   border: none;
   border-radius: 1rem;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   background-color: transparent;
   color: ${colorGrayLabel};
 

--- a/bigbluebutton-html5/imports/ui/components/settings/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/styles.js
@@ -69,7 +69,7 @@ const SettingsTabSelector = styled(Tab)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  font-size: 1rem;
+  font-size: 1.125rem;
   flex: none;
   padding: 1rem;
   color: ${colorGrayDark};
@@ -195,7 +195,7 @@ const ActionButton = styled.button`
   border: none;
   border-radius: 1rem;
   cursor: pointer;
-  font-size: 16px;
+  font-size: 1rem;
   color: #fff;
 
   &:first-child {

--- a/bigbluebutton-html5/imports/ui/components/settings/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/styles.js
@@ -11,7 +11,11 @@ import {
   settingsModalTabSelected,
   colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { fontSizeLarge } from '/imports/ui/stylesheets/styled-components/typography';
+import {
+  fontSizeBase,
+  fontSizeLarge,
+  fontSizeMedium,
+} from '/imports/ui/stylesheets/styled-components/typography';
 import {
   Tab, Tabs, TabList, TabPanel,
 } from 'react-tabs';
@@ -69,7 +73,7 @@ const SettingsTabSelector = styled(Tab)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  font-size: 1.125rem;
+  font-size: ${fontSizeMedium};
   flex: none;
   padding: 1rem;
   color: ${colorGrayDark};
@@ -195,7 +199,7 @@ const ActionButton = styled.button`
   border: none;
   border-radius: 1rem;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   color: #fff;
 
   &:first-child {

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/about/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/about/styles.js
@@ -13,7 +13,7 @@ const Content = styled.div`
 
 const Text = styled.p`
   margin: 8px 0;
-  font-size: 14px;
+  font-size: 1rem;
   color: #333;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/about/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/about/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Styled from '/imports/ui/components/settings/submenus/styles';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
 const Title = styled(Styled.Title)``;
 
@@ -13,7 +14,7 @@ const Content = styled.div`
 
 const Text = styled.p`
   margin: 8px 0;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   color: #333;
 `;
 
@@ -25,8 +26,7 @@ const TableButton = styled.button`
   color: #333;
   background-color: transparent;
   border: none;
-  font-size: 1rem;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   font-weight: 700;
   cursor: pointer;
   padding: 4px 8px;

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
@@ -32,7 +32,7 @@ const FormElement = styled(Styled.FormElement)``;
 const Label = styled(Styled.Label)`
   margin-left: 0.5rem;
   color: ${colorGrayLabel};
-  font-size: 0.9rem;
+  font-size: 1rem;
 `;
 
 const FormElementRight = styled(Styled.FormElementRight)`

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/application/styles.js
@@ -8,6 +8,7 @@ import {
 import { borderSize, borderSizeLarge, lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
 import SpinnerStyles from '/imports/ui/components/common/loading-screen/styles';
 import Styled from '/imports/ui/components/settings/submenus/styles';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
 const Row = styled(Styled.Row)``;
 
@@ -32,7 +33,7 @@ const FormElement = styled(Styled.FormElement)``;
 const Label = styled(Styled.Label)`
   margin-left: 0.5rem;
   color: ${colorGrayLabel};
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
 `;
 
 const FormElementRight = styled(Styled.FormElementRight)`
@@ -47,7 +48,7 @@ const Select = styled(Styled.Select)``;
 const Title = styled(Styled.Title)``;
 
 const ApplicationTitle = styled(Styled.Title)`
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   font-weight: 600;
   margin-bottom: 0;
   padding-bottom: 1.5rem;
@@ -73,7 +74,7 @@ const Separator = styled.hr`
 
 const BoldLabel = styled.label`
   color: ${colorGrayLabel};
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   font-weight: bold;
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/styles.js
@@ -36,7 +36,7 @@ const FormElementRight = styled(Styled.FormElementRight)`
 
 const Label = styled(Styled.Label)`
   margin-left: 0.5rem;
-  font-size: 0.9rem;
+  font-size: 1rem;
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/data-saving/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Styled from '/imports/ui/components/settings/submenus/styles';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
 const Title = styled(Styled.Title)``;
 
@@ -36,7 +37,7 @@ const FormElementRight = styled(Styled.FormElementRight)`
 
 const Label = styled(Styled.Label)`
   margin-left: 0.5rem;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/shortcuts/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/shortcuts/styles.ts
@@ -35,6 +35,7 @@ const ShortcutTable = styled.table`
   border-collapse: collapse;
   margin: 0;
   width: 100%;
+  font-size: 1.125rem;
 
   > tbody > tr:nth-child(even) {
     background-color: ${colorOffWhite};
@@ -82,7 +83,7 @@ const ShortcutsTabSelector = styled(Tab)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  font-size: 1rem;
+  font-size: 1.125rem;
   flex: none;
   padding: 1rem;
   color: ${colorGrayDark};

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/shortcuts/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/shortcuts/styles.ts
@@ -17,7 +17,10 @@ import {
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
-import { fontSizeLarge } from '/imports/ui/stylesheets/styled-components/typography';
+import {
+  fontSizeLarge,
+  fontSizeMedium,
+} from '/imports/ui/stylesheets/styled-components/typography';
 
 const KeyCell = styled.td`
   text-align: center;
@@ -35,7 +38,7 @@ const ShortcutTable = styled.table`
   border-collapse: collapse;
   margin: 0;
   width: 100%;
-  font-size: 1.125rem;
+  font-size: ${fontSizeMedium};
 
   > tbody > tr:nth-child(even) {
     background-color: ${colorOffWhite};
@@ -83,7 +86,7 @@ const ShortcutsTabSelector = styled(Tab)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  font-size: 1.125rem;
+  font-size: ${fontSizeMedium};
   flex: none;
   padding: 1rem;
   color: ${colorGrayDark};

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.js
@@ -19,7 +19,7 @@ const Title = styled.h3`
 `;
 
 const SubTitle = styled.h4`
-  font-size: 0.9rem;
+  font-size: 1rem;
   margin-bottom: 1rem;
 `;
 
@@ -70,7 +70,7 @@ const FormElementRight = styled.div`
 
 const Label = styled.span`
   color: ${colorGrayLabel};
-  font-size: 0.9rem;
+  font-size: 1rem;
 `;
 
 const Select = styled.select`

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/styles.js
@@ -9,17 +9,18 @@ import {
 import { Switch } from '@mui/material';
 import { styled as materialStyled } from '@mui/material/styles';
 import { borderSize, borderSizeLarge } from '/imports/ui/stylesheets/styled-components/general';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
 const Title = styled.h3`
   color: ${colorGrayDark};
   margin: 0;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   font-weight: 600;
   margin-bottom: 0;
 `;
 
 const SubTitle = styled.h4`
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   margin-bottom: 1rem;
 `;
 
@@ -70,7 +71,7 @@ const FormElementRight = styled.div`
 
 const Label = styled.span`
   color: ${colorGrayLabel};
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
 `;
 
 const Select = styled.select`

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
@@ -102,6 +102,7 @@ const TimerSwitchButton = styled(Button)`
   height: 3rem;
   border-radius: ${lgBorderRadius};
   margin: 0 .5rem;
+  font-size: ${fontSizeBase};
 `;
 
 const TimeInputWrapper = styled.div`
@@ -251,7 +252,7 @@ const TimeUnitContainer = styled.div`
 `;
 
 const TimeUnitLabel = styled.span`
-  font-size: 0.80rem;
+  font-size: ${fontSizeBase};
   color: ${colorGray};
   text-transform: capitalize;
 `;
@@ -421,7 +422,7 @@ const TimerPresetsRow = styled.div`
 const TimerPresetButton = styled.button<{disabled?: boolean; isActive?: boolean}>`
   all: unset;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  font-size: 0.95rem;
+  font-size: ${fontSizeBase};
   line-height: 1;
   color: ${colorGrayDark};
   opacity: ${({ disabled }) => (disabled ? 0.4 : 0.7)};
@@ -494,7 +495,7 @@ const TimerAddsRow = styled.div`
 const TimerAddButton = styled.button<{disabled?: boolean}>`
   all: unset;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  font-size: 0.9rem;
+  font-size: ${fontSizeBase};
   line-height: 1.5;
   color: ${colorPrimary};
   background-color: color-mix(in srgb, ${colorBlueLighter} 20%, transparent);
@@ -527,6 +528,7 @@ const ControlButton = styled(Button)`
   border-radius: ${lgBorderRadius};
   height: 3rem;
   width: 100%;
+  font-size: ${fontSizeBase};
 `;
 
 const ResetButton = styled(ControlButton)`

--- a/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/timer/panel/styles.ts
@@ -133,7 +133,7 @@ const IncrementDecrementButton = styled(Button)`
   height: 1.2rem;
   min-width: 0;
   padding: 0;
-  font-size: 1rem;
+  font-size: ${fontSizeBase};
   line-height: 0.9;
 `;
 
@@ -471,7 +471,7 @@ const PresetArrowButton = styled(Button)`
   
   i {
     margin: 0;
-    font-size: 1rem;
+    font-size: ${fontSizeBase};
   }
 
   [dir="rtl"] & i {

--- a/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/crowd-action-buttons/styles.ts
@@ -6,7 +6,7 @@ import {
   colorGrayUserListToolbar,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import {
-  fontSizeSmall,
+  fontSizeBase,
   textFontWeight,
 } from '/imports/ui/stylesheets/styled-components/typography';
 import { ActionButtonProps } from './types';
@@ -31,7 +31,7 @@ const ActionButtonWrapper = styled.div`
 
 const ActionButtonLabel = styled.span`
   color: ${colorGrayDark};
-  font-size: ${fontSizeSmall};
+  font-size: ${fontSizeBase};
   font-weight: ${textFontWeight};
   text-align: center;
   line-height: normal;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-search/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-search/styles.ts
@@ -13,6 +13,7 @@ import {
   lgBorderRadius,
   smPaddingY,
 } from '/imports/ui/stylesheets/styled-components/general';
+import { fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
 
 const SearchContainer = styled.div`
   display: flex;
@@ -41,7 +42,7 @@ const SearchInput = styled.input`
   outline: none;
   background: transparent;
   color: ${colorText};
-  font-size: 0.875rem;
+  font-size: ${fontSizeBase};
   padding: 0;
   margin-left: ${smPaddingX};
 

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/typography.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/typography.js
@@ -1,6 +1,7 @@
 const lineHeightComputed = '1rem';
 const lineHeightBase = '1.25';
 const fontSizeBase = '1rem';
+const fontSizeMedium = '1.125rem';
 const fontSizeSmall = '0.875rem';
 const fontSizeSmaller = '.75rem';
 const fontSizeSmallest = '.35rem';
@@ -23,6 +24,7 @@ export {
   lineHeightComputed,
   lineHeightBase,
   fontSizeBase,
+  fontSizeMedium,
   fontSizeSmall,
   fontSizeSmaller,
   fontSizeSmallest,


### PR DESCRIPTION
### What does this PR do?

Aligns font sizes across some modals and side panels with the Figma design
and the app's design tokens. A number of texts were rendering smaller than
intended — they used `fontSizeSmall` (0.875rem), hardcoded sub-rem values
(0.7–0.95rem), or hardcoded `px` instead of tokens. The Figma canvas is built
on a 16px base, mapped to rem as `Figma px ÷ 16` (Figma 16px → `1rem` =
`fontSizeBase`, which renders 14px on desktop; Figma 18px → `1.125rem` for
left-nav tabs).

Areas updated:
- **Settings modal** — setting labels, section descriptions, and action
  buttons → `1rem`; left nav tabs → `1.125rem`; Shortcuts category tabs and
  table → `1.125rem`; About paragraphs → `1rem`.
- **Timer panel** — Timer/Stopwatch selectors, Start/Stop/Reset/Deactivate,
  hours/minutes/seconds labels, and preset/quick-add buttons → `fontSizeBase`.
- **User list** — "Mute all except presenter" and "Permissions and Policies"
  labels, and the user search input → `fontSizeBase`.
- **Restrictions & Policies modal** — left nav tabs → `1.125rem`.