### PR TITLE
fix(chat): render private chat previews from the chats subscription

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -1477,7 +1477,10 @@ SELECT 	"user"."meetingId",
 		CASE WHEN "chat"."access" = 'PUBLIC_ACCESS' THEN true ELSE false end "public",
         "chat"."pinnedMessageId",
         "chat"."pinnedByUserId",
-        "chat"."pinnedAt"
+        "chat"."pinnedAt",
+        last_msg."lastMessage",
+        last_msg."lastMessageAt",
+        deleted_by."name" AS "lastMessageDeletedByName"
 FROM "user"
 JOIN "chat_user" cu ON cu."meetingId" = "user"."meetingId" AND cu."userId" = "user"."userId"
 --now it will always add chat_user for public chat onUserJoin
@@ -1487,6 +1490,24 @@ LEFT JOIN "chat_user" chat_with ON chat_with."meetingId" = chat."meetingId" AND
                                     chat_with."chatId" = chat."chatId" AND
                                     chat_with."userId" != cu."userId"  AND
                                     chat_with."chatId" != 'MAIN-PUBLIC-GROUP-CHAT'
+--last message preview for the chats list (issue 25416): resolved here so the private
+--chat list renders the preview from the chats subscription itself, instead of gating it
+--behind a per-item subscription that mounts the row a moment later and shifts the list.
+--Index Scan Backward on idx_v_chat_message_unread ("meetingId","chatId","createdAt") -> rows=1.
+LEFT JOIN LATERAL (
+    SELECT cm."message"         AS "lastMessage",
+           cm."createdAt"       AS "lastMessageAt",
+           cm."deletedByUserId" AS "lastMessageDeletedByUserId"
+    FROM "chat_message" cm
+    WHERE cm."meetingId" = "user"."meetingId"
+      AND cm."chatId"    = cu."chatId"
+    ORDER BY cm."createdAt" DESC
+    LIMIT 1
+) last_msg ON true
+--resolve the deleter's display name so a soft-deleted last message (message=NULL,
+--deletedByUserId set) can reuse the existing "deleted by {userName}" preview label.
+LEFT JOIN "user" deleted_by ON deleted_by."meetingId" = "user"."meetingId"
+                           AND deleted_by."userId"    = last_msg."lastMessageDeletedByUserId"
 WHERE cu."visible" is true;
 
 CREATE INDEX "idx_v_chat_with" on chat_user("meetingId","chatId","userId") WHERE "chatId" != 'MAIN-PUBLIC-GROUP-CHAT';

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_chat.yaml
@@ -41,6 +41,9 @@ select_permissions:
         - pinnedMessageId
         - pinnedByUserId
         - pinnedAt
+        - lastMessage
+        - lastMessageAt
+        - lastMessageDeletedByName
       filter:
         _and:
           - meetingId:

--- a/bigbluebutton-html5/imports/ui/Types/chat.ts
+++ b/bigbluebutton-html5/imports/ui/Types/chat.ts
@@ -10,6 +10,9 @@ export interface Chat {
   userId: string;
   participant?: User;
   lastSeenAt: string;
+  lastMessage: string | null;
+  lastMessageAt: string | null;
+  lastMessageDeletedByName: string | null;
   pinnedMessageId: string | null;
   pinnedByUserId: string | null;
   pinnedAt: string | null;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/component.tsx
@@ -293,6 +293,9 @@ const ChatContainer: React.FC = () => {
       totalUnread: chat.totalUnread,
       public: chat.public,
       totalMessages: chat.totalMessages,
+      lastMessage: chat.lastMessage,
+      lastMessageAt: chat.lastMessageAt,
+      lastMessageDeletedByName: chat.lastMessageDeletedByName,
     };
   }) as GraphqlDataHookSubscriptionResponse<Partial<ChatType>[]>;
 

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/private-chat-list/chat-list-item/component.tsx
@@ -8,16 +8,13 @@ import Styled from './styles';
 import PrivateChatListHeader from '../private-chats-header/component';
 import { Input, Layout } from '/imports/ui/components/layout/layoutTypes';
 import { Chat } from '/imports/ui/Types/chat';
