### PR TITLE
fix(audio): assorted fixes and improvements to LiveKit's floor manager

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -56,11 +56,11 @@ trait SystemConfiguration {
   lazy val muteOnStartThreshold = Try(config.getInt("voiceConf.muteOnStartThreshold")).getOrElse(0)
   lazy val dialInEnforceGuestPolicy = Try(config.getBoolean("voiceConf.dialInEnforceGuestPolicy")).getOrElse(true)
   lazy val dialInEnforceMuteOnStart = Try(config.getBoolean("voiceConf.dialInEnforceMuteOnStart")).getOrElse(false)
-  lazy val floorEnabled = Try(config.getBoolean("voiceConf.floorControl.enabled")).getOrElse(false)
+  lazy val floorEnabled = Try(config.getBoolean("voiceConf.floorControl.enabled")).getOrElse(true)
   lazy val minTalkingDuration = Try(config.getDuration(
     "voiceConf.floorControl.minTalkingDuration",
     java.util.concurrent.TimeUnit.MILLISECONDS
-  )).getOrElse(2000L)
+  )).getOrElse(2500L)
   lazy val floorSwitchCooldown = Try(config.getDuration(
     "voiceConf.floorControl.floorSwitchCooldown",
     java.util.concurrent.TimeUnit.MILLISECONDS

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
@@ -9,7 +9,6 @@ import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers
 import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.db.ScreenshareDAO
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
-import org.bigbluebutton.core.apps.voice.AudioFloorManager
 
 trait LiveKitParticipantLeftEvtMsgHdlr {
   this: BaseMeetingActor =>
@@ -26,7 +25,7 @@ trait LiveKitParticipantLeftEvtMsgHdlr {
     for {
       vu <- VoiceUsers.findWIthIntId(liveMeeting.voiceUsers, userId)
     } yield {
-      AudioFloorManager.handleUserLeftVoice(
+      liveMeeting.audioFloorManager.handleUserLeftVoice(
         vu.intId,
         System.currentTimeMillis(),
         liveMeeting,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -50,10 +50,38 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       return None
     }
 
+    pruneStaleSpeakingState(timestamp, liveMeeting, outGW)
+
     if (talking) {
       handleStartTalking(userId, timestamp, liveMeeting, outGW)
     } else {
       handleStopTalking(userId, liveMeeting, outGW)
+    }
+  }
+
+  // Catch all for missed stop-talking/left-voice events. Cleanup is important
+  // as stale entries might accumulate and delay actual floor grants for that user
+  // unnecessarily.
+  private def pruneStaleSpeakingState(
+      now:         Long,
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter
+  )(implicit context: ActorContext): Unit = {
+    // 5 min - likely to be tweaked based on observation (prlanzarin)
+    val ttl = 5 * 60 * 1000L
+    val stale = state.speakingStartTimes.collect {
+      case (userId, startedAt) if now - startedAt >= ttl => userId
+    }.toSet
+
+    if (stale.nonEmpty) {
+      logFloorEvent("none", "stale_speaking_state_pruned", Map(
+        "users" -> stale.mkString(",")
+      ))
+      state = state.copy(speakingStartTimes = state.speakingStartTimes -- stale)
+      if (pendingFloors.exists(pending => stale.contains(pending.userId))) {
+        pendingFloors.filterInPlace(pending => !stale.contains(pending.userId))
+        dispatchPendingGrants(liveMeeting, outGW)
+      }
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -161,9 +161,11 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       outGW:       OutMsgRouter
   ): Option[String] = {
     if (state.currentHolder.contains(userId)) {
+      // A release does not schedule the switch cooldown - only grants do.
+      // Otherwise a floor holder's departure would defer the grant of the next
+      // speaker until after the cooldown unnecessarily.
       state = state.copy(
-        currentHolder = None,
-        lastFloorSwitch = timestamp
+        currentHolder = None
       )
 
       logFloorEvent(userId, "floor_released", Map(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -9,10 +9,9 @@ import scala.collection.mutable
 import org.slf4j.LoggerFactory
 
 case class FloorState(
-    currentHolder:       Option[String]                     = None,
-    lastFloorSwitch:     Long                               = 0L,
-    speakingStartTimes:  Map[String, Long]                  = Map(),
-    talkingStateChanges: Map[String, List[(Boolean, Long)]] = Map()
+    currentHolder:      Option[String]    = None,
+    lastFloorSwitch:    Long              = 0L,
+    speakingStartTimes: Map[String, Long] = Map()
 )
 
 case class PendingFloor(
@@ -44,8 +43,6 @@ object AudioFloorManager extends SystemConfiguration {
     }
 
     stateLock.synchronized {
-      state = cleanupOldState(state, timestamp)
-
       if (talking) {
         handleStartTalking(userId, timestamp, liveMeeting, outGW)
       } else {
@@ -70,17 +67,6 @@ object AudioFloorManager extends SystemConfiguration {
       logData: Map[String, Any]
   ): Unit = {
     log.debug(s"Floor control event=${event} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
-  }
-
-  private def cleanupOldState(state: FloorState, now: Long): FloorState = {
-    val ttl = 5 * 60 * 1000L
-
-    state.copy(
-      talkingStateChanges = state.talkingStateChanges.map {
-        case (userId, changes) =>
-          userId -> changes.filter(_._2 >= (now - ttl))
-      }.filter(_._2.nonEmpty)
-    )
   }
 
   private def scheduleFloorGrant(
@@ -198,8 +184,7 @@ object AudioFloorManager extends SystemConfiguration {
     }
 
     state = state.copy(
-      speakingStartTimes = state.speakingStartTimes - userId,
-      talkingStateChanges = state.talkingStateChanges - userId
+      speakingStartTimes = state.speakingStartTimes - userId
     )
 
     None
@@ -223,8 +208,7 @@ object AudioFloorManager extends SystemConfiguration {
     }
 
     state = state.copy(
-      speakingStartTimes = state.speakingStartTimes - userId,
-      talkingStateChanges = state.talkingStateChanges - userId
+      speakingStartTimes = state.speakingStartTimes - userId
     )
 
     if (state.currentHolder.contains(userId)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -21,7 +21,7 @@ case class PendingFloor(
 )
 
 object AudioFloorManager {
-  // Floor grants are sheculed to the meeting actor so they run on the actor
+  // Floor grants are scheduled to the meeting actor so they run on the actor
   // thread, serialized with the rest of the meeting's message handling.
   case object DispatchFloorGrantsInternalMsg
 }
@@ -95,7 +95,7 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
 
   // Evaluates the floor grant queue: drops stale entries, grants the floor to
   // the head once both its minimum-talking deadline and the grant cooldown
-  // have elapsed, and otherwise re-schedule itself for the earliest instant a i
+  // have elapsed, and otherwise re-schedule itself for the earliest instant a
   // grant can succeed.
   def dispatchPendingGrants(
       liveMeeting: LiveMeeting,
@@ -117,8 +117,8 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
 
       if (now >= readyAt) {
         try {
-          pendingFloors.dequeue()
           grantFloor(head.userId, now, liveMeeting, outGW)
+          pendingFloors.dequeue()
           dispatchPendingGrants(liveMeeting, outGW)
         } catch {
           // Capture so that the queue doesn't stall

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -1,9 +1,8 @@
 package org.bigbluebutton.core.apps.voice
 
-import java.util.concurrent.{ ScheduledFuture, TimeUnit, ScheduledExecutorService, Executors }
+import java.util.concurrent.{ Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.models.{ VoiceUsers, VoiceUserState }
-import scala.concurrent.duration._
+import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.SystemConfiguration
 import scala.collection.mutable
 import org.slf4j.LoggerFactory
@@ -20,15 +19,20 @@ case class PendingFloor(
     timer:     ScheduledFuture[_]
 )
 
-object AudioFloorManager extends SystemConfiguration {
-  private val log = LoggerFactory.getLogger(getClass)
-  private val stateLock = new Object()
-  private var state = FloorState()
+object AudioFloorManager {
+  // This timer is shared across all meetings (light load, no need to creat
+  // one per meeting etc)
   private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r => {
     val t = new Thread(r, "audio-floor-manager")
     t.setDaemon(true)
     t
   })
+}
+
+class AudioFloorManager(meetingId: String) extends SystemConfiguration {
+  private val log = LoggerFactory.getLogger(getClass)
+  private val stateLock = new Object()
+  private var state = FloorState()
   private val pendingFloors = mutable.Queue[PendingFloor]()
 
   def handleUserTalking(
@@ -51,22 +55,12 @@ object AudioFloorManager extends SystemConfiguration {
     }
   }
 
-  def getCurrentFloorHolder: Option[String] = stateLock.synchronized {
-    state.currentHolder
-  }
-
-  def clearFloorState(): Unit = stateLock.synchronized {
-    pendingFloors.foreach(_.timer.cancel(false))
-    pendingFloors.clear()
-    state = FloorState()
-  }
-
   private def logFloorEvent(
       userId:  String,
       event:   String,
       logData: Map[String, Any]
   ): Unit = {
-    log.debug(s"Floor control event=${event} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
+    log.debug(s"Floor control event=${event} meetingId=${meetingId} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
   }
 
   private def scheduleFloorGrant(
@@ -75,7 +69,7 @@ object AudioFloorManager extends SystemConfiguration {
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
   ): Unit = {
-    val future = scheduler.schedule(new Runnable {
+    val future = AudioFloorManager.scheduler.schedule(new Runnable {
       override def run(): Unit = {
         stateLock.synchronized {
           if (pendingFloors.nonEmpty && pendingFloors.head.userId == userId) {
@@ -223,9 +217,11 @@ object AudioFloorManager extends SystemConfiguration {
   }
 
   def destroy(): Unit = stateLock.synchronized {
+    logFloorEvent("none", "floor_manager_destroyed", Map(
+      "pending_grants" -> pendingFloors.size
+    ))
     pendingFloors.foreach(_.timer.cancel(false))
     pendingFloors.clear()
-    scheduler.shutdown()
     state = FloorState()
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -1,10 +1,12 @@
 package org.bigbluebutton.core.apps.voice
 
-import java.util.concurrent.{ Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit }
+import org.apache.pekko.actor.{ ActorContext, Cancellable }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.SystemConfiguration
 import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
 import org.slf4j.LoggerFactory
 
 case class FloorState(
@@ -15,25 +17,27 @@ case class FloorState(
 
 case class PendingFloor(
     userId:    String,
-    startTime: Long,
-    timer:     ScheduledFuture[_]
+    startTime: Long
 )
 
 object AudioFloorManager {
-  // This timer is shared across all meetings (light load, no need to creat
-  // one per meeting etc)
-  private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r => {
-    val t = new Thread(r, "audio-floor-manager")
-    t.setDaemon(true)
-    t
-  })
+  // Floor grants are sheculed to the meeting actor so they run on the actor
+  // thread, serialized with the rest of the meeting's message handling.
+  case object DispatchFloorGrantsInternalMsg
 }
 
+// All state is confined to the meeting actor: the public entry points run in
+// message handlers and the dispatch timer only enqueues
+// DispatchFloorGrantsInternalMsg back to the same actor.
 class AudioFloorManager(meetingId: String) extends SystemConfiguration {
   private val log = LoggerFactory.getLogger(getClass)
-  private val stateLock = new Object()
   private var state = FloorState()
   private val pendingFloors = mutable.Queue[PendingFloor]()
+  // Single grant dispatch timer that evaluates the queue head. Pending grants
+  // carry no timers of their own: any queue or floor-state change re-runs
+  // the dispatch, so a grant blocked by the cooldown (or by queue order) is
+  // retried when possible.
+  private var grantDispatchTask: Option[Cancellable] = None
 
   def handleUserTalking(
       userId:      String,
@@ -41,17 +45,15 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       timestamp:   Long         = System.currentTimeMillis(),
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Option[String] = {
+  )(implicit context: ActorContext): Option[String] = {
     if (!floorEnabled || liveMeeting.props.meetingProp.audioBridge != "livekit") {
       return None
     }
 
-    stateLock.synchronized {
-      if (talking) {
-        handleStartTalking(userId, timestamp, liveMeeting, outGW)
-      } else {
-        handleStopTalking(userId, timestamp)
-      }
+    if (talking) {
+      handleStartTalking(userId, timestamp, liveMeeting, outGW)
+    } else {
+      handleStopTalking(userId, liveMeeting, outGW)
     }
   }
 
@@ -63,24 +65,52 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
     log.debug(s"Floor control event=${event} meetingId=${meetingId} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
   }
 
-  private def scheduleFloorGrant(
-      userId:      String,
-      timestamp:   Long,
+  // Evaluates the floor grant queue: drops stale entries, grants the floor to
+  // the head once both its minimum-talking deadline and the grant cooldown
+  // have elapsed, and otherwise re-schedule itself for the earliest instant a i
+  // grant can succeed.
+  def dispatchPendingGrants(
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Unit = {
-    val future = AudioFloorManager.scheduler.schedule(new Runnable {
-      override def run(): Unit = {
-        stateLock.synchronized {
-          if (pendingFloors.nonEmpty && pendingFloors.head.userId == userId) {
-            pendingFloors.dequeue()
-            grantFloor(userId, timestamp + minTalkingDuration, liveMeeting, outGW)
-          }
-        }
-      }
-    }, minTalkingDuration, TimeUnit.MILLISECONDS)
+  )(implicit context: ActorContext): Unit = {
+    grantDispatchTask.foreach(_.cancel())
+    grantDispatchTask = None
 
-    pendingFloors.enqueue(PendingFloor(userId, timestamp, future))
+    while (pendingFloors.headOption.exists(pending => state.currentHolder.contains(pending.userId))) {
+      pendingFloors.dequeue()
+    }
+
+    pendingFloors.headOption.foreach { head =>
+      val now = System.currentTimeMillis()
+      val readyAt = math.max(
+        head.startTime + minTalkingDuration,
+        state.lastFloorSwitch + floorSwitchCooldown
+      )
+
+      if (now >= readyAt) {
+        try {
+          pendingFloors.dequeue()
+          grantFloor(head.userId, now, liveMeeting, outGW)
+          dispatchPendingGrants(liveMeeting, outGW)
+        } catch {
+          // Capture so that the queue doesn't stall
+          case NonFatal(e) =>
+            log.error(s"Floor control grant dispatch failed meetingId=${meetingId}, re-scheduling", e)
+            scheduleGrantDispatch(floorSwitchCooldown)
+        }
+      } else {
+        scheduleGrantDispatch(readyAt - now)
+      }
+    }
+  }
+
+  private def scheduleGrantDispatch(delayMs: Long)(implicit context: ActorContext): Unit = {
+    import context.dispatcher
+    grantDispatchTask = Some(context.system.scheduler.scheduleOnce(
+      delayMs.milliseconds,
+      context.self,
+      AudioFloorManager.DispatchFloorGrantsInternalMsg
+    ))
   }
 
   private def grantFloor(
@@ -160,26 +190,30 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       timestamp:   Long,
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Option[String] = {
+  )(implicit context: ActorContext): Option[String] = {
     if (!state.speakingStartTimes.contains(userId)) {
       state = state.copy(
         speakingStartTimes = state.speakingStartTimes + (userId -> timestamp)
       )
-      scheduleFloorGrant(userId, timestamp, liveMeeting, outGW)
+      pendingFloors.enqueue(PendingFloor(userId, timestamp))
+      dispatchPendingGrants(liveMeeting, outGW)
     }
 
     None
   }
 
-  private def handleStopTalking(userId: String, timestamp: Long): Option[String] = {
-    pendingFloors.find(_.userId == userId).foreach { pending =>
-      pending.timer.cancel(false)
-      pendingFloors.dequeueFirst(_.userId == userId)
-    }
+  private def handleStopTalking(
+      userId:      String,
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter
+  )(implicit context: ActorContext): Option[String] = {
+    pendingFloors.dequeueFirst(_.userId == userId)
 
     state = state.copy(
       speakingStartTimes = state.speakingStartTimes - userId
     )
+
+    dispatchPendingGrants(liveMeeting, outGW)
 
     None
   }
@@ -189,38 +223,35 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       timestamp:   Long         = System.currentTimeMillis(),
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Option[String] = stateLock.synchronized {
+  )(implicit context: ActorContext): Option[String] = {
     logFloorEvent(userId, "user_left", Map(
       "was_floor_holder" -> state.currentHolder.contains(userId),
       "had_pending_floor" -> pendingFloors.exists(_.userId == userId),
       "speaking_duration" -> state.speakingStartTimes.get(userId).map(timestamp - _)
     ))
 
-    pendingFloors.find(_.userId == userId).foreach { pending =>
-      pending.timer.cancel(false)
-      pendingFloors.dequeueFirst(_.userId == userId)
-    }
+    pendingFloors.dequeueFirst(_.userId == userId)
 
     state = state.copy(
       speakingStartTimes = state.speakingStartTimes - userId
     )
 
-    if (state.currentHolder.contains(userId)) {
+    val wasHolder = state.currentHolder.contains(userId)
+    if (wasHolder) {
       releaseFloor(userId, timestamp, liveMeeting, outGW)
+    }
 
-      pendingFloors.headOption.foreach { next =>
-        grantFloor(next.userId, timestamp, liveMeeting, outGW)
-      }
+    dispatchPendingGrants(liveMeeting, outGW)
 
-      Some(userId)
-    } else None
+    if (wasHolder) Some(userId) else None
   }
 
-  def destroy(): Unit = stateLock.synchronized {
+  def destroy(): Unit = {
     logFloorEvent("none", "floor_manager_destroyed", Map(
       "pending_grants" -> pendingFloors.size
     ))
-    pendingFloors.foreach(_.timer.cancel(false))
+    grantDispatchTask.foreach(_.cancel())
+    grantDispatchTask = None
     pendingFloors.clear()
     state = FloorState()
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
@@ -48,7 +48,7 @@ trait UserLeftVoiceConfEvtMsgHdlr {
     for {
       user <- VoiceUsers.findWithVoiceUserId(liveMeeting.voiceUsers, msg.body.voiceUserId)
     } yield {
-      AudioFloorManager.handleUserLeftVoice(
+      liveMeeting.audioFloorManager.handleUserLeftVoice(
         user.intId,
         System.currentTimeMillis(),
         liveMeeting,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -956,7 +956,7 @@ object VoiceApp extends SystemConfiguration {
         liveMeeting,
         outGW
       )
-      AudioFloorManager.handleUserTalking(
+      liveMeeting.audioFloorManager.handleUserTalking(
         talkingUser.intId,
         talking,
         System.currentTimeMillis(),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.core.running
 
 import org.bigbluebutton.common2.domain.DefaultProps
 import org.bigbluebutton.core.apps._
+import org.bigbluebutton.core.apps.voice.AudioFloorManager
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
 
@@ -27,4 +28,6 @@ class LiveMeeting(
     val guestsWaiting:       GuestsWaiting,
     val clientSettings:      Map[String, Object],
     val plugins:             PluginModel,
-)
+) {
+  val audioFloorManager = new AudioFloorManager(props.meetingProp.intId)
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -285,6 +285,8 @@ class MeetingActor(
       handleMeetingTasksExecutor()
     case CheckPresentationConversions =>
       state = handleCheckPresentationConversions()
+    case AudioFloorManager.DispatchFloorGrantsInternalMsg =>
+      liveMeeting.audioFloorManager.dispatchPendingGrants(liveMeeting, outGW)
     //=============================
 
     // 2x messages

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -267,6 +267,11 @@ class MeetingActor(
     CheckPresentationConversions
   )
 
+  override def postStop(): Unit = {
+    liveMeeting.audioFloorManager.destroy()
+    super.postStop()
+  }
+
   def receive = {
     case SyncVoiceUserStatusInternalMsg =>
       checkVoiceConfUsersStatus()

--- a/bigbluebutton-tests/playwright/audio/floor.spec.ts
+++ b/bigbluebutton-tests/playwright/audio/floor.spec.ts
@@ -1,0 +1,168 @@
+import { type Browser, expect, type TestInfo } from '@playwright/test';
+
+import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { isLiveKit } from '../core/livekit';
+import { test } from '../core/setup/fixtures';
+import { Audio } from './audio';
+import {
+  APOLLO_CLIENT_SETTINGS_MODULE,
+  expectFloorHolder,
+  getOwnUserId,
+  getUserVoiceRows,
+  isApolloClientExposed,
+} from './floorProbe';
+import { connectMicrophone } from './util';
+
+const APOLLO_EXPOSURE_SKIP_REASON =
+  'requires window.__APOLLO_CLIENT__ for the floor probe ' +
+  '(dev bundle or enableApolloDevTools provisioned via clientSettingsOverride)';
+
+// Moderator + attendee in one meeting, both with a connected (muted) microphone.
+const initTwoSpeakers = async (browser: Browser, testInfo: TestInfo) => {
+  const context = await browser.newContext();
+  const audio = new Audio(browser, context);
+  await audio.initModPage(await context.newPage(), { testInfo, createModules: APOLLO_CLIENT_SETTINGS_MODULE });
+  await audio.initUserPage(context, { testInfo });
+  const { modPage, userPage } = audio;
+  test.skip(!(await isApolloClientExposed(modPage.page, ELEMENT_WAIT_TIME)), APOLLO_EXPOSURE_SKIP_REASON);
+  await modPage.waitAndClick(e.joinAudio);
+  await connectMicrophone(modPage);
+  await userPage.waitAndClick(e.joinAudio);
+  await connectMicrophone(userPage);
+  const modUserId = await getOwnUserId(modPage.page);
+  const attendeeUserId = await getOwnUserId(userPage.page);
+  return { modPage, userPage, modUserId, attendeeUserId };
+};
+
+// akka-apps floor control (voiceConf.floorControl) synthesizes floor grants from
+// client-reported talking state on the LiveKit bridge. These tests observe the
+// user_voice.floor GQL states through the floorProbe helpers.
+test.describe('Audio floor control', { tag: ['@ci', '@media'] }, () => {
+  test('floor state is isolated between concurrent meetings', async ({ browser }, testInfo) => {
+    test.skip(!isLiveKit, 'akka-apps floor control is specific to the LiveKit audio bridge');
+
+    // Meeting A: moderator + attendee; meeting B: a single moderator.
+    const {
+      modPage: modA,
+      userPage: attendeeA,
+      modUserId: modAUserId,
+      attendeeUserId: attendeeAUserId,
+    } = await initTwoSpeakers(browser, testInfo);
+    const contextB = await browser.newContext();
+    const audioB = new Audio(browser, contextB);
+    await audioB.initModPage(await contextB.newPage(), {
+      testInfo,
+      fullName: 'ModeratorB',
+      createModules: APOLLO_CLIENT_SETTINGS_MODULE,
+    });
+    test.skip(!(await isApolloClientExposed(audioB.modPage.page, ELEMENT_WAIT_TIME)), APOLLO_EXPOSURE_SKIP_REASON);
+    const modB = audioB.modPage;
+
+    await modB.waitAndClick(e.joinAudio);
+    await connectMicrophone(modB);
+    const modBUserId = await getOwnUserId(modB.page);
+
+    // A's speaker takes A's floor.
+    await modA.waitAndClick(e.unmuteMicButton);
+    await modA.hasElement(e.isTalking, 'moderator A should be talking');
+    await expectFloorHolder(
+      modA.page,
+      modAUserId,
+      'meeting A floor should go to its own speaker',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    // B's speaker takes B's floor; meeting A must be unaffected.
+    await modB.waitAndClick(e.unmuteMicButton);
+    await modB.hasElement(e.isTalking, 'moderator B should be talking');
+    await expectFloorHolder(
+      modB.page,
+      modBUserId,
+      'meeting B floor should go to its own speaker',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await expectFloorHolder(
+      modA.page,
+      modAUserId,
+      'meeting A floor should be unaffected by meeting B activity',
+      ELEMENT_WAIT_TIME,
+    );
+
+    // The floor switches within meeting A: the previous holder must be released
+    // even though another meeting granted a floor in between.
+    await modA.waitAndClick(e.muteMicButton);
+    await attendeeA.waitAndClick(e.unmuteMicButton);
+    await attendeeA.hasElement(e.isTalking, 'attendee A should be talking');
+    await expectFloorHolder(
+      attendeeA.page,
+      attendeeAUserId,
+      'meeting A floor should switch to the next speaker, releasing the previous holder',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await expectFloorHolder(
+      modB.page,
+      modBUserId,
+      'meeting B floor should survive meeting A floor switches',
+      ELEMENT_WAIT_TIME,
+    );
+  });
+
+  test('a continuously talking speaker is not starved of the floor', async ({ browser }, testInfo) => {
+    test.skip(!isLiveKit, 'akka-apps floor control is specific to the LiveKit audio bridge');
+    const { modPage, userPage, modUserId, attendeeUserId } = await initTwoSpeakers(browser, testInfo);
+
+    // Near-simultaneous unmute so floor grants land on the same cooldown window
+    await Promise.all([modPage.waitAndClick(e.unmuteMicButton), userPage.waitAndClick(e.unmuteMicButton)]);
+    await expect(async () => {
+      const rows = await getUserVoiceRows(modPage.page);
+      expect(rows.filter((row) => row.talking).length, 'both speakers should be talking').toBe(2);
+    }).toPass({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    // Both keep talking: the later floor grant lands inside the earlier grant's
+    // cooldown window and must be retried instead of dropped, so each speaker
+    // is granted the floor at some point (lastFloorTime set for both).
+    await expect(async () => {
+      const rows = await getUserVoiceRows(modPage.page);
+      const granted = rows
+        .filter((row) => row.lastFloorTime !== '0')
+        .map((row) => row.userId)
+        .sort();
+      expect(granted, 'both speakers should have held the floor').toEqual([modUserId, attendeeUserId].sort());
+    }).toPass({ timeout: ELEMENT_WAIT_EXTRA_LONG_TIME });
+  });
+
+  test('the next active speaker is promoted when the floor holder leaves', async ({ browser }, testInfo) => {
+    test.skip(!isLiveKit, 'akka-apps floor control is specific to the LiveKit audio bridge');
+    const { modPage, userPage, modUserId, attendeeUserId } = await initTwoSpeakers(browser, testInfo);
+
+    await modPage.waitAndClick(e.unmuteMicButton);
+    await modPage.hasElement(e.isTalking, 'moderator should be talking');
+    await expectFloorHolder(
+      modPage.page,
+      modUserId,
+      'the first speaker should take the floor',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    // The attendee starts talking, the holder then leaves within the pending window.
+    await userPage.waitAndClick(e.unmuteMicButton);
+    await expect(async () => {
+      const rows = await getUserVoiceRows(userPage.page);
+      expect(
+        rows.some((row) => row.userId === attendeeUserId && row.talking),
+        'the attendee should be talking server-side',
+      ).toBeTruthy();
+    }).toPass({ timeout: ELEMENT_WAIT_LONGER_TIME });
+    await modPage.waitAndClick(e.leaveMeetingDropdown);
+    await modPage.waitAndClick(e.directLogoutButton);
+    await modPage.hasElement(e.meetingEndedModal, 'the holder should have left the meeting');
+
+    await expectFloorHolder(
+      userPage.page,
+      attendeeUserId,
+      'the floor should be promoted to the remaining active speaker',
+      ELEMENT_WAIT_EXTRA_LONG_TIME,
+    );
+  });
+});

--- a/bigbluebutton-tests/playwright/audio/floorProbe.ts
+++ b/bigbluebutton-tests/playwright/audio/floorProbe.ts
@@ -1,0 +1,115 @@
+import { expect, type Page as PlaywrightPage } from '@playwright/test';
+
+// window.__APOLLO_CLIENT__ is Apollo's own devtools global - the name is not ours to change.
+/* eslint-disable no-underscore-dangle */
+
+// The audio floor state lives server-side (user_voice.floor/lastFloorTime) and
+// has no dedicated UI element other than the non-guaranteed video grid sorting.
+// This is a way for tests to read floor state through GraphQL directly via Apollo.
+// (window.__APOLLO_CLIENT__).
+// That client is only available at window-level when enableApolloDevTools is on
+// or we have a dev bundle, so whichever specs use this util need to enable it via
+// clientSettingsOverride.
+
+interface FieldNode {
+  kind: string;
+  name: { kind: string; value: string };
+  selectionSet?: { kind: string; selections: FieldNode[] };
+}
+
+const field = (name: string, selections?: FieldNode[]): FieldNode => ({
+  kind: 'Field',
+  name: { kind: 'Name', value: name },
+  ...(selections ? { selectionSet: { kind: 'SelectionSet', selections } } : {}),
+});
+
+const queryDocument = (selections: FieldNode[]) => ({
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      selectionSet: { kind: 'SelectionSet', selections },
+    },
+  ],
+});
+
+const USER_VOICE_QUERY = queryDocument([
+  field('user_voice', [field('userId'), field('talking'), field('floor'), field('lastFloorTime')]),
+]);
+
+const USER_CURRENT_QUERY = queryDocument([field('user_current', [field('userId')])]);
+
+export interface UserVoiceRow {
+  userId: string;
+  talking: boolean;
+  floor: boolean;
+  lastFloorTime: string;
+}
+
+type ApolloQueryWindow = Window & {
+  __APOLLO_CLIENT__?: {
+    query: (options: object) => Promise<{ data: Record<string, unknown> }>;
+  };
+};
+
+export const APOLLO_CLIENT_SETTINGS_MODULE = [
+  '<modules><module name="clientSettingsOverride"><![CDATA[',
+  JSON.stringify({ public: { app: { enableApolloDevTools: true } } }),
+  ']]></module></modules>',
+].join('');
+
+// Guard for the specs: false when the bundle did not publish the client (i.e.
+// a production build whose meeting was created without the settings module
+// taking effect).
+export const isApolloClientExposed = (page: PlaywrightPage, timeout: number): Promise<boolean> =>
+  page
+    .waitForFunction(() => !!(window as ApolloQueryWindow).__APOLLO_CLIENT__, undefined, { timeout })
+    .then(
+      () => true,
+      () => false,
+    );
+
+const runQuery = async (page: PlaywrightPage, queryAst: object): Promise<Record<string, unknown>> =>
+  page.evaluate(async (ast) => {
+    const w = window as ApolloQueryWindow;
+    if (!w.__APOLLO_CLIENT__) {
+      throw new Error(
+        'window.__APOLLO_CLIENT__ is not exposed - the meeting needs enableApolloDevTools (clientSettingsOverride) or a development bundle',
+      );
+    }
+    const res = await w.__APOLLO_CLIENT__.query({ query: ast, fetchPolicy: 'network-only' });
+    return res.data;
+  }, queryAst);
+
+// user_voice is row-filtered by Hasura to the caller's meeting, so any joined page
+// observes exactly its own meeting's voice rows.
+export const getUserVoiceRows = async (page: PlaywrightPage): Promise<UserVoiceRow[]> => {
+  const data = await runQuery(page, USER_VOICE_QUERY);
+  return data.user_voice as UserVoiceRow[];
+};
+
+export const getOwnUserId = async (page: PlaywrightPage): Promise<string> => {
+  const data = await runQuery(page, USER_CURRENT_QUERY);
+  const rows = data.user_current as { userId: string }[];
+  if (!rows?.length) throw new Error('user_current returned no rows');
+  return rows[0].userId;
+};
+
+export const getFloorHolders = async (page: PlaywrightPage): Promise<string[]> => {
+  const rows = await getUserVoiceRows(page);
+  return rows.filter((row) => row.floor).map((row) => row.userId);
+};
+
+// Polls until the meeting observed from `page` has exactly one floor holder: `userId`.
+export const expectFloorHolder = async (
+  page: PlaywrightPage,
+  userId: string,
+  message: string,
+  timeout: number,
+): Promise<void> => {
+  await expect(async () => {
+    const holders = await getFloorHolders(page);
+    expect(holders, message).toEqual([userId]);
+  }).toPass({ timeout });
+};


### PR DESCRIPTION
### What does this PR do?

#### Summary

Do a sweep on akka-apps' audio floor managed used by the LK audio bridge and fix a
few issues:
  - Remove the possibility of cross-meeting floor collisions
  - Improve floor cooldown handling so that switches are more deterministic and reactive
  - Fixes a couple of edge cases regarding floor starvation (simultaneous speaking, stale floor entries)
  - Add a few E2E tests for floor actions (LK only)
  
#### In detail
 
- [refactor(audio): remove unused talkingStateChanges floor tracking](https://github.com/bigbluebutton/bigbluebutton/commit/a1e30a306d110fac7c1888752bee903445dfc1a6) 
  - AudioFloorManager's FloorState.talkingStateChanges has no actual usage.
Drop the field and the consequently stale cleanupOldState.
- [fix(audio): scope audio floor control state per meeting](https://github.com/bigbluebutton/bigbluebutton/commit/537136e6484c06fa1979b8e1d87c70338592ebb1) 
  - AudioFloorManager is an akka-apps-wide singleton, which may cause
collisions when handling audio floor events.
  - Turn AudioFloorManager into a per-meeting class held by LiveMeeting, so
floor grants, releases, CDs and pending queues are meeting-scoped and
releases always resolve in the holder's own meeting, and tear it down
from a MeetingActor postStop hook, which covers every termination path.
- [fix(audio): retry floor grants blocked by the floor cooldown](https://github.com/bigbluebutton/bigbluebutton/commit/0776154733e7c590c4ffdc7c83ac8ec7d00e7cc2) 
  - Replace the per-queued grant timers with a single re-scheduled grant
dispatch that always evaluates the queue head at the earliest instant a
grant can succeed (talking deadline or cooldown expiry, whichever is
later) and re-runs on every queue or floor-state change.
  - This includes the rewrite of the scheduler to use Pekko's scheduleOnce
via an internal DispatchFloorGrantsInternalMsg to the meeting actor,
handled like the other internal meeting timers, so all floor state is
inside the meeting actor lifecycle.
- [fix(audio): do not schedule the floor switch cooldown on release](https://github.com/bigbluebutton/bigbluebutton/commit/11db2d1e7d7d411a8bffea02825e573df9e62c1a) 
  - When a floor holder leaves, the release itself starts a cooldown that
defers the grant to the next pending speaker until after the cooldown
elapses. The cooldown exists to space out floor switches only - a release
event always should come after the cooldown already acted.
- [fix(audio): prune stale speaking states in floor manager](https://github.com/bigbluebutton/bigbluebutton/commit/fbbb3d24a555d0c54cc11a782eeb15d9c419d0b2) 
  - speakingStartTimes entries are removed only by explicit stop-talking or
left-voice events. A user whose events are lost (disconnect, ...) leaves an
entry behind until meeting end. Two obvious issues: queue buildup and
floor grant block for the affected user.
- [tests(audio): cover LiveKit audio floor control](https://github.com/bigbluebutton/bigbluebutton/commit/486f85968145c07a4697f05b4472fc71be8c17ff) 
  - Cover the akka floor manager in E2E tests through a few test scenarios:
    - Floor isolation across two concurrent meetings
    - No starvation when two speakers unmute near-simultaneously
    (both must eventually be granted)
    - Granting of the floor to a remaining active speaker when a floor
    holder leaves the meeting.
  - See commit log for implementation details.
  
### Closes Issue(s)

None