### PR TITLE
docs: clarify allowOverrideClientSettingsOnCreateCall is a server setting, not a /create param

### DIFF
--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -616,18 +616,6 @@ const createEndpointTableData = [
     "description": (<>If passed it will use this string as the name of the presentation uploaded via <code className="language-plaintext highlighter-rouge">preUploadedPresentation</code> (added 2.7.2)</>)
   },
   {
-    "name": "allowOverrideClientSettingsOnCreateCall",
-    "required": false,
-    "default": false,
-    "type": "Boolean",
-    "description": (
-      <>
-        <p>Whether to allow <a href="#clientsettingsoverride">clientSettingsOverride</a> to be included in the body of a POST request. Because the body of the post request is not signed by the <a href="#api-security-model">checksum</a>, this parameter is set to <code>false</code> by default. If you set this to <code>true</code>, you must make sure that the signed parameters of the create API request are not visible to users.</p>
-        <p><i>Added:</i> 3.0.0-alpha.1</p>
-      </>
-    )
-  },
-  {
     "name": "clientSettingsOverride",
     "required": false,
     "type": "JSON",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -114,10 +114,10 @@ Updated in 2.7:
 Updated in 3.0:
 
 - **create**
-  - **Added parameters:** `allowOverrideClientSettingsOnCreateCall`, `loginURL`, `pluginManifests`, `pluginManifestsFetchUrl`, `presentationConversionCacheEnabled`, `maxNumPages`, `multiUserWhiteboardEnabled`, `clientSettingsOverrideJsonUrl`, `sharedNotesEditor`.
+  - **Added parameters:** `loginURL`, `pluginManifests`, `pluginManifestsFetchUrl`, `presentationConversionCacheEnabled`, `maxNumPages`, `multiUserWhiteboardEnabled`, `clientSettingsOverrideJsonUrl`, `sharedNotesEditor`.
   - **Added options:** Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_AND_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY;
   - **Added options:** Parameter `disabledFeatures` supports a few new options: `infiniteWhiteboard`, `deleteChatMessage`, `editChatMessage`, `replyChatMessage`, `chatMessageReactions`, `raiseHand`, `userReactions`, `chatEmojiPicker`, `quizzes`;
-  - **Added POST module:** `clientSettingsOverride`;
+  - **Added POST module:** `clientSettingsOverride` (gated by the server-side setting `allowOverrideClientSettingsOnCreateCall` in `bbb-web.properties`);
   - **Removed:** `breakoutRoomsEnabled`, `learningDashboardEnabled`, `virtualBackgroundsDisabled`. 
 - **join**
   - **Added:** `bot`, `enforceLayout`, `logoutURL`, `firstName`, `lastName`, `userdata-bbb_default_layout`, `userdata-bbb_skip_echotest_if_previous_device`, `userdata-bbb_prefer_dark_theme`. `userdata-bbb_hide_notifications`, `userdata-bbb_hide_controls`, `userdata-bbb_initial_selected_tool`
@@ -501,7 +501,9 @@ For more information about the pre-upload slides check the following [link](http
 We support overriding the client settings (the entire set of options can be found in `/usr/share/bigbluebutton/html5-client/private/config/settings.yml`) as part of the CREATE call.
 Note that these values would have higher precedence over customizations made in `/etc/bigbluebutton/bbb-html5.yml`.
 
-By default this overriding approach on CREATE is disabled. To enable it, please set `allowOverrideClientSettingsOnCreateCall=true` in `/etc/bigbluebutton/bbb-web.properties` or as part of the CREATE call.
+By default this overriding approach on CREATE is disabled. To enable it, set `allowOverrideClientSettingsOnCreateCall=true` in `/etc/bigbluebutton/bbb-web.properties` and restart bbb-web. This is a **server-side setting only** — it is not read from the create request, so passing `allowOverrideClientSettingsOnCreateCall` as a `/create` parameter has no effect.
+
+Because the POST body is not covered by the `/create` [checksum](#api-security-model), only enable this on servers where the signed parameters of the create request are not visible to users. As an alternative that keeps the settings on a checksummed GET parameter, see [`clientSettingsOverrideJsonUrl`](#get-post-create), which does not require `allowOverrideClientSettingsOnCreateCall`.
 
 You can construct the HTTPS POST request as follows:
 


### PR DESCRIPTION
`allowOverrideClientSettingsOnCreateCall` is read only from bbb-web.properties (injected via Spring resources.xml) and consumed as a global in ApiController. It is never read from the create request params (no ApiParams constant, and processCreateParams never reads it), so passing it in a /create call has no effect. The docs incorrectly presented it as a per-create parameter.

- api.md: drop the false "or as part of the CREATE call" enable path; state explicitly it is a server-side setting only; keep the checksum caveat and point to clientSettingsOverrideJsonUrl as the checksummed alternative.
- api.md: remove it from the create "Added parameters" changelog list and note it on the clientSettingsOverride POST module line instead.
- create.tsx: remove the /create parameter table entry (an entry here asserts the value is settable per meeting, which is the reported bug).

Fixes #23051

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->


