### PR TITLE
fix(learning-dashboard): prevent webcam time from exceeding online time

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -660,7 +660,12 @@ class LearningDashboardActor(
   private def handleUserBroadcastCamStoppedEvtMsg(msg: UserBroadcastCamStoppedEvtMsg) {
     for {
       meeting <- meetings.values.find(m => m.intId == msg.header.meetingId)
+      // Fall back to findUserByAnyIntId: a cam-stopped event can arrive right after the user
+      // already left (session closed and currentIntId nulled), which findUserByIntId can't
+      // resolve. Without this the webcam stays open and gets clamped to the meeting's end,
+      // making webcam time exceed online time.
       user <- findUserByIntId(meeting, msg.body.userId)
+        .orElse(findUserByAnyIntId(meeting, msg.body.userId))
     } yield {
       user.webcams.lastOption match {
         case Some(webcam) if webcam.stoppedOn == 0 =>
@@ -1148,6 +1153,20 @@ class LearningDashboardActor(
     }
   }
 
+  // Latest moment the user was still online: the most recent session end across all their
+  // connections, treating a still-open session (leftOn == 0) as lasting until endedOn.
+  private def lastOnlineTime(user: User, endedOn: Long): Long = {
+    user.intIds.values
+      .map { userId =>
+        userId.sessions.lastOption match {
+          case Some(session) if session.leftOn > 0 => session.leftOn
+          case _                                   => endedOn
+        }
+      }
+      .maxOption
+      .getOrElse(endedOn)
+  }
+
   private def userWithLeftProps(user: User, endedOn: Long, forceFlaggedIdsToLeft: Boolean = true): User = {
     user.copy(
       currentIntId = null,
@@ -1158,9 +1177,15 @@ class LearningDashboardActor(
         totalTime = user.talk.totalTime + (if (user.talk.lastTalkStartedOn > 0) (endedOn - user.talk.lastTalkStartedOn) else 0),
         lastTalkStartedOn = 0
       ),
-      webcams = user.webcams.map { webcam =>
-        if(webcam.stoppedOn > 0) webcam
-        else webcam.copy(stoppedOn = endedOn)
+      // Clamp still-open webcams to when the user actually left, so webcam time can't exceed
+      // online time if a cam-stopped event was missed. Users still connected at the meeting end
+      // have lastOnlineTime == endedOn, preserving the previous behavior.
+      webcams = {
+        val clampTo = lastOnlineTime(user, endedOn)
+        user.webcams.map { webcam =>
+          if (webcam.stoppedOn > 0) webcam
+          else webcam.copy(stoppedOn = clampTo)
+        }
       }
     )
   }


### PR DESCRIPTION
### What does this PR do?

Fixes the Learning Dashboard reporting a user's **webcam time as greater than their online time**, which is physically impossible.

The webcam totals are correct as long as each shared camera is closed while the user is still present. The problem was a still-open webcam at the time a user left: nothing closed it, and at meeting end `userWithLeftProps` clamped every open webcam to the meeting's `endedOn` — long after the user had actually left — so the reported webcam time ran past their online time.

Two independent backend causes, both addressed (single file, `LearningDashboardActor.scala`):

- **Dropped cam-stop:** a `UserBroadcastCamStopped` event arriving right after the user left (session already closed and `currentIntId` nulled) couldn't be resolved by `findUserByIntId`, so it was silently discarded and the webcam stayed open. `handleUserBroadcastCamStoppedEvtMsg` now falls back to `findUserByAnyIntId`, so a late stop still closes the correct user's webcam.
- **Safety net:** for abrupt disconnects where no cam-stop ever arrives, `userWithLeftProps` now clamps still-open webcams to the user's actual last leave time (new `lastOnlineTime` helper) instead of the meeting `endedOn`. Users still connected at meeting end are unaffected, since `lastOnlineTime` returns `endedOn` for them.

### Motivation

Users reported impossible values in the engagement report — Webcam time longer than online time for the same user — which undermines trust in the dashboard metrics.

### How to test

1. Start a meeting with at least two users.
2. Have user A share their webcam.
3. User A leaves abruptly while the camera is still on (close the tab / kill the network), and keep at least one other user in the meeting.
4. Let the meeting run for a few more minutes, then end it.
5. Open the Learning Dashboard for that meeting.

**Expected:** user A's *Webcam time* is ≤ their *Online time*. Before this fix, A's webcam time was clamped to the meeting end and exceeded their online time.

Also verify the normal path is unchanged: a user who is still connected (camera on) when the meeting ends still has webcam time counted up to the meeting end.

> Note: the dropped-event path depends on message ordering and can be awkward to trigger deterministically; the meeting-end clamp guarantees the `webcam ≤ online` invariant regardless of whether the stop event is received.

### More

This PR fixes the data at the source (akka). It does not retroactively correct dashboards already generated from previously-stored data.
