### PR TITLE
fix(html5): add real Panopto player to external video share

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/arc-player.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/arc-player.jsx
@@ -1,49 +1,11 @@
-import loadScript from 'load-script';
 import React, { Component } from 'react'
+import getSDK from './get-sdk';
 
 const MATCH_URL = new RegExp("https?:\/\/(.*)(instructuremedia.com)(\/embed)?\/([-abcdef0-9]+)");
 
 const SDK_URL = 'https://files.instructuremedia.com/instructure-media-script/instructure-media-1.1.0.js';
 
 const EMBED_PATH = "/embed/";
-
-// Util function to load an external SDK or return the SDK if it is already loaded
-// From https://github.com/CookPete/react-player/blob/master/src/utils.js
-const resolves = {};
-export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, fetchScript = loadScript) {
-  if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
-    return Promise.resolve(window[sdkGlobal])
-  }
-  return new Promise((resolve, reject) => {
-    // If we are already loading the SDK, add the resolve
-    // function to the existing array of resolve functions
-    if (resolves[url]) {
-      resolves[url].push(resolve);
-      return
-    }
-    resolves[url] = [resolve];
-    const onLoaded = sdk => {
-      // When loaded, resolve all pending promises
-      resolves[url].forEach(resolve => resolve(sdk))
-    };
-    if (sdkReady) {
-      const previousOnReady = window[sdkReady];
-      window[sdkReady] = function () {
-        if (previousOnReady) previousOnReady();
-        onLoaded(window[sdkGlobal])
-      }
-    }
-    fetchScript(url, err => {
-      if (err) {
-        reject(err);
-      }
-      window[sdkGlobal] = url;
-      if (!sdkReady) {
-        onLoaded(window[sdkGlobal])
-      }
-    })
-  })
-}
 
 export class ArcPlayer extends Component {
   static displayName = 'ArcPlayer';

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/get-sdk.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/get-sdk.js
@@ -1,0 +1,43 @@
+import loadScript from 'load-script';
+
+// Util function to load an external SDK or return the SDK if it is already loaded
+// From https://github.com/CookPete/react-player/blob/master/src/utils.js
+const resolves = {};
+export function getSDK(url, sdkGlobal, sdkReady = null, isLoaded = () => true,
+  fetchScript = loadScript) {
+  if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
+    return Promise.resolve(window[sdkGlobal]);
+  }
+  return new Promise((resolve, reject) => {
+    // If we are already loading the SDK, add the resolve
+    // function to the existing array of resolve functions
+    if (resolves[url]) {
+      resolves[url].push(resolve);
+      return;
+    }
+    resolves[url] = [resolve];
+    const onLoaded = (sdk) => {
+      // When loaded, resolve all pending promises
+      resolves[url].forEach((pendingResolve) => pendingResolve(sdk));
+    };
+    if (sdkReady) {
+      const previousOnReady = window[sdkReady];
+      window[sdkReady] = function onSDKReady() {
+        if (previousOnReady) previousOnReady();
+        onLoaded(window[sdkGlobal]);
+      };
+    }
+    fetchScript(url, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      window[sdkGlobal] = url;
+      if (!sdkReady) {
+        onLoaded(window[sdkGlobal]);
+      }
+    });
+  });
+}
+
+export default getSDK;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/get-sdk.js
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/get-sdk.js
@@ -3,22 +3,31 @@ import loadScript from 'load-script';
 // Util function to load an external SDK or return the SDK if it is already loaded
 // From https://github.com/CookPete/react-player/blob/master/src/utils.js
 const resolves = {};
