### PR TITLE
fix(poll): drop out-of-range answerIds to avoid log noise

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/PollHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/PollHdlrHelpers.scala
@@ -6,6 +6,27 @@ import org.bigbluebutton.core.running.OutMsgRouter
 
 object PollHdlrHelpers {
 
+  // Selects the answer ids that will actually be recorded for a poll vote.
+  //
+  // - A single-response question keeps at most the first requested id; a
+  //   multi-response question keeps every distinct requested id.
+  // - Out-of-range ids (negative, or >= the number of options) are dropped so a
+  //   malformed vote can neither crash the meeting actor via the indexed answer
+  //   access that follows nor violate the poll_response foreign key on
+  //   persistence. Invalid votes are silently ignored.
+  //
+  // validAnswerIds is the range of option indices for the question (empty when
+  // the question has no answers), so an empty range drops every requested id.
+  def selectValidAnswerIds(requestedAnswerIds: Seq[Int], multiResponse: Boolean, validAnswerIds: Range): Seq[Int] = {
+    val deduped =
+      if (!multiResponse && requestedAnswerIds.length > 1) {
+        Seq(requestedAnswerIds.head)
+      } else {
+        requestedAnswerIds.distinct
+      }
+    deduped.filter(validAnswerIds.contains)
+  }
+
   def broadcastPollUpdatedEvent(outGW: OutMsgRouter, meetingId: String, userId: String, pollId: String, poll: SimplePollResultOutVO): Unit = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(PollUpdatedEvtMsg.NAME, routing)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToPollReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/polls/RespondToPollReqMsgHdlr.scala
@@ -19,13 +19,15 @@ trait RespondToPollReqMsgHdlr {
         if (poll.stopped) {
           log.info("Ignoring vote from user {} because poll {} is already finished in meeting {}", msg.header.userId, msg.body.pollId, msg.header.meetingId)
         } else {
-          val answers = {
-            if (!poll.questions(0).multiResponse && msg.body.answerIds.length > 1) {
-              Seq(msg.body.answerIds.head)
-            } else {
-              msg.body.answerIds.distinct
-            }
-          }
+          val question = poll.questions.headOption
+          val answerList = question.flatMap(_.answers)
+          // Valid answer ids are the option indices of the poll's question. Any id
+          // outside this range is a malformed/out-of-range vote.
+          val validAnswerIds = answerList.map(_.indices).getOrElse(0 until 0)
+
+          val answers = PollHdlrHelpers.selectValidAnswerIds(
+            msg.body.answerIds, question.exists(_.multiResponse), validAnswerIds
+          )
 
           for {
             (pollId: String, updatedPoll: SimplePollResultOutVO) <- Polls.handleRespondToPollReqMsg(msg.header.userId, poll.id,
@@ -34,8 +36,9 @@ trait RespondToPollReqMsgHdlr {
             PollHdlrHelpers.broadcastPollUpdatedEvent(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, updatedPoll)
             for {
               answerId <- answers
+              options <- answerList
             } yield {
-              val answerText = poll.questions(0).answers.get(answerId).key
+              val answerText = options(answerId).key
               PollHdlrHelpers.broadcastUserRespondedToPollRecordMsg(bus.outGW, liveMeeting.props.meetingProp.intId, msg.header.userId, pollId, answerId, answerText, poll.isSecret)
             }
 

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/apps/polls/PollHdlrHelpersSpec.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core/apps/polls/PollHdlrHelpersSpec.scala
@@ -1,0 +1,66 @@
+package org.bigbluebutton.core.apps.polls
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+// Exercises the answer-id bounds filter that keeps a malformed poll vote from
+// reaching the indexed answer access in the handler (which would crash the
+// meeting actor) or the poll_response foreign key on persistence. The logic
+// lives in the PollHdlrHelpers object so it can be tested in isolation, without
+// standing up a LiveMeeting / MessageBus / poll fixtures.
+//
+// NOTE: extends AnyFlatSpec directly rather than the shared UnitSpec, which
+// currently does not compile against the resolved ScalaTest 3.2.x (UnitSpec
+// still imports the pre-3.2 org.scalatest.FlatSpec / Matchers packages). Same
+// choice WhiteboardModelSpec made.
+class PollHdlrHelpersSpec extends AnyFlatSpec {
+
+  import PollHdlrHelpers.selectValidAnswerIds
+
+  // A two-option question: valid indices are 0 and 1.
+  private val validAnswerIds = 0 until 2
+
+  it should "drop an id past the last option (999)" in {
+    assert(selectValidAnswerIds(Seq(999), multiResponse = false, validAnswerIds) == Seq.empty)
+  }
+
+  it should "drop a negative id (-1)" in {
+    assert(selectValidAnswerIds(Seq(-1), multiResponse = false, validAnswerIds) == Seq.empty)
+  }
+
+  it should "drop Int.MaxValue without an index-out-of-bounds crash" in {
+    assert(selectValidAnswerIds(Seq(2147483647), multiResponse = false, validAnswerIds) == Seq.empty)
+  }
+
+  it should "keep a valid id (0)" in {
+    assert(selectValidAnswerIds(Seq(0), multiResponse = false, validAnswerIds) == Seq(0))
+  }
+
+  it should "return empty for an empty vote (no-op)" in {
+    assert(selectValidAnswerIds(Seq.empty, multiResponse = false, validAnswerIds) == Seq.empty)
+  }
+
+  it should "keep every valid id when the question is multi-response" in {
+    assert(selectValidAnswerIds(Seq(0, 1), multiResponse = true, validAnswerIds) == Seq(0, 1))
+  }
+
+  it should "keep only the first id when the question is single-response" in {
+    assert(selectValidAnswerIds(Seq(0, 1), multiResponse = false, validAnswerIds) == Seq(0))
+  }
+
+  it should "drop a single-response vote whose first id is out of range" in {
+    // Single-response keeps only the head, then bounds-filters it: an
+    // out-of-range head leaves nothing, it does not fall through to a later id.
+    assert(selectValidAnswerIds(Seq(999, 0), multiResponse = false, validAnswerIds) == Seq.empty)
+  }
+
+  it should "drop every id when the question has no answers (empty valid range)" in {
+    // Mirrors the handler's answers=None path: with no answer options the valid
+    // range is empty, so nothing survives the filter.
+    val noOptions = 0 until 0
+    assert(selectValidAnswerIds(Seq(0, 1, 999), multiResponse = true, noOptions) == Seq.empty)
+  }
+
+  it should "collapse duplicate valid ids on a multi-response vote" in {
+    assert(selectValidAnswerIds(Seq(1, 1, 0), multiResponse = true, validAnswerIds) == Seq(1, 0))
+  }
+}

--- a/bbb-graphql-actions/src/actions/pollSubmitUserVote.ts
+++ b/bbb-graphql-actions/src/actions/pollSubmitUserVote.ts
@@ -16,6 +16,10 @@ export default function buildRedisMessage(sessionVariables: Record<string, unkno
     throw new ValidationError('Parameter `answerIds` exceeds the maximum allowed limit of 100 options', 400);
   }
 
+  if(Array.isArray(input.answerIds) && input.answerIds.some(id => !Number.isInteger(id) || id < 0)) {
+    throw new ValidationError('Parameter answerIds must contain only non-negative integers', 400);
+  }
+
   const routing = {
     meetingId: sessionVariables['x-hasura-meetingid'] as String,
     userId: sessionVariables['x-hasura-userid'] as String


### PR DESCRIPTION
## What this changes

When a participant votes on a poll, the client sends a list of `answerIds` (the option indices). The server trusted those indices without checking them against the actual number of poll options. An out-of-range value (e.g. `999`, `-1`, or `Int.MaxValue`) reached the indexed answer access in `RespondToPollReqMsgHdlr` and threw `ArrayIndexOutOfBoundsException` inside the `MeetingActor`, leaving a stack trace in the akka log on every malformed vote.

The meeting itself recovers (akka supervision restarts the actor), but the exception pollutes the log and the malformed vote is lost.

## How it works

Filter `answerIds` to the poll's valid option indices **up front**, so a malformed vote is silently ignored instead of throwing:

- **`RespondToPollReqMsgHdlr`** computes `validAnswerIds` from the question's answer list and passes both the requested ids and the valid range to `PollHdlrHelpers.selectValidAnswerIds`, which dedupes, applies the single/multi-response rule, and drops anything out of range. The two raw `poll.questions(0)` accesses are replaced with `headOption` for consistency.
- **`PollHdlrHelpers.selectValidAnswerIds`** (new) holds the filter logic extracted so it can be unit-tested in isolation.
- **`pollSubmitUserVote.ts`** (defense in depth) rejects non-integer or negative `answerIds` early at the GraphQL-actions layer, before they reach akka.

## Validation (BBB 3.0 from-source, live)

With a 3-option poll open, a viewer submitted `answerIds: [999]`, `[-1]`, `[2147483647]`, and `[0]` via the authenticated GraphQL connection:

| answerIds | Before | After |
|---|---|---|
| `[999]` | `ArrayIndexOutOfBoundsException` in akka log | silently dropped, no error |
| `[-1]` | `ArrayIndexOutOfBoundsException` in akka log | rejected at frontend (400) |
| `[2147483647]` | `ArrayIndexOutOfBoundsException` in akka log | silently dropped, no error |
| `[0]` | recorded normally | recorded normally |

After the fix: 0 `ArrayIndexOutOfBoundsException`, 0 ERROR lines, 0 FK violations in the akka log. Valid votes `[0]`/`[1]`/`[2]` all record correctly with no off-by-one.

Preview below - click the GIF to open the MP4 (higher quality, with controls):

[![Poll vote validation - after fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-08/2c071bd4-2f93-4e7f-921b-d5aa5471ea06/poll-fix-after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-08/305cfd62-8366-4cb9-9b5e-a3f473c6c45d/poll-fix-after.mp4)

## Tests

`PollHdlrHelpersSpec` (new, 10 scenarios): out-of-range dropped, negative dropped, `Int.MaxValue` dropped, valid kept, empty no-op, multi-response keeps all valid, single-response keeps only head, single-response with out-of-range head drops everything, no-options (empty valid range) drops all, dedup. All pass.

```
sbt "testOnly org.bigbluebutton.core.apps.polls.PollHdlrHelpersSpec"
→ Tests: succeeded 10, failed 0
```

Note: the broader `akka-bbb-apps` test suite has pre-existing compilation issues on `v3.0.x-develop` (pre-3.2 ScalaTest imports in `UnitSpec`, `TestDataGen`); this spec extends `AnyFlatSpec` directly to sidestep that, same approach `WhiteboardModelSpec` takes.
