### PR TITLE
fix(apps-gallery): redesign New label as grid tile header to fix content misalignment

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
@@ -108,7 +108,9 @@ const AppItem: React.FC<AppItemProps> = ({
           onClick={functionToBeCalled}
           onKeyDown={handleClickableAreaKeyDown}
         >
-          {isNew && <Styled.NewLabel>{intl.formatMessage(intlMessages.newAppLabel)}</Styled.NewLabel>}
+          <Styled.TileHeader>
+            {isNew && <Styled.TileNewLabel>{intl.formatMessage(intlMessages.newAppLabel)}</Styled.TileNewLabel>}
+          </Styled.TileHeader>
           <Styled.TileOpenButton $pinned={isPinned} aria-hidden="true">
             {resolveIcon(icon)}
           </Styled.TileOpenButton>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -7,7 +7,9 @@ import {
   colorWhite,
   colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { titlesFontWeight, headingsFontWeight, fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
+import {
+  titlesFontWeight, headingsFontWeight, fontSizeBase, fontSizeXS,
+} from '/imports/ui/stylesheets/styled-components/typography';
 import {
   $2xlPadding,
   lgPadding,
@@ -226,7 +228,7 @@ const TileItem = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.5rem 0.75rem 0.75rem;
+  padding: 0.75rem;
   border: 1px solid ${colorBorder};
   border-radius: ${appsButtonsBorderRadius};
   gap: 0.5rem;
@@ -301,6 +303,23 @@ const TileClickableArea = styled.div`
   cursor: pointer;
 `;
 
+const TileHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 1rem;
+`;
+
+const TileNewLabel = styled.span`
+  font-size: ${fontSizeXS};
+  font-weight: ${headingsFontWeight};
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: ${colorPrimary};
+`;
+
 export default {
   PanelContent,
   Separator,
@@ -326,4 +345,6 @@ export default {
   TilePinApp,
   TileTitle,
   TileClickableArea,
+  TileHeader,
+  TileNewLabel,
 };


### PR DESCRIPTION
## Summary

When the apps gallery is in **grid view**, a tile carrying the "New" label renders its icon and title **pushed downward**, misaligning it against tiles without the label. The expected behavior is that the "New" label is added to the tile without changing the position of its content (icon and title).

This PR redesigns the grid tile into a clean three-section vertical layout (header / icon / title) where the "New" label lives as a small, discrete header at the top, and the icon stays centered and aligned across all tiles regardless of the label.

## Root Cause

The grid tile layout was introduced in **#25127** (commit `253c2e6a37c`, "feat(apps-gallery): add search, pin management, and list/grid view toggle"). That PR placed the `NewLabel` styled component as the **first child** of `TileClickableArea`, a `flex-direction: column` container with `gap: 0.5rem`.

Because `NewLabel` is a normal in-flow flex child at the top of the column, it consumes vertical space plus one gap, shoving the icon and title down on every labelled tile. Tiles without `isNew` lack that element, so their icon/title sit higher, producing the misalignment.

In **list view** the same label is placed after the title inside a flex **row** (`RegisteredAppContent`), so it only extends horizontally and never displaces the icon/title.

## Implementation

The tile becomes a three-section vertical stack:

1. **`TileHeader`** (always rendered, `min-height: 1rem`) — holds the "New" label when present, empty space when absent. Reserving this band on **every** tile is what guarantees alignment: the icon's vertical origin is now label-independent.
2. **Icon** (`TileOpenButton`) — centered in the body of the tile.
3. **Title** (`TileTitle`) — at the base.

The "New" label itself (`TileNewLabel`) is no longer a background-filled pill. It is a small `span` styled with `fontSizeXS`, `headingsFontWeight`, `uppercase`, and `letter-spacing: 0.04em` in `colorPrimary` — a discrete header rather than a loud badge. This makes it less prominent than the icon, as a contextual subtitle should be.

The `TileItem` padding changed from `1.5rem 0.75rem 0.75rem` (the asymmetric top padding existed to accommodate the old floating badge/pin) to a symmetric `0.75rem`, so the header sits flush at the top of the box.

Files changed (2):

- `apps-gallery/styles.ts` — adds `TileHeader` and `TileNewLabel` styled components, imports `fontSizeXS`, adjusts `TileItem` padding.
- `apps-gallery/app-item/component.tsx` — wraps the grid-branch label in `<TileHeader>` (always rendered). The list branch is untouched.

`external-app-item/component.tsx` delegates to `AppItem`, so plugin tiles inherit the redesign with no change.

### Why a reserved header instead of `position: absolute`

The previous iteration of this PR used `position: absolute` to float the label in the top-left corner. That removed the displacement but kept the label as a floating badge, which does not read as part of the tile structure. The reserved header makes the label a first-class section of the tile, improves visual rhythm, and aligns icons by construction rather than by removing one element from the flow.

## Manual test cases

| Scenario | Expected | Result |
|---|---|---|
| Grid view, tile with "New" label | Icon + title aligned with tiles without label; "New" as small header at top | ✅ |
| Grid view, tile without "New" label | Icon + title position unchanged (header band reserved) | ✅ |
| Grid view, tile with BOTH pin + "New" | Pin top-right, "New" centered in header, no collision | ✅ |
| List view, tile with "New" label | "New" after title in row (unchanged, still uses `NewLabel`) | ✅ |
| List view, tile without "New" label | Unchanged | ✅ |

## Evidence

**Before (grid view, bug):**

![Before - grid view, New label displaces icon/title](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-03/e7af2c74-acd7-4262-ae23-5543d11e03e3/grid-baseline.png)

**After (grid view, redesigned):**

![After - grid view, New as header, icon centered and aligned](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-03/19484c65-b223-4ab6-8209-89527ed9cdf4/grid-redesign.png)

Preview animado abaixo - clique no GIF pra abrir o MP4 (qualidade maior, com controls):

[![Apps gallery grid - New label redesign](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-03/b51566d9-167e-41b1-8e4c-ea95ef50cba0/redesign-flow.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-03/fa4031be-ce88-4354-8921-5b27cf0d27fe/redesign-flow.mp4)

Timestamps in the MP4:

- **0:00–0:03** — join meeting, apps gallery opens in grid view
- **0:03–0:07** — grid tiles: "New" appears as small header text at top; icons of labelled tiles (Polling, Timer) align with unlabelled tile (Breakout Rooms)
- **0:07–0:11** — toggle to list view: "New" renders as pill after title (unchanged)

## Risks / Notes

- **Mobile not affected.** The grid/list toggle is desktop-only (`!isMobile`); mobile uses list view, which is unchanged.
- **No unit/e2e tests added.** The `apps-gallery` component has zero existing component tests; the fix is a CSS positioning change validated via Playwright visual evidence.
- `external-app-item` (plugin path) is covered by delegation and was not modified.
- A locale with a very long translation of "New" could bring the centered header text close to the pin in the top-right corner; in en/pt-BR ("New"/"Novo") there is no collision. Not addressed (out of scope, no evidence of a real problem).

Closes #25292