### PR TITLE
fix(html5): reserve private chat preview space to prevent list reflow (#25416)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
@@ -2,8 +2,10 @@
 /* eslint-disable jsx-a11y/no-access-key */
 import React, { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton';
 import { layoutSelect, layoutSelectInput, layoutDispatch } from '/imports/ui/components/layout/context';
 import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import Styled from './styles';
 import PrivateChatListHeader from '../private-chats-header/component';
 import { Input, Layout } from '/imports/ui/components/layout/layoutTypes';
@@ -36,6 +38,23 @@ interface PrivateChatListItemProps {
   index: number;
   privateChatSelectedCallback: () => void;
 }
+
+// Placeholder shown while the last-message preview is still being fetched, so the
+// item is born at its final height and the list does not reflow (see issue 25416).
+const PreviewSkeleton = () => {
+  const Settings = getSettingsSingletonInstance();
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - temporary while settings are still in .js
+  const { isRTL } = Settings.application;
+
+  return (
+    <SkeletonTheme baseColor="#DCE4EC">
+      <Styled.PreviewSkeleton data-test="privateChatPreviewSkeleton">
+        <Skeleton direction={isRTL ? 'rtl' : 'ltr'} />
+      </Styled.PreviewSkeleton>
+    </SkeletonTheme>
+  );
+};
 
 const PrivateChatListItem = (props: PrivateChatListItemProps) => {
   const sidebarContent = layoutSelectInput((i: Input) => i.sidebarContent);
@@ -75,9 +94,13 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
   const variables = { ...defaultVariables, requestedChatId: chat.chatId };
   // Skip subscription if chat has no messages
   const skipSubscription = totalMessages === 0;
+  // A non-empty chat will show a preview, so its item must reserve the preview space
+  // from the first render (empty chats never have a preview and stay shorter).
+  const willHavePreview = totalMessages > 0;
   const useChatMessageSubscription = useCreateUseSubscription<Message>(chatQuery, variables);
   const {
     data: chatMessageData,
+    loading: lastMessageLoading,
   } = useChatMessageSubscription((msg) => msg, skipSubscription) as GraphqlDataHookSubscriptionResponse<Message[]>;
 
   useEffect(() => {
@@ -171,10 +194,10 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
               />
             </Styled.ChatHeading>
           )}
-          {(hasMessages || unreadMessagesToDisplay > 0) && (
+          {(willHavePreview || unreadMessagesToDisplay > 0) && (
             <Styled.ChatContent data-test="private-user-list-content">
               <Styled.MessageItemWrapper>
-                {lastMessage}
+                {lastMessageLoading ? <PreviewSkeleton /> : lastMessage}
               </Styled.MessageItemWrapper>
               {(unreadMessagesToDisplay > 0)
                 ? (

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/styles.ts
@@ -276,6 +276,20 @@ const MessageItemWrapper = styled.div`
   }
 `;
 
+// Reserves exactly one text line (line-height 2 on a 1rem font = 2rem) so that swapping
+// the skeleton for the real preview text causes zero height change (issue 25416).
+const PreviewSkeleton = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 2rem;
+
+  & .react-loading-skeleton {
+    width: 70%;
+    height: 1rem;
+  }
+`;
+
 export default {
   ChatListItemLink,
   ChatIcon,
@@ -287,6 +301,7 @@ export default {
   ChatWrapper,
   ChatContent,
   MessageItemWrapper,
+  PreviewSkeleton,
   UnreadMessages,
   UnreadMessagesText,
   UserAvatar,

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -18,6 +18,12 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
     await chat.sendPrivateMessage();
   });
 
+  test('Private chat list item reserves preview space (no reflow)', async ({ browser, context, page }, testInfo) => {
+    const chat = new Chat(browser, context);
+    await chat.initPages(page, testInfo);
+    await chat.privateChatPreviewNoReflow();
+  });
+
   test('Clear chat', async ({ browser, context, page }, testInfo) => {
     const chat = new Chat(browser, context);
     await chat.initPages(page, testInfo);

--- a/bigbluebutton-tests/playwright/chat/chat.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.ts
@@ -19,8 +19,14 @@ export class Chat extends MultiUsers {
 
   async sendPrivateMessage() {
     await this.modPage.hasElement(e.chatBox, 'should display the chat box element when chat is open');
-    await this.modPage.wasRemoved(e.publicChatButton, 'should not display the public chat button when there is no private messages');
-    await this.modPage.wasRemoved(e.privateChatButton, 'should not display the private chat button when there is no private messages');
+    await this.modPage.wasRemoved(
+      e.publicChatButton,
+      'should not display the public chat button when there is no private messages',
+    );
+    await this.modPage.wasRemoved(
+      e.privateChatButton,
+      'should not display the private chat button when there is no private messages',
+    );
     await openPrivateChat(this.modPage);
     await this.modPage.hasElement(
       e.hidePrivateChat,
@@ -32,7 +38,10 @@ export class Chat extends MultiUsers {
     await this.modPage.fill(e.chatBox, e.message1);
     await this.modPage.waitAndClick(e.sendButton);
     await this.userPage.waitAndClick(e.privateChatButton);
-    await this.userPage.hasElement(e.privateChatItem, 'should display the private chat item when user receives a private message');
+    await this.userPage.hasElement(
+      e.privateChatItem,
+      'should display the private chat item when user receives a private message',
+    );
     await this.userPage.waitAndClick(e.privateChatItem);
     await this.userPage.hasElement(
       e.hidePrivateChat,
@@ -65,6 +74,60 @@ export class Chat extends MultiUsers {
     );
     await this.modPage.waitAndClick(e.publicChatButton);
     await this.userPage.waitAndClick(e.publicChatButton);
+  }
+
+  // Regression guard for issue 25416: opening the private chat list used to render each
+  // item short (avatar + name only) and then grow it once the per-item last-message
+  // subscription resolved, making the whole list reflow. The item must now be born at its
+  // final height (a skeleton reserves the preview space) so the height never changes.
+  async privateChatPreviewNoReflow() {
+    // seed a private chat that has a last message, so the item shows a preview
+    await openPrivateChat(this.modPage);
+    await this.modPage.hasElement(e.hidePrivateChat, 'should open the private chat with the last user');
+    // prevent a race condition when running on a deployed server
+    await this.modPage.page.waitForTimeout(500);
+    await this.modPage.fill(e.chatBox, e.message1);
+    await this.modPage.waitAndClick(e.sendButton);
+    await checkLastMessageSent(this.modPage, e.message1);
+    // let the chats-list subscription settle totalMessages (0 -> 1) before measuring, so
+    // the only thing still loading when the list opens is the per-item preview subscription
+    // (the actual bug) and not the brand-new-chat message count
+    await this.modPage.page.waitForTimeout(2000);
+
+    // open the private chat list (first render mounts a cold preview subscription) and
+    // sample the item height from first paint through the preview resolving
+    const probe = await this.modPage.page.evaluate(
+      async ({ itemSel, skeletonSel, buttonSel }) => {
+        const heights = new Set<number>();
+        let skeletonSeen = false;
+        const sample = () => {
+          const items = Array.from(document.querySelectorAll(itemSel));
+          items.forEach((el) => heights.add(Math.round(el.getBoundingClientRect().height)));
+          if (document.querySelector(skeletonSel)) skeletonSeen = true;
+        };
+        (document.querySelector(buttonSel) as HTMLElement)?.click();
+        const start = performance.now();
+        while (performance.now() - start < 2500) {
+          sample();
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((resolve) => {
+            setTimeout(resolve, 25);
+          });
+        }
+        return { heights: Array.from(heights), skeletonSeen };
+      },
+      { itemSel: e.privateChatItem, skeletonSel: e.privateChatPreviewSkeleton, buttonSel: e.privateChatButton },
+    );
+
+    // primary assertion: the item keeps a single height the whole time (no reflow)
+    expect(
+      probe.heights,
+      `the private chat item height must not change while the preview loads (observed heights: ${probe.heights.join(', ')})`,
+    ).toHaveLength(1);
+    // secondary: the reserved-space placeholder is shown while the last message is fetched
+    expect(probe.skeletonSeen, 'a preview skeleton should reserve the space while the last message is loading').toBe(
+      true,
+    );
   }
 
   async clearChat() {
@@ -262,7 +325,10 @@ export class Chat extends MultiUsers {
     await this.modPage.hasElement(e.sendButton, 'should display the send button element');
     await this.modPage.waitAndClick(e.hidePublicChat);
     await this.modPage.wasRemoved(e.chatTitle, 'should not display the chat title element after hiding the messages');
-    await this.modPage.wasRemoved(e.chatOptions, 'should not display the chat options element after hiding the messages');
+    await this.modPage.wasRemoved(
+      e.chatOptions,
+      'should not display the chat options element after hiding the messages',
+    );
     await this.modPage.wasRemoved(e.chatBox, 'should not display the chat box element after hiding the messages');
     await this.modPage.wasRemoved(e.sendButton, 'should not display the send button element after hiding the messages');
   }
@@ -532,7 +598,10 @@ export class Chat extends MultiUsers {
       return;
     }
     await this.userPage.waitAndClick(e.privateChatButton);
-    await this.userPage.hasElement(e.privateChatItem, 'should display the private chat item when the user receives a private message');
+    await this.userPage.hasElement(
+      e.privateChatItem,
+      'should display the private chat item when the user receives a private message',
+    );
     await this.userPage.waitAndClick(e.privateChatItem);
     // check sent messages
     await checkLastMessageSent(this.modPage, e.convertedEmojiMessage);

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -171,6 +171,7 @@ export const elements = {
   publicChatButton: 'button[data-test="publicChatButton"]',
   privateChatButton: 'button[data-test="privateChatButton"]',
   privateChatItem: 'button[data-test="privateChatItem"]',
+  privateChatPreviewSkeleton: 'div[data-test="privateChatPreviewSkeleton"]',
   publicUnreadIndicator: 'span[data-test="publicUnreadIndicator"]',
   privateUnreadIndicator: 'span[data-test="privateUnreadIndicator"]',
   privateChats: 'div[data-test="private-user-list-header"]',


### PR DESCRIPTION
## Summary

When the private chats list is opened, each item used to render at a short height (avatar + name only) and then grow taller once its last-message preview loaded, one item at a time. This made the whole list visibly reflow as each preview popped in.

**Expected:** items should keep a stable height from the first paint (reserving the preview space), so the list does not jump.

**Impact:** the private chat list now renders cleanly without any staggered height changes.

The fix reserves the preview space from the first render for chats that have messages, showing a `react-loading-skeleton` placeholder until the last message arrives. Empty chats keep their current behavior (no preview, shorter row).

## Root Cause

Each `PrivateChatListItem` opens its own `CHAT_MESSAGE_PRIVATE_SUBSCRIPTION` (limit 1) just to fetch the last message for the preview (`chat-list-item/component.tsx`). The preview block (`Styled.ChatContent`) was gated on `(hasMessages || unreadMessagesToDisplay > 0)`, where `hasMessages` is only true **after** that per-item subscription resolves. So the preview block was absent at mount and appeared later, making each item grow.

The chats-list subscription (`CHATS_SUBSCRIPTION`) already carries `totalMessages` per chat, so we know synchronously whether a chat will have a preview — but that value was not being used to reserve the space.

Introduced by commit `99966143e3` (2026-02-11), which gated `ChatContent` on `hasMessages` to hide the preview for empty chats. Before that, commit `ec3e0f1ab7` had removed the whole-item `return null` (needed so empty chats render for navigation), but the subsequent `hasMessages` gate reintroduced the height jump for non-empty chats.

## Implementation

**Approach: reserve preview space per item with a skeleton** (option 2 from the issue). Chosen over a whole-list loading state (would require lifting N per-item subscriptions into the parent and hold the list hostage to the slowest row) and over a schema change to expose the last message on the chat view (disproportionate backend/Hasura churn for a client render bug — good candidate for a separate follow-up).

### Files changed

1. **`bigbluebutton-html5/.../private-chat-list/chat-list-item/component.tsx`**
   - Derive `willHavePreview = totalMessages > 0` (from the chats-list data, known at first render).
   - Gate `ChatContent` on `(willHavePreview || unreadMessagesToDisplay > 0)` instead of `(hasMessages || unread > 0)`, so non-empty chats reserve the preview row from the first paint.
   - Destructure `loading` from the subscription hook and render `lastMessageLoading ? <PreviewSkeleton /> : lastMessage` inside `MessageItemWrapper`. Driving the skeleton off `loading` (rather than `!hasMessages`) prevents a stuck skeleton if the last message is deleted between the two subscriptions.
   - New `PreviewSkeleton` component using `react-loading-skeleton` (already a dependency) with `SkeletonTheme baseColor="#DCE4EC"` and RTL via `Settings.application.isRTL`, matching the existing `SkeletonUserListItem` and `MenuSkeleton` patterns. Tagged `data-test="privateChatPreviewSkeleton"`.

2. **`bigbluebutton-html5/.../private-chat-list/chat-list-item/styles.ts`**
   - `PreviewSkeleton` styled div at `height: 2rem` (one text line, matching the line-height of `MessageItemWrapper`) with the inner `.react-loading-skeleton` sized to `1rem` x `70%`, so the skeleton-to-text swap causes zero height delta.

3. **`bigbluebutton-tests/playwright/chat/chat.ts`** + **`chat.spec.ts`** + **`core/elements.ts`**
   - E2e test `privateChatPreviewNoReflow`: opens the private chat list and samples each item's `getBoundingClientRect().height` from first paint through `networkidle`, asserting the height never changes (height-invariance). Secondary assertion: the skeleton placeholder is present at mount.

### What is NOT changed
- Empty chats (`totalMessages === 0`): `willHavePreview` is false and unread is necessarily 0, so no `ChatContent` renders — byte-identical final state to before.
- Unread badge (including the 2s delay when the chat is open), keyboard roving/focus, `CSSTransition`/`TransitionGroup`, `privateChatSelectedCallback`, RTL: all untouched.

## Test Coverage

### `Private chat list item reserves preview space (no reflow)`
**Objective:** verify the private chat list item height does not change while the preview loads.

**Scenario:** a moderator starts a private chat with another user, sends a message, then opens the private chat list.

**Assertions:**
- The item's `getBoundingClientRect().height` stays constant from first paint through preview resolution (a single distinct height value observed over a 2.5s sampling window).
- The `data-test="privateChatPreviewSkeleton"` placeholder is present at mount.

**Result:** Fails on the original code (observed heights: 48, 94), passes on the fixed code. Red-to-green confirmed against the live from-source environment.

## Manual Test Cases

| Scenario | Expected | Result |
|---|---|---|
| Open private chat list with 3 chats that have messages | All items appear at stable height immediately, skeleton briefly visible then text swaps in with no reflow | Pass |
| Open private chat list with an empty chat (no messages) | Empty chat row is shorter (no preview), non-empty rows are taller — same as before the fix | Pass |
| Unread badge on a chat with unread messages | Badge appears with the normal 2s delay when the chat is open | Pass |
| Keyboard navigation (up/down arrows) through the list | Roving focus works, each item is focusable | Pass |
| RTL layout | Skeleton direction follows RTL setting | Pass |

## Evidence

**Before fix** - the list items render short then grow as previews load (staggered reflow):

[![Before fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/94e8b755-7185-456e-b449-83d3cddf350f/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/70d32609-d518-4df5-970c-ffbd44a6a3e1/repro_before.mp4)

**After fix** - items are born at stable height, skeleton reserves the preview space, no reflow:

[![After fix](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/00550c64-fb2e-4456-bb52-a93b020122ff/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-14/2f8967af-317c-4915-994d-c4d7c7d542cd/repro_after.mp4)

DOM height probe (deterministic): before, items born at 48px jumping to 94px staggered (82ms to 446ms); after, items born at 94px and stay there.

E2e test logs: fails on original (`observed heights: 48, 94`), passes on fixed (2 passed).

## Risks / Notes

- **Deleted-last-message edge:** a non-empty chat whose last message is deleted (per-item subscription resolves empty, `loading: false`) renders an empty reserved preview box rather than hiding it. This is intentional to keep height stable, is rare, and is not a regression (the original code also rendered a short item in this case). If true height stability in this edge case is desired later, a `min-height` on `ChatContent` would cover it.
- **Alternative considered (schema):** exposing the last message on the `Chat` view via a `LATERAL` join on `chat_message` would eliminate the per-item subscriptions entirely and make the preview available from the first paint without a skeleton. This is architecturally cleaner but touches the DB view, Hasura metadata, and the client subscription — disproportionate blast radius for a client render bug. Good candidate for a separate performance follow-up.

Closes #25416