+const rejects = {};
 export function getSDK(url, sdkGlobal, sdkReady = null, isLoaded = () => true,
   fetchScript = loadScript) {
   if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
     return Promise.resolve(window[sdkGlobal]);
   }
   return new Promise((resolve, reject) => {
-    // If we are already loading the SDK, add the resolve
-    // function to the existing array of resolve functions
+    // If we are already loading the SDK, add the resolve/reject
+    // functions to the existing arrays of pending handlers
     if (resolves[url]) {
       resolves[url].push(resolve);
+      rejects[url].push(reject);
       return;
     }
     resolves[url] = [resolve];
+    rejects[url] = [reject];
+    const flushQueues = () => {
+      const pending = { resolves: resolves[url] || [], rejects: rejects[url] || [] };
+      delete resolves[url];
+      delete rejects[url];
+      return pending;
+    };
     const onLoaded = (sdk) => {
       // When loaded, resolve all pending promises
-      resolves[url].forEach((pendingResolve) => pendingResolve(sdk));
+      flushQueues().resolves.forEach((pendingResolve) => pendingResolve(sdk));
     };
     if (sdkReady) {
       const previousOnReady = window[sdkReady];
@@ -29,7 +38,9 @@ export function getSDK(url, sdkGlobal, sdkReady = null, isLoaded = () => true,
     }
     fetchScript(url, (err) => {
       if (err) {
-        reject(err);
+        // Reject every pending caller and clear the queues so a later
+        // getSDK call for the same url starts a fresh load (retryable)
+        flushQueues().rejects.forEach((pendingReject) => pendingReject(err));
         return;
       }
       window[sdkGlobal] = url;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
@@ -4,7 +4,8 @@ import getSDK from './get-sdk';
 // Tenant-agnostic: matches any Panopto host (*.panopto.com, *.panopto.eu, self-hosted).
 // The host capture is restricted to hostname characters plus an optional numeric
 // port, so userinfo ("user@host") or other URL tricks can never reach the SDK.
-const MATCH_URL = /^https?:\/\/([a-zA-Z0-9.-]+(?::\d+)?)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)$/;
+// Extra query params after the id (&autoplay=false...) and fragments are allowed.
+const MATCH_URL = /^https?:\/\/([a-zA-Z0-9.-]+(?::\d+)?)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)(?:&[^#]*)?(?:#.*)?$/;
 
 const SDK_URL = 'https://developers.panopto.com/scripts/embedapi.min.js';
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
@@ -1,16 +1,238 @@
-const MATCH_URL = /https?\:\/\/([^\/]+\/Panopto)(\/Pages\/Viewer\.aspx\?id=)([-a-zA-Z0-9]+)/;
+import loadScript from 'load-script';
+import React, { Component } from 'react';
 
-export class Panopto {
+// Tenant-agnostic: matches any Panopto host (*.panopto.com, *.panopto.eu, self-hosted)
+const MATCH_URL = /https?:\/\/([^/]+)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)/;
+
+const SDK_URL = 'https://developers.panopto.com/scripts/embedapi.min.js';
+
+// The SDK script defines window.EmbedApi; 'PanoptoEmbedApi' is only the
+// loaded-flag key used by getSDK (it must differ from the real global,
+// which getSDK overwrites with the script URL).
+const SDK_GLOBAL = 'PanoptoEmbedApi';
+
+const PLAYER_STATE = {
+  ENDED: 0,
+  PLAYING: 1,
+  PAUSED: 2,
+};
+
+// Util function to load an external SDK or return the SDK if it is already loaded
+// From https://github.com/CookPete/react-player/blob/master/src/utils.js
+const resolves = {};
+export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, fetchScript = loadScript) {
+  if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
+    return Promise.resolve(window[sdkGlobal])
+  }
+  return new Promise((resolve, reject) => {
+    // If we are already loading the SDK, add the resolve
+    // function to the existing array of resolve functions
+    if (resolves[url]) {
+      resolves[url].push(resolve);
+      return
+    }
+    resolves[url] = [resolve];
+    const onLoaded = sdk => {
+      // When loaded, resolve all pending promises
+      resolves[url].forEach(resolve => resolve(sdk))
+    };
+    if (sdkReady) {
+      const previousOnReady = window[sdkReady];
+      window[sdkReady] = function () {
+        if (previousOnReady) previousOnReady();
+        onLoaded(window[sdkGlobal])
+      }
+    }
+    fetchScript(url, err => {
+      if (err) {
+        reject(err);
+      }
+      window[sdkGlobal] = url;
+      if (!sdkReady) {
+        onLoaded(window[sdkGlobal])
+      }
+    })
+  })
+}
+
+export class Panopto extends Component {
+  static displayName = 'Panopto';
 
   static canPlay = url => {
     return MATCH_URL.test(url)
   };
 
-  static getSocialUrl(url) {
-    const m = url.match(MATCH_URL);
-    return 'https://' + m[1] + '/Podcast/Social/' + m[3] + '.mp4';
+  constructor(props) {
+    super(props);
+
+    this.player = this;
+    this._player = null;
+
+    this.onIframeReady = this.onIframeReady.bind(this);
+    this.onReady = this.onReady.bind(this);
+    this.onStateChange = this.onStateChange.bind(this);
+  }
+
+  componentDidMount () {
+    this.props.onMount && this.props.onMount(this)
+  }
+
+  load() {
+    new Promise((resolve, reject) => {
+      this.render();
+      resolve();
+    })
+    .then(() => { return getSDK(SDK_URL, SDK_GLOBAL) })
+    .then(() => {
+      const m = this.props.url.match(MATCH_URL);
+
+      if (!m) {
+        return;
+      }
+
+      // The SDK builds the Embed.aspx iframe src itself, only from the
+      // regex-validated host (m[1]) and session id (m[2]) captured above -
+      // never from the raw user input - and drives it over postMessage.
+      this._player = new window.EmbedApi('panoptoPlayerContainer', {
+        width: '100%',
+        height: '100%',
+        serverName: m[1],
+        sessionId: m[2],
+        videoParams: {
+          // same semantics as the youtube playerVars autoplay: 1 - the embed
+          // starts on share and the presenter's onPlay broadcast follows
+          autoplay: true,
+          interactivity: 'none',
+          showtitle: false,
+          showbrand: false,
+          offerviewer: false,
+        },
+        events: {
+          onIframeReady: this.onIframeReady,
+          onReady: this.onReady,
+          onStateChange: this.onStateChange,
+        },
+      });
+    });
+  }
+
+  onIframeReady() {
+    // Dismiss the embed splash screen so the player loads and starts
+    // emitting state updates (required before any playback control works)
+    this._player.loadVideo();
+  }
+
+  onReady() {
+    this.props.onReady();
+  }
+
+  onStateChange(state) {
+    if (state === PLAYER_STATE.PLAYING) {
+      this.props.onPlay();
+    } else if (state === PLAYER_STATE.PAUSED) {
+      this.props.onPause();
+    } else if (state === PLAYER_STATE.ENDED) {
+      this.props.onEnded();
+    }
+  }
+
+  play() {
+    if (this._player) {
+      this._player.playVideo();
+    }
+  }
+
+  pause() {
+    if (this._player) {
+      this._player.pauseVideo();
+    }
+  }
+
+  stop() {
+    if (this._player) {
+      this._player.stopVideo();
+    }
+  }
+
+  seekTo(seconds) {
+    if (this._player) {
+      this._player.seekTo(seconds);
+    }
+  }
+
+  setVolume(fraction) {
+    if (this._player) {
+      this._player.setVolume(fraction);
+    }
+  }
+
+  getVolume() {
+    return this._player?.getVolume() ?? 1;
+  }
+
+  setLoop(loop) {
+  }
+
+  mute() {
+    if (this._player) {
+      this._player.muteVideo();
+    }
+  }
+
+  unmute() {
+    if (this._player) {
+      this._player.unmuteVideo();
+    }
+  }
+
+  isMuted() {
+    return this._player?.isMuted() ?? false;
+  }
+
+  getDuration() {
+    return this._player?.getDuration() ?? 0;
+  }
+
+  getCurrentTime () {
+    return this._player?.getCurrentTime() ?? 0;
+  }
+
+  getSecondsLoaded () {
+  }
+
+  getPlaybackRate () {
+    return this._player?.getPlaybackRate() ?? 1;
+  }
+
+  setPlaybackRate (rate) {
+    if (this._player) {
+      this._player.setPlaybackRate(rate);
+    }
+  }
+
+  render () {
+    const style = {
+      width: '100%',
+      height: '100%',
+      margin: 0,
+      padding: 0,
+      border: 0,
+      overflow: 'hidden',
+      backgroundColor: 'black',
+    };
+
+    return (
+      <div
+        key={this.props.url}
+        style={style}
+        id={"panoptoPlayerContainer"}
+        ref={(container) => {
+          this.container = container;
+        }}
+      >
+      </div>
+    )
   }
 }
 
 export default Panopto;
-

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
@@ -1,8 +1,10 @@
-import loadScript from 'load-script';
 import React, { Component } from 'react';
+import getSDK from './get-sdk';
 
-// Tenant-agnostic: matches any Panopto host (*.panopto.com, *.panopto.eu, self-hosted)
-const MATCH_URL = /^https?:\/\/([^/]+)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)$/;
+// Tenant-agnostic: matches any Panopto host (*.panopto.com, *.panopto.eu, self-hosted).
+// The host capture is restricted to hostname characters plus an optional numeric
+// port, so userinfo ("user@host") or other URL tricks can never reach the SDK.
+const MATCH_URL = /^https?:\/\/([a-zA-Z0-9.-]+(?::\d+)?)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)$/;
 
 const SDK_URL = 'https://developers.panopto.com/scripts/embedapi.min.js';
 
@@ -17,44 +19,8 @@ const PLAYER_STATE = {
   PAUSED: 2,
 };
 
-// Util function to load an external SDK or return the SDK if it is already loaded
-// From https://github.com/CookPete/react-player/blob/master/src/utils.js
-const resolves = {};
-export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, fetchScript = loadScript) {
-  if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
-    return Promise.resolve(window[sdkGlobal])
-  }
-  return new Promise((resolve, reject) => {
-    // If we are already loading the SDK, add the resolve
-    // function to the existing array of resolve functions
-    if (resolves[url]) {
-      resolves[url].push(resolve);
-      return
-    }
-    resolves[url] = [resolve];
-    const onLoaded = sdk => {
-      // When loaded, resolve all pending promises
-      resolves[url].forEach(resolve => resolve(sdk))
-    };
-    if (sdkReady) {
-      const previousOnReady = window[sdkReady];
-      window[sdkReady] = function () {
-        if (previousOnReady) previousOnReady();
-        onLoaded(window[sdkGlobal])
-      }
-    }
-    fetchScript(url, err => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      window[sdkGlobal] = url;
-      if (!sdkReady) {
-        onLoaded(window[sdkGlobal])
-      }
-    })
-  })
-}
+// Instance-specific suffix so two mounted players never share a DOM id
+let playerInstanceCount = 0;
 
 export class PanoptoPlayer extends Component {
   static displayName = 'PanoptoPlayer';
@@ -68,8 +34,8 @@ export class PanoptoPlayer extends Component {
 
     this.player = this;
     this._player = null;
-    // Instance-specific so two mounted players never share a DOM id
-    this.containerId = `panoptoPlayerContainer-${Math.random().toString(36).slice(2)}`;
+    playerInstanceCount += 1;
+    this.containerId = `panoptoPlayerContainer-${playerInstanceCount}`;
 
     this.onIframeReady = this.onIframeReady.bind(this);
     this.onReady = this.onReady.bind(this);

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/panopto.jsx
@@ -2,7 +2,7 @@ import loadScript from 'load-script';
 import React, { Component } from 'react';
 
 // Tenant-agnostic: matches any Panopto host (*.panopto.com, *.panopto.eu, self-hosted)
-const MATCH_URL = /https?:\/\/([^/]+)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)/;
+const MATCH_URL = /^https?:\/\/([^/]+)\/Panopto\/Pages\/Viewer\.aspx\?id=([-a-zA-Z0-9]+)$/;
 
 const SDK_URL = 'https://developers.panopto.com/scripts/embedapi.min.js';
 
@@ -46,6 +46,7 @@ export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, 
     fetchScript(url, err => {
       if (err) {
         reject(err);
+        return;
       }
       window[sdkGlobal] = url;
       if (!sdkReady) {
@@ -55,8 +56,8 @@ export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, 
   })
 }
 
-export class Panopto extends Component {
-  static displayName = 'Panopto';
+export class PanoptoPlayer extends Component {
+  static displayName = 'PanoptoPlayer';
 
   static canPlay = url => {
     return MATCH_URL.test(url)
@@ -67,6 +68,8 @@ export class Panopto extends Component {
 
     this.player = this;
     this._player = null;
+    // Instance-specific so two mounted players never share a DOM id
+    this.containerId = `panoptoPlayerContainer-${Math.random().toString(36).slice(2)}`;
 
     this.onIframeReady = this.onIframeReady.bind(this);
     this.onReady = this.onReady.bind(this);
@@ -93,7 +96,7 @@ export class Panopto extends Component {
       // The SDK builds the Embed.aspx iframe src itself, only from the
       // regex-validated host (m[1]) and session id (m[2]) captured above -
       // never from the raw user input - and drives it over postMessage.
-      this._player = new window.EmbedApi('panoptoPlayerContainer', {
+      this._player = new window.EmbedApi(this.containerId, {
         width: '100%',
         height: '100%',
         serverName: m[1],
@@ -113,6 +116,11 @@ export class Panopto extends Component {
           onStateChange: this.onStateChange,
         },
       });
+    })
+    .catch((err) => {
+      if (this.props.onError) {
+        this.props.onError(err);
+      }
     });
   }
 
@@ -198,6 +206,8 @@ export class Panopto extends Component {
   }
 
   getSecondsLoaded () {
+    // The Embed API does not expose buffered ranges
+    return 0;
   }
 
   getPlaybackRate () {
@@ -225,7 +235,7 @@ export class Panopto extends Component {
       <div
         key={this.props.url}
         style={style}
-        id={"panoptoPlayerContainer"}
+        id={this.containerId}
         ref={(container) => {
           this.container = container;
         }}
@@ -235,4 +245,4 @@ export class Panopto extends Component {
   }
 }
 
-export default Panopto;
+export default PanoptoPlayer;

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/custom-players/peertube.jsx
@@ -1,48 +1,10 @@
-import loadScript from 'load-script';
 import React, { Component } from 'react'
+import getSDK from './get-sdk';
 
 //To work with PeerTube >=v3.3 URL patterns
 const MATCH_URL = new RegExp("(https?)://(.*)(/videos/watch/|/w/)(.*)");
 
 const SDK_URL = 'https://unpkg.com/@peertube/embed-api@0.0.4/build/player.min.js';
-
-// Util function to load an external SDK or return the SDK if it is already loaded
-// From https://github.com/CookPete/react-player/blob/master/src/utils.js
-const resolves = {};
-export function getSDK (url, sdkGlobal, sdkReady = null, isLoaded = () => true, fetchScript = loadScript) {
-  if (window[sdkGlobal] && isLoaded(window[sdkGlobal])) {
-    return Promise.resolve(window[sdkGlobal])
-  }
-  return new Promise((resolve, reject) => {
-    // If we are already loading the SDK, add the resolve
-    // function to the existing array of resolve functions
-    if (resolves[url]) {
-      resolves[url].push(resolve);
-      return
-    }
-    resolves[url] = [resolve];
-    const onLoaded = sdk => {
-      // When loaded, resolve all pending promises
-      resolves[url].forEach(resolve => resolve(sdk))
-    };
-    if (sdkReady) {
-      const previousOnReady = window[sdkReady];
-      window[sdkReady] = function () {
-        if (previousOnReady) previousOnReady();
-        onLoaded(window[sdkGlobal])
-      }
-    }
-    fetchScript(url, err => {
-      if (err) {
-        reject(err);
-      }
-      window[sdkGlobal] = url;
-      if (!sdkReady) {
-        onLoaded(window[sdkGlobal])
-      }
-    })
-  })
-}
 
 export class PeerTubePlayer extends Component {
   static displayName = 'PeerTubePlayer';

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -42,6 +42,7 @@ import { calculateCurrentTime } from '/imports/ui/components/external-video-play
 
 import PeerTube from '../custom-players/peertube';
 import { ArcPlayer } from '../custom-players/arc-player';
+import Panopto from '../custom-players/panopto';
 import getStorageSingletonInstance from '/imports/ui/services/storage';
 
 const AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS = 5;
@@ -97,6 +98,8 @@ interface ExternalVideoPlayerProps {
 Styled.VideoPlayer.addCustomPlayer(PeerTube);
 // @ts-ignore - ArcPlayer is not typed
 Styled.VideoPlayer.addCustomPlayer(ArcPlayer);
+// @ts-ignore - Panopto is not typed
+Styled.VideoPlayer.addCustomPlayer(Panopto);
 
 const truncateTime = (time: number) => (time < 1 ? 0 : time);
 

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/component.tsx
@@ -38,7 +38,6 @@ const intlMessages = defineMessages({
 });
 
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
-const PANOPTO_MATCH_URL = /https?:\/\/([^/]+\/Panopto)(\/Pages\/Viewer\.aspx\?id=)([-a-zA-Z0-9]+)/;
 
 const YOUTUBE_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com|youtu.be)\/.+$/);
 
@@ -68,11 +67,6 @@ const ExternalVideoPlayerModal: React.FC<ExternalVideoPlayerModalProps> = ({
     if (YOUTUBE_SHORTS_REGEX.test(url)) {
       const shortsUrl = url.replace('shorts/', 'watch?v=');
       externalVideoUrl = shortsUrl;
-    } else if (PANOPTO_MATCH_URL.test(url)) {
-      const m = url.match(PANOPTO_MATCH_URL);
-      if (m && m.length >= 4) {
-        externalVideoUrl = `https://${m[1]}/Podcast/Social/${m[3]}.mp4`;
-      }
     }
 
     if (YOUTUBE_REGEX.test(externalVideoUrl)) {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/service.ts
@@ -1,23 +1,23 @@
 import ReactPlayer from 'react-player';
 
-import { Panopto } from '../../custom-players/panopto';
+import { PanoptoPlayer } from '../../custom-players/panopto';
 
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
 
-const DAILYMOTION_MATCH_URL = /https?:\/\/(?:www\.)?dailymotion\.com\/video\/[a-zA-Z0-9]+(?:\?[^\s]*)?/g;
+const DAILYMOTION_MATCH_URL = /https?:\/\/(?:www\.)?dailymotion\.com\/video\/[a-zA-Z0-9]+(?:\?[^\s]*)?/;
 
 export const isUrlValid = (url: string) => {
   if (YOUTUBE_SHORTS_REGEX.test(url)) {
     const shortsUrl = url.replace('shorts/', 'watch?v=');
 
-    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || Panopto.canPlay(url));
+    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || PanoptoPlayer.canPlay(url));
   }
 
   if (DAILYMOTION_MATCH_URL.test(url)) {
     return false; // Dailymotion is not supported by react-player https://github.com/cookpete/react-player/issues/1772
   }
 
-  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || Panopto.canPlay(url));
+  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || PanoptoPlayer.canPlay(url));
 };
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/service.ts
@@ -1,7 +1,5 @@
 import ReactPlayer from 'react-player';
 
-import { PanoptoPlayer } from '../../custom-players/panopto';
-
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
 
 const DAILYMOTION_MATCH_URL = /https?:\/\/(?:www\.)?dailymotion\.com\/video\/[a-zA-Z0-9]+(?:\?[^\s]*)?/;
@@ -10,14 +8,14 @@ export const isUrlValid = (url: string) => {
   if (YOUTUBE_SHORTS_REGEX.test(url)) {
     const shortsUrl = url.replace('shorts/', 'watch?v=');
 
-    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || PanoptoPlayer.canPlay(url));
+    return /^https.*$/.test(shortsUrl) && ReactPlayer.canPlay(shortsUrl);
   }
 
   if (DAILYMOTION_MATCH_URL.test(url)) {
     return false; // Dailymotion is not supported by react-player https://github.com/cookpete/react-player/issues/1772
   }
 
-  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || PanoptoPlayer.canPlay(url));
+  return /^https.*$/.test(url) && ReactPlayer.canPlay(url);
 };
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/modal/service.ts
@@ -1,7 +1,8 @@
 import ReactPlayer from 'react-player';
 
+import { Panopto } from '../../custom-players/panopto';
+
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
-const PANOPTO_MATCH_URL = /https?:\/\/([^/]+\/Panopto)(\/Pages\/Viewer\.aspx\?id=)([-a-zA-Z0-9]+)/;
 
 const DAILYMOTION_MATCH_URL = /https?:\/\/(?:www\.)?dailymotion\.com\/video\/[a-zA-Z0-9]+(?:\?[^\s]*)?/g;
 
@@ -9,14 +10,14 @@ export const isUrlValid = (url: string) => {
   if (YOUTUBE_SHORTS_REGEX.test(url)) {
     const shortsUrl = url.replace('shorts/', 'watch?v=');
 
-    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || PANOPTO_MATCH_URL.test(url));
+    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || Panopto.canPlay(url));
   }
 
   if (DAILYMOTION_MATCH_URL.test(url)) {
     return false; // Dailymotion is not supported by react-player https://github.com/cookpete/react-player/issues/1772
   }
 
-  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || PANOPTO_MATCH_URL.test(url));
+  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || Panopto.canPlay(url));
 };
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.ts
@@ -1,6 +1,5 @@
 import ReactPlayer from 'react-player';
 
