### PR TITLE
fix: fix regression bug in user list item dropdown 

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/generic-content/generic-content-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/generic-content/generic-content-item/component.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import * as ReactDOM from 'react-dom/client';
 import { GenericContentItemProps } from './types';
-import { lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
 
 const GenericContentItem: React.FC<GenericContentItemProps> = (props) => {
   const {
@@ -28,7 +27,6 @@ const GenericContentItem: React.FC<GenericContentItemProps> = (props) => {
   const style: React.CSSProperties = {
     height: '100%',
     overflow: 'hidden',
-    borderRadius: lgBorderRadius,
   };
   if (width) {
     style.width = width;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-item-toolbar/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-item-toolbar/component.tsx
@@ -94,7 +94,7 @@ const UserItemToolbar: React.FC<UserItemToolbarProps> = ({
         ...makeDropdownPluginItem(beforeUserDropdownItems),
         ...allowedOtherToolbarOptions,
         ...makeDropdownPluginItem(afterUserDropdownItems),
-      ];
+      ].filter((action) => action.allowed);
       return (
         <>
           {addSeparator && <Styled.Pipe key={uniqueId('separator-toolbar')}> | </Styled.Pipe>}


### PR DESCRIPTION
### What does this PR do?

There were 2 things introduced with the new 4.0 (which are easy to workaround, but it can break plugins that previously used them):
- Border radius addition to the menu;
- Filter removal of not allowed items after merging all items in the dropdown menu; 

### Motivation

Some plugins might have broken-UI after the update to 4.0 which should be straight forward.

### How to test

One can use the `sample-user-list-dropdown-plugin` with this component addition:

```tsx
import * as React from 'react';

interface NotificationCardProps {
  userName: string;
}

function NotificationCard({
  userName,
}: NotificationCardProps): React.ReactElement {
  return (
    <div
      style={{
        display: 'flex',
        alignItems: 'flex-start',
        gap: '8px',
        padding: '10px 12px',
        marginBottom: '1rem',
        borderRadius: '0.2rem',
        border: '1px solid #e0e0e0',
        borderLeft: '4px solid #0f70d7',
        backgroundColor: '#f7fbff',
        boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
        fontFamily: 'inherit',
      }}
    >
      <span style={{ fontSize: '18px', lineHeight: '20px' }}>🔔</span>
      <div style={{ display: 'flex', flexDirection: 'column' }}>
        <span style={{ fontSize: '13px', fontWeight: 600, color: '#333' }}>
          {userName}
        </span>
      </div>
    </div>
  );
}

export default NotificationCard;

``` 

as a `UserListDropdownGenericContentInformation` set in `setUserListDropdownItems`.

For the other fix, just pass a not allowed component in `setUserListDropdownItems`, it's not followed

### More

We should wait for the fix of: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/274 in 0.1.x branch so we can update it here as well.