### PR TITLE
fix(html5): fallback to default value in plugin Selector when applicable

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/common/selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/common/selector/component.tsx
@@ -14,6 +14,15 @@ export default function Selector({
 }: SelectorProps): React.ReactNode {
   const [selected, setSelected] = React.useState<string | number>(defaultOption.value);
 
+  // If the currently-selected value is no longer among the options (e.g. a
+  // plugin removed the option that was selected), fall back to the default
+  // rather than rendering an empty value.
+  React.useEffect(() => {
+    const stillValid = options.some((option) => option.value === selected);
+
+    if (!stillValid) setSelected(defaultOption.value);
+  }, [options, defaultOption.value, selected]);
+
   const handleChange = (event: SelectChangeEvent<unknown>) => {
     const value = event.target.value as string | number;
     setSelected(value);


### PR DESCRIPTION
### What does this PR do?

- [fix(html5): fallback to default value in plugin Selector when applicable](https://github.com/bigbluebutton/bigbluebutton/commit/46621f157c132a589d79c9a795b9333b189cc1a2) 
  -  The base Selector component, mostly used by plugins, renders an empty
selection if the newly selected option is not part of the initially
provided list of available values. This breaks valid scenarios such as
resetting the selector to its initial state via nulling/emptying it.
  - Add an effect to Selector that restores it to the provided defaultOption
if the new selection is empty or not part of the supported values.

### Closes Issue(s)

None