### PR TITLE
test(ci): tag deterministic untagged specs with @ci so CI runs them

### DIFF
--- a/bigbluebutton-tests/playwright/chat/privateChatInput.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/privateChatInput.spec.ts
@@ -47,7 +47,7 @@ test.use({
   video: 'retain-on-failure',
 });
 
-test.describe('Private chat input visual evidence', () => {
+test.describe('Private chat input visual evidence', { tag: '@ci' }, () => {
   test('Reproduce the placeholder and caret transition when clearing a narrow private chat input', async ({
     browser,
     context,

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -3,7 +3,7 @@ import { initializePages, linkIssue } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
 import { Layouts } from './layouts';
 
-test.describe.parallel('Unified Layout - meeting create param', () => {
+test.describe.parallel('Unified Layout - meeting create param', { tag: '@ci' }, () => {
   test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
     const layouts = new Layouts(browser, context);
     await initializePages(layouts, browser, {
@@ -16,7 +16,7 @@ test.describe.parallel('Unified Layout - meeting create param', () => {
   });
 });
 
-test.describe.parallel('Unified Layout - meeting create param - with audio', () => {
+test.describe.parallel('Unified Layout - meeting create param - with audio', { tag: '@ci' }, () => {
   test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
     const layouts = new Layouts(browser, context);
     await initializePages(layouts, browser, {
@@ -32,7 +32,7 @@ test.describe.parallel('Unified Layout - meeting create param - with audio', () 
   });
 });
 
-test.describe.parallel('Unified Layout - who-is-talking tiles (no webcams)', () => {
+test.describe.parallel('Unified Layout - who-is-talking tiles (no webcams)', { tag: '@ci' }, () => {
   test('Speaking with no webcams keeps avatar tiles hidden while the presentation is visible', async ({ browser, context }, testInfo) => {
     linkIssue(25235);
     const layouts = new Layouts(browser, context);

--- a/bigbluebutton-tests/playwright/multifunctional-mode/multifunctionalMode.spec.ts
+++ b/bigbluebutton-tests/playwright/multifunctional-mode/multifunctionalMode.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../core/setup/fixtures';
 import { constants as c } from '../parameters/constants';
 import { MultifunctionalMode } from './multifunctionalMode';
 
-test.describe.parallel('Multifunctional Mode', () => {
+test.describe.parallel('Multifunctional Mode', { tag: '@ci' }, () => {
   test('Open a panel in the auxiliary sidebar', async ({ browser, context, page }, testInfo) => {
     const mfm = new MultifunctionalMode(browser, context);
     await mfm.initModPage(page, { testInfo });

--- a/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
+++ b/bigbluebutton-tests/playwright/webcam/gridTileCount.spec.ts
@@ -14,7 +14,7 @@ import {
 // so the overflow path can be exercised with a practical number of webcams.
 // (The issue's own reproduction likewise required a custom pagination config.)
 // When the configured grid size is larger than MAX_GRID_SIZE the test is skipped.
-test.describe('Grid layout participant tile count', () => {
+test.describe('Grid layout participant tile count', { tag: '@ci' }, () => {
   test('tile count plus aggregated overflow equals total participants', async ({
     browser,
     context,


### PR DESCRIPTION
## What & why

CI (`automated-tests.yml`) and the pre-release command **both select tests via `@ci`**, so a spec with no `@ci` tag is executed by *neither* — it silently runs nowhere. Several deterministic 4.0 specs are in exactly that state. This PR tags them `@ci` so they actually run. No test logic changes.

Each passed in the full pre-release sweep against a real 4.0 (LiveKit) server; they were simply never selected by CI.

## Specs tagged `@ci`

| Spec | Note |
|---|---|
| `webcam/gridTileCount.spec.ts` | Self-skips unless `allowOverrideClientSettingsOnCreateCall` is set — which the CI install already provisions, so it belongs in `@ci`. |
| `chat/privateChatInput.spec.ts` | Private-chat input resize regression. |
| `layouts/layouts.spec.ts` — 3 "Unified Layout" describes | `@ci` only (they run in the main CI job against LiveKit); `@media` can be added later for legacy-bridge coverage. |
| `multifunctional-mode/multifunctionalMode.spec.ts` | Its tests keep their existing `@media`; the `@ci` tag on the describe adds main-job coverage. |

(`connectionStatus` is already `@ci`.)
