### PR TITLE
Fix: private chat input placeholder alignment

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/component.tsx
@@ -709,7 +709,6 @@ const ChatMessageForm: React.FC<ChatMessageFormProps> = ({
               onCut={(e) => { e.stopPropagation(); }}
               onCopy={(e) => { e.stopPropagation(); }}
               async
-              $hasContent={message.length > 0}
             />
             {ENABLE_EMOJI_PICKER ? (
               <Tooltip title={<span style={{ fontSize: '0.9rem' }}>{intl.formatMessage(messages.emojiButtonLabel)}</span>} arrow>

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -24,10 +24,6 @@ interface FormProps {
   isRTL: boolean;
 }
 
-interface InputProps {
-  $hasContent?: boolean;
-}
-
 const Form = styled.form<FormProps>`
   flex-grow: 0;
   flex-shrink: 0;
@@ -43,7 +39,7 @@ const Wrapper = styled.div`
   border-radius: 0.75rem;
 `;
 
-const Input = styled(TextareaAutosize)<InputProps>`
+const Input = styled(TextareaAutosize)`
   flex: 1;
   background: transparent;
   background-clip: padding-box;
@@ -56,11 +52,16 @@ const Input = styled(TextareaAutosize)<InputProps>`
   transition: color 0.3s ease, margin-right 0.3s ease;
   font-size: ${fontSizeBase};
   line-height: 1;
-  overflow-y: ${({ $hasContent }) => ($hasContent ? 'auto' : 'hidden')};
-  white-space: ${({ $hasContent }) => ($hasContent ? 'normal' : 'nowrap')};
+  overflow-y: auto;
+  white-space: normal;
   border: ${colorBorder};
   box-shadow: none;
   outline: none;
+
+  &:placeholder-shown {
+    overflow-y: hidden;
+    white-space: nowrap;
+  }
 
   &::-webkit-scrollbar {
     width: 5px;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -53,7 +53,7 @@ const Input = styled(TextareaAutosize)`
   font-size: ${fontSizeBase};
   line-height: 1;
   overflow-y: auto;
-  white-space: normal;
+  white-space: pre-wrap;
   border: ${colorBorder};
   box-shadow: none;
   outline: none;

--- a/bigbluebutton-tests/playwright/chat/privateChatInput.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/privateChatInput.spec.ts
@@ -1,0 +1,149 @@
+import { expect, Locator } from '@playwright/test';
+
+import { elements as e } from '../core/elements';
+import { test } from '../core/setup/fixtures';
+import { Chat } from './chat';
+import { openPrivateChat } from './util';
+
+const LONG_PARTICIPANT_NAME = 'Alexandra-Montgomery-Sutherland';
+const JOIN_PARAMETERS = 'userdata-bbb_override_default_locale=en&userdata-bbb_auto_join_audio=false';
+const VIDEO_FRAME_DELAY = 750;
+const VIEWPORT = { width: 1366, height: 768 };
+
+interface InputMetrics {
+  clientHeight: number;
+  clientWidth: number;
+  overflowX: string;
+  overflowY: string;
+  placeholder: string;
+  scrollLeft: number;
+  scrollHeight: number;
+  scrollWidth: number;
+  value: string;
+  whiteSpace: string;
+}
+
+async function getInputMetrics(input: Locator): Promise<InputMetrics> {
+  return input.evaluate((element: HTMLTextAreaElement) => {
+    const style = window.getComputedStyle(element);
+    return {
+      clientHeight: element.clientHeight,
+      clientWidth: element.clientWidth,
+      overflowX: style.overflowX,
+      overflowY: style.overflowY,
+      placeholder: element.placeholder,
+      scrollHeight: element.scrollHeight,
+      scrollLeft: element.scrollLeft,
+      scrollWidth: element.scrollWidth,
+      value: element.value,
+      whiteSpace: style.whiteSpace,
+    };
+  });
+}
+
+test.use({
+  screenshot: 'only-on-failure',
+  trace: 'off',
+  video: 'retain-on-failure',
+});
+
+test.describe('Private chat input visual evidence', () => {
+  test('Reproduce the placeholder and caret transition when clearing a narrow private chat input', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    await page.setViewportSize(VIEWPORT);
+    const chat = new Chat(browser, context);
+
+    await chat.initModPage(page, {
+      joinParameter: JOIN_PARAMETERS,
+      shouldCloseAudioModal: false,
+      testInfo,
+    });
+    await chat.initUserPage(context, {
+      fullName: LONG_PARTICIPANT_NAME,
+      joinParameter: JOIN_PARAMETERS,
+      shouldCloseAudioModal: false,
+      testInfo,
+    });
+
+    await openPrivateChat(chat.modPage);
+    await chat.modPage.hasElement(e.hidePrivateChat, 'private chat should be open for the moderator');
+
+    const input = chat.modPage.page.locator(e.chatBox);
+    const sidebar = chat.modPage.page.locator(e.sidebarContentMain);
+
+    await expect(input).toHaveAttribute('placeholder', `Message Private Chat with ${LONG_PARTICIPANT_NAME}`);
+    await expect(chat.modPage.page.locator(e.resizeSidebarContentMain)).toBeVisible();
+
+    const initialSidebarWidth = await sidebar.evaluate((element) => element.getBoundingClientRect().width);
+    await chat.modPage.dragResizeHandle(e.resizeSidebarContentMain, 500);
+    await expect
+      .poll(() => sidebar.evaluate((element) => element.getBoundingClientRect().width))
+      .toBeGreaterThan(initialSidebarWidth);
+
+    await chat.modPage.waitAndClick(e.chatTitle);
+    await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+    const expandedMetrics = await getInputMetrics(input);
+    expect(expandedMetrics.scrollWidth, 'placeholder should fit before shrinking the sidebar').toBeLessThanOrEqual(
+      expandedMetrics.clientWidth,
+    );
+    const expandedSidebarWidth = await sidebar.evaluate((element) => element.getBoundingClientRect().width);
+    await chat.modPage.dragResizeHandle(e.resizeSidebarContentMain, -1000);
+    await expect
+      .poll(() => sidebar.evaluate((element) => element.getBoundingClientRect().width))
+      .toBeLessThan(expandedSidebarWidth);
+
+    await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+    const clippedMetrics = await getInputMetrics(input);
+    expect(clippedMetrics.scrollWidth, 'placeholder should be clipped after shrinking the sidebar').toBeGreaterThan(
+      clippedMetrics.clientWidth,
+    );
+    await input.focus();
+    await input.press('Home');
+    await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+
+    // Match the supplied reproduction: type "test", erase it one character at a time,
+    // then repeatedly type and erase a single "a" while the placeholder remains clipped.
+    await input.pressSequentially('test', { delay: 250 });
+    await expect(input).toHaveValue('test');
+    await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+    const transitionMetrics: Array<{ state: string; metrics: InputMetrics }> = [];
+    transitionMetrics.push({ state: 'test', metrics: await getInputMetrics(input) });
+
+    for (let remainingCharacters = 3; remainingCharacters >= 0; remainingCharacters -= 1) {
+      await input.press('Backspace');
+      await expect(input).toHaveValue('test'.slice(0, remainingCharacters));
+      await chat.modPage.page.waitForTimeout(300);
+    }
+
+    transitionMetrics.push({ state: 'placeholder-after-test', metrics: await getInputMetrics(input) });
+    await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+    for (let cycle = 1; cycle <= 3; cycle += 1) {
+      await input.press('a');
+      await expect(input).toHaveValue('a');
+      transitionMetrics.push({ state: `a-${cycle}`, metrics: await getInputMetrics(input) });
+      await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+
+      await input.press('Backspace');
+      await expect(input).toHaveValue('');
+      transitionMetrics.push({ state: `placeholder-after-a-${cycle}`, metrics: await getInputMetrics(input) });
+      await chat.modPage.page.waitForTimeout(VIDEO_FRAME_DELAY);
+    }
+
+    await testInfo.attach('private-chat-input-metrics', {
+      body: Buffer.from(JSON.stringify({ expandedMetrics, clippedMetrics, transitionMetrics }, null, 2)),
+      contentType: 'application/json',
+    });
+
+    const clearedInputHeights = transitionMetrics
+      .filter(({ state }) => state.startsWith('placeholder-after-'))
+      .map(({ metrics }) => metrics.clientHeight);
+    expect(clearedInputHeights, 'clearing the input should restore the original single-line textarea height').toEqual(
+      clearedInputHeights.map(() => clippedMetrics.clientHeight),
+    );
+
+    await Promise.all([chat.modPage.page.close(), chat.userPage.page.close()]);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes the private chat input jumping after text is cleared when a long placeholder is clipped in a narrow sidebar. 
It also adds a regression test covering sidebar resizing and repeated type/clear transitions.

#### before
https://github.com/user-attachments/assets/c2681815-8ca4-45b6-b1a5-7e5ee77e9293

#### after
https://github.com/user-attachments/assets/d0d39cc9-ff30-4dc6-b67d-0c0cfe951abe





### How to test

1. join a meeting with two participants, give the second one a long name
2. open a private chat with the participant
3. increase sidebar width until the full input placeholder fits
4. reduce sidebar width until the placeholder is clipped
5. focus on the input and type something
6. delete the text
7. before the fix, clearing the input caused the textarea to grow and the placeholder/text position to jump vertically - it should not happen after the fix