### PR TITLE
fix(html5): keep BlockNote toolbar visible when editing LaTeX blocks

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/basic-text-style-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/basic-text-style-button/component.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { useCallback } from 'react';
+import {
+  useBlockNoteEditor,
+  useComponentsContext,
+  useDictionary,
+  useEditorState,
+} from '@blocknote/react';
+import { formatKeyboardShortcut } from '@blocknote/core';
+import {
+  RiBold,
+  RiItalic,
+  RiStrikethrough,
+  RiUnderline,
+} from 'react-icons/ri';
+
+type BasicTextStyle = 'bold' | 'italic' | 'underline' | 'strike';
+
+const ICONS: Record<BasicTextStyle, React.ReactElement> = {
+  bold: <RiBold />,
+  italic: <RiItalic />,
+  underline: <RiUnderline />,
+  strike: <RiStrikethrough />,
+};
+
+// Custom replacement for BlockNote's BasicTextStyleButton. The native button
+// hides itself when none of the selected blocks have inline content
+// (`block.content !== undefined`). Our LaTeX custom block is declared
+// `content: 'none'`, so selecting/editing it makes every native style button
+// return null and the whole static formatting toolbar disappears.
+// This version keeps the button mounted regardless of the selected block type:
+// it only renders null when the style is missing from the schema or the editor
+// is read-only. On blocks without inline content the toggle is simply inert,
+// matching the always-visible behaviour of the static toolbar.
+function BasicTextStyleButton(
+  { basicTextStyle }: { basicTextStyle: BasicTextStyle },
+): React.ReactElement | null {
+  const dict = useDictionary();
+  const Components = useComponentsContext()!;
+  const editor = useBlockNoteEditor();
+
+  const state = useEditorState({
+    editor,
+    selector: ({ editor: e }) => {
+      const styleInSchema = basicTextStyle in e.schema.styleSchema
+        && e.schema.styleSchema[basicTextStyle].type === basicTextStyle
+        && e.schema.styleSchema[basicTextStyle].propSchema === 'boolean';
+      if (!e.isEditable || !styleInSchema) return undefined;
+      return { active: basicTextStyle in e.getActiveStyles() };
+    },
+  });
+
+  const toggleStyle = useCallback(() => {
+    editor.focus();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    editor.toggleStyles({ [basicTextStyle]: true } as any);
+  }, [editor, basicTextStyle]);
+
+  if (state === undefined) return null;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test={basicTextStyle}
+      onClick={toggleStyle}
+      isSelected={state.active}
+      label={dict.formatting_toolbar[basicTextStyle].tooltip}
+      mainTooltip={dict.formatting_toolbar[basicTextStyle].tooltip}
+      secondaryTooltip={formatKeyboardShortcut(
+        dict.formatting_toolbar[basicTextStyle].secondary_tooltip,
+        dict.generic.ctrl_shortcut,
+      )}
+      icon={ICONS[basicTextStyle]}
+    />
+  );
+}
+
+export default BasicTextStyleButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/block-type-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/block-type-select/component.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  BlockTypeSelect as NativeBlockTypeSelect,
+  useComponentsContext,
+} from '@blocknote/react';
+import { RiSquareRoot } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's BlockTypeSelect. The native select returns
+// null when no default block-type item matches the active block, which is the
+// case for our LaTeX custom block (`content: 'none'`, type not in the default
+// block-type list). That makes the first line of the static toolbar lose its
+// block-type control while editing a formula.
+//
+// On blocks with editable inline content we delegate to the native component
+// (full block-type switching). On content-less blocks we render an inert,
+// disabled select that still shows the current block ("LaTeX"), keeping the
+// toolbar layout stable. Switching a formula into a paragraph/heading from here
+// is meaningless, hence disabled.
+function BlockTypeSelect(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeBlockTypeSelect />;
+
+  return (
+    <Components.FormattingToolbar.Select
+      className="bn-select"
+      isDisabled
+      items={[
+        {
+          text: 'LaTeX',
+          icon: <RiSquareRoot size={16} />,
+          isSelected: true,
+          onClick: () => {},
+        },
+      ]}
+    />
+  );
+}
+
+export default BlockTypeSelect;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/color-style-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/color-style-button/component.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  ColorStyleButton as NativeColorStyleButton,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { RiFontColor } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's ColorStyleButton. The native button returns
+// null when none of the selected blocks have inline content
+// (`content !== undefined`). Our LaTeX custom block is declared `content: 'none'`,
+// so editing it hides the color control and breaks the first line of the static
+// toolbar.
+//
+// On blocks with editable inline content we delegate to the native component
+// (full text/background color picker). On content-less blocks text color does
+// not apply to the rendered formula, so we render an inert, disabled placeholder
+// that keeps the toolbar layout stable.
+function ColorStyleButton(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeColorStyleButton />;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test="colors"
+      isDisabled
+      label={dict.formatting_toolbar.colors.tooltip}
+      mainTooltip={dict.formatting_toolbar.colors.tooltip}
+      icon={<RiFontColor />}
+    />
+  );
+}
+
+export default ColorStyleButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -18,9 +18,16 @@ import {
   UnnestBlockButton,
   useComponentsContext,
   useCreateBlockNote,
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  DefaultReactSuggestionItem,
 } from '@blocknote/react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Menu as MantineMenu } from '@mantine/core';
