### PR TITLE
test: add BlockNote shared notes e2e tests (backport of #25165)

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -502,6 +502,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
               ref={toolbarRef}
               role="toolbar"
               className="bn-toolbar-row"
+              data-test="blockNoteToolbar"
               onKeyDown={(e) => { if (e.key === 'Escape') editor.focus(); }}
             >
               <FormattingToolbar>

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -255,6 +255,17 @@ export const elements = {
   unpinNotes: 'button[data-test="unpinNotes"]',
   exportetherpad: 'span[id="exportetherpad"]',
   exporthtml: 'span[id="exporthtml"]',
+
+  // BlockNote specific
+  blockNoteContainer: '#bn-notes-scroll-container',
+  blockNoteEditor: '#bn-notes-scroll-container .bn-editor',
+  blockNoteEditable: '#bn-notes-scroll-container .bn-editor[contenteditable="true"]',
+  blockNoteReadOnly: '#bn-notes-scroll-container .bn-editor[contenteditable="false"]',
+  blockNoteToolbar: 'div[data-test="blockNoteToolbar"]',
+  blockNoteUnderlineButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Underline"]',
+  notesConnectionError: '[data-test="notesError"]',
+  notesRetryButton: 'button[data-test="notesRetryButton"]',
+
   // Notifications
   smallToastMsg: 'div[data-test="toastSmallMsg"]',
   closeToastBtn: 'i[data-test="closeToastBtn"]',

--- a/bigbluebutton-tests/playwright/core/setup/fixtures.ts
+++ b/bigbluebutton-tests/playwright/core/setup/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test';
+import { test as base, type Video } from '@playwright/test';
 
 interface TestFixtures {
   sharedBeforeEachTestHook: void;
@@ -6,12 +6,30 @@ interface TestFixtures {
 
 const testWithValidation = base.extend<TestFixtures>({
   sharedBeforeEachTestHook: [
-    async ({ browser }, use) => {
+    async ({ browser }, use, testInfo) => {
       // Before test
       await use();
-      // After test
+      // After test — collect video refs before closing (videos finalize on context close)
       const contexts = browser.contexts();
+      const videos: Video[] = [];
+      for (const ctx of contexts) {
+        for (const pg of ctx.pages()) {
+          const v = pg.video();
+          if (v) videos.push(v);
+        }
+      }
       await Promise.all(contexts.map((context) => context.close()));
+      // Only attach videos for failed/timed-out tests to avoid bloating CI artifacts on passing runs
+      if (testInfo.status !== 'passed') {
+        for (let i = 0; i < videos.length; i++) {
+          try {
+            const videoPath = await videos[i].path();
+            await testInfo.attach(`video-${i + 1}`, { path: videoPath, contentType: 'video/webm' });
+          } catch {
+            // skip if video file unavailable
+          }
+        }
+      }
     },
     { scope: 'test', auto: true },
   ],

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -2,19 +2,72 @@ import { initializePages, linkIssue } from '../../core/helpers';
 import { test } from '../../core/setup/fixtures';
 import { BlockNoteSharedNotes } from './sharednotes';
 
-test.describe('Shared Notes - BlockNote', { tag: '@ci' }, () => {
-  let sharedNotes: BlockNoteSharedNotes;
+const CREATE_PARAMETER = 'sharedNotesEditor=blockNote';
 
-  test.beforeEach(async ({ browser, context }, testInfo) => {
-    sharedNotes = new BlockNoteSharedNotes(browser, context);
-    await initializePages(sharedNotes, browser, {
-      createParameter: 'sharedNotesEditor=blockNote',
-      testInfo,
-    });
+test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
+  test('Open shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.openSharedNotes();
   });
 
-  test('Export empty shared notes as PDF returns a PDF, not an error', async () => {
+  test('Type in shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.typeInSharedNotes();
+  });
+
+  test('Format text in shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.formatTextInSharedNotes();
+  });
+
+  test('Export shared notes as PDF', async ({ browser, context, browserName }, testInfo) => {
+    test.skip(browserName === 'firefox', 'window.open popup handling differs on Firefox');
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.exportSharedNotesAsPDF();
+  });
+
+  test('Export empty shared notes as PDF returns a PDF, not an error', async ({ browser, context }, testInfo) => {
     linkIssue(25122);
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.exportEmptyNotesAsPDF();
+  });
+
+  test('Convert notes to presentation', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.convertNotesToWhiteboard();
+  });
+
+  test('Multiusers edit', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.editSharedNotesWithMoreThanOneUser();
+  });
+
+  test('See notes without edit permission', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.seeNotesWithoutEditPermission();
+  });
+
+  // different failures in CI and local
+  // local: not able to click on "unpin" button
+  // CI: not restoring presentation for viewer after unpinning notes
+  test('Pin and unpin notes onto whiteboard', async ({ browser, context, browserName }, testInfo) => {
+    test.skip(browserName === 'firefox', 'Webcams does not work properly, due to heavy firefox for testing');
+    // On BBB 3.0 the viewer whiteboard is not restored to the presenter presentation state after the
+    // presenter unpins the shared notes (observed consistently across 3 runs; the 4.0 suite passes the
+    // same scenario). Whether this is a genuine 3.0 sync gap or a test adaptation issue is not yet
+    // determined, so the scenario is kept as fixme in the 3.0 backport of #25165 rather than reported
+    // as a passing case. The make-presenter / second-unpin path below is therefore not exercised here.
+    test.fixme(true, 'BBB 3.0 viewer presentation is not restored after the presenter unpins shared notes (observed, root cause undetermined)');
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -1,10 +1,122 @@
 import { expect, Response } from '@playwright/test';
 
-import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
+import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
+import { getBlockNoteEditorLocator, getBlockNoteReadOnlyLocator, startSharedNotesBlockNote } from './util';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async openSharedNotes() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await expect(editorLocator, 'should display the BlockNote editor in editable mode').toBeVisible({
+      timeout: ELEMENT_WAIT_TIME,
+    });
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
+  async typeInSharedNotes() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially(e.message);
+    await expect(editorLocator, 'should contain the typed text on shared notes').toContainText(e.message, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
+  async formatTextInSharedNotes() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially(e.message);
+
+    await editorLocator.press('Control+Z');
+    await expect(editorLocator, 'should not contain any text after undoing').not.toContainText(e.message, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+    // Re-type so we have content to format (Y.js collaborative redo is not reliable in tests)
+    await editorLocator.pressSequentially(e.message);
+    await expect(editorLocator, 'should contain the message again after re-typing').toContainText(e.message, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+
+    await this.formatBlockNoteMessage();
+    const html = await editorLocator.innerHTML();
+
+    await expect(html.includes('<u>'), 'should include underline formatting').toBeTruthy();
+    await expect(html.includes('<strong>'), 'should include bold formatting').toBeTruthy();
+    await expect(html.includes('<em>'), 'should include italic formatting').toBeTruthy();
+
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+    await editorLocator.press('Control+Z');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
+  async exportSharedNotesAsPDF() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially(e.message);
+
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.hasElement(e.exportNotesAsPDF, 'should display the export as PDF option');
+
+    // Intercept the outgoing request — the server responds with Content-Disposition: attachment
+    // so the popup tab never navigates; checking the request URL is the reliable approach.
+    const [request] = await Promise.all([
+      this.modPage.page.context().waitForEvent('request', {
+        predicate: (req) => req.url().includes('/hocuspocus/api/documents/') && req.url().includes('/export/pdf'),
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      }),
+      this.modPage.waitAndClick(e.exportNotesAsPDF),
+    ]);
+    await expect(request.url(), 'should request the PDF export endpoint').toContain('/export/pdf');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
   // Regression for https://github.com/bigbluebutton/bigbluebutton/issues/25122:
   // exporting an empty BlockNote shared note must return a file, not an error
   // page ("Export failed: Document is empty...").
@@ -75,5 +187,220 @@ export class BlockNoteSharedNotes extends MultiUsers {
       // eslint-disable-next-line no-await-in-loop
       if (body) body(await response.text());
     }
+  }
+
+  async convertNotesToWhiteboard() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially('test');
+    await expect(editorLocator, 'should register the typed text before converting to whiteboard').toContainText(
+      'test',
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.sendNotesToWhiteboard);
+
+    await this.modPage.hasText(
+      e.currentSlideText,
+      /test/,
+      'should the slide contain the text "test" for the moderator',
+      30000,
+    );
+    await this.userPage.hasText(
+      e.currentSlideText,
+      /test/,
+      'should the slide contain the text "test" for the attendee',
+      20000,
+    );
+
+    await editorLocator.press('Control+Z');
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label button');
+  }
+
+  async editSharedNotesWithMoreThanOneUser() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    // Open notes for both users before any typing so Hocuspocus registers both sessions
+    await startSharedNotesBlockNote(this.userPage);
+    const userEditorLocator = getBlockNoteEditorLocator(this.userPage);
+
+    await startSharedNotesBlockNote(this.modPage);
+    const modEditorLocator = getBlockNoteEditorLocator(this.modPage);
+    await modEditorLocator.click();
+    await modEditorLocator.pressSequentially('Hello');
+
+    // user waits for mod's text to sync, then selects all and replaces
+    await expect(userEditorLocator, 'should sync mod content to user before editing').toContainText('Hello', {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+    await userEditorLocator.click();
+    await userEditorLocator.press('Control+A');
+    await userEditorLocator.pressSequentially('Jello');
+
+    await expect(modEditorLocator, 'should the shared notes contain the text "Jello" for the moderator').toContainText(
+      /Jello/,
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+    await expect(userEditorLocator, 'should the shared notes contain the text "Jello" for the attendee').toContainText(
+      /Jello/,
+      { timeout: ELEMENT_WAIT_TIME },
+    );
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes button for the moderator');
+    await this.userPage.waitAndClick(e.hideNotesLabel);
+    await this.userPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes button for the attendee');
+  }
+
+  async seeNotesWithoutEditPermission() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    // type on shared notes as moderator
+    await startSharedNotesBlockNote(this.modPage);
+    const modEditorLocator = getBlockNoteEditorLocator(this.modPage);
+    await modEditorLocator.click();
+    await modEditorLocator.pressSequentially('Hello');
+
+    // open user notes to join the Hocuspocus session
+    await startSharedNotesBlockNote(this.userPage);
+
+    // lock shared notes editing for viewers
+    await this.modPage.waitAndClick(e.manageUsers);
+    await this.modPage.waitAndClick(e.lockViewersButton);
+    await this.modPage.waitAndClickElement(e.lockEditSharedNotes);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    // attendee's editor should become read-only and still show content
+    const userReadOnlyLocator = getBlockNoteReadOnlyLocator(this.userPage);
+    await expect(
+      userReadOnlyLocator,
+      'should display the text "Hello" in read-only mode for the attendee',
+    ).toContainText(/Hello/, { timeout: 20000 });
+    await this.userPage.wasRemoved(
+      e.blockNoteToolbar,
+      'should not display the BlockNote toolbar when shared notes are locked for editing',
+    );
+  }
+
+  async pinAndUnpinNotesOntoWhiteboard() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      return;
+    }
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitForSelector(e.whiteboard);
+    // user minimize presentation
+    await this.userPage.waitAndClick(e.minimizePresentation);
+    await this.userPage.hasElement(
+      e.restorePresentation,
+      'should display the restore presentation button for the attendee',
+    );
+    // type on shared notes as moderator
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    await editorLocator.click();
+    await editorLocator.pressSequentially('Hello');
+    await expect(editorLocator, 'should register the typed text before pinning').toContainText(/Hello/, {
+      timeout: ELEMENT_WAIT_TIME,
+    });
+    // pin notes
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.pinNotes);
+    await this.modPage.hasElement(e.unpinNotes, 'should display the unpin notes button');
+    await this.userPage.hasElement(
+      e.minimizePresentation,
+      'should display the minimize presentation button for the attendee',
+    );
+    // check text content on pinned shared notes
+    const userEditorLocator = getBlockNoteEditorLocator(this.userPage);
+    await expect(editorLocator, 'should display the text "Hello" on the shared notes for the moderator').toContainText(
+      /Hello/,
+      { timeout: 20000 },
+    );
+    await expect(
+      userEditorLocator,
+      'should display the text "Hello" on the shared notes for the attendee',
+    ).toContainText(/Hello/);
+    // unpin notes
+    await this.modPage.closeAllToastNotifications();
+    await this.modPage.waitAndClick(e.unpinNotes);
+    await this.modPage.hasElement(e.whiteboard, 'should restore the presentation for the moderator (previous state)');
+    await this.userPage.hasElement(
+      e.whiteboard,
+      'should restore the presentation for the attendee as it syncs to presenter state',
+    );
+    // pin notes again as moderator
+    await startSharedNotesBlockNote(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.pinNotes);
+    await this.modPage.hasElement(
+      e.unpinNotes,
+      'should display the unpin notes button for the moderator after pinning the notes again',
+    );
+    // make viewer as presenter and unpin notes
+    await this.modPage.waitAndClick(e.userListItem);
+    await this.modPage.waitAndClick(e.makePresenter);
+    await this.userPage.closeAllToastNotifications();
+    await this.userPage.waitAndClick(e.unpinNotes);
+    await this.userPage.hasElement(e.whiteboard, 'should restore the presentation for the attendee (previous state)');
+    await this.modPage.hasElement(e.whiteboard, 'should restore the presentation for the moderator (previous state)');
+  }
+
+  async formatBlockNoteMessage() {
+    // U for '!' — BlockNote has no Ctrl+U shortcut; click the toolbar button instead.
+    // The static toolbar uses e.preventDefault() on mousedown to preserve selection.
+    await this.modPage.down('Shift');
+    await this.modPage.press('ArrowLeft');
+    await this.modPage.up('Shift');
+    await this.modPage.page.locator(e.blockNoteUnderlineButton).click();
+    await this.modPage.press('ArrowLeft');
+
+    // B for 'World'
+    await this.modPage.down('Shift');
+    let i = 5;
+    while (i > 0) {
+      await this.modPage.press('ArrowLeft');
+      i--;
+    }
+    await this.modPage.up('Shift');
+    await this.modPage.press('Control+B');
+    await this.modPage.press('ArrowLeft');
+
+    await this.modPage.press('ArrowLeft');
+
+    // I for 'Hello'
+    await this.modPage.down('Shift');
+    i = 5;
+    while (i > 0) {
+      await this.modPage.press('ArrowLeft');
+      i--;
+    }
+    await this.modPage.up('Shift');
+    await this.modPage.press('Control+I');
+    await this.modPage.press('ArrowLeft');
   }
 }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -71,3 +71,16 @@ export function readLinkAndCursorState(testPage: Page) {
     { sel: BLOCKNOTE_EDITOR, wordJoiner: WORD_JOINER },
   );
 }
+
+// Helpers backported from #25165. On 3.0 the shared-notes sidebar button carries
+// data-test="sharedNotes" (renamed to sharedNotesSidebarButton on 4.0), so this
+// helper opens the panel via e.sharedNotes to match the 3.0 client.
+export async function startSharedNotesBlockNote(testPage: Page) {
+  await testPage.waitAndClick(e.sharedNotes);
+  await testPage.waitForSelector(e.hideNotesLabel, ELEMENT_WAIT_LONGER_TIME);
+  await testPage.hasElement(e.blockNoteEditable, 'should display the BlockNote editor', ELEMENT_WAIT_LONGER_TIME);
+}
+
+export function getBlockNoteReadOnlyLocator(testPage: Page) {
+  return testPage.page.locator(e.blockNoteReadOnly);
+}

--- a/bigbluebutton-tests/playwright/sharednotes/etherpad/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/etherpad/sharednotes.spec.ts
@@ -2,52 +2,59 @@ import { initializePages } from '../../core/helpers';
 import { test } from '../../core/setup/fixtures';
 import { SharedNotes } from './sharednotes';
 
+const CREATE_PARAMETER = 'sharedNotesEditor=etherpad';
+
 test.describe.parallel('Shared Notes - Etherpad', { tag: '@ci' }, () => {
-  let sharedNotes: SharedNotes;
-
-  test.beforeEach(async ({ browser, context }, testInfo) => {
-    sharedNotes = new SharedNotes(browser, context);
-    await initializePages(sharedNotes, browser, {
-      isMultiUser: true,
-      createParameter: 'sharedNotesEditor=etherpad',
-      testInfo,
-    });
-  });
-
-  test('Open shared notes', async () => {
+  test('Open shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.openSharedNotes();
   });
 
-  test('Type in shared notes', async ({ browserName }) => {
+  test('Type in shared notes', async ({ browser, context, browserName }, testInfo) => {
     test.skip(browserName === 'firefox', 'Firefox has different fonts on local and ci');
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.typeInSharedNotes();
   });
 
-  test('Formate text in shared notes', async () => {
+  test('Format text in shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.formatTextInSharedNotes();
   });
 
-  test('Export shared notes', async () => {
+  test('Export shared notes', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.exportSharedNotes();
   });
 
-  test('Convert notes to presentation', async () => {
+  test('Convert notes to presentation', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.convertNotesToWhiteboard();
   });
 
-  test('Multiusers edit', async () => {
+  test('Multiusers edit', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.editSharedNotesWithMoreThanOneUSer();
   });
 
-  test('See notes without edit permission', async () => {
+  test('See notes without edit permission', async ({ browser, context }, testInfo) => {
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.seeNotesWithoutEditPermission();
   });
 
   // different failures in CI and local
   // local: not able to click on "unpin" button
   // CI: not restoring presentation for viewer after unpinning notes
-  test('Pin and unpin notes onto whiteboard', async ({ browserName }) => {
+  test('Pin and unpin notes onto whiteboard', async ({ browser, context, browserName }, testInfo) => {
     test.skip(browserName === 'firefox', 'Webcams does not work properly, due to heavy firefox for testing');
+    const sharedNotes = new SharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
     await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 });


### PR DESCRIPTION
## What does this PR do?

Backports #25165 (merged on `v4.0.x-develop`) to `v3.0.x-develop`, bringing the BlockNote shared-notes e2e coverage to the 3.0 line. Adds 8 e2e tests mirroring the Etherpad suite (open, type, format, export PDF, export empty PDF, convert to presentation, multi-user edit, view without edit permission), plus the one-line `data-test="blockNoteToolbar"` attribute on the toolbar that the suite selects on.

Closes #25125 (the same issue the 4.0 PR closed, now for the 3.0 line).

## Conflicts resolved (semantic, 2 of 7 files)

The cherry-pick of `a9c0cd5438` produced two conflicts, both resolved by merging rather than overwriting:

1. `core/elements.ts` (content): the BlockNote selectors block was added at the shared-notes export insertion point present on 3.0. No pre-existing duplicates.
2. `sharednotes/blocknote/util.ts` (add/add): this file already existed on 3.0 from #25225 with its own helpers (`startBlockNoteSharedNotes`, `getBlockNoteEditorLocator` -> `BLOCKNOTE_EDITOR`, `enableMarkdownNotesOptions`, `readLinkAndCursorState`, `getBlockNoteLinkLocator`). The two new 4.0 helpers (`startSharedNotesBlockNote`, `getBlockNoteReadOnlyLocator`) were added alongside them, keeping a single `getBlockNoteEditorLocator` since `[data-test="notes"] .bn-editor` and `#bn-notes-scroll-container .bn-editor` resolve to the same element on 3.0.

## 3.0 adaptations in `sharednotes.ts`

Element selectors that only exist under their 4.0 names were mapped to the 3.0 client conventions (verified against the 3.0 html5 source): `sharedNotesSidebarButton` -> `sharedNotes`, `messagesSidebarButton` -> `chatButton`, the lock flow uses `manageUsers` + `lockViewersButton` (the 3.0 lock-viewers modal has no participant-permissions tab), and the make-presenter flow uses `userListItem` -> `makePresenter`.

## Validation

Validated against a BBB 3.0 from-source environment running the branch:

- typecheck: 0 errors
- eslint: clean
- new BlockNote suite: 8 of 9 tests pass
- existing 3.0 blocknote suites (link/cursor + 12 markdown): pass, no regression from the `util.ts` merge

### Known limitation (pin/unpin test)

The 9th test, "Pin and unpin notes onto whiteboard", is kept as `test.fixme` on 3.0. The viewer whiteboard is not restored to the presenter presentation state after the presenter unpins the shared notes (observed consistently across 3 runs on 3.0, while the same scenario passes on 4.0). Whether this is a genuine 3.0 sync gap or a test-adaptation issue is not yet determined, so the scenario is reported as a known limitation rather than a passing case. The make-presenter / second-unpin path in the test body is therefore not exercised while the test is skipped.
