### PR TITLE
feat: automatic light/dark theme switching via prefers-color-scheme

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -114,6 +114,7 @@ export interface BbbTabletApp {
 
 export interface DarkTheme {
   enabled: boolean
+  autoDetectFromSystem: boolean
 }
 
 export interface WakeLock {

--- a/bigbluebutton-html5/imports/ui/components/app/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/app/component.tsx
@@ -49,6 +49,7 @@ import useJoinLogger from './hooks/useJoinLogger';
 import useAppInitialization from './hooks/useAppInitialization';
 import usePollShortcut from './hooks/usePollShortcut';
 import useUserStatusNotifications from './hooks/useUserStatusNotifications';
+import useSystemThemeSync from './hooks/useSystemThemeSync';
 import { NotesRenderMode } from '/imports/ui/components/notes/constants';
 import RequestPresenterContainer from '/imports/ui/components/request-presenter/container';
 
@@ -107,6 +108,7 @@ const App: React.FC<AppProps> = ({
   useJoinLogger(meetingId, meetingName, isBreakout);
   usePollShortcut(layoutContextDispatch, isPollingEnabled);
   useUserStatusNotifications(meetingId, currentUserAway, currentUserRaiseHand, intl);
+  useSystemThemeSync();
 
   useEffect(() => {
     AppService.setDarkTheme(darkTheme);

--- a/bigbluebutton-html5/imports/ui/components/app/hooks/useSystemThemeSync.ts
+++ b/bigbluebutton-html5/imports/ui/components/app/hooks/useSystemThemeSync.ts
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { getSettingsSingletonInstance, hasPersistedChange } from '/imports/ui/services/settings';
+import { SETTINGS } from '/imports/ui/services/settings/enums';
+import getFromUserSettings from '/imports/ui/services/users-settings';
+import {
+  isSystemThemeAutoDetectEnabled,
+  getSystemDarkThemeMediaQuery,
+} from '/imports/ui/services/settings/system-theme';
+
+// Whether the user has expressed an explicit theme preference that must take
+// precedence over the operating system's prefers-color-scheme:
+//  - the bbb_prefer_dark_theme join parameter, or
+//  - a manually saved "Dark mode" toggle (persisted as a changed setting).
+const hasUserThemePreference = () => {
+  if (getFromUserSettings('bbb_prefer_dark_theme', undefined) !== undefined) {
+    return true;
+  }
+  return hasPersistedChange(SETTINGS.APPLICATION, 'darkTheme');
+};
+
+// Keeps the theme in sync with the operating system's light/dark preference
+// while the user has not chosen a theme manually. The initial value is set by
+// the settings default (see services/settings/index.js); this hook handles the
+// case where the OS preference changes while the meeting is open.
+const useSystemThemeSync = () => {
+  useEffect(() => {
+    if (!isSystemThemeAutoDetectEnabled()) return undefined;
+
+    const mediaQuery = getSystemDarkThemeMediaQuery();
+    if (!mediaQuery) return undefined;
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      // Respect an explicit user choice; only follow the OS otherwise.
+      if (hasUserThemePreference()) return;
+
+      const Settings = getSettingsSingletonInstance();
+      // Update the reactive var so the theme is applied through the existing
+      // settings -> App useEffect chain. This is intentionally not persisted,
+      // so a subsequent OS change is still honored.
+      Settings.application = {
+        ...Settings.application,
+        darkTheme: event.matches,
+      };
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+};
+
+export default useSystemThemeSync;

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -33,6 +33,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       customStyleUrl: null,
       darkTheme: {
         enabled: true,
+        autoDetectFromSystem: true,
       },
       askForConfirmationOnLeave: false,
       wakeLock: {

--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -10,6 +10,7 @@ import {
 } from './enums';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import Auth from '/imports/ui/services/auth';
+import { isSystemThemeAutoDetectEnabled, systemPrefersDarkTheme } from './system-theme';
 
 class Settings {
   constructor(defaultValues = {}) {
@@ -44,9 +45,17 @@ class Settings {
       window.meetingClientSettings.public.app.defaultSettings.application.animations,
     );
 
+    // When system auto-detect is enabled, the OS prefers-color-scheme becomes
+    // the default theme; otherwise fall back to the configured default. The
+    // bbb_prefer_dark_theme parameter (handled by getFromUserSettings) still
+    // takes precedence over both.
+    const darkThemeDefault = isSystemThemeAutoDetectEnabled()
+      ? systemPrefersDarkTheme()
+      : window.meetingClientSettings.public.app.defaultSettings.application.darkTheme;
+
     const showDarkThemeDefault = getFromUserSettings(
       'bbb_prefer_dark_theme',
-      window.meetingClientSettings.public.app.defaultSettings.application.darkTheme,
+      darkThemeDefault,
     );
 
     writableDefaultValues.application.animations = showAnimationsDefault;
@@ -132,6 +141,17 @@ class Settings {
     }
   }
 }
+
+// Whether a given key inside a settings group has been persisted as a
+// user-changed value (i.e. it differs from the default). Used to detect an
+// explicit user choice that should override auto-detected defaults.
+export const hasPersistedChange = (settingGroup, key) => {
+  const APP_CONFIG = window.meetingClientSettings.public.app;
+  const Storage = (APP_CONFIG.userSettingsStorage === 'local') ? LocalStorage : SessionStorage;
+  const storageKey = Settings.getStorageKey({ prepend: CHANGED_SETTINGS, value: `_${settingGroup}` });
+  const saved = Storage.getItem(storageKey);
+  return Boolean(saved && Object.prototype.hasOwnProperty.call(saved, key));
+};
 
 let SettingsSingleton = null;
 export const getSettingsSingletonInstance = () => {

--- a/bigbluebutton-html5/imports/ui/services/settings/system-theme.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/system-theme.js
@@ -1,0 +1,29 @@
+const DARK_COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+// Whether the client is allowed to follow the operating system's
+// light/dark preference (prefers-color-scheme). Requires the dark theme
+// feature to be enabled and auto-detection to be turned on in the config.
+export const isSystemThemeAutoDetectEnabled = () => {
+  const darkThemeConfig = window.meetingClientSettings?.public?.app?.darkTheme;
+  return Boolean(darkThemeConfig?.enabled && darkThemeConfig?.autoDetectFromSystem);
+};
+
+// Returns the MediaQueryList tracking the OS dark-mode preference, or null
+// when matchMedia is unavailable (e.g. very old browsers / test envs).
+export const getSystemDarkThemeMediaQuery = () => (
+  typeof window.matchMedia === 'function'
+    ? window.matchMedia(DARK_COLOR_SCHEME_QUERY)
+    : null
+);
+
+// Whether the operating system currently prefers a dark color scheme.
+export const systemPrefersDarkTheme = () => {
+  const mediaQuery = getSystemDarkThemeMediaQuery();
+  return Boolean(mediaQuery && mediaQuery.matches);
+};
+
+export default {
+  isSystemThemeAutoDetectEnabled,
+  getSystemDarkThemeMediaQuery,
+  systemPrefersDarkTheme,
+};

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -53,6 +53,12 @@ public:
     customStyleUrl: null
     darkTheme:
       enabled: true
+      # When true, the client follows the operating system's light/dark
+      # preference (prefers-color-scheme) as the initial theme, and keeps
+      # following it while the user has not chosen a theme manually. The
+      # per-user "Dark mode" toggle and the bbb_prefer_dark_theme parameter
+      # always take precedence over the detected system theme.
+      autoDetectFromSystem: true
     # the default logoutUrl matches window.location.origin i.e. bigbluebutton.org for demo.bigbluebutton.org
     # in some cases we want only custom logoutUrl to be used when provided on meeting create. Default value: true
     askForConfirmationOnLeave: true

--- a/bigbluebutton-tests/playwright/options/systemTheme.spec.ts
+++ b/bigbluebutton-tests/playwright/options/systemTheme.spec.ts
@@ -1,0 +1,76 @@
+import { linkIssue } from '../core/helpers';
+import { test } from '../core/setup/fixtures';
+import { SystemTheme } from './systemTheme';
+
+// Issue 23496: automatic light/dark theme switching driven by the operating
+// system's prefers-color-scheme. The OS preference is emulated with
+// page.emulateMedia({ colorScheme }); it must be set before the client boots so
+// it is picked up as the initial theme default.
+test.describe('System theme (prefers-color-scheme)', { tag: '@ci' }, () => {
+  test.beforeEach(() => {
+    linkIssue(23496);
+  });
+
+  test('applies the dark theme on load when the OS prefers dark', async ({ browser, context, page }, testInfo) => {
+    const systemTheme = new SystemTheme(browser, context);
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await systemTheme.initModPage(page, { testInfo });
+
+    test.skip(
+      !(await systemTheme.isAutoDetectConfigured()),
+      'requires public.app.darkTheme.autoDetectFromSystem to be enabled on the server under test',
+    );
+
+    await systemTheme.expectDarkTheme(true, 'should apply the dark theme because the OS prefers dark');
+  });
+
+  test('keeps the light theme on load when the OS prefers light', async ({ browser, context, page }, testInfo) => {
+    const systemTheme = new SystemTheme(browser, context);
+    await page.emulateMedia({ colorScheme: 'light' });
+    await systemTheme.initModPage(page, { testInfo });
+
+    test.skip(
+      !(await systemTheme.isAutoDetectConfigured()),
+      'requires public.app.darkTheme.autoDetectFromSystem to be enabled on the server under test',
+    );
+
+    await systemTheme.expectDarkTheme(false, 'should keep the light theme because the OS prefers light');
+  });
+
+  test('switches the theme live when the OS preference changes', async ({ browser, context, page }, testInfo) => {
+    const systemTheme = new SystemTheme(browser, context);
+    await page.emulateMedia({ colorScheme: 'light' });
+    await systemTheme.initModPage(page, { testInfo });
+
+    test.skip(
+      !(await systemTheme.isAutoDetectConfigured()),
+      'requires public.app.darkTheme.autoDetectFromSystem to be enabled on the server under test',
+    );
+
+    await systemTheme.expectDarkTheme(false, 'should start in the light theme');
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await systemTheme.expectDarkTheme(true, 'should switch to dark when the OS switches to dark');
+    await page.emulateMedia({ colorScheme: 'light' });
+    await systemTheme.expectDarkTheme(false, 'should switch back to light when the OS switches to light');
+  });
+
+  test('a manual theme choice overrides the OS preference', async ({ browser, context, page }, testInfo) => {
+    const systemTheme = new SystemTheme(browser, context);
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await systemTheme.initModPage(page, { testInfo });
+
+    test.skip(
+      !(await systemTheme.isAutoDetectConfigured()),
+      'requires public.app.darkTheme.autoDetectFromSystem to be enabled on the server under test',
+    );
+
+    await systemTheme.expectDarkTheme(true, 'should start in the dark theme following the OS');
+    // Explicitly turn dark mode off, recording a user preference for light.
+    await systemTheme.setDarkModeManually();
+    await systemTheme.expectDarkTheme(false, 'should apply light after the user turns dark mode off');
+    // The OS preference toggling must no longer change the theme.
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await systemTheme.expectDarkTheme(false, 'should keep the manual light choice even when the OS prefers dark');
+  });
+});

--- a/bigbluebutton-tests/playwright/options/systemTheme.ts
+++ b/bigbluebutton-tests/playwright/options/systemTheme.ts
@@ -1,0 +1,38 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { MultiUsers } from '../user/multiusers';
+
+export class SystemTheme extends MultiUsers {
+  // Whether OS auto-detection is enabled for this meeting (public.app.darkTheme
+  // .autoDetectFromSystem). It ships enabled by default; the tests guard on it
+  // so they skip cleanly on a server where an admin turned it off.
+  async isAutoDetectConfigured(): Promise<boolean> {
+    return this.modPage.page.evaluate(() => {
+      // @ts-ignore - injected on window by the client at runtime
+      const darkTheme = window.meetingClientSettings?.public?.app?.darkTheme;
+      return Boolean(darkTheme?.enabled && darkTheme?.autoDetectFromSystem);
+    });
+  }
+
+  // Waits until the applied theme matches the expectation. DarkReader injects
+  // <style class="darkreader ..."> elements while the dark theme is enabled and
+  // removes them when it is disabled, so their presence is a reliable signal.
+  async expectDarkTheme(shouldBeDark: boolean, description: string): Promise<void> {
+    await expect
+      .poll(() => this.modPage.page.evaluate(() => document.querySelectorAll('style.darkreader').length > 0), {
+        message: description,
+        timeout: ELEMENT_WAIT_TIME,
+      })
+      .toBe(shouldBeDark);
+  }
+
+  // Opens Settings, flips the "Dark mode" switch and saves, i.e. records an
+  // explicit user theme preference that must override the detected OS theme.
+  async setDarkModeManually(): Promise<void> {
+    await this.modPage.waitAndClick(e.settingsSidebarButton);
+    await this.modPage.waitAndClick(e.darkModeToggleBtn);
+    await this.modPage.waitAndClick(e.saveSettingsButton);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds automatic light/dark theme selection driven by the operating system's
`prefers-color-scheme`, gated by a new client setting
`public.app.darkTheme.autoDetectFromSystem` (default `true`).

When enabled, and while the user has **not** chosen a theme manually:
- the OS preference becomes the initial theme on join (so a dark-mode OS opens
  BigBlueButton in dark mode), and
- the theme follows the OS live if it changes during the meeting
  (via a `matchMedia('(prefers-color-scheme: dark)')` change listener).

An explicit user choice always wins over the detected theme:
- the `bbb_prefer_dark_theme` join parameter, or
- the existing "Dark mode" toggle in Settings (persisted as a changed setting).

Implementation reuses the existing `application.darkTheme` setting and DarkReader
pipeline — the OS preference simply supplies the *default* value and a live
update; nothing about how the theme is rendered changes.

Key files:
- `bigbluebutton-html5/private/config/settings.yml` – new `darkTheme.autoDetectFromSystem` flag (+ types/initial-values)
- `imports/ui/services/settings/system-theme.js` – `prefers-color-scheme` helpers
- `imports/ui/services/settings/index.js` – OS-aware default derivation + `hasPersistedChange`
- `imports/ui/components/app/hooks/useSystemThemeSync.ts` – live OS-change listener (wired into `app/component.tsx`)
- `bigbluebutton-tests/playwright/options/systemTheme.{ts,spec.ts}` – e2e coverage

### Closes Issue(s)
Closes #23496

### Motivation
BigBlueButton currently always defaults to the light theme and requires each user
to opt into dark mode manually on every server/meeting. Users whose OS runs in
dark mode expect the app to respect that preference automatically, as requested
in #23496.

### How to test
No special setup — `autoDetectFromSystem` ships enabled by default.
1. Set your OS/browser to **dark** mode and join a meeting → the client opens in
   dark mode. Set it to **light** and join → it opens in light mode.
2. With no manual override, change the OS theme while in the meeting → the client
   follows it live.
3. Toggle "Dark mode" in Settings (or pass `userdata-bbb_prefer_dark_theme=...`)
   → that choice sticks and is no longer overridden by OS changes.
4. Set `public.app.darkTheme.autoDetectFromSystem: false` → previous behavior
   (always light unless toggled) is restored.

Automated (Playwright), driving the OS preference with
`page.emulateMedia({ colorScheme })`:
