### PR TITLE
fix: Presentation download: filename containing "&" is truncated and saved without its extension

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/MakePresentationDownloadReqMsgHdlr.scala
@@ -12,7 +12,6 @@ import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core.util.RandomStringGenerator
 
 import java.io.File
-import java.net.URI
 
 trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
   this: PresentationPodHdlrs =>
@@ -173,16 +172,18 @@ trait MakePresentationDownloadReqMsgHdlr extends RightsManagementTrait {
         bus.outGW.send(buildStoreAnnotationsInRedisSysMsg(annotations, liveMeeting))
       } else {
         // Return existing uploaded file directly
-        val convertedFileName = new URI(null, null, currentPres.get.filenameConverted, null).getRawPath
-        val originalFilename = new URI(null, null, currentPres.get.name, null).getRawPath
+        val convertedFileName = currentPres.get.filenameConverted
+        val originalFilename = currentPres.get.name
         val originalFileExt = originalFilename.split("\\.").last
         val convertedFileExt = if (convertedFileName != "") convertedFileName.split("\\.").last else ""
 
-        val convertedFileURI = if (convertedFileName != "") List("presentation", "download", meetingId,
-          s"${presId}?presFilename=${presId}.${convertedFileExt}&filename=$convertedFileName").mkString("", File.separator, "")
+        val convertedFileURI = if (convertedFileName != "") PresentationDownloadUrlBuilder.buildFileUri(
+          meetingId, presId, convertedFileExt, convertedFileName
+        )
         else ""
-        val originalFileURI = List("presentation", "download", meetingId,
-          s"${presId}?presFilename=${presId}.${originalFileExt}&filename=$originalFilename").mkString("", File.separator, "")
+        val originalFileURI = PresentationDownloadUrlBuilder.buildFileUri(
+          meetingId, presId, originalFileExt, originalFilename
+        )
 
         val event = buildNewPresFileAvailable("", originalFileURI, convertedFileURI, presId,
           m.body.fileStateType)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationConversionCompletedSysPubMsgHdlr.scala
@@ -8,8 +8,6 @@ import org.bigbluebutton.core.models.PresentationInPod
 import org.bigbluebutton.core.running.LiveMeeting
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
-import java.io.File
-import java.net.URI
 import java.time.{Instant, Duration}
 
 trait PresentationConversionCompletedSysPubMsgHdlr {
@@ -61,9 +59,9 @@ trait PresentationConversionCompletedSysPubMsgHdlr {
 
       PresPresentationDAO.updatePages(presWithConvertedName)
       if (pres.downloadable) {
-        val originalFilename = new URI(null, null, pres.name, null).getRawPath
-        val originalFileURI = List("presentation", "download", meetingId,
-          s"${pres.id}?presFilename=${pres.id}.${originalDownloadableExtension}&filename=$originalFilename").mkString("", File.separator, "")
+        val originalFileURI = PresentationDownloadUrlBuilder.buildFileUri(
+          meetingId, pres.id, originalDownloadableExtension, pres.name
+        )
         PresPresentationDAO.updateDownloadUri(pres.id, originalFileURI)
       }
       if(pres.current) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationDownloadUrlBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationDownloadUrlBuilder.scala
@@ -1,0 +1,23 @@
+package org.bigbluebutton.core.apps.presentationpod
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+object PresentationDownloadUrlBuilder {
+  private def encodeQueryValue(value: String): String = {
+    URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+  }
+
+  def buildFileUri(
+      meetingId:        String,
+      presentationId:   String,
+      fileExtension:    String,
+      downloadFilename: String
+  ): String = {
+    val storedFilename = encodeQueryValue(s"${presentationId}.${fileExtension}")
+    val encodedDownloadFilename = encodeQueryValue(downloadFilename)
+
+    s"presentation/download/${meetingId}/${presentationId}" +
+      s"?presFilename=${storedFilename}&filename=${encodedDownloadFilename}"
+  }
+}


### PR DESCRIPTION
### What does this PR do?

fix broken presentation download if filename has special characters

### Closes Issue(s)
Closes #25425

### How to test
1. Rename any PDF on your computer to `Q3 R&D Report.pdf`
2. Join a meeting as a moderator (you must be the presenter)
3. Click **+ (Actions)** → **Upload/Manage presentations**
4. Upload the file, leave its radio button selected so it becomes the current presentation, and click **Confirm**
5. Wait for the toast *"The current presentation is now: Q3 R&D Report.pdf"*
6. Click **+ (Actions)** → **Upload/Manage presentations** again
7. On the **`Q3 R&D Report.pdf`** row — the one badged **CURRENT**, not `default.pdf` — click the **⋮** (Export options)
8. Click **Enable download of the presentation (pdf)**
9. Click the **⬇** download icon that appears at the bottom-left of the slide
