### PR TITLE
fix(accessibility): change page title based on the content

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/app/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.jsx
@@ -47,6 +47,7 @@ import VoiceActivityAdapter from '../../core/adapters/voice-activity';
 import LayoutObserver from '../layout/observer';
 import BBBLiveKitRoomContainer from '/imports/ui/components/livekit/component';
 import RaiseHandNotifier from '/imports/ui/components/raisehand-notifier/container';
+import DocumentTitleManager from './document-title-manager/component';
 
 const intlMessages = defineMessages({
   userListLabel: {
@@ -364,6 +365,7 @@ class App extends Component {
           }}
         >
           <ActivityCheckContainer />
+          <DocumentTitleManager />
           <ScreenReaderAlertContainer />
           <BannerBarContainer />
           <NotificationsBarContainer />

--- a/bigbluebutton-html5/imports/ui/components/app/document-title-manager/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/app/document-title-manager/component.tsx
@@ -1,0 +1,219 @@
+import React, {
+  useContext, useEffect, useMemo, useState,
+} from 'react';
+import { defineMessages, useIntl } from 'react-intl';
+import * as PluginSdk from 'bigbluebutton-html-plugin-sdk';
+import { GenericContentType } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/generic-content-item/enums';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
+import { layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
+import { PANELS } from '/imports/ui/components/layout/enums';
+import { Layout, Input } from '/imports/ui/components/layout/layoutTypes';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import useChat from '/imports/ui/core/hooks/useChat';
+import { Chat } from '/imports/ui/Types/chat';
+import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
+import { useStorageKey } from '/imports/ui/services/storage/hooks';
+import {
+  DOCUMENT_TITLE_VIEW_CHANGED,
+  getActiveDocumentTitleView,
+} from './service';
+
+const intlMessages = defineMessages({
+  defaultViewLabel: {
+    id: 'app.title.defaultViewLabel',
+    description: 'view name appended to document title',
+  },
+  userListLabel: {
+    id: 'app.userList.label',
+    description: 'view name appended to document title',
+  },
+  chatLabel: {
+    id: 'app.chat.label',
+    description: 'view name appended to document title',
+  },
+  publicChatTitle: {
+    id: 'app.chat.titlePublic',
+    description: 'view name appended to document title',
+  },
+  privateChatTitle: {
+    id: 'app.chat.titlePrivate',
+    description: 'view name appended to document title',
+  },
+  pollTitle: {
+    id: 'app.poll.pollPaneTitle',
+    description: 'view name appended to document title',
+  },
+  captionsTitle: {
+    id: 'app.userList.captionsTitle',
+    description: 'view name appended to document title',
+  },
+  notesTitle: {
+    id: 'app.notes.title',
+    description: 'view name appended to document title',
+  },
+  breakoutRoomsTitle: {
+    id: 'app.createBreakoutRoom.title',
+    description: 'view name appended to document title',
+  },
+  timerTitle: {
+    id: 'app.timer.title',
+    description: 'view name appended to document title',
+  },
+  waitingUsersTitle: {
+    id: 'app.userList.guest.waitingUsers',
+    description: 'view name appended to document title',
+  },
+  uploadPresentationTitle: {
+    id: 'app.presentationUploder.uploadViewTitle',
+    description: 'view name appended to document title',
+  },
+  defaultBreakoutName: {
+    id: 'app.createBreakoutRoom.room',
+    description: 'default breakout room name',
+  },
+});
+
+const getClientTitle = () => {
+  const publicConfig = window.meetingClientSettings?.public;
+  return getFromUserSettings('bbb_client_title', publicConfig?.app?.clientTitle || 'BigBlueButton');
+};
+
+const getChatTitle = (
+  chatId: string,
+  chats: Array<Partial<Chat>> | null | undefined,
+  intl: ReturnType<typeof useIntl>,
+) => {
+  const chatConfig = window.meetingClientSettings.public.chat;
+  const isPublicChatId = chatId === chatConfig.public_id || chatId === chatConfig.public_group_id;
+  const selectedChat = chats?.find((chat) => (
+    chat.chatId === chatId
+    || (isPublicChatId && (chat.chatId === chatConfig.public_id || chat.chatId === chatConfig.public_group_id))
+  ));
+
+  if (selectedChat?.public || isPublicChatId) {
+    return intl.formatMessage(intlMessages.publicChatTitle);
+  }
+
+  if (selectedChat?.participant?.name) {
+    return intl.formatMessage(intlMessages.privateChatTitle, {
+      participantName: selectedChat.participant.name,
+    });
+  }
+
+  return intl.formatMessage(intlMessages.chatLabel);
+};
+
+const DocumentTitleManager: React.FC = () => {
+  const intl = useIntl();
+  const idChatOpen = layoutSelect((i: Layout) => i.idChatOpen);
+  const sidebarNavigation = layoutSelectInput((i: Input) => i.sidebarNavigation);
+  const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
+  const uploadPresentationOpen = !!useStorageKey('showUploadPresentationView');
+  const [registeredViewTitle, setRegisteredViewTitle] = useState<string | null>(getActiveDocumentTitleView());
+  const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
+  const { data: meeting } = useMeeting((m) => ({
+    name: m.name,
+    breakoutPolicies: {
+      sequence: m.breakoutPolicies?.sequence,
+    },
+  }));
+  const { data: chats } = useChat((chat) => ({
+    chatId: chat.chatId,
+    participant: chat.participant,
+    public: chat.public,
+  })) as GraphqlDataHookSubscriptionResponse<Partial<Chat>[]>;
+
+  const genericSidekickContentTitle = useMemo(() => {
+    const { sidebarContentPanel } = sidebarContent;
+    if (!sidebarContentPanel.startsWith(PANELS.GENERIC_CONTENT_SIDEKICK)) return null;
+
+    const genericSidekickContentId = sidebarContentPanel.replace(PANELS.GENERIC_CONTENT_SIDEKICK, '');
+    const genericContentItems = pluginsExtensibleAreasAggregatedState.genericContentItems || [];
+    const genericSidekickContentItems = genericContentItems
+      .filter((item) => item.type === GenericContentType.SIDEKICK_AREA) as PluginSdk.GenericContentSidekickArea[];
+    const genericContentItem = genericSidekickContentItems.find((item) => item.id === genericSidekickContentId);
+
+    return genericContentItem?.name || null;
+  }, [pluginsExtensibleAreasAggregatedState.genericContentItems, sidebarContent]);
+
+  const activeViewTitle = useMemo(() => {
+    if (registeredViewTitle) return registeredViewTitle;
+    if (uploadPresentationOpen) return intl.formatMessage(intlMessages.uploadPresentationTitle);
+
+    switch (sidebarContent.sidebarContentPanel) {
+      case PANELS.CHAT:
+        return getChatTitle(idChatOpen, chats, intl);
+      case PANELS.POLL:
+        return intl.formatMessage(intlMessages.pollTitle);
+      case PANELS.CAPTIONS:
+        return intl.formatMessage(intlMessages.captionsTitle);
+      case PANELS.BREAKOUT:
+        return intl.formatMessage(intlMessages.breakoutRoomsTitle);
+      case PANELS.SHARED_NOTES:
+        return intl.formatMessage(intlMessages.notesTitle);
+      case PANELS.TIMER:
+        return intl.formatMessage(intlMessages.timerTitle);
+      case PANELS.WAITING_USERS:
+        return intl.formatMessage(intlMessages.waitingUsersTitle);
+      default:
+        if (genericSidekickContentTitle) return genericSidekickContentTitle;
+    }
+
+    if (sidebarNavigation.isOpen && sidebarNavigation.sidebarNavPanel === PANELS.USERLIST) {
+      return intl.formatMessage(intlMessages.userListLabel);
+    }
+
+    return intl.formatMessage(intlMessages.defaultViewLabel);
+  }, [
+    chats,
+    genericSidekickContentTitle,
+    idChatOpen,
+    intl,
+    sidebarContent.sidebarContentPanel,
+    sidebarNavigation.isOpen,
+    sidebarNavigation.sidebarNavPanel,
+    registeredViewTitle,
+    uploadPresentationOpen,
+  ]);
+
+  const documentTitle = useMemo(() => {
+    const titleSegments = [getClientTitle()];
+    const meetingName = meeting?.name?.trim();
+    const breakoutNum = meeting?.breakoutPolicies?.sequence;
+
+    if (meetingName) {
+      if (breakoutNum && breakoutNum > 0) {
+        const defaultBreakoutName = intl.formatMessage(intlMessages.defaultBreakoutName, {
+          roomNumber: breakoutNum,
+        });
+
+        titleSegments.push(meetingName === defaultBreakoutName ? `${breakoutNum}` : meetingName);
+      } else {
+        titleSegments.push(meetingName);
+      }
+    }
+
+    if (activeViewTitle) titleSegments.push(activeViewTitle);
+
+    return titleSegments.join(' - ');
+  }, [activeViewTitle, intl, meeting]);
+
+  useEffect(() => {
+    document.title = documentTitle;
+  }, [documentTitle]);
+
+  useEffect(() => {
+    const handleDocumentTitleViewChanged = (event: Event) => {
+      const customEvent = event as CustomEvent<{ activeTitle: string | null }>;
+      setRegisteredViewTitle(customEvent.detail.activeTitle);
+    };
+
+    window.addEventListener(DOCUMENT_TITLE_VIEW_CHANGED, handleDocumentTitleViewChanged);
+    return () => window.removeEventListener(DOCUMENT_TITLE_VIEW_CHANGED, handleDocumentTitleViewChanged);
+  }, []);
+
+  return null;
+};
+
+export default DocumentTitleManager;

--- a/bigbluebutton-html5/imports/ui/components/app/document-title-manager/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/app/document-title-manager/service.ts
@@ -1,0 +1,50 @@
+export const DOCUMENT_TITLE_VIEW_CHANGED = 'bbb-document-title-view-changed';
+
+type DocumentTitleView = {
+  title: string;
+  sequence: number;
+};
+
+const registeredTitleViews = new Map<string, DocumentTitleView>();
+let sequence = 0;
+
+const notifyDocumentTitleViewChanged = () => {
+  window.dispatchEvent(new CustomEvent(DOCUMENT_TITLE_VIEW_CHANGED, {
+    detail: {
+      activeTitle: getActiveDocumentTitleView(),
+    },
+  }));
+};
+
+export const getActiveDocumentTitleView = (): string | null => {
+  const views = Array.from(registeredTitleViews.values());
+  if (views.length === 0) return null;
+
+  views.sort((a, b) => b.sequence - a.sequence);
+  return views[0].title;
+};
+
+export const registerDocumentTitleView = (id: string, title: string) => {
+  if (!id || !title) return;
+
+  const existingView = registeredTitleViews.get(id);
+  registeredTitleViews.set(id, {
+    title,
+    sequence: existingView?.sequence || sequence + 1,
+  });
+
+  if (!existingView) sequence += 1;
+  notifyDocumentTitleViewChanged();
+};
+
+export const unregisterDocumentTitleView = (id: string) => {
+  if (!registeredTitleViews.delete(id)) return;
+  notifyDocumentTitleViewChanged();
+};
+
+let idSequence = 0;
+
+export const createDocumentTitleViewId = (prefix: string) => {
+  idSequence += 1;
+  return `${prefix}-${idSequence}`;
+};

--- a/bigbluebutton-html5/imports/ui/components/app/document-title-manager/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/app/document-title-manager/service.ts
@@ -28,6 +28,8 @@ export const registerDocumentTitleView = (id: string, title: string) => {
   if (!id || !title) return;
 
   const existingView = registeredTitleViews.get(id);
+  if (existingView?.title === title) return;
+
   registeredTitleViews.set(id, {
     title,
     sequence: existingView?.sequence || sequence + 1,

--- a/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-join-confirmation/breakout-join-confirmation-graphql/component.tsx
@@ -224,6 +224,7 @@ const BreakoutJoinConfirmation: React.FC<BreakoutJoinConfirmationProps> = ({
   return (
     <ModalFullscreen
       title={intl.formatMessage(intlMessages.title)}
+      documentTitle={intl.formatMessage(intlMessages.title)}
       confirm={{
         callback: handleJoinBreakoutConfirmation,
         label: intl.formatMessage(intlMessages.confirmLabel),

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/component.tsx
@@ -617,6 +617,11 @@ const CreateBreakoutRoom: React.FC<CreateBreakoutRoomProps> = ({
           ? intl.formatMessage(intlMessages.updateTitle)
           : intl.formatMessage(intlMessages.breakoutRoomTitle)
       }
+      documentTitle={
+        isUpdate
+          ? intl.formatMessage(intlMessages.updateTitle)
+          : intl.formatMessage(intlMessages.breakoutRoomTitle)
+      }
       confirm={
         {
           label: isUpdate

--- a/bigbluebutton-html5/imports/ui/components/common/modal/fullscreen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/fullscreen/component.jsx
@@ -2,6 +2,11 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Styled from './styles';
+import {
+  createDocumentTitleViewId,
+  registerDocumentTitleView,
+  unregisterDocumentTitleView,
+} from '/imports/ui/components/app/document-title-manager/service';
 
 const intlMessages = defineMessages({
   modalClose: {
@@ -38,6 +43,10 @@ const propTypes = {
   }),
   preventClosing: PropTypes.bool,
   shouldCloseOnOverlayClick: PropTypes.bool,
+  documentTitle: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+  ]),
 };
 
 const defaultProps = {
@@ -50,13 +59,19 @@ const defaultProps = {
     disabled: false,
   },
   preventClosing: false,
+  documentTitle: false,
 };
 
 class ModalFullscreen extends PureComponent {
   constructor(props) {
     super(props);
     this.previousFocus = null;
+    this.documentTitleViewId = createDocumentTitleViewId('fullscreen-modal');
     this.handleAction = this.handleAction.bind(this);
+  }
+
+  componentDidMount() {
+    this.updateDocumentTitleView();
   }
 
   componentDidUpdate(prevProps) {
@@ -64,6 +79,11 @@ class ModalFullscreen extends PureComponent {
     if (!prevProps.isOpen && isOpen) {
       this.previousFocus = document.activeElement;
     }
+    this.updateDocumentTitleView();
+  }
+
+  componentWillUnmount() {
+    unregisterDocumentTitleView(this.documentTitleViewId);
   }
 
   handleAction(name) {
@@ -95,6 +115,32 @@ class ModalFullscreen extends PureComponent {
     }, 0);
   }
 
+  getDocumentTitle() {
+    const {
+      documentTitle,
+      title,
+    } = this.props;
+
+    if (!documentTitle) return null;
+    if (typeof documentTitle === 'string') return documentTitle;
+    return title;
+  }
+
+  updateDocumentTitleView() {
+    const {
+      isOpen,
+      preventClosing,
+    } = this.props;
+    const documentTitle = this.getDocumentTitle();
+
+    if ((isOpen || preventClosing) && documentTitle) {
+      registerDocumentTitleView(this.documentTitleViewId, documentTitle);
+      return;
+    }
+
+    unregisterDocumentTitleView(this.documentTitleViewId);
+  }
+
   render() {
     const {
       intl,
@@ -103,6 +149,7 @@ class ModalFullscreen extends PureComponent {
       dismiss,
       className,
       children,
+      documentTitle,
       isOpen,
       preventClosing,
       ...otherProps
@@ -119,7 +166,7 @@ class ModalFullscreen extends PureComponent {
         id="fsmodal"
         isOpen={isOpen || preventClosing}
         contentLabel={title}
-        overlayClassName={"fullscreenModalOverlay"}
+        overlayClassName="fullscreenModalOverlay"
         {...otherProps}
       >
         <Styled.Header>

--- a/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/common/modal/simple/component.jsx
@@ -4,6 +4,11 @@ import { defineMessages, injectIntl } from 'react-intl';
 import FocusTrap from 'focus-trap-react';
 import Styled from './styles';
 import deviceInfo from '/imports/utils/deviceInfo';
+import {
+  createDocumentTitleViewId,
+  registerDocumentTitleView,
+  unregisterDocumentTitleView,
+} from '/imports/ui/components/app/document-title-manager/service';
 
 const intlMessages = defineMessages({
   modalClose: {
@@ -26,6 +31,10 @@ const propTypes = {
   shouldShowCloseButton: PropTypes.bool,
   overlayClassName: PropTypes.string,
   modalIsOpen: PropTypes.bool,
+  documentTitle: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+  ]),
 };
 
 const defaultProps = {
@@ -38,6 +47,7 @@ const defaultProps = {
   overlayClassName: 'modalOverlay',
   headerPosition: 'inner',
   modalIsOpen: false,
+  documentTitle: false,
 };
 
 class ModalSimple extends Component {
@@ -45,6 +55,7 @@ class ModalSimple extends Component {
     super(props);
     this.modalRef = React.createRef();
     this.previousFocus = null;
+    this.documentTitleViewId = createDocumentTitleViewId('simple-modal');
     this.handleDismiss = this.handleDismiss.bind(this);
     this.handleRequestClose = this.handleRequestClose.bind(this);
     this.handleOutsideClick = this.handleOutsideClick.bind(this);
@@ -52,6 +63,7 @@ class ModalSimple extends Component {
 
   componentDidMount() {
     document.addEventListener('mousedown', this.handleOutsideClick, false);
+    this.updateDocumentTitleView();
   }
 
   componentDidUpdate(prevProps) {
@@ -59,10 +71,12 @@ class ModalSimple extends Component {
     if (!prevProps.modalIsOpen && modalIsOpen) {
       this.previousFocus = document.activeElement;
     }
+    this.updateDocumentTitleView();
   }
 
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleOutsideClick, false);
+    unregisterDocumentTitleView(this.documentTitleViewId);
   }
 
   handleDismiss() {
@@ -93,6 +107,33 @@ class ModalSimple extends Component {
     }
   }
 
+  getDocumentTitle() {
+    const {
+      contentLabel,
+      documentTitle,
+      title,
+    } = this.props;
+
+    if (!documentTitle) return null;
+    if (typeof documentTitle === 'string') return documentTitle;
+    return title || contentLabel || null;
+  }
+
+  updateDocumentTitleView() {
+    const {
+      isOpen,
+      modalIsOpen,
+    } = this.props;
+    const documentTitle = this.getDocumentTitle();
+
+    if ((isOpen || modalIsOpen) && documentTitle) {
+      registerDocumentTitleView(this.documentTitleViewId, documentTitle);
+      return;
+    }
+
+    unregisterDocumentTitleView(this.documentTitleViewId);
+  }
+
   render() {
     const {
       id,
@@ -105,6 +146,7 @@ class ModalSimple extends Component {
       onRequestClose,
       shouldShowCloseButton,
       contentLabel,
+      documentTitle,
       headerPosition,
       'data-test': dataTest,
       children,

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/component.jsx
@@ -41,10 +41,6 @@ const intlMessages = defineMessages({
     id: 'app.navBar.toggleUserList.newMsgAria',
     description: 'label for new message screen reader alert',
   },
-  defaultBreakoutName: {
-    id: 'app.createBreakoutRoom.room',
-    description: 'default breakout room name',
-  },
   leaveMeetingLabel: {
     id: 'app.navBar.leaveMeetingBtnLabel',
     description: 'Leave meeting button label',
@@ -67,9 +63,6 @@ const propTypes = {
   presentationTitle: PropTypes.string,
   hasUnreadMessages: PropTypes.bool,
   shortcuts: PropTypes.string,
-  breakoutNum: PropTypes.number,
-  breakoutName: PropTypes.string,
-  meetingName: PropTypes.string,
   pluginNavBarItems: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.string,
   })).isRequired,
@@ -179,25 +172,7 @@ class NavBar extends Component {
   componentDidMount() {
     const {
       shortcuts: TOGGLE_USERLIST_AK,
-      intl,
-      breakoutNum,
-      breakoutName,
-      meetingName,
     } = this.props;
-
-    if (breakoutNum && breakoutNum > 0) {
-      if (breakoutName && meetingName) {
-        const defaultBreakoutName = intl.formatMessage(intlMessages.defaultBreakoutName, {
-          roomNumber: breakoutNum,
-        });
-
-        if (breakoutName === defaultBreakoutName) {
-          document.title = `${breakoutNum} - ${meetingName}`;
-        } else {
-          document.title = `${breakoutName} - ${meetingName}`;
-        }
-      }
-    }
 
     const { isFirefox } = browserInfo;
     const { isMacos } = deviceInfo;

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/container.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { defineMessages, useIntl } from 'react-intl';
+import { useReactiveVar } from '@apollo/client';
 import Auth from '/imports/ui/services/auth';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import NavBar from './component';
@@ -11,21 +11,11 @@ import useChat from '/imports/ui/core/hooks/useChat';
 import useHasUnreadNotes from '../notes/hooks/useHasUnreadNotes';
 import { useShortcut } from '../../core/hooks/useShortcut';
 import useMeeting from '../../core/hooks/useMeeting';
-import { registerTitleView } from '/imports/utils/dom-utils';
-import { useReactiveVar } from '@apollo/client';
 import connectionStatus from '../../core/graphql/singletons/connectionStatus';
-
-const intlMessages = defineMessages({
-  defaultViewLabel: {
-    id: 'app.title.defaultViewLabel',
-    description: 'view name appended to document title',
-  },
-});
 
 const NavBarContainer = ({ children, ...props }) => {
   const { pluginsExtensibleAreasAggregatedState } = useContext(PluginsContext);
   const unread = useHasUnreadNotes();
-  const intl = useIntl();
 
   const sidebarContent = layoutSelectInput((i) => i.sidebarContent);
   const sidebarNavigation = layoutSelectInput((i) => i.sidebarNavigation);
@@ -57,7 +47,6 @@ const NavBarContainer = ({ children, ...props }) => {
   const hideNavBar = getFromUserSettings('bbb_hide_nav_bar', false);
 
   const PUBLIC_CONFIG = window.meetingClientSettings.public;
-  const CLIENT_TITLE = getFromUserSettings('bbb_client_title', PUBLIC_CONFIG.app.clientTitle);
   const IS_DIRECT_LEAVE_BUTTON_ENABLED = getFromUserSettings(
     'bbb_direct_leave_button',
     PUBLIC_CONFIG.app.defaultSettings.application.directLeaveButton,
@@ -68,32 +57,15 @@ const NavBarContainer = ({ children, ...props }) => {
   );
 
   let meetingTitle;
-  let breakoutNum;
-  let breakoutName;
-  let meetingName;
   const connected = useReactiveVar(connectionStatus.getConnectedStatusVar());
 
   const { data: meeting } = useMeeting((m) => ({
     name: m.name,
     meetingId: m.meetingId,
-    breakoutPolicies: {
-      sequence: m.breakoutPolicies.sequence,
-    },
   }));
 
   if (meeting) {
     meetingTitle = meeting.name;
-    const titleString = `${CLIENT_TITLE} - ${meetingTitle}`;
-    document.title = titleString;
-    registerTitleView(intl.formatMessage(intlMessages.defaultViewLabel));
-
-    if (meeting.breakoutPolicies) {
-      breakoutNum = meeting.breakoutPolicies.sequence;
-      if (breakoutNum > 0) {
-        breakoutName = meetingTitle;
-        meetingName = meetingTitle.replace(`(${breakoutName})`, '').trim();
-      }
-    }
   }
 
   if (hideNavBar || navBar.display === false) return null;
@@ -122,9 +94,6 @@ const NavBarContainer = ({ children, ...props }) => {
         shortcuts: toggleUserList,
         meetingId: meeting?.meetingId,
         presentationTitle: meetingTitle,
-        breakoutNum,
-        breakoutName,
-        meetingName,
         isDirectLeaveButtonEnabled: IS_DIRECT_LEAVE_BUTTON_ENABLED,
         // TODO: Remove/Replace
         isConnected: connected,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-uploader/component.jsx
@@ -7,7 +7,6 @@ import Button from '/imports/ui/components/common/button/component';
 import update from 'immutability-helper';
 import logger from '/imports/startup/client/logger';
 import { toast } from 'react-toastify';
-import { registerTitleView, unregisterTitleView } from '/imports/utils/dom-utils';
 import Styled from './styles';
 import PresentationDownloadDropdown from './presentation-download-dropdown/component';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
@@ -310,7 +309,11 @@ class PresentationUploader extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isOpen, presentations: propPresentations, currentPresentation, intl } = this.props;
+    const {
+      isOpen,
+      presentations: propPresentations,
+      currentPresentation,
+    } = this.props;
     const { presentations } = this.state;
     const { presentations: prevPropPresentations } = prevProps;
 
@@ -444,13 +447,8 @@ class PresentationUploader extends Component {
       });
     }
 
-    if (!isOpen && prevProps.isOpen) {
-      unregisterTitleView();
-    }
-
     // Updates presentation list when modal opens to avoid missing presentations
     if (isOpen && !prevProps.isOpen) {
-      registerTitleView(intl.formatMessage(intlMessages.uploadViewTitle));
       const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
       const modal = document.getElementById('upload-modal');
       const firstFocusableElement = modal?.querySelectorAll(focusableElements)[0];

--- a/bigbluebutton-html5/imports/ui/components/settings/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/component.jsx
@@ -336,6 +336,7 @@ class Settings extends Component {
     return (
       <ModalFullscreen
         title={intl.formatMessage(intlMessages.SettingsLabel)}
+        documentTitle={intl.formatMessage(intlMessages.SettingsLabel)}
         confirm={{
           callback: () => {
             this.updateSettings(current, intlMessages.savedAlertLabel, setLocalSettings);

--- a/bigbluebutton-tests/playwright/accessibility/document-title.spec.ts
+++ b/bigbluebutton-tests/playwright/accessibility/document-title.spec.ts
@@ -79,10 +79,12 @@ test.describe.parallel('Accessible routing', { tag: '@ci' }, () => {
     await modPage.waitAndClick(e.modalDismissButton);
 
     await modPage.waitAndClick(e.manageUsers);
-    await modPage.waitAndClick(e.createBreakoutRooms);
-    await expect(modPage.page, 'breakout room creation modal should be reflected in the document title').toHaveTitle(
-      / - Breakout Rooms$/,
-    );
-    await modPage.waitAndClick(e.modalDismissButton);
+    if (await modPage.page.locator(e.createBreakoutRooms).isVisible()) {
+      await modPage.waitAndClick(e.createBreakoutRooms);
+      await expect(modPage.page, 'breakout room creation modal should be reflected in the document title').toHaveTitle(
+        / - Breakout Rooms$/,
+      );
+      await modPage.waitAndClick(e.modalDismissButton);
+    }
   });
 });

--- a/bigbluebutton-tests/playwright/accessibility/document-title.spec.ts
+++ b/bigbluebutton-tests/playwright/accessibility/document-title.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from '@playwright/test';
+
+import { openPrivateChat } from '../chat/util';
+import { elements as e } from '../core/elements';
+import { test } from '../core/setup/fixtures';
+import { openSettings } from '../options/util';
+import { MultiUsers } from '../user/multiusers';
+
+test.describe.parallel('Accessible routing', { tag: '@ci' }, () => {
+  test('updates the document title for active client views', async ({ browser, context, page }, testInfo) => {
+    const session = new MultiUsers(browser, context);
+    await session.initModPage(page, { testInfo });
+    const { modPage } = session;
+
+    await expect(modPage.page, 'initial meeting title should include the active view').toHaveTitle(
+      / - (User list|Public Chat|Default presentation view)$/,
+    );
+
+    if (modPage.settings?.chatEnabled) {
+      if (!(await modPage.page.locator(e.hidePublicChat).isVisible())) {
+        if (!(await modPage.page.locator(e.chatButton).first().isVisible())) {
+          await modPage.waitAndClick(e.userListToggleBtn);
+        }
+
+        if (!(await modPage.page.locator(e.hidePublicChat).isVisible())) {
+          await modPage.waitAndClick(e.chatButton);
+        }
+      }
+
+      await modPage.hasElement(e.hidePublicChat, 'should display public chat');
+      await expect(modPage.page, 'public chat should be reflected in the document title').toHaveTitle(
+        / - Public Chat$/,
+      );
+    }
+
+    if (modPage.settings?.sharedNotesEnabled) {
+      await modPage.waitAndClick(e.sharedNotes);
+      await modPage.hasElement(e.sharedNotesBackground, 'should display shared notes');
+      await expect(modPage.page, 'shared notes should be reflected in the document title').toHaveTitle(
+        / - Shared Notes$/,
+      );
+    }
+
+    if (modPage.settings?.pollEnabled) {
+      await modPage.waitAndClick(e.actions);
+      await modPage.waitAndClick(e.polling);
+      await modPage.hasElement(e.hidePollDesc, 'should display the polling panel');
+      await expect(modPage.page, 'polling should be reflected in the document title').toHaveTitle(/ - Polling$/);
+    }
+
+    await modPage.waitAndClick(e.actions);
+    await modPage.waitAndClick(e.managePresentations);
+    await modPage.hasElement(e.presentationFileUpload, 'should display the presentation upload view');
+    await expect(modPage.page, 'presentation upload should be reflected in the document title').toHaveTitle(
+      / - Upload Presentation$/,
+    );
+  });
+
+  test('updates the document title for private chat', async ({ browser, context, page }, testInfo) => {
+    const session = new MultiUsers(browser, context);
+    await session.initPages(page, testInfo);
+    const { modPage } = session;
+
+    test.skip(!modPage.settings?.chatEnabled, 'Chat is disabled');
+    await openPrivateChat(modPage);
+    await modPage.hasElement(e.hidePrivateChat, 'should display private chat');
+    await expect(modPage.page, 'private chat participant should be reflected in the document title').toHaveTitle(
+      / - Private Chat with Attendee$/,
+    );
+  });
+
+  test('updates the document title for route-like modals', async ({ browser, context, page }, testInfo) => {
+    const session = new MultiUsers(browser, context);
+    await session.initModPage(page, { testInfo });
+    const { modPage } = session;
+
+    await openSettings(modPage);
+    await expect(modPage.page, 'settings modal should be reflected in the document title').toHaveTitle(/ - Settings$/);
+    await modPage.waitAndClick(e.modalDismissButton);
+
+    await modPage.waitAndClick(e.manageUsers);
+    await modPage.waitAndClick(e.createBreakoutRooms);
+    await expect(modPage.page, 'breakout room creation modal should be reflected in the document title').toHaveTitle(
+      / - Breakout Rooms$/,
+    );
+    await modPage.waitAndClick(e.modalDismissButton);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Introduces document title manager component to handle title changes in the client (accessible routing), and set distinct titles for the following pages/components:

Views / Pages

  - Default presentation view
  - User list panel
  - Public Chat
  - Private Chat
  - Polling panel
  - Captions panel
  - Breakout Rooms side panel
  - Shared Notes panel
  - Timer panel
  - Waiting Users management
  - Generic plugin sidekick content

  Modals

  - Upload Presentation
  - Settings
  - Breakout room creation
  - Breakout room join confirmation

### Closes Issue(s)
partially #25177