### PR TITLE
refactor(reactions): drop per-user enable-user-reaction join parameter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-reaction/service.js
+++ b/bigbluebutton-html5/imports/ui/components/user-reaction/service.js
@@ -1,9 +1,8 @@
-import getFromUserSettings from '/imports/ui/services/users-settings';
 import { useIsReactionsEnabled } from '/imports/ui/services/features/index';
 
 const getEnabledSetting = () => window.meetingClientSettings.public.userReaction.enabled;
 
-const useIsEnabled = () => useIsReactionsEnabled() && getFromUserSettings('enable-user-reaction', getEnabledSetting());
+const useIsEnabled = () => useIsReactionsEnabled() && getEnabledSetting();
 
 export default {
   useIsEnabled,


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
The userdata-enable-user-reaction join parameter let an individual user override the reactions toggle.  Remove it along with the now-unused getFromUserSettings import.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Reactions are already gated by the userReactions disabledFeatures flag and public.userReaction.enabled in settings.yml, so the per-user override is redundant.

Caught when trying to document missing userdata- parameters.
