### PR TITLE
feat(audio): add deafenAudioUntilExplicitJoin setting to restore pre-3.0 close-modal behavior

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -42,6 +42,7 @@ export interface App {
   forceListenOnly: boolean
   skipCheck: boolean
   skipCheckOnJoin: boolean
+  deafenAudioUntilExplicitJoin: boolean
   enableDynamicAudioDeviceSelection: boolean
   clientTitle: string
   bbbServerVersion: string

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -89,6 +89,21 @@ const AudioControls: React.FC<AudioControlsProps> = ({
   }, [openAudioModal, closeAudioModal]);
 
   const handleJoinAudio = useCallback((connected: boolean) => {
+    // Clicking "Join audio" is the explicit opt-in that overrides the
+    // deafenAudioUntilExplicitJoin deafen-at-join-time behavior.
+    AudioManager.requestAudioJoin();
+
+    // With deafenAudioUntilExplicitJoin the user may already be connected to the
+    // audio bridge but deafened (transparent listen-only connects on entry, and
+    // we deafen at join time). In that case joining audio just means undeafening
+    // - the connection already exists, so we reuse it instead of reopening the
+    // modal.
+    // @ts-ignore - hybrid meteor/graphql accessor
+    if (AudioManager.isConnected && AudioManager.isDeafened) {
+      AudioManager.setDeafened(false);
+      return;
+    }
+
     if (connected) {
       joinListenOnly();
     } else {

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/component.tsx
@@ -97,10 +97,15 @@ const AudioControls: React.FC<AudioControlsProps> = ({
     // audio bridge but deafened (transparent listen-only connects on entry, and
     // we deafen at join time). In that case joining audio just means undeafening
     // - the connection already exists, so we reuse it instead of reopening the
-    // modal.
+    // modal. We re-enter onAudioJoin (deafened: false) rather than only flipping
+    // the deafened flag: the initial deafened join returns early and skips the
+    // post-join steps (device selection, monitor, "started" event), so those must
+    // run now that the user opted in. onAudioJoin is idempotent for this path -
+    // the skipped steps run exactly once.
     // @ts-ignore - hybrid meteor/graphql accessor
     if (AudioManager.isConnected && AudioManager.isDeafened) {
-      AudioManager.setDeafened(false);
+      // @ts-ignore - hybrid meteor/graphql accessor
+      AudioManager.onAudioJoin({ deafened: false });
       return;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/component.jsx
@@ -25,6 +25,7 @@ import {
 } from '/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service';
 import Session from '/imports/ui/services/storage/in-memory';
 import logger from '/imports/startup/client/logger';
+import AudioManager from '/imports/ui/services/audio-manager';
 
 const propTypes = {
   intl: PropTypes.shape({
@@ -88,6 +89,7 @@ const propTypes = {
   supportsTransparentListenOnly: PropTypes.bool.isRequired,
   getAudioConstraints: PropTypes.func.isRequired,
   isTranscriptionEnabled: PropTypes.bool.isRequired,
+  userSettingsReady: PropTypes.bool,
 };
 
 const intlMessages = defineMessages({
@@ -217,6 +219,7 @@ const AudioModal = ({
   isTranscriptionEnabled,
   updateInputDevices,
   updateOutputDevices,
+  userSettingsReady = true,
 }) => {
   const [content, setContent] = useState(initialContent);
   const [hasError, setHasError] = useState(false);
@@ -424,6 +427,9 @@ const AudioModal = ({
     if (inputStream) changeInputStream(inputStream);
 
     if (!isConnected) {
+      // Confirming the audio settings is an explicit opt-in to hear audio, so it
+      // must override deafenAudioUntilExplicitJoin's deafen-at-join-time behavior.
+      AudioManager.requestAudioJoin();
       handleJoinMicrophone();
       disableAwayMode();
     } else {
@@ -498,10 +504,17 @@ const AudioModal = ({
     );
   };
 
+  const handleEchoTestYes = () => {
+    // Confirming the echo test is an explicit opt-in to hear audio, so it must
+    // override deafenAudioUntilExplicitJoin's deafen-at-join-time behavior.
+    AudioManager.requestAudioJoin();
+    handleJoinMicrophone();
+  };
+
   const renderEchoTest = () => (
     <EchoTest
       handleNo={handleGoToAudioSettings}
-      handleYes={handleJoinMicrophone}
+      handleYes={handleEchoTestYes}
     />
   );
 
@@ -658,6 +671,12 @@ const AudioModal = ({
   };
 
   useEffect(() => {
+    // Wait for the per-user settings to load before triggering any automatic
+    // audio join. The deafen-at-join-time decision (see AudioManager.onAudioJoin,
+    // deafenAudioUntilExplicitJoin) reads those settings, and joining before they
+    // resolve could read a stale default and leave the user undeafened.
+    if (!userSettingsReady) return;
+
     if (!isUsingAudio) {
       if (forceListenOnlyAttendee || audioLocked) {
         handleJoinListenOnly();
@@ -685,6 +704,7 @@ const AudioModal = ({
       }
     }
   }, [
+    userSettingsReady,
     audioLocked,
     isUsingAudio,
     forceListenOnlyAttendee,

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -3,6 +3,7 @@ import { useReactiveVar } from '@apollo/client';
 import { isEqual } from 'radash';
 import browserInfo from '/imports/utils/browserInfo';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import { useUserSettingsReady } from '/imports/ui/core/local-states/useUserSettings';
 import AudioModal from './component';
 import AudioError from '/imports/ui/services/audio-manager/error-codes';
 import AppService from '/imports/ui/components/app/service';
@@ -59,6 +60,8 @@ const AudioModalContainer = (props) => {
     APP_CONFIG.skipEchoTestIfPreviousDevice,
   ) && !deviceInfo.isMobile;
   const autoJoin = getFromUserSettings('bbb_auto_join_audio', APP_CONFIG.autoJoin);
+  const deafenAudioUntilExplicitJoin = getFromUserSettings('bbb_deafen_audio_until_explicit_join', APP_CONFIG.deafenAudioUntilExplicitJoin);
+  const [userSettingsReady] = useUserSettingsReady();
 
   let formattedDialNum = '';
   let formattedTelVoice = '';
@@ -120,17 +123,33 @@ const AudioModalContainer = (props) => {
     const callback = () => {
       setIsOpen(false);
 
-      // When using LiveKit, force joining audio when the modal is closed,
-      // but the user is not connected nor connecting to audio. This also means
-      // that the user will join muted as not clicking "Join Audio" signals
-      // that intention.
-      if (usingLiveKit && !isConnected && !isConnecting) {
+      if (!usingLiveKit) return;
+
+      // When deafenAudioUntilExplicitJoin is enabled, closing the modal means "no
+      // audio". Joining is not optional at the client level with LiveKit
+      // (transparent listen-only connects the user on entry), so the user was
+      // already deafened at join time (see AudioManager.onAudioJoin). Closing
+      // the modal must not force an audio join - just leave them deafened.
+      if (deafenAudioUntilExplicitJoin) return;
+
+      // Default 3.0 behavior: force joining audio when the modal is closed but
+      // the user is not connected nor connecting to audio. This also means that
+      // the user will join muted as not clicking "Join Audio" signals that
+      // intention.
+      if (!isConnected && !isConnecting) {
         joinMic({ muteOnStart: true }).catch((error) => handleJoinError(error, false));
       }
     };
 
     closeModal(callback);
-  }, [isConnected, isConnecting, usingLiveKit, joinMic, setIsOpen]);
+  }, [
+    deafenAudioUntilExplicitJoin,
+    isConnected,
+    isConnecting,
+    usingLiveKit,
+    joinMic,
+    setIsOpen,
+  ]);
   const isTranscriptionEnabled = useIsAudioTranscriptionEnabled();
 
   if (!currentUserData) return null;
@@ -173,6 +192,7 @@ const AudioModalContainer = (props) => {
       combinedDialInNum={combinedDialInNum}
       audioLocked={userLocks.userMic}
       autoJoin={autoJoin}
+      userSettingsReady={userSettingsReady}
       skipCheck={skipCheck}
       skipCheckOnJoin={skipCheckOnJoin}
       isMobileNative={navigator.userAgent.toLowerCase().includes('bbbnative')}

--- a/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { setUserSettings } from '/imports/ui/core/local-states/useUserSettings';
+import { setUserSettings, setUserSettingsReady } from '/imports/ui/core/local-states/useUserSettings';
 import { setUseCurrentLocale } from '/imports/ui/core/local-states/useCurrentLocale';
 import BBBWeb from '/imports/api/bbb-web-api';
 import Session from '/imports/ui/services/storage/in-memory';
@@ -71,6 +71,10 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
             });
             const mergedSettings = filteredData.reduce((acc, item) => Object.assign(acc, item), {});
             setUserSettings(mergedSettings);
+            // Signal that per-user settings are resolved. Consumers gated on this
+            // (e.g. the audio auto-join deafen decision) can now safely read them
+            // instead of falling back to defaults.
+            setUserSettingsReady(true);
             if (typeof mergedSettings.bbb_override_default_locale === 'string') {
               setUseCurrentLocale(mergedSettings.bbb_override_default_locale);
             }

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -12,6 +12,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       forceListenOnly: false,
       skipCheck: false,
       skipCheckOnJoin: false,
+      deafenAudioUntilExplicitJoin: false,
       enableDynamicAudioDeviceSelection: true,
       clientTitle: 'BigBlueButton',
       bbbServerVersion: 'HTML5_FULL_BBB_VERSION',

--- a/bigbluebutton-html5/imports/ui/core/local-states/useUserSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/local-states/useUserSettings.ts
@@ -4,8 +4,16 @@ type genericObject = {[key:string]: boolean | string | string [] | undefined};
 const initialUserSettings: genericObject = {};
 const [useUserSettings, setUserSettings, localUserSettings] = createUseLocalState<genericObject>(initialUserSettings);
 
+// Tracks whether the per-user settings (userdata) have finished loading from
+// GraphQL. getFromUserSettings falls back to defaults until this is true, so
+// consumers whose behavior depends on a setting being resolved (e.g. the audio
+// auto-join deafen decision) should wait for it before acting on that setting.
+const [useUserSettingsReady, setUserSettingsReady] = createUseLocalState<boolean>(false);
+
 export default useUserSettings;
 export {
   setUserSettings,
   localUserSettings,
+  useUserSettingsReady,
+  setUserSettingsReady,
 };

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -24,6 +24,7 @@ import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import { makeVar } from '@apollo/client';
 import { hasMediaDevicesEventTarget } from '/imports/ui/services/webrtc-base/utils';
 import AudioErrors from '/imports/ui/services/audio-manager/error-codes';
+import getFromUserSettings from '/imports/ui/services/users-settings';
 import GrahqlSubscriptionStore, { stringToHash } from '/imports/ui/core/singletons/subscriptionStore';
 import VOICE_ACTIVITY from '../../core/graphql/queries/voiceActivity';
 import {
@@ -123,6 +124,10 @@ class AudioManager {
     this.BREAKOUT_AUDIO_TRANSFER_STATES = BREAKOUT_AUDIO_TRANSFER_STATES;
     this._voiceActivityObserver = null;
     this._inputStreamInactivityTrackers = new Map();
+    // Tracks whether the user explicitly opted into hearing audio. When
+    // deafenAudioUntilExplicitJoin is enabled, the forced/transparent audio join is
+    // deafened at join time unless this is set (see onAudioJoin/requestAudioJoin).
+    this.audioJoinRequestedByUser = false;
 
     this.handlePlayElementFailed = this.handlePlayElementFailed.bind(this);
     this.monitor = this.monitor.bind(this);
@@ -770,9 +775,23 @@ class AudioManager {
     }
   }
 
-  onAudioJoin({ deafened = false } = {}) {
+  onAudioJoin({ deafened } = {}) {
+    // When deafenAudioUntilExplicitJoin is enabled, joining audio must not make the
+    // user hear anyone until they explicitly opt in. The bridge connection
+    // itself is not optional (transparent listen-only connects the user on
+    // entry), so instead of joining and then hearing audio, we deafen at join
+    // time. An explicit "Join audio" action - see requestAudioJoin - overrides
+    // this. The default (flag off) behavior is unchanged: deafened stays false.
+    const deafenAudioUntilExplicitJoin = getFromUserSettings(
+      'bbb_deafen_audio_until_explicit_join',
+      window.meetingClientSettings.public.app.deafenAudioUntilExplicitJoin,
+    );
+    const shouldDeafen = deafened
+      ?? (deafenAudioUntilExplicitJoin
+        && this.isUsingLiveKit()
+        && !this.audioJoinRequestedByUser);
     this.isConnected = true;
-    this.isDeafened = deafened;
+    this.isDeafened = shouldDeafen;
     this.isConnecting = false;
     this.isHangingUp = false;
     const STATS = window.meetingClientSettings.public.stats;
@@ -780,7 +799,7 @@ class AudioManager {
     // If the user is deafened, we don't want to proceed any further until
     // undeafened. Callers that specify deafened = true should handle this case
     // accordingly by calling this method again when the user is undeafened.
-    if (deafened) return;
+    if (shouldDeafen) return;
 
     try {
       if (!this.isListenOnly) {
@@ -881,6 +900,7 @@ class AudioManager {
     this.isHangingUp = false;
     this.autoplayBlocked = false;
     this.isDeafened = true;
+    this.audioJoinRequestedByUser = false;
     this.failedMediaElements = [];
 
     if (this.inputStream && this.bridge?.bridgeName !== 'livekit') {
@@ -1397,6 +1417,24 @@ class AudioManager {
 
   unmute() {
     this.setSenderTrackEnabled(true);
+  }
+
+  // Deafen/undeafen the local user. Deafening is the "no audio" state: the
+  // reactive isDeafened var drives the LiveKit layer to unsubscribe from remote
+  // audio (see useMediaSubscriptions) and to push the deafened state to the
+  // server (see the LiveKit component's userSetDeafened effect). When
+  // deafenAudioUntilExplicitJoin is enabled the user is deafened at join time, and
+  // undeafening them (setDeafened(false)) is how an explicit "Join audio" click
+  // makes them start hearing audio while reusing the existing bridge connection.
+  setDeafened(deafened = true) {
+    this.isDeafened = deafened;
+  }
+
+  // Records that the user explicitly asked to join/hear audio. Consumed by
+  // onAudioJoin so the deafenAudioUntilExplicitJoin deafen-at-join-time behavior is
+  // overridden once the user opts in. Reset on audio exit.
+  requestAudioJoin() {
+    this.audioJoinRequestedByUser = true;
   }
 
   playAlertSound(url) {

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1419,17 +1419,6 @@ class AudioManager {
     this.setSenderTrackEnabled(true);
   }
 
-  // Deafen/undeafen the local user. Deafening is the "no audio" state: the
-  // reactive isDeafened var drives the LiveKit layer to unsubscribe from remote
-  // audio (see useMediaSubscriptions) and to push the deafened state to the
-  // server (see the LiveKit component's userSetDeafened effect). When
-  // deafenAudioUntilExplicitJoin is enabled the user is deafened at join time, and
-  // undeafening them (setDeafened(false)) is how an explicit "Join audio" click
-  // makes them start hearing audio while reusing the existing bridge connection.
-  setDeafened(deafened = true) {
-    this.isDeafened = deafened;
-  }
-
   // Records that the user explicitly asked to join/hear audio. Consumed by
   // onAudioJoin so the deafenAudioUntilExplicitJoin deafen-at-join-time behavior is
   // overridden once the user opts in. Reset on audio exit.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -17,6 +17,14 @@ public:
     # again or reloading page and joining mic again.
     # This setting won't have effect if skipCheck = true
     skipCheckOnJoin: false
+    # When true, the user hears no audio until they explicitly join (click "Join
+    # audio"), restoring the pre-3.0 behavior where the user could end up with no
+    # audio. With LiveKit the audio bridge connection is not optional (transparent
+    # listen-only connects on entry), so instead of avoiding the connection the
+    # user is deafened at join time and undeafened only on an explicit join.
+    # Default false preserves the current 3.0 behavior (the user hears audio once
+    # the modal is closed).
+    deafenAudioUntilExplicitJoin: false
     #
     # Allow users to change microphone/speaker dynamically
     # The device is changed immediately, without the need to rejoin


### PR DESCRIPTION
## Summary

Restores the pre-3.0 (2.7) behavior where the user does not join audio unless they explicitly choose to. Adds a new setting `deafenAudioUntilExplicitJoin` (boolean, default `false`).

When `deafenAudioUntilExplicitJoin: true`, the user joins the LiveKit bridge **deafened at join time** - they never hear audio until they explicitly click "Join audio" in the toolbar.

Closes #25346

## Problem

In BBB 2.7, dismissing the initial audio modal let users stay in the session without any audio connection. In 3.0+ with LiveKit, the user is auto-connected to the bridge (muted) on entry (transparent listen-only), so closing the modal could not prevent the connection.

Thanks to @prlanzarin for the key insight that joining is not optional at the client level with LiveKit, and to @TiagoJacobs for the suggestion to deafen at join time and to rename the setting to reflect what it actually does.

## Implementation

The user joins the LiveKit bridge **deafened at join time** when `deafenAudioUntilExplicitJoin: true`. The deafen is applied in `AudioManager.onAudioJoin`, the single chokepoint where `isDeafened` flips to `false`. An explicit "Join audio" action calls `AudioManager.onAudioJoin({ deafened: false })` to re-enter the join flow, which runs all post-join steps (device setup, monitor, started event) exactly once and undeafens, reusing the existing bridge connection.

The auto-join that triggers the deafen decision is gated on a `userSettingsReady` signal, so it cannot fire on a stale default during the async graphql user-settings load window.

### Changes

9 files, +120/-11:
- `private/config/settings.yml` - new `public.app.deafenAudioUntilExplicitJoin: false`
- `imports/ui/Types/meetingClientSettings.ts` - `deafenAudioUntilExplicitJoin: boolean`
- `imports/ui/core/initial-values/meetingClientSettings.ts` - default `false`
- `imports/ui/services/audio-manager/index.js` - `onAudioJoin` applies `deafened` based on the setting (unless `requestAudioJoin` was set); `requestAudioJoin()` method and flag
- `imports/ui/components/audio/audio-modal/container.jsx` - reads `useUserSettingsReady`, threads to component
- `imports/ui/components/audio/audio-modal/component.jsx` - auto-join useEffect early-returns until `userSettingsReady`; explicit join paths set `requestAudioJoin`
- `imports/ui/components/audio/audio-graphql/audio-controls/component.tsx` - toolbar "Join audio" on a connected-but-deafened user calls `onAudioJoin({ deafened: false })` (re-enters join flow, runs post-join steps)
- `imports/ui/components/custom-users-settings/component.tsx` - sets `userSettingsReady` after applying GraphQL userdata
- `imports/ui/core/local-states/useUserSettings.ts` - new `userSettingsReady` reactive signal

## Validation

Validated on a BBB 3.0 from-source dev environment (LiveKit, media confirmed working) with Playwright. The authoritative signal is per-peer-connection WebRTC inbound-rtp stats (conference tracks) + AudioManager state instrumentation (spies on post-join methods):

| Phase | Test A `deafenAudioUntilExplicitJoin=true` | Test B `=false` (default) |
|---|---|---|
| auto-join (first join) | 0 conference tracks (deafened since join), post-join steps skipped | 1 track, hearing, post-join steps ran |
| after explicit Join Audio | 1 track, hearing, post-join steps ran exactly once (started, monitor, changeOutputDevice) | 1 track, hearing |

Build: `bbb-html5/deploy.sh` rc=0, served bundle carries `deafenAudioUntilExplicitJoin` + `requestAudioJoin` + `onAudioJoin`.

## Known limitations

- `user_voice.deafened` stays `false` in the DB for LiveKit users (pre-existing inconsistency - client-side deafen only for LiveKit). Tracked in follow-up issue #25406.
- Mid-session breakout re-joins in `audio/container.jsx` are not gated on `userSettingsReady` (settings are long-loaded by then).
- 21 pre-existing lint errors in `audio-manager/index.js` (identical count before this change; zero added).

## Backward compatibility

Default is `false` - existing deployments see no behavior change. The default-path logic is byte-for-byte unchanged. Setting `true` is opt-in.
