### PR TITLE
feat: Add bbbctl tool to bbb-config package

### DIFF
--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -39,13 +39,9 @@ mkdir -p staging/etc/bigbluebutton/bbb-conf
 mkdir -p staging/usr/lib/bbb-conf
 cp bin/apply-lib.sh staging/usr/lib/bbb-conf
 
-# Download bbbctl v0.5.0
-wget https://raw.githubusercontent.com/defnull/bbbctl/d292591665332513aa4ce0b997440a2b7304ccf6/src/bbbctl.py -O staging/usr/bin/bbbctl
-
-# Check integrity
-echo "f5fb826ed5f3132e01d6c9e30b0225f45838e27e2f87424ee5331ce37e9e7abd staging/usr/bin/bbbctl" > bbbctl.sha256
-sha256sum -c bbbctl.sha256
-rm bbbctl.sha256
+# Download bbbctl v0.5.1
+wget https://raw.githubusercontent.com/defnull/bbbctl/v0.5.1/src/bbbctl.py -O staging/usr/bin/bbbctl
+echo "9fe4db93f2ff18cfdd31b1cc0ce38439918f54634129cde3f1f852ae7096b79d staging/usr/bin/bbbctl" | sha256sum -c
 chmod 755 staging/usr/bin/bbbctl
 
 mkdir -p staging/etc/cron.daily

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -39,7 +39,13 @@ mkdir -p staging/etc/bigbluebutton/bbb-conf
 mkdir -p staging/usr/lib/bbb-conf
 cp bin/apply-lib.sh staging/usr/lib/bbb-conf
 
-wget https://raw.githubusercontent.com/defnull/bbbctl/refs/tags/v0.5.0/src/bbbctl.py -O staging/usr/bin/bbbctl
+# Download bbbctl v0.5.0
+wget https://raw.githubusercontent.com/defnull/bbbctl/d292591665332513aa4ce0b997440a2b7304ccf6/src/bbbctl.py -O staging/usr/bin/bbbctl
+
+# Check integrity
+echo "f5fb826ed5f3132e01d6c9e30b0225f45838e27e2f87424ee5331ce37e9e7abd staging/usr/bin/bbbctl" > bbbctl.sha256
+sha256sum -c bbbctl.sha256
+rm bbbctl.sha256
 chmod 755 staging/usr/bin/bbbctl
 
 mkdir -p staging/etc/cron.daily

--- a/build/packages-template/bbb-config/build.sh
+++ b/build/packages-template/bbb-config/build.sh
@@ -39,6 +39,9 @@ mkdir -p staging/etc/bigbluebutton/bbb-conf
 mkdir -p staging/usr/lib/bbb-conf
 cp bin/apply-lib.sh staging/usr/lib/bbb-conf
 
+wget https://raw.githubusercontent.com/defnull/bbbctl/refs/tags/v0.5.0/src/bbbctl.py -O staging/usr/bin/bbbctl
+chmod 755 staging/usr/bin/bbbctl
+
 mkdir -p staging/etc/cron.daily
 cp cron.daily/* staging/etc/cron.daily
 


### PR DESCRIPTION
### What does this PR do?
This PR adds the `bbbctl` tool from @defnull to the bbb-config package

### Motivation
`bbbctl` is a very useful tool which allows the administrator to interact with the server API. You ca create a meeting without a frontend, list meetings end meetings etc
