### PR TITLE
build: Bump Hasura from 2.49.3 to 2.49.4

### DIFF
--- a/build/packages-template/bbb-graphql-server/build.sh
+++ b/build/packages-template/bbb-graphql-server/build.sh
@@ -22,7 +22,7 @@ for dir in $DIRS; do
   mkdir -p staging$dir
 done
 
-HASURA_VERSION=v2.49.3
+HASURA_VERSION=v2.49.4
 
 git clone --branch $HASURA_VERSION https://github.com/iMDT/hasura-graphql-engine.git
 cat hasura-graphql-engine/hasura-graphql.part-a* > hasura-graphql


### PR DESCRIPTION
Bumps the Hasura GraphQL Engine version used by the `bbb-graphql-server` build from `v2.49.3` to `v2.49.4`, following the same pattern as #25349.

## What changes

A single line in `build/packages-template/bbb-graphql-server/build.sh`:

```
-HASURA_VERSION=v2.49.3
+HASURA_VERSION=v2.49.4
```

This variable feeds two consumers in the build script:
- `git clone --branch $HASURA_VERSION` from the iMDT fork (`iMDT/hasura-graphql-engine`)
- the upstream Hasura CLI download URL (`hasura/graphql-engine/releases/download/${HASURA_VERSION}`)

## Validation

Built and deployed `bbb-graphql-server` from-source with the bumped version in a running BBB 3.0 environment (`v3.0.x-develop` at `4ad56e1c`):

- `v2.49.4` exists in the iMDT fork (branch, SHA `02f0271f`) and resolves via `git clone --branch`
- Upstream CLI asset `cli-hasura-linux-amd64` for `v2.49.4` downloads (HTTP 200)
- Deployed binary reports `Hasura GraphQL Engine: v2.49.4` (`/v1/version` confirms `{"version":"v2.49.4"}`)
- `/healthz` returns OK; `bbb-graphql-server` service is `active`