### PR TITLE
fix: broadcast external video seek detected via onProgress discontinuity

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/external-video-player/external-video-player-graphql/component.tsx
@@ -47,6 +47,32 @@ import getStorageSingletonInstance from '/imports/ui/services/storage';
 
 const AUTO_PLAY_BLOCK_DETECTION_TIMEOUT_SECONDS = 5;
 const TWITCH_VIDEO_SEEK_TIME_WINDOW = 1; // Twitch video seek time in seconds
+// react-player reports onProgress on this interval (its default; BBB does not override it).
+// It is passed to the player explicitly (progressInterval below) so a future prop change
+// cannot silently halve the detector's sensitivity.
+const PROGRESS_INTERVAL_SECONDS = 1;
+// Minimum divergence (seconds) between the expected playback position and the reported one
+// for a tick to be treated as a seek that react-player did not surface via onSeek (which is
+// every provider except FilePlayer, e.g. a YouTube scrub). A normal tick advances by about
+// playerPlaybackRate seconds, so a jump larger than a couple of intervals is a seek.
+// Sub-threshold scrubs (up to ~2s) are NOT broadcast, and nothing re-syncs the viewer
+// position periodically (viewers only re-seek when updatedAt changes), so a missed scrub
+// leaves viewers permanently offset by that amount and repeated small scrubs accumulate.
+// The threshold is a deliberate trade: tiny drags do not yank viewers, at the cost of a
+// standing offset that is only corrected by the next above-threshold seek.
+const SEEK_DETECTION_THRESHOLD_SECONDS = 2 * PROGRESS_INTERVAL_SECONDS;
+// After detecting a discontinuity, stash it and confirm on the next tick that the new
+// position is a sustained playback point before broadcasting. A single-tick glitch (a
+// YouTube ad boundary, where getCurrentTime returns the ad position near 0, or a buffering
+// hiccup) reports a transient position that self-corrects, so demanding two consistent ticks
+// filters it at the cost of ~1s of viewer-follow latency (viewers already lag by about that).
+// This path is the only seek propagation for every provider except FilePlayer, so the
+// insurance is worth it.
+const SEEK_CONFIRMATION_THRESHOLD_SECONDS = SEEK_DETECTION_THRESHOLD_SECONDS;
+// Minimum wall-clock gap between two broadcast seeks from the discontinuity detector. Cheap
+// insurance against a provider whose getCurrentTime oscillates and would otherwise fan out a
+// mutation (a DB write plus a recording event) to every participant every tick.
+const MIN_SEEK_BROADCAST_INTERVAL_SECONDS = 2;
 
 const intlMessages = defineMessages({
   autoPlayWarning: {
@@ -199,10 +225,33 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const presenterRef = useRef(isPresenter);
   const [reactPlayerPlaying, setReactPlayerPlaying] = React.useState(false);
+  // Mirrors reactPlayerPlaying for synchronous reads inside callbacks (avoids a stale
+  // closure): handleOnPlay must know whether this was a real resume or a YouTube re-play
+  // after buffering on a seek.
+  const reactPlayerPlayingRef = useRef(false);
   const firstPlayRef = useRef(true);
   const [playerUrl, setPlayerUrl] = React.useState('');
   const lastCursorRef = useRef<{ position: number, updateAt: number }>({ position: 0, updateAt: 0 });
+  // Tracks the last onProgress tick (playedSeconds + wall-clock) so handleProgress
+  // can detect a seek the player did not surface via onSeek (every provider except
+  // FilePlayer, e.g. a YouTube scrub).
+  const lastProgressRef = useRef<{ playedSeconds: number, at: number } | null>(null);
+  // A detected discontinuity awaiting the two-tick confirmation (see
+  // SEEK_CONFIRMATION_THRESHOLD_SECONDS). Reset wherever the baseline is reset.
+  const pendingSeekRef = useRef<{ playedSeconds: number, at: number } | null>(null);
+  // Wall-clock of the last seek broadcast by the discontinuity detector, for the rate limit.
+  const lastSeekBroadcastAtRef = useRef(0);
+  // Monotonic tick counter: getPlaybackRate can be async (Vimeo), so two handleProgress
+  // invocations can be in flight; a stale tick must not emit or seed the baseline.
+  const tickSeqRef = useRef(0);
   const [stopExternalVideoShare] = useMutation(EXTERNAL_VIDEO_STOP);
+
+  // Keep the synchronous mirror ref and the state in sync so the ref never drifts from
+  // reactPlayerPlaying (the ref is read inside async callbacks to dodge a stale closure).
+  const setPlayerPlaying = (value: boolean) => {
+    reactPlayerPlayingRef.current = value;
+    setReactPlayerPlaying(value);
+  };
 
   let currentTime = getServerCurrentTime();
 
@@ -338,6 +387,13 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     } else {
       setPlayerUrl(videoUrl);
     }
+    // New video (or a player remount via playerKey rides the same reset path): clear the
+    // progress baseline so a stale position from the previous video is not misread as a seek
+    // on the first tick, drop any pending discontinuity, and reset the playing mirror so it
+    // does not carry a stale "was playing" into the fresh player.
+    lastProgressRef.current = null;
+    pendingSeekRef.current = null;
+    reactPlayerPlayingRef.current = false;
   }, [videoUrl, isPresenter]);
 
   useEffect(() => {
@@ -418,6 +474,13 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         setVolume(playerVolume > 1 ? playerVolume / 100 : playerVolume);
       }
 
+      // Reset the progress baseline on any presenter change. A stalled or autoplay-blocked
+      // viewer promoted to presenter would otherwise broadcast a spurious seek from its
+      // stale position on the first tick, yanking the whole meeting. A null baseline is the
+      // safe state (the next tick re-seeds).
+      lastProgressRef.current = null;
+      pendingSeekRef.current = null;
+
       presenterRef.current = isPresenter;
     }
   }, [isPresenter]);
