### PR TITLE
fix(video): never let the grid overflow tile consume a camera slot, +

### DIFF
--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -168,6 +168,9 @@ runs:
         sed -i "s/exports.DEBUG = false/exports.DEBUG = true/" /usr/local/bigbluebutton/bbb-graphql-actions/config.js
         sudo yq -y -i '.log_level = "TRACE"' /usr/share/bbb-graphql-middleware/config.yml
         echo "HASURA_GRAPHQL_LOG_LEVEL=debug" | tee -a /etc/bigbluebutton/bbb-graphql-server.env
+        # Tests provision per-meeting client settings via the clientSettingsOverride
+        # create module (e.g. webcam/gridTileCount); the property defaults to false.
+        echo "allowOverrideClientSettingsOnCreateCall=true" | tee -a /etc/bigbluebutton/bbb-web.properties
         cat > /etc/bigbluebutton/bbb-conf/apply-config.sh << HERE
         #!/bin/bash
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -320,7 +320,7 @@ export const useIsPaginationEnabled = () => {
   return myPageSize > 0 && paginationEnabled;
 };
 
-export const useGridUsers = (visibleStreamCount: number) => {
+export const useGridUsers = (visibleStreamCount: number, visibleUserCount: number) => {
   const gridSize = useGridSize();
   const userCount = getCountData();
   const isGridEnabled = useStorageKey('isGridEnabled');
@@ -444,11 +444,14 @@ export const useGridUsers = (visibleStreamCount: number) => {
 
     gridItems.current = newGridUsers;
 
-    const overflow = Math.max(userCount - gridSize, 0);
-
-    // if there's overflow, we replace the last grid user with the overflow tile,
-    // so we need to add 1 to the overflow count to account for the replaced user
-    overflowCount.current = overflow > 0 ? overflow + 1 : 0;
+    // Hidden users = everyone not visible on this page. Count in USERS, not
+    // stream tiles as a user with several cameras holds several tiles. The
+    // overflow tile replaces the last avatar when avatars exist (+1: the
+    // replaced user joins the count); on a full-camera page it takes a new
+    // slot instead and replaces no one.
+    const hidden = Math.max(userCount - visibleUserCount - newGridUsers.length, 0);
+    const replacedAvatar = newGridUsers.length > 0 ? 1 : 0;
+    overflowCount.current = hidden > 0 ? hidden + replacedAvatar : 0;
   } else {
     gridItems.current = [];
     overflowCount.current = 0;
@@ -768,7 +771,14 @@ export const useVideoStreams = () => {
     }
   }
 
-  const { gridUsers, overflowCount } = useGridUsers(streams.length);
+  // Off-page local cameras stay in the array with render: false. Count only
+  // what actually renders on this page. Slots are tiles (stream count); the
+  // hidden math is per-user (distinct userIds).
+  const renderedStreams = streams.filter((s) => !('render' in s) || s.render !== false);
+  const { gridUsers, overflowCount } = useGridUsers(
+    renderedStreams.length,
+    new Set(renderedStreams.map((s) => s.userId)).size,
+  );
 
   return {
     streams,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -147,7 +147,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
   componentDidUpdate(prevProps: VideoListProps) {
     const {
-      layoutType, cameraDock, streams, focusedId,
+      layoutType, cameraDock, streams, focusedId, overflowCount,
     } = this.props;
     const { width: cameraDockWidth, height: cameraDockHeight } = cameraDock;
     const {
@@ -155,14 +155,19 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       cameraDock: prevCameraDock,
       streams: prevStreams,
       focusedId: prevFocusedId,
+      overflowCount: prevOverflowCount,
     } = prevProps;
     const { width: prevCameraDockWidth, height: prevCameraDockHeight } = prevCameraDock;
 
+    // The overflow tile can mount/unmount without a stream-count change (users
+    // joining or leaving with no camera), and a tile the grid template was not
+    // computed for lands in an implicit auto-height row.
     if (layoutType !== prevLayoutType
       || focusedId !== prevFocusedId
       || cameraDockWidth !== prevCameraDockWidth
       || cameraDockHeight !== prevCameraDockHeight
-      || streams.length !== prevStreams.length) {
+      || streams.length !== prevStreams.length
+      || overflowCount !== prevOverflowCount) {
       this.handleCanvasResize();
     }
   }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -230,13 +230,21 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       layoutContextDispatch,
       isGridEnabled,
       gridSize,
+      overflowCount,
     } = this.props;
     const visibleStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
     );
+    const videoCount = visibleStreams.filter((item) => item.type !== VIDEO_TYPES.GRID).length;
+    const hasGridItems = visibleStreams.length > videoCount;
+    const overflowTileShown = isGridEnabled && overflowCount > 0;
+    // "grid == page": cameras always get their slots, so capacity grows to the
+    // page when cameras alone meet/exceed the grid size. The overflow tile
+    // consumes an extra slot only when there is no avatar for it to replace.
     let numItems = isGridEnabled
-      ? Math.min(gridSize, visibleStreams.length)
+      ? Math.min(Math.max(gridSize, videoCount), visibleStreams.length)
       : visibleStreams.length;
+    if (overflowTileShown && !hasGridItems) numItems += 1;
 
     if (numItems < 1 || !this.canvas || !this.grid) {
       return;
@@ -370,7 +378,6 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       pluginUserCameraHelperPerPosition,
       isGridEnabled,
       overflowCount,
-      gridSize,
     } = this.props;
     const numOfStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
@@ -378,9 +385,21 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
     const shouldShowOverflowTile = isGridEnabled && overflowCount > 0;
 
-    const streamsToHide = (numOfStreams - gridSize + 1) * -1;
-    const streamsToRender = shouldShowOverflowTile && streamsToHide < 0
-      ? streams.slice(0, streamsToHide)
+    // The overflow tile may only take an avatar's slot, never a camera's.
+    // Avatars (GRID items) are appended after video streams, so remove the last
+    // GRID item; on a full-camera page there is none and the tile gets its own
+    // slot ("grid == page" keeps every camera of the page visible).
+    let lastGridUserIndex = -1;
+    if (shouldShowOverflowTile) {
+      for (let i = streams.length - 1; i >= 0; i -= 1) {
+        if (streams[i].type === VIDEO_TYPES.GRID) {
+          lastGridUserIndex = i;
+          break;
+        }
+      }
+    }
+    const streamsToRender = lastGridUserIndex !== -1
+      ? streams.filter((_, idx) => idx !== lastGridUserIndex)
       : streams;
 
     const videoItems = streamsToRender.map((item) => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -422,6 +422,8 @@ class VideoList extends Component<VideoListProps, VideoListState> {
           key={key}
           $focused={isFocused}
           data-test="webcamVideoItem"
+          data-video-type={isStream ? 'stream' : 'grid'}
+          data-user-name={name}
         >
           <VideoListItemContainer
             pluginUserCameraHelperPerPosition={pluginUserCameraHelperPerPosition}
@@ -455,6 +457,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
           key="overflow-tile"
           $focused={false}
           data-test="overflowTile"
+          data-overflow-count={overflowCount}
         >
           <OverflowTile overflowCount={overflowCount} />
         </Styled.VideoListItem>,
@@ -488,6 +491,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
 
         {!streams.length && !isGridEnabled ? null : (
           <Styled.VideoList
+            data-test="webcamVideoList"
             ref={(ref) => {
               this.grid = ref;
             }}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/component.tsx
@@ -47,7 +47,10 @@ const OverflowTile: React.FC<OverflowTileProps> = ({ overflowCount }) => {
   const displayCount = Math.min(overflowCount, 3);
 
   return (
-    <Styled.OverflowTileContainer data-test="overflowTile" isClickable={!isUserListPanelOpen} onClick={() => handleOpenUserList()}>
+    <Styled.OverflowTileContainer
+      isClickable={!isUserListPanelOpen}
+      onClick={() => handleOpenUserList()}
+    >
       <Styled.OverflowTileContent>
         <Styled.AvatarsContainer $count={displayCount}>
           {Array.from({ length: displayCount }, (_, index) => (

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -600,6 +600,8 @@ export const elements = {
   webcamConnecting: 'div[data-test="webcamConnecting"]',
   webcamContainer: 'video[data-test="videoContainer"]',
   webcamVideoItem: 'div[data-test="webcamVideoItem"]',
+  webcamStreamItem: 'div[data-test="webcamVideoItem"][data-video-type="stream"]',
+  webcamVideoList: 'div[data-test="webcamVideoList"]',
   overflowTile: 'div[data-test="overflowTile"]',
   videoDropdownMenu: 'button[data-test="videoDropdownMenu"]',
   advancedVideoSettingsBtn: 'li[data-test="advancedVideoSettingsButton"]',

--- a/bigbluebutton-tests/playwright/core/helpers.ts
+++ b/bigbluebutton-tests/playwright/core/helpers.ts
@@ -115,13 +115,29 @@ export function createMeetingUrl(createParameter?: string, customMeetingId?: str
   return url;
 }
 
-export function createMeetingPromise(createParameter?: string, customMeetingId?: string): Promise<AxiosResponse> {
+export function createMeetingPromise(
+  createParameter?: string,
+  customMeetingId?: string,
+  createModules?: string,
+): Promise<AxiosResponse> {
   const url = createMeetingUrl(createParameter, customMeetingId);
+  // Modules (e.g. clientSettingsOverride) travel in the POST body; the
+  // checksum covers the query string either way.
+  if (createModules !== undefined) {
+    return axios.post(url, createModules, {
+      adapter: 'http',
+      headers: { 'Content-Type': 'application/xml' },
+    });
+  }
   return axios.get(url, { adapter: 'http' });
 }
 
-export async function createMeeting(createParameter?: string, customMeetingId?: string): Promise<string> {
-  const promise = createMeetingPromise(createParameter, customMeetingId);
+export async function createMeeting(
+  createParameter?: string,
+  customMeetingId?: string,
+  createModules?: string,
+): Promise<string> {
+  const promise = createMeetingPromise(createParameter, customMeetingId, createModules);
   const response = await promise;
   expect(response.status).toEqual(200);
   const xmlResponse = await xml2js.parseStringPromise(response.data);

--- a/bigbluebutton-tests/playwright/core/page.ts
+++ b/bigbluebutton-tests/playwright/core/page.ts
@@ -32,6 +32,7 @@ export interface InitOptionsProps {
   fullName?: string;
   meetingId?: string;
   createParameter?: string;
+  createModules?: string;
   joinParameter?: string;
   customMeetingId?: string;
   isRecording?: boolean;
@@ -104,6 +105,7 @@ export class Page {
       fullName,
       meetingId,
       createParameter,
+      createModules,
       joinParameter,
       customMeetingId,
       skipSessionDetailsModal = true,
@@ -120,7 +122,7 @@ export class Page {
 
     await helpers.setBrowserLogs(this, forceErrorLogFailure);
 
-    this.meetingId = meetingId || (await helpers.createMeeting(createParameter, customMeetingId));
+    this.meetingId = meetingId || (await helpers.createMeeting(createParameter, customMeetingId, createModules));
     const joinUrl = helpers.getJoinURL({
       meetingID: this.meetingId,
       fullName: this.username,

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
@@ -1,5 +1,10 @@
 import { test } from '../core/setup/fixtures';
-import { GridTileCount, MAX_GRID_SIZE } from './gridTileCount';
+import {
+  GEOMETRY_CLIENT_SETTINGS_MODULE,
+  GridTileCount,
+  MAX_GRID_SIZE,
+  PAGINATION_CLIENT_SETTINGS_MODULE,
+} from './gridTileCount';
 
 // Regression test for issue 25073 (backport of PR 25103):
 // "Unified Layout: tile count plus aggregated users does not match total participant count".
@@ -16,7 +21,7 @@ test.describe('Grid layout participant tile count', () => {
     page,
   }, testInfo) => {
     const gridTileCount = new GridTileCount(browser, context);
-    await gridTileCount.initModPage(page, { testInfo });
+    await gridTileCount.initModPage(page, { testInfo, createModules: PAGINATION_CLIENT_SETTINGS_MODULE });
 
     const gridSize = await gridTileCount.getConfiguredGridSize();
     test.skip(
@@ -30,5 +35,61 @@ test.describe('Grid layout participant tile count', () => {
     test.setTimeout((gridSize + 2) * 25_000 + 60_000);
 
     await gridTileCount.checkTileCountMatchesParticipants(gridSize);
+  });
+
+  // Regression: the overflow tile must never consume a camera slot (grid grows
+  // to the page instead), its count must reflect the actually-hidden users, and
+  // pagination must reach every camera, ie no camera stranded across pages.
+  test('overflow tile never hides a camera and pagination reaches every camera', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const gridTileCount = new GridTileCount(browser, context);
+    await gridTileCount.initModPage(page, { testInfo, createModules: PAGINATION_CLIENT_SETTINGS_MODULE });
+
+    const gridSize = await gridTileCount.getConfiguredGridSize();
+    test.skip(
+      !Number.isFinite(gridSize) || gridSize < 1 || gridSize > MAX_GRID_SIZE,
+      `requires public.kurento.pagination.desktopGridSizes <= ${MAX_GRID_SIZE} ` +
+        `to exercise the overflow path with a practical number of webcams (configured: ${gridSize})`,
+    );
+
+    // Encodes "page size == grid size" (full-camera first page + a second
+    // page), provisioned above; the guard reads the effective settings.
+    const pageSize = await gridTileCount.getEffectiveModeratorPageSize(gridSize + 2);
+    test.skip(
+      pageSize !== gridSize,
+      `effective moderator page size (${pageSize}) must equal the grid size (${gridSize}) - ` +
+        'enable allowOverrideClientSettingsOnCreateCall or configure a matching paginationThresholds entry',
+    );
+
+    test.setTimeout((gridSize + 2) * 25_000 + 60_000);
+
+    await gridTileCount.checkCameraPrecedenceAcrossPages(gridSize);
+  });
+
+  // Regression: the overflow tile mounting on an otherwise unchanged grid (a
+  // camera-less late join) must trigger a grid-template recompute; a stale
+  // template squashes the tile into an implicit auto-height row. Provisions
+  // the smallest grid (2) that exercises the mechanism to keep CI cost down.
+  test('overflow tile keeps camera-cell geometry when appearing on a static grid', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const gridTileCount = new GridTileCount(browser, context);
+    await gridTileCount.initModPage(page, { testInfo, createModules: GEOMETRY_CLIENT_SETTINGS_MODULE });
+
+    const gridSize = await gridTileCount.getConfiguredGridSize();
+    test.skip(
+      !Number.isFinite(gridSize) || gridSize < 1 || gridSize > MAX_GRID_SIZE,
+      `requires public.kurento.pagination.desktopGridSizes <= ${MAX_GRID_SIZE} ` +
+        `to exercise the overflow path with a practical number of webcams (configured: ${gridSize})`,
+    );
+
+    test.setTimeout((gridSize + 2) * 25_000 + 60_000);
+
+    await gridTileCount.checkOverflowTileGeometryOnLateJoin(gridSize);
   });
 });

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.ts
@@ -13,6 +13,55 @@ import { MultiUsers } from '../user/multiusers';
 // pagination config from the issue (e.g. 24).
 export const MAX_GRID_SIZE = Number(process.env.GRID_TILE_COUNT_MAX_GRID_SIZE) || 8;
 
+export const TARGET_GRID_SIZE = 4;
+
+// Pagination config these scenarios encode, provisioned per-meeting as a
+// clientSettingsOverride create module (bbb-web only reads the inline
+// override from the POST body); the spec guards skip (naming the remedies)
+// when it doesn't take effect.
+const PAGINATION_SETTINGS_JSON = JSON.stringify({
+  public: {
+    kurento: {
+      pagination: {
+        desktopGridSizes: { moderator: TARGET_GRID_SIZE, viewer: TARGET_GRID_SIZE },
+      },
+      paginationThresholds: {
+        enabled: true,
+        thresholds: [
+          {
+            users: TARGET_GRID_SIZE,
+            desktopPageSizes: { moderator: TARGET_GRID_SIZE, viewer: TARGET_GRID_SIZE },
+          },
+        ],
+      },
+    },
+  },
+});
+
+export const PAGINATION_CLIENT_SETTINGS_MODULE = [
+  '<modules><module name="clientSettingsOverride"><![CDATA[',
+  PAGINATION_SETTINGS_JSON,
+  ']]></module></modules>',
+].join('');
+
+// The geometry scenario is grid-size-agnostic, so it provisions the smallest
+// grid that exercises the mechanism: 3 participants instead of 5.
+export const GEOMETRY_GRID_SIZE = 2;
+
+export const GEOMETRY_CLIENT_SETTINGS_MODULE = [
+  '<modules><module name="clientSettingsOverride"><![CDATA[',
+  JSON.stringify({
+    public: {
+      kurento: {
+        pagination: {
+          desktopGridSizes: { moderator: GEOMETRY_GRID_SIZE, viewer: GEOMETRY_GRID_SIZE },
+        },
+      },
+    },
+  }),
+  ']]></module></modules>',
+].join('');
+
 export class GridTileCount extends MultiUsers {
   // Reads the effective grid size delivered to the client through meetingClientSettings.
   async getConfiguredGridSize(): Promise<number> {
@@ -47,26 +96,19 @@ export class GridTileCount extends MultiUsers {
       viewers.push(viewer);
     }
 
-    // Switch the moderator to the grid (video focus) layout, which renders every
-    // participant as a tile.
-    await this.modPage.waitAndClick(e.optionsButton);
-    await this.modPage.waitAndClick(e.manageLayoutBtn);
-    await this.modPage.waitAndClick(e.focusOnVideo);
-    await this.modPage.waitAndClick(e.updateLayoutBtn);
+    // Grid mode in this client (Unified Layout) = minimizing the presentation,
+    // which renders every participant as a tile.
+    await this.modPage.waitAndClick(e.minimizePresentation);
 
-    // The layout may keep a second, off-screen video list for measurement. Both are
-    // the same component rendering the same data, so scope the counts to the single
-    // list that owns an overflow tile (its tiles are siblings of the overflow tile).
-    const overflowTile = this.modPage.page.locator(e.overflowTile).first();
+    const videoList = this.modPage.page.locator(e.webcamVideoList);
+    const overflowTile = videoList.locator(e.overflowTile);
     await expect(
       overflowTile,
       'the aggregated overflow tile should appear when webcams exceed the grid size',
     ).toBeVisible({ timeout: ELEMENT_WAIT_LONGER_TIME });
 
-    const videoList = overflowTile.locator('xpath=..');
     const visibleTiles = await videoList.locator(e.webcamVideoItem).count();
-    const overflowText = await overflowTile.innerText();
-    const overflowCount = Number(overflowText.match(/\+\s*(\d+)/)?.[1] ?? '0');
+    const overflowCount = Number(await overflowTile.getAttribute('data-overflow-count'));
 
     // Core invariant from the bug report: visible tiles + aggregated users === total participants.
     expect(
@@ -80,5 +122,171 @@ export class GridTileCount extends MultiUsers {
       visibleTiles,
       `visible tiles (${visibleTiles}) should not exceed the grid size (${gridSize})`,
     ).toBeLessThanOrEqual(gridSize);
+  }
+
+  // Effective moderator page size for a given user count, mirroring the
+  // client's threshold resolution: paginationThresholds (when enabled)
+  // override the base desktopPageSizes once the user count reaches them.
+  async getEffectiveModeratorPageSize(userCount: number): Promise<number> {
+    return this.modPage.page.evaluate((count) => {
+      // @ts-ignore - injected on window by the client at runtime
+      const pagination = window.meetingClientSettings?.public?.kurento?.pagination;
+      // @ts-ignore - injected on window by the client at runtime
+      const thresholdsConf = window.meetingClientSettings?.public?.kurento?.paginationThresholds;
+      let size = Number(pagination?.desktopPageSizes?.moderator ?? 0);
+      if (thresholdsConf?.enabled && Array.isArray(thresholdsConf.thresholds)) {
+        const applicable = thresholdsConf.thresholds
+          .filter((t: { users: number }) => t.users <= count)
+          .sort((a: { users: number }, b: { users: number }) => b.users - a.users)[0];
+        if (applicable?.desktopPageSizes?.moderator != null) {
+          size = Number(applicable.desktopPageSizes.moderator);
+        }
+      }
+      return size;
+    }, userCount);
+  }
+
+  // Regression for the grid-mode camera-precedence bug: the "+N" overflow tile
+  // must never consume a camera's slot (a full page of cameras stays fully
+  // visible, ie "grid == page"), the aggregated count must reflect the users
+  // actually hidden, and page navigation must reach every active camera (no
+  // camera may be unreachable on all pages).
+  async checkCameraPrecedenceAcrossPages(gridSize: number): Promise<void> {
+    // One camera more than the page size forces both a full-camera first page
+    // and a second page.
+    const webcamUsers = gridSize + 1;
+    const totalParticipants = webcamUsers + 1; // + the moderator (observer, no webcam)
+    const expectedNames: string[] = [];
+
+    for (let i = 0; i < webcamUsers; i += 1) {
+      const name = `Attendee${i + 1}`;
+      // eslint-disable-next-line no-await-in-loop
+      const viewerPage = await this.context.newPage();
+      const viewer = new Page(this.browser, viewerPage, this.modPage.testInfo);
+      // eslint-disable-next-line no-await-in-loop
+      await viewer.init(false, {
+        fullName: name,
+        meetingId: this.modPage.meetingId,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await viewer.shareWebcam({ shouldConfirmSharing: true });
+      expectedNames.push(name);
+    }
+
+    // Grid mode in this client (Unified Layout) = minimizing the presentation.
+    await this.modPage.waitAndClick(e.minimizePresentation);
+
+    const videoList = this.modPage.page.locator(e.webcamVideoList);
+    const overflowTile = videoList.locator(e.overflowTile);
+    await expect(overflowTile, 'the aggregated overflow tile should appear (hidden users exist)').toBeVisible({
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+
+    const cameraTiles = videoList.locator(e.webcamStreamItem);
+
+    // Camera precedence: the first page holds pageSize (== grid size here)
+    // cameras, and the overflow tile must not have eaten one of them.
+    await expect(
+      cameraTiles,
+      `a full page of ${gridSize} cameras must stay visible, ie the overflow tile must not consume a camera slot`,
+    ).toHaveCount(gridSize, { timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Truthful aggregation: hidden users = participants − visible cameras
+    // (no avatar was replaced, so no +1 correction applies).
+    const overflowCount = Number(await overflowTile.getAttribute('data-overflow-count'));
+    expect(
+      overflowCount,
+      `the overflow tile should count exactly the hidden users (${totalParticipants} − ${gridSize} visible cameras)`,
+    ).toBe(totalParticipants - gridSize);
+
+    // Geometry: the tile occupies a regular grid cell. A stale grid template
+    // (not recomputed for the extra tile) drops it into an implicit auto-height
+    // row, rendering it as a thin strip instead of a camera-sized cell.
+    const tileBox = await overflowTile.boundingBox();
+    const cameraBox = await cameraTiles.first().boundingBox();
+    expect(tileBox, 'the overflow tile must have a bounding box').not.toBeNull();
+    expect(cameraBox, 'camera tiles must have a bounding box').not.toBeNull();
+    expect(
+      Math.abs((tileBox?.height ?? 0) - (cameraBox?.height ?? 1)),
+      `the overflow tile (${tileBox?.height}px) must be as tall as a camera cell (${cameraBox?.height}px)`,
+    ).toBeLessThanOrEqual(2);
+
+    // Reachability: every camera must be visible on some page.
+    const cameraNames = async () =>
+      cameraTiles.evaluateAll((tiles) => tiles.map((tile) => tile.getAttribute('data-user-name') ?? ''));
+    const seenNames = new Set<string>(await cameraNames());
+    const page1Signature = [...seenNames].sort().join('|');
+
+    await this.modPage.waitAndClick(e.nextPageVideoPagination);
+    await expect
+      .poll(async () => (await cameraNames()).sort().join('|'), {
+        message: 'navigating to the next page should change the visible cameras',
+        timeout: ELEMENT_WAIT_LONGER_TIME,
+      })
+      .not.toBe(page1Signature);
+
+    (await cameraNames()).forEach((name) => seenNames.add(name));
+    expectedNames.forEach((name) => {
+      expect(seenNames.has(name), `camera of ${name} must be reachable on some page (no camera may be stranded)`).toBe(
+        true,
+      );
+    });
+  }
+
+  // Regression for the squashed overflow tile: when the tile mounts on an
+  // otherwise unchanged grid (a user joins without a camera, so no stream or
+  // dock resize accompanies it), the grid template must be recomputed for the
+  // extra tile; a stale template drops it into an implicit auto-height row.
+  async checkOverflowTileGeometryOnLateJoin(gridSize: number): Promise<void> {
+    // Everyone on the grid has a camera: moderator + (gridSize - 1) attendees.
+    await this.modPage.shareWebcam();
+    for (let i = 0; i < gridSize - 1; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const viewerPage = await this.context.newPage();
+      const viewer = new Page(this.browser, viewerPage, this.modPage.testInfo);
+      // eslint-disable-next-line no-await-in-loop
+      await viewer.init(false, {
+        fullName: `Attendee${i + 1}`,
+        meetingId: this.modPage.meetingId,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await viewer.shareWebcam({ shouldConfirmSharing: true });
+    }
+
+    // Grid mode with a full page of cameras and no hidden users: no tile yet.
+    await this.modPage.waitAndClick(e.minimizePresentation);
+    const videoList = this.modPage.page.locator(e.webcamVideoList);
+    const overflowTile = videoList.locator(e.overflowTile);
+    const cameraTiles = videoList.locator(e.webcamStreamItem);
+    await expect(cameraTiles, `all ${gridSize} cameras should be on the grid before the late join`).toHaveCount(
+      gridSize,
+      { timeout: ELEMENT_WAIT_LONGER_TIME },
+    );
+    await expect(overflowTile, 'no overflow tile while nobody is hidden').toBeHidden();
+
+    // A user joins WITHOUT a camera: the tile mounts with no stream change.
+    const lateViewerPage = await this.context.newPage();
+    const lateViewer = new Page(this.browser, lateViewerPage, this.modPage.testInfo);
+    await lateViewer.init(false, {
+      fullName: 'LateJoiner',
+      meetingId: this.modPage.meetingId,
+    });
+    await expect(overflowTile, 'the overflow tile should appear for the camera-less late joiner').toBeVisible({
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+
+    // The tile must occupy a regular, camera-sized grid cell.
+    const tileBox = await overflowTile.boundingBox();
+    const cameraBox = await cameraTiles.first().boundingBox();
+    expect(tileBox, 'the overflow tile must have a bounding box').not.toBeNull();
+    expect(cameraBox, 'camera tiles must have a bounding box').not.toBeNull();
+    expect(
+      Math.abs((tileBox?.height ?? 0) - (cameraBox?.height ?? 1)),
+      `the overflow tile (${tileBox?.height}px) must be as tall as a camera cell (${cameraBox?.height}px)`,
+    ).toBeLessThanOrEqual(2);
+    expect(
+      Math.abs((tileBox?.width ?? 0) - (cameraBox?.width ?? 1)),
+      `the overflow tile (${tileBox?.width}px) must be as wide as a camera cell (${cameraBox?.width}px)`,
+    ).toBeLessThanOrEqual(2);
   }
 }


### PR DESCRIPTION
### What does this PR do?

- [fix(video): never let the grid overflow tile consume a camera slot](https://github.com/bigbluebutton/bigbluebutton/pull/25362/changes/d75c39e3993371787cf74698426a536803a701f7)
  - The overflow tile is created by trimming the tail of the combined
streams array. Avatars are appended after cameras, so on a page fully
occupied by cameras the trim removes a live camera: a 4-slot grid with
4 cameras shows only 3, the aggregated count gains a bogus +1, and
since pagination chunks by page size upstream of the trim, the removed
camera is unreachable on every page. Regression from the tile-count
fix (#25103, #25254).
  - The tile now only takes an avatar's slot; on a full-camera page it
occupies a new slot instead ("grid == page"). Hidden users are counted
from what the page actually shows, with the +1 correction applied only
when an avatar is really replaced.
- [fix(video): recompute the grid template when the overflow tile toggles](https://github.com/bigbluebutton/bigbluebutton/pull/25362/commits/fa12e9c155c13a8f0efa3b8fd324dfda89877339)
  - The grid template only recomputes when the stream count, layout, focus
or dock size changes. The overflow tile mounts and unmounts on
overflowCount transitions that change none of those (a user joins or
leaves without a camera), so the extra tile lands in an implicit
auto-height CSS grid row and renders as a thin strip instead of a
camera-sized cell. Recompute on overflowCount changes as well.

#### Auxiliary changes

- [test(playwright): support create modules in the POST body](https://github.com/bigbluebutton/bigbluebutton/pull/25362/changes/5430df32f81c586d86a0f0eb2213ce93a6fd30d6)
  - bbb-web reads the inline clientSettingsOverride only from the create
POST body as an XML module; the GET query param variant is silently
ignored. Let tests pass createModules through init/createMeeting. The
checksum still covers only the query string.
- [test(video): cover grid overflow camera precedence and pagination](https://github.com/bigbluebutton/bigbluebutton/pull/25362/changes/2e694f78b9880a95b3772ad55951808b2af4a29b)
  - Add regression tests that cover: full camera page stays visible,
accurate grid+cam aggregated count, pagination reaches every camera,
and the overflow tile keeps camera-cell geometry when it mounts on a
static grid (a stale grid template drops it into an implicit
auto-height row). The geometry spec provisions the smallest grid that
exercises the mechanism to keep CI cost down.
  - Additionally, switch the grid test spec to use minimize-presentation:
the v3.0 layout modal does not exist in v4.0, so adaptation was needed.
The overflow tile also no longer duplicates data-test="overflowTile",
which was incorrect and made the AI that introduced the test in https://github.com/bigbluebutton/bigbluebutton/pull/25254
hallucinate about "two video lists being rendered".
- [build(ci): allow client settings override on create for tests](https://github.com/bigbluebutton/bigbluebutton/pull/25362/changes/3a89404f824e1060d3c0b90b3241ce35c98ead0e)
  - The grid regression specs provision their pagination config through a
clientSettingsOverride create module, which bbb-web only honors when
allowOverrideClientSettingsOnCreateCall is set - it defaults to false,
so without this the specs skip on every CI run. Set it once at install
time; bbb-conf --restart already reloads bbb-web afterwards.
### Closes Issue(s)

None

### How to test

- Config: 
  - grid size 4 (M) / 4 (V); 
  - default pagination 0/0; 
  - pagination threshold at 4 users: 4/4; 
  - showAudioOnlyOnFirstPage: false (optional)
- Scenario: 6 users                                                                                                                                                                                                                             

With the presentation minimized (grid active), use a fixed session that it not sharing webcams to verify:                                                                                                                                                                                                                                                                                  
- 0 cameras: grid shows 3 participant avatars + "3 more users" tile.                                                                                                                                                                                                                                                   
- 4 users sharing cameras: expect 4 cameras and overflow tile showing "2 more users".                                                                                                                                                                                                                                                                                                    
- 5 users sharing cameras: expect 4 cameras + "2 more users" + page buttons; switching pages should show the remaining camera and avatar placeholder for the user.                                                                                                                                                                                                                                            

Presentation maximized (no grid): pagination works as expected with 5 cameras.
