### PR TITLE
fix(docs): use valid font-weight for Open Sans SemiBold @font-face

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -71,14 +71,14 @@ html {
 @font-face {
     font-family: 'Open Sans';
     src: url('/static/fonts/OpenSans-SemiBold.ttf');
-    font-weight: bolder;
+    font-weight: 600;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Open Sans';
     src: url('/static/fonts/OpenSans-SemiBoldItalic.ttf');
-    font-weight: bolder;
+    font-weight: 600;
     font-style: italic;
 }
 


### PR DESCRIPTION
### What does this PR do?
Fixes an invalid `@font-face` descriptor in the docs site CSS. The `'Open Sans'`
SemiBold and SemiBoldItalic faces declared `font-weight: bolder`, which is not a
valid value for the `font-weight` **descriptor** — `bolder`/`lighter` are relative
keywords that are only valid on the `font-weight` **property**. Both faces now use
the correct absolute weight `600`.

### Closes Issue(s)
Closes #
<!-- No GitHub issue; reported by SonarQube rule css:S8775
     "At-rule descriptor values should be valid" (Blocker / Reliability). -->

### Motivation
Because `bolder` is invalid, browsers discard the whole descriptor and the two
SemiBold faces fall back to `font-weight: normal` (400). They then collide with
the Regular faces already registered at 400, and since a later duplicate descriptor
wins, normal body text gets rendered from the SemiBold file (too heavy) while
requests for weight 600 have no dedicated face. Registering SemiBold at 600
restores the intended weight ladder (300 → 400 → 600 → 700).

### How to test
1. Build/serve the docs site (`cd docs && npm ci && npm run build`, then
   `NODE_ENV=production npx docusaurus serve`).
2. Confirm normal body text renders in Regular (not a heavier weight) and that
   semibold headings/text render in SemiBold.
3. Re-run the SonarQube scan and confirm css:S8775 no longer reports on
   `docs/src/css/custom.css`.

Before / after (docs @font-face rules rendered with the real Open Sans TTFs):

before:
<img width="1560" height="1440" alt="docs-before" src="https://github.com/user-attachments/assets/461c27c7-6eae-4ecb-8456-20d79cb450e9" />

after:
<img width="1560" height="1440" alt="docs-after" src="https://github.com/user-attachments/assets/150a97e9-118a-4ced-9d70-5b16ab119a1c" />

