### PR TITLE
fix(html5): retry locale fetch on transient network failure

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -24,11 +24,17 @@ interface IntlLoaderProps extends IntlLoaderContainerProps {
   setCurrentLocale: (locale: string) => void;
 }
 
-// Waits `ms` before resolving, but resolves early if the signal aborts. The
-// abort listener is always detached: on normal completion the setTimeout
-// callback removes it, and on abort the once:true listener has already fired.
-// This prevents listeners from piling up across retries on a long-lived signal.
+// Waits `ms` before resolving, but resolves early if the signal aborts. If the
+// signal is already aborted when called, resolve synchronously without arming a
+// timeout. The abort listener is always detached: on normal completion the
+// setTimeout callback removes it, and on abort the once:true listener has
+// already fired. This prevents listeners from piling up across retries on a
+// long-lived signal.
 const waitForDelay = (ms: number, signal: AbortSignal): Promise<void> => new Promise((resolve) => {
+  if (signal.aborted) {
+    resolve();
+    return;
+  }
   const onAbort = () => {
     clearTimeout(timer);
     resolve();
@@ -80,7 +86,15 @@ const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown>
         },
         `Locale fetch failed for ${locale}, retrying in ${delay}ms`,
       );
-      return waitForDelay(delay, signal).then(() => attempt(retryCount + 1));
+      return waitForDelay(delay, signal).then(() => {
+        // The delay may have resolved early because the signal aborted while we
+        // were waiting. Skip the extra fetch (it would only reject) and fall
+        // back instead.
+        if (signal.aborted) {
+          return false;
+        }
+        return attempt(retryCount + 1);
+      });
     });
 
   return attempt(0);

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -24,55 +24,47 @@ interface IntlLoaderProps extends IntlLoaderContainerProps {
   setCurrentLocale: (locale: string) => void;
 }
 
-// Waits `ms` before resolving, but resolves early if the signal aborts. If the
-// signal is already aborted when called, resolve synchronously without arming a
-// timeout. The abort listener is always detached: on normal completion the
-// setTimeout callback removes it, and on abort the once:true listener has
-// already fired. This prevents listeners from piling up across retries on a
-// long-lived signal.
-const waitForDelay = (ms: number, signal: AbortSignal): Promise<void> => new Promise((resolve) => {
+// Waits `ms` and resolves to true, or resolves early to false if the signal
+// aborts (already aborted at call time, or aborts while waiting). The abort
+// listener is always detached: the setTimeout callback removes it on normal
+// completion, and the once:true listener removes itself when it fires. This
+// keeps listeners from piling up across retries on a long-lived signal.
+const waitForDelay = (ms: number, signal: AbortSignal): Promise<boolean> => new Promise((resolve) => {
   if (signal.aborted) {
-    resolve();
+    resolve(false);
     return;
   }
   const onAbort = () => {
     clearTimeout(timer);
-    resolve();
+    resolve(false);
   };
   const timer = setTimeout(() => {
     signal.removeEventListener('abort', onAbort);
-    resolve();
+    resolve(true);
   }, ms);
   signal.addEventListener('abort', onAbort, { once: true });
 });
 
 const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown> => {
   const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
-  const localesPath = 'locales';
-  const url = `${localesPath}/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`;
+  const url = `locales/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`;
 
-  const attempt = (retryCount: number): Promise<unknown> => fetch(url, { signal })
-    .then((response) => {
+  const attempt = async (retryCount: number): Promise<unknown> => {
+    try {
+      const response = await fetch(url, { signal });
       // A genuine HTTP error (e.g. 404 for a locale that does not exist) is a
-      // legitimate fallback, not a transient failure: resolve false so the
-      // merge step falls back to another locale. Retrying would never help.
-      if (!response.ok) {
+      // legitimate fallback, not a transient failure: resolve false so the merge
+      // step falls back to another locale. Retrying would never help.
+      if (!response.ok) return false;
+      return response.json().catch(() => {
+        logger.error({ logCode: 'intl_parse_locale_SyntaxError' }, `Could not parse locale file ${locale}.json, invalid json`);
         return false;
-      }
-      return response.json()
-        .then((jsonResponse) => jsonResponse)
-        .catch(() => {
-          logger.error({ logCode: 'intl_parse_locale_SyntaxError' }, `Could not parse locale file ${locale}.json, invalid json`);
-          return false;
-        });
-    })
-    .catch((error) => {
+      });
+    } catch (error) {
       // The fetch itself rejected (network down/changed -> TypeError: Failed to
       // fetch). Retry with backoff until the network recovers, unless the
       // component has unmounted (signal aborted).
-      if (signal.aborted) {
-        return false;
-      }
+      if (signal.aborted) return false;
       const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
       logger.warn(
         {
@@ -81,21 +73,18 @@ const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown>
             locale,
             retryCount,
             delay,
-            error: error?.message,
+            error: error instanceof Error ? error.message : String(error),
           },
         },
         `Locale fetch failed for ${locale}, retrying in ${delay}ms`,
       );
-      return waitForDelay(delay, signal).then(() => {
-        // The delay may have resolved early because the signal aborted while we
-        // were waiting. Skip the extra fetch (it would only reject) and fall
-        // back instead.
-        if (signal.aborted) {
-          return false;
-        }
-        return attempt(retryCount + 1);
-      });
-    });
+      // waitForDelay resolves false when the signal aborted before or during the
+      // wait; skip the doomed next fetch and fall back instead.
+      const completed = await waitForDelay(delay, signal);
+      if (!completed) return false;
+      return attempt(retryCount + 1);
+    }
+  };
 
   return attempt(0);
 };

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -24,6 +24,22 @@ interface IntlLoaderProps extends IntlLoaderContainerProps {
   setCurrentLocale: (locale: string) => void;
 }
 
+// Waits `ms` before resolving, but resolves early if the signal aborts. The
+// abort listener is always detached: on normal completion the setTimeout
+// callback removes it, and on abort the once:true listener has already fired.
+// This prevents listeners from piling up across retries on a long-lived signal.
+const waitForDelay = (ms: number, signal: AbortSignal): Promise<void> => new Promise((resolve) => {
+  const onAbort = () => {
+    clearTimeout(timer);
+    resolve();
+  };
+  const timer = setTimeout(() => {
+    signal.removeEventListener('abort', onAbort);
+    resolve();
+  }, ms);
+  signal.addEventListener('abort', onAbort, { once: true });
+});
+
 const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown> => {
   const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
   const localesPath = 'locales';
@@ -55,17 +71,16 @@ const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown>
       logger.warn(
         {
           logCode: 'intl_fetch_locale_retry',
-          extraInfo: { locale, retryCount, delay, error: error?.message },
+          extraInfo: {
+            locale,
+            retryCount,
+            delay,
+            error: error?.message,
+          },
         },
         `Locale fetch failed for ${locale}, retrying in ${delay}ms`,
       );
-      return new Promise((resolve) => {
-        const timer = setTimeout(() => resolve(attempt(retryCount + 1)), delay);
-        signal.addEventListener('abort', () => {
-          clearTimeout(timer);
-          resolve(false);
-        }, { once: true });
-      });
+      return waitForDelay(delay, signal).then(() => attempt(retryCount + 1));
     });
 
   return attempt(0);

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -1,15 +1,21 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
-import { LoadingContext } from '/imports/ui/components/common/loading-screen/loading-screen-HOC/component';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 import useCurrentLocale from '/imports/ui/core/local-states/useCurrentLocale';
 import logger from './logger';
 
