### PR TITLE
fix(whiteboard): prevent crash when slide changes while a viewer is editing

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2270,6 +2270,17 @@ const Whiteboard = React.memo((props) => {
   React.useEffect(() => {
     const formattedPageId = parseInt(curPageIdRef.current, 10);
     if (tlEditorRef.current && formattedPageId !== 0) {
+      // If a viewer is mid-edit (select.editing_shape) when the slide changes,
+      // the store mutation below (cleanupStore + setCurrentPage) removes the shape
+      // being edited out from under tldraw, leaving the editor in editing_shape with
+      // a dangling editingShapeId. The next pointer-down then hits EditingShape's
+      // `Expected an editing shape!` assertion and crashes the client (issue 25332).
+      // Commit the in-progress edit first so tldraw exits editing_shape (running
+      // EditingShape.onExit) while the shape still exists. Guarded so a normal slide
+      // change (no active edit) never resets the presenter's current tool.
+      if (tlEditorRef.current.getEditingShape()) {
+        tlEditorRef.current.complete();
+      }
       tlEditorRef.current.store.mergeRemoteChanges(() => {
         tlEditorRef.current.batch(() => {
           const currentPageId = `page:${formattedPageId}`;

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -587,6 +587,9 @@ export const elements = {
   wbMoveToFront: 'button[data-testid="menu-item.bring-to-front"]',
   wbPaste: 'button[data-testid="menu-item.paste"]',
   wbTextTrue: 'div[data-hastext="true"]',
+  // tldraw renders this textarea only while a shape is actively being edited
+  // (select.editing_shape state) - used to gate on "is editing", not just "has text"
+  wbEditingTextArea: 'textarea.tl-text-input',
   wbDrawnArrow: 'div[data-shape-type="arrow"]',
   wbAutoHideToggleBtn: 'input[data-test="autoHideToolbarToggleBtn"]',
   turnInfiniteWhiteboardOn: 'button[data-test="turnInfiniteWhiteboardOn"]',

--- a/bigbluebutton-tests/playwright/whiteboard/slideChangeWhileEditing.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/slideChangeWhileEditing.ts
@@ -1,0 +1,86 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { MultiUsers } from '../user/multiusers';
+
+export class SlideChangeWhileEditing extends MultiUsers {
+  // Regression test for issue 25332.
+  // A viewer editing a whiteboard text shape used to crash the client with
+  // "Expected an editing shape!" when the presenter changed the slide while the
+  // viewer was still mid-edit: the slide-change effect mutated the tldraw store
+  // (removing the shape being edited) without first taking the editor out of the
+  // select.editing_shape state, so the viewer's next pointer-down hit tldraw's
+  // editing-shape assertion and tripped the error boundary.
+  async crashOnSlideChangeWhileEditing() {
+    // The viewer is the page that crashed, so watch it for uncaught errors.
+    const viewerPageErrors: string[] = [];
+    this.userPage.page.on('pageerror', (err) => viewerPageErrors.push(err.message));
+
+    await this.modPage.hasElement(
+      e.whiteboard,
+      'should display the whiteboard for the presenter',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.userPage.hasElement(e.whiteboard, 'should display the whiteboard for the viewer');
+    // Changing slides requires a deck with at least two slides; the default
+    // presentation provides them (same assumption as the skipSlide test).
+    await this.modPage.hasElement(e.nextSlide, 'should display the next-slide control (deck has >= 2 slides)');
+
+    // Presenter grants multi-user whiteboard so the viewer can draw.
+    await this.modPage.waitAndClick(e.multiUsersWhiteboardOn);
+
+    // Viewer enters select.editing_shape: pick the text tool, click the canvas and
+    // type some text. Do NOT click away or press Escape/Enter - that would commit
+    // the edit and leave editing_shape, defeating the precondition.
+    await this.userPage.waitAndClick(e.wbTextShape);
+    const wbBox = await this.userPage.page.locator(e.whiteboard).boundingBox();
+    if (!wbBox) throw new Error('whiteboard boundingBox is null');
+    const textX = wbBox.x + 0.4 * wbBox.width;
+    const textY = wbBox.y + 0.4 * wbBox.height;
+    await this.userPage.page.mouse.click(textX, textY);
+    await this.userPage.page.waitForTimeout(300);
+    await this.userPage.page.keyboard.type('Hello');
+
+    // Deterministic precondition: the text shape exists (wbTextTrue) AND the editor
+    // is actively editing it (tldraw only renders the editing textarea while
+    // isEditing is true). Asserting both avoids racing the slide change against an
+    // edit that has not actually entered editing_shape yet.
+    await this.userPage.hasElement(e.wbTextTrue, 'viewer should have a text shape with content');
+    await this.userPage.hasElement(e.wbEditingTextArea, 'viewer should be actively editing the text shape');
+
+    // The race: presenter advances the slide while the viewer is mid-edit. Give the
+    // slide-change effect time to run on the viewer (it mutates the tldraw store).
+    await this.modPage.waitAndClick(e.nextSlide);
+    await this.userPage.page.waitForTimeout(2500);
+
+    // The viewer's next pointer-down on the canvas is what used to throw
+    // "Expected an editing shape!". Probe a few spots (incl. where the now-removed
+    // text shape was) so the pointer-down resolves to the dangling editing shape.
+    const probePoints = [
+      [0.5, 0.5],
+      [0.6, 0.55],
+      [0.4, 0.4],
+    ];
+    for (const [fx, fy] of probePoints) {
+      await this.userPage.page.mouse.move(wbBox.x + fx * wbBox.width, wbBox.y + fy * wbBox.height);
+      await this.userPage.page.mouse.down();
+      await this.userPage.page.waitForTimeout(150);
+      await this.userPage.page.mouse.up();
+      await this.userPage.page.waitForTimeout(800);
+    }
+    // Give the client a beat to surface any async error / error boundary.
+    await this.userPage.page.waitForTimeout(1000);
+
+    const editingShapeErrors = viewerPageErrors.filter((m) => /Expected an editing shape/i.test(m));
+    expect(
+      editingShapeErrors,
+      `viewer must not throw "Expected an editing shape!" on slide change while editing (got: ${editingShapeErrors.join(' | ')})`,
+    ).toHaveLength(0);
+    // The whiteboard must still be mounted (not replaced by the error-boundary fallback).
+    await this.userPage.hasElement(
+      e.whiteboard,
+      'whiteboard should still be mounted on the viewer after the slide change',
+    );
+  }
+}

--- a/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
@@ -6,6 +6,7 @@ import { ChangeStyles } from './changeStyles';
 import { DrawShape } from './drawShape';
 import { ShapeOptions } from './shapeOptions';
 import { ShapeTools } from './shapeTools';
+import { SlideChangeWhileEditing } from './slideChangeWhileEditing';
 import { TextShape } from './textShape';
 import { WhiteboardResize } from './whiteboardResize';
 
@@ -160,6 +161,13 @@ test.describe.parallel('Whiteboard tools', { tag: '@ci' }, () => {
     await textShape.initModPage(page, { testInfo });
     await textShape.initUserPage(context, { testInfo });
     await textShape.realTimeTextTyping();
+  });
+
+  test('No crash on slide change while a viewer is editing', async ({ browser, context, page }, testInfo) => {
+    const slideChange = new SlideChangeWhileEditing(browser, context);
+    await slideChange.initModPage(page, { testInfo });
+    await slideChange.initUserPage(context, { testInfo });
+    await slideChange.crashOnSlideChangeWhileEditing();
   });
 
   test.describe.parallel('Shape Options', () => {


### PR DESCRIPTION
## What's happening

When multi-user whiteboard is on and a viewer is actively editing a text/shape (mid-interaction, before committing), a presenter changing the slide used to crash the viewer's whiteboard with `Expected an editing shape!`. Only the editing viewer was affected; everyone else was fine, and the viewer could recover by minimising and restoring the presentation panel.

Closes #25332

## Why it crashes

The `[curPageId]` effect in `component.jsx` handles slide changes by mutating the tldraw store: it removes shapes that belong to the old page (`cleanupStore`), switches the current page (`setCurrentPage`), and clears history — all inside one batch. The problem: it does this **without first taking the editor out of the `select.editing_shape` state**. So the shape being edited gets removed from under the editor while the state machine is still parked in `editing_shape` with a dangling `editingShapeId`. The viewer's next pointer-down then calls `getEditingShape()`, gets `undefined`, and tldraw throws `Expected an editing shape!` — which trips the error boundary and shows the recovery dialog.

## The fix

Exit the editing interaction **before** the store mutation:

```js
// component.jsx, top of the [curPageId] effect, before cleanupStore/setCurrentPage
if (tlEditorRef.current.getEditingShape()) {
  tlEditorRef.current.complete();
}
```

`complete()` dispatches the `complete` event → `EditingShape.onComplete` → the parent state node transitions to `idle` → `onExit` runs and clears `editingShapeId` cleanly, **while the shape still exists**. This mirrors the approach PR #21727 took for the same class of bug in `hooks.js` (`setEditingShape(null)` alone doesn't leave the `editing_shape` state node, so the next pointer-down still throws — `complete()` does).

The guard on `getEditingShape()` is deliberate: without it, an unconditional `complete()`/tool reset would also fire on a plain slide change and reset the presenter's active tool. With the guard, a normal slide change (no active edit) is completely unaffected.

### Behavioural note (intentional)

When the presenter changes the slide while a viewer is mid-edit, the in-progress (uncommitted) annotation on the old slide is discarded. This is expected: the slide change destroys the old page's editable surface anyway, so the annotation couldn't have been committed regardless. The alternative (auto-committing partial edits on slide change) would land half-finished text/shapes on the board, which is worse.

### Second callsite

There's another `editor.setCurrentPage(...)` in `handleTldrawMount` (~L1567). It runs only at mount time, when no interactive edit can exist yet (the editor was just constructed), so guarding it would be dead code. Left unguarded on purpose.

## Non-regression test

New e2e test `bigbluebutton-tests/playwright/whiteboard/slideChangeWhileEditing.ts` (registered in `whiteboard.spec.ts`):

- Enables multi-user whiteboard, viewer enters `editing_shape` (text tool → click canvas → type — **without** clicking away, which would commit and leave the editing state).
- Deterministic precondition: waits for both `wbTextTrue` **and** `wbEditingTextArea` (the textarea tldraw only renders while actively editing), so the test never races the slide change against an edit that hasn't actually entered `editing_shape`.
- Registers a `pageerror` listener on the **viewer** page (the one that crashes), then the **presenter** advances the slide.
- Probes a few pointer-downs on the viewer's canvas (the exact gesture that used to throw).
- Asserts zero `Expected an editing shape` errors and that the whiteboard stays mounted.

### Red-then-green proof

- **Red** (pre-fix bundle `0f013afd`): the test fails — the viewer pageerror is captured (6 errors), the whiteboard falls into the "Reset data" recovery dialog, slide content is gone.
- **Green** (fixed bundle `db1253f`): `2 passed (24s)`, same sequence, 0 errors, clean Page 2, whiteboard mounted.

The existing `Skip slide` regression test also continues to pass.

## Visual evidence

Each MP4 below is the full repro sequence (~30s, low-res to keep the upload small). The same scripted flow runs against the pre-fix bundle (crash) and the fixed bundle (no crash).

Timeline of what to look for in each MP4:
- 0:00–0:18 — presenter enables multi-user whiteboard; viewer picks the text tool, clicks the canvas and types "Hello" (the viewer is now in `editing_shape`).
- ~0:18 — presenter advances to the next slide (the `[curPageId]` effect fires on the viewer).
- 0:18–0:30 — viewer's next pointer-downs on the canvas.

| Before (pre-fix) | After (fix) |
|---|---|
| Viewer hits the tldraw "Reset data" recovery dialog (`Expected an editing shape!` crash); slide content gone. | Same sequence: whiteboard cleanly mounted on Page 2, no error. |
| [![Before: crash](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-30/4bb06640-8a0d-4eae-852a-7a41ba3716d9/25332-fixed-preview.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-30/4b1a55ad-14e7-414d-bab6-82084c9ec862/25332-baseline-crash.mp4) | [![After: no crash](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-30/4bb06640-8a0d-4eae-852a-7a41ba3716d9/25332-fixed-preview.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-06-30/a3321e87-7eb3-46af-b7ae-3271f7105505/25332-fixed.mp4) |

Click either GIF to open the full MP4 with controls.
