### PR TITLE
[4.0]docs: replace architecture PNG with inline Mermaid diagram; update for 4.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,34 @@ $ npx docusaurus clear  # ensure cached content is not interfering with your cha
 $ rm -r versioned_docs versioned_sidebars versions.json  # if you build multiple versions
 ```
 
+## Diagrams
+
+There are two ways to add a diagram, in order of preference:
+
+1. **Inline Mermaid (preferred).** Mermaid is enabled site-wide
+   (`markdown: { mermaid: true }` plus `@docusaurus/theme-mermaid` in
+   `docusaurus.config.js`), so a fenced ` ```mermaid ` code block renders
+   natively — no image asset to manage, the diagram is diffable and
+   reviewable in the PR, and it follows the site's light/dark theme.
+   The architecture diagram in `docs/development/architecture.md` and the
+   plugin-loading flows in `docs/plugins.md` are authored this way. Edit
+   the text directly and preview with `npx docusaurus start`.
+
+2. **Exported image (for complex / hand-placed diagrams).** Keep the
+   editable source and its exported raster together under one basename in
+   `static/img/diagrams/` (e.g. `my-diagram.drawio` +
+   `my-diagram.drawio.png`) and reference the export with a root-absolute
+   path and meaningful alt text:
+
+   ```markdown
+   ![Descriptive alt text](/img/diagrams/my-diagram.drawio.png)
+   ```
+
+   Keep the path exact — Docusaurus serves `/img/...` from `static/`
+   as-is and will *not* fail the build if the file is missing (the image
+   just 404s / renders broken), unlike a broken doc link, which throws
+   under `onBrokenLinks: 'throw'`.
+
 ## Cutting a new release
 
 The docs for all versions are build and deployed from the `develop`-branch,

--- a/docs/docs/development/architecture.md
+++ b/docs/docs/development/architecture.md
@@ -18,6 +18,8 @@ The following diagram provides a high-level view of how BigBlueButton's componen
 
 ```mermaid
 flowchart TB
+  %% Blue = new/default in 4.0 · grey-dashed = alternative/opt-in path
+
   %% ── Edge / reverse proxies ──────────────────────────
   client[client]
   haproxy[HAProxy]
@@ -28,16 +30,14 @@ flowchart TB
   nginx --> haproxy
   thirdparty --> nginx
 
-  %% ── HTML5 client, GraphQL stack & datastores ────────
-  html5[bbb-html5]
+  %% ── HTML5 client, GraphQL stack & datastore ─────────
+  html5["bbb-html5<br/>(static client)"]
   gqlmw[graphql-middleware]
   hasura["graphql-server<br/>(Hasura)"]
   gqlactions[graphql-actions]
-  mongo[("MongoDB<br/>(being decommissioned)")]
   postgres[(PostgreSQL)]
 
   html5 --> haproxy
-  html5 <--> mongo
   haproxy <--> gqlmw
   gqlmw <--> hasura
   gqlmw --> gqlactions
@@ -48,29 +48,53 @@ flowchart TB
 
   %% ── Core apps ───────────────────────────────────────
   akkaapps[akka-apps]
-  akkafsesl[akka-fsesl]
   webapi[Web API]
   redis[RedisPubSub]
 
   akkaapps --> postgres
-  akkaapps --> akkafsesl
   akkaapps <--> redis
   akkaapps --> redisdb
   webapi <--> nginx
   webapi <--> redis
 
-  %% ── Media ───────────────────────────────────────────
-  sfu[webrtc-sfu]
-  freeswitch[FreeSWITCH]
-  mediasoup[mediasoup]
+  %% ── Media: LiveKit (default) ─────────────────────────
+  livekit["LiveKit server<br/>(default A/V/screenshare)"]:::neo
+  livekitsip["LiveKit SIP<br/>(dial-in)"]:::neo
+  sfu["bbb-webrtc-sfu<br/>(media controller)"]
   recorder[webrtc-recorder]
 
+  nginx <--> livekit
+  livekitsip --> livekit
+  sfu <--> livekit
   sfu <--> nginx
   sfu <--> redis
+  recorder <--> livekit
   sfu <--> recorder
-  sfu --> mediasoup
-  sfu --> freeswitch
-  akkafsesl <--> freeswitch
+
+  %% ── Media: mediasoup + FreeSWITCH (alternative) ──────
+  mediasoup["mediasoup<br/>(alternative)"]:::alt
+  freeswitch["FreeSWITCH<br/>(alternative / dial-in)"]:::alt
+  akkafsesl[akka-fsesl]:::alt
+
+  sfu -.-> mediasoup
+  mediasoup -.-> freeswitch
+  akkaapps -.-> akkafsesl
+  akkafsesl -.-> freeswitch
+
+  %% ── Shared notes: BlockNote (default) ────────────────
+  sharednotes["bbb-shared-notes-server<br/>(Hocuspocus / Yjs)"]:::neo
+  blocknotedb[("blocknote_app<br/>(Yjs docs)")]:::neo
+
+  nginx <--> sharednotes
+  sharednotes <--> blocknotedb
+  sharednotes <--> redis
+
+  %% ── Shared notes: Etherpad (alternative) ─────────────
+  pads["bbb-pads<br/>(alternative)"]:::alt
+  etherpad["Etherpad<br/>(alternative)"]:::alt
+
+  redis <--> pads
+  pads <--> etherpad
 
   %% ── Presentation conversion & static files ──────────
   prescon[Presentation Conversion]
@@ -81,12 +105,10 @@ flowchart TB
   prescon --> redis
   presfiles --> nginx
 
-  %% ── Recording, pads & other Redis consumers ─────────
+  %% ── Recording & other Redis consumers ────────────────
   exportann[export-annotations]
   webhooks[webhooks]
   transcription[transcription-controller]
-  pads[bbb-pads]
-  etherpad[Etherpad]
   redisdb[(RedisDB)]
   recproc[recording processor]
 
@@ -94,15 +116,13 @@ flowchart TB
   exportann --> presfiles
   redis <--> webhooks
   redis <--> transcription
-  redis <--> pads
-  pads <--> etherpad
   redisdb --> recproc
 
   %% ── Styling ─────────────────────────────────────────
   classDef store fill:#e8ecf3,stroke:#5b6b8c,color:#1c2733;
-  classDef deprecated fill:#f2f2f2,stroke:#b0b0b0,color:#8a8a8a,stroke-dasharray:4 4;
+  classDef alt   fill:#f2f2f2,stroke:#b0b0b0,color:#7a7a7a,stroke-dasharray:4 4;
+  classDef neo   fill:#e6f0ff,stroke:#2b6cb0,color:#12345a;
   class postgres,presfiles,redisdb store;
-  class mongo deprecated;
 ```
 
 We'll break down each component in more detail below.

