### PR TITLE
build(bbb-livekit): use default scheduler/niceness for livekit-sip

### DIFF
--- a/build/packages-template/bbb-livekit/livekit-sip.service
+++ b/build/packages-template/bbb-livekit/livekit-sip.service
@@ -15,8 +15,6 @@ Restart=always
 TimeoutStopSec=5
 User=bigbluebutton
 Group=bigbluebutton
-CPUSchedulingPolicy=fifo
-Nice=19
 
 [Install]
 WantedBy=multi-user.target bigbluebutton.target


### PR DESCRIPTION
### What does this PR do?

- [build(bbb-livekit): use default scheduler/niceness for livekit-sip](https://github.com/bigbluebutton/bigbluebutton/commit/4d01dcb4bc1a04cc9dfd4299ac3072db94e2e7cc) 
  - livekit-sip does not warrant the use of the FIFO scheduler, nor should
it require special niceness when compared to other processes. It's
likely this way due to a copy-paste leftover from livekit-server's
service - which is more justified in having special scheduling, but is
also likely to be taken off the FIFO scheduler later on (with special
niceness still).
  - An additional  problem with this is that it is a possible culprit of
causing a CPU peg issue during BBB boot/restarts.
  - Revert livekit-sip back to the common scheduler and niceness regime.
Should now match what it was originally intended to have, as well as
mitigates the CPU peg issue mentioned above.

### Closes Issue(s)

None