### PR TITLE
build: Bump Hasura from 2.48.14 to 2.49.3

### DIFF
--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -22,7 +22,7 @@ for dir in $DIRS; do
   mkdir -p staging$dir
 done
 
-HASURA_VERSION=v2.48.14
+HASURA_VERSION=v2.49.3
 
 git clone --branch $HASURA_VERSION https://github.com/iMDT/hasura-graphql-engine.git
 cat hasura-graphql-engine/hasura-graphql.part-a* > hasura-graphql


### PR DESCRIPTION
More details: https://github.com/hasura/graphql-engine/releases