### PR TITLE
fix(video-provider): clear stale grid avatars when a presentation is open

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -47,9 +47,6 @@ import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
-import { layoutSelect } from '/imports/ui/components/layout/context';
-import { Layout } from '/imports/ui/components/layout/layoutTypes';
-import { LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import createUseSubscription, { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 import useUserMediaGroupStateStream from '/imports/ui/components/livekit/selective-subscription/mediaGroupStateStream';
@@ -377,6 +374,17 @@ export const useGridUsers = (visibleStreamCount: number, visibleUserCount: numbe
     true,
   );
 
+  if (!isGridEnabled) {
+    gridItems.current = [];
+    overflowCount.current = 0;
+    overflowUsers.current = [];
+    return {
+      gridUsers: gridItems.current,
+      overflowCount: overflowCount.current,
+      overflowUsers: overflowUsers.current,
+    };
+  }
+
   if (gridLoading) {
     return {
       gridUsers: gridItems.current,
@@ -539,14 +547,12 @@ export const useAudioOnlyUsers = (): AudioOnlyStream[] => {
     true,
   );
   const { data, loading, errors } = useAudioOnlySubscription();
-  const layoutType = layoutSelect((i: Layout) => i.layoutType);
+  const isGridEnabled = useStorageKey('isGridEnabled');
   const {
     showAudioOnlyOnFirstPage,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
 
-  const isUnifiedLayout = layoutType === LAYOUT_TYPE.UNIFIED_LAYOUT;
-
-  if (!showAudioOnlyOnFirstPage || !isUnifiedLayout) return [];
+  if (!showAudioOnlyOnFirstPage || !isGridEnabled) return [];
   if (loading) return [];
 
   if (errors) {
@@ -657,8 +663,7 @@ export const useVideoStreams = () => {
   let streams: StreamItem[] = [...videoStreams];
   let totalNumberOfOtherStreams: number | undefined;
 
-  const layoutType = layoutSelect((i: Layout) => i.layoutType);
-  const isUnifiedLayout = layoutType === LAYOUT_TYPE.UNIFIED_LAYOUT;
+  const isGridEnabled = useStorageKey('isGridEnabled') as boolean;
   const {
     paginationSorting: PAGINATION_SORTING,
     defaultSorting: DEFAULT_SORTING,
@@ -667,8 +672,8 @@ export const useVideoStreams = () => {
     partitionPrivilegedStreams,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
 
-  const showAudioOnlyOnFirstPage = showAudioOnlyOnFirstPageSetting && isUnifiedLayout;
-  const maxAudioOnlyUsers = isUnifiedLayout ? maxAudioOnlyUsersSetting : 0;
+  const showAudioOnlyOnFirstPage = showAudioOnlyOnFirstPageSetting && isGridEnabled;
+  const maxAudioOnlyUsers = isGridEnabled ? maxAudioOnlyUsersSetting : 0;
 
   if (connectingStream) streams.push(connectingStream);
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -47,6 +47,9 @@ import { SETTINGS } from '/imports/ui/services/settings/enums';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import { VIDEO_TYPES } from '/imports/ui/components/video-provider/enums';
+import { layoutSelect } from '/imports/ui/components/layout/context';
+import { Layout } from '/imports/ui/components/layout/layoutTypes';
+import { LAYOUT_TYPE } from '/imports/ui/components/layout/enums';
 import createUseSubscription, { useCreateUseSubscription } from '/imports/ui/core/hooks/createUseSubscription';
 import { filterByMeetingId } from '/imports/ui/core/utils/subscriptionFilters';
 import useUserMediaGroupStateStream from '/imports/ui/components/livekit/selective-subscription/mediaGroupStateStream';
@@ -547,12 +550,16 @@ export const useAudioOnlyUsers = (): AudioOnlyStream[] => {
     true,
   );
   const { data, loading, errors } = useAudioOnlySubscription();
-  const isGridEnabled = useStorageKey('isGridEnabled');
+  const layoutType = layoutSelect((i: Layout) => i.layoutType);
   const {
     showAudioOnlyOnFirstPage,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
 
-  if (!showAudioOnlyOnFirstPage || !isGridEnabled) return [];
+  const isUnifiedLayout = layoutType === LAYOUT_TYPE.UNIFIED_LAYOUT;
+
+  // Gate on the layout, not isGridEnabled: audio-only tiles must still appear alongside a real
+  // webcam over an open presentation in the unified layout (issues #25235/#25359).
+  if (!showAudioOnlyOnFirstPage || !isUnifiedLayout) return [];
   if (loading) return [];
 
   if (errors) {
@@ -663,7 +670,8 @@ export const useVideoStreams = () => {
   let streams: StreamItem[] = [...videoStreams];
   let totalNumberOfOtherStreams: number | undefined;
 
-  const isGridEnabled = useStorageKey('isGridEnabled') as boolean;
+  const layoutType = layoutSelect((i: Layout) => i.layoutType);
+  const isUnifiedLayout = layoutType === LAYOUT_TYPE.UNIFIED_LAYOUT;
   const {
     paginationSorting: PAGINATION_SORTING,
     defaultSorting: DEFAULT_SORTING,
@@ -672,8 +680,8 @@ export const useVideoStreams = () => {
     partitionPrivilegedStreams,
   } = window.meetingClientSettings.public.kurento.cameraSortingModes;
 
-  const showAudioOnlyOnFirstPage = showAudioOnlyOnFirstPageSetting && isGridEnabled;
-  const maxAudioOnlyUsers = isGridEnabled ? maxAudioOnlyUsersSetting : 0;
+  const showAudioOnlyOnFirstPage = showAudioOnlyOnFirstPageSetting && isUnifiedLayout;
+  const maxAudioOnlyUsers = isUnifiedLayout ? maxAudioOnlyUsersSetting : 0;
 
   if (connectingStream) streams.push(connectingStream);
 


### PR DESCRIPTION
### What does this PR do?
Clears the stale grid-avatar cache so camera-less "avatar" tiles stop lingering in the camera dock over a maximized presentation. Audio-only tiles are intentionally left scoped to the unified layout (not grid-only), so speaking tiles still appear alongside a shared webcam over an open presentation — per #25235/#25359.

### Closes Issue(s)
Closes None

### How to test
1. Join a meeting in the unified layout with several participants; unmute mics.
2. Share one webcam so the camera dock appears over the presentation.
3. Minimize the presentation (grid shows cameras + avatars), then maximize it again.
   - Before: camera-less avatar tiles linger in the dock over the presentation (with `showAudioOnlyOnFirstPage=false`, more than `maxAudioOnlyUsers` appear).
   - After: only the real webcam(s) remain; grid avatars are gone.
4. With `showAudioOnlyOnFirstPage=true`: speaking tiles still appear alongside the webcam over the open presentation (unchanged, per #25235/#25359).