@@ -440,10 +503,17 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (currentTime > playerCurrentTime) {
       playerRef?.current?.seekTo(currentTime, 'seconds');
     }
+    // Reset the progress baseline; the first onProgress tick after start seeds it. A start is
+    // also the remount path (new player mounts), so reset the pending discontinuity and the
+    // playing mirror too.
+    lastProgressRef.current = null;
+    pendingSeekRef.current = null;
+    reactPlayerPlayingRef.current = false;
   };
 
   const handleOnPlay = async () => {
-    setReactPlayerPlaying(true);
+    const wasPlaying = reactPlayerPlayingRef.current;
+    setPlayerPlaying(true);
     const internalPlayer = playerRef.current?.getInternalPlayer();
     const url = new URL(videoUrl);
     const isTwitch = url.hostname === 'twitch.tv' || url.hostname === 'www.twitch.tv';
@@ -475,10 +545,17 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (firstPlayRef.current) {
       firstPlayRef.current = false;
     }
+    // Reset the baseline only on a genuine paused->playing transition. react-player also
+    // fires onPlay when YouTube re-enters PLAYING after buffering on a far seek; nulling
+    // the baseline there would swallow the very discontinuity we need to detect (#25472).
+    if (!wasPlaying) {
+      lastProgressRef.current = null;
+      pendingSeekRef.current = null;
+    }
   };
 
   const handleOnStop = async () => {
-    setReactPlayerPlaying(false);
+    setPlayerPlaying(false);
     if (isPresenter && playing) {
       const internalPlayer = playerRef.current?.getInternalPlayer();
       let rate = (internalPlayer instanceof HTMLVideoElement || internalPlayer instanceof HTMLAudioElement)
@@ -499,21 +576,103 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
     if (!isPresenter && playing) {
       playVideo(playerRef.current as ReactPlayer);
     }
+    // A pause resets the baseline so the following progress tick seeds fresh
+    // instead of accumulating drift against the pre-pause position.
+    lastProgressRef.current = null;
+    pendingSeekRef.current = null;
   };
 
   const handleProgress = async (state: OnProgressProps) => {
     setPlayed(state.played);
     setLoaded(state.loaded);
+    // Snapshot the baseline and wall-clock before the await below. getPlaybackRate can be
+    // async (Vimeo), so an interleaved handleOnSeek could otherwise land between the read
+    // and the write; capturing here keeps this tick consistent and lets the write below be
+    // skipped when a fresher baseline was synced meanwhile.
+    const now = Date.now();
+    const baseline = lastProgressRef.current;
+    // Claim a monotonic sequence for this tick. If a newer tick starts while we await the
+    // (possibly async) rate read below, the newer one owns the cycle and this stale tick must
+    // not emit a seek or seed the baseline. This closes the tick-vs-tick race, distinct from
+    // the interleaved handleOnSeek case the identity guard on the baseline write covers.
+    tickSeqRef.current += 1;
+    const seq = tickSeqRef.current;
     if (playing && isPresenter) {
       currentTime = getServerCurrentTime();
     }
     const interPlayerPlaybackRate = await getPlaybackRate(playerRef.current as ReactPlayer);
-    if (isPresenter && interPlayerPlaybackRate !== playerPlaybackRate) {
-      sendMessage('seek', {
-        rate: interPlayerPlaybackRate,
-        time: currentTime,
-        state: playing ? 'playing' : '',
-      });
+    const isLatestTick = tickSeqRef.current === seq;
+
+    if (isPresenter && isLatestTick) {
+      // Emit at most one seek per tick. A real seek (position discontinuity) takes
+      // precedence over a bare playback-rate change and carries the real local position
+      // (state.playedSeconds) instead of the pre-seek, server-derived currentTime.
+      let seekMessage: { rate: number; time: number; state: string } | null = null;
+
+      // Detect a seek react-player did not surface via onSeek (every provider except
+      // FilePlayer, e.g. a YouTube scrub). Extrapolate the expected position from the last
+      // tick using the real playback rate, then use a SIGNED drift so the three cases stay
+      // separate: a jump AHEAD of the extrapolation is a fast-forward seek; a move BACKWARD
+      // past the last reported position is a backward seek; a playhead that advanced but by
+      // less than wall-clock predicted (drift < -threshold, still moving forward) is a stall,
+      // not a seek, and is left alone. This is why a backgrounded presenter tab does not yank
+      // every viewer backward, and why a small backward scrub is no longer silently dropped.
+      if (playing && baseline) {
+        const elapsedSeconds = (now - baseline.at) / 1000;
+        const expectedPosition = baseline.playedSeconds + (elapsedSeconds * interPlayerPlaybackRate);
+        const drift = state.playedSeconds - expectedPosition;
+        const jumpedAhead = drift > SEEK_DETECTION_THRESHOLD_SECONDS;
+        const jumpedBack = state.playedSeconds < baseline.playedSeconds - SEEK_DETECTION_THRESHOLD_SECONDS;
+        const discontinuity = jumpedAhead || jumpedBack;
+
+        const pending = pendingSeekRef.current;
+        if (pending) {
+          // Two-tick confirmation: broadcast only when this tick continues playback from the
+          // stashed discontinuity (it settled on a sustained position). A one-tick glitch
+          // (a YouTube ad boundary reporting the ad position near 0, or buffering) does not
+          // continue, so it is discarded here instead of yanking the whole meeting to 0:02
+          // and writing that into the recording. Rate-limited as insurance against a provider
+          // whose getCurrentTime oscillates.
+          const pendingElapsed = (now - pending.at) / 1000;
+          const expectedFromPending = pending.playedSeconds + (pendingElapsed * interPlayerPlaybackRate);
+          const confirmed = Math.abs(state.playedSeconds - expectedFromPending) <= SEEK_CONFIRMATION_THRESHOLD_SECONDS;
+          pendingSeekRef.current = null;
+          if (confirmed
+            && (now - lastSeekBroadcastAtRef.current) >= MIN_SEEK_BROADCAST_INTERVAL_SECONDS * 1000) {
+            seekMessage = {
+              rate: interPlayerPlaybackRate,
+              time: state.playedSeconds,
+              state: 'playing',
+            };
+            lastSeekBroadcastAtRef.current = now;
+          } else if (discontinuity) {
+            // Not the continuation we expected, but still discontinuous: re-arm on this new
+            // position so a genuine seek that landed mid-glitch is not lost.
+            pendingSeekRef.current = { playedSeconds: state.playedSeconds, at: now };
+          }
+        } else if (discontinuity) {
+          pendingSeekRef.current = { playedSeconds: state.playedSeconds, at: now };
+        }
+      }
+
+      if (!seekMessage && interPlayerPlaybackRate !== playerPlaybackRate) {
+        seekMessage = {
+          rate: interPlayerPlaybackRate,
+          time: currentTime,
+          state: playing ? 'playing' : '',
+        };
+      }
+
+      if (seekMessage) {
+        sendMessage('seek', seekMessage);
+      }
+    }
+
+    // Seed the baseline for the next tick, but only if this is still the latest tick and no
+    // interleaved handler advanced the baseline while we awaited the playback rate; otherwise
+    // a stale tick would clobber a synced handleOnSeek baseline and cause a duplicate emit.
+    if (isLatestTick && lastProgressRef.current === baseline) {
+      lastProgressRef.current = { playedSeconds: state.playedSeconds, at: now };
     }
 
     const storedVolume = storage.getItem('externalVideoVolume');
@@ -545,6 +704,14 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
         position: typeof cursor === 'number' ? cursor : cursor.position,
         updateAt: Date.now(),
       };
+      // Sync the progress baseline so the next handleProgress tick does not re-detect this
+      // same seek as a discontinuity and emit a duplicate, and drop any pending discontinuity
+      // this native seek supersedes.
+      lastProgressRef.current = {
+        playedSeconds: typeof cursor === 'number' ? cursor : cursor.position,
+        at: Date.now(),
+      };
+      pendingSeekRef.current = null;
     } else {
       playVideo(playerRef.current as ReactPlayer);
     }
@@ -627,6 +794,7 @@ const ExternalVideoPlayer: React.FC<ExternalVideoPlayerProps> = ({
               url={playerUrl}
               playing={playing}
               playbackRate={playerPlaybackRate}
+              progressInterval={PROGRESS_INTERVAL_SECONDS * 1000}
               key={playerKey}
               height="100%"
               width="100%"

--- a/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.spec.ts
@@ -121,6 +121,18 @@ test.describe.parallel('Presentation', { tag: '@ci' }, () => {
       await presentation.startExternalVideo();
       await presentation.endExternalVideo();
     });
+
+    // https://github.com/bigbluebutton/bigbluebutton/issues/25472
+    // Regression: presenter scrubbing the external video while playing must broadcast the
+    // new position. Adapters like YouTube do not emit a seek event, so before the fix the
+    // viewer stayed stuck. Asserts the viewer's playhead follows the presenter's seek.
+    test('Seek external video while playing', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25472);
+      const presentation = new Presentation(browser, context);
+      await presentation.initPages(page, testInfo);
+      await presentation.startExternalVideo();
+      await presentation.seekExternalVideoWhilePlaying();
+    });
   });
 
   test.describe.parallel('Manage', () => {

--- a/bigbluebutton-tests/playwright/presentation/presentation.ts
+++ b/bigbluebutton-tests/playwright/presentation/presentation.ts
@@ -190,6 +190,100 @@ export class Presentation extends MultiUsers {
     await this.modPage.hasElement(e.whiteboard, 'should display the whiteboard after stopping the external video');
   }
 
+  // Regression test for issue #25472: when the presenter scrubs the external video while
+  // it is playing, the new position must be broadcast so viewers follow. react-player only
+  // surfaces a native seek event for FilePlayer; every hosted provider (YouTube here, plus
+  // Vimeo, Twitch, etc.) does not, so the client detects the discontinuity in onProgress and
+  // re-broadcasts it. This test drives YouTube, the common case. We assert the behaviour
+  // users actually care about: the viewer's playhead advances to the presenter's new
+  // position. That is stronger than counting outbound mutations and immune to WebSocket
+  // timing. Assumes startExternalVideo() already shared the video (chained in the spec).
+  async seekExternalVideoWhilePlaying() {
+    const { externalVideoPlayer } = this.modPage.settings || {};
+    // startExternalVideo() already asserted the share button is absent when the feature is
+    // disabled; nothing to seek in that case.
+    if (!externalVideoPlayer) return;
+
+    // startExternalVideo() already fetched both frames and asserted the video element is
+    // present for moderator and viewer, so we only fetch the handles we need to drive here.
+    const modFrame = await this.modPage.getYoutubeFrame();
+    if (!modFrame) throw Error('Failed to get video frame element for moderator');
+    const userFrame = await this.userPage.getYoutubeFrame();
+    if (!userFrame) throw Error('Failed to get video frame element for attendee');
+
+    const readCurrentTime = (frame: typeof modFrame) =>
+      frame.frame.locator('video').evaluate((v: HTMLVideoElement) => v.currentTime);
+
+    // Let the video play a few onProgress ticks so the presenter's baseline is seeded. Poll
+    // for real advance (one tick is enough) instead of a fixed 15s wait, which cuts most of
+    // that time off this @ci test.
+    const playbackStart = await readCurrentTime(modFrame);
+    await expect
+      .poll(() => readCurrentTime(modFrame), {
+        message: 'moderator video should be playing before the seek',
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      })
+      .toBeGreaterThan(playbackStart + 3);
+
+    // Derive the seek target from the real duration instead of a hardcoded value: if
+    // youtubeLink changes, a fixed target could exceed the video length, YouTube would clamp
+    // to the end and fire onEnded, nulling the baseline (an opaque failure). The guard also
+    // covers v.duration being NaN (metadata not loaded), which would otherwise yield
+    // seekTarget = NaN, a no-op seekTo, and an opaque toBeGreaterThan(NaN) failure.
+    const duration = await modFrame.frame.locator('video').evaluate((v: HTMLVideoElement) => v.duration);
+    expect(duration, 'fixture video must be long enough to seek within').toBeGreaterThan(120);
+    const seekTarget = Math.floor(duration * 0.75);
+
+    // Self-validate against a fixture swap: the seek target must be well ahead of where
+    // natural playback has reached, or "the viewer followed the seek" would be satisfied by
+    // ordinary playback and prove nothing.
+    const beforeSeek = await readCurrentTime(userFrame);
+    expect(seekTarget - beforeSeek, 'seek target must be far ahead of natural playback').toBeGreaterThan(60);
+
+    // Scrub the YouTube player forward while it is playing. This is the path that does not
+    // emit a react-player onSeek event (the root cause of #25472). Scope the iframe lookup to
+    // the shared-video container (e.youtubeFrame) for consistency with getYoutubeFrame.
+    await this.modPage.page.evaluate(
+      ({ target, frameSelector }) => {
+        const iframe = document.querySelector<HTMLIFrameElement>(`${frameSelector} iframe`);
+        if (iframe && iframe.contentWindow) {
+          iframe.contentWindow.postMessage(
+            JSON.stringify({ event: 'command', func: 'seekTo', args: [target, true] }),
+            '*',
+          );
+        }
+      },
+      { target: seekTarget, frameSelector: e.youtubeFrame },
+    );
+
+    // Assert the PRESENTER actually seeked before checking the viewer. If the postMessage
+    // silently no-ops (YouTube protocol change, enablejsapi regression, iframe not matched),
+    // failing here points at the command, not at a phantom "viewer did not follow" product bug.
+    await expect
+      .poll(() => readCurrentTime(modFrame), {
+        message: 'presenter should have seeked',
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      })
+      .toBeGreaterThan(seekTarget - 5);
+
+    // YouTube re-buffers after a seek, so the viewer lands a little short of the target and
+    // then climbs; allow this much slack below the target when confirming the follow.
+    const VIEWER_FOLLOW_TOLERANCE_SECONDS = 15;
+    await expect
+      .poll(() => readCurrentTime(userFrame), {
+        message: 'viewer should follow the presenter mid-play external video seek',
+        timeout: ELEMENT_WAIT_EXTRA_LONG_TIME,
+      })
+      .toBeGreaterThan(seekTarget - VIEWER_FOLLOW_TOLERANCE_SECONDS);
+
+    // Upper-bound the viewer position so an overshoot to the end (which a one-sided lower
+    // bound would let pass) fails the test instead of reading as a follow.
+    const viewerAfter = await readCurrentTime(userFrame);
+    expect(viewerAfter, 'viewer should land near the seek target, not overshoot to the end').toBeLessThan(
+      seekTarget + 30,
+    );
+  }
+
   async uploadSinglePresentationTest() {
     // wait for whiteboard to load and no notifications
     await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);


### PR DESCRIPTION
### What does this PR do?

When the presenter scrubs a shared external video while it is playing, viewers do not follow — they stay at the old position.

react-player only fires `onSeek` for plain media files (mp4/audio). YouTube, Vimeo, Twitch, Facebook, DailyMotion and the custom BBB players (peertube, arc-player, panopto) never fire it, so a scrub on the embedded player never reached the client and no `externalVideoUpdate` was sent. Seeking while paused already worked, since pause and resume both broadcast the current position — only mid-play seeks were affected.

The presenter's client now detects the seek from the playback position itself: on each `onProgress` tick it compares the reported position against where playback should be by now, and broadcasts a seek when the two diverge by more than 2s. Viewers follow it like any other seek.

Guards so this never yanks viewers on its own:
- a detected jump is only broadcast after the next tick confirms playback continued from it, so a one-off glitch (YouTube ad boundary, buffering) is discarded;
- a playhead that advanced *less* than expected is treated as a stall, not a backward seek — this is what a throttled background tab looks like;
- at most one detected seek every 2s, and the baseline is reset on video change, play/pause and presenter change.

### Closes Issue(s)

Closes #25472

### How to test

1. As presenter, share an external video (YouTube reproduces the bug) and let it play.
2. Drag the presenter's playhead forward, then backward.
3. The viewer should jump to the same position within about a second.
4. With no scrubbing, the viewer should keep advancing normally and never jump backwards.

Automated: `presentation.spec.ts` → `Seek external video while playing`.

### More

- Verified live on 3.0 from source: forward and backward seeks both follow with a ~0.2s gap; [short video of presenter scrubbing and viewer following](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-07-23/39515cdf-d63f-41ef-b3eb-c00ca7c0afd4/seek-follow.mp4).
- Scrubs under 2s are intentionally not broadcast (tiny drags should not yank viewers), and nothing re-syncs periodically, so a viewer can stay off by that much until the next larger seek.
- 4.0 has an equivalent component and likely the same defect; out of scope here per the issue's version.