-import { PanoptoPlayer } from './custom-players/panopto';
 import { ExternalVideo } from '/imports/ui/Types/meeting';
 
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
@@ -9,10 +8,10 @@ const isUrlValid = (url: string) => {
   if (YOUTUBE_SHORTS_REGEX.test(url)) {
     const shortsUrl = url.replace('shorts/', 'watch?v=');
 
-    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || PanoptoPlayer.canPlay(shortsUrl));
+    return /^https.*$/.test(shortsUrl) && ReactPlayer.canPlay(shortsUrl);
   }
 
-  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || PanoptoPlayer.canPlay(url));
+  return /^https.*$/.test(url) && ReactPlayer.canPlay(url);
 };
 
 // Convert state (Number) to playing (Boolean)

--- a/bigbluebutton-html5/imports/ui/components/external-video-player/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/service.ts
@@ -1,6 +1,6 @@
 import ReactPlayer from 'react-player';
 
-import { Panopto } from './custom-players/panopto';
+import { PanoptoPlayer } from './custom-players/panopto';
 import { ExternalVideo } from '/imports/ui/Types/meeting';
 
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
@@ -9,10 +9,10 @@ const isUrlValid = (url: string) => {
   if (YOUTUBE_SHORTS_REGEX.test(url)) {
     const shortsUrl = url.replace('shorts/', 'watch?v=');
 
-    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || Panopto.canPlay(shortsUrl));
+    return /^https.*$/.test(shortsUrl) && (ReactPlayer.canPlay(shortsUrl) || PanoptoPlayer.canPlay(shortsUrl));
   }
 
