### PR TITLE
[4.0] refactor: make pageId opaque UUID (decouple from page num)

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -109,7 +109,7 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
               val height: Double = presentationPage.height
               val whiteboardHistory: Array[AnnotationVO] = liveMeeting.wbModel.getHistory(whiteboardId)
 
-              val page = new PresentationPageForExport(pageNumber, width, height, whiteboardHistory)
+              val page = new PresentationPageForExport(pageNumber, whiteboardId, width, height, whiteboardHistory)
               getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages :+ page)
             case None =>
               getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -102,14 +102,18 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
 
         if (pageNumber >= 1 && pageNumber <= pageCount) {
 
-          val whiteboardId = s"${presId}/${pageNumber.toString}"
-          val presentationPage: PresentationPage = currentPres.get.pages(whiteboardId)
-          val width: Double = presentationPage.width
-          val height: Double = presentationPage.height
-          val whiteboardHistory: Array[AnnotationVO] = liveMeeting.wbModel.getHistory(whiteboardId)
+          PresentationInPod.getPageByNum(currentPres.get, pageNumber) match {
+            case Some(presentationPage) =>
+              val whiteboardId = presentationPage.id
+              val width: Double = presentationPage.width
+              val height: Double = presentationPage.height
+              val whiteboardHistory: Array[AnnotationVO] = liveMeeting.wbModel.getHistory(whiteboardId)
 
-          val page = new PresentationPageForExport(pageNumber, width, height, whiteboardHistory)
-          getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages :+ page)
+              val page = new PresentationPageForExport(pageNumber, width, height, whiteboardHistory)
+              getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages :+ page)
+            case None =>
+              getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages)
+          }
         } else {
           getPresentationPagesForExport(pages, pageCount, presId, currentPres, liveMeeting, storeAnnotationPages)
         }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodsApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationPodsApp.scala
@@ -38,6 +38,14 @@ object PresentationPodsApp {
     state.presentationPodManager.getAllPresentationPodsInMeeting()
   }
 