-import { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
-import { Message } from '/imports/ui/Types/message';
-import { GraphqlDataHookSubscriptionResponse } from '/imports/ui/Types/hook';
-import {
-  CHAT_MESSAGE_PRIVATE_SUBSCRIPTION,
-} from '/imports/ui/components/chat/chat-graphql/chat-message-list/page/queries';
 
 const intlMessages = defineMessages({
   privateChatUnkownUser: {
     id: 'app.userList.chatListItem.unknownParticipant',
+  },
+  privateChatDeletedMessage: {
+    id: 'app.chat.deleteMessage',
   },
   privateChatAriaLabelNoUnread: {
     id: 'app.userList.chatListItem.noUnread',
@@ -63,22 +60,6 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
 
   const CHAT_CONFIG = window.meetingClientSettings.public.chat;
   const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
-
-  const chatQuery = CHAT_MESSAGE_PRIVATE_SUBSCRIPTION;
-  const totalMessages = chat.totalMessages || 0;
-  // Ensure offset is never negative (happens when chat is empty)
-  const offset = totalMessages > 0 ? totalMessages - 1 : 0;
-  const defaultVariables = {
-    offset,
-    limit: 1,
-  }; // to get only the last message from private chat
-  const variables = { ...defaultVariables, requestedChatId: chat.chatId };
-  // Skip subscription if chat has no messages
-  const skipSubscription = totalMessages === 0;
-  const useChatMessageSubscription = useCreateUseSubscription<Message>(chatQuery, variables);
-  const {
-    data: chatMessageData,
-  } = useChatMessageSubscription((msg) => msg, skipSubscription) as GraphqlDataHookSubscriptionResponse<Message[]>;
 
   useEffect(() => {
     // Clear any previous timeout to prevent multiple executions
@@ -136,10 +117,17 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
   );
   const ariaLabel = unreadCount > 0 ? unreadMessagesLabel : noUnreadMessagesLabel;
 
-  // Handle empty chats (no messages yet)
-  const hasMessages = chatMessageData && chatMessageData.length > 0;
-  const lastMessage = hasMessages ? chatMessageData[0]?.message : '';
-  const lastMessageTime = hasMessages ? new Date(chatMessageData[0]?.createdAt) : null;
+  // The last message preview now comes from the chats subscription itself (issue 25416),
+  // so it renders with the item on the first paint instead of after a separate per-item
+  // subscription that mounted the row a moment later and shifted the list.
+  const hasLastMessage = chat.lastMessageAt != null;
+  // A soft-deleted last message keeps its row with message=NULL and deletedByUserId set;
+  // reuse the existing localized "deleted by {userName}" label shown in the message list.
+  const isLastMessageDeleted = hasLastMessage && chat.lastMessage == null;
+  const lastMessage = isLastMessageDeleted
+    ? intl.formatMessage(intlMessages.privateChatDeletedMessage, { userName: chat.lastMessageDeletedByName ?? '' })
+    : (chat.lastMessage ?? '');
+  const lastMessageTime = chat.lastMessageAt ? new Date(chat.lastMessageAt) : null;
 
   return (
     <Styled.ChatListItem
@@ -171,7 +159,7 @@ const PrivateChatListItem = (props: PrivateChatListItemProps) => {
               />
             </Styled.ChatHeading>
           )}
-          {(hasMessages || unreadMessagesToDisplay > 0) && (
+          {(hasLastMessage || unreadMessagesToDisplay > 0) && (
             <Styled.ChatContent data-test="private-user-list-content">
               <Styled.MessageItemWrapper>
                 {lastMessage}

--- a/bigbluebutton-html5/imports/ui/core/graphql/queries/chatSubscription.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/queries/chatSubscription.ts
@@ -23,6 +23,9 @@ const CHATS_SUBSCRIPTION = gql`
       totalUnread
       public
       lastSeenAt
+      lastMessage
+      lastMessageAt
+      lastMessageDeletedByName
       pinnedMessageId
       pinnedAt
       pinnedBy {

--- a/bigbluebutton-tests/playwright/chat/chat.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/chat.spec.ts
@@ -2,6 +2,7 @@ import { test } from '../core/setup/fixtures';
 import { Chat } from './chat';
 import { Jumbomoji } from './jumbomoji';
 import { MessageActions } from './messageActions';
+import { PrivateChatListPreview } from './privateChatListPreview';
 
 test.describe.parallel('Chat', { tag: '@ci' }, () => {
   // https://docs.bigbluebutton.org/3.0/testing/release-testing/#public-message-automated
@@ -166,6 +167,23 @@ test.describe.parallel('Chat', { tag: '@ci' }, () => {
     const jumbomoji = new Jumbomoji(browser, context);
     await jumbomoji.initModPage(page, { testInfo });
     await jumbomoji.verifyJumbomoji();
+  });
+
+  test('Private chat preview renders at first paint', async ({ browser, context, page }, testInfo) => {
+    const preview = new PrivateChatListPreview(browser, context);
+    await preview.initModPage(page, { testInfo });
+    await preview.initUserPageWithDelayedPreview(testInfo);
+    await preview.previewRendersAtFirstPaint();
+  });
+
+  test('Private chat preview shows deleted label for a soft-deleted last message', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const preview = new PrivateChatListPreview(browser, context);
+    await preview.initPages(page, testInfo);
+    await preview.deletedLastMessageRendersDeletedLabel();
   });
 
   test.describe('Message actions', () => {

--- a/bigbluebutton-tests/playwright/chat/privateChatListPreview.ts
+++ b/bigbluebutton-tests/playwright/chat/privateChatListPreview.ts
@@ -1,15 +1,15 @@
 import { expect, TestInfo } from '@playwright/test';
 
-import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
 import { openPrivateChat } from './util';
 
 // Hold back the per-item chat_message_private frames long enough to be deterministic.
-const PREVIEW_FRAME_DELAY = 4000;
+const PREVIEW_FRAME_DELAY = ELEMENT_WAIT_TIME;
 // The preview must appear well before the delayed per-item frame would arrive.
-const PREVIEW_ASSERT_TIMEOUT = 1500;
+const PREVIEW_ASSERT_TIMEOUT = Math.floor(ELEMENT_WAIT_TIME * 0.3);
 
 export class PrivateChatListPreview extends MultiUsers {
   // Regression test for issue 25416: the private chats list rendered each item header

--- a/bigbluebutton-tests/playwright/chat/privateChatListPreview.ts
+++ b/bigbluebutton-tests/playwright/chat/privateChatListPreview.ts
@@ -1,0 +1,122 @@
+import { expect, TestInfo } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { MultiUsers } from '../user/multiusers';
+import { openPrivateChat } from './util';
+
+// Hold back the per-item chat_message_private frames long enough to be deterministic.
+const PREVIEW_FRAME_DELAY = 4000;
+// The preview must appear well before the delayed per-item frame would arrive.
+const PREVIEW_ASSERT_TIMEOUT = 1500;
+
+export class PrivateChatListPreview extends MultiUsers {
+  // Regression test for issue 25416: the private chats list rendered each item header
+  // immediately but gated the message preview behind a separate per-item subscription
+  // (chat_message_private). When that subscription resolved a moment later the preview
+  // mounted and the item grew, making the list jump.
+  //
+  // The fix brings the last message into the chats subscription itself (v_chat.lastMessage
+  // via a LATERAL join), so the preview is available with the item on the first paint and
+  // the per-item subscription is gone.
+  //
+  // The attendee page routes the graphql WebSocket and delays only the chat_message_private
+  // frames. On the pre-fix client the preview is gated by those (now delayed) frames, so the
+  // preview text is absent at first paint and this test fails. On the fixed client the preview
+  // arrives with the chats subscription (not delayed), so it is present from the first paint.
+  async initUserPageWithDelayedPreview(testInfo: TestInfo) {
+    const rawPage = await this.context.newPage();
+    await rawPage.routeWebSocket(/\/graphql/, (ws) => {
+      const server = ws.connectToServer();
+      ws.onMessage((message) => server.send(message));
+      server.onMessage((message) => {
+        const asText = typeof message === 'string' ? message : '';
+        if (asText.includes('chat_message_private')) {
+          setTimeout(() => ws.send(message), PREVIEW_FRAME_DELAY);
+        } else {
+          ws.send(message);
+        }
+      });
+    });
+    this.userPage = new Page(this.browser, rawPage, testInfo);
+    await this.userPage.init(false, { fullName: 'Attendee', meetingId: this.modPage.meetingId });
+  }
+
+  async previewRendersAtFirstPaint() {
+    // Moderator opens a private chat with the attendee and sends one message.
+    await openPrivateChat(this.modPage);
+    await this.modPage.hasElement(
+      e.hidePrivateChat,
+      'should display the hide private chat element when the moderator opens a private chat',
+    );
+    // prevent a race condition when running on a deployed server
+    await this.modPage.page.waitForTimeout(500);
+    await this.modPage.fill(e.chatBox, e.message1);
+    await this.modPage.waitAndClick(e.sendButton);
+
+    // Attendee opens the private chats list. The item appears from the chats subscription,
+    // which (unlike the delayed per-item frames) is not held back.
+    await this.userPage.waitAndClick(e.privateChatButton);
+    await this.userPage.hasElement(
+      e.privateChatItem,
+      'should display the private chat item when the attendee receives a private message',
+    );
+
+    const chatItem = this.userPage.page.locator(e.privateChatItem).first();
+
+    // The preview text must be present essentially immediately, well before the delayed
+    // per-item frame would arrive. On the pre-fix client this window elapses with no preview.
+    await expect(
+      chatItem.locator(e.privateChatListContent),
+      'should render the last message preview at first paint, without waiting for a per-item subscription',
+    ).toContainText(e.message1, { timeout: PREVIEW_ASSERT_TIMEOUT });
+
+    // No loading placeholder is rendered: the preview is real from the first paint.
+    await expect(
+      chatItem.locator('.react-loading-skeleton'),
+      'should not render a loading skeleton placeholder in the preview slot',
+    ).toHaveCount(0);
+  }
+
+  async deletedLastMessageRendersDeletedLabel() {
+    // Moderator opens a private chat with the attendee and sends one message.
+    await openPrivateChat(this.modPage);
+    await this.modPage.hasElement(
+      e.hidePrivateChat,
+      'should display the hide private chat element when the moderator opens a private chat',
+    );
+    await this.modPage.page.waitForTimeout(500);
+    await this.modPage.fill(e.chatBox, e.message1);
+    await this.modPage.waitAndClick(e.sendButton);
+    await this.modPage.hasText(
+      e.chatUserMessageText,
+      e.message1,
+      'should display the message sent by the moderator inside the private chat',
+    );
+
+    // Soft-delete the last message (message row is kept with message=NULL and deletedByUserId set).
+    const lastMessageItem = this.modPage.page.locator(e.chatMessageItem).last();
+    await lastMessageItem.hover();
+    await this.modPage.waitAndClick(e.deleteMessageButton);
+    await this.modPage.hasElement(e.simpleModal, 'should display the delete message confirmation modal');
+    await this.modPage.waitAndClick(e.confirmDeleteChatMessageButton);
+    await expect(
+      lastMessageItem,
+      'should display the deleted label inside the private chat after deleting the last message',
+    ).toContainText(`This message has been deleted by ${this.modPage.username}`);
+
+    // Back on the private chats list, the preview slot must show the same deleted label
+    // (lastMessage is NULL but lastMessageAt is set), not an empty preview.
+    await this.modPage.waitAndClick(e.privateChatBackButton);
+    await this.modPage.hasElement(
+      e.privateChatItem,
+      'should display the private chat item again on the private chats list',
+    );
+    const chatItem = this.modPage.page.locator(e.privateChatItem).first();
+    await expect(
+      chatItem.locator(e.privateChatListContent),
+      'should render the deleted-message label in the private chat preview slot',
+    ).toContainText(`This message has been deleted by ${this.modPage.username}`, { timeout: ELEMENT_WAIT_LONGER_TIME });
+  }
+}

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -174,6 +174,7 @@ export const elements = {
   publicUnreadIndicator: 'span[data-test="publicUnreadIndicator"]',
   privateUnreadIndicator: 'span[data-test="privateUnreadIndicator"]',
   privateChats: 'div[data-test="private-user-list-header"]',
+  privateChatListContent: 'div[data-test="private-user-list-content"]',
   privateChat: 'div[data-test="messageContent"] p>>nth=1',
   hidePublicChat: 'button[data-test="hidePublicChat"]',
   hidePrivateChat: 'button[data-test="hidePrivateChat"]',


### PR DESCRIPTION
### What does this PR do?

When opening the private chats list, each row's last-message preview was fetched by a separate per-item subscription (`chat_message_private`) and arrived after the row itself, so rows grew one by one and the list visibly jumped.

This PR moves the last message into the chats subscription itself: `v_chat` now exposes `lastMessage`, `lastMessageAt` and `lastMessageDeletedByName` through a `LEFT JOIN LATERAL` (served by the existing `idx_v_chat_message_unread` index, no new index needed). The client reads those fields directly and the per-item subscription is removed, so previews render on the first paint and the list stays stable. It is also cheaper — the N+1 offset query per row becomes a single index probe.

When the last message was deleted, the preview reuses the existing localized "This message has been deleted by {userName}" label instead of showing an empty row.

### Closes Issue(s)

Closes #25416

### How to test

The schema changed (`bbb_schema.sql` + Hasura metadata), so bbb-graphql-server needs to be redeployed/reloaded first.

1. Join a meeting with a moderator and an attendee and exchange a few private messages.
2. Open the private chats list: previews must be visible as soon as the rows appear, with no staggered height jumps.
3. Delete the last message of a private chat: its preview should show "This message has been deleted by {userName}".

Automated: two new Playwright tests in `chat/privateChatListPreview.ts` (part of the chat suite). The first delays the old per-item subscription frames on the wire and asserts the preview still renders immediately, so it fails on the previous implementation.

### More

- No new locale strings — the deleted-message label reuses `app.chat.deleteMessage`.
- If the user who deleted the message has already left the meeting, the deleter name resolves to NULL and the label renders with an empty name — same behavior the message list already has.
- [ ] Added/updated documentation
