### PR TITLE
fix(html5): prevent crash from browser auto-translation

### DIFF
--- a/bigbluebutton-html5/client/main.html
+++ b/bigbluebutton-html5/client/main.html
@@ -20,6 +20,11 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta charset="utf-8">
+  <!-- Block browser auto-translation: translators (e.g. Google Translate) rewrite
+       text nodes out from under React, desyncing the virtual DOM and crashing the
+       client (insertBefore NotFoundError) on the next render. Use in-app i18n. -->
+  <meta name="google" content="notranslate">
+  <script>document.documentElement.setAttribute('translate', 'no');</script>
   <title>BigBlueButton</title>
   <link rel="stylesheet" href="stylesheets/normalize.css" crossorigin="anonymous"/>
   <style>

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/user-name-with-subs/component.tsx
@@ -88,20 +88,23 @@ const UserNameWithSubs: React.FC<UserNameWithSubsProps> = ({
     || lockSettings.webcamsOnlyForModerator
   ));
 
+  // Labels are wrapped in <span> rather than pushed as bare strings: a bare text
+  // node rendered as a sibling of element nodes is what browser translators
+  // rewrite, desyncing React and crashing the list on re-render (see main.html).
   if (subjectUser.presenter && LABEL.presenter) {
-    subs.push(intl.formatMessage(intlMessages.presenter));
+    subs.push(<span key="bbb-presenter">{intl.formatMessage(intlMessages.presenter)}</span>);
   }
   if (subjectUser.isModerator && LABEL.moderator) {
-    subs.push(intl.formatMessage(intlMessages.moderator));
+    subs.push(<span key="bbb-moderator">{intl.formatMessage(intlMessages.moderator)}</span>);
   }
   if (subjectUser.guest && LABEL.guest) {
-    subs.push(intl.formatMessage(intlMessages.guest));
+    subs.push(<span key="bbb-guest">{intl.formatMessage(intlMessages.guest)}</span>);
   }
   if (subjectUser.mobile && LABEL.mobile) {
-    subs.push(intl.formatMessage(intlMessages.mobile));
+    subs.push(<span key="bbb-mobile">{intl.formatMessage(intlMessages.mobile)}</span>);
   }
   if (subjectUser.bot && LABEL.bot) {
-    subs.push(intl.formatMessage(intlMessages.bot));
+    subs.push(<span key="bbb-bot">{intl.formatMessage(intlMessages.bot)}</span>);
   }
   if ((subjectUser.locked || subjectUser.userLockSettings?.disablePublicChat)
       && (subjectUser.userLockSettings?.disablePublicChat || hasActiveLockSettingExcludingPresenterPolicy)


### PR DESCRIPTION
### What does this PR do?

- [fix(html5): prevent crash from browser auto-translation](https://github.com/bigbluebutton/bigbluebutton/commit/1593d88e0b819b44f20965c9f8b74dfafdcfd1db) 
  - Machine translators (e.g. Chrome/Google Translate) rewrite text nodes
in place by wrapping them in <font> elements, desyncing the DOM from
React's virtual tree. The next render that inserts a sibling, such as
the user list re-rendering when a participant joins, makes React call
insertBefore against a node the translator moved, throwing NotFoundError
and crashing the whole client through the startup error boundary.
  - Block page translation at the document level (notranslate meta and a
translate="no" root attribute); the client already ships full i18n.
  - Wrap the user-name status labels in <span> instead of emitting bare
text nodes, so a mutation there hits span contents rather than a
React-tracked sibling, ie defense in depth against other DOM mutators.

### Closes Issue(s)

None

### How to test

1. Load the client in a locale different from your Chrome UI language (e.g. force                                                                                                                                                                                                                                        
PT-BR while Chrome is English) so Chrome sees a "foreign" page.                                                                                                                                                                                                                                                   
2. Join the meeting with user u1; open the **Participants** panel                                                                                                                                                                                                                            
3. u1: turn on translation: accept Chrome's offer, or right-click -> **Translate to English**,                                                                                                                                                                                                                                
   or click the address-bar Translate icon.                                                                                                                                                                                                                                                                              
4. Have a **second user join** (u2). 
5. u1: the client should crash without this fix, and work as expected with the fix.