### PR TITLE
fix: The .csv export for LAD has the user 'Anonymous'

### DIFF
--- a/bbb-learning-dashboard/src/services/UserService.js
+++ b/bbb-learning-dashboard/src/services/UserService.js
@@ -217,7 +217,9 @@ export function makeUserCSVData(users, polls, intl) {
     // Add the anonymous answers
     anonymousRecord += `,"${pollValues[i].anonymousAnswers.join('\r\n')}"`;
   }
-  userRecords.Anonymous = anonymousRecord;
+  if (pollValues.some((poll) => poll.anonymous)) {
+    userRecords.Anonymous = anonymousRecord;
+  }
 
   return [
     header,

--- a/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.ts
+++ b/bigbluebutton-tests/playwright/learningdashboard/learningdashboard.ts
@@ -193,5 +193,8 @@ export class LearningDashboard extends MultiUsers {
     ];
 
     await checkTextContent(dataCSV.content, dataToCheck);
+    expect(dataCSV.content, 'should not include an anonymous row when no anonymous polls were created').not.toMatch(
+      /^"Anonymous"(?:,|$)/m,
+    );
   }
 }


### PR DESCRIPTION
### What does this PR do?

Updates learning dashboard exported csv to only include anonymous user if an anonymous poll was created in the meeting and includes a check for it in existing learning dashboard test.

### Closes Issue(s)
Closes #25447

### How to test
1. Start a session
2. Open the Learning Analytics Dashboard
3. Choose "Download session data"
4. View the downloaded .csv