+  def findPresentationPage(state: MeetingState2x, pageId: String): Option[(PresentationInPod, PresentationPage)] = {
+    (for {
+      pod <- state.presentationPodManager.getAllPresentationPodsInMeeting()
+      pres <- pod.presentations.values
+      page <- pres.pages.get(pageId)
+    } yield (pres, page)).headOption
+  }
+
   def getNumberOfPresentationPods(state: MeetingState2x): Int = state.presentationPodManager.getNumberOfPods()
 
   def translatePresentationPodToVO(pod: PresentationPod): PresentationPodVO = {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/ResizeAndMovePagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/ResizeAndMovePagePubMsgHdlr.scala
@@ -46,11 +46,10 @@ trait ResizeAndMovePagePubMsgHdlr extends RightsManagementTrait {
       val yOffset: Double = msg.body.yOffset
       val widthRatio: Double = msg.body.widthRatio
       val heightRatio: Double = msg.body.heightRatio
-      val slideNumber: Int = msg.body.slideNumber
 
       val newState = for {
         pod <- PresentationPodsApp.getPresentationPodIfPresenter(state, podId, msg.header.userId)
-        (updatedPod, page) <- pod.resizePage(presentationId, pageId, xOffset, yOffset, widthRatio, heightRatio, slideNumber)
+        (updatedPod, page) <- pod.resizePage(presentationId, pageId, xOffset, yOffset, widthRatio, heightRatio)
 
       } yield {
         broadcastEvent(msg, podId, page)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/SetCurrentPagePubMsgHdlr.scala
@@ -22,7 +22,7 @@ trait SetCurrentPagePubMsgHdlr extends RightsManagementTrait {
       PermissionCheck.ejectUserForFailedPermission(meetingId, msg.header.userId, reason, bus.outGW, liveMeeting)
       state
     } else {
-      def broadcastSetCurrentPageEvtMsg(podId: String, presentationId: String, pageId: String, userId: String): Unit = {
+      def broadcastSetCurrentPageEvtMsg(podId: String, presentationId: String, pageId: String, pageNum: Int, userId: String): Unit = {
         val routing = Routing.addMsgToClientRouting(
           MessageTypes.BROADCAST_TO_MEETING,
           liveMeeting.props.meetingProp.intId, userId
@@ -30,7 +30,7 @@ trait SetCurrentPagePubMsgHdlr extends RightsManagementTrait {
         val envelope = BbbCoreEnvelope(SetCurrentPageEvtMsg.NAME, routing)
         val header = BbbClientMsgHeader(SetCurrentPageEvtMsg.NAME, liveMeeting.props.meetingProp.intId, userId)
 
-        val body = SetCurrentPageEvtMsgBody(podId, presentationId, pageId)
+        val body = SetCurrentPageEvtMsgBody(podId, presentationId, pageId, pageNum)
         val event = SetCurrentPageEvtMsg(header, body)
         val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
         bus.outGW.send(msgEvent)
@@ -43,11 +43,13 @@ trait SetCurrentPagePubMsgHdlr extends RightsManagementTrait {
 
       val newState = for {
         pod <- PresentationPodsApp.getPresentationPodIfPresenter(state, podId, userId)
+        pres <- pod.getPresentation(presentationId)
+        page <- pres.pages.get(pageId)
         updatedPod <- pod.setCurrentPage(presentationId, pageId)
       } yield {
 
         if (pod.currentPresenter == userId) {
-          broadcastSetCurrentPageEvtMsg(pod.id, presentationId, pageId, userId)
+          broadcastSetCurrentPageEvtMsg(pod.id, presentationId, pageId, page.num, userId)
 
           val pods = state.presentationPodManager.addPod(updatedPod)
           state.update(pods)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/DeleteWhiteboardAnnotationsPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/DeleteWhiteboardAnnotationsPubMsgHdlr.scala
@@ -2,21 +2,26 @@ package org.bigbluebutton.core.apps.whiteboard
 
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
 import org.bigbluebutton.core.bus.MessageBus
+import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.Users2x
 import org.bigbluebutton.core.running.LiveMeeting
 
 trait DeleteWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
-  def handle(msg: DeleteWhiteboardAnnotationsPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+  def handle(msg: DeleteWhiteboardAnnotationsPubMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: DeleteWhiteboardAnnotationsPubMsg, removedAnnotationsIds: Array[String]): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
       val envelope = BbbCoreEnvelope(DeleteWhiteboardAnnotationsEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(DeleteWhiteboardAnnotationsEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 
-      val body = DeleteWhiteboardAnnotationsEvtMsgBody(msg.body.whiteboardId, removedAnnotationsIds)
+      val (presentationId, pageNum) = PresentationPodsApp.findPresentationPage(state, msg.body.whiteboardId)
+        .map { case (pres, page) => (pres.id, page.num) }
+        .getOrElse(("", 0))
+      val body = DeleteWhiteboardAnnotationsEvtMsgBody(msg.body.whiteboardId, removedAnnotationsIds, presentationId, pageNum)
       val event = DeleteWhiteboardAnnotationsEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/DeleteWhiteboardAnnotationsPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/DeleteWhiteboardAnnotationsPubMsgHdlr.scala
@@ -20,7 +20,10 @@ trait DeleteWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
 
       val (presentationId, pageNum) = PresentationPodsApp.findPresentationPage(state, msg.body.whiteboardId)
         .map { case (pres, page) => (pres.id, page.num) }
-        .getOrElse(("", 0))
+        .getOrElse {
+          log.warning(s"page lookup miss for whiteboardId=${msg.body.whiteboardId} in meeting=${liveMeeting.props.meetingProp.intId}; recording fallback values")
+          ("", 0)
+        }
       val body = DeleteWhiteboardAnnotationsEvtMsgBody(msg.body.whiteboardId, removedAnnotationsIds, presentationId, pageNum)
       val event = DeleteWhiteboardAnnotationsEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
@@ -21,7 +21,10 @@ trait SendCursorPositionPubMsgHdlr extends RightsManagementTrait {
 
       val (presentationId, pageNum) = PresentationPodsApp.findPresentationPage(state, msg.body.whiteboardId)
         .map { case (pres, page) => (pres.id, page.num) }
-        .getOrElse(("", 0))
+        .getOrElse {
+          log.warning(s"page lookup miss for whiteboardId=${msg.body.whiteboardId} in meeting=${liveMeeting.props.meetingProp.intId}; recording fallback values")
+          ("", 0)
+        }
       val body = SendCursorPositionEvtMsgBody(msg.body.whiteboardId, userIsViewer, msg.body.xPercent, msg.body.yPercent, presentationId, pageNum)
       val event = SendCursorPositionEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendCursorPositionPubMsgHdlr.scala
@@ -4,20 +4,25 @@ import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
 import org.bigbluebutton.core.db.PresPageCursorDAO
+import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 
 trait SendCursorPositionPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
-  def handle(msg: SendCursorPositionPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+  def handle(msg: SendCursorPositionPubMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
     def broadcastEvent(msg: SendCursorPositionPubMsg, userIsViewer: Boolean): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
       val envelope = BbbCoreEnvelope(SendCursorPositionEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(SendCursorPositionEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 
-      val body = SendCursorPositionEvtMsgBody(msg.body.whiteboardId, userIsViewer, msg.body.xPercent, msg.body.yPercent)
+      val (presentationId, pageNum) = PresentationPodsApp.findPresentationPage(state, msg.body.whiteboardId)
+        .map { case (pres, page) => (pres.id, page.num) }
+        .getOrElse(("", 0))
+      val body = SendCursorPositionEvtMsgBody(msg.body.whiteboardId, userIsViewer, msg.body.xPercent, msg.body.yPercent, presentationId, pageNum)
       val event = SendCursorPositionEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -54,7 +54,10 @@ trait SendWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
         val annotations = sendWhiteboardAnnotations(msg.body.whiteboardId, msg.header.userId, msg.body.annotations, liveMeeting, userState.presenter, userState.role == Roles.MODERATOR_ROLE)
         val (presentationId, pageNum) = PresentationPodsApp.findPresentationPage(state, msg.body.whiteboardId)
           .map { case (pres, page) => (pres.id, page.num) }
-          .getOrElse(("", 0))
+          .getOrElse {
+            log.warning(s"page lookup miss for whiteboardId=${msg.body.whiteboardId} in meeting=${liveMeeting.props.meetingProp.intId}; recording fallback values")
+            ("", 0)
+          }
         broadcastEvent(msg, msg.body.whiteboardId, annotations, presentationId, pageNum)
       } else {
         //val meetingId = liveMeeting.props.meetingProp.intId

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/whiteboard/SendWhiteboardAnnotationPubMsgHdlr.scala
@@ -4,19 +4,21 @@ import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.bus.MessageBus
 import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
+import org.bigbluebutton.core.apps.presentationpod.PresentationPodsApp
+import org.bigbluebutton.core.domain.MeetingState2x
 import org.bigbluebutton.core.models.{ Roles, Users2x }
 
 trait SendWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
   this: WhiteboardApp2x =>
 
-  def handle(msg: SendWhiteboardAnnotationsPubMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+  def handle(msg: SendWhiteboardAnnotationsPubMsg, state: MeetingState2x, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
 
-    def broadcastEvent(msg: SendWhiteboardAnnotationsPubMsg, whiteboardId: String, annotations: Array[AnnotationVO]): Unit = {
+    def broadcastEvent(msg: SendWhiteboardAnnotationsPubMsg, whiteboardId: String, annotations: Array[AnnotationVO], presentationId: String, pageNum: Int): Unit = {
       val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, msg.header.userId)
       val envelope = BbbCoreEnvelope(SendWhiteboardAnnotationsEvtMsg.NAME, routing)
       val header = BbbClientMsgHeader(SendWhiteboardAnnotationsEvtMsg.NAME, liveMeeting.props.meetingProp.intId, msg.header.userId)
 
-      val body = SendWhiteboardAnnotationsEvtMsgBody(whiteboardId, annotations)
+      val body = SendWhiteboardAnnotationsEvtMsgBody(whiteboardId, annotations, presentationId, pageNum)
       val event = SendWhiteboardAnnotationsEvtMsg(header, body)
       val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
       bus.outGW.send(msgEvent)
@@ -50,7 +52,10 @@ trait SendWhiteboardAnnotationsPubMsgHdlr extends RightsManagementTrait {
         // }
         // println("============= Printed Sanitized annotations  ============")
         val annotations = sendWhiteboardAnnotations(msg.body.whiteboardId, msg.header.userId, msg.body.annotations, liveMeeting, userState.presenter, userState.role == Roles.MODERATOR_ROLE)
-        broadcastEvent(msg, msg.body.whiteboardId, annotations)
+        val (presentationId, pageNum) = PresentationPodsApp.findPresentationPage(state, msg.body.whiteboardId)
+          .map { case (pres, page) => (pres.id, page.num) }
+          .getOrElse(("", 0))
+        broadcastEvent(msg, msg.body.whiteboardId, annotations, presentationId, pageNum)
       } else {
         //val meetingId = liveMeeting.props.meetingProp.intId
         //val reason = "No permission to send a whiteboard annotation."

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -130,7 +130,10 @@ object Polls {
       pod <- state.presentationPodManager.getDefaultPod()
       pres <- pod.getCurrentPresentation()
       page <- PresentationInPod.getCurrentPage(pres)
-      shape = pollResultToWhiteboardShape(result, page, poll.questions(0).quiz, showAnswer)
+      // deskshare polls have no backing presentation; leave their presentation
+      // identity empty, like the recorder defaults below
+      shapePresId = if (result.id.contains("deskshare")) "" else pres.id
+      shape = pollResultToWhiteboardShape(result, page, shapePresId, poll.questions(0).quiz, showAnswer)
       annot <- send(result, shape)
     } yield {
       lm.wbModel.addAnnotations(annot.wbId, lm.props.meetingProp.intId, requesterId, Array[AnnotationVO](annot), isPresenter = false, isModerator = false)
@@ -297,6 +300,7 @@ object Polls {
   private def pollResultToWhiteboardShape(
       result:     SimplePollResultOutVO,
       page:       PresentationPage,
+      presId:     String,
       quiz:       Boolean,
       showAnswer: Boolean
   ): scala.collection.immutable.Map[String, Object] = {
@@ -371,6 +375,10 @@ object Polls {
     props += "fill" -> "black"
     props += "color" -> "black"
     props += "question" -> result.questionText.getOrElse("")
+
+    // The whiteboard client keeps only shapes whose meta identifies the presentation
+    // being displayed; client-drawn shapes set this themselves on persist.
+    meta += "presentationId" -> presId
 
     shape += "x" -> java.lang.Double.valueOf(x)
     shape += "y" -> java.lang.Double.valueOf(y)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -140,7 +140,9 @@ object Polls {
       val annotationEnvelope = BbbCoreEnvelope(SendWhiteboardAnnotationsEvtMsg.NAME, annotationRouting)
       val annotationHeader = BbbClientMsgHeader(SendWhiteboardAnnotationsEvtMsg.NAME, lm.props.meetingProp.intId, requesterId)
 
-      val annotMsgBody = SendWhiteboardAnnotationsEvtMsgBody(annot.wbId, Array[AnnotationVO](annot))
+      // deskshare polls have no backing presentation page; mirror the recorder's empty defaults
+      val (annotPresId, annotPageNum) = if (annot.wbId == "deskshare") ("", 0) else (pres.id, page.num)
+      val annotMsgBody = SendWhiteboardAnnotationsEvtMsgBody(annot.wbId, Array[AnnotationVO](annot), annotPresId, annotPageNum)
       val annotationEvent = SendWhiteboardAnnotationsEvtMsg(annotationHeader, annotMsgBody)
       val annotationMsgEvent = BbbCommonEnvCoreMsg(annotationEnvelope, annotationEvent)
       bus.outGW.send(annotationMsgEvent)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Polls.scala
@@ -377,7 +377,7 @@ object Polls {
     shape += "isLocked" -> java.lang.Boolean.valueOf(false)
     shape += "index" -> "a1"
     shape += "rotation" -> Integer.valueOf(0)
-    shape += "parentId" -> s"page:${page.num}"
+    shape += "parentId" -> s"page:${page.id}"
     shape += "typeName" -> "shape"
     shape += "opacity" -> Integer.valueOf(1)
     shape += "id" -> s"shape:poll-result-${result.id}"

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -181,7 +181,7 @@ case class PresentationPod(id: String, currentPresenter: String,
 
   def resizePage(presentationId: String, pageId: String,
                  xOffset: Double, yOffset: Double, widthRatio: Double,
-                 heightRatio: Double, slideNumber: Int): Option[(PresentationPod, PresentationPage)] = {
+                 heightRatio: Double): Option[(PresentationPod, PresentationPage)] = {
     val minZoom = 25.0
     val maxZoom = 400.0
 
@@ -196,7 +196,7 @@ case class PresentationPod(id: String, currentPresenter: String,
       page <- pres.pages.get(pageId)
     } yield {
       val nPage = page.copy(xOffset = checkedXOffset, yOffset = checkedYOffset,
-        widthRatio = checkedWidth, heightRatio = checkedHeight, num = slideNumber)
+        widthRatio = checkedWidth, heightRatio = checkedHeight)
       val nPages = pres.pages + (nPage.id -> nPage)
       val newPres = pres.copy(pages = nPages)
       (addPresentation(newPres), nPage)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/PresentationPods.scala
@@ -61,6 +61,10 @@ object PresentationInPod {
     pres.pages.values find (p => p.current)
   }
 
+  def getPageByNum(pres: PresentationInPod, num: Int): Option[PresentationPage] = {
+    pres.pages.values find (p => p.num == num)
+  }
+
 }
 
 case class PresentationInPod(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -532,13 +532,13 @@ class MeetingActor(
 
       // Whiteboard
       case m: SendCursorPositionPubMsg =>
-        wbApp.handle(m, liveMeeting, msgBus)
+        wbApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
         updateUserLastActivity(m.header.userId)
       case m: DeleteWhiteboardAnnotationsPubMsg =>
-        wbApp.handle(m, liveMeeting, msgBus)
+        wbApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
         updateUserLastActivity(m.header.userId)
       case m: SendWhiteboardAnnotationsPubMsg =>
-        wbApp.handle(m, liveMeeting, msgBus)
+        wbApp.handle(m, state, liveMeeting, msgBus) // passing state but not modifying it
         updateUserLastActivity(m.header.userId)
       case m: GetWhiteboardAnnotationsReqMsg => wbApp.handle(m, liveMeeting, msgBus)
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/LearningDashboardActor.scala
@@ -121,6 +121,7 @@ case class PresentationSlide(
                               setOn: Long = System.currentTimeMillis(),
                               presentationName: String,
                               pageToken: String = "",
+                              pageId: String = "",
                             )
 
 
@@ -285,7 +286,7 @@ class LearningDashboardActor(
         for {
           page <- msg.body.presentation.pages.find(p => p.current)
         } yield {
-          this.setPresentationSlide(meeting.intId, msg.body.presentation.id,page.num, msg.body.presentation.name, page.pageToken)
+          this.setPresentationSlide(meeting.intId, msg.body.presentation.id,page.num, msg.body.presentation.name, page.pageToken, page.id)
         }
       }
     }
@@ -298,7 +299,7 @@ class LearningDashboardActor(
       presentation <- presentations.get(msg.body.presentationId)
       page <- presentation.pages.find(p => p.id == msg.body.pageId)
     } yield {
-      this.setPresentationSlide(meeting.intId, msg.body.presentationId,page.num, presentation.name, page.pageToken)
+      this.setPresentationSlide(meeting.intId, msg.body.presentationId,page.num, presentation.name, page.pageToken, page.id)
     }
   }
 
@@ -308,7 +309,7 @@ class LearningDashboardActor(
     } yield {
       meeting.presentationSlides.lastOption match {
         case Some(slide) if slide.presentationId == msg.body.presentationId =>
-          this.setPresentationSlide(meeting.intId, "",0, "", "")
+          this.setPresentationSlide(meeting.intId, "",0, "", "", "")
         case _ => // No matching current presentation slide to remove.
       }
     }
@@ -325,7 +326,7 @@ class LearningDashboardActor(
       previousSlide match {
         case Some(slide) =>
           //Set last page showed for this presentation
-          this.setPresentationSlide(meeting.intId, msg.body.presentationId, slide.pageNum, slide.presentationName, slide.pageToken)
+          this.setPresentationSlide(meeting.intId, msg.body.presentationId, slide.pageNum, slide.presentationName, slide.pageToken, slide.pageId)
         case None =>
           //If none page was showed yet, set the current page (page 1 by default)
           for {
@@ -333,13 +334,13 @@ class LearningDashboardActor(
             presentation <- presentations.get(msg.body.presentationId)
             page <- presentation.pages.find(s => s.current == true)
           } yield  {
-            this.setPresentationSlide(meeting.intId, msg.body.presentationId,page.num, presentation.name, page.pageToken)
+            this.setPresentationSlide(meeting.intId, msg.body.presentationId,page.num, presentation.name, page.pageToken, page.id)
           }
       }
     }
   }
 
-  private def setPresentationSlide(meetingId: String, presentationId: String, pageNum: Long, presentationName: String, pageToken: String) {
+  private def setPresentationSlide(meetingId: String, presentationId: String, pageNum: Long, presentationName: String, pageToken: String, pageId: String) {
     for {
       meeting <- meetings.values.find(m => m.intId == meetingId)
     } yield {
@@ -349,7 +350,7 @@ class LearningDashboardActor(
       }
 
       if (shouldAppendSlide) {
-        val updatedMeeting = meeting.copy(presentationSlides = meeting.presentationSlides :+ PresentationSlide(presentationId, pageNum, presentationName = presentationName, pageToken = pageToken))
+        val updatedMeeting = meeting.copy(presentationSlides = meeting.presentationSlides :+ PresentationSlide(presentationId, pageNum, presentationName = presentationName, pageToken = pageToken, pageId = pageId))
 
         meetings += (updatedMeeting.intId -> updatedMeeting)
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/endpoint/redis/RedisRecorderActor.scala
@@ -251,7 +251,7 @@ class RedisRecorderActor(
     ev.setMeetingId(msg.header.meetingId)
     ev.setPodId(msg.body.podId)
     ev.setPresentationName(msg.body.presentationId)
-    ev.setSlide(getPageNum(msg.body.pageId))
+    ev.setSlide(msg.body.pageNum)
     ev.setId(msg.body.pageId)
 
     record(msg.header.meetingId, ev.toMap.asJava)
@@ -357,8 +357,8 @@ class RedisRecorderActor(
     msg.body.annotations.foreach(annotation => {
       val ev = new AddTldrawShapeWhiteboardRecordEvent()
       ev.setMeetingId(msg.header.meetingId)
-      ev.setPresentation(getPresentationId(annotation.wbId))
-      ev.setPageNumber(getPageNum(annotation.wbId))
+      ev.setPresentation(msg.body.presentationId)
+      ev.setPageNumber(msg.body.pageNum)
       ev.setWhiteboardId(annotation.wbId)
       ev.setUserId(annotation.userId)
       ev.setAnnotationId(annotation.id)
@@ -371,8 +371,8 @@ class RedisRecorderActor(
   private def handleSendCursorPositionEvtMsg(msg: SendCursorPositionEvtMsg) {
     val ev = new WhiteboardCursorMoveRecordEvent()
     ev.setMeetingId(msg.header.meetingId)
-    ev.setPresentation(getPresentationId(msg.body.whiteboardId))
-    ev.setPageNumber(getPageNum(msg.body.whiteboardId))
+    ev.setPresentation(msg.body.presentationId)
+    ev.setPageNumber(msg.body.pageNum)
     ev.setWhiteboardId(msg.body.whiteboardId)
     ev.setUserId(msg.header.userId)
     ev.setXPercent(msg.body.xPercent)
@@ -397,8 +397,8 @@ class RedisRecorderActor(
     msg.body.annotationsIds.foreach(annotationId => {
       val ev = new DeleteTldrawShapeRecordEvent()
       ev.setMeetingId(msg.header.meetingId)
-      ev.setPresentation(getPresentationId(msg.body.whiteboardId))
-      ev.setPageNumber(getPageNum(msg.body.whiteboardId))
+      ev.setPresentation(msg.body.presentationId)
+      ev.setPageNumber(msg.body.pageNum)
       ev.setWhiteboardId(msg.body.whiteboardId)
       ev.setUserId(msg.header.userId)
       ev.setShapeId(annotationId)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
@@ -39,7 +39,7 @@ case class SetPresentationDownloadablePubMsgBody(podId: String, presentationId: 
 object ResizeAndMovePagePubMsg { val NAME = "ResizeAndMovePagePubMsg" }
 case class ResizeAndMovePagePubMsg(header: BbbClientMsgHeader, body: ResizeAndMovePagePubMsgBody) extends StandardMsg
 case class ResizeAndMovePagePubMsgBody(podId: String, presentationId: String, pageId: String, xOffset: Double,
-                                       yOffset: Double, widthRatio: Double, heightRatio: Double, slideNumber: Int)
+                                       yOffset: Double, widthRatio: Double, heightRatio: Double)
 
 object SlideResizedPubMsg { val NAME = "SlideResizedPubMsg" }
 case class SlideResizedPubMsg(header: BbbClientMsgHeader, body: SlideResizedPubMsgBody) extends StandardMsg

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationPodsMsgs.scala
@@ -397,7 +397,7 @@ case class GetAllPresentationPodsRespMsgBody(pods: Vector[PresentationPodVO])
 
 object SetCurrentPageEvtMsg { val NAME = "SetCurrentPageEvtMsg" }
 case class SetCurrentPageEvtMsg(header: BbbClientMsgHeader, body: SetCurrentPageEvtMsgBody) extends BbbCoreMsg
-case class SetCurrentPageEvtMsgBody(podId: String, presentationId: String, pageId: String)
+case class SetCurrentPageEvtMsgBody(podId: String, presentationId: String, pageId: String, pageNum: Int)
 
 object SetPageInfiniteWhiteboardEvtMsg { val NAME = "SetPageInfiniteWhiteboardEvtMsg" }
 case class SetPageInfiniteWhiteboardEvtMsg(header: BbbClientMsgHeader, body: SetPageInfiniteWhiteboardEvtMsgBody) extends BbbCoreMsg

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
@@ -5,6 +5,7 @@ case class AnnotationVO(id: String, annotationInfo: scala.collection.immutable.M
 
 case class PresentationPageForExport(
   page: Int,
+  pageId: String,
   width: Double,
   height: Double,
   annotations: Array[AnnotationVO],

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/WhiteboardMsgs.scala
@@ -70,15 +70,15 @@ case class GetWhiteboardAnnotationsRespMsgBody(whiteboardId: String, annotations
 
 object SendCursorPositionEvtMsg { val NAME = "SendCursorPositionEvtMsg" }
 case class SendCursorPositionEvtMsg(header: BbbClientMsgHeader, body: SendCursorPositionEvtMsgBody) extends BbbCoreMsg
-case class SendCursorPositionEvtMsgBody(whiteboardId: String, userIsViewer: Boolean, xPercent: Double, yPercent: Double)
+case class SendCursorPositionEvtMsgBody(whiteboardId: String, userIsViewer: Boolean, xPercent: Double, yPercent: Double, presentationId: String, pageNum: Int)
 
 object SendWhiteboardAnnotationsEvtMsg { val NAME = "SendWhiteboardAnnotationsEvtMsg" }
 case class SendWhiteboardAnnotationsEvtMsg(header: BbbClientMsgHeader, body: SendWhiteboardAnnotationsEvtMsgBody) extends BbbCoreMsg
-case class SendWhiteboardAnnotationsEvtMsgBody(whiteboardId: String, annotations: Array[AnnotationVO])
+case class SendWhiteboardAnnotationsEvtMsgBody(whiteboardId: String, annotations: Array[AnnotationVO], presentationId: String, pageNum: Int)
 
 object DeleteWhiteboardAnnotationsEvtMsg { val NAME = "DeleteWhiteboardAnnotationsEvtMsg" }
 case class DeleteWhiteboardAnnotationsEvtMsg(header: BbbClientMsgHeader, body: DeleteWhiteboardAnnotationsEvtMsgBody) extends BbbCoreMsg
-case class DeleteWhiteboardAnnotationsEvtMsgBody(whiteboardId: String, annotationsIds: Array[String])
+case class DeleteWhiteboardAnnotationsEvtMsgBody(whiteboardId: String, annotationsIds: Array[String], presentationId: String, pageNum: Int)
 
 // ------------ akka-apps to client ------------
 object StoreAnnotationsInRedisSysMsg { val NAME = "StoreAnnotationsInRedisSysMsg" }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ConversionUpdateMessage.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/ConversionUpdateMessage.java
@@ -91,11 +91,13 @@ public class ConversionUpdateMessage {
 			ArrayList<Map<String, String>> pages = new ArrayList<Map<String, String>>();
 			
 			for (int i = 1; i <= pres.getNumberOfPages(); i++) {
+				String pageId = pres.getOrMintPageId(i);
 				Map<String, String> page = new HashMap<String, String>();
 				page.put("num", Integer.toString(i));
-				page.put("thumb", basePresUrl + "/thumbnail/" + i);
-				page.put("text", basePresUrl + "/textfiles/" + i);
-				
+				page.put("id", pageId);
+				page.put("thumb", basePresUrl + "/thumbnail/" + pageId);
+				page.put("text", basePresUrl + "/textfiles/" + pageId);
+
 				pages.add(page);
 			}
 			

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/UploadedPresentation.java
@@ -21,6 +21,9 @@ package org.bigbluebutton.presentation;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.io.FilenameUtils;
 
 public final class UploadedPresentation {
@@ -46,6 +49,11 @@ public final class UploadedPresentation {
   private long maxPageConversionTime;
 
   private boolean defaultPresentation;
+
+  // Page identity: opaque UUID per page, minted once when the page's files are
+  // first created on disk. Every on-disk filename, URL and message must consume
+  // the id from this map instead of deriving identity from the page number.
+  private final ConcurrentHashMap<Integer, String> pageIds = new ConcurrentHashMap<>();
 
   public UploadedPresentation(String podId,
                               String meetingId,
@@ -252,5 +260,19 @@ public final class UploadedPresentation {
       return maxPageConversionTime;
     }
     return maxPageConversionTime * numberOfPages;
+  }
+
+  public String getOrMintPageId(int page) {
+    return pageIds.computeIfAbsent(page, p -> UUID.randomUUID().toString());
+  }
+
+  // Restores an id minted by a previous conversion (cache manifest); a fresh
+  // mint never overwrites a restored id.
+  public void seedPageId(int page, String pageId) {
+    pageIds.putIfAbsent(page, pageId);
+  }
+
+  public Map<Integer, String> getPageIds() {
+    return pageIds;
   }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PageIdManifest.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PageIdManifest.java
@@ -1,0 +1,55 @@
+package org.bigbluebutton.presentation.imp;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.bigbluebutton.presentation.UploadedPresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.TreeMap;
+
+// Persists the page-number to pageId mapping of a conversion as pages.json in
+// the presentation directory. The on-disk filenames are keyed by the opaque
+// pageId, so a conversion restored from the S3 cache can only be matched back
+// to page numbers through this manifest.
+public class PageIdManifest {
+    private static final Logger log = LoggerFactory.getLogger(PageIdManifest.class);
+
+    public static final String FILENAME = "pages.json";
+
+    private static final Type MAP_TYPE = new TypeToken<TreeMap<String, String>>() {}.getType();
+
+    public static void save(UploadedPresentation pres) {
+        File manifest = new File(pres.getUploadedFile().getParent() + File.separatorChar + FILENAME);
+        Map<String, String> byPageNum = new TreeMap<>();
+        for (Map.Entry<Integer, String> e : pres.getPageIds().entrySet()) {
+            byPageNum.put(String.valueOf(e.getKey()), e.getValue());
+        }
+        try {
+            Files.write(manifest.toPath(), new Gson().toJson(byPageNum).getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.error("Failed to write page id manifest {}: {}", manifest.getAbsolutePath(), e.getMessage());
+        }
+    }
+
+    public static void seedFrom(UploadedPresentation pres) {
+        File manifest = new File(pres.getUploadedFile().getParent() + File.separatorChar + FILENAME);
+        if (!manifest.exists()) return;
+        try {
+            String json = new String(Files.readAllBytes(manifest.toPath()), StandardCharsets.UTF_8);
+            Map<String, String> byPageNum = new Gson().fromJson(json, MAP_TYPE);
+            if (byPageNum == null) return;
+            for (Map.Entry<String, String> e : byPageNum.entrySet()) {
+                pres.seedPageId(Integer.parseInt(e.getKey()), e.getValue());
+            }
+            log.info("Restored {} page ids from manifest for presentation {}", byPageNum.size(), pres.getId());
+        } catch (Exception e) {
+            log.warn("Ignoring unreadable page id manifest {}: {}", manifest.getAbsolutePath(), e.getMessage());
+        }
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PngCreatorImp.java
@@ -60,7 +60,7 @@ public class PngCreatorImp implements PngCreator {
 			pngDir.mkdir();
 
         if (useBlank) {
-            createBlankPng(pngDir, page);
+            createBlankPng(pngDir, pres, page);
             return true;
         }
 
@@ -75,9 +75,9 @@ public class PngCreatorImp implements PngCreator {
 		}
 
 		long start = System.currentTimeMillis();
-		renamePng(pngDir, page);
+		renamePng(pngDir, pres, page);
 		// Create blank thumbnails for pages that failed to generate a thumbnail.
-		createBlankPng(pngDir, page);
+		createBlankPng(pngDir, pres, page);
 		long end = System.currentTimeMillis();
 		//System.out.println("*** GENERATE BLANK PNG " + (end - start));
 
@@ -101,7 +101,7 @@ public class PngCreatorImp implements PngCreator {
 			}
 		}
 
-		createBlankPng(dir, page);
+		createBlankPng(dir, pres, page);
 	}
 
 	private boolean generatePng(File pngsDir, UploadedPresentation pres, int page, File pageFile)
@@ -117,7 +117,7 @@ public class PngCreatorImp implements PngCreator {
 		}
 
 		String source = pageFile.getAbsolutePath();
-		String dest = pngsDir.getAbsolutePath() + File.separator + "slide-" + page + ".png";
+		String dest = pngsDir.getAbsolutePath() + File.separator + "slide-" + pres.getOrMintPageId(page) + ".png";
 
 		// Skip processing if the destination file exists, as it was likely restored from the cache
 		if(Files.exists(Paths.get(dest))) {
@@ -177,7 +177,7 @@ public class PngCreatorImp implements PngCreator {
 		return new File(presentationFile.getParent() + File.separatorChar + "pngs");
 	}
 
-	private void renamePng(File dir, int page) {
+	private void renamePng(File dir, UploadedPresentation pres, int page) {
 		/*
 		 * If more than 1 file, filename like 'temp-png-X.png' else filename is
 		 * 'temp-png.png'
@@ -201,7 +201,7 @@ public class PngCreatorImp implements PngCreator {
 					// We are interested in the second match.
 					int pageNum = Integer.parseInt(matcher.group(2).trim());
 					if (pageNum == page) {
-						String newFilename = "slide-" + (page) + ".png";
+						String newFilename = "slide-" + pres.getOrMintPageId(page) + ".png";
 						File renamedFile = new File(
 								dir.getAbsolutePath() + File.separator + newFilename);
 						files[i].renameTo(renamedFile);
@@ -213,15 +213,15 @@ public class PngCreatorImp implements PngCreator {
 			File oldFilename = new File(
 							dir.getAbsolutePath() + File.separator + dir.list()[0]);
 			//System.out.println("*** PPNG file " + oldFilename.getAbsolutePath());
-			String newFilename = "slide-1.png";
+			String newFilename = "slide-" + pres.getOrMintPageId(1) + ".png";
 			File renamedFile = new File(
 							oldFilename.getParent() + File.separator + newFilename);
 			oldFilename.renameTo(renamedFile);
 		}
 	}
 
-	private void createBlankPng(File pngsDir, int page) {
-		File png = new File(pngsDir.getAbsolutePath() + File.separator + "slide-" + page + ".png");
+	private void createBlankPng(File pngsDir, UploadedPresentation pres, int page) {
+		File png = new File(pngsDir.getAbsolutePath() + File.separator + "slide-" + pres.getOrMintPageId(page) + ".png");
 		if (!png.exists()) {
 			log.info("Copying blank png for slide {}", page);
 			copyBlankPng(png);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/PresentationFileProcessor.java
@@ -77,6 +77,9 @@ public class PresentationFileProcessor {
                 S3Object s3Object = s3FileManager.download(remoteFileName);
                 File parentDir = new File(pres.getUploadedFile().getParent());
                 TarGzManager.decompress(s3Object, parentDir.getAbsolutePath());
+                // Cached files are named by pageId; without the manifest the
+                // restored files cannot be matched back to page numbers.
+                PageIdManifest.seedFrom(pres);
                 log.info("Presentation outputs restored from cache successfully for {}.", pres.getId());
             }
         } catch (Exception e) {
@@ -91,6 +94,13 @@ public class PresentationFileProcessor {
         } else if (SupportedFileTypes.isImageFile(pres.getFileType())) {
             pres.setNumberOfPages(1);
         }
+
+        // Single mint point: page identity is fixed here, before any file is
+        // written, and recorded in the manifest so cache restores keep it.
+        for (int page = 1; page <= pres.getNumberOfPages(); page++) {
+            pres.getOrMintPageId(page);
+        }
+        PageIdManifest.save(pres);
 
         long maxConversionTime = pres.getMaxTotalConversionTime();
         processUploadedPresentation(pres);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SlidesGenerationProgressNotifier.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SlidesGenerationProgressNotifier.java
@@ -130,6 +130,7 @@ public class SlidesGenerationProgressNotifier {
             generateBasePresUrl(pres),
             pres.getUploadedFile().getParent(),
             pageGenerated,
+            pres.getOrMintPageId(pageGenerated),
             (pageGenerated == 1));
     messagingService.sendDocConversionMsg(progress);
   }
@@ -153,7 +154,8 @@ public class SlidesGenerationProgressNotifier {
       pres.getId(), pres.getTemporaryPresentationId(), pres.getId(),
       pres.getName(), "notUsedYet", "notUsedYet",
       pres.isDownloadable(), pres.isRemovable(), ConversionMessageConstants.CONVERSION_COMPLETED_KEY,
-      pres.getNumberOfPages(), generateBasePresUrl(pres), pres.isCurrent(), pres.isDefaultPresentation(), pres.getFilenameConverted());
+      pres.getNumberOfPages(), generateBasePresUrl(pres), pres.isCurrent(), pres.isDefaultPresentation(), pres.getFilenameConverted(),
+      pres.getPageIds());
     messagingService.sendDocConversionMsg(progress);
   }
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -51,7 +51,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         if (!svgImagesPresentationDir.exists())
             svgImagesPresentationDir.mkdir();
 
-        File destSvg = new File(svgImagesPresentationDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".svg");
+        File destSvg = new File(svgImagesPresentationDir.getAbsolutePath() + File.separatorChar + "slide" + pres.getOrMintPageId(page) + ".svg");
 
         if (useBlank) {
             copyBlankSvg(destSvg);
@@ -88,7 +88,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
         }
 
-        File destSvg = new File(dir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".svg");
+        File destSvg = new File(dir.getAbsolutePath() + File.separatorChar + "slide" + pres.getOrMintPageId(page) + ".svg");
         copyBlankSvg(destSvg);
     }
 
@@ -132,7 +132,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         String dest;
 
         // Skip processing if the destination file exists, as it was likely restored from the cache
-        File destsvg = new File(imagePresentationDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".svg");
+        File destsvg = new File(imagePresentationDir.getAbsolutePath() + File.separatorChar + "slide" + pres.getOrMintPageId(page) + ".svg");
         if(destsvg.exists()) {
             return true;
         }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java
@@ -51,7 +51,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         if (!svgImagesPresentationDir.exists())
             svgImagesPresentationDir.mkdir();
 
-        File destSvg = new File(svgImagesPresentationDir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
+        File destSvg = new File(svgImagesPresentationDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".svg");
 
         if (useBlank) {
             copyBlankSvg(destSvg);
@@ -88,7 +88,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
             }
         }
 
-        File destSvg = new File(dir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
+        File destSvg = new File(dir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".svg");
         copyBlankSvg(destSvg);
     }
 
@@ -132,7 +132,7 @@ public class SvgImageCreatorImp implements SvgImageCreator {
         String dest;
 
         // Skip processing if the destination file exists, as it was likely restored from the cache
-        File destsvg = new File(imagePresentationDir.getAbsolutePath() + File.separatorChar + "slide" + page + ".svg");
+        File destsvg = new File(imagePresentationDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".svg");
         if(destsvg.exists()) {
             return true;
         }
@@ -428,20 +428,6 @@ public class SvgImageCreatorImp implements SvgImageCreator {
 
     private File determineSvgImagesDirectory(File presentationFile) {
         return new File(presentationFile.getParent() + File.separatorChar + "svgs");
-    }
-
-    private void copyBlankSvgs(File svgssDir, int pageCount) {
-    	File[] svgs = svgssDir.listFiles();
-
-		if (svgs.length != pageCount) {
-			for (int i = 1; i <= pageCount; i++) {
-				File svg = new File(svgssDir.getAbsolutePath() + File.separator + "slide" + i + ".svg");
-				if (!svg.exists()) {
-					log.info("Copying blank svg for slide {}", i);
-					copyBlankSvg(svg);
-				}
-			}
-		}
     }
 
 	private void copyBlankSvg(File svg) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TarGzManager.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TarGzManager.java
@@ -42,6 +42,13 @@ public class TarGzManager {
                     addFileToTarGz(taos, pageFile, "");
                 }
             }
+
+            // The files above are named by pageId; the manifest is the only way
+            // to map them back to page numbers on a cache restore.
+            File manifestFile = new File(sourceDirectory + "/" + PageIdManifest.FILENAME);
+            if (manifestFile.exists()) {
+                addFileToTarGz(taos, manifestFile, "");
+            }
         }
 
         return tempTarGzFile;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/TextFileCreatorImp.java
@@ -51,7 +51,7 @@ public class TextFileCreatorImp implements TextFileCreator {
       textfilesDir.mkdir();
 
     if (useBlank) {
-        createBlankTextFile(textfilesDir, page);
+        createBlankTextFile(textfilesDir, pres, page);
         return true;
     }
 
@@ -63,7 +63,7 @@ public class TextFileCreatorImp implements TextFileCreator {
     }
 
     if (!success) {
-      createBlankTextFile(textfilesDir, page);
+      createBlankTextFile(textfilesDir, pres, page);
     }
 
     return success;
@@ -81,14 +81,14 @@ public class TextFileCreatorImp implements TextFileCreator {
       }
     }
 
-    createBlankTextFile(dir, page);
+    createBlankTextFile(dir, pres, page);
   }
 
   private boolean generateTextFile(File textfilesDir,
       UploadedPresentation pres, int page) throws InterruptedException {
     boolean success = true;
     String source = pres.getUploadedFile().getAbsolutePath();
-    String dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-" + page + ".txt";
+    String dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".txt";
     String COMMAND = "";
 
     // Skip processing if the destination file exists, as it was likely restored from the cache
@@ -97,7 +97,7 @@ public class TextFileCreatorImp implements TextFileCreator {
     }
 
     if (SupportedFileTypes.isImageFile(pres.getFileType())) {
-      dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-1.txt";
+      dest = textfilesDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(1) + ".txt";
       String text = "No text could be retrieved for the slide";
 
       File file = new File(dest);
@@ -156,8 +156,8 @@ public class TextFileCreatorImp implements TextFileCreator {
         presentationFile.getParent() + File.separatorChar + "textfiles");
   }
 
-  private void createBlankTextFile(File textFilesDir, int page) {
-    File textFile = new File(textFilesDir.getAbsolutePath() + File.separatorChar + "slide-" + page + ".txt");
+  private void createBlankTextFile(File textFilesDir, UploadedPresentation pres, int page) {
+    File textFile = new File(textFilesDir.getAbsolutePath() + File.separatorChar + "slide-" + pres.getOrMintPageId(page) + ".txt");
     try {
       boolean created = textFile.createNewFile();
       if (created) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/ThumbnailCreatorImp.java
@@ -62,7 +62,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
       thumbsDir.mkdir();
 
     if (useBlank) {
-        createBlankThumbnail(thumbsDir, page);
+        createBlankThumbnail(thumbsDir, pres, page);
         return true;
     }
 
@@ -73,11 +73,11 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
       success = false;
     }
 
-    renameThumbnails(thumbsDir, page);
+    renameThumbnails(thumbsDir, pres, page);
 
     // Create blank thumbnails for pages that failed to generate a thumbnail.
     if (!success) {
-      createBlankThumbnail(thumbsDir, page);
+      createBlankThumbnail(thumbsDir, pres, page);
     }
 
 
@@ -87,7 +87,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
   private boolean generateThumbnail(File thumbsDir, UploadedPresentation pres, int page, File pageFile)
       throws InterruptedException {
     String source = pageFile.getAbsolutePath();
-    String dest = thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + page + ".png";
+    String dest = thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + pres.getOrMintPageId(page) + ".png";
     String COMMAND = "";
 
     // Skip processing if the destination file exists, as it was likely restored from the cache
@@ -96,7 +96,6 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
     }
 
     if (SupportedFileTypes.isImageFile(pres.getFileType())) {
-      dest = thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + page + ".png";
       COMMAND = IMAGEMAGICK_DIR + File.separatorChar + "convert -thumbnail 150x150 "  + source + " " + dest;
     } else {
       String pdftocairoDest = thumbsDir.getAbsolutePath() + File.separatorChar + TEMP_THUMB_NAME + "-" + page; // the "-x.png" is appended automagically
@@ -144,7 +143,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
       }
     }
 
-    createBlankThumbnail(dir, page);
+    createBlankThumbnail(dir, pres, page);
   }
 
   private File determineThumbnailDirectory(File presentationFile) {
@@ -152,7 +151,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
         presentationFile.getParent() + File.separatorChar + "thumbnails");
   }
 
-  private void renameThumbnails(File dir, int page) {
+  private void renameThumbnails(File dir, UploadedPresentation pres, int page) {
     /*
      * If more than 1 file, filename like 'temp-thumb-X.png' else filename is
      * 'temp-thumb.png'
@@ -173,7 +172,7 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
           // We are interested in the second match.
           int pageNum = Integer.valueOf(matcher.group(2).trim()).intValue();
           if (pageNum == page) {
-            String newFilename = "thumb-" + (page) + ".png";
+            String newFilename = "thumb-" + pres.getOrMintPageId(page) + ".png";
             File renamedFile = new File(
                     dir.getAbsolutePath() + File.separatorChar + newFilename);
             file.renameTo(renamedFile);
@@ -183,24 +182,23 @@ public class ThumbnailCreatorImp implements ThumbnailCreator {
     } else if (dir.list().length == 1) {
       File oldFilename = new File(
           dir.getAbsolutePath() + File.separatorChar + dir.list()[0]);
-      String newFilename = "thumb-1.png";
+      int pageNum = 1;
 
       // Might be the first thumbnail of a set and it might be out of order
-      // Avoid setting the second/third/... slide as thumb-1.png
+      // Avoid setting the second/third/... slide as the first page's thumb
       matcher = PAGE_NUMBER_PATTERN.matcher(oldFilename.getAbsolutePath());
       if (matcher.matches()) {
-        int pageNum = Integer.valueOf(matcher.group(2).trim()).intValue();
-        newFilename = "thumb-" + (pageNum) + ".png";
+        pageNum = Integer.valueOf(matcher.group(2).trim()).intValue();
       }
 
       File renamedFile = new File(
-          oldFilename.getParent() + File.separatorChar + newFilename);
+          oldFilename.getParent() + File.separatorChar + "thumb-" + pres.getOrMintPageId(pageNum) + ".png");
       oldFilename.renameTo(renamedFile);
     }
   }
 
-  private void createBlankThumbnail(File thumbsDir, int page) {
-    File thumb = new File(thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + page + ".png");
+  private void createBlankThumbnail(File thumbsDir, UploadedPresentation pres, int page) {
+    File thumb = new File(thumbsDir.getAbsolutePath() + File.separatorChar + "thumb-" + pres.getOrMintPageId(page) + ".png");
     if (!thumb.exists()) {
       log.info("Copying blank thumbnail for slide {}", page);
       copyBlankThumbnail(thumb);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/DocPageCompletedProgress.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/DocPageCompletedProgress.java
@@ -1,5 +1,7 @@
 package org.bigbluebutton.presentation.messages;
 
+import java.util.Map;
+
 public class DocPageCompletedProgress implements IDocConversionMsg {
   public final String podId;
   public final String meetingId;
@@ -17,13 +19,16 @@ public class DocPageCompletedProgress implements IDocConversionMsg {
   public final Boolean current;
   public final Boolean defaultPresentation;
   public final String filenameConverted;
+  // Page number to pageId, as minted by the conversion pipeline.
+  public final Map<Integer, String> pageIds;
 
 
   public DocPageCompletedProgress(String podId, String meetingId, String presId, String temporaryPresentationId, String presInstance,
                                   String filename, String uploaderId, String authzToken,
                                   Boolean downloadable, Boolean removable, String key,
-                                  Integer numPages, String presBaseUrl, Boolean current, 
-                                  Boolean defaultPresentation, String filenameConverted) {
+                                  Integer numPages, String presBaseUrl, Boolean current,
+                                  Boolean defaultPresentation, String filenameConverted,
+                                  Map<Integer, String> pageIds) {
     this.podId = podId;
     this.meetingId = meetingId;
     this.presId = presId;
@@ -40,5 +45,6 @@ public class DocPageCompletedProgress implements IDocConversionMsg {
     this.current = current;
     this.defaultPresentation = defaultPresentation;
     this.filenameConverted = filenameConverted;
+    this.pageIds = pageIds;
   }
 }

--- a/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/DocPageGeneratedProgress.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/presentation/messages/DocPageGeneratedProgress.java
@@ -17,6 +17,7 @@ public class DocPageGeneratedProgress implements IDocConversionMsg {
   public final String presParentPath;
   public final Boolean current;
   public final Integer page;
+  public final String pageId;
 
   public DocPageGeneratedProgress(String podId,
                                   String meetingId,
@@ -33,6 +34,7 @@ public class DocPageGeneratedProgress implements IDocConversionMsg {
                                   String presBaseUrl,
                                   String presParentPath,
                                   Integer page,
+                                  String pageId,
                                   Boolean current) {
     this.podId = podId;
     this.meetingId = meetingId;
@@ -49,6 +51,7 @@ public class DocPageGeneratedProgress implements IDocConversionMsg {
     this.presBaseUrl = presBaseUrl;
     this.presParentPath = presParentPath;
     this.page = page;
+    this.pageId = pageId;
     this.current = current;
   }
 }

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -261,7 +261,10 @@ object MsgBuilder {
   def generatePresentationPages(presId: String, numPages: Int, presBaseUrl: String, pageTokenSecret: String = ""): scala.collection.immutable.Map[String, PageVO] = {
     val pages = new scala.collection.mutable.HashMap[String, PageVO]
     for (i <- 1 to numPages) {
-      val id = java.util.UUID.randomUUID().toString
+      // Placeholder id: the conversion-completed handler rebuilds pages from
+      // meeting state, whose ids were minted in generatePresentationPage. Do
+      // not mint fresh UUIDs here or the same page gets two competing ids.
+      val id = i.toString
       val num = i
       val current = if (i == 1) true else false
       val pageToken = if (pageTokenSecret.nonEmpty) generatePageToken(presId, i, pageTokenSecret) else ""

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -151,7 +151,7 @@ object MsgBuilder {
     }.getOrElse("")
 
     PresentationPageConvertedVO(
-      id = s"$presId/$page",
+      id = java.util.UUID.randomUUID().toString,
       num = page,
       urls = urls,
       content = content,
@@ -261,7 +261,7 @@ object MsgBuilder {
   def generatePresentationPages(presId: String, numPages: Int, presBaseUrl: String, pageTokenSecret: String = ""): scala.collection.immutable.Map[String, PageVO] = {
     val pages = new scala.collection.mutable.HashMap[String, PageVO]
     for (i <- 1 to numPages) {
-      val id = presId + "/" + i
+      val id = java.util.UUID.randomUUID().toString
       val num = i
       val current = if (i == 1) true else false
       val pageToken = if (pageTokenSecret.nonEmpty) generatePageToken(presId, i, pageTokenSecret) else ""

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -25,10 +25,10 @@ object MsgBuilder {
   private lazy val imageResolutionService: ImageResolutionService = new ImageResolutionService
   private lazy val logger: Logger = LoggerFactory.getLogger("msg-builder")
 
-  private def generatePageToken(presId: String, page: Int, secret: String): String = {
+  private def generatePageToken(presId: String, pageId: String, secret: String): String = {
     val mac = Mac.getInstance("HmacSHA256")
     mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"))
-    mac.doFinal(s"$presId|$page".getBytes(StandardCharsets.UTF_8)).map("%02x".format(_)).mkString
+    mac.doFinal(s"$presId|$pageId".getBytes(StandardCharsets.UTF_8)).map("%02x".format(_)).mkString
   }
 
   def buildDestroyMeetingSysCmdMsg(msg: DestroyMeetingMessage): BbbCommonEnvCoreMsg = {
@@ -104,20 +104,22 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, req)
   }
 
-  def generatePresentationPage(presId: String, presBaseUrl: String, presParentPath: String, page: Int, pageTokenSecret: String = ""): PresentationPageConvertedVO = {
-    val pageToken = if (pageTokenSecret.nonEmpty) generatePageToken(presId, page, pageTokenSecret) else ""
+  // Consumes the pageId minted by the conversion pipeline (the id under which
+  // the page's files were written to disk); never mints a new one.
+  def generatePresentationPage(presId: String, presBaseUrl: String, presParentPath: String, page: Int, pageId: String, pageTokenSecret: String = ""): PresentationPageConvertedVO = {
+    val pageToken = if (pageTokenSecret.nonEmpty) generatePageToken(presId, pageId, pageTokenSecret) else ""
     val tokenParam = if (pageToken.nonEmpty) "?pageToken=" + pageToken else ""
-    val thumbUrl = presBaseUrl + "/thumbnail/" + page + tokenParam
-    val txtUrl = presBaseUrl + "/textfiles/" + page + tokenParam
-    val svgUrl = presBaseUrl + "/svg/" + page + tokenParam
-    val pngUrl = presBaseUrl + "/png/" + page + tokenParam
+    val thumbUrl = presBaseUrl + "/thumbnail/" + pageId + tokenParam
+    val txtUrl = presBaseUrl + "/textfiles/" + pageId + tokenParam
+    val svgUrl = presBaseUrl + "/svg/" + pageId + tokenParam
+    val pngUrl = presBaseUrl + "/png/" + pageId + tokenParam
 
     val urls = Map("thumb" -> thumbUrl, "text" -> txtUrl, "svg" -> svgUrl, "png" -> pngUrl)
 
     // get SVG dimensions
     var width = 1440D
     var height = 1080D
-    val pageAbsoluteSvgPath = presParentPath + "/svgs/slide" + page.toString + ".svg"
+    val pageAbsoluteSvgPath = presParentPath + "/svgs/slide-" + pageId + ".svg"
 
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {
@@ -137,7 +139,7 @@ object MsgBuilder {
 
     val content = Try {
       val maxChars: Int = 1024 * 1024 // limit ~1 MB to avoid OOM
-      val pageAbsoluteTxtPath = presParentPath + "/textfiles/slide-" + page.toString + ".txt"
+      val pageAbsoluteTxtPath = presParentPath + "/textfiles/slide-" + pageId + ".txt"
       Using(Source.fromFile(pageAbsoluteTxtPath, StandardCharsets.UTF_8.name())) { source =>
         val buffer = new StringBuilder
         val iter = source.iter
@@ -151,7 +153,7 @@ object MsgBuilder {
     }.getOrElse("")
 
     PresentationPageConvertedVO(
-      id = java.util.UUID.randomUUID().toString,
+      id = pageId,
       num = page,
       urls = urls,
       content = content,
@@ -167,7 +169,7 @@ object MsgBuilder {
     val envelope = BbbCoreEnvelope(PresentationPageConvertedSysMsg.NAME, routing)
     val header = BbbClientMsgHeader(PresentationPageConvertedSysMsg.NAME, msg.meetingId, msg.authzToken)
 
-    val page = generatePresentationPage(msg.presId, msg.presBaseUrl, msg.presParentPath, msg.page.intValue(), pageTokenSecret)
+    val page = generatePresentationPage(msg.presId, msg.presBaseUrl, msg.presParentPath, msg.page.intValue(), msg.pageId, pageTokenSecret)
 
     val body = PresentationPageConvertedSysMsgBody(
       podId = msg.podId,
@@ -246,7 +248,7 @@ object MsgBuilder {
     val envelope = BbbCoreEnvelope(PresentationConversionCompletedSysPubMsg.NAME, routing)
     val header = BbbClientMsgHeader(PresentationConversionCompletedSysPubMsg.NAME, msg.meetingId, msg.authzToken)
 
-    val pages = generatePresentationPages(msg.presId, msg.numPages.intValue(), msg.presBaseUrl, pageTokenSecret)
+    val pages = generatePresentationPages(msg.presId, msg.numPages.intValue(), msg.presBaseUrl, msg.pageIds, pageTokenSecret)
     val presentation = PresentationVO(msg.presId, msg.temporaryPresentationId, msg.filename,
       current = msg.current.booleanValue(), pages.values.toVector, msg.downloadable.booleanValue(),
       msg.removable.booleanValue(),
@@ -258,21 +260,21 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, req)
   }
 
-  def generatePresentationPages(presId: String, numPages: Int, presBaseUrl: String, pageTokenSecret: String = ""): scala.collection.immutable.Map[String, PageVO] = {
+  def generatePresentationPages(presId: String, numPages: Int, presBaseUrl: String,
+                                pageIds: java.util.Map[Integer, String], pageTokenSecret: String = ""): scala.collection.immutable.Map[String, PageVO] = {
     val pages = new scala.collection.mutable.HashMap[String, PageVO]
     for (i <- 1 to numPages) {
-      // Placeholder id: the conversion-completed handler rebuilds pages from
-      // meeting state, whose ids were minted in generatePresentationPage. Do
-      // not mint fresh UUIDs here or the same page gets two competing ids.
-      val id = i.toString
+      // Consume the id minted by the conversion pipeline. Do not mint fresh
+      // UUIDs here or the same page gets two competing ids.
+      val id = Option(pageIds.get(Integer.valueOf(i))).getOrElse(i.toString)
       val num = i
       val current = if (i == 1) true else false
-      val pageToken = if (pageTokenSecret.nonEmpty) generatePageToken(presId, i, pageTokenSecret) else ""
+      val pageToken = if (pageTokenSecret.nonEmpty) generatePageToken(presId, id, pageTokenSecret) else ""
       val tokenParam = if (pageToken.nonEmpty) "?pageToken=" + pageToken else ""
-      val thumbnail = presBaseUrl + "/thumbnail/" + i + tokenParam
+      val thumbnail = presBaseUrl + "/thumbnail/" + id + tokenParam
 
-      val txtUri = presBaseUrl + "/textfiles/" + i + tokenParam
-      val svgUri = presBaseUrl + "/svg/" + i + tokenParam
+      val txtUri = presBaseUrl + "/textfiles/" + id + tokenParam
+      val svgUri = presBaseUrl + "/svg/" + id + tokenParam
 
       val p = PageVO(id = id, num = num, thumbUri = thumbnail,
         txtUri = txtUri, svgUri = svgUri, current = current, pageToken = pageToken)

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/MsgBuilder.scala
@@ -119,7 +119,7 @@ object MsgBuilder {
     // get SVG dimensions
     var width = 1440D
     var height = 1080D
-    val pageAbsoluteSvgPath = presParentPath + "/svgs/slide-" + pageId + ".svg"
+    val pageAbsoluteSvgPath = presParentPath + "/svgs/slide" + pageId + ".svg"
 
     val dims = readSvgDims(pageAbsoluteSvgPath)
     dims match {

--- a/bbb-export-annotations/workers/collector.js
+++ b/bbb-export-annotations/workers/collector.js
@@ -76,11 +76,12 @@ async function collectAnnotationsFromRedis() {
     // If there's a PDF file, we leverage the existing converted SVG slides
     for (const p of pages) {
       const pageNumber = p.page;
-      const imageName = `slide${pageNumber}`;
+      // On-disk slide files are named by the opaque pageId; the job's dropbox
+      // keeps ordinal names so the downstream steps stay position-based.
       const convertedSVG = path.join(
           exportJob.presLocation,
           'svgs',
-          `${imageName}.svg`);
+          `slide-${p.pageId}.svg`);
 
       const outputFile = path.join(dropbox, `slide${pageNumber}.svg`);
 

--- a/bbb-export-annotations/workers/collector.js
+++ b/bbb-export-annotations/workers/collector.js
@@ -81,7 +81,7 @@ async function collectAnnotationsFromRedis() {
       const convertedSVG = path.join(
           exportJob.presLocation,
           'svgs',
-          `slide-${p.pageId}.svg`);
+          `slide${p.pageId}.svg`);
 
       const outputFile = path.join(dropbox, `slide${pageNumber}.svg`);
 

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -365,7 +365,7 @@ async function processPresentationAnnotations() {
     const svgBackgroundSlide = path.join(
         exportJob.presLocation,
         'svgs',
-        `slide-${currentSlide.pageId}.svg`);
+        `slide${currentSlide.pageId}.svg`);
 
     let backgroundFormat = '';
     if (fs.existsSync(`${bgImagePath}.png`)) {

--- a/bbb-export-annotations/workers/process.js
+++ b/bbb-export-annotations/workers/process.js
@@ -365,7 +365,7 @@ async function processPresentationAnnotations() {
     const svgBackgroundSlide = path.join(
         exportJob.presLocation,
         'svgs',
-        `slide${currentSlide.page}.svg`);
+        `slide-${currentSlide.pageId}.svg`);
 
     let backgroundFormat = '';
     if (fs.existsSync(`${bgImagePath}.png`)) {

--- a/bbb-graphql-actions/src/actions/presentationSetZoom.ts
+++ b/bbb-graphql-actions/src/actions/presentationSetZoom.ts
@@ -7,7 +7,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
       [
         {name: 'presentationId', type: 'string', required: true},
         {name: 'pageId', type: 'string', required: true},
-        {name: 'pageNum', type: 'int', required: true},
         {name: 'xOffset', type: 'number', required: true},
         {name: 'yOffset', type: 'number', required: true},
         {name: 'widthRatio', type: 'number', required: true},
@@ -32,7 +31,6 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     podId: 'DEFAULT_PRESENTATION_POD',
     presentationId: input.presentationId,
     pageId: input.pageId,
-    slideNumber: input.pageNum,
     xOffset: input.xOffset,
     yOffset: input.yOffset,
     widthRatio: input.widthRatio,

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1666,7 +1666,7 @@ SELECT pres_presentation."meetingId",
         SELECT pp."urlsJson"->>'thumb'
         FROM "pres_page" pp
         WHERE pp."presentationId" = pres_presentation."presentationId"
-          AND pp.num = 1
+        ORDER BY pp.num
         LIMIT 1
     ) as "firstPageThumbnailUrl",
     case when pres_presentation."exportToChatStatus" is not null

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1635,6 +1635,9 @@ CREATE UNLOGGED TABLE "pres_page" (
 );
 CREATE INDEX "idx_pres_page_presentationId" ON "pres_page"("presentationId");
 CREATE INDEX "idx_pres_page_presentationId_curr" ON "pres_page"("presentationId") where "current" is true;
+--Page ids are opaque UUIDs, so this is what keeps a re-sent page notification
+--from silently inserting a duplicate row for the same slide
+CREATE UNIQUE INDEX "idx_pres_page_presentationId_num" ON "pres_page"("presentationId", "num");
 
 CREATE OR REPLACE VIEW public.v_pres_presentation AS
 SELECT pres_presentation."meetingId",

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1636,8 +1636,12 @@ CREATE UNLOGGED TABLE "pres_page" (
 CREATE INDEX "idx_pres_page_presentationId" ON "pres_page"("presentationId");
 CREATE INDEX "idx_pres_page_presentationId_curr" ON "pres_page"("presentationId") where "current" is true;
 --Page ids are opaque UUIDs, so this is what keeps a re-sent page notification
---from silently inserting a duplicate row for the same slide
-CREATE UNIQUE INDEX "idx_pres_page_presentationId_num" ON "pres_page"("presentationId", "num");
+--from silently inserting a duplicate row for the same slide. It is deferred to
+--commit time because "num" is a mutable position attribute: renumbering pages
+--in place (e.g. shifting them to open room for an insert) transiently collides
+--within a transaction even though the final state is unique.
+ALTER TABLE "pres_page" ADD CONSTRAINT "pres_page_presentationId_num_unique"
+    UNIQUE ("presentationId", "num") DEFERRABLE INITIALLY DEFERRED;
 
 CREATE OR REPLACE VIEW public.v_pres_presentation AS
 SELECT pres_presentation."meetingId",

--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -522,7 +522,6 @@ type Mutation {
   presentationSetZoom(
     presentationId: String!
     pageId: String!
-    pageNum: Int!
     xOffset: Float!
     yOffset: Float!
     widthRatio: Float!

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -221,17 +221,17 @@ class StatusTable extends React.Component {
                 const padding = isRTL ? 'paddingLeft' : 'paddingRight';
                 const URLPrefix = `/bigbluebutton/presentation/${meetingId}/${meetingId}`;
                 const {
-                  presentationId, pageNum, pageToken, presentationName,
+                  presentationId, pageNum, pageId, pageToken, presentationName,
                 } = slide || {};
                 const tokenParams = pageToken && sessionToken
                   ? `?${new URLSearchParams({ pageToken, sessionToken })}`
                   : '';
                 const slideUrl = presentationBase
-                  ? `${presentationBase}/${presentationId}/svgs/slide${pageNum}.svg`
-                  : `${URLPrefix}/${presentationId}/svg/${pageNum}${tokenParams}`;
+                  ? `${presentationBase}/${presentationId}/svgs/slide-${pageId}.svg`
+                  : `${URLPrefix}/${presentationId}/svg/${pageId}${tokenParams}`;
                 const thumbUrl = presentationBase
-                  ? `${presentationBase}/${presentationId}/thumbnails/thumb-${pageNum}.png`
-                  : `${URLPrefix}/${presentationId}/thumbnail/${pageNum}${tokenParams}`;
+                  ? `${presentationBase}/${presentationId}/thumbnails/thumb-${pageId}.png`
+                  : `${URLPrefix}/${presentationId}/thumbnail/${pageId}${tokenParams}`;
                 return (
                   <td
                     style={{

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -227,7 +227,7 @@ class StatusTable extends React.Component {
                   ? `?${new URLSearchParams({ pageToken, sessionToken })}`
                   : '';
                 const slideUrl = presentationBase
-                  ? `${presentationBase}/${presentationId}/svgs/slide-${pageId}.svg`
+                  ? `${presentationBase}/${presentationId}/svgs/slide${pageId}.svg`
                   : `${URLPrefix}/${presentationId}/svg/${pageId}${tokenParams}`;
                 const thumbUrl = presentationBase
                   ? `${presentationBase}/${presentationId}/thumbnails/thumb-${pageId}.png`

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -660,7 +660,6 @@ class Presentation extends PureComponent {
         setIsToolbarVisible={this.setIsToolbarVisible}
         isToolbarVisible={isToolbarVisible}
         amIPresenter={userIsPresenter}
-        slideNum={currentSlide?.num}
         currentUser={currentUser}
         whiteboardId={currentSlide?.id}
       />

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -835,7 +835,7 @@ class Presentation extends PureComponent {
                     getSvgRef={this.getSvgRef}
                     tldrawAPI={tldrawAPI}
                     setTldrawAPI={this.setTldrawAPI}
-                    curPageId={currentSlide?.num.toString() || '0'}
+                    curPageId={currentSlide?.id}
                     svgUri={currentSlide?.svgUri}
                     intl={intl}
                     presentationWidth={svgWidth}

--- a/bigbluebutton-html5/imports/ui/components/presentation/mutations.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/mutations.jsx
@@ -1,11 +1,10 @@
 import { gql } from '@apollo/client';
 
 export const PRESENTATION_SET_ZOOM = gql`
-  mutation PresentationSetZoom($presentationId: String!, $pageId: String!, $pageNum: Int!, $xOffset: Float!, $yOffset: Float!, $widthRatio: Float!, $heightRatio: Float!) {
+  mutation PresentationSetZoom($presentationId: String!, $pageId: String!, $xOffset: Float!, $yOffset: Float!, $widthRatio: Float!, $heightRatio: Float!) {
     presentationSetZoom(
       presentationId: $presentationId,
       pageId: $pageId,
-      pageNum: $pageNum,
       xOffset: $xOffset,
       yOffset: $yOffset,
       widthRatio: $widthRatio,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-menu/component.jsx
@@ -144,7 +144,6 @@ const PresentationMenu = (props) => {
     setIsToolbarVisible,
     allowSnapshotOfCurrentSlide = false,
     presentationDropdownItems,
-    slideNum,
     currentUser,
     whiteboardId,
     persistShape,
@@ -159,7 +158,7 @@ const PresentationMenu = (props) => {
   const extractSlideContentToImage = async () => {
     const { isIos } = deviceInfo;
     const { isSafari } = browserInfo;
-    const backgroundShape = tldrawAPI.getCurrentPageShapes().find((s) => s.id === `shape:BG-${slideNum}`);
+    const backgroundShape = tldrawAPI.getCurrentPageShapes().find((s) => s.id === `shape:BG-${whiteboardId}`);
     const shapes = tldrawAPI.getCurrentPageShapes();
     const pollShape = shapes.find((shape) => shape.type === 'poll');
     const svgElem = await tldrawAPI.getSvg(
@@ -272,7 +271,7 @@ const PresentationMenu = (props) => {
         updateUiDataHookPCurrentWhiteboardSVGWithAnnotationsForPlugin,
       );
     };
-  }, [tldrawAPI, slideNum]);
+  }, [tldrawAPI, whiteboardId]);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const toastId = useRef('presentation-menu-toast');
   const dropdownRef = useRef(null);
@@ -347,7 +346,7 @@ const PresentationMenu = (props) => {
         dataArray.forEach((originalShape) => {
           const shape = {
             ...originalShape,
-            parentId: `page:${slideNum}`,
+            parentId: `page:${whiteboardId}`,
             meta: {
               ...originalShape.meta,
               createdBy: currentUser.userId,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -335,6 +335,7 @@ class PresentationToolbar extends PureComponent {
       intl,
       zoom,
       isConnected,
+      presentationPagesLoaded,
       isPollingEnabled,
       amIPresenter,
       startPoll,
@@ -412,7 +413,7 @@ class PresentationToolbar extends PureComponent {
             aria-describedby={
               startOfSlides ? 'noPrevSlideDesc' : 'prevSlideDesc'
             }
-            disabled={startOfSlides || !isConnected}
+            disabled={startOfSlides || !isConnected || !presentationPagesLoaded}
             color="light"
             circle
             icon="left_arrow"
@@ -432,7 +433,7 @@ class PresentationToolbar extends PureComponent {
               aria-describedby="skipSlideDesc"
               aria-live="polite"
               aria-relevant="all"
-              disabled={!isConnected}
+              disabled={!isConnected || !presentationPagesLoaded}
               value={currentSlideNum}
               onChange={this.handleSkipToSlideChange}
               data-test="skipSlide"
@@ -446,7 +447,7 @@ class PresentationToolbar extends PureComponent {
             aria-describedby={
               endOfSlides ? 'noNextSlideDesc' : 'nextSlideDesc'
             }
-            disabled={endOfSlides || !isConnected}
+            disabled={endOfSlides || !isConnected || !presentationPagesLoaded}
             color="light"
             circle
             icon="right_arrow"
@@ -574,6 +575,7 @@ PresentationToolbar.propTypes = {
   fitToWidth: PropTypes.bool.isRequired,
   zoom: PropTypes.number.isRequired,
   isConnected: PropTypes.bool.isRequired,
+  presentationPagesLoaded: PropTypes.bool.isRequired,
   fullscreenElementId: PropTypes.string.isRequired,
   fullscreenAction: PropTypes.string.isRequired,
   isFullscreen: PropTypes.bool.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -119,6 +119,10 @@ const PresentationToolbarContainer = (props) => {
     },
   );
 
+  // Navigation resolves slide numbers to page ids through this subscription,
+  // so the controls stay disabled until its first payload arrives.
+  const presentationPagesLoaded = presentationPagesData !== undefined;
+
   const resetSlide = () => {
     const { pageId, num } = currentPresentationPage;
     presentationSetZoom({
@@ -144,9 +148,11 @@ const PresentationToolbarContainer = (props) => {
   };
 
   const setPresentationPageInfiniteWhiteboard = (infiniteWhiteboard) => {
+    const pageId = currentPresentationPage?.pageId;
+    if (!pageId) return;
     presentationSetPageInfiniteWhiteboard({
       variables: {
-        pageId: currentPresentationPage?.pageId,
+        pageId,
         infiniteWhiteboard,
       },
     });
@@ -238,6 +244,7 @@ const PresentationToolbarContainer = (props) => {
         allowInfiniteWhiteboard={allowInfiniteWhiteboard}
         // TODO: Remove this
         isConnected={connected}
+        presentationPagesLoaded={presentationPagesLoaded}
         maxNumberOfActiveUsers={WHITEBOARD_CONFIG.maxNumberOfActiveUsers}
         numberOfJoinedUsers={numberOfJoinedUsers}
         {...{

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -11,6 +11,7 @@ import Session from '/imports/ui/services/storage/in-memory';
 import { useMeetingIsBreakout } from '/imports/ui/components/app/service';
 import useDeduplicatedSubscription from '/imports/ui/core/hooks/useDeduplicatedSubscription';
 import { USER_AGGREGATE_COUNT_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
+import { PRESENTATION_PAGES_SUBSCRIPTION } from '/imports/ui/components/whiteboard/queries';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import { DEVICE_TYPE } from '/imports/ui/components/layout/enums';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
@@ -110,6 +111,14 @@ const PresentationToolbarContainer = (props) => {
     PRESENTATION_SET_PAGE_INFINITE_WHITEBOARD,
   );
 
+  const { data: presentationPagesData } = useDeduplicatedSubscription(
+    PRESENTATION_PAGES_SUBSCRIPTION,
+    {
+      variables: { presentationId },
+      skip: !userIsPresenter || !presentationId,
+    },
+  );
+
   const resetSlide = () => {
     const { pageId, num } = currentPresentationPage;
     presentationSetZoom({
@@ -135,18 +144,19 @@ const PresentationToolbarContainer = (props) => {
   };
 
   const setPresentationPageInfiniteWhiteboard = (infiniteWhiteboard) => {
-    const pageId = `${presentationId}/${currentSlideNum}`;
     presentationSetPageInfiniteWhiteboard({
       variables: {
-        pageId,
+        pageId: currentPresentationPage?.pageId,
         infiniteWhiteboard,
       },
     });
   };
 
   const skipToSlide = (slideNum) => {
-    const slideId = `${presentationId}/${slideNum}`;
-    setPresentationPage(slideId);
+    const page = (presentationPagesData?.pres_page || []).find((p) => p.num === slideNum);
+    if (page) {
+      setPresentationPage(page.pageId);
+    }
   };
 
   const previousSlide = () => {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -137,7 +137,8 @@ const Whiteboard = React.memo((props) => {
     currentUser = defaultUser,
     whiteboardId = undefined,
     zoomSlide,
-    curPageNum: curPageId,
+    curPageNum,
+    curPageId,
     zoomChanger,
     isMultiUserActive,
     isRTL,
@@ -221,6 +222,7 @@ const Whiteboard = React.memo((props) => {
   const fitToWidthRef = useRef(fitToWidth);
   const whiteboardIdRef = React.useRef(whiteboardId);
   const curPageIdRef = React.useRef(curPageId);
+  const curPageNumRef = React.useRef(curPageNum);
   const hasWBAccessRef = React.useRef(hasWBAccess);
   const isModeratorRef = React.useRef(isModerator);
   const currentPresentationPageRef = React.useRef(currentPresentationPage);
@@ -421,6 +423,10 @@ const Whiteboard = React.memo((props) => {
   React.useEffect(() => {
     curPageIdRef.current = curPageId;
   }, [curPageId]);
+
+  React.useEffect(() => {
+    curPageNumRef.current = curPageNum;
+  }, [curPageNum]);
 
   React.useEffect(() => {
     isModeratorRef.current = isModerator;
@@ -887,7 +893,7 @@ const Whiteboard = React.memo((props) => {
     {
       meta: {},
       id: currentPageId,
-      name: `Slide ${currentPageId?.split(':')[1]}`,
+      name: `Slide ${curPageNumRef.current}`,
       index: 'a1',
       typeName: 'page',
     },
@@ -962,9 +968,8 @@ const Whiteboard = React.memo((props) => {
     throwIfInvalid(yOffset, `camera.y ${description}`);
 
     const camera = tlEditorRef.current.getCamera();
-    const formattedPageId = Number(curPageIdRef.current);
-    if (Number.isNaN(formattedPageId)) {
-      throw new Error(`Invalid formattedPageId ${description}: ${formattedPageId}`);
+    if (!curPageIdRef.current) {
+      throw new Error(`Missing current pageId ${description}`);
     }
 
     const updatedCurrentCam = {
@@ -1535,8 +1540,7 @@ const Whiteboard = React.memo((props) => {
 
     if (editor && curPageIdRef.current) {
       const page = [];
-      const formattedPageId = parseInt(curPageIdRef.current, 10);
-      const currentPageId = `page:${formattedPageId}`;
+      const currentPageId = `page:${curPageIdRef.current}`;
       const currPageExists = tlEditorRef.current?.getPage(currentPageId);
 
       if (!currPageExists) {
@@ -1982,7 +1986,7 @@ const Whiteboard = React.memo((props) => {
 
   React.useEffect(() => {
     const handleArrowPress = (event) => {
-      const currPageNum = parseInt(curPageIdRef.current, 10);
+      const currPageNum = curPageNumRef.current;
       const shapeSelected = tlEditorRef.current.getSelectedShapes()?.length > 0;
       const changeSlide = (direction) => {
         if (!currentPresentationPage) return;
@@ -2265,8 +2269,7 @@ const Whiteboard = React.memo((props) => {
   };
 
   React.useEffect(() => {
-    const formattedPageId = parseInt(curPageIdRef.current, 10);
-    if (tlEditorRef.current && formattedPageId !== 0) {
+    if (tlEditorRef.current && curPageIdRef.current) {
       // If a viewer is mid-edit (select.editing_shape) when the slide changes,
       // the store mutation below (cleanupStore + setCurrentPage) removes the shape
       // being edited out from under tldraw, leaving the editor in editing_shape with
@@ -2280,7 +2283,7 @@ const Whiteboard = React.memo((props) => {
       }
       tlEditorRef.current.store.mergeRemoteChanges(() => {
         tlEditorRef.current.batch(() => {
-          const currentPageId = `page:${formattedPageId}`;
+          const currentPageId = `page:${curPageIdRef.current}`;
           const tlZ = tlEditorRef.current.getCamera()?.z;
           const cameras = [];
           const pages = [];
@@ -2291,10 +2294,10 @@ const Whiteboard = React.memo((props) => {
           }
           const allRecords = tlEditorRef.current.store.allRecords();
           const cameraRecords = allRecords.filter(
-            (record) => record.typeName === 'camera' && record.id === `camera:page:${formattedPageId}`,
+            (record) => record.typeName === 'camera' && record.id === `camera:page:${curPageIdRef.current}`,
           );
           if (cameraRecords?.length < 1) {
-            cameras.push(createCamera(formattedPageId, tlZ));
+            cameras.push(createCamera(curPageIdRef.current, tlZ));
           }
           cleanupStore(currentPageId);
           updateStore(pages, cameras);
@@ -2467,6 +2470,7 @@ Whiteboard.propTypes = {
   whiteboardId: PropTypes.string,
   zoomSlide: PropTypes.func.isRequired,
   curPageNum: PropTypes.number.isRequired,
+  curPageId: PropTypes.string.isRequired,
   presentationWidth: PropTypes.number.isRequired,
   presentationHeight: PropTypes.number.isRequired,
   zoomChanger: PropTypes.func.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -14,6 +14,7 @@ import { throttle } from 'radash';
 import {
   CURRENT_PRESENTATION_PAGE_SUBSCRIPTION,
   CURRENT_PAGE_WRITERS_SUBSCRIPTION,
+  PRESENTATION_PAGES_SUBSCRIPTION,
 } from './queries';
 import {
   initDefaultPages,
@@ -164,6 +165,14 @@ const WhiteboardContainer = (props) => {
     },
   );
 
+  const { data: presentationPagesData } = useDeduplicatedSubscription(
+    PRESENTATION_PAGES_SUBSCRIPTION,
+    {
+      variables: { presentationId },
+      skip: !isPresenter || !presentationId,
+    },
+  );
+
   const whiteboardWriters = whiteboardWritersData?.user_whiteboardWriteAccess || [];
   const wBAccessChanged = usePrevious(hasWBAccess) !== hasWBAccess;
 
@@ -183,8 +192,10 @@ const WhiteboardContainer = (props) => {
   };
 
   const skipToSlide = (slideNum) => {
-    const slideId = `${presentationId}/${slideNum}`;
-    setPresentationPage(slideId);
+    const page = (presentationPagesData?.pres_page || []).find((p) => p.num === slideNum);
+    if (page) {
+      setPresentationPage(page.pageId);
+    }
   };
 
   const removeShapes = (shapeIds) => {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -210,13 +210,12 @@ const WhiteboardContainer = (props) => {
   const zoomSlide = debounce((
     widthRatio, heightRatio, xOffset, yOffset, currPage = currentPresentationPage,
   ) => {
-    const { pageId, num } = currPage;
+    const { pageId } = currPage;
 
     presentationSetZoom({
       variables: {
         presentationId,
         pageId,
-        pageNum: num,
         xOffset,
         yOffset,
         widthRatio,
@@ -446,7 +445,7 @@ const WhiteboardContainer = (props) => {
 
   const { isIphone, isPhone } = deviceInfo;
 
-  const assetId = AssetRecordType.createId(curPageNum);
+  const assetId = AssetRecordType.createId(curPageId);
   const assets = [{
     id: assetId,
     typeName: 'asset',
@@ -488,7 +487,7 @@ const WhiteboardContainer = (props) => {
     isLocked: true,
     opacity: 1,
     meta: {},
-    id: `shape:BG-${curPageNum}`,
+    id: `shape:BG-${curPageId}`,
     type: 'image',
     props: {
       w: currentPresentationPage?.scaledWidth + 1.5 || 1,
@@ -498,7 +497,7 @@ const WhiteboardContainer = (props) => {
       url: '',
       crop: null,
     },
-    parentId: `page:${curPageNum}`,
+    parentId: `page:${curPageId}`,
     index: 'a0',
     typeName: 'shape',
   });
@@ -557,6 +556,7 @@ const WhiteboardContainer = (props) => {
           selectedLayout: Settings?.layout?.selectedLayout,
           isInfiniteWhiteboard,
           curPageNum,
+          curPageId,
           setEditor,
           layoutChanged,
         }}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/queries.ts
@@ -136,6 +136,24 @@ export const CURRENT_PRESENTATION_PAGE_SUBSCRIPTION = gql`subscription CurrentPr
   }
 }`;
 
+export interface PresentationPagesSubscriptionResponse {
+  pres_page: Array<Pick<PresentationPage, 'pageId' | 'num'>>;
+}
+
+// All pages of a presentation (presenter-only permission on pres_page), used to
+// resolve a page number to its opaque pageId without rebuilding the id client-side.
+export const PRESENTATION_PAGES_SUBSCRIPTION = gql`
+  subscription PresentationPagesSubscription($presentationId: String!) {
+    pres_page(
+      where: { presentationId: { _eq: $presentationId } },
+      order_by: { num: asc }
+    ) {
+      pageId
+      num
+    }
+  }
+`;
+
 export const PRESENTATIONS_SUBSCRIPTION = gql`
   subscription PresentationsSubscription {
     pres_presentation {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -1,9 +1,7 @@
 import Auth from '/imports/ui/services/auth';
-import PollService from '/imports/ui/components/poll/service';
 import { defineMessages } from 'react-intl';
 import { DefaultColorThemePalette } from '@bigbluebutton/tldraw';
 import { notify } from '/imports/ui/services/notification';
-import caseInsensitiveReducer from '/imports/utils/caseInsensitiveReducer';
 import { debounce } from '/imports/utils/debounce';
 import { isValidShapeType } from './utils';
 
@@ -153,102 +151,6 @@ const toggleToolsAnimations = (activeAnim, anim, time, hasWBAccess = false) => {
   };
 
   return checkElementsAndRun();
-};
-
-const formatAnnotations = (annotations, intl, curPageId, currentPresentationPage) => {
-  const result = {};
-
-  annotations.forEach((annotation) => {
-    if (!annotation.annotationInfo) return;
-
-    let { annotationInfo } = annotation;
-
-    if (annotationInfo.questionType) {
-      // poll result, convert it to text and create tldraw shape
-      if (!annotationInfo.props) {
-        annotationInfo.answers = annotationInfo.answers.reduce(
-          caseInsensitiveReducer, [],
-        );
-        const pollResult = PollService.getPollResultString(annotationInfo, intl)
-          .split('<br/>').join('\n').replace(/(<([^>]+)>)/ig, '');
-
-        const lines = pollResult.split('\n');
-        const longestLine = lines.reduce((a, b) => (a.length > b.length ? a : b), '').length;
-
-        // Text measurement estimation
-        const averageCharWidth = 14;
-        const lineHeight = 32;
-        const padding = 2;
-
-        const annotationWidth = longestLine * averageCharWidth;
-        const annotationHeight = lines.length * lineHeight;
-
-        const slideWidth = currentPresentationPage?.scaledWidth;
-        const slideHeight = currentPresentationPage?.scaledHeight;
-        const xPosition = slideWidth - annotationWidth - padding;
-        const yPosition = slideHeight - annotationHeight - padding;
-
-        annotationInfo = {
-          x: xPosition,
-          y: yPosition,
-          isLocked: false,
-          rotation: 0,
-          typeName: 'shape',
-          opacity: 1,
-          parentId: `page:${curPageId}`,
-          index: 'a1',
-          id: `${annotationInfo.id}`,
-          meta: {},
-          type: 'poll',
-          props: {
-            color: 'black',
-            fill: 'semi',
-            w: annotationWidth,
-            h: annotationHeight,
-            answers: annotationInfo.answers,
-            numRespondents: annotationInfo.numRespondents,
-            numResponders: annotationInfo.numResponders,
-            questionText: annotationInfo.questionText,
-            questionType: annotationInfo.questionType,
-            question: annotationInfo.question || '',
-          },
-        };
-      } else {
-        annotationInfo = {
-          x: annotationInfo.x,
-          isLocked: annotationInfo.isLocked,
-          y: annotationInfo.y,
-          rotation: annotationInfo.rotation,
-          typeName: annotationInfo.typeName,
-          opacity: annotationInfo.opacity,
-          parentId: annotationInfo.parentId,
-          index: annotationInfo.index,
-          id: annotationInfo.id,
-          meta: annotationInfo.meta,
-          type: 'poll',
-          props: {
-            color: 'black',
-            fill: 'semi',
-            h: annotationInfo.props.h,
-            w: annotationInfo.props.w,
-            answers: annotationInfo.answers,
-            numRespondents: annotationInfo.numRespondents,
-            numResponders: annotationInfo.numResponders,
-            questionText: annotationInfo.questionText,
-            questionType: annotationInfo.questionType,
-            question: annotationInfo.question || '',
-          },
-        };
-      }
-
-      const cpg = parseInt(annotationInfo?.id?.split?.('/')?.[1], 10);
-      if (cpg !== parseInt(curPageId, 10)) return;
-
-      annotationInfo.questionType = false;
-    }
-    result[annotationInfo.id] = annotationInfo;
-  });
-  return result;
 };
 
 const getCustomEditorAssetUrls = () => {
@@ -477,7 +379,6 @@ export {
   notifyNotAllowedChange,
   notifyShapeNumberExceeded,
   toggleToolsAnimations,
-  formatAnnotations,
   getCustomEditorAssetUrls,
   getCustomAssetUrls,
   debouncedUpdateShapes,

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/UrlMappings.groovy
@@ -30,14 +30,14 @@ class UrlMappings {
     "/bigbluebutton/presentation/$conference/$room/$presentation_name/thumbnail/$id"(controller: "presentation") {
       action = [GET: 'showThumbnail']
       constraints {
-        id matches: /\d+/
+        id matches: /[A-Za-z0-9\-]+/
       }
     }
 
     "/bigbluebutton/presentation/$conference/$room/$presentation_name/png/$id"(controller: "presentation") {
       action = [GET: 'showPng']
       constraints {
-        id matches: /\d+/
+        id matches: /[A-Za-z0-9\-]+/
       }
     }
 
@@ -48,7 +48,7 @@ class UrlMappings {
     "/bigbluebutton/presentation/$conference/$room/$presentation_name/svg/$id"(controller: "presentation") {
       action = [GET: 'showSvgImage']
       constraints {
-        id matches: /\d+/
+        id matches: /[A-Za-z0-9\-]+/
       }
     }
 
@@ -59,7 +59,7 @@ class UrlMappings {
     "/bigbluebutton/presentation/$conference/$room/$presentation_name/textfiles/$id"(controller: "presentation") {
       action = [GET: 'showTextfile']
       constraints {
-        id matches: /\d+/
+        id matches: /[A-Za-z0-9\-]+/
       }
     }
 

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/PresentationController.groovy
@@ -44,8 +44,9 @@ class PresentationController {
   DefaultMimeUtility grailsMimeUtility
 
   private static final Pattern SLIDE_URI_PATTERN = Pattern.compile(
-    '/bigbluebutton/presentation/([A-Za-z0-9\\-]+)/([A-Za-z0-9\\-]+)/([A-Za-z0-9\\-]+)/(svg|thumbnail|textfiles|png)/(\\d+)'
+    '/bigbluebutton/presentation/([A-Za-z0-9\\-]+)/([A-Za-z0-9\\-]+)/([A-Za-z0-9\\-]+)/(svg|thumbnail|textfiles|png)/([A-Za-z0-9\\-]+)'
   )
+  private static final Pattern PAGE_ID_PATTERN = Pattern.compile('[A-Za-z0-9\\-]+')
   private static final Pattern DOWNLOAD_URI_PATTERN = Pattern.compile(
     '/bigbluebutton/presentation/download/([A-Za-z0-9\\-]+)/([A-Za-z0-9\\-]+)'
   )
@@ -96,8 +97,8 @@ class PresentationController {
         def pageToken = extractQueryParam(uri, "pageToken")
         if (presentationService.pageTokenSecret) {
           def presId = slideMatcher.group(3)
-          def pageNum = slideMatcher.group(5)
-          def expectedToken = generatePageToken(presId, Integer.parseInt(pageNum), presentationService.pageTokenSecret)
+          def pageId = slideMatcher.group(5)
+          def expectedToken = generatePageToken(presId, pageId, presentationService.pageTokenSecret)
           if (pageToken == null || pageToken != expectedToken) {
             response.setStatus(403)
             response.outputStream << 'invalid-token'
@@ -152,10 +153,10 @@ class PresentationController {
     return UriComponentsBuilder.fromUriString(uri).build().getQueryParams().getFirst(paramName)
   }
 
-  private static String generatePageToken(String presId, int page, String secret) {
+  private static String generatePageToken(String presId, String pageId, String secret) {
     Mac mac = Mac.getInstance("HmacSHA256")
     mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"))
-    return mac.doFinal("${presId}|${page}".getBytes(StandardCharsets.UTF_8)).collect { String.format('%02x', it) }.join()
+    return mac.doFinal("${presId}|${pageId}".getBytes(StandardCharsets.UTF_8)).collect { String.format('%02x', it) }.join()
   }
 
   private UserSession validateSession() {
@@ -377,8 +378,8 @@ class PresentationController {
     if (conf != userSession.meetingID) { response.setStatus(403); return }
     if (presentationService.pageTokenSecret) {
       def pageToken = params.pageToken
-      if (!slide?.isInteger()) { response.setStatus(403); return }
-      def expected = generatePageToken(presentationName, Integer.parseInt(slide), presentationService.pageTokenSecret)
+      if (!slide || !PAGE_ID_PATTERN.matcher(slide).matches()) { response.setStatus(403); return }
+      def expected = generatePageToken(presentationName, slide, presentationService.pageTokenSecret)
       if (pageToken == null || pageToken != expected) { response.setStatus(403); return }
     }
 
@@ -411,8 +412,8 @@ class PresentationController {
     if (conf != userSession.meetingID) { response.setStatus(403); return }
     if (presentationService.pageTokenSecret) {
       def pageToken = params.pageToken
-      if (!thumb?.isInteger()) { response.setStatus(403); return }
-      def expected = generatePageToken(presentationName, Integer.parseInt(thumb), presentationService.pageTokenSecret)
+      if (!thumb || !PAGE_ID_PATTERN.matcher(thumb).matches()) { response.setStatus(403); return }
+      def expected = generatePageToken(presentationName, thumb, presentationService.pageTokenSecret)
       if (pageToken == null || pageToken != expected) { response.setStatus(403); return }
     }
 
@@ -446,8 +447,8 @@ class PresentationController {
     if (conf != userSession.meetingID) { response.setStatus(403); return }
     if (presentationService.pageTokenSecret) {
       def pageToken = params.pageToken
-      if (!png?.isInteger()) { response.setStatus(403); return }
-      def expected = generatePageToken(presentationName, Integer.parseInt(png), presentationService.pageTokenSecret)
+      if (!png || !PAGE_ID_PATTERN.matcher(png).matches()) { response.setStatus(403); return }
+      def expected = generatePageToken(presentationName, png, presentationService.pageTokenSecret)
       if (pageToken == null || pageToken != expected) { response.setStatus(403); return }
     }
 
@@ -478,8 +479,8 @@ class PresentationController {
     if (conf != userSession.meetingID) { response.setStatus(403); return }
     if (presentationService.pageTokenSecret) {
       def pageToken = params.pageToken
-      if (!textfile?.isInteger()) { response.setStatus(403); return }
-      def expected = generatePageToken(presentationName, Integer.parseInt(textfile), presentationService.pageTokenSecret)
+      if (!textfile || !PAGE_ID_PATTERN.matcher(textfile).matches()) { response.setStatus(403); return }
+      def expected = generatePageToken(presentationName, textfile, presentationService.pageTokenSecret)
       if (pageToken == null || pageToken != expected) { response.setStatus(403); return }
     }
 

--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -121,7 +121,7 @@ class PresentationService {
 	}
 
 	def showSvgImage(String conf, String room, String presentationName, String id) {
-		new File(roomDirectory(conf, room).absolutePath + File.separatorChar + presentationName + File.separatorChar + "svgs" + File.separatorChar + "slide-${id}.svg")
+		new File(roomDirectory(conf, room).absolutePath + File.separatorChar + presentationName + File.separatorChar + "svgs" + File.separatorChar + "slide${id}.svg")
 	}
 
 	def showThumbnail = {conf, room, presentationName, thumb ->

--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -121,7 +121,7 @@ class PresentationService {
 	}
 
 	def showSvgImage(String conf, String room, String presentationName, String id) {
-		new File(roomDirectory(conf, room).absolutePath + File.separatorChar + presentationName + File.separatorChar + "svgs" + File.separatorChar + "slide${id}.svg")
+		new File(roomDirectory(conf, room).absolutePath + File.separatorChar + presentationName + File.separatorChar + "svgs" + File.separatorChar + "slide-${id}.svg")
 	}
 
 	def showThumbnail = {conf, room, presentationName, thumb ->

--- a/bigbluebutton-web/nginx-confs/presentation-slides.nginx
+++ b/bigbluebutton-web/nginx-confs/presentation-slides.nginx
@@ -28,7 +28,7 @@
         location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/svg\/(?<page_id>[A-Za-z0-9\-]+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type image/svg+xml;
-                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide-$page_id.svg;
+                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide$page_id.svg;
                 add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
                 add_header 'Access-Control-Allow-Credentials' 'true' always;
         }

--- a/bigbluebutton-web/nginx-confs/presentation-slides.nginx
+++ b/bigbluebutton-web/nginx-confs/presentation-slides.nginx
@@ -25,10 +25,10 @@
                 set $bbb_cors_origin '*';
         }
 
-        location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/svg\/(?<page_num>\d+)$ {
+        location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/svg\/(?<page_id>[A-Za-z0-9\-]+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type image/svg+xml;
-                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide$page_num.svg;
+                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/svgs/slide-$page_id.svg;
                 add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
                 add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
@@ -41,18 +41,18 @@
                 add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
 
-        location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/thumbnail\/(?<page_num>\d+)$ {
+        location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/thumbnail\/(?<page_id>[A-Za-z0-9\-]+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type image/png;
-                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/thumbnails/thumb-$page_num.png;
+                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/thumbnails/thumb-$page_id.png;
                 add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
                 add_header 'Access-Control-Allow-Credentials' 'true' always;
         }
 
-        location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/textfiles\/(?<page_num>\d+)$ {
+        location ~^\/bigbluebutton\/presentation\/(?<meeting_id_1>[A-Za-z0-9\-]+)\/(?<meeting_id_2>[A-Za-z0-9\-]+)\/(?<pres_id>[A-Za-z0-9\-]+)\/textfiles\/(?<page_id>[A-Za-z0-9\-]+)$ {
                 auth_request /bigbluebutton/presentation/checkAuthorization;
                 default_type text/plain;
-                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/textfiles/slide-$page_num.txt;
+                alias    /var/bigbluebutton/$meeting_id_2/$meeting_id_2/$pres_id/textfiles/slide-$page_id.txt;
                 add_header 'Access-Control-Allow-Origin' $bbb_cors_origin always;
                 add_header 'Access-Control-Allow-Credentials' 'true' always;
         }

--- a/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/presentation.rb
@@ -22,9 +22,25 @@
 
 require 'rubygems'
 require 'nokogiri'
+require 'json'
 
 module BigBlueButton
   class Presentation
+    # Reads the page-number to pageId manifest (pages.json) written by the
+    # conversion pipeline. On-disk slide files are named by the opaque pageId,
+    # so this is the only way to resolve a page number to its files without
+    # consulting the events. Returns an empty hash for pre-pageId recordings.
+    def self.read_page_id_manifest(presentation_dir)
+      manifest_file = "#{presentation_dir}/pages.json"
+      return {} unless File.exist?(manifest_file)
+      begin
+        JSON.parse(File.read(manifest_file)).transform_keys(&:to_i)
+      rescue StandardError => e
+        BigBlueButton.logger.warn("Ignoring unreadable page id manifest #{manifest_file}: #{e.message}")
+        {}
+      end
+    end
+
     # Get the presentations.
     def self.get_presentations(events_xml)
       BigBlueButton.logger.info("Task: Getting presentations from events")      
@@ -124,16 +140,21 @@ module BigBlueButton
         presentation_id = presentation_event.xpath("presentationName").text
         presentation_filename = presentation_filenames[presentation_id]
         # Set textfile directory
-        textfiles_dir = "#{process_dir}/presentation/#{presentation_id}/textfiles"
+        pres_process_dir = "#{process_dir}/presentation/#{presentation_id}"
+        textfiles_dir = "#{pres_process_dir}/textfiles"
+        # Page files are named by pageId on current recordings; fall back to
+        # the page number for recordings that predate the manifest.
+        manifest = self.read_page_id_manifest(pres_process_dir)
         # Set presentation hashmap to be returned
         unless presentation_filename == "default.pdf"
           presentation[:id] = presentation_id
           presentation[:filename] = presentation_filename
           presentation[:slides] = {}
           for i in 1..3
-            if File.file?("#{textfiles_dir}/slide-#{i}.txt")
-              text_from_slide = self.get_text_from_slide(textfiles_dir, i)
-              presentation[:slides][i] = { :alt => text_from_slide == nil ? '' : text_from_slide }
+            page_file_id = manifest[i] || i
+            if File.file?("#{textfiles_dir}/slide-#{page_file_id}.txt")
+              text_from_slide = self.get_text_from_slide(textfiles_dir, page_file_id)
+              presentation[:slides][i] = { :alt => text_from_slide == nil ? '' : text_from_slide, :page_file_id => page_file_id }
             end
           end
           # Break because something else than default.pdf was found

--- a/record-and-playback/presentation/scripts/process/presentation.rb
+++ b/record-and-playback/presentation/scripts/process/presentation.rb
@@ -155,6 +155,11 @@ unless FileTest.directory?(target_dir)
       FileUtils.mkdir_p target_pres_dir
       FileUtils.mkdir_p "#{target_pres_dir}/textfiles"
 
+      # Page files are named by pageId on current recordings; carry the
+      # manifest along so the publish step can resolve page numbers too.
+      page_ids = BigBlueButton::Presentation.read_page_id_manifest(pres_dir)
+      FileUtils.cp("#{pres_dir}/pages.json", target_pres_dir) if File.exist?("#{pres_dir}/pages.json")
+
       images = Dir.glob("#{pres_dir}/#{pres}.{jpg,jpeg,png,gif,JPG,JPEG,PNG,GIF}")
       if images.empty?
         pres_name = "#{pres_dir}/#{pres}"
@@ -175,13 +180,15 @@ unless FileTest.directory?(target_dir)
         unless pres_pdf.empty?
           text = {}
           1.upto(num_pages) do |page|
+            page_file_id = page_ids[page] || page
             BigBlueButton::Presentation.extract_png_page_from_pdf(
               page, pres_pdf, "#{target_pres_dir}/slide-#{page}.png", '1600x1600'
             ) if !version_atleast_2_6_0
-            next unless File.exist?("#{pres_dir}/textfiles/slide-#{page}.txt")
-            t = File.read("#{pres_dir}/textfiles/slide-#{page}.txt", encoding: 'UTF-8')
+            next unless File.exist?("#{pres_dir}/textfiles/slide-#{page_file_id}.txt")
+            t = File.read("#{pres_dir}/textfiles/slide-#{page_file_id}.txt", encoding: 'UTF-8')
+            # Key by page number: the json is a positional index for players
             text["slide-#{page}"] = t.encode('UTF-8', invalid: :replace)
-            FileUtils.cp("#{pres_dir}/textfiles/slide-#{page}.txt", "#{target_pres_dir}/textfiles")
+            FileUtils.cp("#{pres_dir}/textfiles/slide-#{page_file_id}.txt", "#{target_pres_dir}/textfiles")
           end
           presentation_text[pres] = text
         end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -468,9 +468,15 @@ def svg_render_image(svg, slide, shapes, tldraw, tldraw_shapes)
   image['text'] = slide[:text] if slide[:text]
   svg << image
 
-  return if slide_deskshare || !shapes.dig(presentation, slide_number)
+  # Shapes are keyed by page identity. Re-resolve the key on a miss: a slide
+  # without an explicit id (the initial slide of a recording, for example) may
+  # have been resolved before its identity was learned from a shape event.
+  page_shapes = shapes[slide[:page_key]] ||
+                shapes[page_identity_key(nil, presentation, slide_number)]
 
-  shapes = shapes[presentation][slide_number]
+  return if slide_deskshare || !page_shapes
+
+  shapes = page_shapes
 
   if !tldraw
     canvas = doc.create_element('g',
@@ -564,6 +570,42 @@ def determine_slide_number(slide, current_slide)
   slide
 end
 
+# Page identity: shapes, navigation and assets are keyed by the page's stable
+# id, not by its (mutable) number. Current recordings carry the opaque pageId
+# in the events (<id> on GotoSlideEvent, <whiteboardId> on whiteboard events);
+# older recordings carry a composite "<presentationId>/<pageNum>" id or no id
+# at all, in which case the composite form is reconstructed from the number.
+@page_key_by_pres_num = {}
+@page_id_manifests = {}
+
+def presentation_page_id_manifest(presentation)
+  @page_id_manifests[presentation] ||=
+    BigBlueButton::Presentation.read_page_id_manifest("#{@process_dir}/presentation/#{presentation}")
+end
+
+def page_identity_key(explicit_id, presentation, slide_number)
+  return explicit_id unless explicit_id.nil? || explicit_id.empty?
+
+  manifest_id = presentation_page_id_manifest(presentation)[slide_number + 1]
+  return manifest_id if manifest_id
+
+  learned = @page_key_by_pres_num[[presentation, slide_number]]
+  return learned if learned
+
+  # Composite form is 1-based, matching the ids recorded by BBB versions
+  # where the whiteboardId was "<presentationId>/<pageNum>"
+  "#{presentation}/#{slide_number + 1}"
+end
+
+# Remembers an explicit page id seen on a whiteboard event, so slides that
+# never get an explicit id of their own (for example the initial slide of a
+# recording without a manifest) can still be matched to their shapes.
+def learn_page_key(explicit_id, presentation, slide_number)
+  return if explicit_id.nil? || explicit_id.empty?
+
+  @page_key_by_pres_num[[presentation, slide_number]] ||= explicit_id
+end
+
 def clean_arrow_end_or_start_props(props)
   if props['type'] == 'binding'
     # Remove 'x' and 'y' for 'binding' type
@@ -582,12 +624,16 @@ def events_parse_tldraw_shape(shapes, event, current_presentation, current_slide
   presentation = determine_presentation(presentation, current_presentation)
   slide = determine_slide_number(slide, current_slide)
 
+  # Key shapes by the page's stable identity
+  whiteboard_id = event.at_xpath('whiteboardId')&.text
+  learn_page_key(whiteboard_id, presentation, slide)
+  page_key = page_identity_key(whiteboard_id, presentation, slide)
+
   # Set up the shapes data structures if needed
-  shapes[presentation] ||= {}
-  shapes[presentation][slide] ||= []
+  shapes[page_key] ||= []
 
   # We only need to deal with shapes for this slide
-  shapes = shapes[presentation][slide]
+  shapes = shapes[page_key]
 
   # Set up the structure for this shape
   shape = {}
@@ -637,12 +683,16 @@ def events_parse_shape(shapes, event, current_presentation, current_slide, times
   presentation = determine_presentation(presentation, current_presentation)
   slide = determine_slide_number(slide, current_slide)
 
+  # Key shapes by the page's stable identity
+  whiteboard_id = event.at_xpath('whiteboardId')&.text
+  learn_page_key(whiteboard_id, presentation, slide)
+  page_key = page_identity_key(whiteboard_id, presentation, slide)
+
   # Set up the shapes data structures if needed
-  shapes[presentation] ||= {}
-  shapes[presentation][slide] ||= []
+  shapes[page_key] ||= []
 
   # We only need to deal with shapes for this slide
-  shapes = shapes[presentation][slide]
+  shapes = shapes[page_key]
 
   # Set up the structure for this shape
   shape = {}
@@ -764,12 +814,16 @@ def events_parse_undo(shapes, event, current_presentation, current_slide, timest
   # Newer undo messages have the shape id, making this a lot easier
   shape_id = event.at_xpath('shapeId')&.text
 
+  # Key shapes by the page's stable identity
+  whiteboard_id = event.at_xpath('whiteboardId')&.text
+  learn_page_key(whiteboard_id, presentation, slide)
+  page_key = page_identity_key(whiteboard_id, presentation, slide)
+
   # Set up the shapes data structures if needed
-  shapes[presentation] ||= {}
-  shapes[presentation][slide] ||= []
+  shapes[page_key] ||= []
 
   # We only need to deal with shapes for this slide
-  shapes = shapes[presentation][slide]
+  shapes = shapes[page_key]
 
   if shape_id
     # If we have the shape id, we simply have to update the undo time on
@@ -805,12 +859,16 @@ def events_parse_clear(shapes, event, current_presentation, current_slide, times
   full_clear = full_clear ? (full_clear.text == 'true') : true
   user_id = event.at_xpath('userId')&.text
 
+  # Key shapes by the page's stable identity
+  whiteboard_id = event.at_xpath('whiteboardId')&.text
+  learn_page_key(whiteboard_id, presentation, slide)
+  page_key = page_identity_key(whiteboard_id, presentation, slide)
+
   # Set up the shapes data structures if needed
-  shapes[presentation] ||= {}
-  shapes[presentation][slide] ||= []
+  shapes[page_key] ||= []
 
   # We only need to deal with shapes for this slide
-  shapes = shapes[presentation][slide]
+  shapes = shapes[page_key]
 
   if full_clear
     BigBlueButton.logger.info("Clear: removing all shapes")
@@ -837,9 +895,18 @@ def events_get_image_info(slide, tldraw)
     slide[:src] = 'presentation/logo.png'
   else
     slide_nr = slide[:slide] + 1
-    tldraw ? slide[:src] = "presentation/#{slide_presentation}/svgs/slide#{slide_nr}.svg"
-           : slide[:src] = "presentation/#{slide_presentation}/slide-#{slide_nr}.png"
-    slide[:text] = "presentation/#{slide_presentation}/textfiles/slide-#{slide_nr}.txt"
+    page_key = slide[:page_key]
+
+    # Slide files are named by pageId on current recordings and by page
+    # number on older ones: use whichever exists on disk.
+    if tldraw
+      id_src = "presentation/#{slide_presentation}/svgs/slide-#{page_key}.svg"
+      slide[:src] = File.exist?("#{@process_dir}/#{id_src}") ? id_src : "presentation/#{slide_presentation}/svgs/slide#{slide_nr}.svg"
+    else
+      slide[:src] = "presentation/#{slide_presentation}/slide-#{slide_nr}.png"
+    end
+    id_text = "presentation/#{slide_presentation}/textfiles/slide-#{page_key}.txt"
+    slide[:text] = File.exist?("#{@process_dir}/#{id_text}") ? id_text : "presentation/#{slide_presentation}/textfiles/slide-#{slide_nr}.txt"
   end
   image_path = "#{@process_dir}/#{slide[:src]}"
 
@@ -885,8 +952,10 @@ def process_presentation(package_dir)
 
   # Current presentation/slide state
   current_presentation_slide = {}
+  current_presentation_page_key = {}
   current_presentation = ''
   current_slide = 0
+  current_page_key = nil
   # Current pan/zoom state
   current_x_offset = current_y_offset = 0.0
   current_width_ratio = current_height_ratio = 100.0
@@ -923,11 +992,17 @@ def process_presentation(package_dir)
     when 'SharePresentationEvent'
       current_presentation = event.at_xpath('presentationName').text
       current_slide = current_presentation_slide[current_presentation].to_i
+      current_page_key = current_presentation_page_key[current_presentation]
       slide_changed = panzoom_changed = true
 
     when 'GotoSlideEvent'
       current_slide = event.at_xpath('slide').text.to_i
+      # Current recordings identify the page explicitly (opaque pageId; a
+      # composite "presId/num" id on older ones)
+      goto_page_id = event.at_xpath('id')&.text
+      current_page_key = goto_page_id && !goto_page_id.empty? ? goto_page_id : nil
       current_presentation_slide[current_presentation] = current_slide
+      current_presentation_page_key[current_presentation] = current_page_key
       slide_changed = panzoom_changed = true
 
     when 'ResizeAndMoveSlideEvent'
@@ -992,10 +1067,11 @@ def process_presentation(package_dir)
     # Perform slide finalization
     if slide_changed
       slide = slides.last
+      resolved_page_key = page_identity_key(current_page_key, current_presentation, current_slide)
 
       if slide &&
          (slide[:presentation] == current_presentation) &&
-         (slide[:slide] == current_slide) &&
+         (slide[:page_key] == resolved_page_key) &&
          (slide[:deskshare] == deskshare)
         BigBlueButton.logger.info('Presentation/Slide: skipping, no changes')
       else
@@ -1004,10 +1080,11 @@ def process_presentation(package_dir)
           svg_render_image(svg, slide, shapes, tldraw, tldraw_shapes)
         end
 
-        BigBlueButton.logger.info("Presentation #{current_presentation} Slide #{current_slide} Deskshare #{deskshare}")
+        BigBlueButton.logger.info("Presentation #{current_presentation} Slide #{current_slide} Page key #{resolved_page_key} Deskshare #{deskshare}")
         slide = {
           presentation: current_presentation,
           slide: current_slide,
+          page_key: resolved_page_key,
           in: timestamp,
           deskshare: deskshare,
         }
@@ -1467,7 +1544,7 @@ begin
                     presentation[:slides].each do |key, val|
                       attributes = { width: '176', height: '136', alt: val[:alt]&.to_s || '' }
                       xml.image(attributes) do
-                        xml.text("#{playback_protocol}://#{playback_host}/presentation/#{@meeting_id}/presentation/#{presentation[:id]}/thumbnails/thumb-#{key}.png")
+                        xml.text("#{playback_protocol}://#{playback_host}/presentation/#{@meeting_id}/presentation/#{presentation[:id]}/thumbnails/thumb-#{val[:page_file_id] || key}.png")
                       end
                     end
                   end

--- a/record-and-playback/presentation/scripts/publish/presentation.rb
+++ b/record-and-playback/presentation/scripts/publish/presentation.rb
@@ -900,7 +900,7 @@ def events_get_image_info(slide, tldraw)
     # Slide files are named by pageId on current recordings and by page
     # number on older ones: use whichever exists on disk.
     if tldraw
-      id_src = "presentation/#{slide_presentation}/svgs/slide-#{page_key}.svg"
+      id_src = "presentation/#{slide_presentation}/svgs/slide#{page_key}.svg"
       slide[:src] = File.exist?("#{@process_dir}/#{id_src}") ? id_src : "presentation/#{slide_presentation}/svgs/slide#{slide_nr}.svg"
     else
       slide[:src] = "presentation/#{slide_presentation}/slide-#{slide_nr}.png"


### PR DESCRIPTION
# refactor: make pageId opaque UUID (decouple from page num)

## What this changes (and why)

`pageId` today is not opaque: it is constructed as `"<presId>/<num>"` and that composite leaks the page's ordinal position into the id itself. This coupling blocks features that need to renumber slides mid-presentation (e.g. `insertPages(position, file)` in the plugin SDK), because renumbering `num` would silently break whiteboard navigation, recording playback, and poll-to-slide linkage, all of which derive `num` (or `presId`) by splitting the id on `"/"`.

This PR is **preparatory**: it makes `pageId` an opaque UUID (v4) minted once at page creation, with `num` carried as a separate, independently-mutable order field. The feature (`insertPages`) lands in a follow-up PR built on top of the now-stable `pageId`. **No user-facing behavior changes**: this is a pure refactor validated end-to-end against the pre-refactor baseline.

## How it works (the design decision)

- **Mint point:** `MsgBuilder` (`bbb-common-web`) now mints `pageId = java.util.UUID.randomUUID().toString` at the two page-creation sites (`:154`, `:264`). UUID v4 was chosen over ULID because `java.util.UUID` is already a project dependency (`Util.java`) and `pres_page.num` already provides ordering; there is no value in a sortable id. The composite `presId/num` form is gone.
- **Recorder decoupling (the critical lockstep):** `RedisRecorderActor` used to split the id (`getPageNum`/`getPresentationId`) to recover `pageNumber`/`presentationId` for the recording's `events.xml`. Once `pageId` is a UUID with no `"/"`, that split silently returns `0`/`""` and annotations lose their slide association. The 4 live recorder paths now read **explicit `presentationId`/`pageNum` fields** propagated onto the Evt message bodies (`bbb-common-message`), populated at each Evt's mint site. The recorded `events.xml` format is unchanged (still integers), so already-processed recordings stay replayable.
- **State threading (akka-bbb-apps):** the 3 whiteboard Pub handlers (`SendWhiteboardAnnotation`, `SendCursorPosition`, `DeleteWhiteboardAnnotations`) previously received only `liveMeeting` (which does not hold the page model). They now take `state: MeetingState2x`, replicating the existing poll-handler dispatch pattern, and resolve `presentationId`/`pageNum` via two small helpers (`findPresentationPage`, `getPageByNum`) over `PresentationInPod.pages`. Missing pod/presentation/page returns `Option` and skips gracefully (upload-race safe).
- **Client (route chosen, keeps pageId opaque end-to-end):** the 3 client sites that reconstructed `pageId = \`${presentationId}/${num}\`` (`skipToSlide` in `whiteboard/container.jsx` and `presentation-toolbar/container.jsx`; `setPresentationPageInfiniteWhiteboard` in the toolbar) now obtain the opaque `pageId` from a new `pres_page` GraphQL subscription (all pages of the current presentation, exposing `num` + `pageId`). The server-side infra already exists: the `v_pres_page` view is exposed via Hasura with a presenter-only permission that matches exactly the 3 call sites. The alternative route (client sends `num`, server resolves) would have touched 8 graphql-actions + 4 handlers without state, rejected as disproportionate.
- **Polls (`Polls.scala`):** `pollId` is minted as `"<pageId>/<timestamp>"` for prefix-matching via `getRunningPollThatStartsWith`. With `pageId` now a UUID, that form still holds and the prefix-match is preserved. A 5th mint of `SendWhiteboardAnnotationsEvtMsgBody` (poll-result broadcast, `Polls.scala:145`) was found during implementation and threaded with the new fields in-place (`pres`/`page` in scope from the enclosing for-comprehension).
- **ClearWhiteboard recorder path:** left as-is. It still calls the legacy `getPageNum`/`getPresentationId` split helpers, but the path is unreachable in 4.0 (no producer of `ClearWhiteboardEvtMsg` exists; "clear all" goes through `DeleteWhiteboardAnnotations` with an empty list). Marked legacy; not worth threading fields into a dead path.

## No data migration, no schema change

`pres_page.pageId` is `varchar(100)` PRIMARY KEY: a UUID string fits without a column-type migration. Pages already persisted with the composite `presId/num` id only exist in **already-processed recordings** (static SVG/HTML on disk); the Ruby player reads integer `pageNumber`/`slide` from `events.xml` and never parses the id, so legacy recordings replay unchanged. New recordings write integer fields via the now-field-driven recorder.

## Validation (E2E in a running from-source BBB 4.0)

Baseline (pre-refactor) and after-refactor runs of the same flow were recorded and compared:

- create meeting → upload 15-page PDF → switch presentation → `skipToSlide` (Slide 5) → hand-drawn annotation → custom poll (attendee responded) → publish poll result to whiteboard → recording active.
- **Result: pixel-identical UX.** Same client layout, same flow, same annotation, same poll result. Recording processed and replayable; `events.xml` diff is only `<whiteboardId>` becoming a UUID (which the Ruby player does not parse); all `<slide>`/`<pageNumber>` integers unchanged.
- Additional coverage (declared, not all on video): rejoin same meeting, export-with-annotations (download handler path), delete annotations, infinite-whiteboard toggle. Legacy recording (composite id) still replays.

Preview below: click each GIF for the full MP4 (with controls). Navigation moments in each MP4: skipToSlide at ~00:24, annotation + poll at ~00:50.

**Baseline (pre-refactor):**

[![Baseline E2E flow](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-06/c356c692-303c-4974-a4d6-e6cde49dc1f4/preview.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-06/e71241cc-6618-4782-bb34-d356e4a6a85a/baseline-meeting-flow.mp4)

**After (post-refactor, identical UX):**

[![After E2E flow](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-06/2df79a81-8f53-4681-92b3-3b4647f02a45/preview.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-06/ba50b487-6773-45c9-a37d-aa9a18d72f37/after-meeting-flow.mp4)

## Not covered by the E2E (declared, not omitted)

Breakout rooms, multi-pod presentations, cursor rendered in a second browser viewer, and `bigbluebutton-mobile` (separate repo, not in this clone) were not exercised. The decoupling paths for these resolve through the same `findPresentationPage` scan (UUID uniqueness makes it robust across pods) and the same Evt-field-propagation pattern, but they are honestly untested.

## Follow-up

`insertPages(position, file)` in the plugin SDK: blocked until this lands.