+import {
+  filterSuggestionItems,
+  insertOrUpdateBlockForSlashMenu,
+} from '@blocknote/core/extensions';
 
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
@@ -35,6 +42,8 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
+import createLatexBlock from './latex-block/LatexBlock';
+import 'katex/dist/katex.min.css';
 
 // Force-retain `Awareness` against a webpack tree-shaking interaction that
 // otherwise drops this class while keeping its `extends Observable` expression,
@@ -182,6 +191,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   const schema = BlockNoteSchema.create({
     blockSpecs: {
       ...remainingBlockSpecs,
+      latex: createLatexBlock(),
     },
   });
 
@@ -449,8 +459,27 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        slashMenu={false}
         renderEditor={false}
       >
+        <SuggestionMenuController
+          triggerCharacter="/"
+          getItems={async (query) => filterSuggestionItems(
+            [
+              ...getDefaultReactSlashMenuItems(editor),
+              {
+                title: 'LaTeX Formula',
+                onItemClick: () => {
+                  insertOrUpdateBlockForSlashMenu(editor, { type: 'latex' });
+                },
+                aliases: ['latex', 'math', 'formula', 'equation'],
+                group: 'Other',
+                subtext: 'Insert a LaTeX math formula',
+              } as DefaultReactSuggestionItem,
+            ],
+            query,
+          )}
+        />
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
           <ToolbarWithAccessibleMenus>
             <div

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -440,6 +440,18 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             bottom: auto !important;
             transform: translateY(0) !important;
           }