-  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || Panopto.canPlay(url));
+  return /^https.*$/.test(url) && (ReactPlayer.canPlay(url) || PanoptoPlayer.canPlay(url));
 };
 
 // Convert state (Number) to playing (Boolean)

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/smart-video-share/container.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useMutation } from '@apollo/client';
 import { SmartMediaShare } from './component';
-import Panopto from '../../../external-video-player/custom-players/panopto';
 import { EXTERNAL_VIDEO_START } from '../../../external-video-player/mutations';
 
 const YOUTUBE_SHORTS_REGEX = new RegExp(/^(?:https?:\/\/)?(?:www\.)?(youtube\.com\/shorts)\/.+$/);
@@ -15,8 +14,6 @@ const SmartMediaShareContainer = (props) => {
     if (YOUTUBE_SHORTS_REGEX.test(url)) {
       const shortsUrl = url.replace('shorts/', 'watch?v=');
       externalVideoUrl = shortsUrl;
-    } else if (Panopto.canPlay(url)) {
-      externalVideoUrl = Panopto.getSocialUrl(url);
     }
 
     startExternalVideo({ variables: { externalVideoUrl } });


### PR DESCRIPTION
## What's happening

When a presenter shares a Panopto link via **Share External Video**, the player area goes black and the browser shows *"No video with supported format and MIME type found."* The video never plays. This affects any Panopto tenant where the "Public Podcast" download feature is disabled - which is Panopto's default.

## Why it breaks

BBB has no real Panopto player. A legacy hack rewrites the shared `Viewer.aspx?id=<id>` URL into a direct `Podcast/Social/<id>.mp4` download URL and hands that to ReactPlayer's FilePlayer (`<video src>`). On most Panopto tenants that download endpoint returns **HTTP 403 with `content-type: text/html`** (the "Public Podcast" feature is off by default), so the `<video>` element receives HTML instead of media and fails with a format/MIME error.

The video itself is publicly reachable - `Viewer.aspx` and `Embed.aspx` both return 200. The bug is entirely that BBB routes playback through an endpoint most tenants keep closed.

## The fix

Replace the URL rewrite with a **real Panopto custom player**, following the same pattern already used in-repo by PeerTube and ArcPlayer (`ReactPlayer.addCustomPlayer`):

- `external-video-player/custom-players/panopto.jsx` - rewritten from a 16-line stub-with-rewrite into a full custom player that loads the official Panopto Embed SDK, which creates the `Embed.aspx` iframe and drives it via `postMessage` (play / pause / seek / volume / mute / getCurrentTime / getDuration / playback rate).
- `external-video-player-graphql/component.tsx` - registers `Panopto` alongside PeerTube/ArcPlayer.
- `modal/component.tsx` + `presentation-toolbar/smart-video-share/container.jsx` - the `Podcast/Social.mp4` rewrite is removed; the original Viewer URL is shared unchanged.
- `modal/service.ts` - validation now calls `Panopto.canPlay` (single regex source, consolidated).

The host regex is **tenant-agnostic** (`[^/]+/Panopto/Pages/Viewer.aspx`), covering `*.panopto.com`, `*.panopto.eu`, and self-hosted instances. The embed iframe `src` is built only from the regex-validated host and session id capture groups - never from raw user input.

## Prior art / coordination

Upstream PR 24120 ("First real implementation of Panopto Player", base `v4.0.x-release`, open) goes the same direction but has two gaps this PR avoids: its `canPlay` only matches `panopto.com` (would still miss this issue's `.eu` instance), and its `getCurrentTime`/`getDuration` are stubbed to `null`, which breaks presenter-viewer sync. This PR targets the `3.0` line (where the bug was reported, BBB 3.0.22) with a complete implementation.

## Evidence

Before the fix - dead player (the bug):

![Before fix: Panopto share shows dead black player](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-08/5b1fc3ea-9128-402b-95e6-3b5f081589f0/before_panopto_t2.png)

After the fix - the Panopto embed plays inside the BBB player. The demo recording is itself a near-static Panopto screencast, but the player controls and progressing timestamp are visible at 00:17. Preview GIF below - click it to open the full-quality MP4 with controls:

[![Panopto embed playing after fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-08/10c32908-02b3-44bf-ac5b-36a91f97bea8/pr-demo.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-08/d62628ce-a5ae-47fd-a728-a2e651abffbc/pr-demo.mp4)

Timestamps in the MP4:
- 00:08 - Share External Video modal, Panopto URL entered
- 00:17 - Panopto embed playing (player controls + timestamp 0:04/0:21 visible)
- 00:17-00:28 - playback progresses (scenes change)
- 00:36 - YouTube regression check (still plays)

## Scope / limitations

- Validated: BBB 3.0 from-source, desktop Chromium, presenter single-user, Panopto embed playing, YouTube regression.
- Not covered by this validation: mobile client, second viewer (sync multi-viewer), audible audio, and private Panopto videos (Embed.aspx shows Panopto's login in-iframe; sync works only for authenticated viewers - still better than a dead player). Only the issue's tenant (`falmouth.cloud.panopto.eu`) was tested live; the regex covers other hosts by construction.

Closes #25384