-// Backoff between locale fetch retries: 1s, 2s, then 5s repeated. A network
-// rejection (e.g. ERR_NETWORK_CHANGED) retries indefinitely until it succeeds
-// or the component unmounts (the fetch is aborted); the client must never be
-// left on a blank screen because a transient network blip dropped the locale.
+// Backoff between locale fetch retries: 1s, 2s, then 5s repeated, each with up
+// to 500ms of random jitter to avoid a thundering herd of clients retrying in
+// lockstep after a shared network blip. A network rejection (e.g.
+// ERR_NETWORK_CHANGED) keeps retrying until it succeeds, the component unmounts
+// (the fetch is aborted), or the total retry time exceeds MAX_RETRY_DURATION.
+// The client must never be left on a blank screen because a transient network
+// blip dropped the locale.
 const RETRY_DELAYS = [1000, 2000, 5000];
+// Mirrors CustomUsersSettings' CONNECTION_TIMEOUT (the parent in client/main.tsx):
+// stop retrying after this long and let the failure propagate so the loading
+// state resolves instead of spinning forever.
+const MAX_RETRY_DURATION = 60000;
 
 interface LocaleJson {
   [key: string]: string;
@@ -48,6 +54,7 @@ const waitForDelay = (ms: number, signal: AbortSignal): Promise<boolean> => new 
 const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown> => {
   const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
   const url = `locales/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`;
+  const startTime = Date.now();
 
   const attempt = async (retryCount: number): Promise<unknown> => {
     try {
@@ -56,16 +63,21 @@ const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown>
       // legitimate fallback, not a transient failure: resolve false so the merge
       // step falls back to another locale. Retrying would never help.
       if (!response.ok) return false;
-      return response.json().catch(() => {
+      return await response.json();
+    } catch (error) {
+      // The component unmounted mid-flight: stop, do not retry.
+      if (signal.aborted) return false;
+      // Malformed JSON is not transient (the file is served but corrupt), so
+      // retrying is pointless. Fall back to another locale.
+      if (error instanceof SyntaxError) {
         logger.error({ logCode: 'intl_parse_locale_SyntaxError' }, `Could not parse locale file ${locale}.json, invalid json`);
         return false;
-      });
-    } catch (error) {
+      }
       // The fetch itself rejected (network down/changed -> TypeError: Failed to
-      // fetch). Retry with backoff until the network recovers, unless the
-      // component has unmounted (signal aborted).
-      if (signal.aborted) return false;
-      const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
+      // fetch). Retry with backoff until the network recovers, unless we have
+      // already spent MAX_RETRY_DURATION trying: then let the failure propagate.
+      if (Date.now() - startTime > MAX_RETRY_DURATION) throw error;
+      const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)] + Math.random() * 500;
       logger.warn(
         {
           logCode: 'intl_fetch_locale_retry',
@@ -144,8 +156,6 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   currentLocale,
   setCurrentLocale,
 }) => {
-  const loadingContextInfo = useContext(LoadingContext);
-
   const [fetching, setFetching] = React.useState(false);
   const [normalizedLocale, setNormalizedLocale] = React.useState(navigator.language.replace('_', '-'));
   const [messages, setMessages] = React.useState<LocaleJson>({});
@@ -157,6 +167,13 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
     buildFetchLocale('index', signal)
       .then((resp) => {
         if (signal.aborted) return;
+        // The index fetch fell back to false (e.g. 404 or corrupt index.json):
+        // there is no locale list to work from, so resolve the loading state
+        // instead of crashing on .map or spinning on a blank screen.
+        if (!Array.isArray(resp)) {
+          setFetching(false);
+          return;
+        }
         const data = fetchLocaleOptions(
           locale,
           init,
@@ -182,10 +199,9 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
             const typedResp = resp as Array<LocaleJson | boolean>;
             const foundLocales = typedResp.filter((locale) => locale instanceof Object) as LocaleJson[];
             if (foundLocales.length === 0) {
-              const error = `${{ logCode: 'intl_fetch_locale_error' }},Could not fetch any locale file for ${languageSets.join(', ')}`;
-              loadingContextInfo.setLoading(false);
-              logger.error(error);
-              throw new Error(error);
+              logger.error({ logCode: 'intl_fetch_locale_error', extraInfo: { languageSets } }, 'Could not fetch any locale file');
+              setFetching(false);
+              return;
             }
             const mergedLocale = foundLocales
               .reduce((acc, locale: LocaleJson) => Object.assign(acc, locale), {});
@@ -194,16 +210,28 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
             setCurrentLocale(replacedLocale);
             setMessages(mergedLocale);
             if (!init) {
-              loadingContextInfo.setLoading(false);
+              setFetching(false);
             }
           }).catch((error) => {
-            loadingContextInfo.setLoading(false);
-            throw new Error(error);
+            logger.error(
+              {
+                logCode: 'intl_fetch_locale_error',
+                extraInfo: { error: error instanceof Error ? error.message : String(error) },
+              },
+              'Error fetching localized messages',
+            );
+            setFetching(false);
           });
       })
-      .catch(() => {
-        loadingContextInfo.setLoading(false);
-        throw new Error('unable to fetch localized messages');
+      .catch((error) => {
+        logger.error(
+          {
+            logCode: 'intl_fetch_locale_error',
+            extraInfo: { error: error instanceof Error ? error.message : String(error) },
+          },
+          'Unable to fetch localized messages',
+        );
+        setFetching(false);
       });
   }, []);
 

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -1,8 +1,15 @@
 import React, { useCallback, useContext, useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import { LoadingContext } from '/imports/ui/components/common/loading-screen/loading-screen-HOC/component';
+import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 import useCurrentLocale from '/imports/ui/core/local-states/useCurrentLocale';
 import logger from './logger';
+
+// Backoff between locale fetch retries: 1s, 2s, then 5s repeated. A network
+// rejection (e.g. ERR_NETWORK_CHANGED) retries indefinitely until it succeeds
+// or the component unmounts (the fetch is aborted); the client must never be
+// left on a blank screen because a transient network blip dropped the locale.
+const RETRY_DELAYS = [1000, 2000, 5000];
 
 interface LocaleJson {
   [key: string]: string;
@@ -17,24 +24,51 @@ interface IntlLoaderProps extends IntlLoaderContainerProps {
   setCurrentLocale: (locale: string) => void;
 }
 
-const buildFetchLocale = (locale: string) => {
+const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown> => {
   const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
   const localesPath = 'locales';
+  const url = `${localesPath}/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`;
 
-  return new Promise((resolve) => {
-    fetch(`${localesPath}/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`)
-      .then((response) => {
-        if (!response.ok) {
-          return resolve(false);
-        }
-        return response.json()
-          .then((jsonResponse) => resolve(jsonResponse))
-          .catch(() => {
-            logger.error({ logCode: 'intl_parse_locale_SyntaxError' }, `Could not parse locale file ${locale}.json, invalid json`);
-            resolve(false);
-          });
+  const attempt = (retryCount: number): Promise<unknown> => fetch(url, { signal })
+    .then((response) => {
+      // A genuine HTTP error (e.g. 404 for a locale that does not exist) is a
+      // legitimate fallback, not a transient failure: resolve false so the
+      // merge step falls back to another locale. Retrying would never help.
+      if (!response.ok) {
+        return false;
+      }
+      return response.json()
+        .then((jsonResponse) => jsonResponse)
+        .catch(() => {
+          logger.error({ logCode: 'intl_parse_locale_SyntaxError' }, `Could not parse locale file ${locale}.json, invalid json`);
+          return false;
+        });
+    })
+    .catch((error) => {
+      // The fetch itself rejected (network down/changed -> TypeError: Failed to
+      // fetch). Retry with backoff until the network recovers, unless the
+      // component has unmounted (signal aborted).
+      if (signal.aborted) {
+        return false;
+      }
+      const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
+      logger.warn(
+        {
+          logCode: 'intl_fetch_locale_retry',
+          extraInfo: { locale, retryCount, delay, error: error?.message },
+        },
+        `Locale fetch failed for ${locale}, retrying in ${delay}ms`,
+      );
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => resolve(attempt(retryCount + 1)), delay);
+        signal.addEventListener('abort', () => {
+          clearTimeout(timer);
+          resolve(false);
+        }, { once: true });
       });
-  });
+    });
+
+  return attempt(0);
 };
 
 const fetchLocaleOptions = (locale: string, init: boolean, localesList: string[] = []) => {
@@ -100,10 +134,11 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   const [fallbackOnEmptyLocaleString, setFallbackOnEmptyLocaleString] = React.useState(false);
   const skipInitialLocaleFetch = React.useRef(true);
 
-  const fetchLocalizedMessages = useCallback((locale: string, init: boolean) => {
+  const fetchLocalizedMessages = useCallback((locale: string, init: boolean, signal: AbortSignal) => {
     setFetching(true);
-    buildFetchLocale('index')
+    buildFetchLocale('index', signal)
       .then((resp) => {
+        if (signal.aborted) return;
         const data = fetchLocaleOptions(
           locale,
           init,
@@ -123,8 +158,9 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
           normalizedLocale,
         ])).filter((locale) => locale);
 
-        Promise.all(languageSets.map((locale) => buildFetchLocale(locale)))
+        Promise.all(languageSets.map((locale) => buildFetchLocale(locale, signal)))
           .then((resp) => {
+            if (signal.aborted) return;
             const typedResp = resp as Array<LocaleJson | boolean>;
             const foundLocales = typedResp.filter((locale) => locale instanceof Object) as LocaleJson[];
             if (foundLocales.length === 0) {
@@ -154,13 +190,16 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
     const language = navigator.languages ? navigator.languages[0] : navigator.language;
     // if currentLocale was already overridden before this component mounted, use it instead
     if (currentLocale !== normalizedLocale) {
-      fetchLocalizedMessages(currentLocale, false);
+      fetchLocalizedMessages(currentLocale, false, controller.signal);
     } else {
-      fetchLocalizedMessages(language, true);
+      fetchLocalizedMessages(language, true, controller.signal);
     }
+    // Aborts any in-flight fetch and clears a pending retry timeout on unmount.
+    return () => controller.abort();
   }, []);
 
   useEffect(() => {
@@ -168,11 +207,14 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
     // Prevents redundant initial locale fetches when a locale override is detected at mount time
     if (skipInitialLocaleFetch.current) {
       skipInitialLocaleFetch.current = false;
-      return;
+      return undefined;
     }
     if (currentLocale !== normalizedLocale) {
-      fetchLocalizedMessages(currentLocale, false);
+      const controller = new AbortController();
+      fetchLocalizedMessages(currentLocale, false, controller.signal);
+      return () => controller.abort();
     }
+    return undefined;
   }, [currentLocale]);
 
   useEffect(() => {
@@ -197,7 +239,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
     >
       {children}
     </IntlProvider>
-  ) : null;
+  ) : <LoadingScreen />;
 };
 
 const IntlLoaderContainer: React.FC<IntlLoaderContainerProps> = ({

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -5,7 +5,7 @@ import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 import useCurrentLocale from '/imports/ui/core/local-states/useCurrentLocale';
 import logger from './logger';
 
-// Backoff between locale fetch retries: 1s, 2s, then 5s repeated, each with full
+// Backoff between locale fetch retries: 1s, 2s, then 5s repeated, each with equal
 // jitter (the effective delay is uniformly random in [base/2, base]) to avoid a
 // thundering herd of clients retrying in lockstep after a shared network blip. A
 // transient failure (a network rejection such as ERR_NETWORK_CHANGED, or a 5xx/429
@@ -24,6 +24,12 @@ const MAX_RETRY_DURATION = 60000;
 
 interface LocaleJson {
   [key: string]: string;
+}
+
+// The locales index is an array of available locale entries; only `name` is used
+// to build the usable-locale list, so that is all we type here.
+interface LocaleIndexEntry {
+  name: string;
 }
 
 interface IntlLoaderContainerProps {
@@ -56,13 +62,30 @@ const waitForDelay = (ms: number, signal: AbortSignal): Promise<boolean> => new 
   signal.addEventListener('abort', onAbort, { once: true });
 });
 
-const buildFetchLocale = (locale: string, signal: AbortSignal, deadline: number): Promise<unknown> => {
+const buildFetchLocale = <T = LocaleJson>(
+  locale: string,
+  signal: AbortSignal,
+  deadline: number,
+): Promise<T | false> => {
   const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
   const url = `locales/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`;
 
-  const attempt = async (retryCount: number): Promise<unknown> => {
+  const attempt = async (retryCount: number): Promise<T | false> => {
+    // Per-attempt controller: composes the outer unmount signal with a timeout so a
+    // hung fetch (server accepts the connection but never responds) still aborts at
+    // the shared deadline instead of stranding the client on the loading screen.
+    // Aborting attemptController (not the outer signal) keeps the outer/unmount
+    // abort distinguishable from the deadline timeout in the catch below. We do not
+    // use AbortSignal.any(): Safari 16 support is required (see index.html).
+    const attemptController = new AbortController();
+    const onOuterAbort = () => attemptController.abort();
+    signal.addEventListener('abort', onOuterAbort, { once: true });
+    // A once-listener never fires for an already-dispatched abort, so if the outer
+    // signal aborted before this attempt began, mirror it onto attemptController now.
+    if (signal.aborted) attemptController.abort();
+    const timeoutId = setTimeout(() => attemptController.abort(), Math.max(0, deadline - Date.now()));
     try {
-      const response = await fetch(url, { signal });
+      const response = await fetch(url, { signal: attemptController.signal });
       if (!response.ok) {
         // 5xx and 429 are transient (server overloaded / rate limited): fall
         // through to the retry path by throwing so the catch handles the backoff.
@@ -74,7 +97,7 @@ const buildFetchLocale = (locale: string, signal: AbortSignal, deadline: number)
         // step falls back to another locale. Retrying would never help.
         return false;
       }
-      return await response.json();
+      return await response.json() as T;
     } catch (error) {
       // The component unmounted mid-flight: stop, do not retry.
       if (signal.aborted) return false;
@@ -102,7 +125,11 @@ const buildFetchLocale = (locale: string, signal: AbortSignal, deadline: number)
         );
         return false;
       }
-      const baseDelay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
+      // Clamp the backoff to the time left before the deadline so the wait cannot
+      // overshoot the budget (which would push the give-up past MAX_RETRY_DURATION).
+      const remaining = deadline - Date.now();
+      const baseDelay = Math.min(RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)], remaining);
+      // Equal jitter: uniformly random in [base/2, base].
       const delay = baseDelay / 2 + (Math.random() * baseDelay) / 2;
       logger.warn(
         {
@@ -121,6 +148,12 @@ const buildFetchLocale = (locale: string, signal: AbortSignal, deadline: number)
       const completed = await waitForDelay(delay, signal);
       if (!completed) return false;
       return attempt(retryCount + 1);
+    } finally {
+      // Detach this attempt's timeout and outer-abort listener so neither piles up
+      // across retries. Running before the recursive attempt's promise settles is
+      // fine: the next attempt owns its own controller, timeout and listener.
+      clearTimeout(timeoutId);
+      signal.removeEventListener('abort', onOuterAbort);
     }
   };
 
@@ -196,7 +229,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
     // this load, so the whole load is bounded by MAX_RETRY_DURATION rather than
     // each fetch getting its own (which could stack to ~2x in the worst case).
     const deadline = Date.now() + MAX_RETRY_DURATION;
-    buildFetchLocale('index', signal, deadline)
+    buildFetchLocale<LocaleIndexEntry[]>('index', signal, deadline)
       .then((resp) => {
         if (signal.aborted) return;
         // The index fetch fell back to false (e.g. 404, corrupt index.json, or the
@@ -211,7 +244,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
         const data = fetchLocaleOptions(
           locale,
           init,
-          (resp as { name: string }[]).map((l) => l.name),
+          resp.map((l) => l.name),
         );
 
         const {
@@ -230,8 +263,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
         Promise.all(languageSets.map((locale) => buildFetchLocale(locale, signal, deadline)))
           .then((resp) => {
             if (signal.aborted) return;
-            const typedResp = resp as Array<LocaleJson | boolean>;
-            const foundLocales = typedResp.filter((locale) => locale instanceof Object) as LocaleJson[];
+            const foundLocales = resp.filter((locale): locale is LocaleJson => locale !== false);
             if (foundLocales.length === 0) {
               logger.error({ logCode: 'intl_fetch_locale_none_error', extraInfo: { languageSets } }, 'Could not fetch any locale file');
               setHasError(true);

--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -1,20 +1,25 @@
 import React, { useCallback, useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
+import { ErrorScreen } from '/imports/ui/components/error-screen/component';
 import useCurrentLocale from '/imports/ui/core/local-states/useCurrentLocale';
 import logger from './logger';
 
-// Backoff between locale fetch retries: 1s, 2s, then 5s repeated, each with up
-// to 500ms of random jitter to avoid a thundering herd of clients retrying in
-// lockstep after a shared network blip. A network rejection (e.g.
-// ERR_NETWORK_CHANGED) keeps retrying until it succeeds, the component unmounts
-// (the fetch is aborted), or the total retry time exceeds MAX_RETRY_DURATION.
-// The client must never be left on a blank screen because a transient network
-// blip dropped the locale.
+// Backoff between locale fetch retries: 1s, 2s, then 5s repeated, each with full
+// jitter (the effective delay is uniformly random in [base/2, base]) to avoid a
+// thundering herd of clients retrying in lockstep after a shared network blip. A
+// transient failure (a network rejection such as ERR_NETWORK_CHANGED, or a 5xx/429
+// response) keeps retrying until it succeeds, the component unmounts (the fetch is
+// aborted), or the shared deadline passes. On give-up the client shows an error
+// screen instead of a blank one: the client must never be left on a blank screen
+// because a transient network blip dropped the locale.
 const RETRY_DELAYS = [1000, 2000, 5000];
 // Mirrors CustomUsersSettings' CONNECTION_TIMEOUT (the parent in client/main.tsx):
-// stop retrying after this long and let the failure propagate so the loading
-// state resolves instead of spinning forever.
+// stop retrying after this long and give up so the loading state resolves into an
+// error screen instead of spinning forever. The deadline is shared across the
+// index fetch and every language-set fetch of a single load (threaded from
+// fetchLocalizedMessages), so the whole load is bounded by one budget rather than
+// each fetch getting its own.
 const MAX_RETRY_DURATION = 60000;
 
 interface LocaleJson {
@@ -51,18 +56,24 @@ const waitForDelay = (ms: number, signal: AbortSignal): Promise<boolean> => new 
   signal.addEventListener('abort', onAbort, { once: true });
 });
 
-const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown> => {
+const buildFetchLocale = (locale: string, signal: AbortSignal, deadline: number): Promise<unknown> => {
   const clientVersion = window.meetingClientSettings.public.app.html5ClientBuild;
   const url = `locales/${locale !== 'index' ? `${locale}.json?v=${clientVersion}` : ''}`;
-  const startTime = Date.now();
 
   const attempt = async (retryCount: number): Promise<unknown> => {
     try {
       const response = await fetch(url, { signal });
-      // A genuine HTTP error (e.g. 404 for a locale that does not exist) is a
-      // legitimate fallback, not a transient failure: resolve false so the merge
-      // step falls back to another locale. Retrying would never help.
-      if (!response.ok) return false;
+      if (!response.ok) {
+        // 5xx and 429 are transient (server overloaded / rate limited): fall
+        // through to the retry path by throwing so the catch handles the backoff.
+        if (response.status >= 500 || response.status === 429) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        // Any other HTTP error (e.g. 404 for a locale that does not exist) is a
+        // legitimate fallback, not a transient failure: resolve false so the merge
+        // step falls back to another locale. Retrying would never help.
+        return false;
+      }
       return await response.json();
     } catch (error) {
       // The component unmounted mid-flight: stop, do not retry.
@@ -73,11 +84,26 @@ const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown>
         logger.error({ logCode: 'intl_parse_locale_SyntaxError' }, `Could not parse locale file ${locale}.json, invalid json`);
         return false;
       }
-      // The fetch itself rejected (network down/changed -> TypeError: Failed to
-      // fetch). Retry with backoff until the network recovers, unless we have
-      // already spent MAX_RETRY_DURATION trying: then let the failure propagate.
-      if (Date.now() - startTime > MAX_RETRY_DURATION) throw error;
-      const delay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)] + Math.random() * 500;
+      // A transient failure: the fetch rejected (network down/changed ->
+      // TypeError: Failed to fetch) or the response was a 5xx/429. Retry with
+      // backoff until the network recovers, unless the shared deadline has
+      // passed: then give up and fall back so the load can resolve.
+      if (Date.now() > deadline) {
+        logger.error(
+          {
+            logCode: 'intl_fetch_locale_giveup',
+            extraInfo: {
+              locale,
+              retryCount,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          },
+          `Gave up fetching locale ${locale} after ${retryCount} retries: retry budget exhausted`,
+        );
+        return false;
+      }
+      const baseDelay = RETRY_DELAYS[Math.min(retryCount, RETRY_DELAYS.length - 1)];
+      const delay = baseDelay / 2 + (Math.random() * baseDelay) / 2;
       logger.warn(
         {
           logCode: 'intl_fetch_locale_retry',
@@ -88,7 +114,7 @@ const buildFetchLocale = (locale: string, signal: AbortSignal): Promise<unknown>
             error: error instanceof Error ? error.message : String(error),
           },
         },
-        `Locale fetch failed for ${locale}, retrying in ${delay}ms`,
+        `Locale fetch failed for ${locale}, retrying in ${Math.round(delay)}ms`,
       );
       // waitForDelay resolves false when the signal aborted before or during the
       // wait; skip the doomed next fetch and fall back instead.
@@ -157,6 +183,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   setCurrentLocale,
 }) => {
   const [fetching, setFetching] = React.useState(false);
+  const [hasError, setHasError] = React.useState(false);
   const [normalizedLocale, setNormalizedLocale] = React.useState(navigator.language.replace('_', '-'));
   const [messages, setMessages] = React.useState<LocaleJson>({});
   const [fallbackOnEmptyLocaleString, setFallbackOnEmptyLocaleString] = React.useState(false);
@@ -164,13 +191,20 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
 
   const fetchLocalizedMessages = useCallback((locale: string, init: boolean, signal: AbortSignal) => {
     setFetching(true);
-    buildFetchLocale('index', signal)
+    setHasError(false);
+    // Single budget shared across the index fetch and every language-set fetch of
+    // this load, so the whole load is bounded by MAX_RETRY_DURATION rather than
+    // each fetch getting its own (which could stack to ~2x in the worst case).
+    const deadline = Date.now() + MAX_RETRY_DURATION;
+    buildFetchLocale('index', signal, deadline)
       .then((resp) => {
         if (signal.aborted) return;
-        // The index fetch fell back to false (e.g. 404 or corrupt index.json):
-        // there is no locale list to work from, so resolve the loading state
-        // instead of crashing on .map or spinning on a blank screen.
+        // The index fetch fell back to false (e.g. 404, corrupt index.json, or the
+        // retry budget was exhausted): there is no locale list to work from, so
+        // surface the error screen instead of crashing on .map or spinning on a
+        // blank screen.
         if (!Array.isArray(resp)) {
+          setHasError(true);
           setFetching(false);
           return;
         }
@@ -193,13 +227,14 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
           normalizedLocale,
         ])).filter((locale) => locale);
 
-        Promise.all(languageSets.map((locale) => buildFetchLocale(locale, signal)))
+        Promise.all(languageSets.map((locale) => buildFetchLocale(locale, signal, deadline)))
           .then((resp) => {
             if (signal.aborted) return;
             const typedResp = resp as Array<LocaleJson | boolean>;
             const foundLocales = typedResp.filter((locale) => locale instanceof Object) as LocaleJson[];
             if (foundLocales.length === 0) {
-              logger.error({ logCode: 'intl_fetch_locale_error', extraInfo: { languageSets } }, 'Could not fetch any locale file');
+              logger.error({ logCode: 'intl_fetch_locale_none_error', extraInfo: { languageSets } }, 'Could not fetch any locale file');
+              setHasError(true);
               setFetching(false);
               return;
             }
@@ -209,28 +244,28 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
             setNormalizedLocale(replacedLocale);
             setCurrentLocale(replacedLocale);
             setMessages(mergedLocale);
-            if (!init) {
-              setFetching(false);
-            }
+            setFetching(false);
           }).catch((error) => {
             logger.error(
               {
-                logCode: 'intl_fetch_locale_error',
+                logCode: 'intl_fetch_locale_merge_error',
                 extraInfo: { error: error instanceof Error ? error.message : String(error) },
               },
               'Error fetching localized messages',
             );
+            setHasError(true);
             setFetching(false);
           });
       })
       .catch((error) => {
         logger.error(
           {
-            logCode: 'intl_fetch_locale_error',
+            logCode: 'intl_fetch_locale_index_error',
             extraInfo: { error: error instanceof Error ? error.message : String(error) },
           },
           'Unable to fetch localized messages',
         );
+        setHasError(true);
         setFetching(false);
       });
   }, []);
@@ -277,7 +312,19 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
     }
   }, [fetching]);
 
-  return !fetching || Object.keys(messages).length > 0 ? (
+  const hasMessages = Object.keys(messages).length > 0;
+
+  // Three render states: (1) locale loading failed completely and we have nothing
+  // to show -> ErrorScreen (its named export guards for a null intl and falls back
+  // to hardcoded English, so it is safe outside IntlProvider); (2) still fetching
+  // with no messages yet -> LoadingScreen; (3) done or we already have a usable
+  // locale -> render the app. A failed locale *switch* keeps the working app up
+  // (hasMessages is true), so ErrorScreen only ever replaces a blank screen.
+  if (hasError && !hasMessages) {
+    return <ErrorScreen />;
+  }
+
+  return !fetching || hasMessages ? (
     <IntlProvider
       fallbackOnEmptyString={fallbackOnEmptyLocaleString}
       locale={normalizedLocale.replace('_', '-').replace('@', '-')}


### PR DESCRIPTION
## What's happening

When someone joins a BigBlueButton meeting, the HTML5 client loads locale files (translation strings) during startup. If the network has a brief hiccup at that exact moment - for example, the user's laptop switches from Wi-Fi to a different network, causing Chrome to report `ERR_NETWORK_CHANGED` - the locale fetch fails and the client is left on a **blank white screen** with no recovery. The user has to manually reload the page.

The root cause is in `intlLoader.tsx`: `buildFetchLocale` calls `fetch()` inside a `new Promise()` with **no `.catch()`**. When the fetch rejects (a network error), the internal `resolve` never fires, the promise hangs forever, and the rejection becomes unhandled (`Uncaught (in promise) TypeError: Failed to fetch`). Because `IntlLoader` is an ancestor of the entire app tree, its `null` render blanks out everything - no spinner, no error, no way forward.

## The fix

All changes are in a single file (`intlLoader.tsx`), following the pattern already established by the neighboring `settings-loader/component.tsx`:

1. **Retry with backoff, bounded by a shared deadline.** `buildFetchLocale` now catches transient failures and retries with delays of `[1s, 2s, 5s, 5s, ...]` (full jitter: each effective delay is uniformly random in `[base/2, base]` to avoid a thundering herd). The retries are bounded by a single **60s deadline shared across the index fetch and every language-set fetch of one load** (mirrors `CustomUsersSettings`' `CONNECTION_TIMEOUT`), so the whole load is capped by one budget instead of each fetch getting its own. Transient failures that are retried: network rejections (`ERR_NETWORK_CHANGED`) and `5xx`/`429` responses. Non-transient failures still fall back immediately to the default locale: `404` and other `4xx` HTTP errors, and JSON parse errors.

2. **Give up gracefully into an ErrorScreen instead of a blank screen.** When retries exhaust the 60s budget and no locale could be loaded at all, the client renders the standard BBB `ErrorScreen` ("Oops, something went wrong") instead of leaving the user stranded with raw message ids or a blank page. The give-up path resolves to a fallback (no thrown rejection), so a partial success is preserved: if one locale fetches successfully and another `404`s, the client still renders with the working locale.

3. **`AbortController` + cleanup.** An `AbortSignal` is propagated to all fetch calls and the retry timers. On unmount, in-flight fetches are aborted and pending retry `setTimeout`s are cleared, so no orphaned loops remain.

4. **Three render states.** While the locale is being fetched (or retried), the user sees the standard BBB loading spinner (`LoadingScreen`); on complete failure with nothing to show, the `ErrorScreen`; otherwise the app renders normally. A failed locale *switch* (when the app already has a working locale) keeps the app up rather than replacing it with the error screen.

## Evidence

Animated preview below - click the GIF to open the MP4 (higher quality with controls):

[![Locale fetch retry demo](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-15/f965c7f8-67f5-43d4-9de7-c1b5d21d117b/demo.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-15/60615ed1-8851-4eed-ad2e-bd76054afa18/demo.mp4)

What the video shows: locale requests are blocked (simulating `ERR_NETWORK_CHANGED`), the client shows the loading spinner (not a blank screen), then after the network recovers the locale loads and the client renders normally with the audio modal.

## Testing

Validated with E2E Playwright tests against a from-source BBB 3.0 environment, covering three states:

1. **Transient recovery:** locale requests blocked mid-startup, spinner visible (not blank), then the client recovers fully once the network is released (locale loads, meeting renders, audio modal appears), with zero unhandled `TypeError`s.
2. **Complete give-up:** all locale requests blocked for the full 60s budget - the spinner is shown throughout, then the client resolves into the `ErrorScreen` ("Oops, something went wrong", rendered in the hardcoded English fallback since intl is null), never a blank screen and never raw message ids.
3. **Partial failure:** the index and the fallback locale (`en`) fetch successfully while the region locale (`pt_BR`, `pt`) returns `404` - the client renders normally with the working locale, no error screen.

**Note on automated tests:** the HTML5 client startup path (`imports/startup/`) does not have committed unit tests, and the BBB client testing convention is E2E via Playwright in `bigbluebutton-tests`. Adding a committed regression spec for this scenario (locale fetch interception during startup) would be a reasonable follow-up, but it requires test infrastructure that intercepts at the browser-network level during a brief startup window - outside the scope of this fix.

Closes #25418

---

**Updated evidence (ErrorScreen + partial failure):**

![ErrorScreen after 60s cap](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-15/a27283eb-ea9d-4b44-a702-6ddb4d54d748/s1-errorscreen.png)

ErrorScreen shown after the 60s retry budget is exhausted with no locale available - no raw message ids, no blank screen.

![Partial locale failure](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-15/5d6e2b9c-6cd6-4d3e-b7f0-9a43cd3efde7/s2-partial-rendered.png)

Partial failure: `en` fetched successfully while `pt_BR`/`pt` returned 404 - client renders normally with the working locale.
