### PR TITLE
refactor(core): Remove deprecated lockSettingsDisableNote (singular) create parameter

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -99,7 +99,6 @@ public class ApiParams {
     public static final String LOCK_SETTINGS_DISABLE_MIC = "lockSettingsDisableMic";
     public static final String LOCK_SETTINGS_DISABLE_PRIVATE_CHAT = "lockSettingsDisablePrivateChat";
     public static final String LOCK_SETTINGS_DISABLE_PUBLIC_CHAT = "lockSettingsDisablePublicChat";
-    public static final String DEPRECATED_LOCK_SETTINGS_DISABLE_NOTES = "lockSettingsDisableNote";
     public static final String LOCK_SETTINGS_DISABLE_NOTES = "lockSettingsDisableNotes";
     public static final String LOCK_SETTINGS_HIDE_USER_LIST = "lockSettingsHideUserList";
     public static final String LOCK_SETTINGS_LOCK_ON_JOIN = "lockSettingsLockOnJoin";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -394,13 +394,6 @@ public class ParamsProcessorUtil {
 			String lockSettingsDisableNotesParam = params.get(ApiParams.LOCK_SETTINGS_DISABLE_NOTES);
 			if (!StringUtils.isEmpty(lockSettingsDisableNotesParam)) {
 				lockSettingsDisableNotes = Boolean.parseBoolean(lockSettingsDisableNotesParam);
-			} else {
-				// To be removed after deprecation period
-				lockSettingsDisableNotesParam = params.get(ApiParams.DEPRECATED_LOCK_SETTINGS_DISABLE_NOTES);
-				if (!StringUtils.isEmpty(lockSettingsDisableNotesParam)) {
-					log.warn("[DEPRECATION] use lockSettingsDisableNotes instead of lockSettingsDisableNote");
-					lockSettingsDisableNotes = Boolean.parseBoolean(lockSettingsDisableNotesParam);
-				}
 			}
 
 			Boolean lockSettingsHideUserList = defaultLockSettingsHideUserList;

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -180,6 +180,7 @@ BBB_WEB_ETC_CONFIG="/etc/bigbluebutton/bbb-web.properties"
 # Properties that have been retired and should no longer be set by administrators.
 # bbb-conf --check will warn if any of these are found in $BBB_WEB_ETC_CONFIG.
 RETIRED_BBB_WEB_PROPERTIES=(
+    lockSettingsDisableNote           # Renamed in BBB 2.5 (use lockSettingsDisableNotes instead)
     breakoutRoomsEnabled              # Removed in BBB 3.0
     learningDashboardEnabled          # Removed in BBB 3.0
     defaultGuestWaitURL               # Removed in BBB 3.0

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -247,7 +247,7 @@ const createEndpointTableData = [
     "required": false,
     "type": "Boolean",
     "default": false,
-    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable notes in the meeting. (added 2.2)</>)
+    "description": (<>Setting to <code className="language-plaintext highlighter-rouge">true</code> will disable notes in the meeting. (added 2.2)<br /><br />The deprecated singular alias <code className="language-plaintext highlighter-rouge">lockSettingsDisableNote</code> was removed in 4.0.</>)
   },
   {
     "name": "lockSettingsHideUserList",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -133,6 +133,7 @@ Updated in 4.0:
 - **create**
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`).
   - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel) and `pinChatMessage`.
+  - **Removed parameter:** `lockSettingsDisableNote` (singular); use `lockSettingsDisableNotes` (plural) instead.
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -255,7 +255,7 @@ The deprecated REST endpoint `/api/rest/clientSettings` has been removed. Client
 
 #### Removed
 
-_None._
+- `lockSettingsDisableNote` is no longer recognized; use `lockSettingsDisableNotes` instead. The singular property was renamed in BBB 2.5.
 
 #### Value changed
 


### PR DESCRIPTION
### What does this PR do?

removes deprecated parameter `lockSettingsDisableNote` and updates documentation.

### Closes Issue(s)
Closes #25458