+          /* LaTeX block: remove selection outline and increase rendered formula size */
+          .ProseMirror-selectednode > .bn-block-content > .latex-block,
+          .bn-block-content.ProseMirror-selectednode > .latex-block {
+            outline: none !important;
+            border-radius: 0 !important;
+          }
+          .latex-block .katex {
+            font-size: 1.4em;
+          }
+          .latex-block-textarea::placeholder {
+            color: #9b9a97;
+          }
         `}
       </style>
       {notificationErrorMessage && (

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -8,14 +8,9 @@ import '@blocknote/mantine/style.css';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Awareness } from 'y-protocols/awareness';
 import {
-  BasicTextStyleButton,
   BlockNoteViewEditor,
-  BlockTypeSelect,
-  ColorStyleButton,
   ComponentsContext,
   FormattingToolbar,
-  NestBlockButton,
-  UnnestBlockButton,
   useComponentsContext,
   useCreateBlockNote,
   getDefaultReactSlashMenuItems,
@@ -42,6 +37,11 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import logger from '/imports/startup/client/logger';
 import { notify } from '../../services/notification';
 import TextAlignSelect from './text-align-select/component';
+import BasicTextStyleButton from './basic-text-style-button/component';
+import BlockTypeSelect from './block-type-select/component';
+import ColorStyleButton from './color-style-button/component';
+import NestBlockButton from './nest-block-button/component';
+import UnnestBlockButton from './unnest-block-button/component';
 import createLatexBlock from './latex-block/LatexBlock';
 import 'katex/dist/katex.min.css';
 

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
@@ -1,0 +1,166 @@
+// @ts-nocheck -- BlockNote schema-generic types unresolved for custom block; safe POC
+import { createReactBlockSpec } from '@blocknote/react';
+import * as React from 'react';
+import katex from 'katex';
+
+const LatexBlockContent: React.FC<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  block: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editor: any;
+}> = ({ block, editor }) => {
+  const [editing, setEditing] = React.useState(
+    !block.props.formula || block.props.formula === '',
+  );
+  const [formula, setFormula] = React.useState(block.props.formula || '');
+  const [error, setError] = React.useState<string | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    setFormula(block.props.formula || '');
+  }, [block.props.formula]);
+
+  React.useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [editing]);
+
+  const renderFormula = () => {
+    if (!formula || formula.trim() === '') {
+      return (
+        <span className="latex-block-placeholder">
+          Click to insert LaTeX formula
+        </span>
+      );
+    }
+    try {
+      const html = katex.renderToString(formula, {
+        displayMode: block.props.displayMode ?? false,
+        throwOnError: true,
+      });
+      return (
+        <span
+          className="latex-block-rendered"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      );
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Invalid LaTeX';
+      return (
+        <span className="latex-block-error">
+          {msg}
+        </span>
+      );
+    }
+  };
+
+  const commitFormula = (newFormula: string) => {
+    const trimmed = newFormula.trim();
+    editor.updateBlock(block, {
+      type: 'latex' as const,
+      props: {
+        formula: trimmed,
+        displayMode: block.props.displayMode ?? false,
+      },
+    });
+    setError(null);
+    if (trimmed) {
+      try {
+        katex.renderToString(trimmed, {
+          displayMode: block.props.displayMode ?? false,
+          throwOnError: true,
+        });
+        setEditing(false);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Invalid LaTeX');
+      }
+    } else {
+      setEditing(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && e.shiftKey) {
+      // Shift+Enter = commit and render
+      e.preventDefault();
+      commitFormula(formula);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setFormula(block.props.formula || '');
+      setError(null);
+      setEditing(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="latex-block latex-block-editing" contentEditable={false}>
+        <div className="latex-block-label">LaTeX</div>
+        <textarea
+          ref={textareaRef}
+          className="latex-block-textarea"
+          value={formula}
+          onChange={(e) => {
+            setFormula(e.target.value);
+            setError(null);
+          }}
+          onBlur={() => commitFormula(formula)}
+          onKeyDown={handleKeyDown}
+          placeholder="E = mc^2 \\\\ \text{or try: } \\\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}"
+          rows={3}
+        />
+        {error && <div className="latex-block-error">{error}</div>}
+        <div className="latex-block-hint">
+          Press Enter+Shift to render &bull; Esc to cancel
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`latex-block latex-block-rendered ${block.props.displayMode ? 'latex-block-display' : 'latex-block-inline'}`}
+      contentEditable={false}
+      onClick={() => setEditing(true)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setEditing(true);
+        }
+      }}
+    >
+      <div className="latex-block-label">LaTeX</div>
+      <div className="latex-block-content">{renderFormula()}</div>
+    </div>
+  );
+};
+
+export const createLatexBlock = createReactBlockSpec(
+  {
+    type: 'latex',
+    propSchema: {
+      formula: {
+        default: '',
+      },
+      displayMode: {
+        default: false,
+      },
+    },
+    content: 'none',
+  },
+  {
+    render: (props) => {
+      return (
+        <LatexBlockContent
+          block={props.block}
+          editor={props.editor}
+        />
+      );
+    },
+  },
+);
+
+export default createLatexBlock;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/latex-block/LatexBlock.tsx
@@ -96,7 +96,6 @@ const LatexBlockContent: React.FC<{
   if (editing) {
     return (
       <div className="latex-block latex-block-editing" contentEditable={false}>
-        <div className="latex-block-label">LaTeX</div>
         <textarea
           ref={textareaRef}
           className="latex-block-textarea"
@@ -107,7 +106,7 @@ const LatexBlockContent: React.FC<{
           }}
           onBlur={() => commitFormula(formula)}
           onKeyDown={handleKeyDown}
-          placeholder="E = mc^2 \\\\ \text{or try: } \\\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}"
+          placeholder="Write something in LaTeX"
           rows={3}
         />
         {error && <div className="latex-block-error">{error}</div>}
@@ -132,7 +131,6 @@ const LatexBlockContent: React.FC<{
         }
       }}
     >
-      <div className="latex-block-label">LaTeX</div>
       <div className="latex-block-content">{renderFormula()}</div>
     </div>
   );

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/nest-block-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/nest-block-button/component.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  NestBlockButton as NativeNestBlockButton,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { RiIndentIncrease } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's NestBlockButton. The native button returns
+// null when none of the selected blocks have inline content
+// (`content !== undefined`). Our LaTeX custom block is declared `content: 'none'`,
+// so editing it hides the nest control and breaks the first line of the static
+// toolbar.
+//
+// On blocks with editable inline content we delegate to the native component
+// (it already disables itself when nesting is not possible). On content-less
+// blocks nesting a formula is meaningless, so we render an inert, disabled
+// placeholder that keeps the toolbar layout stable.
+function NestBlockButton(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeNestBlockButton />;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test="nestBlock"
+      isDisabled
+      label={dict.formatting_toolbar.nest.tooltip}
+      mainTooltip={dict.formatting_toolbar.nest.tooltip}
+      icon={<RiIndentIncrease />}
+    />
+  );
+}
+
+export default NestBlockButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/text-align-select/component.tsx
@@ -109,7 +109,22 @@ function TextAlignSelect(): React.ReactElement | null {
     [editor, state],
   );
 
-  if (!state) return null;
+  // The selector returns null for blocks without a textAlignment prop (e.g. our
+  // LaTeX custom block, declared `content: 'none'`). Returning null here would
+  // drop this control from the first line of the static toolbar. Instead render
+  // an inert, disabled placeholder so the toolbar layout stays stable; text
+  // alignment does not apply to a rendered formula.
+  if (!state) {
+    return (
+      <Components.FormattingToolbar.Button
+        className="bn-button"
+        isDisabled
+        label={dict.formatting_toolbar.align_left.tooltip}
+        mainTooltip={dict.formatting_toolbar.align_left.tooltip}
+        icon={<RiAlignLeft size={16} />}
+      />
+    );
+  }
 
   const currentItem = ALIGN_ITEMS.find((a) => a.value === state.alignment)!;
 

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/unnest-block-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/unnest-block-button/component.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import {
+  UnnestBlockButton as NativeUnnestBlockButton,
+  useComponentsContext,
+  useDictionary,
+} from '@blocknote/react';
+import { RiIndentDecrease } from 'react-icons/ri';
+import useActiveBlockHasContent from '../use-active-block-has-content';
+
+// Custom replacement for BlockNote's UnnestBlockButton. The native button returns
+// null when none of the selected blocks have inline content
+// (`content !== undefined`). Our LaTeX custom block is declared `content: 'none'`,
+// so editing it hides the unnest control and breaks the first line of the static
+// toolbar.
+//
+// On blocks with editable inline content we delegate to the native component
+// (it already disables itself when unnesting is not possible). On content-less
+// blocks unnesting a formula is meaningless, so we render an inert, disabled
+// placeholder that keeps the toolbar layout stable.
+function UnnestBlockButton(): React.ReactElement | null {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+  const hasContent = useActiveBlockHasContent();
+
+  if (hasContent) return <NativeUnnestBlockButton />;
+
+  return (
+    <Components.FormattingToolbar.Button
+      className="bn-button"
+      data-test="unnestBlock"
+      isDisabled
+      label={dict.formatting_toolbar.unnest.tooltip}
+      mainTooltip={dict.formatting_toolbar.unnest.tooltip}
+      icon={<RiIndentDecrease />}
+    />
+  );
+}
+
+export default UnnestBlockButton;

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/use-active-block-has-content.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/use-active-block-has-content.ts
@@ -1,0 +1,24 @@
+import { useBlockNoteEditor, useEditorState } from '@blocknote/react';
+
+// Returns whether the active selection contains at least one block with editable
+// inline content (`content !== undefined`).
+//
+// BlockNote's stock toolbar components (BlockTypeSelect, ColorStyleButton,
+// NestBlockButton, UnnestBlockButton) hide themselves - return null - when this
+// is false. Our LaTeX custom block is declared `content: 'none'`, so selecting
+// or editing it makes those components disappear and tears the first line of the
+// static formatting toolbar apart. The custom wrappers in the sibling folders
+// use this flag to keep those components mounted (inert) on content-less blocks,
+// mirroring the always-visible behaviour expected from a static toolbar.
+export default function useActiveBlockHasContent(): boolean {
+  const editor = useBlockNoteEditor();
+
+  return useEditorState({
+    editor,
+    selector: ({ editor: e }) => {
+      if (!e.isEditable) return false;
+      const blocks = e.getSelection()?.blocks ?? [e.getTextCursorPosition().block];
+      return blocks.some((block) => block.content !== undefined);
+    },
+  });
+}

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -51,6 +51,7 @@
         "hark": "^1.2.3",
         "html-to-image": "^1.11.13",
         "immutability-helper": "~2.8.1",
+        "katex": "^0.16.47",
         "langmap": "0.0.16",
         "livekit-client": "2.17.3",
         "makeup-screenreader-trap": "0.0.5",
@@ -7369,7 +7370,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -11578,6 +11578,22 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/keyv": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -94,6 +94,7 @@
     "hark": "^1.2.3",
     "html-to-image": "^1.11.13",
     "immutability-helper": "~2.8.1",
+    "katex": "^0.16.47",
     "langmap": "0.0.16",
     "livekit-client": "2.17.3",
     "makeup-screenreader-trap": "0.0.5",

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/latex-formatting-toolbar.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/latex-formatting-toolbar.spec.ts
@@ -1,0 +1,19 @@
+import { initializePages } from '../../core/helpers';
+import { test } from '../../core/setup/fixtures';
+import { BlockNoteSharedNotes } from './sharednotes';
+
+test.describe('Shared Notes - BlockNote LaTeX block', () => {
+  let sharedNotes: BlockNoteSharedNotes;
+
+  test.beforeEach(async ({ browser, context }, testInfo) => {
+    sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, {
+      createParameter: 'sharedNotesEditor=blockNote',
+      testInfo,
+    });
+  });
+
+  test('Formatting toolbar stays visible while editing a LaTeX block', async () => {
+    await sharedNotes.latexBlockKeepsFormattingToolbar();
+  });
+});

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -4,6 +4,28 @@ import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constant
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 
+// BlockNote-internal selectors (the editor library does not expose data-test
+// attributes for these). The static formatting toolbar lives in the custom
+// `.bn-toolbar-row` container (see bn-shared-notes/component.tsx); each
+// BasicTextStyleButton renders with `data-test=<style>` (e.g. "bold").
+const blockNote = {
+  editor: '.bn-editor',
+  // Second toolbar line: BasicTextStyleButton renders with data-test=<style>.
+  toolbarBoldButton: '.bn-toolbar-row [data-test="bold"]',
+  // First toolbar line: color and nest buttons. Custom wrappers keep these
+  // mounted (inert) on the content-less LaTeX block; the native components hide
+  // them. They render with a stable `data-test` on both the native (text block)
+  // and the inert (LaTeX block) path, so they are reliable handles for "the
+  // first toolbar line is present". Each is separate so the test fails pointing
+  // at whichever button regressed. (The block-type select trigger has no stable
+  // selector - BlockNote's `.bn-select` class is on the open dropdown only.)
+  toolbarColorsButton: '.bn-toolbar-row [data-test="colors"]',
+  toolbarNestButton: '.bn-toolbar-row [data-test="nestBlock"]',
+  slashMenu: '.bn-suggestion-menu',
+  slashMenuItem: '.bn-suggestion-menu-item',
+  latexTextarea: '.latex-block-textarea',
+};
+
 export class BlockNoteSharedNotes extends MultiUsers {
   // Regression for https://github.com/bigbluebutton/bigbluebutton/issues/25122:
   // exporting an empty BlockNote shared note must return a file, not an error
@@ -75,5 +97,92 @@ export class BlockNoteSharedNotes extends MultiUsers {
       // eslint-disable-next-line no-await-in-loop
       if (body) body(await response.text());
     }
+  }
+
+  // Reproduces the bug where editing a LaTeX block hides the BlockNote
+  // formatting toolbar. The toolbar buttons (BasicTextStyleButton) only render
+  // when the active selection contains a block with editable text content
+  // (`content !== undefined`). The LaTeX custom block is declared `content:
+  // 'none'`, so as soon as it becomes the active block the bold/italic/etc.
+  // buttons return null and the toolbar disappears. It should stay visible.
+  async latexBlockKeepsFormattingToolbar() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+
+    const { page } = this.modPage;
+
+    // Open the BlockNote shared notes panel and wait for the editor.
+    await this.modPage.waitAndClick(e.sharedNotes, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.hasElement(
+      e.sharedNotesBackground,
+      'should display the shared notes panel',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.hasElement(blockNote.editor, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+
+    // Baseline: editing a normal text block keeps the full formatting toolbar
+    // visible. This also proves the selectors are correct (the toolbar exists
+    // and these are the right handles for "the formatting toolbar"). Both lines
+    // must be present: the second line (bold) and the first line (block type
+    // select, colors, nest).
+    await this.modPage.waitAndClick(blockNote.editor);
+    await page.keyboard.type('Baseline paragraph');
+    await this.modPage.hasElement(
+      blockNote.toolbarBoldButton,
+      'baseline: the second toolbar line (bold button) should be visible when editing a text block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarColorsButton,
+      'baseline: the first toolbar line (color button) should be visible when editing a text block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarNestButton,
+      'baseline: the first toolbar line (nest button) should be visible when editing a text block',
+    );
+
+    // Insert a LaTeX block via the slash menu (/latex -> "LaTeX Formula").
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('/latex');
+    await this.modPage.hasElement(blockNote.slashMenu, 'should display the slash command menu');
+    await page.locator(blockNote.slashMenuItem, { hasText: 'LaTeX Formula' }).first().click();
+
+    // A freshly inserted LaTeX block has an empty formula, so it opens directly
+    // in editing mode (its textarea is rendered and focused). Click it to make
+    // sure the LaTeX block is the active/edited block.
+    await this.modPage.hasElement(
+      blockNote.latexTextarea,
+      'should display the LaTeX block editing textarea',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.waitAndClick(blockNote.latexTextarea);
+
+    // Capture the editor state at the assertion point (toolbar should be here).
+    const screenshotPath = 'test-results/latex-formatting-toolbar.png';
+    await page.screenshot({ path: screenshotPath });
+    if (this.modPage.testInfo) {
+      await this.modPage.testInfo.attach('latex-block-editing', { path: screenshotPath });
+    }
+
+    // The bug: while editing the LaTeX block the toolbar lines disappear because
+    // the LaTeX block is `content: 'none'` and the stock toolbar components hide
+    // on content-less blocks. Both lines must remain visible: the second line
+    // (bold) and the first line (block type select, colors, nest).
+    await this.modPage.hasElement(
+      blockNote.toolbarBoldButton,
+      'the second toolbar line (bold button) should remain visible while editing a LaTeX block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarColorsButton,
+      'the first toolbar line (color button) should remain visible while editing a LaTeX block',
+    );
+    await this.modPage.hasElement(
+      blockNote.toolbarNestButton,
+      'the first toolbar line (nest button) should remain visible while editing a LaTeX block',
+    );
   }
 }

--- a/bigbluebutton-web/project/build.properties
+++ b/bigbluebutton-web/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/bigbluebutton-web/project/build.properties
+++ b/bigbluebutton-web/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2


### PR DESCRIPTION
## Problem

When editing a LaTeX block in the BlockNote Shared Notes editor, the entire formatting toolbar disappears. The LaTeX custom block is declared with `content: 'none'` (it stores its formula in `props`, not inline content), and BlockNote's toolbar components return `null` when the active block has no inline content — causing the whole toolbar to vanish.

## Root cause

BlockNote's toolbar components check whether the active block has editable text content (`content !== undefined`). When a LaTeX block is selected, these components return `null`:

- `BasicTextStyleButton` (bold/italic/underline/strike)
- `BlockTypeSelect` (block type selector)
- `ColorStyleButton` (text color)
- `NestBlockButton` / `UnnestBlockButton` (nesting)
- `TextAlignSelect` (text alignment)

## Fix

Created custom wrapper components that render **inert placeholders** on content-less blocks, keeping the toolbar layout intact. Toggle actions are disabled (no-op) on blocks where they don't apply — buttons stay visible but do nothing on a LaTeX formula.

The `content: 'none'` declaration on the LaTeX block was intentionally left unchanged, as it correctly reflects the block's editing model (formula stored in `props`, not inline content).

### Files changed

- `use-active-block-has-content.ts` — shared hook for the content check
- `basic-text-style-button/component.tsx` — wrapper for bold/italic/underline/strike
- `block-type-select/component.tsx` — wrapper for block type selector
- `color-style-button/component.tsx` — wrapper for text color
- `nest-block-button/component.tsx` — wrapper for nest block
- `unnest-block-button/component.tsx` — wrapper for unnest block
- `text-align-select/component.tsx` — modified to show inert placeholder instead of null
- `component.tsx` — imports updated to use local wrappers

### Evidence

**Before** — toolbar disappears when editing a LaTeX block:

![Before](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/e75464c0-4455-41bc-9605-150f04e866ec/latex-toolbar-before.png)

**After** — complete toolbar (both lines) visible:

![After](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-23/d83db8bb-e743-4733-b7c1-6c65fc81eeb5/latex-toolbar-after.png)

### Test

Added E2E test (`latex-formatting-toolbar.spec.ts`) that verifies the toolbar stays visible while editing a LaTeX block:
1. Creates a meeting, joins as moderator, opens Shared Notes
2. Types a paragraph — baseline assertion: toolbar visible (passes)
3. Inserts a LaTeX block via `/latex` slash command
4. Asserts the toolbar (both lines) remains visible — passes after fix