### PR TITLE
fix(core): API parameter downloadable is not working

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
@@ -8,6 +8,8 @@ import org.bigbluebutton.core.models.PresentationInPod
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
+import java.io.File
+import java.net.URI
 import java.time.{Instant, Duration}
 
 trait PresentationConversionCompletedSysPubMsgHdlr {
@@ -58,6 +60,12 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
       pods = pods.addPresentationToPod(pod.id, presWithConvertedName)
 
       PresPresentationDAO.updatePages(presWithConvertedName)
+      if (pres.downloadable) {
+        val originalFilename = new URI(null, null, pres.name, null).getRawPath
+        val originalFileURI = List("presentation", "download", meetingId,
+          s"${pres.id}?presFilename=${pres.id}.${originalDownloadableExtension}&filename=$originalFilename").mkString("", File.separator, "")
+        PresPresentationDAO.updateDownloadUri(pres.id, originalFileURI)
+      }
       if(pres.current) {
         val notifyEvent = MsgBuilder.buildNotifyAllInMeetingEvtMsg(
           meetingId,
@@ -93,4 +101,3 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
 
   }
 }
-


### PR DESCRIPTION
### What does this PR do?

enable original downloads for API-inserted presentations

### Closes Issue(s)
Closes #25412

### How to test
1. Send a create or insertDocument request with attribute `downloadable="true" `
2. Join meeting
3. See download of the presentation button
