### PR TITLE
feat(audio): add deafenAudioUntilExplicitJoin setting (LiveKit)

### DIFF
--- a/bbb-graphql-server/metadata/actions.graphql
+++ b/bbb-graphql-server/metadata/actions.graphql
@@ -643,7 +643,7 @@ type Mutation {
 
 type Mutation {
   userSetDeafened(
-    userId: String!
+    userId: String
     deafened: Boolean!
   ): Boolean
 }

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -42,6 +42,7 @@ export interface App {
   forceListenOnly: boolean
   skipCheck: boolean
   skipCheckOnJoin: boolean
+  deafenAudioUntilExplicitJoin: boolean
   enableDynamicAudioDeviceSelection: boolean
   clientTitle: string
   bbbServerVersion: string

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/container.jsx
@@ -59,6 +59,10 @@ const AudioModalContainer = (props) => {
     APP_CONFIG.skipEchoTestIfPreviousDevice,
   ) && !deviceInfo.isMobile;
   const autoJoin = getFromUserSettings('bbb_auto_join_audio', APP_CONFIG.autoJoin);
+  const deafenAudioUntilExplicitJoin = getFromUserSettings(
+    'bbb_deafen_audio_until_explicit_join',
+    APP_CONFIG.deafenAudioUntilExplicitJoin,
+  );
 
   let formattedDialNum = '';
   let formattedTelVoice = '';
@@ -120,17 +124,22 @@ const AudioModalContainer = (props) => {
     const callback = () => {
       setIsOpen(false);
 
-      // When using LiveKit, force joining audio when the modal is closed,
-      // but the user is not connected nor connecting to audio. This also means
-      // that the user will join muted as not clicking "Join Audio" signals
-      // that intention.
-      if (usingLiveKit && !isConnected && !isConnecting) {
+      if (!usingLiveKit) return;
+
+      // deafenAudioUntilExplicitJoin: closing the modal must not force a join -
+      // the user stays deafened until they explicitly join audio.
+      if (deafenAudioUntilExplicitJoin) return;
+
+      // Force joining audio when the modal is closed, but the user is not
+      // connected nor connecting to audio. This also means that the user will
+      // join muted as not clicking "Join Audio" signals that intention.
+      if (!isConnected && !isConnecting) {
         joinMic({ muteOnStart: true }).catch((error) => handleJoinError(error, false));
       }
     };
 
     closeModal(callback);
-  }, [isConnected, isConnecting, usingLiveKit, joinMic, setIsOpen]);
+  }, [deafenAudioUntilExplicitJoin, isConnected, isConnecting, usingLiveKit, joinMic, setIsOpen]);
   const isTranscriptionEnabled = useIsAudioTranscriptionEnabled();
 
   if (!currentUserData) return null;

