### PR TITLE
fix(shared-notes): match the BlockNote font to the client

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { BlockNoteView } from '@blocknote/mantine';
 import * as BlockNoteLocales from '@blocknote/core/locales';
 import { BlockNoteSchema, defaultBlockSpecs } from '@blocknote/core';
-import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { Awareness } from 'y-protocols/awareness';
@@ -405,6 +404,16 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <style>
         {`
+          /* BlockNote ships Inter and hardcodes it; inherit the client font
+             instead (body in main.html) so Shared Notes matches the rest of the
+             UI. Both selectors are needed: '.bn-root' (toolbar and menus) sets
+             the font from a '--bn-font-family' default, and '.bn-default-styles'
+             (the editor content) sets Inter on its own. 'inherit' also follows
+             the per-language body overrides, e.g. body.lang-fa -> Tahoma. */
+          .bn-root,
+          .bn-default-styles {
+            font-family: inherit;
+          }
           .bn-toolbar-row .mantine-Button-label {
             display: none;
           }


### PR DESCRIPTION
### What does this PR do?
Makes the Shared Notes (BlockNote) editor render in the client's font instead of
the Inter font BlockNote bundles.

BlockNote sets Inter in two independent places:

- `.bn-root` resolves `font-family` from a `--bn-font-family` default holding the
  Inter stack — this covers the formatting toolbar and its menus.
- `.bn-default-styles` hardcodes the same stack on the editor content and ignores
  the variable entirely.

Overriding either one alone leaves the other in Inter, so both now use
`font-family: inherit` and follow the document font (`body` in
`client/main.html`). Inheriting rather than naming `'Source Sans Pro'` keeps the
per-language overrides working — `body.lang-fa` still resolves to Tahoma — and
tracks any deployment that rebrands the body font.

Also drops the `@blocknote/core/fonts/inter.css` import: it was the only
reference to Inter in the client, and it pulled in 9 `@font-face` blocks over 18
woff/woff2 files that are now unused.



### Motivation
The Shared Notes panel visibly stood out from the rest of the client — notes text
and the formatting toolbar rendered in Inter while everything else uses
Source Sans Pro.


### How to test

1. Join a meeting, open **Shared Notes**, and type some text.
2. The notes text and the formatting toolbar should now visually match the
   sidebar labels, chat, and user list.
3. In DevTools, no `inter-v12-latin-*.woff2` font requests should be made.