--- a/docs/docs/development/architecture.md
+++ b/docs/docs/development/architecture.md
@@ -16,7 +16,94 @@ This page describes the overall architecture of BigBlueButton and how these comp
 
 The following diagram provides a high-level view of how BigBlueButton's components work together.
 
-![Architecture Overview](/img/diagrams/BBB30arch.drawio.png)
+```mermaid
+flowchart TB
+  %% ── Edge / reverse proxies ──────────────────────────
+  client[client]
+  haproxy[HAProxy]
+  nginx[NginX]
+  thirdparty[3rd party]
+
+  client <--> haproxy
+  nginx --> haproxy
+  thirdparty --> nginx
+
+  %% ── HTML5 client, GraphQL stack & datastores ────────
+  html5[bbb-html5]
+  gqlmw[graphql-middleware]
+  hasura["graphql-server<br/>(Hasura)"]
+  gqlactions[graphql-actions]
+  mongo[("MongoDB<br/>(being decommissioned)")]
+  postgres[(PostgreSQL)]
+
+  html5 --> haproxy
+  html5 <--> mongo
+  haproxy <--> gqlmw
+  gqlmw <--> hasura
+  gqlmw --> gqlactions
+  gqlmw <--> redis
+  gqlactions --> redis
+  hasura --> nginx
+  postgres --> hasura
+
+  %% ── Core apps ───────────────────────────────────────
+  akkaapps[akka-apps]
+  akkafsesl[akka-fsesl]
+  webapi[Web API]
+  redis[RedisPubSub]
+
+  akkaapps --> postgres
+  akkaapps --> akkafsesl
+  akkaapps <--> redis
+  akkaapps --> redisdb
+  webapi <--> nginx
+  webapi <--> redis
+
+  %% ── Media ───────────────────────────────────────────
+  sfu[webrtc-sfu]
+  freeswitch[FreeSWITCH]
+  mediasoup[mediasoup]
+  recorder[webrtc-recorder]
+
+  sfu <--> nginx
+  sfu <--> redis
+  sfu <--> recorder
+  sfu --> mediasoup
+  sfu --> freeswitch
+  akkafsesl <--> freeswitch
+
+  %% ── Presentation conversion & static files ──────────
+  prescon[Presentation Conversion]
+  presfiles[(presentation files)]
+
+  webapi --> prescon
+  prescon --> presfiles
+  prescon --> redis
+  presfiles --> nginx
+
+  %% ── Recording, pads & other Redis consumers ─────────
+  exportann[export-annotations]
+  webhooks[webhooks]
+  transcription[transcription-controller]
+  pads[bbb-pads]
+  etherpad[Etherpad]
+  redisdb[(RedisDB)]
+  recproc[recording processor]
+
+  redis <--> exportann
+  exportann --> presfiles
+  redis <--> webhooks
+  redis <--> transcription
+  redis <--> pads
+  pads <--> etherpad
+  redisdb --> recproc
+
+  %% ── Styling ─────────────────────────────────────────
+  classDef store fill:#e8ecf3,stroke:#5b6b8c,color:#1c2733;
+  classDef deprecated fill:#f2f2f2,stroke:#b0b0b0,color:#8a8a8a,stroke-dasharray:4 4;
+  class postgres,presfiles,redisdb store;
+  class mongo deprecated;
+```
 
 We'll break down each component in more detail below.
 