--- a/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/component.tsx
@@ -88,6 +88,9 @@ const LiveKitObserver = ({
   const isMuted = useReactiveVar(AudioManager._isMuted.value) as boolean;
   // @ts-ignore
   const isDeafened = useReactiveVar(AudioManager._isDeafened.value) as boolean;
+  const { data: currentUser } = useCurrentUser((u) => ({
+    voice: u.voice,
+  }));
 
   useEffect(() => {
     logger.info({
@@ -109,15 +112,21 @@ const LiveKitObserver = ({
     });
   }, [isSpeaking, isMuted]);
 
+  // The LiveKit room connects on entry regardless of an explicit audio join, so
+  // akka creates the voice record deafened=false while the client defaults to
+  // deafened. The client owns the deafened state and must reflect it on the
+  // voice record whenever either changes to guarantee it is always up-to-date.
   useEffect(() => {
-    if (!usingAudio) return;
+    const voiceJoined = currentUser?.voice?.joined ?? false;
+
+    if (!usingAudio || !voiceJoined) return;
 
     setUserDeafened({
       variables: {
         deafened: isDeafened,
       },
     });
-  }, [isDeafened]);
+  }, [isDeafened, currentUser?.voice?.joined]);
 
   useEffect(() => {
     let mappedQuality = MetricStatus.Normal;

--- a/bigbluebutton-html5/imports/ui/components/livekit/mutations.ts
+++ b/bigbluebutton-html5/imports/ui/components/livekit/mutations.ts
@@ -9,7 +9,7 @@ export const USER_SET_TALKING = gql`
 `;
 
 export const USER_SET_DEAFENED = gql`
-  mutation UserSetDeafened($userId: String!, $deafened: Boolean!) {
+  mutation UserSetDeafened($userId: String, $deafened: Boolean!) {
     userSetDeafened(
       userId: $userId,
       deafened: $deafened

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -12,6 +12,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       forceListenOnly: false,
       skipCheck: false,
       skipCheckOnJoin: false,
+      deafenAudioUntilExplicitJoin: false,
       enableDynamicAudioDeviceSelection: true,
       clientTitle: 'BigBlueButton',
       bbbServerVersion: 'HTML5_FULL_BBB_VERSION',

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -17,6 +17,11 @@ public:
     # again or reloading page and joining mic again.
     # This setting won't have effect if skipCheck = true
     skipCheckOnJoin: false
+    # deafenAudioUntilExplicitJoin: when true, the user hears no audio until
+    # they explicitly join audio - use when joining should be an explicit opt-in.
+    # Only applicable to the *LiveKit* audio bridge, as its audio connection
+    # is not optional. bbb-webrtc-sfu always treat audio join as optional.
+    deafenAudioUntilExplicitJoin: false
     #
     # Allow users to change microphone/speaker dynamically
     # The device is changed immediately, without the need to rejoin


### PR DESCRIPTION
### What does this PR do?

#### Summary

Adds a client setting `deafenAudioUntilExplicitJoin` (default `false`, LiveKit only) that restores the ability to **opt out of audio by closing the audio modal**, like the bbb-webrtc-sfu audio bridge allows. 
When enabled, closing the modal without joining leaves the user with no audio (deafened) until they explicitly join; skip-check and every explicit join (microphone / listen-only / echo test) behave exactly as before: _join audio_ (deafened=false).

Additionally, fix deafened state propagation between client and server and make the deafen mutation userId field optional as it is supposed to be.

#### In detail

- [feat(audio): add deafenAudioUntilExplicitJoin setting](https://github.com/bigbluebutton/bigbluebutton/commit/fcb09e192f8b109ac00d11a5674375fb5d04b02c) 
  - Add a client setting, deafenAudioUntilExplicitJoin (default false, LiveKit only):
when the user closes the audio modal without joining, the client no longer forces
a muted join, so the user stays deafened and ends up with no audio, thus
restoring the ability to opt out of audio that the bbb-webrtc-sfu bridge had.
- [fix(audio): reflect the client deafened state on the LiveKit voice record](https://github.com/bigbluebutton/bigbluebutton/commit/e8b76cfe443b94ccbac298633c1093b658338989) 
  - With LiveKit the room connects on entry and akka creates the voice record with
deafened=false, regardless of whether the user has joined audio at the client
level. The client defaults to deafened and only undeafens on an explicit join,
so a not-joined user (deafenAudioUntilExplicitJoin, or autoJoin=false) displayed
as in-audio to everyone and its deafened state never reached the server.
- [fix(graphql): make userSetDeafened userId optional to match the handler](https://github.com/bigbluebutton/bigbluebutton/commit/d82590c73f4a33b5ff68952f388e62fad91ddce2) 
  - The userSetDeafened action declared userId: String! but the graphql-actions
handler treats it as optional, falling back to the caller's own userId
(routing.userId) when omitted - which is how the LiveKit self-deafen path calls
it. Declare userId: String so the contract reflects the actual behaviour.


**Supersedes #25393:** the original approach deafened *at join time* (partially correct), but reinforced it with a `requestAudioJoin` step and a `handleJoinAudio` short circuit. That flow wrongly deafened **skip-check auto-joins**, breaking the opt-out semantics skip-check has had since at least 2.4. This PR scopes the setting to the close-modal decline only and drops the extra code, and adds the deafen-state sync the original left as a known limitation.

### Closes Issue(s)

Closes #25346

### Motivation

With bbb-webrtc-sfu, dismissing the initial audio modal let a user stay in the session with no audio. In 3.0+ with LiveKit the audio bridge connects on entry (the connection is not optional at the client level), so closing the modal would not prevent it. 

This is **by design** and proven to be beneficial in the majority of use cases - but there are scenarios where the old behavior is desired. 

### How to test
| # | deafen flag | Extra join flag | Action | Expected: hearing? |
|---|---|---|---|---|
| 1 | **ON** | - | Close the modal (X), don't join | **No** |                                                                                                                                                                                    
| 2 | OFF | - | Close the modal (X) | **Yes** (joined muted) |                                                                                                                                                                                    
| 3 | **ON** | - | Modal → Microphone → pass echo test → Join | **Yes** |
| 4 | **ON** | - | Do step 1, then click the **"Join audio"** toolbar button | **Yes** (modal → join) |
| 5 | OFF | `skipCheck=true` | (nothing — auto-joins) | **Yes** |
| 6 | **ON** | `skipCheck=true` | (nothing — auto-joins) | **Yes** |
| 7 | **ON** | `skipCheckOnJoin=true` (first join) | (nothing - auto-joins) | **Yes** |
| 8 | **ON** | `forceListenOnly=true` (viewer) | (nothing - auto listen-only) | **Yes** |
| 9 | **ON** | `autoJoin=false` | (irrelevant - audio does not join) | **No** | 
| 9 | **OFF** | `autoJoin=false` | (irrelevant - audio does not join) | **No** | 

### More

- Supersedes #25393
- Note for follow-ups: we need to adjust the default initial deafened state in the SFU <-> akka-apps audio join RPC to match the client's (deafened=true). It'd avoid the audio state "flapping" the use rlist for newly joined users. It's a minor thing, though, and itrequires a separate PR with more careful thought behind it.