### PR TITLE
chore(akka): bump shared JVM dependency versions

### DIFF
--- a/akka-bbb-apps/build.sbt
+++ b/akka-bbb-apps/build.sbt
@@ -42,7 +42,7 @@ testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/scalatest-reports")
 
 Seq(Revolver.settings: _*)
-lazy val bbbAppsAkka = (project in file(".")).settings(name := "bbb-apps-akka", libraryDependencies ++= Dependencies.runtime).settings(compileSettings)
+lazy val bbbAppsAkka = (project in file(".")).settings(name := "bbb-apps-akka", libraryDependencies ++= Dependencies.runtime, dependencyOverrides ++= Dependencies.overrides).settings(compileSettings)
 
 // See https://github.com/scala-ide/scalariform
 // Config file is in ./.scalariform.conf

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -15,15 +15,17 @@ object Dependencies {
     val pekkoVersion = "1.0.1"
     val pekkoHttpVersion = "1.0.0"
     val gson = "2.8.9"
-    val jackson = "2.13.5"
-    val logback = "1.2.13"
+    val jackson = "2.18.9"
+    val netty = "4.1.135.Final"
+    val logback = "1.5.38"
+    val slf4j = "2.0.17"
     val quicklens = "1.7.5"
     val spray = "1.3.6"
     val semver = "0.10.2"
     val commonmark = "0.27.0"
 
     // Apache Commons
-    val lang = "3.12.0"
+    val lang = "3.18.0"
     val codec = "1.15"
     val httpcomponents = "4.5.14"
 
@@ -32,14 +34,14 @@ object Dependencies {
 
     // Database
     val slick = "3.4.1"
-    val postgresql = "42.5.0"
+    val postgresql = "42.7.13"
     val slickPg = "0.21.1"
 
     // Test
     val scalaTest = "3.2.11"
     val mockito = "2.23.0"
     val akkaTestKit = "2.6.0"
-    val jacksonDataFormat = "2.13.5"
+    val jacksonDataFormat = "2.18.9"
   }
 
   object Compile {
@@ -117,4 +119,20 @@ object Dependencies {
     Compile.slickPgSprayJson,
     Compile.postgresql,
     Compile.jacksonDataFormat) ++ testing
+
+  // Force security-patched versions on transitively-pulled artifacts so the
+  // whole jackson suite stays aligned and netty is at a fixed release.
+  val overrides = Seq(
+    "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson,
+    "io.netty" % "netty-handler" % Versions.netty,
+    "io.netty" % "netty-codec" % Versions.netty,
+    "io.netty" % "netty-common" % Versions.netty,
+    "io.netty" % "netty-buffer" % Versions.netty,
+    "io.netty" % "netty-transport" % Versions.netty,
+    "io.netty" % "netty-resolver" % Versions.netty,
+    // logback 1.5.x is an slf4j-2.x provider; pin slf4j-api 2.x so the
+    // ServiceLoader binding resolves (pekko-slf4j is runtime-compatible).
+    "org.slf4j" % "slf4j-api" % Versions.slf4j)
 }

--- a/akka-bbb-fsesl/build.sbt
+++ b/akka-bbb-fsesl/build.sbt
@@ -43,7 +43,7 @@ testOptions in Test += Tests.Argument(TestFrameworks.Specs2, "html", "console", 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/scalatest-reports")
 
 Seq(Revolver.settings: _*)
-lazy val bbbFseslAkka = (project in file(".")).settings(name := "bbb-fsesl-akka", libraryDependencies ++= Dependencies.runtime).settings(compileSettings)
+lazy val bbbFseslAkka = (project in file(".")).settings(name := "bbb-fsesl-akka", libraryDependencies ++= Dependencies.runtime, dependencyOverrides ++= Dependencies.overrides).settings(compileSettings)
 
 // See https://github.com/scala-ide/scalariform
 // Config file is in ./.scalariform.conf

--- a/akka-bbb-fsesl/project/Dependencies.scala
+++ b/akka-bbb-fsesl/project/Dependencies.scala
@@ -14,10 +14,13 @@ object Dependencies {
     // Libraries
     val pekkoVersion = "1.0.1"
     val pekkoHttpVersion = "1.0.0"
-    val logback = "1.2.13"
+    val logback = "1.5.38"
+    val jackson = "2.18.9"
+    val netty = "4.1.135.Final"
+    val slf4j = "2.0.17"
 
     // Apache Commons
-    val lang = "3.12.0"
+    val lang = "3.18.0"
     val codec = "1.15"
 
     // BigBlueButton
@@ -83,4 +86,22 @@ object Dependencies {
     Compile.bbbFseslClient,
     Compile.pekkoHttp,
     Compile.pekkoHttpSprayJson) ++ testing
+
+  // Force security-patched versions on transitively-pulled artifacts (jackson
+  // suite kept aligned; netty at a fixed release).
+  val overrides = Seq(
+    "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson,
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson,
+    "io.netty" % "netty-handler" % Versions.netty,
+    "io.netty" % "netty-codec" % Versions.netty,
+    "io.netty" % "netty-common" % Versions.netty,
+    "io.netty" % "netty-buffer" % Versions.netty,
+    "io.netty" % "netty-transport" % Versions.netty,
+    "io.netty" % "netty-resolver" % Versions.netty,
+    // logback 1.5.x is an slf4j-2.x provider; pin slf4j-api 2.x so the
+    // ServiceLoader binding resolves (pekko-slf4j is runtime-compatible).
+    "org.slf4j" % "slf4j-api" % Versions.slf4j)
 }


### PR DESCRIPTION


<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->

Updated dependencies:
bbb-apps-akka and bbb-fsesl-akka:
- jackson 2.13.5 -> 2.18.9, aligned across the suite via dependencyOverrides
- pin netty to 4.1.135.Final via dependencyOverrides (transitive)
- logback 1.2.13 -> 1.5.38, with slf4j-api pinned to 2.0.17
- commons-lang3 3.12.0 -> 3.18.0
- postgresql 42.5.0 -> 42.7.13 (bbb-apps-akka only)

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
These dependencies were dangerously outdated

