### PR TITLE
fix(html5): prevent white flash on slide change

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -756,6 +756,7 @@ export interface Whiteboard {
   maxNumberOfAnnotations: number
   maxNumberOfActiveUsers: number
   maxHistoryStackSize: number
+  slideSwapDecodeTimeoutMs: number
   lockToolbarTools: boolean
   annotations: Annotations
   allowInfiniteWhiteboard: boolean

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -45,11 +45,14 @@ import DeleteSelectedItemsTool from './custom-tools/delete-selected-items/compon
 import SessionStorage from '/imports/ui/services/storage/session';
 
 const CAMERA_TYPE = 'camera';
-// Upper bound (ms) for waiting on the new slide's background image to decode before
-// swapping the visible page. Warm HTTP cache resolves in sub-frame time; a cold or
-// slow asset falls back to this bound so navigation is never worse than before the
-// decode-gate (issue 25397).
-const SLIDE_SWAP_DECODE_TIMEOUT = 1500;
+// Fallback upper bound (ms) for waiting on the new slide's background image to decode
+// before swapping the visible page, used when meetingClientSettings does not provide
+// public.whiteboard.slideSwapDecodeTimeoutMs. A warm HTTP cache resolves in sub-frame
+// time; a cold or slow asset falls back to this bound so navigation is never worse than
+// before the decode-gate (issue 25397). Note: on links slower than this bound the timeout
+// fires before the asset is paintable and the original white flash still shows - the gate
+// mitigates the common cold-cache case, it does not eliminate the worst (very slow) case.
+const SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT = 1500;
 const colorStyles = [
   'black',
   'blue',
@@ -2285,12 +2288,17 @@ const Whiteboard = React.memo((props) => {
     let cancelled = false;
 
     const applyPageSwap = () => {
-      // Rapid navigation / unmount guard: while we were awaiting the decode the user
-      // may have moved to another slide (or the component unmounted). Both refs are
-      // updated elsewhere (curPageIdRef in its own [curPageId] effect, isMountedRef on
-      // unmount), so a late decode for an abandoned page can't clobber the current one
-      // (e.g. 1 -> 9 -> 3: decode(9) resolving after we already applied 3 is dropped).
-      if (cancelled || !isMountedRef.current) return;
+      // Rapid navigation / unmount guard: while we were awaiting the decode the user may
+      // have navigated to another slide, or this effect may have been cleaned up (React
+      // runs the cleanup below on unmount and before re-running the effect). The
+      // `cancelled` flag - set in that cleanup - covers both cases fully, so a late decode
+      // for an abandoned page can't clobber the current one (e.g. 1 -> 9 -> 3: decode(9)
+      // resolving after we already applied 3 is dropped because effect(9) was cancelled and
+      // curPageIdRef no longer matches). The editor can also be torn down between the decode
+      // starting and resolving, so re-check tlEditorRef here - it was only checked at effect
+      // entry, synchronously, before we awaited.
+      if (cancelled) return;
+      if (!tlEditorRef.current) return;
       if (parseInt(curPageIdRef.current, 10) !== formattedPageId) return;
 
       // If a viewer is mid-edit (select.editing_shape) when the slide changes,
@@ -2341,12 +2349,24 @@ const Whiteboard = React.memo((props) => {
       }
     };
 
-    // bgShape references the same authenticated, deterministic SVG URL that tldraw will
-    // paint (Auth.authenticateURL is idempotent), so priming a detached Image reuses the
-    // HTTP cache the swap needs - no extra fetch on a warm cache.
+    // `assets` is derived from the same currentPresentationPage as curPageId, in the same
+    // render (container.jsx:137-153, :439-453), so it is never stale relative to the page
+    // being swapped: assets[0].props.src is the background for THIS curPageId. A stale src
+    // would silently disable the gate (the swap just returns) with no symptom other than
+    // the bug returning, so keep that derivation in lock-step with curPageId.
+    //
+    // bgShape references the same authenticated, deterministic, immutable SVG URL that
+    // tldraw will paint (Auth.authenticateURL is idempotent: the same sessionToken yields
+    // the same URL and cache key). presentation-slides.nginx sends
+    // `Cache-Control: private, immutable` on these assets, so priming a detached Image
+    // warms the browser cache and tldraw's later background-image load is a cache hit - no
+    // second network transfer or auth_request subrequest per slide change.
     const bgShapeSrc = assets?.[0]?.props?.src;
     if (!bgShapeSrc) {
-      // No background asset to wait on (e.g. blank/infinite whiteboard) - swap now.
+      // No background asset URL to gate on: currentPresentationPage has no svgUrl, so
+      // container.jsx:447 leaves src undefined. This is the missing-svgUrl case - the src
+      // is derived regardless of infiniteWhiteboard - so there is simply nothing to decode.
+      // Swap now.
       applyPageSwap();
       return undefined;
     }
@@ -2354,19 +2374,38 @@ const Whiteboard = React.memo((props) => {
     const img = new Image();
     img.src = bgShapeSrc;
     let fallbackTimer;
+    const decodeTimeout = window.meetingClientSettings?.public?.whiteboard?.slideSwapDecodeTimeoutMs
+      ?? SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT;
     Promise.race([
       // decode() rejects on a broken/401/malformed asset; swallow it so a bad asset
       // degrades to "apply the swap anyway" (the pre-fix behavior) and never wedges
       // navigation on the old slide.
       img.decode().catch(() => {}),
       new Promise((resolve) => {
-        fallbackTimer = setTimeout(resolve, SLIDE_SWAP_DECODE_TIMEOUT);
+        fallbackTimer = setTimeout(resolve, decodeTimeout);
       }),
-    ]).then(applyPageSwap);
+    ])
+      .then(applyPageSwap)
+      .catch((error) => {
+        // applyPageSwap runs the store mutation that used to run synchronously in the
+        // effect body, where a throw landed in ErrorBoundaryWithReload (container.jsx) and
+        // the client recovered with a reload. Inside this async .then a throw would instead
+        // escape as an unhandled promise rejection - no boundary, no reload, editor left
+        // half-swapped between two pages. Log it so the failure is observable, never silent.
+        logger.error({ logCode: 'SlideSwapDecodeGate' }, `Deferred page swap failed: ${error}`);
+      })
+      .finally(() => {
+        // Clear the fallback timer on the decode-wins path too: the cleanup below only runs
+        // on unmount / effect re-run, not when the race resolves normally.
+        if (fallbackTimer) clearTimeout(fallbackTimer);
+      });
 
     return () => {
       cancelled = true;
       if (fallbackTimer) clearTimeout(fallbackTimer);
+      // Release the detached decode Image so a burst of rapid navigation doesn't pin a
+      // queue of half-decoded SVGs in flight (the rapid-nav case guarded above).
+      img.src = '';
     };
   }, [curPageId]);
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -45,6 +45,11 @@ import DeleteSelectedItemsTool from './custom-tools/delete-selected-items/compon
 import SessionStorage from '/imports/ui/services/storage/session';
 
 const CAMERA_TYPE = 'camera';
+// Upper bound (ms) for waiting on the new slide's background image to decode before
+// swapping the visible page. Warm HTTP cache resolves in sub-frame time; a cold or
+// slow asset falls back to this bound so navigation is never worse than before the
+// decode-gate (issue 25397).
+const SLIDE_SWAP_DECODE_TIMEOUT = 1500;
 const colorStyles = [
   'black',
   'blue',
@@ -2269,15 +2274,35 @@ const Whiteboard = React.memo((props) => {
 
   React.useEffect(() => {
     const formattedPageId = parseInt(curPageIdRef.current, 10);
-    if (tlEditorRef.current && formattedPageId !== 0) {
+    if (!tlEditorRef.current || formattedPageId === 0) return undefined;
+
+    // The visible page swap (cleanupStore + updateStore(bgShape) + setCurrentPage)
+    // used to run synchronously here, so the new page's background image-shape was
+    // mounted before its SVG had been fetched/decoded, leaving the presentation area
+    // blank until the asset arrived (issue 25397). Defer the swap behind a decode-gate
+    // so it only happens once the new slide's background is paintable, double-buffering
+    // the change instead of flashing white.
+    let cancelled = false;
+
+    const applyPageSwap = () => {
+      // Rapid navigation / unmount guard: while we were awaiting the decode the user
+      // may have moved to another slide (or the component unmounted). Both refs are
+      // updated elsewhere (curPageIdRef in its own [curPageId] effect, isMountedRef on
+      // unmount), so a late decode for an abandoned page can't clobber the current one
+      // (e.g. 1 -> 9 -> 3: decode(9) resolving after we already applied 3 is dropped).
+      if (cancelled || !isMountedRef.current) return;
+      if (parseInt(curPageIdRef.current, 10) !== formattedPageId) return;
+
       // If a viewer is mid-edit (select.editing_shape) when the slide changes,
       // the store mutation below (cleanupStore + setCurrentPage) removes the shape
       // being edited out from under tldraw, leaving the editor in editing_shape with
       // a dangling editingShapeId. The next pointer-down then hits EditingShape's
       // `Expected an editing shape!` assertion and crashes the client (issue 25332).
       // Commit the in-progress edit first so tldraw exits editing_shape (running
-      // EditingShape.onExit) while the shape still exists. Guarded so a normal slide
-      // change (no active edit) never resets the presenter's current tool.
+      // EditingShape.onExit) while the shape still exists. Run it here, at the moment
+      // of the swap (not on effect entry), so it stays adjacent to the mutation it
+      // protects. Guarded so a normal slide change (no active edit) never resets the
+      // presenter's current tool.
       if (tlEditorRef.current.getEditingShape()) {
         tlEditorRef.current.complete();
       }
@@ -2314,7 +2339,35 @@ const Whiteboard = React.memo((props) => {
           adjustCameraOnMount(true);
         });
       }
+    };
+
+    // bgShape references the same authenticated, deterministic SVG URL that tldraw will
+    // paint (Auth.authenticateURL is idempotent), so priming a detached Image reuses the
+    // HTTP cache the swap needs - no extra fetch on a warm cache.
+    const bgShapeSrc = assets?.[0]?.props?.src;
+    if (!bgShapeSrc) {
+      // No background asset to wait on (e.g. blank/infinite whiteboard) - swap now.
+      applyPageSwap();
+      return undefined;
     }
+
+    const img = new Image();
+    img.src = bgShapeSrc;
+    let fallbackTimer;
+    Promise.race([
+      // decode() rejects on a broken/401/malformed asset; swallow it so a bad asset
+      // degrades to "apply the swap anyway" (the pre-fix behavior) and never wedges
+      // navigation on the old slide.
+      img.decode().catch(() => {}),
+      new Promise((resolve) => {
+        fallbackTimer = setTimeout(resolve, SLIDE_SWAP_DECODE_TIMEOUT);
+      }),
+    ]).then(applyPageSwap);
+
+    return () => {
+      cancelled = true;
+      if (fallbackTimer) clearTimeout(fallbackTimer);
+    };
   }, [curPageId]);
 
   React.useEffect(() => {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -47,12 +47,12 @@ import SessionStorage from '/imports/ui/services/storage/session';
 const CAMERA_TYPE = 'camera';
 // Fallback upper bound (ms) for waiting on the new slide's background image to decode
 // before swapping the visible page, used when meetingClientSettings does not provide
-// public.whiteboard.slideSwapDecodeTimeoutMs. A warm HTTP cache resolves in sub-frame
-// time; a cold or slow asset falls back to this bound so navigation is never worse than
-// before the decode-gate (issue 25397). Note: on links slower than this bound the timeout
-// fires before the asset is paintable and the original white flash still shows - the gate
-// mitigates the common cold-cache case, it does not eliminate the worst (very slow) case.
-const SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT = 1500;
+// public.whiteboard.slideSwapDecodeTimeoutMs. Kept short: a warm/near cache decodes in
+// sub-frame time and wins the race, while a cold or slow asset falls through fast to the
+// old (un-gated) behavior rather than pinning the toolbar/zoom UI - which are NOT gated -
+// on a stale slide for long. Above this bound the original white flash still shows; the
+// gate mitigates the common near-cache case, it does not eliminate the worst (slow) case.
+const SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT = 250;
 const colorStyles = [
   'black',
   'blue',
@@ -199,6 +199,10 @@ const Whiteboard = React.memo((props) => {
   const [isMounting, setIsMounting] = React.useState(true);
   const [cursorType, setCursorType] = React.useState('');
   const [cursorZoom, setCursorZoom] = React.useState({ slideZoom: 1, containerZoom: 1 });
+  // Re-surfaces a deferred slide-swap failure into render so ErrorBoundaryWithReload can
+  // catch it (see the decode-gate effect). Setting state with a function that throws makes
+  // the throw happen during render, where the boundary sees it - a bare .catch could not.
+  const [, setSwapError] = React.useState();
   const updateCursorZoomRef = React.useRef(null);
 
   if (isMounting) {
@@ -2253,13 +2257,6 @@ const Whiteboard = React.memo((props) => {
     }
   }, [otherCursors, whiteboardWriters]);
 
-  const updateStore = (pages, cameras) => {
-    tlEditorRef.current.store.put(pages);
-    tlEditorRef.current.store.put(cameras);
-    tlEditorRef.current.store.put(assets);
-    tlEditorRef.current.store.put(bgShape);
-  };
-
   const finalizeStore = () => {
     tlEditorRef.current.history.clear();
   };
@@ -2279,61 +2276,67 @@ const Whiteboard = React.memo((props) => {
     const formattedPageId = parseInt(curPageIdRef.current, 10);
     if (!tlEditorRef.current || formattedPageId === 0) return undefined;
 
-    // The visible page swap (cleanupStore + updateStore(bgShape) + setCurrentPage)
-    // used to run synchronously here, so the new page's background image-shape was
-    // mounted before its SVG had been fetched/decoded, leaving the presentation area
-    // blank until the asset arrived (issue 25397). Defer the swap behind a decode-gate
-    // so it only happens once the new slide's background is paintable, double-buffering
-    // the change instead of flashing white.
+    // The new page's background image-shape used to be mounted here synchronously, before
+    // its SVG had been fetched/decoded, leaving the presentation area blank until the asset
+    // arrived (issue 25397). We defer only the VISIBLE part of the swap (cleanupStore +
+    // background + setCurrentPage) behind a decode-gate so the page becomes visible once it
+    // is paintable, double-buffering the change instead of flashing white.
     let cancelled = false;
+    const currentPageId = `page:${formattedPageId}`;
+
+    // Create the new page + its camera record synchronously, before the gate. These records
+    // are invisible (nothing renders until setCurrentPage runs in applyPageSwap), but remote
+    // annotations for the new page arrive via debouncedUpdateShapes (service.js, 175ms)
+    // parented to `page:N`. With the visible swap now deferred behind the decode - commonly
+    // past 175ms on the cold-cache path this fix targets - that debounce would otherwise put
+    // page-parented shapes before the page exists, and tldraw drops them or throws in
+    // ensureStoreIsUsable (inside a debounce callback, no error boundary). Creating the page
+    // up front keeps the parent present regardless of gate timing.
+    const ensurePageAndCamera = () => {
+      tlEditorRef.current.store.mergeRemoteChanges(() => {
+        tlEditorRef.current.batch(() => {
+          const pages = [];
+          const cameras = [];
+          if (!tlEditorRef.current.getPage(currentPageId)) {
+            pages.push(...createPage(currentPageId));
+          }
+          const cameraExists = tlEditorRef.current.store.allRecords().some(
+            (record) => record.typeName === 'camera' && record.id === `camera:${currentPageId}`,
+          );
+          if (!cameraExists) {
+            cameras.push(createCamera(formattedPageId, tlEditorRef.current.getCamera()?.z));
+          }
+          if (pages.length) tlEditorRef.current.store.put(pages);
+          if (cameras.length) tlEditorRef.current.store.put(cameras);
+        });
+      });
+    };
 
     const applyPageSwap = () => {
-      // Rapid navigation / unmount guard: while we were awaiting the decode the user may
-      // have navigated to another slide, or this effect may have been cleaned up (React
-      // runs the cleanup below on unmount and before re-running the effect). The
-      // `cancelled` flag - set in that cleanup - covers both cases fully, so a late decode
-      // for an abandoned page can't clobber the current one (e.g. 1 -> 9 -> 3: decode(9)
-      // resolving after we already applied 3 is dropped because effect(9) was cancelled and
-      // curPageIdRef no longer matches). The editor can also be torn down between the decode
-      // starting and resolving, so re-check tlEditorRef here - it was only checked at effect
-      // entry, synchronously, before we awaited.
+      // Rapid-navigation / unmount guard: while awaiting the decode the user may have
+      // navigated on, or the effect may have been cleaned up (React runs the cleanup below
+      // on unmount and before re-running the effect). The `cancelled` flag - set in that
+      // cleanup - covers both, so a late decode for an abandoned page can't clobber the
+      // current one; re-check tlEditorRef too since the editor can be torn down mid-decode.
       if (cancelled) return;
       if (!tlEditorRef.current) return;
       if (parseInt(curPageIdRef.current, 10) !== formattedPageId) return;
 
-      // If a viewer is mid-edit (select.editing_shape) when the slide changes,
-      // the store mutation below (cleanupStore + setCurrentPage) removes the shape
-      // being edited out from under tldraw, leaving the editor in editing_shape with
-      // a dangling editingShapeId. The next pointer-down then hits EditingShape's
-      // `Expected an editing shape!` assertion and crashes the client (issue 25332).
-      // Commit the in-progress edit first so tldraw exits editing_shape (running
-      // EditingShape.onExit) while the shape still exists. Run it here, at the moment
-      // of the swap (not on effect entry), so it stays adjacent to the mutation it
-      // protects. Guarded so a normal slide change (no active edit) never resets the
-      // presenter's current tool.
+      // If a viewer is mid-edit (select.editing_shape) when the slide changes, the store
+      // mutation below removes the shape being edited out from under tldraw, leaving a
+      // dangling editingShapeId; the next pointer-down then trips EditingShape's `Expected
+      // an editing shape!` assertion and crashes the client (issue 25332). Commit the
+      // in-progress edit first so tldraw exits editing_shape while the shape still exists.
+      // Guarded so a normal slide change never resets the presenter's current tool.
       if (tlEditorRef.current.getEditingShape()) {
         tlEditorRef.current.complete();
       }
       tlEditorRef.current.store.mergeRemoteChanges(() => {
         tlEditorRef.current.batch(() => {
-          const currentPageId = `page:${formattedPageId}`;
-          const tlZ = tlEditorRef.current.getCamera()?.z;
-          const cameras = [];
-          const pages = [];
-          const currPageExists = tlEditorRef.current?.getPage(currentPageId);
-          if (!currPageExists) {
-            const currentPage = createPage(currentPageId);
-            pages.push(...currentPage);
-          }
-          const allRecords = tlEditorRef.current.store.allRecords();
-          const cameraRecords = allRecords.filter(
-            (record) => record.typeName === 'camera' && record.id === `camera:page:${formattedPageId}`,
-          );
-          if (cameraRecords?.length < 1) {
-            cameras.push(createCamera(formattedPageId, tlZ));
-          }
+          // Page + camera already exist (ensurePageAndCamera ran synchronously above).
           cleanupStore(currentPageId);
-          updateStore(pages, cameras);
+          tlEditorRef.current.store.put(assets);
+          tlEditorRef.current.store.put(bgShape);
           tlEditorRef.current.setCurrentPage(currentPageId);
           finalizeStore();
         });
@@ -2349,37 +2352,33 @@ const Whiteboard = React.memo((props) => {
       }
     };
 
-    // `assets` is derived from the same currentPresentationPage as curPageId, in the same
-    // render (container.jsx:137-153, :439-453), so it is never stale relative to the page
-    // being swapped: assets[0].props.src is the background for THIS curPageId. A stale src
-    // would silently disable the gate (the swap just returns) with no symptom other than
-    // the bug returning, so keep that derivation in lock-step with curPageId.
-    //
-    // bgShape references the same authenticated, deterministic, immutable SVG URL that
-    // tldraw will paint (Auth.authenticateURL is idempotent: the same sessionToken yields
-    // the same URL and cache key). presentation-slides.nginx sends
-    // `Cache-Control: private, immutable` on these assets, so priming a detached Image
-    // warms the browser cache and tldraw's later background-image load is a cache hit - no
-    // second network transfer or auth_request subrequest per slide change.
+    ensurePageAndCamera();
+
+    // `assets` is derived from the same currentPresentationPage as curPageId in the same
+    // render (container.jsx:439-453), so assets[0].props.src is the background for THIS
+    // page and is never stale relative to it. A stale src would silently disable the gate
+    // (the swap just returns), so keep that derivation in lock-step with curPageId.
     const bgShapeSrc = assets?.[0]?.props?.src;
     if (!bgShapeSrc) {
-      // No background asset URL to gate on: currentPresentationPage has no svgUrl, so
-      // container.jsx:447 leaves src undefined. This is the missing-svgUrl case - the src
-      // is derived regardless of infiniteWhiteboard - so there is simply nothing to decode.
-      // Swap now.
+      // No background URL to gate on (currentPresentationPage has no svgUrl): nothing to
+      // decode, so swap now.
       applyPageSwap();
       return undefined;
     }
 
+    // Prime a detached Image so the visible swap only happens once the new slide's
+    // background is decodable. When the SVG is browser-cacheable (see the sibling
+    // Cache-Control PR) this prime also warms the cache tldraw's later same-origin no-cors
+    // load reuses; on cluster-proxy/cross-origin setups the entries may not be shared, in
+    // which case the gate still works but without the cache-hit saving.
     const img = new Image();
     img.src = bgShapeSrc;
     let fallbackTimer;
     const decodeTimeout = window.meetingClientSettings?.public?.whiteboard?.slideSwapDecodeTimeoutMs
       ?? SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT;
     Promise.race([
-      // decode() rejects on a broken/401/malformed asset; swallow it so a bad asset
-      // degrades to "apply the swap anyway" (the pre-fix behavior) and never wedges
-      // navigation on the old slide.
+      // decode() rejects on a broken/401/malformed asset; swallow it so a bad asset degrades
+      // to "apply the swap anyway" (the pre-fix behavior) and never wedges navigation.
       img.decode().catch(() => {}),
       new Promise((resolve) => {
         fallbackTimer = setTimeout(resolve, decodeTimeout);
@@ -2387,12 +2386,12 @@ const Whiteboard = React.memo((props) => {
     ])
       .then(applyPageSwap)
       .catch((error) => {
-        // applyPageSwap runs the store mutation that used to run synchronously in the
-        // effect body, where a throw landed in ErrorBoundaryWithReload (container.jsx) and
-        // the client recovered with a reload. Inside this async .then a throw would instead
-        // escape as an unhandled promise rejection - no boundary, no reload, editor left
-        // half-swapped between two pages. Log it so the failure is observable, never silent.
+        // The synchronous swap used to throw straight into ErrorBoundaryWithReload, which
+        // recovered with a reload. Inside this async chain a throw would escape as an
+        // unhandled rejection - no boundary, no reload. Log it, then re-surface it into
+        // render via setSwapError so the boundary still sees it.
         logger.error({ logCode: 'SlideSwapDecodeGate' }, `Deferred page swap failed: ${error}`);
+        setSwapError(() => { throw error; });
       })
       .finally(() => {
         // Clear the fallback timer on the decode-wins path too: the cleanup below only runs
@@ -2403,9 +2402,9 @@ const Whiteboard = React.memo((props) => {
     return () => {
       cancelled = true;
       if (fallbackTimer) clearTimeout(fallbackTimer);
-      // Release the detached decode Image so a burst of rapid navigation doesn't pin a
-      // queue of half-decoded SVGs in flight (the rapid-nav case guarded above).
-      img.src = '';
+      // Release the detached decode Image so a burst of rapid navigation doesn't pin a queue
+      // of half-decoded SVGs in flight.
+      img.removeAttribute('src');
     };
   }, [curPageId]);
 

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -824,6 +824,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       maxNumberOfAnnotations: 300,
       maxNumberOfActiveUsers: 25,
       maxHistoryStackSize: 400,
+      slideSwapDecodeTimeoutMs: 250,
       lockToolbarTools: false,
       allowInfiniteWhiteboard: false,
       allowInfiniteWhiteboardInBreakouts: false,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1129,10 +1129,11 @@ public:
     # default value is 400, adjusted for maxNumberOfAnnotations being 300
     maxHistoryStackSize: 400
     # Upper bound (ms) for waiting on a new slide's background image to decode before
-    # swapping the visible page (issue 25397). A warm cache resolves in sub-frame time; a
-    # cold/slow asset falls back to this bound so navigation is never worse than before the
-    # decode-gate. Latency above this bound still shows the original white flash.
-    slideSwapDecodeTimeoutMs: 1500
+    # swapping the visible page (issue 25397). Kept short: a warm/near cache resolves in
+    # sub-frame time and gates the swap, while a cold/slow asset falls through fast to the
+    # old (un-gated) behavior instead of leaving the un-gated toolbar/zoom UI on a stale
+    # slide. Latency above this bound still shows the original white flash.
+    slideSwapDecodeTimeoutMs: 250
     lockToolbarTools: false
     annotations:
       status:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1128,6 +1128,11 @@ public:
     # This is the number of times we can press undo (plus 100 providing a safe margin for some shapes with extra entries)
     # default value is 400, adjusted for maxNumberOfAnnotations being 300
     maxHistoryStackSize: 400
+    # Upper bound (ms) for waiting on a new slide's background image to decode before
+    # swapping the visible page (issue 25397). A warm cache resolves in sub-frame time; a
+    # cold/slow asset falls back to this bound so navigation is never worse than before the
+    # decode-gate. Latency above this bound still shows the original white flash.
+    slideSwapDecodeTimeoutMs: 1500
     lockToolbarTools: false
     annotations:
       status:

--- a/bigbluebutton-tests/playwright/whiteboard/slideChangeBlank.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/slideChangeBlank.ts
@@ -1,6 +1,6 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
-import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { MultiUsers } from '../user/multiusers';
 
@@ -9,16 +9,18 @@ import { MultiUsers } from '../user/multiusers';
 const TARGET = 9;
 
 // How long the intercepted background SVG response is held back. Must be comfortably
-// shorter than the fix's slideSwapDecodeTimeoutMs (1500ms default) so the decode reliably
-// wins the race and gates the swap, leaving margin for CI scheduling jitter between the
-// fetch starting and the response being delivered (a thin margin lets the fallback timer
-// win under load and flake the test).
+// shorter than the decode-gate timeout in force during the test so the decode reliably
+// wins the race and gates the swap, with margin for CI scheduling jitter between the fetch
+// starting and the response being delivered.
 const NET_DELAY_MS = 600;
 
-// Mirror of the source default (component.jsx SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT /
-// meetingClientSettings.public.whiteboard.slideSwapDecodeTimeoutMs). The broken-asset path
-// must resolve the race well before this wall rather than stalling to it.
-const SLIDE_SWAP_DECODE_TIMEOUT_MS = 1500;
+// Decode-gate timeout the test forces at runtime (via window.meetingClientSettings, exactly
+// where the component reads it - see whiteboard/component.jsx). We raise it well above the
+// shipped default so the deliberate NET_DELAY_MS response reliably loses to the decode
+// rather than to the fallback timer, keeping the gate assertions deterministic regardless of
+// the server's configured value. Overriding it here also exercises the runtime-read wiring:
+// if the component ignored the setting and used its own default, these tests would flake.
+const FORCED_DECODE_TIMEOUT_MS = 5000;
 
 // Note on the anchored `/svg/<n>(?:\?|["')]|$)` regex used throughout: it matches a
 // `.tl-image` background-image URL for slide <n> without also matching `/svg/20` or
@@ -29,12 +31,29 @@ const SLIDE_SWAP_DECODE_TIMEOUT_MS = 1500;
 // Regression tests for issue 25397 (blank presentation area on slide change).
 //
 // Before the fix, the [curPageId] effect in whiteboard/component.jsx swapped the
-// visible tldraw page (cleanupStore + updateStore(bgShape) + setCurrentPage)
-// synchronously, mounting the new slide's background image-shape before its SVG had
-// been fetched/decoded. On a cold cache (or a slow link) the presentation area went
-// white until the asset arrived. The fix defers the swap behind an Image.decode()
-// gate (bounded by a timeout) so the page only becomes visible once it is paintable.
+// visible tldraw page (cleanupStore + background + setCurrentPage) synchronously,
+// mounting the new slide's background image-shape before its SVG had been
+// fetched/decoded. On a cold cache (or a slow link) the presentation area went white
+// until the asset arrived. The fix defers the visible swap behind an Image.decode()
+// gate (bounded by a configurable timeout) so the page only becomes visible once it is
+// paintable.
 export class SlideChangeBlank extends MultiUsers {
+  // Force the decode-gate timeout on a page to a known value. The component reads
+  // window.meetingClientSettings.public.whiteboard.slideSwapDecodeTimeoutMs on every slide
+  // change, so setting it here deterministically controls the race the tests depend on.
+  static async setDecodeTimeout(page: Page, ms: number) {
+    await page.evaluate((v: number) => {
+      const settings = (
+        window as unknown as {
+          meetingClientSettings?: { public?: { whiteboard?: { slideSwapDecodeTimeoutMs?: number } } };
+        }
+      ).meetingClientSettings;
+      if (settings?.public?.whiteboard) {
+        settings.public.whiteboard.slideSwapDecodeTimeoutMs = v;
+      }
+    }, ms);
+  }
+
   async waitForFirstSlidePainted() {
     await this.modPage.hasElement(
       e.whiteboard,
@@ -69,6 +88,9 @@ export class SlideChangeBlank extends MultiUsers {
     const delayMs = NET_DELAY_MS;
 
     await this.waitForFirstSlidePainted();
+    // Raise the gate timeout so the held-back response (NET_DELAY_MS) reliably wins the race
+    // against the fallback timer; the assertion below then measures the gate, not the timer.
+    await SlideChangeBlank.setDecodeTimeout(page, FORCED_DECODE_TIMEOUT_MS);
 
     // Instrument the page: record, on the page clock, the first moment the target
     // slide's background is mounted into the DOM.
@@ -131,7 +153,7 @@ export class SlideChangeBlank extends MultiUsers {
         return p.tSwap !== null && p.tResp !== null;
       },
       undefined,
-      { timeout: 15000 },
+      { timeout: ELEMENT_WAIT_EXTRA_LONG_TIME },
     );
 
     const probe = await page.evaluate(
@@ -173,14 +195,11 @@ export class SlideChangeBlank extends MultiUsers {
       await page.route(`**/svg/${target}**`, (route) => route.abort());
 
       await this.modPage.selectSlide(`Slide ${target}`);
-      // Measure the gate from AFTER selection: a rejected decode short-circuits the race,
-      // so the swap must land well before the fallback wall rather than stalling to it.
-      const start = Date.now();
 
-      // Navigation must still complete: the page swap runs even though the asset is broken
-      // (there is simply nothing to paint). The `.tl-image` for the target page is mounted.
-      // The outer timeout is deliberately larger than the decode-timeout wall so the
-      // elapsed assertion below - not this wait - is what catches a stall.
+      // Navigation must still complete: the swap runs even though the asset is broken (there
+      // is simply nothing to paint), so the `.tl-image` for the target page mounts. We assert
+      // the outcome (swap happens, no error), not the timing: measuring elapsed from after
+      // selectSlide would include the akka/Hasura round-trip and flake on a loaded box.
       await page.waitForFunction(
         (tgt) => {
           const imgs = document.querySelectorAll('.tl-image');
@@ -189,13 +208,8 @@ export class SlideChangeBlank extends MultiUsers {
           );
         },
         target,
-        { timeout: SLIDE_SWAP_DECODE_TIMEOUT_MS * 4 },
+        { timeout: ELEMENT_WAIT_LONGER_TIME },
       );
-      const elapsed = Date.now() - start;
-      expect(
-        elapsed,
-        `a rejected decode must short-circuit the gate, not stall to the ${SLIDE_SWAP_DECODE_TIMEOUT_MS}ms decode wall`,
-      ).toBeLessThan(SLIDE_SWAP_DECODE_TIMEOUT_MS);
 
       // The whiteboard is still mounted (no error boundary fallback) and no uncaught
       // decode rejection surfaced.
@@ -214,22 +228,25 @@ export class SlideChangeBlank extends MultiUsers {
           );
         },
         undefined,
-        { timeout: 10000 },
+        { timeout: ELEMENT_WAIT_LONGER_TIME },
       );
     } finally {
       page.off('pageerror', onPageError);
     }
   }
 
-  // Regression guard for the isMountedRef strand (PR #69 review, finding #1). isMountedRef
-  // is not "the component is mounted": it flips true only late, inside adjustCameraOnMount
-  // after camera calibration (~1.5s after the whiteboard mounts). If applyPageSwap gated on
-  // it, a slide change arriving during that calibration window (a viewer following a
-  // presenter who navigates right after the viewer joins) was dropped and never retried
-  // (the effect only re-fires on curPageId change), permanently stranding the viewer on the
-  // wrong slide. The fix removes that guard; the cancelled flag already covers unmount. Here
-  // a viewer joins, the presenter immediately jumps to a far slide, and the viewer MUST
-  // follow. On the unfixed code this hangs on slide 1.
+  // Invariant: a slide change that arrives while a viewer is still calibrating its camera
+  // (right after join) must still be applied - the viewer must converge to the presenter's
+  // slide, not be permanently stranded on slide 1. isMountedRef is not "the component is
+  // mounted": it flips true only late, inside adjustCameraOnMount's double-rAF, and
+  // adjustCameraOnMount is itself invoked from the decode-gated applyPageSwap. Gating the
+  // swap on isMountedRef therefore drops a slide change that lands during that window (the
+  // effect only re-fires on curPageId change, so the drop is permanent).
+  //
+  // We force that window deterministically: hold back the viewer's slide-1 background and
+  // raise the viewer's decode-gate timeout, so slide 1's applyPageSwap - and thus its
+  // adjustCameraOnMount, and thus isMountedRef flipping true - stays pending while the
+  // presenter jumps to a far slide. The viewer MUST follow.
   async viewerFollowsSlideChangeDuringMount() {
     const target = TARGET;
 
@@ -237,10 +254,26 @@ export class SlideChangeBlank extends MultiUsers {
     // Bring a viewer in; they follow the presenter's current slide.
     await this.initUserPage(this.modPage.context);
     await this.userPage.hasElement(e.whiteboard, 'viewer should see the whiteboard', ELEMENT_WAIT_LONGER_TIME);
-    await this.userPage.hasElement(e.currentSlideImg, 'viewer should see the first slide background');
 
-    // Navigate immediately, while the viewer is still calibrating (isMountedRef not yet
-    // set). No awaited delay here: the change must land inside that window.
+    // Keep the viewer inside the calibration window: raise its decode-gate timeout and hold
+    // back slide 1's background so slide 1's applyPageSwap (which runs adjustCameraOnMount,
+    // which sets isMountedRef) stays pending. released lets late duplicates through so no
+    // long delay is left in flight at teardown.
+    await SlideChangeBlank.setDecodeTimeout(this.userPage.page, FORCED_DECODE_TIMEOUT_MS);
+    let released = false;
+    await this.userPage.page.route('**/svg/1**', async (route) => {
+      if (released) {
+        await route.continue().catch(() => {});
+        return;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, FORCED_DECODE_TIMEOUT_MS);
+      });
+      await route.continue().catch(() => {});
+    });
+
+    // Navigate immediately, while the viewer's slide-1 swap (and camera calibration) is
+    // still pending. No awaited delay here: the change must land inside that window.
     await this.modPage.selectSlide(`Slide ${target}`);
 
     // The viewer must converge to the target slide. Since the buggy drop is permanent, a
@@ -253,8 +286,11 @@ export class SlideChangeBlank extends MultiUsers {
         );
       },
       target,
-      { timeout: 15000 },
+      { timeout: ELEMENT_WAIT_EXTRA_LONG_TIME },
     );
+
+    released = true;
+    await this.userPage.page.unrouteAll({ behavior: 'ignoreErrors' });
 
     // Confirm it is actually the target slide (not merely still slide 1).
     const onTarget = await this.userPage.page.evaluate((tgt) => {
@@ -265,8 +301,8 @@ export class SlideChangeBlank extends MultiUsers {
     }, target);
     expect(
       onTarget,
-      `viewer must follow the presenter to slide ${target} even when it changes during camera ` +
-        'calibration; a permanent strand here is the isMountedRef guard bug (PR #69 finding #1).',
+      `viewer must follow the presenter to slide ${target} even when the change arrives during camera ` +
+        'calibration; a permanent strand here means the swap was gated on isMountedRef again.',
     ).toBe(true);
   }
 }

--- a/bigbluebutton-tests/playwright/whiteboard/slideChangeBlank.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/slideChangeBlank.ts
@@ -1,0 +1,184 @@
+import { expect } from '@playwright/test';
+
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { MultiUsers } from '../user/multiusers';
+
+// Regression tests for issue 25397 (blank presentation area on slide change).
+//
+// Before the fix, the [curPageId] effect in whiteboard/component.jsx swapped the
+// visible tldraw page (cleanupStore + updateStore(bgShape) + setCurrentPage)
+// synchronously, mounting the new slide's background image-shape before its SVG had
+// been fetched/decoded. On a cold cache (or a slow link) the presentation area went
+// white until the asset arrived. The fix defers the swap behind an Image.decode()
+// gate (bounded by a timeout) so the page only becomes visible once it is paintable.
+export class SlideChangeBlank extends MultiUsers {
+  // Deferred far-slide index. Slide 1 is the initial page; the forward prefetch
+  // window is only 2 slides, so a slide this far ahead is guaranteed cold.
+  static TARGET = 9;
+
+  // How long the intercepted background SVG response is held back. Must be shorter
+  // than the fix's SLIDE_SWAP_DECODE_TIMEOUT (1500ms) so the decode wins the race
+  // and gates the swap (rather than the timeout fallback firing).
+  static NET_DELAY_MS = 1000;
+
+  async waitForFirstSlidePainted() {
+    await this.modPage.hasElement(
+      e.whiteboard,
+      'should display the whiteboard for the presenter',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.modPage.hasElement(e.currentSlideImg, 'should display the first slide background');
+    // Let slide 1's asset finish loading/decoding so the initial paint is not what we measure.
+    await this.modPage.page.waitForTimeout(3000);
+    // The default presentation must have enough slides to jump far ahead.
+    await this.modPage.waitForSelector(e.skipSlide);
+  }
+
+  // No white flash: the new slide's background must not become visible in the DOM
+  // before its image has been delivered/decoded. We hold back the target SVG's
+  // network response, and assert the tldraw page swap (a `.tl-image` whose
+  // background-image references `/svg/<target>`) never happens before that response.
+  async noBlankOnSlideChange() {
+    const { page } = this.modPage;
+    const target = SlideChangeBlank.TARGET;
+    const delayMs = SlideChangeBlank.NET_DELAY_MS;
+
+    await this.waitForFirstSlidePainted();
+
+    // Instrument the page: record, on the page clock, the first moment the target
+    // slide's background is mounted into the DOM.
+    await page.evaluate((tgt) => {
+      const marker = `/svg/${tgt}`;
+      const probe = { tSwap: null as number | null, tResp: null as number | null };
+      (window as unknown as { bbbBlankProbe: typeof probe }).bbbBlankProbe = probe;
+      const iv = setInterval(() => {
+        if (probe.tSwap !== null) {
+          clearInterval(iv);
+          return;
+        }
+        const imgs = document.querySelectorAll('.tl-image');
+        for (const el of Array.from(imgs)) {
+          const bg = (el as HTMLElement).style?.backgroundImage || '';
+          if (bg.includes(marker)) {
+            probe.tSwap = Date.now();
+            clearInterval(iv);
+            return;
+          }
+        }
+      }, 10);
+    }, target);
+
+    // Hold back the FIRST request for the target slide's background SVG (the fix and
+    // tldraw both fetch it), then stamp the delivery time (page clock) right before
+    // letting it through. Later duplicate requests continue immediately so no long
+    // delay is left in flight at teardown; the page.evaluate is guarded because a late
+    // callback can fire after the page starts closing.
+    let firstHandled = false;
+    await page.route(`**/svg/${target}**`, async (route) => {
+      if (firstHandled) {
+        await route.continue().catch(() => {});
+        return;
+      }
+      firstHandled = true;
+      await new Promise((resolve) => {
+        setTimeout(resolve, delayMs);
+      });
+      await page
+        .evaluate(() => {
+          const probe = (window as unknown as { bbbBlankProbe: { tResp: number | null } }).bbbBlankProbe;
+          if (probe.tResp === null) probe.tResp = Date.now();
+        })
+        .catch(() => {});
+      await route.continue().catch(() => {});
+    });
+
+    await this.modPage.selectSlide(`Slide ${target}`);
+
+    // Wait (bounded) for BOTH the asset delivery (tResp, ~NET_DELAY_MS after the fetch
+    // starts) AND the DOM swap (tSwap). Waiting for both avoids reading the probe while
+    // the delayed response is still in flight: the buggy synchronous swap sets tSwap at
+    // ~200ms, long before the held-back response records tResp, so a naive
+    // "wait for tSwap" would read tResp as still-null and mis-report the failure.
+    await page.waitForFunction(
+      () => {
+        const p = (window as unknown as { bbbBlankProbe: { tSwap: number | null; tResp: number | null } })
+          .bbbBlankProbe;
+        return p.tSwap !== null && p.tResp !== null;
+      },
+      undefined,
+      { timeout: 15000 },
+    );
+
+    const probe = await page.evaluate(
+      () => (window as unknown as { bbbBlankProbe: { tSwap: number | null; tResp: number | null } }).bbbBlankProbe,
+    );
+
+    // Drop any routes still in flight so their callbacks do not run against a closing page.
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+
+    expect(probe.tResp, 'the target slide SVG request should have been intercepted and delivered').not.toBeNull();
+    expect(
+      probe.tSwap,
+      `slide ${target} must not become visible before its background image is delivered/decoded ` +
+        `(swap at ${probe.tSwap}ms, asset delivered at ${probe.tResp}ms). A swap before the asset arrives ` +
+        'is the white flash of issue 25397.',
+    ).toBeGreaterThanOrEqual(probe.tResp as number);
+  }
+
+  // Broken / undecodable asset must degrade, never wedge navigation. This guards the
+  // async decode-gate the fix introduces: the decode().catch + timeout race must still
+  // resolve (and run the swap) when the asset can never decode, and must not leak an
+  // uncaught rejection or trip the error boundary.
+  async brokenAssetDegradesWithoutHanging() {
+    const { page } = this.modPage;
+    const target = SlideChangeBlank.TARGET;
+
+    await this.waitForFirstSlidePainted();
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (err) => pageErrors.push(err.message));
+
+    // Make the target slide's background permanently unreachable (network error ->
+    // Image.decode() rejects).
+    await page.route(`**/svg/${target}**`, (route) => route.abort());
+
+    const start = Date.now();
+    await this.modPage.selectSlide(`Slide ${target}`);
+
+    // Navigation must still complete: the page swap runs even though the asset is broken
+    // (there is simply nothing to paint). The `.tl-image` for the target page is mounted.
+    await page.waitForFunction(
+      (tgt) => {
+        const marker = `/svg/${tgt}`;
+        const imgs = document.querySelectorAll('.tl-image');
+        return Array.from(imgs).some((el) => ((el as HTMLElement).style?.backgroundImage || '').includes(marker));
+      },
+      target,
+      // Fix timeout is 1500ms; a rejected decode should resolve well before this bound.
+      { timeout: 8000 },
+    );
+    const elapsed = Date.now() - start;
+    expect(elapsed, 'a broken asset must not stall navigation up to (or past) the decode timeout wall').toBeLessThan(
+      8000,
+    );
+
+    // The whiteboard is still mounted (no error boundary fallback) and no uncaught
+    // decode rejection surfaced.
+    await this.modPage.hasElement(e.whiteboard, 'whiteboard should remain mounted after a broken slide asset');
+    const decodeErrors = pageErrors.filter((m) => /decode|Uncaught \(in promise\)/i.test(m));
+    expect(decodeErrors, `no uncaught decode errors expected (got: ${pageErrors.join(' | ')})`).toHaveLength(0);
+
+    // The client is not wedged: navigating to a healthy slide still swaps normally.
+    await page.unroute(`**/svg/${target}**`);
+    await this.modPage.selectSlide('Slide 2');
+    await page.waitForFunction(
+      () => {
+        const imgs = document.querySelectorAll('.tl-image');
+        return Array.from(imgs).some((el) => ((el as HTMLElement).style?.backgroundImage || '').includes('/svg/2'));
+      },
+      undefined,
+      { timeout: 10000 },
+    );
+  }
+}

--- a/bigbluebutton-tests/playwright/whiteboard/slideChangeBlank.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/slideChangeBlank.ts
@@ -4,6 +4,28 @@ import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { MultiUsers } from '../user/multiusers';
 
+// Deferred far-slide index. Slide 1 is the initial page; the forward prefetch window is
+// only 2 slides, so a slide this far ahead is guaranteed cold.
+const TARGET = 9;
+
+// How long the intercepted background SVG response is held back. Must be comfortably
+// shorter than the fix's slideSwapDecodeTimeoutMs (1500ms default) so the decode reliably
+// wins the race and gates the swap, leaving margin for CI scheduling jitter between the
+// fetch starting and the response being delivered (a thin margin lets the fallback timer
+// win under load and flake the test).
+const NET_DELAY_MS = 600;
+
+// Mirror of the source default (component.jsx SLIDE_SWAP_DECODE_TIMEOUT_DEFAULT /
+// meetingClientSettings.public.whiteboard.slideSwapDecodeTimeoutMs). The broken-asset path
+// must resolve the race well before this wall rather than stalling to it.
+const SLIDE_SWAP_DECODE_TIMEOUT_MS = 1500;
+
+// Note on the anchored `/svg/<n>(?:\?|["')]|$)` regex used throughout: it matches a
+// `.tl-image` background-image URL for slide <n> without also matching `/svg/20` or
+// `/svg/21` (the URL is followed by `?` for the sessionToken query, or the closing
+// quote/paren of the CSS url()). It is inlined inside each page.evaluate/waitForFunction
+// because those callbacks run in the browser and cannot close over a Node-scope helper.
+
 // Regression tests for issue 25397 (blank presentation area on slide change).
 //
 // Before the fix, the [curPageId] effect in whiteboard/component.jsx swapped the
@@ -13,15 +35,6 @@ import { MultiUsers } from '../user/multiusers';
 // white until the asset arrived. The fix defers the swap behind an Image.decode()
 // gate (bounded by a timeout) so the page only becomes visible once it is paintable.
 export class SlideChangeBlank extends MultiUsers {
-  // Deferred far-slide index. Slide 1 is the initial page; the forward prefetch
-  // window is only 2 slides, so a slide this far ahead is guaranteed cold.
-  static TARGET = 9;
-
-  // How long the intercepted background SVG response is held back. Must be shorter
-  // than the fix's SLIDE_SWAP_DECODE_TIMEOUT (1500ms) so the decode wins the race
-  // and gates the swap (rather than the timeout fallback firing).
-  static NET_DELAY_MS = 1000;
-
   async waitForFirstSlidePainted() {
     await this.modPage.hasElement(
       e.whiteboard,
@@ -29,8 +42,19 @@ export class SlideChangeBlank extends MultiUsers {
       ELEMENT_WAIT_LONGER_TIME,
     );
     await this.modPage.hasElement(e.currentSlideImg, 'should display the first slide background');
-    // Let slide 1's asset finish loading/decoding so the initial paint is not what we measure.
-    await this.modPage.page.waitForTimeout(3000);
+    // Wait for the actual condition (slide 1's background painted) instead of a fixed
+    // sleep, so the initial paint is settled but we do not burn a flat 3s per test.
+    await this.modPage.page.waitForFunction(
+      () => {
+        const imgs = document.querySelectorAll('.tl-image');
+        return Array.from(imgs).some((el) => {
+          const bg = (el as HTMLElement).style?.backgroundImage || '';
+          return bg.includes('/svg/');
+        });
+      },
+      undefined,
+      { timeout: ELEMENT_WAIT_LONGER_TIME },
+    );
     // The default presentation must have enough slides to jump far ahead.
     await this.modPage.waitForSelector(e.skipSlide);
   }
@@ -41,15 +65,15 @@ export class SlideChangeBlank extends MultiUsers {
   // background-image references `/svg/<target>`) never happens before that response.
   async noBlankOnSlideChange() {
     const { page } = this.modPage;
-    const target = SlideChangeBlank.TARGET;
-    const delayMs = SlideChangeBlank.NET_DELAY_MS;
+    const target = TARGET;
+    const delayMs = NET_DELAY_MS;
 
     await this.waitForFirstSlidePainted();
 
     // Instrument the page: record, on the page clock, the first moment the target
     // slide's background is mounted into the DOM.
     await page.evaluate((tgt) => {
-      const marker = `/svg/${tgt}`;
+      const svgMatches = (bg: string): boolean => new RegExp(`/svg/${tgt}(?:\\?|["')]|$)`).test(bg);
       const probe = { tSwap: null as number | null, tResp: null as number | null };
       (window as unknown as { bbbBlankProbe: typeof probe }).bbbBlankProbe = probe;
       const iv = setInterval(() => {
@@ -60,7 +84,7 @@ export class SlideChangeBlank extends MultiUsers {
         const imgs = document.querySelectorAll('.tl-image');
         for (const el of Array.from(imgs)) {
           const bg = (el as HTMLElement).style?.backgroundImage || '';
-          if (bg.includes(marker)) {
+          if (svgMatches(bg)) {
             probe.tSwap = Date.now();
             clearInterval(iv);
             return;
@@ -132,53 +156,117 @@ export class SlideChangeBlank extends MultiUsers {
   // uncaught rejection or trip the error boundary.
   async brokenAssetDegradesWithoutHanging() {
     const { page } = this.modPage;
-    const target = SlideChangeBlank.TARGET;
+    const target = TARGET;
 
     await this.waitForFirstSlidePainted();
 
+    // Note: route.abort() below makes Playwright log "failed to load resource" console
+    // errors for the aborted SVG. They are harmless here (that is the scenario) but would
+    // trip a run with CONSOLE_FAIL=true (core/helpers.ts). We only assert on pageerror.
     const pageErrors: string[] = [];
-    page.on('pageerror', (err) => pageErrors.push(err.message));
+    const onPageError = (err: Error) => pageErrors.push(err.message);
+    page.on('pageerror', onPageError);
 
-    // Make the target slide's background permanently unreachable (network error ->
-    // Image.decode() rejects).
-    await page.route(`**/svg/${target}**`, (route) => route.abort());
+    try {
+      // Make the target slide's background permanently unreachable (network error ->
+      // Image.decode() rejects).
+      await page.route(`**/svg/${target}**`, (route) => route.abort());
 
-    const start = Date.now();
+      await this.modPage.selectSlide(`Slide ${target}`);
+      // Measure the gate from AFTER selection: a rejected decode short-circuits the race,
+      // so the swap must land well before the fallback wall rather than stalling to it.
+      const start = Date.now();
+
+      // Navigation must still complete: the page swap runs even though the asset is broken
+      // (there is simply nothing to paint). The `.tl-image` for the target page is mounted.
+      // The outer timeout is deliberately larger than the decode-timeout wall so the
+      // elapsed assertion below - not this wait - is what catches a stall.
+      await page.waitForFunction(
+        (tgt) => {
+          const imgs = document.querySelectorAll('.tl-image');
+          return Array.from(imgs).some((el) =>
+            new RegExp(`/svg/${tgt}(?:\\?|["')]|$)`).test((el as HTMLElement).style?.backgroundImage || ''),
+          );
+        },
+        target,
+        { timeout: SLIDE_SWAP_DECODE_TIMEOUT_MS * 4 },
+      );
+      const elapsed = Date.now() - start;
+      expect(
+        elapsed,
+        `a rejected decode must short-circuit the gate, not stall to the ${SLIDE_SWAP_DECODE_TIMEOUT_MS}ms decode wall`,
+      ).toBeLessThan(SLIDE_SWAP_DECODE_TIMEOUT_MS);
+
+      // The whiteboard is still mounted (no error boundary fallback) and no uncaught
+      // decode rejection surfaced.
+      await this.modPage.hasElement(e.whiteboard, 'whiteboard should remain mounted after a broken slide asset');
+      const decodeErrors = pageErrors.filter((m) => /decode|Uncaught \(in promise\)/i.test(m));
+      expect(decodeErrors, `no uncaught decode errors expected (got: ${pageErrors.join(' | ')})`).toHaveLength(0);
+
+      // The client is not wedged: navigating to a healthy slide still swaps normally.
+      await page.unroute(`**/svg/${target}**`);
+      await this.modPage.selectSlide('Slide 2');
+      await page.waitForFunction(
+        () => {
+          const imgs = document.querySelectorAll('.tl-image');
+          return Array.from(imgs).some((el) =>
+            /\/svg\/2(?:\?|["')]|$)/.test((el as HTMLElement).style?.backgroundImage || ''),
+          );
+        },
+        undefined,
+        { timeout: 10000 },
+      );
+    } finally {
+      page.off('pageerror', onPageError);
+    }
+  }
+
+  // Regression guard for the isMountedRef strand (PR #69 review, finding #1). isMountedRef
+  // is not "the component is mounted": it flips true only late, inside adjustCameraOnMount
+  // after camera calibration (~1.5s after the whiteboard mounts). If applyPageSwap gated on
+  // it, a slide change arriving during that calibration window (a viewer following a
+  // presenter who navigates right after the viewer joins) was dropped and never retried
+  // (the effect only re-fires on curPageId change), permanently stranding the viewer on the
+  // wrong slide. The fix removes that guard; the cancelled flag already covers unmount. Here
+  // a viewer joins, the presenter immediately jumps to a far slide, and the viewer MUST
+  // follow. On the unfixed code this hangs on slide 1.
+  async viewerFollowsSlideChangeDuringMount() {
+    const target = TARGET;
+
+    await this.waitForFirstSlidePainted();
+    // Bring a viewer in; they follow the presenter's current slide.
+    await this.initUserPage(this.modPage.context);
+    await this.userPage.hasElement(e.whiteboard, 'viewer should see the whiteboard', ELEMENT_WAIT_LONGER_TIME);
+    await this.userPage.hasElement(e.currentSlideImg, 'viewer should see the first slide background');
+
+    // Navigate immediately, while the viewer is still calibrating (isMountedRef not yet
+    // set). No awaited delay here: the change must land inside that window.
     await this.modPage.selectSlide(`Slide ${target}`);
 
-    // Navigation must still complete: the page swap runs even though the asset is broken
-    // (there is simply nothing to paint). The `.tl-image` for the target page is mounted.
-    await page.waitForFunction(
+    // The viewer must converge to the target slide. Since the buggy drop is permanent, a
+    // generous wait still fails on unfixed code (the viewer stays on slide 1).
+    await this.userPage.page.waitForFunction(
       (tgt) => {
-        const marker = `/svg/${tgt}`;
         const imgs = document.querySelectorAll('.tl-image');
-        return Array.from(imgs).some((el) => ((el as HTMLElement).style?.backgroundImage || '').includes(marker));
+        return Array.from(imgs).some((el) =>
+          new RegExp(`/svg/${tgt}(?:\\?|["')]|$)`).test((el as HTMLElement).style?.backgroundImage || ''),
+        );
       },
       target,
-      // Fix timeout is 1500ms; a rejected decode should resolve well before this bound.
-      { timeout: 8000 },
-    );
-    const elapsed = Date.now() - start;
-    expect(elapsed, 'a broken asset must not stall navigation up to (or past) the decode timeout wall').toBeLessThan(
-      8000,
+      { timeout: 15000 },
     );
 
-    // The whiteboard is still mounted (no error boundary fallback) and no uncaught
-    // decode rejection surfaced.
-    await this.modPage.hasElement(e.whiteboard, 'whiteboard should remain mounted after a broken slide asset');
-    const decodeErrors = pageErrors.filter((m) => /decode|Uncaught \(in promise\)/i.test(m));
-    expect(decodeErrors, `no uncaught decode errors expected (got: ${pageErrors.join(' | ')})`).toHaveLength(0);
-
-    // The client is not wedged: navigating to a healthy slide still swaps normally.
-    await page.unroute(`**/svg/${target}**`);
-    await this.modPage.selectSlide('Slide 2');
-    await page.waitForFunction(
-      () => {
-        const imgs = document.querySelectorAll('.tl-image');
-        return Array.from(imgs).some((el) => ((el as HTMLElement).style?.backgroundImage || '').includes('/svg/2'));
-      },
-      undefined,
-      { timeout: 10000 },
-    );
+    // Confirm it is actually the target slide (not merely still slide 1).
+    const onTarget = await this.userPage.page.evaluate((tgt) => {
+      const imgs = document.querySelectorAll('.tl-image');
+      return Array.from(imgs).some((el) =>
+        new RegExp(`/svg/${tgt}(?:\\?|["')]|$)`).test((el as HTMLElement).style?.backgroundImage || ''),
+      );
+    }, target);
+    expect(
+      onTarget,
+      `viewer must follow the presenter to slide ${target} even when it changes during camera ` +
+        'calibration; a permanent strand here is the isMountedRef guard bug (PR #69 finding #1).',
+    ).toBe(true);
   }
 }

--- a/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
@@ -190,6 +190,17 @@ test.describe.parallel('Whiteboard tools', { tag: '@ci' }, () => {
     await blank.brokenAssetDegradesWithoutHanging();
   });
 
+  test('Viewer follows a slide change that happens during camera calibration', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    linkIssue(25397);
+    const blank = new SlideChangeBlank(browser, context);
+    await blank.initModPage(page, { testInfo });
+    await blank.viewerFollowsSlideChangeDuringMount();
+  });
+
   test.describe.parallel('Shape Options', () => {
     test('Duplicate', async ({ browser, context, page }, testInfo) => {
       const shapeOptions = new ShapeOptions(browser, context);
@@ -214,19 +225,11 @@ test.describe.parallel('Whiteboard tools', { tag: '@ci' }, () => {
     await runResizeTest('cameraResyncVisual', browser, context, page, testInfo);
   });
 
-  test('Camera re-sync visual regression after resize with canvas zoom', async ({
-    browser,
-    context,
-    page,
-  }, testInfo) => {
+  test('Camera re-sync visual regression after resize with canvas zoom', async ({ browser, context, page }, testInfo) => {
     await runResizeTest('cameraResyncZoomedVisual', browser, context, page, testInfo);
   });
 
-  test('Camera zoom is preserved after minimizing and restoring the presentation', async ({
-    browser,
-    context,
-    page,
-  }, testInfo) => {
+  test('Camera zoom is preserved after minimizing and restoring the presentation', async ({ browser, context, page }, testInfo) => {
     await runResizeTest('cameraResyncAfterMinimizeRestore', browser, context, page, testInfo);
   });
 });

--- a/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
+++ b/bigbluebutton-tests/playwright/whiteboard/whiteboard.spec.ts
@@ -1,11 +1,13 @@
 import type { Browser, BrowserContext, Page, TestInfo } from '@playwright/test';
 
 import { elements as e } from '../core/elements';
+import { linkIssue } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
 import { ChangeStyles } from './changeStyles';
 import { DrawShape } from './drawShape';
 import { ShapeOptions } from './shapeOptions';
 import { ShapeTools } from './shapeTools';
+import { SlideChangeBlank } from './slideChangeBlank';
 import { SlideChangeWhileEditing } from './slideChangeWhileEditing';
 import { TextShape } from './textShape';
 import { WhiteboardResize } from './whiteboardResize';
@@ -170,6 +172,24 @@ test.describe.parallel('Whiteboard tools', { tag: '@ci' }, () => {
     await slideChange.crashOnSlideChangeWhileEditing();
   });
 
+  test('No blank presentation area on slide change with a cold cache', async ({ browser, context, page }, testInfo) => {
+    linkIssue(25397);
+    const blank = new SlideChangeBlank(browser, context);
+    await blank.initModPage(page, { testInfo });
+    await blank.noBlankOnSlideChange();
+  });
+
+  test('Slide change with a broken background asset degrades without hanging', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    linkIssue(25397);
+    const blank = new SlideChangeBlank(browser, context);
+    await blank.initModPage(page, { testInfo });
+    await blank.brokenAssetDegradesWithoutHanging();
+  });
+
   test.describe.parallel('Shape Options', () => {
     test('Duplicate', async ({ browser, context, page }, testInfo) => {
       const shapeOptions = new ShapeOptions(browser, context);
@@ -194,11 +214,19 @@ test.describe.parallel('Whiteboard tools', { tag: '@ci' }, () => {
     await runResizeTest('cameraResyncVisual', browser, context, page, testInfo);
   });
 
-  test('Camera re-sync visual regression after resize with canvas zoom', async ({ browser, context, page }, testInfo) => {
+  test('Camera re-sync visual regression after resize with canvas zoom', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
     await runResizeTest('cameraResyncZoomedVisual', browser, context, page, testInfo);
   });
 
-  test('Camera zoom is preserved after minimizing and restoring the presentation', async ({ browser, context, page }, testInfo) => {
+  test('Camera zoom is preserved after minimizing and restoring the presentation', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
     await runResizeTest('cameraResyncAfterMinimizeRestore', browser, context, page, testInfo);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the presentation area flashing white for a moment when the slide changes.

Each slide is a separate tldraw page whose background is an image-shape pointing at that slide's SVG. The `[curPageId]` effect swapped the visible page synchronously — it mounted the new background shape and called `setCurrentPage` before the SVG had been fetched — and CSS paints nothing for a `background-image` whose resource hasn't loaded, so the canvas went blank until the asset arrived. On a warm cache it's a sub-frame flicker; on a cold one (backward navigation, or a forward jump past the 2-slide prefetch window) it's a clearly visible blank.

Now the visible part of the swap (`cleanupStore` + background + `setCurrentPage`) waits on an `Image.decode()` of the new background, bounded by a short timeout (`whiteboard.slideSwapDecodeTimeoutMs`, default 250ms). The previous slide stays painted until the new one is paintable, and a slow or broken asset falls through to the old behavior instead of blocking navigation.

The page and camera records are still created synchronously, ahead of the gate: remote annotations for the new page arrive on a 175ms debounce parented to `page:N`, so the parent has to exist regardless of how long the decode takes.

### Closes Issue(s)

Closes #25397

### How to test

1. Join as presenter with a multi-slide presentation, with the cache disabled (DevTools → Network → Disable cache) and some throttling — that's what makes the flash visible.
2. Jump forward past the prefetch window (slide 1 → 9), then navigate backwards.
3. The previous slide should stay visible until the new one paints — no white canvas in between.
4. Worth also checking: rapid navigation (1 → 9 → 3) should settle on slide 3, and changing slides while editing a text shape should not crash (issue 25332).

Automated: three Playwright specs in `whiteboard/slideChangeBlank.ts` — no blank on a cold slide change (this one fails on the old code), broken asset degrades without hanging, and a viewer following a slide change that arrives while its camera is still calibrating.

### More

- Known limitation: if the background takes longer than the timeout, the fallback fires and the original flash still shows. The gate covers the common near-cache case, not the worst one.
- The timeout is deliberately short because the toolbar, zoom and camera are not gated — a long wait would leave them showing a slide the canvas hasn't caught up to yet.
- Making the slide SVG properly browser-cacheable, so the decode prime warms the cache tldraw later reuses, is a separate PR (#71) — it carries an authorization tradeoff on the cache lifetime that deserves its own review.
