### PR TITLE
chore: update SDK version for the last we have published

### DIFF
--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.100",
+        "bigbluebutton-html-plugin-sdk": "0.0.102",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6804,9 +6804,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.100",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.100.tgz",
-      "integrity": "sha512-Ge/CXQBCMwdfR6qjx4VI4SuCmEoH7rMW0t4d01ENiYi+mxLHi2HW8hiZvsEnlaw1D8KTN7ETSjhiHzL6J5070A==",
+      "version": "0.0.102",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.102.tgz",
+      "integrity": "sha512-6Bkgk6faaVlQdsKIEGBk93+QDOtKOoO6sgmu9GeY4vdJcILTam9A2mSKKYH+tC3FBYPb37MKveuARWn5oxtsdQ==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.100",
+    "bigbluebutton-html-plugin-sdk": "0.0.102",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -599,4 +599,4 @@ pluginManifestCacheRefreshIntervalMinutes=60
 # List the parameters without including the 'userdata-' prefix
 getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools
 
-html5PluginSdkVersion=0.0.100
+html5PluginSdkVersion=0.0.102


### PR DESCRIPTION
### What does this PR do?

It updates the plugin SDK version to the last v0.0.102

### Motivation

[This fix](https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/269) is of great importance since it resolves a breaking change that occurred in core of BBB (it broke one getter function from the plugin API)
