### PR TITLE
feat(sidebar-navigation): make buttons layout configurable

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -592,8 +592,15 @@ export interface Layout {
   showLeaveSessionLabel: boolean
 }
 
+export interface SidebarNavigationButtons {
+  top: string[]
+  center: string[]
+  bottom: string[]
+}
+
 export interface SidebarNavigation {
   appsToLabelAsNew: string[]
+  buttons: SidebarNavigationButtons
 }
 
 export interface Pads {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/apps-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/apps-list-item/component.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { PANELS } from '/imports/ui/components/layout/enums';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
-import { BaseSidebarButtonProps } from '../types';
+import useIsSpecificPanelOpened from '../hooks/useIsSpecificPanelOpened';
 
 const intlMessages = defineMessages({
   wigetsLabel: {
@@ -11,8 +11,9 @@ const intlMessages = defineMessages({
   },
 });
 
-const AppsListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
+const AppsListItem: React.FC = () => {
   const intl = useIntl();
+  const isOpened = useIsSpecificPanelOpened(PANELS.APPS_GALLERY);
   const label = intl.formatMessage(intlMessages.wigetsLabel);
 
   return (

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/audio-captions-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/audio-captions-list-item/component.tsx
@@ -6,7 +6,7 @@ import {
   showInSidebarNavigation,
   useIsAudioTranscriptionEnabled,
 } from '/imports/ui/components/audio/audio-graphql/audio-captions/service';
-import { BaseSidebarButtonProps } from '../types';
+import useIsSpecificPanelOpened from '../hooks/useIsSpecificPanelOpened';
 
 const intlMessages = defineMessages({
   audioCaptionsLabel: {
@@ -15,8 +15,9 @@ const intlMessages = defineMessages({
   },
 });
 
-const AudioCaptionsListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
+const AudioCaptionsListItem: React.FC = () => {
   const intl = useIntl();
+  const isOpened = useIsSpecificPanelOpened(PANELS.AUDIO_CAPTIONS);
   const isEnabled = useIsAudioTranscriptionEnabled();
   const shouldShowInSidebarNavigation = showInSidebarNavigation();
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/buttons-registry.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/buttons-registry.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ProfileListItem from './profile-list-item/component';
+import UsersListItem from './users-list-item/component';
+import ChatListItem from './chat-list-item/component';
+import UserNotesListItemContainer from './user-notes-list-item/component';
+import AppsListItem from './apps-list-item/component';
+import AudioCaptionsListItem from './audio-captions-list-item/component';
+import LearningDashboardListItem from './learning-dashboard-list-item/component';
+import SettingsListItem from './settings-list-item/component';
+
+// 'pinned-apps' is intentionally not in this map: it needs the
+// sidebarNavigationInput prop and is special-cased in component.tsx.
+export const PINNED_APPS_BUTTON_ID = 'pinned-apps';
+
+const SIDEBAR_BUTTONS_REGISTRY: Record<string, React.ComponentType> = {
+  profile: ProfileListItem,
+  'user-list': UsersListItem,
+  chat: ChatListItem,
+  notes: UserNotesListItemContainer,
+  'apps-gallery': AppsListItem,
+  'audio-captions': AudioCaptionsListItem,
+  'learning-dashboard': LearningDashboardListItem,
+  settings: SettingsListItem,
+};
+
+export default SIDEBAR_BUTTONS_REGISTRY;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/chat-list-item/component.tsx
@@ -8,7 +8,7 @@ import { useShortcut } from '../../../core/hooks/useShortcut';
 import { useIsChatEnabled } from '/imports/ui/services/features';
 import useHasUnreadChatMessages from '../../chat/hooks/useHasUnreadChatMessages';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
-import { BaseSidebarButtonProps } from '../types';
+import useIsSpecificPanelOpened from '../hooks/useIsSpecificPanelOpened';
 
 const intlMessages = defineMessages({
   messagesTitle: {
@@ -25,10 +25,11 @@ const intlMessages = defineMessages({
   },
 });
 
-const ChatListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
+const ChatListItem: React.FC = () => {
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
   const intl = useIntl();
+  const isOpened = useIsSpecificPanelOpened(PANELS.CHAT);
 
   const {
     hasUnreadMessages,

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -2,27 +2,20 @@ import React, {
   useRef,
   useState,
   useEffect,
+  useCallback,
   memo,
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import CustomLogo from './custom-logo/component';
-import ProfileListItem from './profile-list-item/component';
 import getFromUserSettings from '/imports/ui/services/users-settings';
-import ChatListItem from './chat-list-item/component';
-import UserNotesListItemContainer from './user-notes-list-item/component';
-import UsersListItem from './users-list-item/component';
-import AppsListItem from './apps-list-item/component';
-import AudioCaptionsListItem from './audio-captions-list-item/component';
-import LearningDashboardListItem from './learning-dashboard-list-item/component';
-import SettingsListItem from './settings-list-item/component';
 import PinnedApps from './pinned-apps/component';
+import SIDEBAR_BUTTONS_REGISTRY, { PINNED_APPS_BUTTON_ID } from './buttons-registry';
 import { SidebarNavigation as SidebarNavigationInput } from '../layout/layoutTypes';
 import getSettingsSingletonInstance from '/imports/ui/services/settings';
-import { useIsLearningDashboardEnabled } from '/imports/ui/services/features';
 import { PANELS } from '/imports/ui/components/layout/enums';
 import { layoutSelectInput } from '/imports/ui/components/layout/context';
 import { Input } from '/imports/ui/components/layout/layoutTypes';
-import useIsPanelOpened from './hooks/useIsPanelOpened';
+import logger from '/imports/startup/client/logger';
 import Styled from './styles';
 
 interface SidebarNavigationProps {
@@ -34,7 +27,6 @@ interface SidebarNavigationProps {
   height: number,
   width: number,
   sidebarNavigationInput: SidebarNavigationInput,
-  isModerator: boolean,
   hasUnreadMessages: boolean,
   hasUnreadNotes: boolean,
 }
@@ -69,12 +61,16 @@ const SidebarNavigation = ({
   height,
   width,
   sidebarNavigationInput,
-  isModerator,
   hasUnreadMessages,
   hasUnreadNotes,
 }: SidebarNavigationProps) => {
   const intl = useIntl();
   const showBrandingArea = getFromUserSettings('bbb_display_branding_area', window.meetingClientSettings.public.app.branding.displayBrandingArea);
+  const {
+    top: topButtons = [],
+    center: centerButtons = [],
+    bottom: bottomButtons = [],
+  } = window.meetingClientSettings.public.sidebarNavigation.buttons;
 
   const scrollRef = useRef<HTMLDivElement>(null);
   // Prevents vertical scrollbox background to be shown on dark mode when there is no scroll
@@ -85,9 +81,7 @@ const SidebarNavigation = ({
   const Settings = getSettingsSingletonInstance();
   const animations = Settings?.application?.animations;
   const hasNotification = hasUnreadMessages || hasUnreadNotes;
-  const isLearningDashboardEnabled = useIsLearningDashboardEnabled();
   const { sidebarContentPanel } = layoutSelectInput((i: Input) => i.sidebarContent);
-  const isOpened = useIsPanelOpened();
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -132,6 +126,39 @@ const SidebarNavigation = ({
       setIsExpanded(false);
     }
   }, [sidebarContentPanel]);
+
+  useEffect(() => {
+    [...topButtons, ...centerButtons, ...bottomButtons].forEach((buttonId) => {
+      if (buttonId === PINNED_APPS_BUTTON_ID) return;
+      if (!SIDEBAR_BUTTONS_REGISTRY[buttonId]) {
+        logger.warn({
+          logCode: 'sidebar_navigation_unknown_button_id',
+          extraInfo: { buttonId },
+        }, `Sidebar navigation: unknown button id "${buttonId}" configured in settings.yml, it will not be rendered`);
+      }
+    });
+    // Configured button ids come from static startup settings, validate once on mount.
+  }, []);
+
+  const renderButton = useCallback((buttonId: string) => {
+    if (buttonId === PINNED_APPS_BUTTON_ID) {
+      return (
+        <PinnedApps
+          key={buttonId}
+          sidebarNavigationInput={sidebarNavigationInput}
+        />
+      );
+    }
+
+    const ButtonComponent = SIDEBAR_BUTTONS_REGISTRY[buttonId];
+    if (!ButtonComponent) return null;
+
+    return <ButtonComponent key={buttonId} />;
+  }, [sidebarNavigationInput]);
+
+  const hasTopContent = showBrandingArea || topButtons.length > 0;
+  const hasCenterContent = centerButtons.length > 0;
+  const hasBottomContent = bottomButtons.length > 0;
 
   return (
     <Styled.NavigationSidebarBackdrop
@@ -181,27 +208,19 @@ const SidebarNavigation = ({
         >
           <Styled.Top>
             {showBrandingArea && <CustomLogo />}
-            <ProfileListItem isOpened={isOpened(PANELS.PROFILE)} />
-            <UsersListItem isOpened={isOpened(PANELS.USERLIST)} />
-            <ChatListItem isOpened={isOpened(PANELS.CHAT)} />
-            <UserNotesListItemContainer isOpened={isOpened(PANELS.SHARED_NOTES)} />
+            {topButtons.map((buttonId) => renderButton(buttonId))}
           </Styled.Top>
 
-          <Styled.Separator />
+          {hasTopContent && hasCenterContent && <Styled.Separator />}
 
           <Styled.Center>
-            <AppsListItem isOpened={isOpened(PANELS.APPS_GALLERY)} />
-            <PinnedApps
-              sidebarNavigationInput={sidebarNavigationInput}
-            />
+            {centerButtons.map((buttonId) => renderButton(buttonId))}
           </Styled.Center>
 
-          <Styled.Separator />
+          {hasCenterContent && hasBottomContent && <Styled.Separator />}
 
           <Styled.Bottom>
-            <AudioCaptionsListItem isOpened={isOpened(PANELS.AUDIO_CAPTIONS)} />
-            { isLearningDashboardEnabled && isModerator ? <LearningDashboardListItem /> : null }
-            <SettingsListItem />
+            {bottomButtons.map((buttonId) => renderButton(buttonId))}
           </Styled.Bottom>
         </Styled.NavigationSidebarListItemsContainer>
       </Styled.NavigationSidebar>

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/container.tsx
@@ -142,7 +142,6 @@ const SidebarNavigationContainer = () => {
       width={width}
       height={height}
       sidebarNavigationInput={sidebarNavigationInput}
-      isModerator={isModerator}
       hasUnreadMessages={hasUnreadMessages}
       hasUnreadNotes={hasUnreadNotes}
     />

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/hooks/useIsPanelOpened.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/hooks/useIsPanelOpened.ts
@@ -2,6 +2,13 @@ import { useCallback } from 'react';
 import { layoutSelectInput } from '/imports/ui/components/layout/context';
 import { Input } from '/imports/ui/components/layout/layoutTypes';
 
+// Returns a checker function rather than a single boolean because some
+// callers (e.g. PinnedApps) need to check a dynamic, variable-length list of
+// panel ids from one hook call inside a .map() - a parameterized hook can't
+// be called a variable number of times per render. Callers that only ever
+// check one fixed, statically-known panel id should use
+// useIsSpecificPanelOpened instead, which avoids re-rendering on unrelated
+// panel toggles.
 const useIsPanelOpened = () => {
   const { sidebarContentPanel } = layoutSelectInput((i: Input) => i.sidebarContent);
   const {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/hooks/useIsSpecificPanelOpened.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/hooks/useIsSpecificPanelOpened.ts
@@ -1,0 +1,17 @@
+import { layoutSelectInput } from '/imports/ui/components/layout/context';
+import { Input } from '/imports/ui/components/layout/layoutTypes';
+
+// Selects the boolean directly (instead of the whole sidebarContent/
+// sidebarContentAuxiliary object useIsPanelOpened reads) so
+// use-context-selector's reference-equality check only re-renders this
+// component when ITS OWN panel's open state flips, not on every sidebar
+// panel toggle. Only use this for a fixed, statically-known panelId - for a
+// dynamic/variable-length set of ids (e.g. looping over pinned apps), use
+// useIsPanelOpened instead, since a parameterized hook can't be called a
+// variable number of times per render.
+const useIsSpecificPanelOpened = (panelId: string) => layoutSelectInput((i: Input) => (
+  i.sidebarContent.sidebarContentPanel === panelId
+  || (i.sidebarContentAuxiliary.isOpen === true && i.sidebarContentAuxiliary.sidebarContentPanel === panelId)
+));
+
+export default useIsSpecificPanelOpened;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/learning-dashboard-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/learning-dashboard-list-item/component.tsx
@@ -2,6 +2,9 @@ import React, { useCallback, memo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import LearningDashboardService from '/imports/ui/components/learning-dashboard/service';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import { useIsLearningDashboardEnabled } from '/imports/ui/services/features';
+import { User } from '/imports/ui/Types/user';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
 
 const intlMessages = defineMessages({
@@ -13,6 +16,9 @@ const intlMessages = defineMessages({
 
 const LearningDashboardListItem = () => {
   const intl = useIntl();
+  const isLearningDashboardEnabled = useIsLearningDashboardEnabled();
+  const { data: currentUser } = useCurrentUser((u: Partial<User>) => ({ isModerator: u?.isModerator }));
+  const isModerator = currentUser?.isModerator || false;
   const { data: meetingInfo } = useMeeting((meeting) => ({
     learningDashboardAccessToken: meeting.learningDashboardAccessToken,
     isBreakout: meeting?.isBreakout,
@@ -24,7 +30,7 @@ const LearningDashboardListItem = () => {
 
   const label = intl.formatMessage(intlMessages.learningDashboardLabel);
 
-  if (meetingInfo?.isBreakout) return null;
+  if (!isLearningDashboardEnabled || !isModerator || meetingInfo?.isBreakout) return null;
 
   return (
     <SidebarNavigationButton

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/profile-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/profile-list-item/component.tsx
@@ -1,8 +1,8 @@
 import React, { memo } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { PANELS } from '../../layout/enums';
-import { BaseSidebarButtonProps } from '../types';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
+import useIsSpecificPanelOpened from '../hooks/useIsSpecificPanelOpened';
 
 const intlMessages = defineMessages({
   profileLabel: {
@@ -11,8 +11,9 @@ const intlMessages = defineMessages({
   },
 });
 
-const ProfileListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
+const ProfileListItem: React.FC = () => {
   const intl = useIntl();
+  const isOpened = useIsSpecificPanelOpened(PANELS.PROFILE);
 
   const label = intl.formatMessage(intlMessages.profileLabel);
 

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/types.ts
@@ -1,3 +1,0 @@
-export interface BaseSidebarButtonProps {
-  isOpened: boolean;
-}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/user-notes-list-item/component.tsx
@@ -4,7 +4,7 @@ import NotesService from '/imports/ui/components/notes/service';
 import useHasUnreadNotes from '/imports/ui/components/notes/hooks/useHasUnreadNotes';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
-import { BaseSidebarButtonProps } from '../types';
+import useIsSpecificPanelOpened from '../hooks/useIsSpecificPanelOpened';
 import { PANELS } from '/imports/ui/components/layout/enums';
 import useLockContext from '/imports/ui/components/lock-viewers/hooks/useLockContext';
 import { GET_PAD_ID, GetPadIdQueryResponse } from '/imports/ui/components/notes/queries';
@@ -46,9 +46,9 @@ const intlMessages = defineMessages({
   },
 });
 
-const UserNotesListItemContainerGraphql: React.FC<BaseSidebarButtonProps> = (props) => {
-  const { isOpened } = props;
+const UserNotesListItemContainerGraphql: React.FC = () => {
   const intl = useIntl();
+  const isOpened = useIsSpecificPanelOpened(PANELS.SHARED_NOTES);
   const { userLocks } = useLockContext();
   const disableNotes = userLocks.userNotes;
   const hasUnreadNotes = useHasUnreadNotes({ isNotesPanelOpened: isOpened });

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/users-list-item/component.tsx
@@ -8,7 +8,7 @@ import { useShortcut } from '/imports/ui/core/hooks/useShortcut';
 import SidebarNavigationButton from '/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component';
 import { RAISED_HAND_USERS, RaisedHandUsersSubscriptionResponse, USER_AGGREGATE_COUNT_SUBSCRIPTION } from '/imports/ui/core/graphql/queries/users';
 import { UserAggregateCountSubscriptionResponse } from '/imports/ui/components/user-list/types';
-import { BaseSidebarButtonProps } from '../types';
+import useIsSpecificPanelOpened from '../hooks/useIsSpecificPanelOpened';
 import Styled from './styles';
 
 const intlMessages = defineMessages({
@@ -18,9 +18,10 @@ const intlMessages = defineMessages({
   },
 });
 
-const UsersListItem: React.FC<BaseSidebarButtonProps> = ({ isOpened }) => {
+const UsersListItem: React.FC = () => {
   const TOGGLE_USER_LIST_SHORTCUT = useShortcut('toggleUserList');
   const intl = useIntl();
+  const isOpened = useIsSpecificPanelOpened(PANELS.USERLIST);
 
   const {
     data: usersCountData,

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -609,6 +609,11 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
     },
     sidebarNavigation: {
       appsToLabelAsNew: [],
+      buttons: {
+        top: ['profile', 'user-list', 'chat', 'notes'],
+        center: ['apps-gallery', 'pinned-apps'],
+        bottom: ['audio-captions', 'learning-dashboard', 'settings'],
+      },
     },
     pads: {
       url: 'ETHERPAD_HOST',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -827,6 +827,24 @@ public:
     usersPerUserListPage: 50
     syncCameraDockSizeAndPosition: true
   sidebarNavigation:
+    # Controls which built-in sidebar navigation buttons are rendered, in
+    # which section (top/center/bottom) and in what order. Omitting an id
+    # hides that button. This is a full replacement list, not an allow/deny
+    # list over a hidden default - if you customize it, remember to add any
+    # new ids introduced by future upstream versions.
+    buttons:
+      top:
+        - profile
+        - user-list
+        - chat
+        - notes
+      center:
+        - apps-gallery
+        - pinned-apps
+      bottom:
+        - audio-captions
+        - learning-dashboard
+        - settings
     # Controls which apps should have the "new" label in the apps gallery.
     # Possible values: 'poll', 'breakoutroom', 'timer', 'audio-captions'.
     # For plugins, refer to the isNew flag in the plugin's own settings.


### PR DESCRIPTION
### What does this PR do?
Sidebar buttons (profile, chat, notes, settings, etc.) are hardcoded into three fixed JSX blocks, giving the sidebar no flexibility — any change in order requires a direct code change.

Introduce a `buttons.{top,center,bottom}` block in settings.yml and a button-id registry so deployments can hide or reorder built-in buttons without touching the component tree. The current button layout is preserved as the default configuration.

NOTE: The branding-area/logo is not affected by this setting and is always rendered at the top of the sidebar navigation.

Different disposition example for the following setting:
```
  sidebarNavigation:
    buttons:
      top:
        - settings
        - notes
        - user-list
      center:
        - pinned-apps
        - apps-gallery
      bottom:
        - learning-dashboard
        - profile
        - chat
```
<img height="500" alt="Screenshot from 2026-07-07 17-16-42" src="https://github.com/user-attachments/assets/26c09f73-6802-4618-95ef-b66cc8153850" />



### Closes Issue(s)
Closes N/A

### Motivation
Allow deployments to change the set of buttons in the navigation sidebar and its disposition without having to touch the code.
