### PR TITLE
fix(video-provider): preview real user avatars in the camera overflow tile

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
@@ -3,6 +3,8 @@ import {
   userIndicatorsOffset,
   mdPaddingY,
   indicatorPadding,
+  avatarBorderRadius,
+  moderatorAvatarBorderRadius,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
   colorPrimary,
@@ -99,9 +101,8 @@ const Talking = styled.div`
 
 const Avatar = styled.div`
   position: relative;
-  height: 2.25rem;
-  width: 2.25rem;
-  border-radius: 50%;
+  aspect-ratio: 1;
+  border-radius: ${avatarBorderRadius};
   text-align: center;
   font-size: .85rem;
   border: 2px solid transparent;
@@ -152,7 +153,9 @@ const Avatar = styled.div`
   }
 
   ${({ moderator }) => moderator && `
-    border-radius: 5px;
+    border-radius: ${moderatorAvatarBorderRadius};
+    background-color: ${colorUserModerator};
+    color: ${colorUserModerator};
   `}
 
   ${({ presenter }) => presenter && `

--- a/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/user-avatar/styles.js
@@ -13,6 +13,7 @@ import {
   colorSuccess,
   colorDanger,
   colorOffWhite,
+  colorUserModerator,
 } from '/imports/ui/stylesheets/styled-components/palette';
 
 const Content = styled.div`

--- a/bigbluebutton-html5/imports/ui/components/video-provider/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/component.tsx
@@ -16,7 +16,7 @@ import MediaStreamUtils from '/imports/utils/media-stream-utils';
 import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
 import { shouldForceRelay } from '/imports/ui/services/bbb-webrtc-sfu/utils';
 import WebRtcPeer from '/imports/ui/services/webrtc-base/peer';
-import { VideoItem } from './types';
+import { GridItem, VideoItem } from './types';
 import { Output } from '/imports/ui/components/layout/layoutTypes';
 import { VIDEO_TYPES } from './enums';
 
@@ -98,6 +98,7 @@ interface VideoProviderProps {
   isClientConnected: boolean;
   totalNumberOfStreams: number;
   overflowCount: number;
+  overflowUsers: GridItem[];
   isUserLocked: boolean;
   currentVideoPageIndex: number;
   streams: VideoItem[];
@@ -1374,6 +1375,7 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
       handleVideoFocus,
       isGridEnabled,
       overflowCount,
+      overflowUsers,
     } = this.props;
 
     return (
@@ -1386,6 +1388,7 @@ class VideoProvider extends Component<VideoProviderProps, VideoProviderState> {
           handleVideoFocus,
           isGridEnabled,
           overflowCount,
+          overflowUsers,
         }}
         onVideoItemMount={this.createVideoTag}
         onVideoItemUnmount={this.destroyVideoTag}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
@@ -93,6 +93,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
     streams,
     gridUsers,
     overflowCount,
+    overflowUsers,
     totalNumberOfStreams,
     totalNumberOfOtherStreams,
   } = useVideoStreams();
@@ -176,6 +177,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
     viewParticipantsWebcams,
     totalNumberOfStreams,
     overflowCount,
+    overflowUsers,
     isUserLocked,
     currentVideoPageIndex,
     streams: usersVideo,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -320,13 +320,16 @@ export const useIsPaginationEnabled = () => {
   return myPageSize > 0 && paginationEnabled;
 };
 
-export const useGridUsers = (visibleStreamCount: number) => {
+const OVERFLOW_TILE_PREVIEW_LIMIT = 3;
+
+export const useGridUsers = (visibleStreamCount: number, visibleUserCount: number) => {
   const gridSize = useGridSize();
   const userCount = getCountData();
   const isGridEnabled = useStorageKey('isGridEnabled');
   const canOnlySeeModeratorCameras = useCanOnlySeeModeratorCameras();
   const gridItems = useRef<GridItem[]>([]);
   const overflowCount = useRef<number>(0);
+  const overflowUsers = useRef<GridItem[]>([]);
 
   const { data: meeting } = useMeeting((m) => ({
     meetingId: m.meetingId,
@@ -352,6 +355,9 @@ export const useGridUsers = (visibleStreamCount: number) => {
     voice: u.voice,
   }));
 
+  const baseGridUserLimit = Math.max(gridSize - visibleStreamCount, 0);
+  const hasOverflow = userCount > gridSize;
+
   const {
     data: gridData,
     error: gridError,
@@ -363,7 +369,7 @@ export const useGridUsers = (visibleStreamCount: number) => {
       // otherwise keep everyone ([true, false]). The current user is re-added client-side
       // below (the query can't reference it without breaking Hasura multiplexing).
       variables: {
-        limit: Math.max(gridSize - visibleStreamCount, 0),
+        limit: hasOverflow ? baseGridUserLimit + OVERFLOW_TILE_PREVIEW_LIMIT : baseGridUserLimit,
         moderatorValues: canOnlySeeModeratorCameras ? [true] : [true, false],
       },
       skip: !isGridEnabled,
@@ -371,7 +377,13 @@ export const useGridUsers = (visibleStreamCount: number) => {
     true,
   );
 
-  if (gridLoading) return { gridUsers: gridItems.current, overflowCount: overflowCount.current };
+  if (gridLoading) {
+    return {
+      gridUsers: gridItems.current,
+      overflowCount: overflowCount.current,
+      overflowUsers: overflowUsers.current,
+    };
+  }
 
   if (gridError) {
     logger.error({
@@ -442,19 +454,32 @@ export const useGridUsers = (visibleStreamCount: number) => {
       }
     }
 
-    gridItems.current = newGridUsers;
+    // The grid page shows at most baseGridUserLimit avatar users. When there is
+    // overflow we over-fetch a few extra users (OVERFLOW_TILE_PREVIEW_LIMIT) purely
+    // to preview their avatars inside the overflow tile — those extras must not
+    // land in the grid itself, so keep the grid slice and the preview slice apart.
+    gridItems.current = newGridUsers.slice(0, baseGridUserLimit);
+    overflowUsers.current = newGridUsers.slice(baseGridUserLimit);
 
-    const overflow = Math.max(userCount - gridSize, 0);
-
-    // if there's overflow, we replace the last grid user with the overflow tile,
-    // so we need to add 1 to the overflow count to account for the replaced user
-    overflowCount.current = overflow > 0 ? overflow + 1 : 0;
+    // Hidden users = everyone not visible on this page. Count in USERS, not
+    // stream tiles as a user with several cameras holds several tiles. The
+    // overflow tile replaces the last avatar when avatars exist (+1: the
+    // replaced user joins the count); on a full-camera page it takes a new
+    // slot instead and replaces no one.
+    const hidden = Math.max(userCount - visibleUserCount - gridItems.current.length, 0);
+    const replacedAvatar = gridItems.current.length > 0 ? 1 : 0;
+    overflowCount.current = hidden > 0 ? hidden + replacedAvatar : 0;
   } else {
     gridItems.current = [];
+    overflowUsers.current = [];
     overflowCount.current = 0;
   }
 
-  return { gridUsers: gridItems.current, overflowCount: overflowCount.current };
+  return {
+    gridUsers: gridItems.current,
+    overflowCount: overflowCount.current,
+    overflowUsers: overflowUsers.current,
+  };
 };
 
 export const useSharedDevices = () => {
@@ -760,12 +785,27 @@ export const useVideoStreams = () => {
     }
   }
 
-  const { gridUsers, overflowCount } = useGridUsers(streams.length);
+  // Off-page local cameras stay in the array with render: false. Count only
+  // what actually renders on this page. Slots are tiles (stream count); the
+  // hidden math is per-user (distinct userIds).
+  const renderedStreams = streams.filter((s) => !('render' in s) || s.render !== false);
+  const renderedUserIds = new Set(renderedStreams.map((s) => s.userId));
+  const { gridUsers, overflowCount, overflowUsers } = useGridUsers(
+    renderedStreams.length,
+    renderedUserIds.size,
+  );
+
+  // Preview a few of the hidden users' avatars in the overflow tile, skipping any
+  // who are already rendered on this page so a face never appears twice.
+  const overflowPreviewUsers = overflowUsers
+    .filter((u) => !renderedUserIds.has(u.userId))
+    .slice(0, Math.min(overflowCount, OVERFLOW_TILE_PREVIEW_LIMIT));
 
   return {
     streams,
     gridUsers: gridUsers.filter((u) => !streams.find((s) => s.userId === u.userId)),
     overflowCount,
+    overflowUsers: overflowPreviewUsers,
     totalNumberOfStreams: streams.length,
     totalNumberOfOtherStreams,
   };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -459,7 +459,8 @@ export const useGridUsers = (visibleStreamCount: number, visibleUserCount: numbe
     // to preview their avatars inside the overflow tile — those extras must not
     // land in the grid itself, so keep the grid slice and the preview slice apart.
     gridItems.current = newGridUsers.slice(0, baseGridUserLimit);
-    overflowUsers.current = newGridUsers.slice(baseGridUserLimit);
+    // The tile replaces the last grid avatar, so preview that user too
+    overflowUsers.current = newGridUsers.slice(Math.max(gridItems.current.length - 1, 0));
 
     // Hidden users = everyone not visible on this page. Count in USERS, not
     // stream tiles as a user with several cameras holds several tiles. The

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -681,6 +681,10 @@ export const useVideoStreams = () => {
       || !senderIdsInGroups.has(vs.userId));
   }
 
+  // Snapshot of all streams the viewer may see, before pagination trims to the current
+  // page — used to recover off-page webcam users for the overflow preview below.
+  const allowedStreams = [...streams];
+
   if (isPaginationEnabled) {
     const chunkIndex = currentVideoPageIndex * myPageSize;
     const sortingMethod = (numberOfPages > 1) ? PAGINATION_SORTING : DEFAULT_SORTING;
@@ -795,10 +799,35 @@ export const useVideoStreams = () => {
     renderedUserIds.size,
   );
 
-  // Preview a few of the hidden users' avatars in the overflow tile, skipping any
-  // who are already rendered on this page so a face never appears twice.
-  const overflowPreviewUsers = overflowUsers
+  // GRID_USERS_SUBSCRIPTION excludes camera-sharers, so hidden webcam users never reach
+  // `overflowUsers`. Recover them from allowedStreams (deduped by userId) as grid-shaped items.
+  const seenPreviewUserId = new Set<string>();
+  const hiddenCameraUsers: GridItem[] = [];
+  allowedStreams.forEach((s) => {
+    if (
+      s.type !== VIDEO_TYPES.STREAM
+      || renderedUserIds.has(s.userId)
+      || seenPreviewUserId.has(s.userId)
+    ) return;
+    seenPreviewUserId.add(s.userId);
+    hiddenCameraUsers.push({
+      ...s.user,
+      voice: {
+        joined: s.voice?.joined ?? false,
+        listenOnly: s.voice?.listenOnly ?? false,
+        userId: s.userId,
+      },
+      type: VIDEO_TYPES.GRID,
+    });
+  });
+
+  // Preview the first few hidden users' avatars: merge hidden grid + webcam users, order
+  // them like the grid subscription (nameSortable, userId), and drop anyone already on-page.
+  const overflowPreviewUsers = [...overflowUsers, ...hiddenCameraUsers]
     .filter((u) => !renderedUserIds.has(u.userId))
+    .sort((a, b) => (
+      a.nameSortable.localeCompare(b.nameSortable) || a.userId.localeCompare(b.userId)
+    ))
     .slice(0, Math.min(overflowCount, OVERFLOW_TILE_PREVIEW_LIMIT));
 
   return {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -23,7 +23,7 @@ import VideoListContainer from '/imports/ui/components/video-provider/video-list
 import logger from '/imports/startup/client/logger';
 import { notifyStreamStateChange } from '/imports/ui/services/bbb-webrtc-sfu/stream-state-service';
 import BBBVideoStream from '/imports/ui/services/webrtc-base/bbb-video-stream';
-import { VideoItem } from '/imports/ui/components/video-provider/types';
+import { GridItem, VideoItem } from '/imports/ui/components/video-provider/types';
 import { Output } from '/imports/ui/components/layout/layoutTypes';
 import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
 import {
@@ -76,6 +76,7 @@ interface LiveKitCameraBridgeProps {
   lockUser: () => void;
   stopVideo: (cameraId?: string) => void;
   overflowCount: number;
+  overflowUsers: GridItem[];
 }
 
 interface LiveKitCameraBridgeRefs {
@@ -105,6 +106,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   lockUser,
   stopVideo,
   overflowCount,
+  overflowUsers,
 }) => {
   const intl = useIntl();
   const connectionState = useConnectionState(liveKitRoom);
@@ -636,6 +638,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     // even if not used explicitly. Not ideal, but it works (_for now_) - prlanzarin
     cameraTracks,
     overflowCount,
+    overflowUsers,
   ]);
 
   useEffect(() => {
@@ -655,6 +658,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       onVideoItemUnmount={destroyVideoTag}
       onVirtualBgDrop={startVirtualBackgroundByDrop}
       overflowCount={overflowCount}
+      overflowUsers={overflowUsers}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/component.tsx
@@ -12,7 +12,7 @@ import playAndRetry from '/imports/utils/mediaElementPlayRetry';
 import VideoService from '/imports/ui/components/video-provider/service';
 import { ACTIONS } from '/imports/ui/components/layout/enums';
 import { Output } from '/imports/ui/components/layout/layoutTypes';
-import { VideoItem } from '/imports/ui/components/video-provider/types';
+import { GridItem, VideoItem } from '/imports/ui/components/video-provider/types';
 import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
 import { UserCameraHelperAreas } from '../../plugins-engine/extensible-areas/components/user-camera-helper/types';
 
@@ -79,6 +79,7 @@ interface VideoListProps {
   handleVideoFocus: (id: string) => void;
   isGridEnabled: boolean;
   overflowCount: number;
+  overflowUsers: GridItem[];
   streams: VideoItem[];
   intl: IntlShape;
   setUserCamerasRequestedFromPlugin: React.Dispatch<React.SetStateAction<UpdatedDataForUserCameraDomElement[]>>;
@@ -371,6 +372,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
       isGridEnabled,
       overflowCount,
       gridSize,
+      overflowUsers,
     } = this.props;
     const numOfStreams = streams.filter(
       (item) => item.type === VIDEO_TYPES.GRID || !('render' in item) || item.render !== false,
@@ -432,7 +434,7 @@ class VideoList extends Component<VideoListProps, VideoListState> {
           $focused={false}
           data-test="overflowTile"
         >
-          <OverflowTile overflowCount={overflowCount} />
+          <OverflowTile overflowCount={overflowCount} overflowUsers={overflowUsers} />
         </Styled.VideoListItem>,
       );
     }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/container.tsx
@@ -7,7 +7,7 @@ import { UserCameraHelperButton, UserCameraHelperInterface, UserCameraHelperItem
 import VideoList from '/imports/ui/components/video-provider/video-list/component';
 import { layoutSelect, layoutDispatch } from '/imports/ui/components/layout/context';
 import { useNumberOfPages, useGridSize } from '/imports/ui/components/video-provider/hooks';
-import { VideoItem } from '/imports/ui/components/video-provider/types';
+import { GridItem, VideoItem } from '/imports/ui/components/video-provider/types';
 import { Layout, Output } from '/imports/ui/components/layout/layoutTypes';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 import { UpdatedDataForUserCameraDomElement } from 'bigbluebutton-html-plugin-sdk/dist/cjs/dom-element-manipulation/user-camera/types';
@@ -24,6 +24,7 @@ interface VideoListContainerProps {
   handleVideoFocus: (id: string) => void;
   isGridEnabled: boolean;
   overflowCount: number;
+  overflowUsers: GridItem[];
   onVideoItemMount: (stream: string, video: HTMLVideoElement) => void;
   onVideoItemUnmount: (stream: string) => void;
   onVirtualBgDrop: (stream: string, type: string, name: string, data: string) => Promise<unknown>;
@@ -40,6 +41,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
     handleVideoFocus,
     isGridEnabled,
     overflowCount,
+    overflowUsers,
     onVideoItemMount,
     onVideoItemUnmount,
     onVirtualBgDrop,
@@ -115,6 +117,7 @@ const VideoListContainer: React.FC<VideoListContainerProps> = (props) => {
           handleVideoFocus={handleVideoFocus}
           isGridEnabled={isGridEnabled}
           overflowCount={overflowCount}
+          overflowUsers={overflowUsers}
           streams={streams}
           onVideoItemMount={onVideoItemMount}
           onVideoItemUnmount={onVideoItemUnmount}

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/component.tsx
@@ -4,9 +4,11 @@ import Styled from './styles';
 import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
 import { Input } from '/imports/ui/components/layout/layoutTypes';
 import { PANELS, ACTIONS } from '/imports/ui/components/layout/enums';
+import { GridItem } from '/imports/ui/components/video-provider/types';
 
 interface OverflowTileProps {
   overflowCount: number;
+  overflowUsers: GridItem[];
 }
 
 const intlMessages = defineMessages({
@@ -16,7 +18,7 @@ const intlMessages = defineMessages({
   },
 });
 
-const OverflowTile: React.FC<OverflowTileProps> = ({ overflowCount }) => {
+const OverflowTile: React.FC<OverflowTileProps> = ({ overflowCount, overflowUsers }) => {
   const intl = useIntl();
   const layoutContextDispatch = layoutDispatch();
 
@@ -40,22 +42,24 @@ const OverflowTile: React.FC<OverflowTileProps> = ({ overflowCount }) => {
     });
   };
 
-  const displayCount = Math.min(overflowCount, 3);
-
   return (
     <Styled.OverflowTileContainer data-test="overflowTile" isClickable={!isUserListPanelOpen} onClick={() => handleOpenUserList()}>
       <Styled.OverflowTileContent>
-        <Styled.AvatarsContainer $count={displayCount}>
-          {Array.from({ length: displayCount }, (_, index) => (
-            <Styled.AvatarWrapper key={index} $index={index}>
-              <Styled.Avatar $color="#4a148c">
-                <Styled.AvatarInitials>
-                  Us
-                </Styled.AvatarInitials>
-              </Styled.Avatar>
-            </Styled.AvatarWrapper>
-          ))}
-        </Styled.AvatarsContainer>
+        {overflowUsers.length > 0 && (
+          <Styled.AvatarsContainer $count={overflowUsers.length}>
+            {overflowUsers.map((user, index) => (
+              <Styled.AvatarWrapper key={user.userId} $index={index}>
+                <Styled.Avatar $color={user.color} $avatar={user.avatar} $moderator={user.isModerator}>
+                  {!user.avatar && (
+                    <Styled.AvatarInitials>
+                      {user.name.toLowerCase().slice(0, 2)}
+                    </Styled.AvatarInitials>
+                  )}
+                </Styled.Avatar>
+              </Styled.AvatarWrapper>
+            ))}
+          </Styled.AvatarsContainer>
+        )}
         <Styled.OverflowText>
           {intl.formatMessage(intlMessages.overflowUsers, { overflowCount })}
         </Styled.OverflowText>

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/overflow-tile/styles.ts
@@ -4,6 +4,10 @@ import {
   webcamBackgroundColor,
   webcamPlaceholderBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
+import {
+  avatarBorderRadius,
+  moderatorAvatarBorderRadius,
+} from '/imports/ui/stylesheets/styled-components/general';
 
 const OverflowTileContainer = styled.div<{ isClickable: boolean }>`
   position: relative;
@@ -67,16 +71,24 @@ const AvatarWrapper = styled.div<{ $index: number }>`
   z-index: ${({ $index }) => 3 - $index};
 `;
 
-const Avatar = styled.div<{ $color: string }>`
+const Avatar = styled.div<{ $color: string; $avatar?: string; $moderator?: boolean }>`
   width: 50px;
   height: 50px;
-  border-radius: 50%;
+  border-radius: ${({ $moderator }) => ($moderator ? moderatorAvatarBorderRadius : avatarBorderRadius)};
   background-color: ${({ $color }) => $color};
   display: flex;
   align-items: center;
   justify-content: center;
   border: 2px solid ${webcamBackgroundColor};
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+
+  ${({ $avatar }) => $avatar && `
+    background-image: url(${$avatar});
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  `}
 `;
 
 const AvatarInitials = styled.span`
@@ -84,6 +96,7 @@ const AvatarInitials = styled.span`
   font-weight: 600;
   color: ${colorWhite};
   user-select: none;
+  text-transform: capitalize;
 `;
 
 const OverflowText = styled.div`

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -3,6 +3,8 @@ const borderSize = '2px';
 const borderSizeLarge = '3px';
 const borderRadius = '.2rem';
 const borderRadiusRounded = '.5rem';
+const avatarBorderRadius = '50%';
+const moderatorAvatarBorderRadius = '5px';
 const smPaddingX = '.75rem';
 const smPaddingY = '.3rem';
 const mdPaddingY = '.45rem';
@@ -187,4 +189,6 @@ export {
   xlPadding,
   xsPadding,
   borderRadiusRounded,
+  avatarBorderRadius,
+  moderatorAvatarBorderRadius,
 };

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -18,6 +18,8 @@ const colorBlueLighterChannel = '146 188 234';
 
 const colorTransparent = 'var(--color-transparent, #ff000000)';
 
+const colorUserModerator = 'var(--color-user-moderator, #7B209F)';
+
 const colorPrimary = 'var(--color-primary, #0F70D7)';
 const colorDanger = 'var(--color-danger, #DF2721)';
 const colorDangerDark = 'var(--color-danger-dark, #AE1010)';


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/bigbluebutton/bigbluebutton/pull/25370 changes to v3.0.x:

_When the webcam grid overflows, the "+N users" tile used to render generic "Us" placeholder circles. It now previews the next users that didn't fit using their real avatar, respecting the moderator/participant avatar shape used elsewhere in the app._
