### PR TITLE
fix(chat): prevent reply preview from clipping long messages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-reply-intention/styles.tsx
@@ -69,9 +69,20 @@ const HtmlContent = styled.div`
     max-height: 100%;
   }
 
+  & p,
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   & p {
     margin: 0;
-    white-space: pre-wrap;
   }
 
   & pre:has(code), p code:not(pre > code) {


### PR DESCRIPTION
### What does this PR do?
Fixes the reply preview (the box shown above the message input when
you reply to a chat message) visually slicing long messages in half.

### Closes Issue(s)
Closes None

### More
<img width="370" height="156" alt="Screenshot from 2026-07-01 13-31-55" src="https://github.com/user-attachments/assets/96a60ae3-32cb-4fa5-9385-46c492c96014" />

