### PR TITLE
fix(bbb-apps-akka): prevent breakout-room panel staleness from join-time read race

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/BreakoutRoomUsersUpdateMsgHdlr.scala
@@ -20,10 +20,15 @@ trait BreakoutRoomUsersUpdateMsgHdlr extends HandlerHelpers {
       val updatedRoom = room.copy(users = msg.users, voiceUsers = msg.voiceUsers)
 
       //Update user lastActivityTime in parent room (to avoid be ejected while is in Breakout room)
-      for {
-        breakoutRoomUser <- updatedRoom.users
-        parentMeetingUser <- findUserInMainRoom(liveMeeting.users2x, breakoutRoomUser.extId)
-      } yield Users2x.updateLastUserActivity(liveMeeting.users2x, parentMeetingUser)
+      updatedRoom.users.foreach { breakoutRoomUser =>
+        findUserInMainRoom(liveMeeting.users2x, breakoutRoomUser.extId) match {
+          case Some(parentMeetingUser) => Users2x.updateLastUserActivity(liveMeeting.users2x, parentMeetingUser)
+          case None => log.info(
+            "breakoutAudit: findUserInMainRoom MISS extId={} breakoutRoomId={} parentMeetingId={}",
+            breakoutRoomUser.extId, updatedRoom.id, liveMeeting.props.meetingProp.intId
+          )
+        }
+      }
 
       //Update lastBreakout in registeredUsers to avoid lose this info when the user leaves
       for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/BreakoutRoomUserDAO.scala
@@ -5,6 +5,7 @@ import org.bigbluebutton.core.domain.{BreakoutRoom2x, BreakoutUser}
 import org.bigbluebutton.core.models.RegisteredUser
 import org.bigbluebutton.core.running.LiveMeeting
 import slick.jdbc.PostgresProfile.api._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 case class BreakoutRoomUserDbModel(
       breakoutRoomMeetingId:  String,
@@ -61,21 +62,54 @@ object BreakoutRoomUserDAO {
   }
 
   def updateUserJoined(breakoutRoomUser: BreakoutUser, parentMeetingUser: RegisteredUser, breakoutRoom: BreakoutRoom2x) = {
-      DatabaseConnection.enqueue(
+      // Single source of presence truth, computed once per audit tick and reused below for both the
+      // self-correcting presence UPDATE and the buid-set log (avoids re-evaluating the same EXISTS).
+      val presenceCheck =
+        sql"""select exists (
+                select 1
+                from "user"
+                where "user"."meetingId" = ${breakoutRoom.id}
+                and "user"."userId" = ${breakoutRoomUser.userId}
+                and "currentlyInMeeting" is true
+              )""".as[Boolean].head
+
+      // (a) ALWAYS-RUNNING presence update: self-corrects in_room if the join-time read race locked it
+      //     wrong. Guarded so it writes ONLY when the stored value actually differs from the computed
+      //     truth: in steady state (already correct) IS DISTINCT FROM is false -> no match, no write, no
+      //     trigger, no dead-tuple churn; when stuck wrong it matches and corrects on the next tick.
+      def presenceUpdate(presenceExists: Boolean) =
+        sqlu"""UPDATE "breakoutRoom_user" SET
+                "isUserCurrentlyInRoom" = ${presenceExists}
+                WHERE "meetingId" = ${parentMeetingUser.meetingId}
+                AND "userId" = ${parentMeetingUser.id}
+                AND "breakoutRoomMeetingId" = ${breakoutRoom.id}
+                AND "isUserCurrentlyInRoom" IS DISTINCT FROM ${presenceExists}"""
+
+      // (b) ONE-SHOT breakoutRoomUserId/joinedAt update: keeps the optimization (runs once), guarded by
+      //     the stale-write check. No longer touches isUserCurrentlyInRoom - that is (a)'s job now.
+      val buidUpdate =
         sqlu"""UPDATE "breakoutRoom_user" SET
                 "breakoutRoomUserId" = ${breakoutRoomUser.userId},
-                "joinedAt" = current_timestamp,
-                "isUserCurrentlyInRoom" = exists (
-                  select 1
-                  from "user"
-                  where "user"."meetingId" = ${breakoutRoom.id}
-                  and "user"."userId" = ${breakoutRoomUser.userId}
-                  and "currentlyInMeeting" is true
-                )
+                "joinedAt" = current_timestamp
                 WHERE "meetingId" = ${parentMeetingUser.meetingId}
                 AND "userId" = ${parentMeetingUser.id}
                 AND "breakoutRoomMeetingId" = ${breakoutRoom.id}
                 AND "breakoutRoomUserId" is distinct from ${breakoutRoomUser.userId}"""
+
+      DatabaseConnection.enqueue(
+        (for {
+          presenceExists <- presenceCheck
+          _ <- presenceUpdate(presenceExists)
+          rowsAffected <- buidUpdate
+        } yield {
+          // Fires once, at buid-set: a presenceExists=false here IS the join-time read race firing.
+          if (rowsAffected != 0) {
+            DatabaseConnection.logger.info(
+              "breakoutAudit: presence at buid-set parentUserId={} breakoutRoomId={} breakoutUserId={} presenceExists={}",
+              parentMeetingUser.id, breakoutRoom.id, breakoutRoomUser.userId, presenceExists.toString
+            )
+          }
+        })
       )
   }
 


### PR DESCRIPTION
## What happened (the symptom)

Teachers using "Manage Breakout Rooms" occasionally saw a participant shown as **absent from a room they were demonstrably inside** — connected, with audio/video/chat working — for the entire session. Refreshing the teacher's tab usually cleared it. The breakout room itself was healthy; only the parent-side bookkeeping was wrong. (Support report: a guest user never appeared in the panel for 90+ minutes despite being in the breakout the whole time.)

## Root cause: a join-time read race

The panel subscribes to a view that reads `breakoutRoom_user.isUserCurrentlyInRoom`. Two writers maintain that column:

- **Writer A** — a 10-second parent-side audit (`BreakoutRoomUserDAO.updateUserJoined`) sets `breakoutRoomUserId` AND `isUserCurrentlyInRoom` in the SAME `UPDATE`, computing presence via `EXISTS(SELECT … "currentlyInMeeting" is true)`. A stale-write guard (`"breakoutRoomUserId" IS DISTINCT FROM …`) makes this `UPDATE` run **only once** per row — after the first run, Writer A is permanently locked out of that row.
- **Writer B** — a Postgres trigger `AFTER UPDATE OF "currentlyInMeeting" ON "user"` that mirrors `currentlyInMeeting` into `isUserCurrentlyInRoom`. It fires **only on a value CHANGE** (the function guards `NEW <> OLD`), and not on `INSERT`.

The race: if the audit tick runs **before** the breakout-side join has committed `currentlyInMeeting = true`, Writer A's `EXISTS` reads **false** → `isUserCurrentlyInRoom` is written `false` AND the guard locks Writer A out of the row. If the user then stays connected with a stable `currentlyInMeeting = true` (no further change), **Writer B never fires** (no transition) → the column is stuck `false` for the entire session. That is exactly "connected and functioning, but never in the panel."

Confirmed live: instrumentation logging the `EXISTS` result at the moment `breakoutRoomUserId` is first set shows `presenceExists = false` firing naturally on joins — the race is real, not rare.

## What this changes

Split `updateUserJoined` into two `UPDATE`s, enqueued together as one DBIO (same batching idiom, no `db.run`):
1. **Presence `UPDATE`** (guarded on value change): `SET "isUserCurrentlyInRoom" = <truth> WHERE … AND "isUserCurrentlyInRoom" IS DISTINCT FROM <truth>`, where `<truth> = EXISTS(…"currentlyInMeeting" is true)`. It writes **only when the stored value differs from truth** — a wrong initial value (the race outcome) self-corrects on the next 10s tick; a correct value is a no-op (no rewrite, no trigger cascade, no tuple churn).
2. **One-shot `"breakoutRoomUserId"`/`"joinedAt"` `UPDATE`** (keeps the original `IS DISTINCT FROM` guard/optimization): runs once.

The `EXISTS` truth is computed once per tick and reused for the SET value, the guard, and the diagnostic log. Net effect: `isUserCurrentlyInRoom` is corrected whenever it drifts from reality, without steady-state write amplification. This guard is deliberately different from the original bug's lockout: that one keyed on `breakoutRoomUserId` (immutable after set → locked forever); this one keys on value-vs-truth, which differs whenever the value is wrong → it can never lock out a correction. Writer B remains the fast-path for `currentlyInMeeting` transitions.

## How it was verified (live, from-source v3.0.x-develop build)

**Self-correction (the core proof)** — with a user connected in a breakout (`currentlyInMeeting = true`), setting `isUserCurrentlyInRoom = false` directly (simulating the race outcome) reproduces the bug state (panel shows the participant with no room badge), then **self-corrects to `true` within one audit tick (~8-15s)** with the room badge restored. `currentlyInMeeting` stayed `true` throughout. Without the fix this stays `false` indefinitely (Writer A locked, Writer B doesn't fire).

Before (bug state) → after (self-corrected):

![bug state — participant present but no room badge](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-24/6deff13d-62fd-4a44-8716-6fb75271f847/r1-bugstate-panel-sm.jpg)

![after one tick — room badge restored](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-24/1ea856ab-b8a0-48b2-aa2d-19ebf35ee6a4/r1b-selfcorrect-panel.png)

**No write amplification (the guard works)** — in steady state (all values correct) `pg_stat_user_tables.n_tup_upd` for `breakoutRoom_user` is flat across 4-5 ticks (e.g. `425 → 425`); it only bumps when a wrong value is actually corrected (`425 → 427` on a constructed wrong-state, then flat again). Contrast: the unguarded variant rewrote every row every tick (414 updates vs 24 live rows). The guarded UPDATE is a true no-op when correct.

**Normal flows unaffected** — create / assign / move-between-rooms / end / disconnect-reconnect all leave the panel accurate; DB `isUserCurrentlyInRoom` matches reality:

![normal flow — correct room counts](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-24/6a025b4f-956f-45d9-a68b-af6f73af4839/r1-normalflow-panel-sm.jpg)

**No regressions** — akka rebuilt clean (`sbt debian:packageBin`, rc 0), booted clean, no new errors/exceptions across the test runs (journal error scan excluding benign PresentationPageCount/HttpIdleTimeout/analytics = 0).

## Observability (included)

- `BreakoutRoomUsersUpdateMsgHdlr`: logs `breakoutAudit: findUserInMainRoom MISS …` when the parent-side user lookup fails.
- `BreakoutRoomUserDAO`: logs `breakoutAudit: presence at buid-set … presenceExists=<bool>` **once**, at the moment `breakoutRoomUserId` is first set (the race catcher — `presenceExists=false` here IS the join-time race firing).

Future occurrences become a single `grep "breakoutAudit:" bbb-apps-akka.log`.

## Scope

Two files in `akka-bbb-apps`, +52/-13. Does NOT touch `AnalyticsActor` (move-user analytics logging landed separately in #25326). No schema, client, or Hasura changes.

## Honest limitations

- The race mechanism reproduces naturally (instrumented logging catches `presenceExists=false` at buid-set on joins). The full "stuck-invisible-for-90-min" end-to-end symptom is demonstrated via a constructed race outcome (set `isUserCurrentlyInRoom=false` while connected), not captured as a single natural case — it requires the specific `currentlyInMeeting` lifecycle that is intermittent. The mechanism is the only one consistent with every detail of the report.
- `setOffline(true)` did not clear `isUserCurrentlyInRoom` within a 40s window because BBB's server-side presence timeout exceeds the audit window — pre-existing presence-detection latency, not a regression.

## Review notes (draft)

Opened as draft for team review. Two non-blocking nits surfaced in pre-review and are noted for consideration:
- A sub-millisecond read-then-write TOCTOU exists (the standalone `EXISTS` read vs the non-transactional presence `UPDATE`); it self-heals on the next tick and the trigger remains the real-time path. Adding `.transactionally` to the composed action would close it — open to doing so.
- The standalone `EXISTS` now runs once per tick per breakout user (the original skipped it when the buid-guard failed). It's a cheap indexed read (not a write), intrinsic to enabling self-correction.
