### PR TITLE
fix(bbb-web): render a response when insertDocument body has no presentation module

### DIFF
--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1209,6 +1209,19 @@ class ApiController {
                     RESP_CODE_FAILED), contentType: "text/xml")
           }
         }
+      } else {
+        withFormat {
+          xml {
+            render(text: responseBuilder.buildInsertDocumentResponse(
+                    "Request body must contain a presentation module with at least one document.",
+                    RESP_CODE_FAILED), contentType: "text/xml")
+          }
+          '*' {
+            render(text: responseBuilder.buildInsertDocumentResponse(
+                    "Request body must contain a presentation module with at least one document.",
+                    RESP_CODE_FAILED), contentType: "text/xml")
+          }
+        }
       }
     }else {
       log.warn("Meeting with externalID ${externalMeetingId} doesn't exist.")
@@ -1582,7 +1595,7 @@ class ApiController {
     if (!xmlModules.containsKey("presentation")) {
       if (isFromInsertAPI) {
         log.warn("Insert Document API called without a payload - ignoring")
-        return;
+        return false;
       }
 
      if (hasPresentationUrlInParameter) {


### PR DESCRIPTION
### What does this PR do?

Fixes `insertDocument` so it always renders BigBlueButton's XML response contract, instead of silently falling through to a framework 500 page when the request body has no `<module name="presentation">` element.

`uploadDocuments()` had three possible outcomes but the call site in `insertDocument` only checked two of them:
- `true` → success, renders `SUCCESS`
- `false` (presentation feature disabled) → renders `FAILED` with a specific message
- a bare `return;` (Groovy → `null`) when the body has no presentation module → matched **neither** branch, so `insertDocument` returned without calling `render(...)` at all

With nothing rendered, Grails falls back to resolving a view for the action, finds none, and the caller gets a bare HTTP 500 with no XML body — instead of the documented `<response><returncode>FAILED</returncode>...</response>` format every other failure path in this API returns.

This PR:
- Changes the missing-payload path in `uploadDocuments()` to `return false` explicitly instead of an implicit null return.
- Adds the missing `else` branch in `insertDocument` that renders a `FAILED` response naming the actual problem ("Request body must contain a presentation module with at least one document.").

### Motivation

Any integrator who calls `insertDocument` with an empty, malformed, or wrong-module-name body currently gets an opaque 500 with no BBB error payload — nothing actionable to log or branch on, and no indication of what part of the request was wrong.

### How to test

1. Create a meeting and note its `meetingID`.
2. Call `insertDocument` with a POST body that has no `presentation` module, e.g.:
   ```bash
   curl -s -X POST "https://{your-host}/bigbluebutton/api/insertDocument?meetingID={meetingID}&checksum={checksum}" \
     --header "Content-Type: application/xml" --data '<modules><module name="not-presentation"/></modules>'