### PR TITLE
fix(media-area): add id to drop up

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/actions-bar/media-area/media-sharing/component.tsx
@@ -451,6 +451,7 @@ const MediaSharingModal: React.FC<MediaSharingModalProps> = ({
         isRTL={isRTL}
         actionsBarHeight={actionsBarStyle.height}
         reducedWidth={!amIPresenter && amIModerator}
+        id="mediaAreaDropUp"
       >
         {!amIPresenter
           ? renderTakePresenterView()


### PR DESCRIPTION
### What does this PR do?
Currently, there is no way of selecting the media-area drop up, because it is not a modal and has no specific attributes(data-test, id, class list with react_Modal, etc), which makes it hard to style this specific component via custom-styles.

Adds an ID attribute with "mediaAreaDropUp" to the media area drop-up container, so it can be very easily selected via css selectors.

### Closes Issue(s)
Closes --