### PR TITLE
test(recording): use BlockNote editor for shared-notes recording step

### DIFF
--- a/bigbluebutton-tests/playwright/recording/recording.ts
+++ b/bigbluebutton-tests/playwright/recording/recording.ts
@@ -6,7 +6,7 @@ import { elements as e, playbackElements } from '../core/elements';
 import { getRecordings } from '../core/endpoints';
 import { Page } from '../core/page';
 import { skipSlide } from '../presentation/util';
-import { getNotesLocator, startSharedNotes } from '../sharednotes/etherpad/util';
+import { getBlockNoteEditorLocator, startSharedNotesBlockNote } from '../sharednotes/blocknote/util';
 import { MultiUsers } from '../user/multiusers';
 
 export class Recording extends MultiUsers {
@@ -74,8 +74,9 @@ export class Recording extends MultiUsers {
     await skipSlide(this.modPage);
 
     // type on shared notes
-    await startSharedNotes(this.modPage);
-    const notesLocator = getNotesLocator(this.modPage);
+    await startSharedNotesBlockNote(this.modPage);
+    const notesLocator = getBlockNoteEditorLocator(this.modPage);
+    await notesLocator.click();
     await notesLocator.pressSequentially(e.testMessage);
     await expect(notesLocator, 'should contain the typed text on shared notes').toContainText(e.testMessage, {
       timeout: ELEMENT_WAIT_TIME,


### PR DESCRIPTION




<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Switch the recording flow to the BlockNote util (startSharedNotesBlockNote
+ getBlockNoteEditorLocator, click + pressSequentially). The default editor is already BlockNote, so no create-call override is needed.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none (but 2 tests were failing last few days)

### Motivation
<!-- What inspired you to submit this pull request? -->
The recording e2e opened shared notes through the Etherpad util, which waits for iframe[title="pad"]. Since BlockNote became the default editor that iframe never appears, so recordMeeting() (run in beforeAll) timed out on "should display the etherpad frame" and failed every Recording test.


```
Error:   [Chromium] › recording/recording.spec.ts › Recording › Player › Play/Pause
Error: should display the etherpad frame
  expect(locator).toBeVisible() failed
  Locator: locator('iframe[title="pad"]')
  Expected: visible
  Timeout: 20000ms
  Error: element(s) not found
```

Follow up from https://github.com/bigbluebutton/bigbluebutton/pull/25124 and https://github.com/bigbluebutton/bigbluebutton/pull/25165