### PR TITLE
[Backport of #25403] fix(data-consumption): prevent hook usage counter from going negative

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/utils.ts
@@ -10,6 +10,19 @@ import { ObjectToCustomSubscriptionHookContainerMap } from './domain/shared/cust
 import { ObjectToCustomQueryHookContainerMap } from './domain/shared/custom-query/types';
 import { ObjectToCustomHookContainerMap } from './types';
 import { EssentialHookInformation } from './domain/shared/types';
+import logger from '/imports/startup/client/logger';
+
+const applyHookUsageCountDelta = (hookName: string, currentCount: number, delta: number) => {
+  const newCount = currentCount + delta;
+  if (newCount < 0) {
+    logger.warn({
+      logCode: 'attempt_to_decrement_hook_usage_below_zero',
+      extraInfo: { hookName, currentCount, delta },
+    }, 'Attempted to decrement hook usage count below zero. This should not happen and indicates that something went wrong.');
+    return 0;
+  }
+  return newCount;
+};
 
 const hookUsageSetStateCallback = (
   removeEntry: boolean, mapObj: Map<string, Map<string, ObjectToCustomHookContainerMap>>,
@@ -24,7 +37,11 @@ const hookUsageSetStateCallback = (
     } else {
       const versionIncrement = (delta > 0 ? 1 : 0);
       mapToBeSet.set(hookArgumentsAsKey, {
-        count: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.count || 0) + delta,
+        count: applyHookUsageCountDelta(
+          hookName,
+          mapObj.get(hookName)?.get(hookArgumentsAsKey)?.count || 0,
+          delta,
+        ),
         version: (mapObj.get(hookName)?.get(hookArgumentsAsKey)?.version ?? 0) + versionIncrement,
         hookArguments,
       });
@@ -51,7 +68,11 @@ const updateHookUsage = (
       const newMap = new Map<string, EssentialHookInformation>(mapObj.entries());
       const versionIncrement = (delta > 0 ? 1 : 0);
       newMap.set(hookName, {
-        count: (mapObj.get(hookName)?.count || 0) + delta,
+        count: applyHookUsageCountDelta(
+          hookName,
+          (mapObj.get(hookName)?.count || 0),
+          delta,
+        ),
         version: (mapObj.get(hookName)?.version ?? 0) + versionIncrement,
       });
       return newMap;

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.0.104",
+        "bigbluebutton-html-plugin-sdk": "0.0.105",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -6822,9 +6822,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.0.104",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.104.tgz",
-      "integrity": "sha512-LiR9dTnIKENxnjf0qy8ztQBaiU10SMEI0zS5Z0D8LuqbSsKlWk3HTzgvC6JxFHnvP4xuvG/YYENFFwTcxIKr6w==",
+      "version": "0.0.105",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.0.105.tgz",
+      "integrity": "sha512-3SvXWPKg6VJjUIznbFlleCWW/l9BDLZbVxfVfsLifMaLo9dfJ+4LP3i8VvVokk/fdEDL/wu8RVloqpjin+rkYg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.0.104",
+    "bigbluebutton-html-plugin-sdk": "0.0.105",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -610,4 +610,4 @@ pluginManifestCacheRefreshIntervalMinutes=60
 # List the parameters without including the 'userdata-' prefix
 getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools
 
-html5PluginSdkVersion=0.0.104
+html5PluginSdkVersion=0.0.105


### PR DESCRIPTION
### What does this PR do?
The usage counter that tracks how many plugins are listening to a given subscription can reach negative values, which is invalid and likely indicates a bug in the unsubscribe logic.

Extract the hook usage update logic into a dedicated function that guards against negative values and logs a warning when such an update is attempted.

### Closes Issue(s)
Closes N/A

### More
Closely related to:
- bigbluebutton/bigbluebutton-html-plugin-sdk#275
- https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/278
- https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/279
- https://github.com/bigbluebutton/bigbluebutton/pull/25403