### PR DESCRIPTION
## What

Replaces the high-level architecture diagram on the **Architecture** page
(`docs/development/architecture.md`) — previously a raster PNG exported from
diagrams.net — with an inline `mermaid` flowchart, then refreshes the topology
to reflect **BigBlueButton 4.0** (the old PNG still depicted the earlier
"3.1"/3.x layout).

Also adds a short **Diagrams** section to `docs/README.md` documenting the
convention: inline Mermaid preferred; exported image (editable source + PNG
under one basename) for complex/hand-placed diagrams.

**Reviewable in two commits:**
1. `docs: replace architecture PNG with inline Mermaid diagram` — the faithful
   1:1 PNG→Mermaid conversion (plus the README Diagrams note).
2. `docs: update architecture diagram for BigBlueButton 4.0` — the 4.0
   topology changes to that diagram.

## 4.0 topology updates (commit 2)

- **MongoDB removed** — fully decommissioned in 4.0; `bbb-html5` is now a
  static client fed by GraphQL → Hasura → PostgreSQL.
- **LiveKit is the default media server** — adds `LiveKit server`
  (audio/video/screenshare) and `LiveKit SIP` (dial-in); `bbb-webrtc-sfu` is
  relabelled as the media *controller* (LiveKit token/webhook handling).
- **mediasoup / FreeSWITCH / akka-fsesl** demoted to the *alternative* media
  bridge (opt-in via bridge config).
- **BlockNote is the default shared-notes editor** — adds the new
  `bbb-shared-notes-server` (Hocuspocus/Yjs) and its separate `blocknote_app`
  Postgres store; **Etherpad + bbb-pads** kept but marked *alternative*.

Legend: blue = new/default in 4.0; grey-dashed = alternative/opt-in path.

## Why

- **Diffable** — a node/edge change is a one-line edit reviewable in the PR,
  not an opaque ~195 KB binary.
- **No round-trip** — edit in place; no diagrams.net + re-export step.
- **Theme-aware** — follows the docs site's light/dark theme.
- Zero config — Mermaid is already enabled site-wide (`markdown.mermaid` +
  `@docusaurus/theme-mermaid`), and diagrams already ship in `docs/plugins.md`.

## Notes

- `BBB30arch.drawio` + `BBB30arch.drawio.png` are intentionally left in place:
  the 3.0 docs version still references the PNG, and the deployed multi-version
  site serves it from `develop`'s global `static/`. The file can be removed
  later, once every built version that references it has been converted.
- The 4.0 topology was derived from source + packaging (bbb-web properties,
  html5 bridge config, akka handlers, the in-tree `bbb-shared-notes-server`,
  `bbb-livekit` packaging). A few edge-level details for `bbb-webrtc-sfu` /
  `bbb-webrtc-recorder` (fetched at build time, not in-tree) were deliberately
  kept out of the diagram to avoid overstating.
- Mermaid's auto-layout differs from the hand-placed drawio.

## How to verify

`cd docs && npm ci && npx docusaurus start`, then open `/development/architecture`.



<img width="4904" height="2332" alt="bbb40-architecture" src="https://github.com/user-attachments/assets/8ecca98f-cc88-42cd-8811-2a50b7942c9a" />
