### PR TITLE
Add analytics logging for breakout move-user request

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/AnalyticsActor.scala
@@ -231,6 +231,7 @@ class AnalyticsActor(val includeChat: Boolean) extends Actor with ActorLogging {
 
       // Breakouts
       case m: CreateBreakoutRoomsCmdMsg => logMessage(msg)
+      case m: ChangeUserBreakoutReqMsg => logMessage(msg)
 
       case _ => // ignore message
     }


### PR DESCRIPTION
## What

When a moderator moves a user into a breakout room (the "Manage breakout rooms" panel -> drag action), the action is processed correctly server-side but leaves **no trace** in `bbb-apps-akka.log`. Every other breakout action (`CreateBreakoutRoomsCmdMsg`, `EndAllBreakoutRoomsMsg`, `UpdateBreakoutRoomsTimeReqMsg`, ...) is logged by `AnalyticsActor`, but the move-user request falls through to the silent default case.

This makes post-incident investigation of breakout-room support tickets effectively impossible — there is no server-side record of how a user ended up in a breakout room.

## Why it matters

The `-- analytics --` log lines are how operators reconstruct what happened in a meeting. Every other breakout action emits one; the move-user action did not, creating a blind spot exactly where support questions tend to cluster ("how did this user get into that room?").

## The change

Add one case branch to `AnalyticsActor.scala`, next to the existing breakout cases, following the identical pattern:

```scala
// Breakouts
case m: CreateBreakoutRoomsCmdMsg => logMessage(msg)
case m: ChangeUserBreakoutReqMsg => logMessage(msg)   // added
```

`ChangeUserBreakoutReqMsg` is the **inbound moderator request**. Logging it captures who moved whom and the from/to breakout rooms, e.g.:

```json
{ "envelope": { "name": "ChangeUserBreakoutReqMsg",
                "routing": { "meetingId": "<meeting>", "userId": "<moderator>" } },
  "core": { "body": { "meetingId": "<meeting>", "userId": "<moved user>",
                      "fromBreakoutId": "<from>", "toBreakoutId": "<to>" } } }
```

Additive logging only — no behavior change.

## Why only the request, not the outbound events

The outbound counterparts (`ChangeUserBreakoutEvtMsg`, `BreakoutRoomJoinURLEvtMsg`) carry **signed join URLs** that embed the participant's display name and the meeting password. Logging them would write those credentials to the akka log in plaintext. The inbound request already captures the full move action without any URL, so observability is complete without exposing credentials. The separate "ask to join" / join-URL-request flow is already observable via its inbound `RequestBreakoutJoinURLReqMsg`, which `AnalyticsActor` already logs.

## Verification

Reproduced on a 3.0 from-source dev environment (synthetic users). Before the change the message was absent from `bbb-apps-akka.log`; after, a move-user action produces the analytics line:

- `grep -c ChangeUserBreakoutReqMsg` before: `0` -> after: `1`
- `CreateBreakoutRoomsCmdMsg` (control): `>0` before and after (unchanged)

The logged body contains only internal identifiers (meeting id, internal user/room ids) — no join URL, no password.
