### PR TITLE
fix: presentation download system message in chat export

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
@@ -12,6 +12,7 @@ export const GET_CHAT_MESSAGE_HISTORY = gql`
 query getChatMessageHistory {
   chat_message_public(order_by: {createdAt: asc}) {
     message
+    messageAsHtml
     messageId
     messageType
     messageMetadata

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -104,6 +104,8 @@ export const generateExportedMessages = (
       case ChatMessageType.API:
       case ChatMessageType.BREAKOUT_ROOM:
       case ChatMessageType.PLUGIN:
+        messageText = htmlDecode(message.messageAsHtml || message.message || '');
+        break;
       case ChatMessageType.TEXT:
       default:
         messageText = htmlDecode(message.message || '');

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -123,7 +123,7 @@ export const generateExportedMessages = (
       case ChatMessageType.API:
       case ChatMessageType.BREAKOUT_ROOM:
       case ChatMessageType.PLUGIN:
-        messageText = htmlDecode(message.messageAsHtml || message.message || '');
+        messageText = htmlDecode(message.message || message.messageAsHtml || '');
         break;
       case ChatMessageType.TEXT:
       default:

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -39,6 +39,10 @@ const intlMessages = defineMessages({
     defaultMessage: 'Presentation available for download',
     description: 'used in exported chat before a presentation filename',
   },
+  breakoutCallModerator: {
+    id: 'app.chat.breakoutCallModerator',
+    description: 'Breakout room call moderator system message',
+  },
 });
 
 export const htmlDecode = (input: string) => {
@@ -99,6 +103,21 @@ export const generateExportedMessages = (
         const { filename } = parsePresentationMetadata(message.messageMetadata);
         const presentationAvailable = intl.formatMessage(intlMessages.presentationAvailableForDownload);
         messageText = `${presentationAvailable}: ${filename}`;
+        break;
+      }
+      case ChatMessageType.BREAKOUT_CALL_MODERATOR: {
+        const metadata = (() => {
+          try {
+            const parsed = JSON.parse(message.messageMetadata);
+            return parsed && typeof parsed === 'object' ? parsed : {};
+          } catch {
+            return {};
+          }
+        })();
+        messageText = intl.formatMessage(intlMessages.breakoutCallModerator, {
+          userName: message.senderName,
+          roomName: metadata.roomName || '',
+        });
         break;
       }
       case ChatMessageType.API:

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -3,7 +3,7 @@ import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { IntlShape, defineMessages } from 'react-intl';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
 import PollService from '/imports/ui/components/poll/service';
-import getPresentationDownloadData from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
+import { parsePresentationMetadata } from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
 
 const intlMessages = defineMessages({
   chatClear: {
@@ -37,7 +37,7 @@ const intlMessages = defineMessages({
   presentationAvailableForDownload: {
     id: 'app.presentationUploader.export.availableForDownload',
     defaultMessage: 'Presentation available for download',
-    description: 'used in exported chat before a presentation download filename and URL',
+    description: 'used in exported chat before a presentation filename',
   },
 });
 
@@ -96,9 +96,9 @@ export const generateExportedMessages = (
         break;
       }
       case ChatMessageType.PRESENTATION: {
-        const { absoluteDownloadUrl, filename } = getPresentationDownloadData(message.messageMetadata);
+        const { filename } = parsePresentationMetadata(message.messageMetadata);
         const presentationAvailable = intl.formatMessage(intlMessages.presentationAvailableForDownload);
-        messageText = `${presentationAvailable}: ${filename} - ${absoluteDownloadUrl}`;
+        messageText = `${presentationAvailable}: ${filename}`;
         break;
       }
       case ChatMessageType.API:

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -3,6 +3,7 @@ import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { IntlShape, defineMessages } from 'react-intl';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
 import PollService from '/imports/ui/components/poll/service';
+import getPresentationDownloadData from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
 
 const intlMessages = defineMessages({
   chatClear: {
@@ -33,6 +34,11 @@ const intlMessages = defineMessages({
     id: 'app.chat.isPresenterSetBy',
     description: 'message when user is set presenter by someone else',
   },
+  presentationAvailableForDownload: {
+    id: 'app.presentationUploader.export.availableForDownload',
+    defaultMessage: 'Presentation available for download',
+    description: 'used in exported chat before a presentation download filename and URL',
+  },
 });
 
 export const htmlDecode = (input: string) => {
@@ -51,6 +57,11 @@ export const generateExportedMessages = (
     const hourMin = `[${hour}:${min}]`;
     let userName = message.user ? `[${message.user.name} : ${message.user.role}]: ` : '';
     let messageText = '';
+
+    if (message.deletedBy) {
+      messageText = intl.formatMessage(intlMessages.deleteMessage, { userName: message.deletedBy.name });
+      return `${acc}${hourMin} ${userName}${messageText}\n`;
+    }
 
     switch (message.messageType) {
       case ChatMessageType.CHAT_CLEAR:
@@ -84,11 +95,18 @@ export const generateExportedMessages = (
           : `${message.senderName} ${intl.formatMessage(intlMessages.userNotAway)}`;
         break;
       }
+      case ChatMessageType.PRESENTATION: {
+        const { absoluteDownloadUrl, filename } = getPresentationDownloadData(message.messageMetadata);
+        const presentationAvailable = intl.formatMessage(intlMessages.presentationAvailableForDownload);
+        messageText = `${presentationAvailable}: ${filename} - ${absoluteDownloadUrl}`;
+        break;
+      }
+      case ChatMessageType.API:
+      case ChatMessageType.BREAKOUT_ROOM:
+      case ChatMessageType.PLUGIN:
       case ChatMessageType.TEXT:
       default:
-        messageText = message.message
-          ? htmlDecode(message.message)
-          : intl.formatMessage(intlMessages.deleteMessage, { userName: message.deletedBy?.name });
+        messageText = htmlDecode(message.message || '');
         break;
     }
     return `${acc}${hourMin} ${userName}${messageText}\n`;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/component.tsx
@@ -1,29 +1,12 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import Auth from '/imports/ui/services/auth';
 import Styled from './styles';
 import Icon from '/imports/ui/components/common/icon/component';
+import getPresentationDownloadData from './service';
 
 interface ChatMessagePresentationContentProps {
   metadata: string;
 }
-interface Metadata {
-  fileURI: string;
-  filename: string;
-}
-
-function assertAsMetadata(metadata: unknown): asserts metadata is Metadata {
-  if (typeof metadata !== 'object' || metadata === null) {
-    throw new Error('metadata is not an object');
-  }
-  if (typeof (metadata as Metadata).fileURI !== 'string') {
-    throw new Error('metadata.fileURI is not a string');
-  }
-  if (typeof (metadata as Metadata).filename !== 'string') {
-    throw new Error('metadata.fileName is not a string');
-  }
-}
-
 const intlMessages = defineMessages({
   download: {
     id: 'app.presentation.downloadLabel',
@@ -39,21 +22,14 @@ const ChatMessagePresentationContent: React.FC<ChatMessagePresentationContentPro
   metadata: string,
 }) => {
   const intl = useIntl();
-  const presentationData = JSON.parse(string) as unknown;
-  assertAsMetadata(presentationData);
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore - temporary, while meteor exists in the project
-  const APP_CONFIG = window.meetingClientSettings.public.app;
-
-  const downloadUrl = Auth.authenticateURL(`${APP_CONFIG.bbbWebBase}/${presentationData.fileURI}`);
+  const { downloadUrl, filename } = getPresentationDownloadData(string);
   const parseFilename = (filename = '') => {
     const substrings = filename.split('.');
     substrings.pop();
     const filenameWithoutExtension = substrings.join('');
     return filenameWithoutExtension;
   };
-  const parsedFileName = parseFilename(presentationData.filename);
+  const parsedFileName = parseFilename(filename);
 
   return (
     <Styled.ContentWrapper data-test="downloadPresentationContainer">
@@ -62,7 +38,7 @@ const ChatMessagePresentationContent: React.FC<ChatMessagePresentationContentPro
       </Styled.IconWrapper>
 
       <Styled.TextWrapper>
-        <span>{presentationData.filename}</span>
+        <span>{filename}</span>
         <Styled.AnnotationText>
           {intl.formatMessage(intlMessages.withWhiteboardAnnotations)}
         </Styled.AnnotationText>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
@@ -1,0 +1,37 @@
+import Auth from '/imports/ui/services/auth';
+
+interface PresentationMetadata {
+  fileURI: string;
+  filename: string;
+}
+
+function assertAsPresentationMetadata(metadata: unknown): asserts metadata is PresentationMetadata {
+  if (typeof metadata !== 'object' || metadata === null) {
+    throw new Error('metadata is not an object');
+  }
+  if (typeof (metadata as PresentationMetadata).fileURI !== 'string') {
+    throw new Error('metadata.fileURI is not a string');
+  }
+  if (typeof (metadata as PresentationMetadata).filename !== 'string') {
+    throw new Error('metadata.filename is not a string');
+  }
+}
+
+const getPresentationDownloadData = (metadata: string) => {
+  const presentationData = JSON.parse(metadata) as unknown;
+  assertAsPresentationMetadata(presentationData);
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const APP_CONFIG = window.meetingClientSettings.public.app;
+  const downloadUrl = Auth.authenticateURL(`${APP_CONFIG.bbbWebBase}/${presentationData.fileURI}`);
+  const absoluteDownloadUrl = new URL(downloadUrl, window.location.origin).toString();
+
+  return {
+    absoluteDownloadUrl,
+    downloadUrl,
+    filename: presentationData.filename,
+  };
+};
+
+export default getPresentationDownloadData;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
@@ -17,18 +17,22 @@ function assertAsPresentationMetadata(metadata: unknown): asserts metadata is Pr
   }
 }
 
-const getPresentationDownloadData = (metadata: string) => {
+export const parsePresentationMetadata = (metadata: string) => {
   const presentationData = JSON.parse(metadata) as unknown;
   assertAsPresentationMetadata(presentationData);
+
+  return presentationData;
+};
+
+const getPresentationDownloadData = (metadata: string) => {
+  const presentationData = parsePresentationMetadata(metadata);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const APP_CONFIG = window.meetingClientSettings.public.app;
   const downloadUrl = Auth.authenticateURL(`${APP_CONFIG.bbbWebBase}/${presentationData.fileURI}`);
-  const absoluteDownloadUrl = new URL(downloadUrl, window.location.origin).toString();
 
   return {
-    absoluteDownloadUrl,
     downloadUrl,
     filename: presentationData.filename,
   };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -398,6 +398,7 @@
     "app.presentationUploader.exportCurrentStatePresentation": "Send out a download link for the presentation including whiteboard annotations",
     "app.presentationUploader.enableOriginalPresentationDownload": "Enable download of the presentation ({fileExtension})",
     "app.presentationUploader.disableOriginalPresentationDownload": "Disable download of the original presentation ({fileExtension})",
+    "app.presentationUploader.export.availableForDownload": "Presentation available for download",
     "app.presentationUploader.export.withWhiteboardAnnotations": "with whiteboard annotations",
     "app.presentationUploader.dropdownExportOptions": "Export options",
     "app.presentationUploader.dropdownExportOptionsUncomplete": "Disabled until upload is complete",


### PR DESCRIPTION
### What does this PR do?

Updates chat export to correctly handle deleted messages and exported slides messages.

### Closes Issue(s)
Closes #25387

### How to test

1. Join a meeting as presenter.
2. Open **Media Area ->  Slides**.
3. On the current presentation, open the export dropdown (three-dots menu) and click **Send out a download link for the presentation including whiteboard annotations**.
4. Wait for the annotated PDF to be generated. A "Presentation available for download" card appears in Public Chat with the filename and a download button.
5. In the chat header, click **⋮ → Save**.
6. Open the downloaded `.txt` file.
7. Check the line for the download-link message.
