### PR TITLE
fix(html5): stop recording confirmation toast from blocking other modals

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -125,22 +125,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
   const showButton = Service.mayIRecord(isModerator, allowStartStopRecording);
   const isRTL = layoutSelect((i: Layout) => i.isRTL);
 
-  const {
-    isOpen: isRecordingModalOpen,
-    open: openRecordingModal,
-    close: closeRecordingModal,
-  } = useModalRegistration({
-    id: 'recordingIndicatorModal',
-    priority: 'high',
-  });
-
-  const setIsRecordingModalOpen = useCallback((isOpen: boolean) => {
-    if (isOpen) {
-      openRecordingModal();
-    } else {
-      closeRecordingModal();
-    }
-  }, [openRecordingModal, closeRecordingModal]);
+  const [isRecordingModalOpen, setIsRecordingModalOpen] = useState(false);
 
   const closeRecordingConfirmation = useCallback(() => {
     setIsRecordingModalOpen(false);
@@ -341,9 +326,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
         <RecordingContainer
           amIModerator={isModerator}
           onRequestClose={closeRecordingConfirmation}
-          priority="high"
           setIsOpen={setIsRecordingModalOpen}
-          isOpen={isRecordingModalOpen}
         />
       ) : null}
     </>

--- a/bigbluebutton-html5/imports/ui/components/recording/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/recording/container.tsx
@@ -13,10 +13,6 @@ interface RecordingContainerProps {
   setIsOpen: (visible: boolean) => void;
   amIModerator: boolean;
   onRequestClose: () => void;
-  // eslint-disable-next-line react/no-unused-prop-types
-  priority: string;
-  // eslint-disable-next-line react/no-unused-prop-types
-  isOpen: boolean;
 }
 
 const RecordingContainer: React.FC<RecordingContainerProps> = (props) => {

--- a/bigbluebutton-tests/playwright/recording/recording.ts
+++ b/bigbluebutton-tests/playwright/recording/recording.ts
@@ -118,6 +118,36 @@ export class Recording extends MultiUsers {
     return playbackUrl;
   }
 
+  async recordingToastDoesNotBlockModals() {
+    await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.hasElement(
+      e.recordingIndicator,
+      'should display the recording indicator once the moderator joins the meeting',
+    );
+
+    // open the recording confirmation toast (non-blocking, lives in react-toastify)
+    await this.modPage.waitAndClick(e.recordingIndicator);
+    await this.modPage.hasElement(
+      e.confirmRecordingButton,
+      'should display the Confirm button in the recording confirmation toast',
+    );
+    await this.modPage.hasElement(
+      e.cancelRecordingButton,
+      'should display the Cancel button in the recording confirmation toast',
+    );
+
+    // with the toast still open, opening the webcam settings modal must not be blocked by it
+    await this.modPage.waitAndClick(e.joinVideo);
+    await this.modPage.hasElement(
+      e.webcamSettingsModal,
+      'should open the webcam settings modal immediately while the recording confirmation toast is still open',
+    );
+    await this.modPage.hasElement(
+      e.confirmRecordingButton,
+      'recording confirmation toast should coexist with the webcam settings modal',
+    );
+  }
+
   async accessPlayback() {
     // check elements
     await this.playbackPage.hasElement(playbackElements.topBar, 'should display the playback top bar');

--- a/bigbluebutton-tests/playwright/recording/recordingModal.spec.ts
+++ b/bigbluebutton-tests/playwright/recording/recordingModal.spec.ts
@@ -1,0 +1,13 @@
+import { linkIssue } from '../core/helpers';
+import { test } from '../core/setup/fixtures';
+import { constants as c } from '../parameters/constants';
+import { Recording } from './recording';
+
+test.describe('Recording confirmation toast', { tag: '@ci' }, () => {
+  test('Does not block other modals from opening', async ({ browser, context, page }, testInfo) => {
+    linkIssue(25323);
+    const recording = new Recording(browser, context);
+    await recording.initModPage(page, { createParameter: c.recordMeeting, testInfo });
+    await recording.recordingToastDoesNotBlockModals();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

When a moderator clicks the recording button, a **Start recording** confirmation pops up. While it's open, clicking the camera, audio settings, or connection status buttons does nothing — and the moment you dismiss the confirmation, all of those modals open one after another (they'd been silently queued).

The confirmation is a non-blocking `react-toastify` toast, but a recent refactor (`a3e438c47e`) moved it into the central modal controller with `priority: 'high'`. That controller only keeps **one** modal open at a time, so the toast grabbed the single slot and every other (`priority: 'low'`) modal was queued and rendered `null` — making the buttons look dead.

The fix returns the toast to its own local `useState`, so it no longer competes for the modal slot and can coexist with the other modals (its original behavior). The real dialog on this component, `recordingNotifyModal`, stays in the controller since it genuinely is a blocking modal.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/25323

### How to test

1. As a moderator, join a meeting with recording enabled.
2. Click the recording button — the **Start recording** confirmation appears.
3. Leaving it open, click the camera (or audio settings / connection status) button.
4. The modal should open right away, with the recording confirmation still on screen. Before this fix, nothing happened until the confirmation was closed.

### More

- Restores the pre-refactor behavior; the toast's open / close / dedup logic is untouched.
- Adds an e2e test (`recording/recordingModal.spec.ts`) that opens the recording confirmation and asserts the webcam settings modal still opens alongside it.
