### PR TITLE
feat(audio-captions): alert possible wrong microphone when webspeech

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -126,7 +126,17 @@ export interface AudioCaptions {
   mobile: boolean
   provider: string
   showInSidebarNavigation: boolean
+  microphoneAlert: MicrophoneAlert
   language: Language
+}
+
+export interface MicrophoneAlert {
+  enabled: boolean
+  helpLink: string
+  threshold: number
+  speakingThreshold: number
+  duration: number
+  interval: number
 }
 
 export interface Language {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-captions/speech/component.tsx
@@ -5,7 +5,10 @@ import React, {
 } from 'react';
 // @ts-ignore - it has no types
 import { diff } from '@mconf/bbb-diff';
+// @ts-ignore - it has no types
+import hark from 'hark';
 import { useReactiveVar, useMutation } from '@apollo/client';
+import { defineMessages, useIntl } from 'react-intl';
 import { debounce } from '/imports/utils/debounce';
 import {
   SpeechRecognitionAPI,
@@ -29,6 +32,18 @@ import {
 import { SET_SPEECH_LOCALE } from '/imports/ui/core/graphql/mutations/userMutations';
 import { SUBMIT_TEXT } from './mutations';
 import useIsAudioConnected from '/imports/ui/components/audio/audio-graphql/hooks/useIsAudioConnected';
+import { notify } from '/imports/ui/services/notification';
+
+const intlMessages = defineMessages({
+  microphoneAlertMessage: {
+    id: 'app.audio.captions.speech.microphoneAlert.message',
+    description: 'Alert when WebSpeech is active but audio energy is detected without transcription',
+  },
+  microphoneAlertHelpLabel: {
+    id: 'app.audio.captions.speech.microphoneAlert.helpLabel',
+    description: 'Label for the knowledge base link in the microphone alert toast',
+  },
+});
 
 const THROTTLE_TIMEOUT = 200;
 
@@ -51,6 +66,7 @@ interface AudioCaptionsSpeechProps {
   locale: string;
   connected: boolean;
   muted: boolean;
+  inputStream: MediaStream | null;
 }
 const speechHasStarted = {
   started: false,
@@ -59,7 +75,9 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
   locale,
   connected,
   muted,
+  inputStream,
 }) => {
+  const intl = useIntl();
   const resultRef = useRef({
     id: generateId(),
     transcript: '',
@@ -72,6 +90,11 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
   const speechRecognitionRef = useRef<ReturnType<typeof SpeechRecognitionAPI>>(null);
   const prevIdRef = useRef('');
   const prevTranscriptRef = useRef('');
+  const lastTranscriptionAtRef = useRef<number>(0);
+  const alertShownRef = useRef<boolean>(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const harkInstanceRef = useRef<any>(null);
+  const speakingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [setSpeechLocaleMutation] = useMutation(SET_SPEECH_LOCALE);
   const isAudioTranscriptionEnabled = useIsAudioTranscriptionEnabled();
   const fixedLocaleResult = useFixedLocale();
@@ -205,6 +228,9 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
 
     logger.debug('Transcription event', resultIndex, results, target);
 
+    lastTranscriptionAtRef.current = Date.now();
+    alertShownRef.current = false;
+
     const { id } = resultRef.current;
 
     const { transcript } = results[resultIndex][0];
@@ -334,6 +360,73 @@ const AudioCaptionsSpeech: React.FC<AudioCaptionsSpeechProps> = ({
     }
   }, [connected, muted, locale]);
 
+  useEffect(() => {
+    const MICROPHONE_ALERT_CONFIG = window.meetingClientSettings.public.app.audioCaptions.microphoneAlert;
+    const {
+      enabled,
+      interval,
+      threshold,
+      speakingThreshold,
+      duration,
+      helpLink,
+    } = MICROPHONE_ALERT_CONFIG;
+
+    if (
+      !enabled
+      || !isWebSpeechApi()
+      || !hasSpeechRecognitionSupport()
+      || !isAudioTranscriptionEnabled
+      || locale === ''
+      || muted
+      || !connected
+      || !inputStream
+    ) {
+      return () => {};
+    }
+
+    alertShownRef.current = false;
+
+    harkInstanceRef.current = hark(inputStream, { interval, threshold });
+
+    harkInstanceRef.current.on('speaking', () => {
+      if (alertShownRef.current) return;
+      if (speakingTimerRef.current) return;
+
+      const speakingStartedAt = Date.now();
+      speakingTimerRef.current = setTimeout(() => {
+        if (alertShownRef.current) return;
+        if (lastTranscriptionAtRef.current >= speakingStartedAt) return;
+
+        alertShownRef.current = true;
+        const message = intl.formatMessage(intlMessages.microphoneAlertMessage);
+        const options: Record<string, unknown> = { autoClose: duration || false };
+        if (helpLink) {
+          options.helpLink = helpLink;
+          options.helpLabel = intl.formatMessage(intlMessages.microphoneAlertHelpLabel);
+        }
+        notify(message, 'warning', 'warning', options);
+      }, speakingThreshold);
+    });
+
+    harkInstanceRef.current.on('stopped_speaking', () => {
+      if (speakingTimerRef.current) {
+        clearTimeout(speakingTimerRef.current);
+        speakingTimerRef.current = null;
+      }
+    });
+
+    return () => {
+      if (speakingTimerRef.current) {
+        clearTimeout(speakingTimerRef.current);
+        speakingTimerRef.current = null;
+      }
+      if (harkInstanceRef.current) {
+        harkInstanceRef.current.stop();
+        harkInstanceRef.current = null;
+      }
+    };
+  }, [connected, muted, inputStream, locale, isAudioTranscriptionEnabled]);
+
   return null;
 };
 
@@ -341,6 +434,8 @@ const AudioCaptionsSpeechContainer: React.FC = () => {
   /* eslint no-underscore-dangle: 0 */
   // @ts-ignore
   const isMuted = useReactiveVar(AudioManager._isMuted.value) as boolean;
+  // @ts-ignore
+  const inputStream = useReactiveVar(AudioManager._inputStream) as MediaStream | null;
   const isConnected = useIsAudioConnected();
 
   const {
@@ -359,6 +454,7 @@ const AudioCaptionsSpeechContainer: React.FC = () => {
       locale={currentUser.speechLocale ?? ''}
       connected={isConnected}
       muted={isMuted}
+      inputStream={inputStream}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -62,6 +62,14 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         mobile: false,
         provider: 'webspeech',
         showInSidebarNavigation: false,
+        microphoneAlert: {
+          enabled: true,
+          helpLink: '',
+          threshold: -50,
+          speakingThreshold: 5000,
+          duration: 10000,
+          interval: 200,
+        },
         language: {
           available: [
             'en-US',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -98,6 +98,23 @@ public:
       # If true, the transcriptions and captions settings are displayed as an
       # entry in the sidebar navigation rather than a button in the actions bar
       showInSidebarNavigation: false
+      # Alert shown when WebSpeech is enabled and the user is on floor but nothing is being
+      # transcribed, suggesting a wrong microphone device or noisy environment.
+      microphoneAlert:
+        enabled: true
+        # URL to a knowledge base article about microphone settings (empty = no link shown)
+        helpLink: ''
+        # Audio energy threshold (dB) used to detect that the user is speaking.
+        # More negative values are more sensitive (e.g. -60 picks up quieter audio).
+        threshold: -50
+        # How long (ms) the user must be speaking with no transcription result
+        # before the alert is triggered.
+        speakingThreshold: 5000
+        # How long (ms) the alert toast stays on screen before auto-dismissing.
+        # Set to 0 to require manual dismissal.
+        duration: 10000
+        # How often (ms) the audio energy is checked to determine if the user is speaking.
+        interval: 200
       language:
         # Available languages will depend on the transcription service
         # Google: https://cloud.google.com/speech-to-text/docs/speech-to-text-supported-languages

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -971,6 +971,8 @@
     "app.audio.captions.speech.disabled": "Disabled",
     "app.audio.captions.speech.unsupported": "Your browser doesn't support speech recognition. Your audio won't be transcribed",
     "app.audio.captions.speech.auto": "Auto Detect",
+    "app.audio.captions.speech.microphoneAlert.message": "Audio detected but nothing is being transcribed. Your browser may be using the wrong microphone, or there is too much background noise.",
+    "app.audio.captions.speech.microphoneAlert.helpLabel": "Learn more",
     "app.audio.captions.select.af-ZA": "Afrikaans",
     "app.audio.captions.select.sq-AL": "Albanian",
     "app.audio.captions.select.am-ET": "Amharic",


### PR DESCRIPTION
### What does this PR do?
The microphone used by the webspeech API and the one use to in-meeting communication might differ if the default microphone in the OS is not the one used in the meeting. In this scenario, a user would speak, the talking indicator would confirm the microphone is correct, but webspeech would not generate any transcription for the person, because the internally selected microphone in the browser is not correct.

Add a new mechanism that raises a toast notification alert when a user speaks(has floor) for a specific
time(`audioCaptions.microphoneAlert.speakingThreshold`) with no transcription generated. The alert consists of a message pointing to a wrong microphone selection in the browser/OS level - with the possibility to show a link to a "learn
more"(`audioCaptions.microphoneAlert.helpLink`) page with directions of how to fix/change that - OR that the user microphone is correct but has too much background noise. The other configurations under `audioCaptions.microphoneAlert` follow roughly the same semantics of the muted alert.

<img width="1916" height="1045" alt="Recording 2026-06-29 at 13 03 58" src="https://github.com/user-attachments/assets/a0cd2dd1-1adb-4c55-bdcf-94705b50269e" />



### Closes Issue(s)
Closes #24637 

### How to test
1. Select the different/muted default mic in the OS before opening the browser
2. Enable audio captions, set provider as webspeech and enable microphoneAlert in settings.yml
3. Create and join meeting
4. Change the in-meeting microphone to the correct one using the microphone chevron
5. Enable transcription in the transcription panel
6. Unmute microphone and speak for a couple of seconds
7. See microphone alert toast
