### PR TITLE
refactor(bbb-web): remove dead logoutTimer / clientLogoutTimerInMinutes code

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -42,7 +42,6 @@ public class ApiParams {
     public static final String IS_BREAKOUT = "isBreakout";
     public static final String LOGO = "logo";
     public static final String DARK_LOGO = "darklogo";
-    public static final String LOGOUT_TIMER = "logoutTimer";
     public static final String LOGIN_URL = "loginURL";
     public static final String LOGOUT_URL = "logoutURL";
     public static final String MAX_PARTICIPANTS = "maxParticipants";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -143,7 +143,6 @@ public class ParamsProcessorUtil {
 
     private Long maxPresentationFileUpload = 30000000L; // 30MB
 
-    private Integer clientLogoutTimerInMinutes = 0;
     private Integer defaultMeetingExpireIfNoUserJoinedInMinutes = 5;
     private Integer defaultMeetingExpireWhenLastUserLeftInMinutes = 1;
   	private Integer userInactivityInspectTimerInMinutes = 120;
@@ -610,7 +609,6 @@ public class ParamsProcessorUtil {
         boolean record = processRecordMeeting(params.get(ApiParams.RECORD));
         int maxUsers = processMaxUser(params.get(ApiParams.MAX_PARTICIPANTS));
         int meetingDuration = processMeetingDuration(params.get(ApiParams.DURATION));
-        int logoutTimer = processLogoutTimer(params.get(ApiParams.LOGOUT_TIMER));
 
         // Banner parameters
         String bannerText = params.get(ApiParams.BANNER_TEXT);
@@ -993,7 +991,6 @@ public class ParamsProcessorUtil {
                 .withDuration(meetingDuration)
                 .withLoginUrl(loginUrl)
                 .withLogoutUrl(logoutUrl)
-                .withLogoutTimer(logoutTimer)
                 .withBannerText(bannerText).withBannerColor(bannerColor)
                 .withTelVoice(telVoice).withWebVoice(webVoice)
                 .withDialNumber(dialNumber)
@@ -1359,18 +1356,6 @@ public class ParamsProcessorUtil {
     return mDuration;
   }
 
-	public int processLogoutTimer(String logoutTimer) {
-		int mDuration = clientLogoutTimerInMinutes;
-
-		try {
-			mDuration = Integer.parseInt(logoutTimer);
-		} catch(Exception ex) {
-			mDuration = clientLogoutTimerInMinutes;
-		}
-
-		return mDuration;
-	}
-
     public boolean isTestMeeting(String telVoice) {
         return ((!StringUtils.isEmpty(telVoice)) && (!StringUtils.isEmpty(testVoiceBridge))
                 && (telVoice.equals(testVoiceBridge)));
@@ -1683,10 +1668,6 @@ public class ParamsProcessorUtil {
 
     public void setDefaultMeetingLayout(String meetingLayout) {
 		this.defaultMeetingLayout =  meetingLayout;
-	}
-
-	public void setClientLogoutTimerInMinutes(Integer value) {
-		clientLogoutTimerInMinutes = value;
 	}
 
 	public void setMeetingExpireWhenLastUserLeftInMinutes(Integer value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -62,7 +62,6 @@ public class Meeting {
 	private String welcomeMsgForModerators = "";
 	private String loginUrl;
 	private String logoutUrl;
-	private int logoutTimer = 0;
 	private int maxUsers;
 	private String bannerColor = "#FFFFFF";
 	private String bannerText = "";
@@ -170,7 +169,6 @@ public class Meeting {
         bannerText = builder.bannerText;
         loginUrl = builder.loginUrl;
         logoutUrl = builder.logoutUrl;
-        logoutTimer = builder.logoutTimer;
         defaultAvatarURL = builder.defaultAvatarURL;
         defaultBotAvatarURL = builder.defaultBotAvatarURL;
 				defaultWebcamBackgroundURL = builder.defaultWebcamBackgroundURL;
@@ -661,10 +659,6 @@ public class Meeting {
 		return maxUserConcurrentAccesses;
 	}
 
-	public int getLogoutTimer() {
-		return logoutTimer;
-	}
-
 	public String getBannerColor() {
 		return bannerColor;
 	}
@@ -1082,7 +1076,6 @@ public class Meeting {
 			private String cameraBridge;
 			private String screenShareBridge;
 			private String audioBridge;
-    	private int logoutTimer;
     	private Map<String, String> metadata;
     	private Map<String, String> pluginMetadataParametersMap;
     	private String dialNumber;
@@ -1314,11 +1307,6 @@ public class Meeting {
     	public Builder withLogoutUrl(String l) {
     	  logoutUrl = l;
     	  return this;
-    	}
-
-    	public Builder withLogoutTimer(int l) {
-    		logoutTimer = l;
-    		return this;
     	}
 
     	public Builder withBannerColor(String c) {

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -270,10 +270,6 @@ maxUserConcurrentAccesses=3
 # Current default is 0 (meeting doesn't end).
 defaultMeetingDuration=0
 
-# Number of minutes to logout client if user
-# isn't responsive
-clientLogoutTimerInMinutes=0
-
 # End meeting if no user joined within
 # a period of time after meeting created.
 meetingExpireIfNoUserJoinedInMinutes=5

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -239,7 +239,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="userInactivityThresholdInMinutes" value="${userInactivityThresholdInMinutes}"/>
         <property name="userActivitySignResponseDelayInMinutes" value="${userActivitySignResponseDelayInMinutes}"/>
         <property name="maxPresentationFileUpload" value="${maxFileSizeUpload}"/>
-        <property name="clientLogoutTimerInMinutes" value="${clientLogoutTimerInMinutes}"/>
         <property name="muteOnStart" value="${muteOnStart}"/>
         <property name="cameraBridge" value="${cameraBridge}"/>
         <property name="screenShareBridge" value="${screenShareBridge}"/>

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1523,7 +1523,6 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `defaultGuestPolicy` | Default guest policy applied to meetings | ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR | ALWAYS_ACCEPT _`overwritable`_ (via `guestPolicy`) |
 | `authenticatedGuest` | Enable authenticated guest mode | true/false | true |
 | `defaultAllowPromoteGuestToModerator` | Allows moderators to promote guests to moderators when `authenticatedGuest` is enabled | true/false | false _`overwritable`_ (via `allowPromoteGuestToModerator`) |
-| `clientLogoutTimerInMinutes` | Number of minutes to logout client if user isn't responsive | Integer (0=disable) | 0 |
 | `meetingExpireIfNoUserJoinedInMinutes` | End meeting if no user joined within a period of time after meeting created | Integer | 5 _`overwritable`_ |
 | `meetingExpireWhenLastUserLeftInMinutes` | Number of minutes to end meeting when the last user left | Integer (0=disable) | 1 _`overwritable`_ |
 | `endWhenNoModerator` | End meeting when there are no moderators after a certain period of time | true/false | false _`overwritable`_ |


### PR DESCRIPTION
## Summary

The `/create` parameter `logoutTimer` and its server default `clientLogoutTimerInMinutes` are parsed and stored on the bbb-web `Meeting` object but are never consumed anywhere downstream. Setting either has no runtime effect. This is leftover Flash-client-era plumbing that was never migrated into the akka-apps / HTML5 pipeline. This PR removes the dead code.

**Expected behavior:** no observable behavior changes, since the value was already a no-op. Idle-user ejection remains fully handled by the akka-apps user-inactivity monitor (`userInactivityInspectTimerInMinutes` / `userInactivityThresholdInMinutes` / `userActivitySignResponseDelayInMinutes` in `MeetingActor`), which is untouched.

**Impact for users:** none at runtime. Admins who had `clientLogoutTimerInMinutes` set in an override see the line become inert (no startup error); callers still sending `logoutTimer=` on `/create` get the same silent-ignore as any unrecognized param.

## Root Cause

Not a bug - dead code. The "logout timer" originated with the Flash client: BBB would disconnect a client unresponsive for N minutes. It was made server-configurable via `clientLogoutTimerInMinutes` in `bigbluebutton.properties` in Dec 2017 (commit `beed7a1058`), with a per-meeting `/create` override `logoutTimer`.

When the HTML5 client + akka-apps replaced Flash, the value was never carried into the new message pipeline (`DefaultProps` / `DurationProps` -> `MeetingActor`). `Meeting.getLogoutTimer()` has had zero callers across the monorepo since that migration. Completing the feature would duplicate the user-inactivity monitor, so removal is the right call.

## Implementation

Pure deletion: 38 lines removed across 6 files, zero insertions. The full parse -> store -> expose chain is deleted atomically so no dangling reference survives:

| File | What is removed |
|---|---|
| `bbb-common-web/.../api/ApiParams.java` | `LOGOUT_TIMER` constant |
| `bbb-common-web/.../api/ParamsProcessorUtil.java` | `clientLogoutTimerInMinutes` field, the `processLogoutTimer(String)` method, its single call site, the `.withLogoutTimer(...)` builder invocation, and the `setClientLogoutTimerInMinutes` setter |
| `bbb-common-web/.../api/domain/Meeting.java` | `logoutTimer` field, constructor assignment, `getLogoutTimer()` getter, Builder field and `withLogoutTimer(int)` method |
| `bigbluebutton-web/grails-app/conf/bigbluebutton.properties` | `clientLogoutTimerInMinutes=0` and its two comment lines |
| `bigbluebutton-web/grails-app/conf/spring/resources.xml` | the `<property name="clientLogoutTimerInMinutes" .../>` Spring binding |
| `docs/docs/administration/customize.md` | the `clientLogoutTimerInMinutes` row in the "Other meeting configs" table |

**Why each file:** each holds one link of the chain (constant -> processor -> domain -> properties -> Spring wiring -> docs). Removing any subset would leave a broken reference; the six are coupled.

**Decisions:**
- Removal (not "finish implementing"): the described behavior is already provided by the akka-apps user-inactivity audit; wiring `logoutTimer` would duplicate it.
- No changelog file: the repo has no top-level CHANGELOG; per prior art (PR #25441, redundant join-parameter removal) the commit message is the record.
- Line endings preserved byte-for-byte on the 4 mixed-ending files (Java/XML) so the diff is surgical.

## Test Coverage

No automated test added: the change is a deletion of untested dead code with no new behavior, and `git grep -i logouttimer` across `bigbluebutton-tests` returns no existing test that references either symbol (nothing to update, nothing that exercises the removed path). An E2E test asserting "this param does nothing" would assert the absence of a side-channel that never existed, adding maintenance cost without value.

The validation is structural + runtime (see Manual Test Cases / Evidence).

## Manual Test Cases

| Scenario | Expected | Obtained |
|---|---|---|
| `bbb-common-web` rebuild after removal | compiles, no dangling reference | rc=0, "27 Scala sources and 290 Java sources -> done compiling" |
| `bigbluebutton-web` redeploy + `bbb-web` restart | starts clean, no Spring BeanCreation/placeholder error | rc=0, "Started Application in 8.073 seconds", context up without `clientLogoutTimerInMinutes` |
| `/create` with `logoutTimer=5` (removed param) | HTTP 200 SUCCESS (unrecognized param silently ignored, same as baseline) | HTTP 200 SUCCESS |
| `/create` without the param | HTTP 200 SUCCESS | HTTP 200 SUCCESS |
| `git grep -niE 'logoutTimer\|clientLogoutTimerInMinutes'` | empty | empty (rc=1) |
| Idle-user ejection (`userInactivity*` in akka) | unaffected (untouched code path) | not exercised this run; code path unchanged by construction |

## Evidence

No visual evidence: this is a non-visual refactor (dead-code removal). The proof is the compile + runtime smoke below.

**Compile (bbb-common-web, from-source in container `bbb3-ip-10-111-12-123`):**
```
27 Scala sources and 290 Java sources -> done compiling
[deploy.sh rc=0]
```

**bbb-web startup (post-redeploy, post-restart):**
```
Started Application in 8.073 seconds
Grails application running
[no BeanCreationException, no placeholder resolution error]
```

**`/create` smoke (HTTP + XML responsecode=SUCCESS):**
- with `logoutTimer=5`: HTTP 200, `<returncode>SUCCESS</returncode>`
- without the param: HTTP 200, `<returncode>SUCCESS</returncode>`

**Sweep (post-edit):**
```
$ git grep -niE 'logoutTimer|clientLogoutTimerInMinutes'
[empty, rc=1]
```

## Risks / Notes

- **Not a breaking change.** The BBB `/create` endpoint already ignores unrecognized params silently; removing the `LOGOUT_TIMER` read means a caller still sending `logoutTimer=` gets the same behavior as sending `foo=bar`, ignored, no error. No observable value changes because `getLogoutTimer()` was never read.
- **Admin override inert, not broken.** If a deployment has `clientLogoutTimerInMinutes=...` in `/etc/bigbluebutton/bbb-web.properties`, removing the Spring binding + setter leaves the line inert (a property source key with no bean target does not fail startup). Non-fatal; worth a release-notes callout as a removed (previously non-functional) parameter.
- **Pre-existing environment noise (not regressions):** the dev container's wildcard cert expired (`NotAfter Jul 18 2026`), so the `default.pdf` presentation download fails on `/create`; this is present in the baseline too and is non-fatal (the meeting is still created with `SUCCESS`). Scalariform/Object-inference compile warnings are pre-existing.
- **Not browser/media-tested:** out of scope; the change does not touch the client or akka.
- **Docs:** `docs/docs/data/create.tsx` documents `/create` params but never had a `logoutTimer` entry; only the `customize.md` admin table documented it (now removed).

Closes #25430


---

**Note:** This supersedes PR Tainan404/bigbluebutton#68, which carried 100 commits because its branch diverged 437 commits from `v3.0.x-develop`. This PR contains the identical diff (6 files, 38 deletions, verified via cherry-pick of `652fcf2d`) on a clean branch off `v3.0.x-develop`.
