### PR TITLE
refactor(bbb-web): process pre-uploaded slides async on a bounded pool

### DIFF
--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -80,7 +80,7 @@ dependencies {
   implementation "org.apache.grails:grails-services"
   implementation "org.apache.grails:grails-url-mappings"
   implementation "org.apache.grails:grails-interceptors"
-
+  implementation "org.apache.grails:grails-async"
   implementation "org.apache.grails:grails-views-gson"
   implementation "org.apache.grails:grails-cache"
 

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -80,7 +80,7 @@ dependencies {
   implementation "org.apache.grails:grails-services"
   implementation "org.apache.grails:grails-url-mappings"
   implementation "org.apache.grails:grails-interceptors"
-  implementation "org.apache.grails:grails-async"
+
   implementation "org.apache.grails:grails-views-gson"
   implementation "org.apache.grails:grails-cache"
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -88,6 +88,12 @@ numFileProcessorThreads=2
 numPluginManifestsFetchingThreads=5
 
 #------------------------------------
+# Number of threads used to download and process pre-uploaded presentations
+# (/create and /insertDocument) without delaying the API response
+#------------------------------------
+numPresentationDownloadThreads=5
+
+#------------------------------------
 # Each plugin manifest fetch shouldn't take longer than this time (seconds)
 #------------------------------------
 pluginManifestFetchTimeout=15

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -296,6 +296,7 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="preUploadedPresentationOverrideDefault" value="${beans.presentationService.preUploadedPresentationOverrideDefault}"/>
         <property name="scanUploadedPresentationFiles" value="${scanUploadedPresentationFiles}"/>
         <property name="pageTokenSecret" value="${pageTokenSecret}"/>
+        <property name="numDownloadThreads" value="${numPresentationDownloadThreads}"/>
     </bean>
 
     <bean id="pdfPageDownscaler" class="org.bigbluebutton.presentation.imp.PdfPageDownscaler">

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -47,6 +47,7 @@ import org.bigbluebutton.web.services.turn.StunTurnService
 import org.bigbluebutton.web.services.turn.TurnEntry
 import org.codehaus.groovy.util.ListHashMap
 import org.json.JSONArray
+import static grails.async.Promises.*
 
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.http.HttpServletRequest

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -248,12 +248,8 @@ class ApiController {
     }
 
     if (meetingService.createMeeting(newMeeting)) {
-
-      // Run slow pre-uploaded slides handling async for fast API responses
-      task {
-        // See if the request came with pre-uploading of presentation.
-        uploadDocuments(xmlModules, newMeeting, false);
-      }
+      // See if the request came with pre-uploading of presentation.
+      uploadDocuments(xmlModules, newMeeting, false);
 
       respondWithConference(newMeeting, null, null)
     } else {
@@ -1662,9 +1658,13 @@ class ApiController {
           if (document.current) {
             isDefaultPresentation = true
           }
-          downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(),
-                  document.current /* default presentation */, '', false,
-                  true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+
+          // Run slow download and processing async for fast API responses
+          task {
+            downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(),
+                    document.current /* default presentation */, '', false,
+                    true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+          }
         } else {
           log.error "Default presentation could not be read, it is (" + presentationService.defaultUploadedPresentation + ")", "error"
         }
@@ -1698,8 +1698,12 @@ class ApiController {
             log.debug("user provided filename: [${document.@filename}]");
             fileName = document.@filename.toString();
           }
-          downloadAndProcessDocument(document.@url.toString(), conf.getInternalId(), isCurrent /* default presentation */,
-                  fileName, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+
+          // Run slow download and processing async for fast API responses
+          task {
+            downloadAndProcessDocument(document.@url.toString(), conf.getInternalId(), isCurrent /* default presentation */,
+                    fileName, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+          }
         } else if (!StringUtils.isEmpty(document.@name.toString())) {
           def b64 = new Base64()
           def decodedBytes = b64.decode(document.text().getBytes())

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -47,7 +47,6 @@ import org.bigbluebutton.web.services.turn.StunTurnService
 import org.bigbluebutton.web.services.turn.TurnEntry
 import org.codehaus.groovy.util.ListHashMap
 import org.json.JSONArray
-import static grails.async.Promises.*
 
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.http.HttpServletRequest
@@ -1660,7 +1659,7 @@ class ApiController {
           }
 
           // Run slow download and processing async for fast API responses
-          task {
+          presentationService.submitPresentationTask(conf.getInternalId(), "default presentation") {
             downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(),
                     document.current /* default presentation */, '', false,
                     true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
@@ -1700,8 +1699,9 @@ class ApiController {
           }
 
           // Run slow download and processing async for fast API responses
-          task {
-            downloadAndProcessDocument(document.@url.toString(), conf.getInternalId(), isCurrent /* default presentation */,
+          def documentUrl = document.@url.toString()
+          presentationService.submitPresentationTask(conf.getInternalId(), documentUrl) {
+            downloadAndProcessDocument(documentUrl, conf.getInternalId(), isCurrent /* default presentation */,
                     fileName, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
           }
         } else if (!StringUtils.isEmpty(document.@name.toString())) {
@@ -1709,8 +1709,9 @@ class ApiController {
           def decodedBytes = b64.decode(document.text().getBytes())
 
           // Run slow processing async for fast API responses
-          task {
-            processDocumentFromRawBytes(decodedBytes, document.@name.toString(),
+          def documentName = document.@name.toString()
+          presentationService.submitPresentationTask(conf.getInternalId(), documentName) {
+            processDocumentFromRawBytes(decodedBytes, documentName,
                     conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
           }
         } else {
@@ -1810,8 +1811,8 @@ class ApiController {
       try {
         presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1], "UTF-8");
       } catch (UnsupportedEncodingException e) {
+        // Runs off the request thread: log only, rendering a response here is not possible
         log.error "Couldn't decode the uploaded file name.", e
-        invalid("fileNameError", "Cannot decode the uploaded file name")
         return;
       }
     } else {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -248,7 +248,15 @@ class ApiController {
 
     if (meetingService.createMeeting(newMeeting)) {
       // See if the request came with pre-uploading of presentation.
-      uploadDocuments(xmlModules, newMeeting, false);
+      // The meeting is already created and running, so a failure in the
+      // synchronous portion of the upload handling must not turn a successful
+      // creation into a 500 — log it and still respond with success (the actual
+      // download/processing runs async and reports its own failures).
+      try {
+        uploadDocuments(xmlModules, newMeeting, false);
+      } catch (Exception e) {
+        log.error("Failed to handle pre-uploaded presentations for meeting [${newMeeting.getInternalId()}]", e)
+      }
 
       respondWithConference(newMeeting, null, null)
     } else {

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1707,8 +1707,12 @@ class ApiController {
         } else if (!StringUtils.isEmpty(document.@name.toString())) {
           def b64 = new Base64()
           def decodedBytes = b64.decode(document.text().getBytes())
-          processDocumentFromRawBytes(decodedBytes, document.@name.toString(),
-                  conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
+
+          // Run slow processing async for fast API responses
+          task {
+            processDocumentFromRawBytes(decodedBytes, document.@name.toString(),
+                    conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
+          }
         } else {
           log.debug("presentation module config found, but it did not contain url or name attributes");
         }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -247,9 +247,14 @@ class ApiController {
     }
 
     if (meetingService.createMeeting(newMeeting)) {
+
+      // Run slow pre-uploaded slides handling async for fast API responses
+      task {
+        // See if the request came with pre-uploading of presentation.
+        uploadDocuments(xmlModules, newMeeting, false);
+      }
+
       respondWithConference(newMeeting, null, null)
-      // See if the request came with pre-uploading of presentation.
-      uploadDocuments(xmlModules, newMeeting, false);  //
     } else {
       // Translate the external meeting id into an internal meeting id.
       String internalMeetingId = paramsProcessorUtil.convertToInternalMeetingId(params.meetingID);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1192,7 +1192,8 @@ class ApiController {
       requestBody = StringUtils.isEmpty(requestBody) ? null : requestBody
 
       def xmlModules = processRequestXmlModules(requestBody)
-      if (uploadDocuments(xmlModules, meeting, true)) {
+      def uploadResult = uploadDocuments(xmlModules, meeting, true)
+      if (uploadResult == true) {
         withFormat {
           xml {
             render(text: responseBuilder.buildInsertDocumentResponse("Presentation is being uploaded", RESP_CODE_SUCCESS)
@@ -1200,6 +1201,19 @@ class ApiController {
           }
           '*' {
             render(text: responseBuilder.buildInsertDocumentResponse("Presentation is being uploaded", RESP_CODE_SUCCESS)
+                    , contentType: "text/xml")
+          }
+        }
+      } else if (uploadResult == "invalid_filename") {
+        withFormat {
+          xml {
+            render(text: responseBuilder.buildInsertDocumentResponse(
+                    "One or more documents could not be uploaded due to an invalid filename.", RESP_CODE_FAILED)
+                    , contentType: "text/xml")
+          }
+          '*' {
+            render(text: responseBuilder.buildInsertDocumentResponse(
+                    "One or more documents could not be uploaded due to an invalid filename.", RESP_CODE_FAILED)
                     , contentType: "text/xml")
           }
         }
@@ -1645,6 +1659,14 @@ class ApiController {
       presentationListHasCurrent = hasCurrent;
     }
 
+    // Filenames are validated synchronously (on the request thread) while the
+    // request is still in scope; the slow download/processing is only submitted
+    // afterwards. Collect the submissions and defer them so that, for
+    // insertDocument, an invalid filename can be reported as a failed response
+    // instead of being silently skipped.
+    def pendingPresentationTasks = []
+    boolean invalidFilenameFound = false
+
     listOfPresentation.eachWithIndex { document, index ->
       def Boolean isCurrent = false;
       def Boolean isRemovable = true;
@@ -1664,11 +1686,14 @@ class ApiController {
           def defaultPresFilename = resolvePresentationFilename(defaultPresentationUrl, '', false)
           if (defaultPresFilename == null) {
             log.error("Skipping default presentation: could not derive a valid filename from [${defaultPresentationUrl}]")
+            invalidFilenameFound = true
           } else {
-            presentationService.submitPresentationTask(conf.getInternalId(), "default presentation") {
-              downloadAndProcessDocument(defaultPresentationUrl, conf.getInternalId(),
-                      document.current /* default presentation */, defaultPresFilename, false,
-                      true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+            pendingPresentationTasks << {
+              presentationService.submitPresentationTask(conf.getInternalId(), "default presentation") {
+                downloadAndProcessDocument(defaultPresentationUrl, conf.getInternalId(),
+                        document.current /* default presentation */, defaultPresFilename, false,
+                        true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+              }
             }
           }
         } else {
@@ -1711,10 +1736,13 @@ class ApiController {
           def presOrigFilename = resolvePresentationFilename(documentUrl, fileName, isPreUploadedPresentationFromParameter)
           if (presOrigFilename == null) {
             log.error("Skipping presentation [${documentUrl}]: could not derive a valid filename")
+            invalidFilenameFound = true
           } else {
-            presentationService.submitPresentationTask(conf.getInternalId(), documentUrl) {
-              downloadAndProcessDocument(documentUrl, conf.getInternalId(), isCurrent /* default presentation */,
-                      presOrigFilename, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+            pendingPresentationTasks << {
+              presentationService.submitPresentationTask(conf.getInternalId(), documentUrl) {
+                downloadAndProcessDocument(documentUrl, conf.getInternalId(), isCurrent /* default presentation */,
+                        presOrigFilename, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+              }
             }
           }
         } else if (!StringUtils.isEmpty(document.@name.toString())) {
@@ -1723,13 +1751,16 @@ class ApiController {
           def documentName = resolvePresentationFilename(null, document.@name.toString(), false)
           if (documentName == null) {
             log.error("Skipping raw-bytes presentation: invalid document name [${document.@name}]")
+            invalidFilenameFound = true
           } else {
             def b64 = new Base64()
             def decodedBytes = b64.decode(document.text().getBytes())
 
-            presentationService.submitPresentationTask(conf.getInternalId(), documentName) {
-              processDocumentFromRawBytes(decodedBytes, documentName,
-                      conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
+            pendingPresentationTasks << {
+              presentationService.submitPresentationTask(conf.getInternalId(), documentName) {
+                processDocumentFromRawBytes(decodedBytes, documentName,
+                        conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
+              }
             }
           }
         } else {
@@ -1737,6 +1768,17 @@ class ApiController {
         }
       }
     }
+
+    // For insertDocument, reject the whole request if any document had an invalid
+    // filename so the caller reports a failure rather than a misleading SUCCESS.
+    // For create, invalid documents are just skipped (logged above) and meeting
+    // creation still proceeds with the valid ones.
+    if (isFromInsertAPI && invalidFilenameFound) {
+      log.warn("insertDocument rejected for meeting [${conf.getInternalId()}]: one or more documents had an invalid filename")
+      return "invalid_filename"
+    }
+
+    pendingPresentationTasks.each { it() }
     return true
   }
 
@@ -1832,8 +1874,12 @@ class ApiController {
     String presOrigFilename
     if (StringUtils.isEmpty(providedFilename)) {
       try {
-        presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1], "UTF-8")
-      } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+        // Derive the name from the URL path only, dropping any query string or
+        // fragment (e.g. presigned S3 links carry ?X-Amz-... parameters that are
+        // not part of the filename), then percent-decode it.
+        String urlPath = new URL(address.toString()).getPath()
+        presOrigFilename = URLDecoder.decode(FilenameUtils.getName(urlPath), "UTF-8")
+      } catch (MalformedURLException | UnsupportedEncodingException | IllegalArgumentException e) {
         log.error "Couldn't decode the uploaded file name from [${address}].", e
         return null
       }

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ApiController.groovy
@@ -1658,11 +1658,18 @@ class ApiController {
             isDefaultPresentation = true
           }
 
-          // Run slow download and processing async for fast API responses
-          presentationService.submitPresentationTask(conf.getInternalId(), "default presentation") {
-            downloadAndProcessDocument(presentationService.defaultUploadedPresentation, conf.getInternalId(),
-                    document.current /* default presentation */, '', false,
-                    true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+          // Validate the filename on the request thread; only then run the slow
+          // download and processing async for fast API responses
+          def defaultPresentationUrl = presentationService.defaultUploadedPresentation
+          def defaultPresFilename = resolvePresentationFilename(defaultPresentationUrl, '', false)
+          if (defaultPresFilename == null) {
+            log.error("Skipping default presentation: could not derive a valid filename from [${defaultPresentationUrl}]")
+          } else {
+            presentationService.submitPresentationTask(conf.getInternalId(), "default presentation") {
+              downloadAndProcessDocument(defaultPresentationUrl, conf.getInternalId(),
+                      document.current /* default presentation */, defaultPresFilename, false,
+                      true, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+            }
           }
         } else {
           log.error "Default presentation could not be read, it is (" + presentationService.defaultUploadedPresentation + ")", "error"
@@ -1698,21 +1705,32 @@ class ApiController {
             fileName = document.@filename.toString();
           }
 
-          // Run slow download and processing async for fast API responses
+          // Validate the filename on the request thread, where failures are still
+          // tied to the request; only then run the slow download and processing async
           def documentUrl = document.@url.toString()
-          presentationService.submitPresentationTask(conf.getInternalId(), documentUrl) {
-            downloadAndProcessDocument(documentUrl, conf.getInternalId(), isCurrent /* default presentation */,
-                    fileName, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+          def presOrigFilename = resolvePresentationFilename(documentUrl, fileName, isPreUploadedPresentationFromParameter)
+          if (presOrigFilename == null) {
+            log.error("Skipping presentation [${documentUrl}]: could not derive a valid filename")
+          } else {
+            presentationService.submitPresentationTask(conf.getInternalId(), documentUrl) {
+              downloadAndProcessDocument(documentUrl, conf.getInternalId(), isCurrent /* default presentation */,
+                      presOrigFilename, isDownloadable, isRemovable, isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI);
+            }
           }
         } else if (!StringUtils.isEmpty(document.@name.toString())) {
-          def b64 = new Base64()
-          def decodedBytes = b64.decode(document.text().getBytes())
+          // Validate the document name on the request thread; only then run the
+          // slow processing async
+          def documentName = resolvePresentationFilename(null, document.@name.toString(), false)
+          if (documentName == null) {
+            log.error("Skipping raw-bytes presentation: invalid document name [${document.@name}]")
+          } else {
+            def b64 = new Base64()
+            def decodedBytes = b64.decode(document.text().getBytes())
 
-          // Run slow processing async for fast API responses
-          def documentName = document.@name.toString()
-          presentationService.submitPresentationTask(conf.getInternalId(), documentName) {
-            processDocumentFromRawBytes(decodedBytes, documentName,
-                    conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
+            presentationService.submitPresentationTask(conf.getInternalId(), documentName) {
+              processDocumentFromRawBytes(decodedBytes, documentName,
+                      conf.getInternalId(), isCurrent, isDownloadable, isRemovable/* default presentation */, isDefaultPresentation, isFromInsertAPI);
+            }
           }
         } else {
           log.debug("presentation module config found, but it did not contain url or name attributes");
@@ -1803,21 +1821,38 @@ class ApiController {
     }
   }
 
-  private downloadAndProcessDocument(address, meetingId, current, fileName, isDownloadable, isRemovable,
-                                 isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI) {
-    log.debug("ApiController#downloadAndProcessDocument(${address}, ${meetingId}, ${fileName})");
-    String presOrigFilename;
-    if (StringUtils.isEmpty(fileName)) {
+  /**
+   * Derives and validates a presentation's original filename, either from the
+   * caller-provided name or from the last segment of the download address.
+   * Runs on the request thread, before the async download/processing task is
+   * submitted, so invalid filenames are detected while the request is still
+   * being handled. Returns null when no valid filename can be derived.
+   */
+  private String resolvePresentationFilename(address, String providedFilename, Boolean allowMissingExtension) {
+    String presOrigFilename
+    if (StringUtils.isEmpty(providedFilename)) {
       try {
-        presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1], "UTF-8");
-      } catch (UnsupportedEncodingException e) {
-        // Runs off the request thread: log only, rendering a response here is not possible
-        log.error "Couldn't decode the uploaded file name.", e
-        return;
+        presOrigFilename = URLDecoder.decode(address.tokenize("/")[-1], "UTF-8")
+      } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+        log.error "Couldn't decode the uploaded file name from [${address}].", e
+        return null
       }
     } else {
-      presOrigFilename = fileName;
+      presOrigFilename = providedFilename
     }
+
+    String presFilename = FilenameUtils.getName(presOrigFilename)
+    String filenameExt = FilenameUtils.getExtension(presOrigFilename)
+    if (StringUtils.isEmpty(presFilename) || (StringUtils.isEmpty(filenameExt) && !allowMissingExtension)) {
+      log.error("Invalid presentation filename [${presOrigFilename}]")
+      return null
+    }
+    return presOrigFilename
+  }
+
+  private downloadAndProcessDocument(address, meetingId, current, presOrigFilename, isDownloadable, isRemovable,
+                                 isDefaultPresentation, isPreUploadedPresentationFromParameter, isFromInsertAPI) {
+    log.debug("ApiController#downloadAndProcessDocument(${address}, ${meetingId}, ${presOrigFilename})");
 
     def uploadFailed = false
     def uploadFailReasons = new ArrayList<String>()
@@ -1857,7 +1892,7 @@ class ApiController {
             }
             break
           default:
-            log.error("Failed to download presentation=[${address}], meeting=[${meetingId}], fileName=[${fileName}]")
+            log.error("Failed to download presentation=[${address}], meeting=[${meetingId}], fileName=[${presOrigFilename}]")
             uploadFailReasons.add("failed_to_download_file")
             uploadFailed = true
         }

--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -23,8 +23,13 @@ import org.bigbluebutton.api.service.ServiceUtils
 import org.bigbluebutton.presentation.DocumentConversionService
 import org.bigbluebutton.presentation.UploadedPresentation
 import org.springframework.beans.factory.annotation.Autowired
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class PresentationService {
 
@@ -41,6 +46,40 @@ class PresentationService {
 	def preUploadedPresentationOverrideDefault
 	def scanUploadedPresentationFiles
 	def pageTokenSecret
+	def numDownloadThreads
+
+	private ExecutorService downloadExecutor
+
+	@PostConstruct
+	void initDownloadExecutor() {
+		int threads = (numDownloadThreads ?: 5) as int
+		AtomicInteger threadSeq = new AtomicInteger()
+		downloadExecutor = Executors.newFixedThreadPool(threads, { Runnable r ->
+			Thread t = new Thread(r, "pres-download-" + threadSeq.incrementAndGet())
+			t.daemon = true
+			return t
+		} as ThreadFactory)
+	}
+
+	@PreDestroy
+	void shutdownDownloadExecutor() {
+		downloadExecutor?.shutdownNow()
+	}
+
+	/**
+	 * Runs presentation download/processing off the request thread so API responses
+	 * are not delayed by it. The pool is bounded (numPresentationDownloadThreads) and
+	 * any failure escaping the work closure is logged with meeting context.
+	 */
+	void submitPresentationTask(String meetingId, String source, Closure work) {
+		downloadExecutor.submit({
+			try {
+				work()
+			} catch (Throwable t) {
+				log.error("Failed to process pre-uploaded presentation for meeting [${meetingId}], source [${source}]", t)
+			}
+		} as Runnable)
+	}
 
 	def deletePresentation = {conf, room, filename ->
 		def directory = new File(roomDirectory(conf, room).absolutePath + File.separatorChar + filename)

--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -60,7 +60,11 @@ class PresentationService {
 
 	@PostConstruct
 	void initDownloadExecutor() {
-		int threads = (numDownloadThreads ?: 5) as int
+		// Clamp to at least 1: a configured 0 or negative would make the
+		// ThreadPoolExecutor constructor throw and fail bean initialization.
+		// (numDownloadThreads is injected as a String, so "0" is truthy here and
+		// slips past the Elvis default — only null/empty falls back to 5.)
+		int threads = Math.max(1, (numDownloadThreads ?: 5) as int)
 		AtomicInteger threadSeq = new AtomicInteger()
 		ThreadFactory threadFactory = { Runnable r ->
 			Thread t = new Thread(r, "pres-download-" + threadSeq.incrementAndGet())

--- a/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
+++ b/bigbluebutton-web/grails-app/services/org/bigbluebutton/web/services/PresentationService.groovy
@@ -27,7 +27,10 @@ import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -48,17 +51,31 @@ class PresentationService {
 	def pageTokenSecret
 	def numDownloadThreads
 
+	// Bounds how many tasks may wait for a free download thread, as a multiple of
+	// the pool size. Keeps a burst of create/insertDocument requests from queueing
+	// without limit (each raw-bytes task can hold a whole file in memory).
+	private static final int DOWNLOAD_QUEUE_CAPACITY_PER_THREAD = 20
+
 	private ExecutorService downloadExecutor
 
 	@PostConstruct
 	void initDownloadExecutor() {
 		int threads = (numDownloadThreads ?: 5) as int
 		AtomicInteger threadSeq = new AtomicInteger()
-		downloadExecutor = Executors.newFixedThreadPool(threads, { Runnable r ->
+		ThreadFactory threadFactory = { Runnable r ->
 			Thread t = new Thread(r, "pres-download-" + threadSeq.incrementAndGet())
 			t.daemon = true
 			return t
-		} as ThreadFactory)
+		} as ThreadFactory
+		// Fixed pool with a *bounded* queue. Executors.newFixedThreadPool would use an
+		// unbounded queue, letting bursts pile up until the heap is exhausted; here
+		// excess tasks are rejected (see submitPresentationTask) instead.
+		downloadExecutor = new ThreadPoolExecutor(
+				threads, threads,
+				0L, TimeUnit.MILLISECONDS,
+				new LinkedBlockingQueue<Runnable>(threads * DOWNLOAD_QUEUE_CAPACITY_PER_THREAD),
+				threadFactory,
+				new ThreadPoolExecutor.AbortPolicy())
 	}
 
 	@PreDestroy
@@ -69,16 +86,24 @@ class PresentationService {
 	/**
 	 * Runs presentation download/processing off the request thread so API responses
 	 * are not delayed by it. The pool is bounded (numPresentationDownloadThreads) and
-	 * any failure escaping the work closure is logged with meeting context.
+	 * backed by a bounded queue; if it is saturated the task is rejected and logged
+	 * rather than queued without limit. Any failure escaping the work closure is
+	 * logged with meeting context. Returns false when the task could not be accepted.
 	 */
-	void submitPresentationTask(String meetingId, String source, Closure work) {
-		downloadExecutor.submit({
-			try {
-				work()
-			} catch (Throwable t) {
-				log.error("Failed to process pre-uploaded presentation for meeting [${meetingId}], source [${source}]", t)
-			}
-		} as Runnable)
+	boolean submitPresentationTask(String meetingId, String source, Closure work) {
+		try {
+			downloadExecutor.submit({
+				try {
+					work()
+				} catch (Throwable t) {
+					log.error("Failed to process pre-uploaded presentation for meeting [${meetingId}], source [${source}]", t)
+				}
+			} as Runnable)
+			return true
+		} catch (RejectedExecutionException e) {
+			log.error("Rejected pre-uploaded presentation task, download pool saturated for meeting [${meetingId}], source [${source}]", e)
+			return false
+		}
 	}
 
 	def deletePresentation = {conf, room, filename ->

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -966,7 +966,7 @@ $ sudo bbb-conf --restart
 
 #### Tune parallel downloads of pre-uploaded presentations
 
-Presentations pre-uploaded through the `create` or `insertDocument` API calls are downloaded and processed in the background, on a bounded thread pool, so the API response is not delayed. By default up to 5 documents are downloaded in parallel per server; further documents wait in a queue. To change this, add an overwrite rule in `/etc/bigbluebutton/bbb-web.properties` and set the `numPresentationDownloadThreads` value:
+Presentations pre-uploaded through the `create` or `insertDocument` API calls are downloaded and processed in the background, on a bounded thread pool, so the API response is not delayed. By default up to 5 documents are downloaded in parallel per server; additional documents wait in a bounded queue. If the server is under sustained overload and that queue is full, further presentation tasks are rejected (and logged) instead of being queued without limit, which protects the server from running out of memory. To change the parallelism, add an overwrite rule in `/etc/bigbluebutton/bbb-web.properties` and set the `numPresentationDownloadThreads` value:
 
 ```properties
 numPresentationDownloadThreads=5
@@ -975,7 +975,7 @@ numPresentationDownloadThreads=5
 After you save the changes to `/etc/bigbluebutton/bbb-web.properties`, restart the BigBlueButton server with
 
 ```bash
-$ sudo bbb-conf --restart
+sudo bbb-conf --restart
 ```
 
 #### Increase the file size for an uploaded presentation

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -964,6 +964,20 @@ After you save the changes to `/etc/bigbluebutton/bbb-web.properties`, restart t
 $ sudo bbb-conf --restart
 ```
 
+#### Tune parallel downloads of pre-uploaded presentations
+
+Presentations pre-uploaded through the `create` or `insertDocument` API calls are downloaded and processed in the background, on a bounded thread pool, so the API response is not delayed. By default up to 5 documents are downloaded in parallel per server; further documents wait in a queue. To change this, add an overwrite rule in `/etc/bigbluebutton/bbb-web.properties` and set the `numPresentationDownloadThreads` value:
+
+```properties
+numPresentationDownloadThreads=5
+```
+
+After you save the changes to `/etc/bigbluebutton/bbb-web.properties`, restart the BigBlueButton server with
+
+```bash
+$ sudo bbb-conf --restart
+```
+
 #### Increase the file size for an uploaded presentation
 
 The default maximum file upload size for an uploaded presentation is 30 MB.

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -966,7 +966,7 @@ $ sudo bbb-conf --restart
 
 #### Tune parallel downloads of pre-uploaded presentations
 
-Presentations pre-uploaded through the `create` or `insertDocument` API calls are downloaded and processed in the background, on a bounded thread pool, so the API response is not delayed. By default up to 5 documents are downloaded in parallel per server; additional documents wait in a bounded queue. If the server is under sustained overload and that queue is full, further presentation tasks are rejected (and logged) instead of being queued without limit, which protects the server from running out of memory. To change the parallelism, add an overwrite rule in `/etc/bigbluebutton/bbb-web.properties` and set the `numPresentationDownloadThreads` value:
+Presentations pre-uploaded through the `create` or `insertDocument` API calls are downloaded and processed in the background, on a bounded thread pool, so the API response is not delayed. By default up to 5 documents are downloaded in parallel per server; additional documents wait in a bounded queue. If the server is under sustained overload and that queue is full, further presentation tasks are rejected (and logged) instead of being queued without limit, which protects the server from running out of memory. A rejected presentation is not uploaded into the meeting, and — like a download or conversion failure — this is not reflected in the `create`/`insertDocument` API response (which has already returned); it is only visible in the server log. To change the parallelism, add an overwrite rule in `/etc/bigbluebutton/bbb-web.properties` and set the `numPresentationDownloadThreads` value (values below 1 are treated as 1):
 
 ```properties
 numPresentationDownloadThreads=5

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -607,7 +607,7 @@ const createEndpointTableData = [
     "name": "preUploadedPresentation",
     "required": false,
     "type": "String",
-    "description": (<>If passed with a valid presentation file url, this presentation will override the default presentation. To only upload but not set as default, also pass <code className="language-plaintext highlighter-rouge">preUploadedPresentationOverrideDefault=false</code> (added 2.7.2)</>)
+    "description": (<>If passed with a valid presentation file url, this presentation will override the default presentation. To only upload but not set as default, also pass <code className="language-plaintext highlighter-rouge">preUploadedPresentationOverrideDefault=false</code> (added 2.7.2). The file is downloaded and processed in the background: the create response does not wait for it, and download or conversion failures are reported to meeting clients rather than in the create response.</>)
   },
   {
     "name": "preUploadedPresentationName",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -738,6 +738,8 @@ See [Passing user metadata to the client on join](/administration/customize/#pas
 
 This endpoint insert one or more documents into a running meeting via API call.
 
+The documents are downloaded and converted in the background: a `SUCCESS` response means the request was accepted, not that the documents are already available in the meeting. Download or conversion failures are reported to the meeting clients (and the server log), not in the API response. The same applies to presentations pre-uploaded through the `create` call (`preUploadedPresentation` or a request body with a `presentation` module).
+
 **Resource URL:**
 
 https&#58;//yourserver.com/bigbluebutton/api/insertDocument?[parameters]&checksum=[checksum]

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -738,7 +738,7 @@ See [Passing user metadata to the client on join](/administration/customize/#pas
 
 This endpoint insert one or more documents into a running meeting via API call.
 
-The documents are downloaded and converted in the background: a `SUCCESS` response means the request was accepted, not that the documents are already available in the meeting. Download or conversion failures are reported to the meeting clients (and the server log), not in the API response. The same applies to presentations pre-uploaded through the `create` call (`preUploadedPresentation` or a request body with a `presentation` module).
+The documents are downloaded and converted in the background: a `SUCCESS` response means the request was accepted, not that the documents are already available in the meeting. Download or conversion failures — and, when the server is overloaded, tasks rejected because the background download pool is saturated — are reported to the meeting clients (and the server log), not in the API response. The same applies to presentations pre-uploaded through the `create` call (`preUploadedPresentation` or a request body with a `presentation` module).
 
 **Resource URL:**
 


### PR DESCRIPTION
### What does this PR do?

Runs pre-uploaded presentation download and processing **asynchronously**, off the API request thread, so `create` and `insertDocument` respond immediately instead of blocking until every presentation has been downloaded and converted. Downloads also run **in parallel** rather than sequentially, so the time until all presentations are available inside the meeting is bounded by the slowest single file, not their sum.

This **supersedes #25333** (by @samuelwei) — it builds directly on that branch and keeps its commits, then replaces the `grails-async` `task {}` mechanism with a bounded, supervised executor after review discussion. Final state:

- Introduces `PresentationService.submitPresentationTask(...)`, backed by a bounded fixed-size thread pool (`@PostConstruct`-created, `@PreDestroy`-shut-down, daemon threads) sized by a new `numPresentationDownloadThreads` property (default 5), following the existing `numConversionThreads` / `numPluginManifestsFetchingThreads` convention. This replaces `grails-async`'s default **unbounded** promise pool and removes the `grails-async` dependency entirely.
- Wraps every submitted task in `try/catch(Throwable)` with meeting + source context, so a failure in the background download/processing is logged instead of being silently swallowed (as it was with unread promises).
- Validates the presentation filename **synchronously on the request thread** (`resolvePresentationFilename(...)`), before a task is submitted, at all three submit sites (default presentation, URL documents, raw-bytes documents) — so invalid filenames are rejected while the request is still in scope rather than dying quietly inside a background thread. This also catches `URLDecoder.decode`'s (reachable) `IllegalArgumentException` on malformed percent-encoding, and closes a pre-existing gap where the raw-bytes path's name-validation result was discarded.

### Closes Issue(s)

Closes #25331

### Motivation

`create` and `insertDocument` were blocked by the time it takes to download and convert pre-uploaded presentations. #24931 / #24971 attempted to fix this by responding before uploading on the same thread, but that does not change the client-observed response time: BBB's response is chunked, so it only completes when the Grails controller action returns — after the synchronous download. #25331 demonstrates the delay still occurs. Genuine off-thread hand-off is the only approach that removes it, and doing the downloads on a bounded pool keeps the fix from spawning an unbounded number of threads under a burst of API calls.

### How to test

1. Stand up an HTTP server that serves a PDF after an artificial delay (e.g. a small script that sleeps 5–8s before responding), reachable from the BBB server.
2. Call `create` with `preUploadedPresentation=<that URL>`.
3. **Expected:** the `create` response returns immediately (in the time of meeting creation alone), not after the download delay. Measure full-response time with `curl -w` or the browser Network tab — before this change it grows by roughly the download delay; after, it does not.
4. Join the meeting; the presentation still appears once its background download + conversion finish.
5. **Parallelism:** call `create`/`insertDocument` with several `<document url=.../>` entries pointing at the delayed server — they are downloaded concurrently (observable as overlapping requests on the source server), not one after another.
6. **Failure isolation:** point `preUploadedPresentation` at a 404/unreachable URL — `create` still returns `SUCCESS` promptly and the failure is logged server-side.

Tuning: `numPresentationDownloadThreads` in `/etc/bigbluebutton/bbb-web.properties` (default 5).

### More
<!-- Anything else we should know when reviewing? -->
- [x] Added/updated documentation (`docs/development/api.md`, `docs/data/create.tsx`, `docs/administration/customize.md`
