### PR TITLE
refactor(layout): remove redundant bbb_change_layout join parameter

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -119,10 +119,9 @@ const PushLayoutEngine = (props) => {
     const { selectedLayout: currentLayout } = Settings.layout;
     const hasLayoutEngineLoadedOnce = Session.getItem('hasLayoutEngineLoadedOnce');
 
-    const changeLayout = LAYOUT_TYPE[getFromUserSettings('bbb_change_layout', null)];
     const defaultLayout = LAYOUT_TYPE[getFromUserSettings('bbb_default_layout', null)];
     const enforcedLayout = LAYOUT_TYPE[enforceLayoutResult] || null;
-    const contextLayout = enforcedLayout || changeLayout || defaultLayout
+    const contextLayout = enforcedLayout || defaultLayout
       || meetingLayout || currentLayout;
 
     Session.setItem('isGridEnabled', currentLayout === LAYOUT_TYPE.UNIFIED_LAYOUT && !presentationIsOpen);


### PR DESCRIPTION

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Removes redundant `userdata-bbb_change_layout` join parameter (keeping the documented `userdata-bbb_default_layout`)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Drop the parameter and keep `userdata-bbb_default_layout` as the single layout join parameter.






### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Removes the redundant, undocumented `userdata-bbb_change_layout` join parameter, keeping the documented `userdata-bbb_default_layout` as the single layout join parameter. The only reference in the codebase was in `pushLayoutEngine.jsx` (the local `changeLayout` lookup and its slot in the layout-precedence chain) — there are no server-side (bbb-web/akka), test, or documentation references, so the change is two lines.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
`userdata-bbb_change_layout` and `userdata-bbb_default_layout` are functionally duplicates: both resolve a userdata value against the same `LAYOUT_TYPE` map and feed the same `selectedLayout`/`contextLayout` chain, differing only in precedence (`change_layout` wins when both are set). Maintaining two join parameters for the same behavior is confusing and unnecessary.

The two arrived through independent lineages that were never deduplicated:

- **`userdata-bbb_change_layout`** — added in BBB 2.6 as part of the new Layout Manager (#14833). It was **never documented** (no reference in `docs/` in any version, nor anywhere in git history), and its originally-intended values (`smart` / `videoFocus` / `presentationFocus` / `custom`) no longer exist in `LAYOUT_TYPE`, so they now resolve to `undefined`. Only the current layout names work — which is exactly `bbb_default_layout`'s value set.
- **`userdata-bbb_default_layout`** — added in BBB 3.0 (#19844, a port of #19616). This is **not** a fresh feature: it's the userdata home for the pre-existing top-level `defaultLayout` join parameter, which lost its delivery channel when the `/enter` API was removed in 3.0. It carries the sanctioned `defaultLayout` semantics and is documented in both `administration/customize.md` and the API changelog (`development/api.md`, which records `defaultLayout` being replaced by `userdata-bbb_default_layout`).

**Why it's safe to remove `bbb_change_layout`:**
- **Zero documentation footprint** — it was never listed in the join-parameter tables in any released version (2.6/2.7/3.0/4.0), so no integrator was ever directed to use it.
- **Its legacy values are already dead** — the original values resolve to `undefined` today, so any realistic current usage must already pass a *current* layout name, for which `userdata-bbb_default_layout` is a drop-in replacement with identical behavior.
- **Fully localized** — no references in bbb-web, akka-apps, tests, or docs; the removal touches only two lines in `pushLayoutEngine.jsx`.

Result: `userdata-bbb_default_layout` remains as the single, documented layout join parameter.