### PR TITLE
fix(recording): Ruby 3.2 File.exists? deprecation in BigBlueButton recording sanity worker

### DIFF
--- a/record-and-playback/core/scripts/sanity/sanity.rb
+++ b/record-and-playback/core/scripts/sanity/sanity.rb
@@ -50,7 +50,8 @@ logger = BigBlueButton.logger
 
 def check_events_xml(raw_dir,meeting_id)
   filepath = "#{raw_dir}/#{meeting_id}/events.xml"
-  raise Exception, "Events file doesn't exist." if not File.exist?(filepath)
+  raise Exception, "Events file doesn't exist." unless File.exist?(filepath)
+
   bad_doc = Nokogiri::XML(File.open(filepath)) { |config| config.options = Nokogiri::XML::ParseOptions::STRICT }
 end
 

--- a/record-and-playback/core/scripts/sanity/sanity.rb
+++ b/record-and-playback/core/scripts/sanity/sanity.rb
@@ -50,7 +50,7 @@ logger = BigBlueButton.logger
 
 def check_events_xml(raw_dir,meeting_id)
   filepath = "#{raw_dir}/#{meeting_id}/events.xml"
-  raise Exception, "Events file doesn't exists." if not File.exist?(filepath)
+  raise Exception, "Events file doesn't exist." if not File.exist?(filepath)
   bad_doc = Nokogiri::XML(File.open(filepath)) { |config| config.options = Nokogiri::XML::ParseOptions::STRICT }
 end
 

--- a/record-and-playback/core/scripts/sanity/sanity.rb
+++ b/record-and-playback/core/scripts/sanity/sanity.rb
@@ -50,7 +50,7 @@ logger = BigBlueButton.logger
 
 def check_events_xml(raw_dir,meeting_id)
   filepath = "#{raw_dir}/#{meeting_id}/events.xml"
-  raise Exception,  "Events file doesn't exists." if not File.exists?(filepath)
+  raise Exception, "Events file doesn't exists." if not File.exist?(filepath)
   bad_doc = Nokogiri::XML(File.open(filepath)) { |config| config.options = Nokogiri::XML::ParseOptions::STRICT }
 end
 


### PR DESCRIPTION
…ty worker

### What does this PR do?
See title.

### Closes Issue(s)
Closes #25007

### Motivation
Recordings broken on a docker based deployment.

### How to test
- in a docker based deployment
- record a meeting
- check if the recording appears on the recordings page or if generation stalls
