### PR TITLE
fix: app gallery design fixes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/app-item/component.tsx
@@ -88,6 +88,7 @@ const AppItem: React.FC<AppItemProps> = ({
   if (viewMode === APPS_GALLERY_VIEW_MODE.GRID) {
     return (
       <Styled.TileItem key={`${appKey}${isPinned}`} data-test={dataTest}>
+        {isNew && <Styled.TileNewLabel>{intl.formatMessage(intlMessages.newAppLabel)}</Styled.TileNewLabel>}
         <TooltipContainer title={isPinned ? unpinTooltip : pinTooltip}>
           <Styled.TilePinApp
             role="button"
@@ -108,7 +109,6 @@ const AppItem: React.FC<AppItemProps> = ({
           onClick={functionToBeCalled}
           onKeyDown={handleClickableAreaKeyDown}
         >
-          {isNew && <Styled.NewLabel>{intl.formatMessage(intlMessages.newAppLabel)}</Styled.NewLabel>}
           <Styled.TileOpenButton $pinned={isPinned} aria-hidden="true">
             {resolveIcon(icon)}
           </Styled.TileOpenButton>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -1,14 +1,16 @@
 import React, {
   memo,
   useCallback,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { AppsGalleryProps, APPS_GALLERY_VIEW_MODE, AppsGalleryViewModeType } from './types';
 import { PANELS } from '/imports/ui/components/layout/enums';
-import { layoutSelectOutput } from '/imports/ui/components/layout/context';
 import { InjectedAppGalleryItem } from '/imports/ui/components/layout/layoutTypes';
+import { appsPanelItemsSpacing } from '/imports/ui/stylesheets/styled-components/general';
 import Styled from './styles';
 import AppItem from './app-item/component';
 import ExternalAppItem from './external-app-item/component';
@@ -64,9 +66,11 @@ const intlMessages = defineMessages({
 
 const VIEW_MODE_STORAGE_KEY = 'apps-gallery-view-mode';
 
-// Below this sidebar-content width a two-column grid can't fit two legible
-// tiles, so the gallery falls back to the list view regardless of preference.
-const GRID_MIN_SIDEBAR_WIDTH = 340; // px
+// A two-column grid stays with a good look while each tile is at least this wide;
+// below it the "NEW" pill overlaps the app icon (the case this guards). The
+// switch is computed from the measured content width (see the ResizeObserver in
+// the component) against this floor plus the real column gap
+const MIN_GRID_TILE_WIDTH = 140; // px
 
 const getInitialViewMode = (): AppsGalleryViewModeType => {
   if (deviceInfo.isMobile) return APPS_GALLERY_VIEW_MODE.LIST;
@@ -88,10 +92,32 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
   const [viewMode, setViewMode] = useState<AppsGalleryViewModeType>(getInitialViewMode);
   const [meetingSettings] = useMeetingSettings();
   const { isMobile } = deviceInfo;
-  const sidebarContent = layoutSelectOutput((i: { sidebarContent: { width: number } }) => i.sidebarContent);
-  const isNarrow = Boolean(sidebarContent?.width && sidebarContent.width < GRID_MIN_SIDEBAR_WIDTH);
+  const scrollBoxRef = useRef<HTMLDivElement>(null);
+  const [gridFits, setGridFits] = useState(true);
+  const isNarrow = !gridFits;
   const effectiveViewMode = isNarrow ? APPS_GALLERY_VIEW_MODE.LIST : viewMode;
   const appsToLabelAsNew = meetingSettings?.public?.sidebarNavigation?.appsToLabelAsNew || [];
+
+  // Fall back to the list view whenever the rendered content area can no longer
+  // fit two legible grid tiles, measured from the real element so panel padding
+  // and column changes are accounted for without a hand-tuned breakpoint.
+  useLayoutEffect(() => {
+    const el = scrollBoxRef.current;
+    if (!el) return undefined;
+    const check = () => {
+      const styles = getComputedStyle(el);
+      const contentWidth = el.clientWidth
+        - parseFloat(styles.paddingLeft) - parseFloat(styles.paddingRight);
+      const remInPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+      const columnGap = parseFloat(appsPanelItemsSpacing) * remInPx;
+      setGridFits(contentWidth >= 2 * MIN_GRID_TILE_WIDTH + columnGap);
+    };
+    check();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
   const shouldAddIsNewLabel = useCallback((id: string) => appsToLabelAsNew.includes(id), [appsToLabelAsNew]);
 
   const pinTooltip = intl.formatMessage(intlMessages.pinTooltip);
@@ -225,7 +251,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           </Styled.ViewToggleWrapper>
         )}
       </Styled.DescWrapper>
-      <Styled.Wrapper id="scroll-box">
+      <Styled.Wrapper ref={scrollBoxRef} id="scroll-box">
         {renderedPinnedApps.length > 0 && (
           effectiveViewMode === APPS_GALLERY_VIEW_MODE.GRID
             ? <Styled.TileAppsWrapper>{renderedPinnedApps}</Styled.TileAppsWrapper>

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -7,6 +7,7 @@ import React, {
 import { defineMessages, useIntl } from 'react-intl';
 import { AppsGalleryProps, APPS_GALLERY_VIEW_MODE, AppsGalleryViewModeType } from './types';
 import { PANELS } from '/imports/ui/components/layout/enums';
+import { layoutSelectOutput } from '/imports/ui/components/layout/context';
 import { InjectedAppGalleryItem } from '/imports/ui/components/layout/layoutTypes';
 import Styled from './styles';
 import AppItem from './app-item/component';
@@ -51,6 +52,10 @@ const intlMessages = defineMessages({
     id: 'app.appsGallery.gridViewLabel',
     description: 'Tooltip label for the grid view toggle button',
   },
+  gridViewDisabledLabel: {
+    id: 'app.appsGallery.gridViewDisabledLabel',
+    description: 'Tooltip label for the grid view toggle button when disabled on a narrow panel',
+  },
   listViewLabel: {
     id: 'app.appsGallery.listViewLabel',
     description: 'Tooltip label for the list view toggle button',
@@ -58,6 +63,10 @@ const intlMessages = defineMessages({
 });
 
 const VIEW_MODE_STORAGE_KEY = 'apps-gallery-view-mode';
+
+// Below this sidebar-content width a two-column grid can't fit two legible
+// tiles, so the gallery falls back to the list view regardless of preference.
+const GRID_MIN_SIDEBAR_WIDTH = 340; // px
 
 const getInitialViewMode = (): AppsGalleryViewModeType => {
   if (deviceInfo.isMobile) return APPS_GALLERY_VIEW_MODE.LIST;
@@ -79,12 +88,16 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
   const [viewMode, setViewMode] = useState<AppsGalleryViewModeType>(getInitialViewMode);
   const [meetingSettings] = useMeetingSettings();
   const { isMobile } = deviceInfo;
+  const sidebarContent = layoutSelectOutput((i: { sidebarContent: { width: number } }) => i.sidebarContent);
+  const isNarrow = Boolean(sidebarContent?.width && sidebarContent.width < GRID_MIN_SIDEBAR_WIDTH);
+  const effectiveViewMode = isNarrow ? APPS_GALLERY_VIEW_MODE.LIST : viewMode;
   const appsToLabelAsNew = meetingSettings?.public?.sidebarNavigation?.appsToLabelAsNew || [];
   const shouldAddIsNewLabel = useCallback((id: string) => appsToLabelAsNew.includes(id), [appsToLabelAsNew]);
 
   const pinTooltip = intl.formatMessage(intlMessages.pinTooltip);
   const unpinTooltip = intl.formatMessage(intlMessages.unpinTooltip);
   const gridViewLabel = intl.formatMessage(intlMessages.gridViewLabel);
+  const gridViewDisabledLabel = intl.formatMessage(intlMessages.gridViewDisabledLabel);
   const listViewLabel = intl.formatMessage(intlMessages.listViewLabel);
 
   const handleViewModeChange = (mode: AppsGalleryViewModeType) => {
@@ -123,7 +136,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
         onClick={onClick}
         pinTooltip={pinTooltip}
         unpinTooltip={unpinTooltip}
-        viewMode={viewMode}
+        viewMode={effectiveViewMode}
       />
     );
   };
@@ -133,7 +146,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
       .sort((a, b) => registeredApps[a].name.localeCompare(registeredApps[b].name))
       .filter((key) => !normalizedQuery || registeredApps[key].name.toLowerCase().includes(normalizedQuery))
       .map((key) => renderAppItem(key, true))
-  ), [registeredApps, pinnedApps, normalizedQuery, pinTooltip, unpinTooltip, shouldAddIsNewLabel, viewMode]);
+  ), [registeredApps, pinnedApps, normalizedQuery, pinTooltip, unpinTooltip, shouldAddIsNewLabel, effectiveViewMode]);
 
   const renderedUnpinnedApps = useMemo(() => {
     const unpinnedKeys = Object.keys(registeredApps)
@@ -151,7 +164,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
       .sort((a, b) => registeredApps[a].name.localeCompare(registeredApps[b].name));
 
     return [...newApps, ...regularApps].map((key) => renderAppItem(key, false));
-  }, [registeredApps, pinnedApps, normalizedQuery, pinTooltip, unpinTooltip, shouldAddIsNewLabel, viewMode]);
+  }, [registeredApps, pinnedApps, normalizedQuery, pinTooltip, unpinTooltip, shouldAddIsNewLabel, effectiveViewMode]);
 
   return (
     <>
@@ -186,12 +199,13 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
         </span>
         {!isMobile && (
           <Styled.ViewToggleWrapper>
-            <TooltipContainer title={gridViewLabel}>
+            <TooltipContainer title={isNarrow ? gridViewDisabledLabel : gridViewLabel}>
               <Styled.ViewToggleButton
-                $active={viewMode === APPS_GALLERY_VIEW_MODE.GRID}
-                onClick={() => handleViewModeChange(APPS_GALLERY_VIEW_MODE.GRID)}
-                aria-pressed={viewMode === APPS_GALLERY_VIEW_MODE.GRID}
-                aria-label={gridViewLabel}
+                $active={effectiveViewMode === APPS_GALLERY_VIEW_MODE.GRID}
+                onClick={() => !isNarrow && handleViewModeChange(APPS_GALLERY_VIEW_MODE.GRID)}
+                aria-pressed={effectiveViewMode === APPS_GALLERY_VIEW_MODE.GRID}
+                aria-disabled={isNarrow}
+                aria-label={isNarrow ? gridViewDisabledLabel : gridViewLabel}
                 data-test="appsGalleryGridView"
               >
                 <Icon iconName="apps_tiles" />
@@ -199,9 +213,9 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
             </TooltipContainer>
             <TooltipContainer title={listViewLabel}>
               <Styled.ViewToggleButton
-                $active={viewMode === APPS_GALLERY_VIEW_MODE.LIST}
+                $active={effectiveViewMode === APPS_GALLERY_VIEW_MODE.LIST}
                 onClick={() => handleViewModeChange(APPS_GALLERY_VIEW_MODE.LIST)}
-                aria-pressed={viewMode === APPS_GALLERY_VIEW_MODE.LIST}
+                aria-pressed={effectiveViewMode === APPS_GALLERY_VIEW_MODE.LIST}
                 aria-label={listViewLabel}
                 data-test="appsGalleryListView"
               >
@@ -213,7 +227,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
       </Styled.DescWrapper>
       <Styled.Wrapper id="scroll-box">
         {renderedPinnedApps.length > 0 && (
-          viewMode === APPS_GALLERY_VIEW_MODE.GRID
+          effectiveViewMode === APPS_GALLERY_VIEW_MODE.GRID
             ? <Styled.TileAppsWrapper>{renderedPinnedApps}</Styled.TileAppsWrapper>
             : <Styled.PinnedAppsWrapper>{renderedPinnedApps}</Styled.PinnedAppsWrapper>
         )}
@@ -221,7 +235,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           <Styled.SectionSeparator />
         )}
         {renderedUnpinnedApps.length > 0 && (
-          viewMode === APPS_GALLERY_VIEW_MODE.GRID
+          effectiveViewMode === APPS_GALLERY_VIEW_MODE.GRID
             ? <Styled.TileAppsWrapper>{renderedUnpinnedApps}</Styled.TileAppsWrapper>
             : <Styled.UnpinnedAppsWrapper>{renderedUnpinnedApps}</Styled.UnpinnedAppsWrapper>
         )}

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -298,6 +298,11 @@ const TilePinApp = styled.div<{ pinned: boolean }>`
   padding: 0.25rem;
   cursor: pointer;
 
+  [dir="rtl"] & {
+    right: auto;
+    left: 0.4rem;
+  }
+
   > i {
     font-size: 100%;
     color: ${({ pinned }) => (pinned ? colorPrimary : unpinnedAppIconColor)};

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -132,8 +132,9 @@ const PinApp = styled.div<{pinned: boolean}>`
 const DescWrapper = styled.div`
   padding: 0 ${contentSidebarPadding} 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  gap: 0.5rem;
 `;
 
 const BoldText = styled.span`
@@ -230,11 +231,20 @@ const ViewToggleButton = styled.button<{ $active: boolean }>`
     background-color: ${appsGalleryOutlineColor};
     color: ${colorPrimary};
   }
+
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+
+    &:hover {
+      background-color: transparent;
+      color: ${unpinnedAppIconColor};
+    }
+  }
 `;
 
 const TileAppsWrapper = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: ${appsPanelItemsSpacing};
   width: 100%;
 `;

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -291,6 +291,7 @@ const TilePinApp = styled.div<{ pinned: boolean }>`
   position: absolute;
   top: 0.4rem;
   right: 0.4rem;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -332,6 +333,15 @@ const TileClickableArea = styled.div`
   gap: ${appsPanelItemsSpacing};
   width: 100%;
   cursor: pointer;
+
+  /* Stretch the click target over the whole tile so the "NEW" badge and the
+     surrounding padding also open the app; the pin stays clickable via its
+     higher z-index. */
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
 `;
 
 export default {

--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/styles.ts
@@ -7,7 +7,12 @@ import {
   colorWhite,
   colorBorder,
 } from '/imports/ui/stylesheets/styled-components/palette';
-import { titlesFontWeight, headingsFontWeight, fontSizeBase } from '/imports/ui/stylesheets/styled-components/typography';
+import {
+  titlesFontWeight,
+  headingsFontWeight,
+  fontSizeBase,
+  fontSizeSmall,
+} from '/imports/ui/stylesheets/styled-components/typography';
 import {
   $2xlPadding,
   lgPadding,
@@ -138,11 +143,23 @@ const BoldText = styled.span`
 const NewLabel = styled.span`
   background-color: ${colorPrimary};
   color: ${colorWhite};
-  padding: 0.1rem 0.75rem;
-  border-radius: 10px;
-  font-size: ${fontSizeBase};
+  padding: 0.125rem 0.5rem;
+  border-radius: ${lgBorderRadius};
+  font-size: ${fontSizeSmall};
+  font-weight: ${headingsFontWeight};
   text-transform: uppercase;
-  flex-shrink: 1;
+  flex-shrink: 0;
+`;
+
+const TileNewLabel = styled(NewLabel)`
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+
+  [dir="rtl"] & {
+    left: auto;
+    right: 0.75rem;
+  }
 `;
 
 const SearchWrapper = styled.div`
@@ -168,6 +185,7 @@ const SearchWrapper = styled.div`
 
 const SearchInput = styled.input`
   flex: 1;
+  min-width: 0;
   border: none;
   outline: none;
   background: transparent;
@@ -180,7 +198,7 @@ const SearchInput = styled.input`
 `;
 
 const SectionSeparator = styled.hr`
-  width: calc(100% - 2 * ${contentSidebarPadding});
+  width: 100%;
   border: none;
   border-top: 1px solid ${colorBorder};
   margin: 0;
@@ -216,7 +234,7 @@ const ViewToggleButton = styled.button<{ $active: boolean }>`
 
 const TileAppsWrapper = styled.div`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
   gap: ${appsPanelItemsSpacing};
   width: 100%;
 `;
@@ -226,10 +244,10 @@ const TileItem = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 1.5rem 0.75rem 0.75rem;
+  padding: 2rem 1rem;
   border: 1px solid ${colorBorder};
-  border-radius: ${appsButtonsBorderRadius};
-  gap: 0.5rem;
+  border-radius: ${lgBorderRadius};
+  gap: ${appsPanelItemsSpacing};
   cursor: pointer;
   overflow: hidden;
 
@@ -244,7 +262,7 @@ const TileOpenButton = styled.span<{ $pinned: boolean }>`
   justify-content: center;
   width: 2.75rem;
   height: 2.75rem;
-  border-radius: 50%;
+  border-radius: ${appsButtonsBorderRadius};
 
   ${({ $pinned }) => ($pinned ? `
     background-color: ${colorPrimary};
@@ -296,7 +314,7 @@ const TileClickableArea = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: ${appsPanelItemsSpacing};
   width: 100%;
   cursor: pointer;
 `;
@@ -315,6 +333,7 @@ export default {
   DescWrapper,
   BoldText,
   NewLabel,
+  TileNewLabel,
   SearchWrapper,
   SearchInput,
   SectionSeparator,

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -180,6 +180,7 @@
     "app.appsGallery.pinTooltip": "Pin app",
     "app.appsGallery.unpinTooltip": "Unpin app",
     "app.appsGallery.gridViewLabel": "Grid view",
+    "app.appsGallery.gridViewDisabledLabel": "Not enough space for grid view — expand the panel to use it",
     "app.appsGallery.listViewLabel": "List view",
     "app.appsGallery.newAppLabel": "New",
     "app.appsGallery.modal.title": "Oops!",


### PR DESCRIPTION
### What does this PR do?
Applies the latest design updates to the **Apps Gallery** sidebar panel and
makes it behave gracefully when the panel is narrow:


https://github.com/user-attachments/assets/e1374a04-288c-4fad-9891-def88cd446ba



- **"NEW" tag** — restyled as a small semibold pill and repositioned: pinned
  to the top-left corner of the tile in grid view, and inline before the pin
  icon in list view (RTL-aware).
- **Tile styling** — rounded-square app-icon container (instead of a circle)
  and tile geometry (radius, padding, gaps) aligned with the mocks.
- **Layout polish** — the section separator now spans the full content width,
  and the search input can shrink so it never clips the view toggles.
- **Responsive behavior** — below a minimum sidebar-content width a two-column
  grid can't fit two legible tiles, so the gallery falls back to the **list
  view**. The grid toggle is disabled while narrow (greyed, non-interactive)
  with a tooltip explaining why, and the user's grid/list preference is kept
  so grid returns automatically once the panel is widened.

### Motivation
Bring the Apps Gallery in line with the latest Figma mocks, and fix the grid
breaking at narrow sidebar widths — where the "NEW" label overlapped the app
icon and titles were truncated.

### Closes
Close https://github.com/bigbluebutton/bigbluebutton/issues/25292

### How to test
1. Join a meeting as a moderator (presenter, to get Polls). Open the **Apps
   Gallery** from the sidebar navigation.
2. Confirm search, pin/unpin, and the grid/list view toggle all work.
3. **"NEW" tag:** flag an app as new — set
   `public.sidebarNavigation.appsToLabelAsNew` (e.g. `["timer"]`) in the
   bbb-html5 settings, or use a plugin with `isNew: true`. The app shows a
   "NEW" pill: top-left in grid view, before the pin icon in list view.
4. **Narrow-width fallback:** drag the sidebar panel narrow — the gallery
   switches to the list view and the grid toggle becomes disabled (greyed,
   `not-allowed` cursor) with the tooltip *"Not enough space for grid view —
   expand the panel to use it"*. Widen the panel again — it returns to grid,
   honoring your previous preference.