### PR TITLE
fix(audio): default microphone handling on Chrome (fixes #25400)

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -1,12 +1,18 @@
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import logger from '/imports/startup/client/logger';
 import { getStorageSingletonInstance } from '/imports/ui/services/storage';
+import browserInfo from '/imports/utils/browserInfo';
+import deviceInfo from '/imports/utils/deviceInfo';
 
 const AUDIO_SESSION_NUM_KEY = 'AudioSessionNumber';
 const DEFAULT_INPUT_DEVICE_ID = '';
 const DEFAULT_OUTPUT_DEVICE_ID = '';
 const INPUT_DEVICE_ID_KEY = 'audioInputDeviceId';
 const OUTPUT_DEVICE_ID_KEY = 'audioOutputDeviceId';
+// Chromium's virtual device ID that always resolves to the current OS
+// default input/output device. Only meaningful on Blink-based desktop
+// browsers - see getAudioConstraints() below.
+const SYSTEM_DEFAULT_DEVICE_ID = 'default';
 
 const getAudioSessionNumber = () => {
   let currItem = parseInt(sessionStorage.getItem(AUDIO_SESSION_NUM_KEY), 10);
@@ -102,6 +108,17 @@ const getAudioConstraints = (constraintFields = {}) => {
 
   if (deviceId) {
     matchConstraints.deviceId = { exact: deviceId };
+  } else if (browserInfo.isBlink && !deviceInfo.isMobile) {
+    // Chrome (M123+) can prioritize a per-origin pinned capture device over
+    // an omitted or "ideal" deviceId - see
+    // https://groups.google.com/a/chromium.org/g/blink-dev/c/El5jaGnhVu4
+    // An "exact" constraint is the only documented way to override that and
+    // actually get the OS default device. Guarded to Blink desktop only: the
+    // "default" virtual device only exists on Chromium, and on Firefox/Safari
+    // this would throw OverconstrainedError. Mobile is excluded because it
+    // was never affected (single microphone) and "default" is not guaranteed
+    // to exist there.
+    matchConstraints.deviceId = { exact: SYSTEM_DEFAULT_DEVICE_ID };
   }
 
   return matchConstraints;
@@ -126,7 +143,22 @@ const doGUM = async (constraints, retryOnFailure = false) => {
         },
       }, 'Audio getUserMedia returned OverconstrainedError, rollback');
 
-      return navigator.mediaDevices.getUserMedia({ audio: true });
+      // The stored device is gone or never matched, so forget it. Otherwise
+      // a forced "exact" deviceId (see getAudioConstraints()) keeps pinning
+      // it on every later attempt. NotReadableError is left alone: the
+      // device exists, it's just busy right now.
+      if (error.name !== 'NotReadableError') {
+        getStorageSingletonInstance().removeItem(INPUT_DEVICE_ID_KEY);
+      }
+
+      // Retry without the deviceId but keep the audio processing constraints
+      // (AGC/echo cancellation/noise suppression). Falling back to
+      // `{ audio: true }` would silently capture with the browser's defaults.
+      const { deviceId, ...retryConstraints } = constraints?.audio ?? {};
+
+      return navigator.mediaDevices.getUserMedia({
+        audio: Object.keys(retryConstraints).length > 0 ? retryConstraints : true,
+      });
     }
 
     // Not OverconstrainedError - bubble up the error.

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -120,28 +120,9 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   const { enabled: muteAlertEnabled } = MUTE_ALERT_CONFIG;
 
   const updateRemovedDevices = useCallback((
-    audioInputDevices: MediaDeviceInfo[],
+    audioInputDevices: InputDeviceInfo[],
     audioOutputDevices: MediaDeviceInfo[],
   ) => {
-    if (inputDeviceId
-      && (inputDeviceId !== DEFAULT_DEVICE)
-      && !audioInputDevices.find((d) => d.deviceId === inputDeviceId)) {
-      const fallbackInputDevice = audioInputDevices[0];
-
-      if (fallbackInputDevice?.deviceId) {
-        logger.warn({
-          logCode: 'audio_input_live_selector',
-          extraInfo: {
-            fallbackDeviceId: fallbackInputDevice?.deviceId,
-            fallbackDeviceLabel: fallbackInputDevice?.label,
-          },
-        }, 'Current input device was removed. Fallback to default device');
-        liveChangeInputDevice(fallbackInputDevice.deviceId).catch(() => {
-          notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
-        });
-      }
-    }
-
     if (outputDeviceId
       && (outputDeviceId !== DEFAULT_DEVICE)
       && !audioOutputDevices.find((d) => d.deviceId === outputDeviceId)) {
@@ -160,7 +141,44 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
         });
       }
     }
-  }, [inputDeviceId, outputDeviceId]);
+
+    // --- Input device (microphone) ---
+    // getUserMedia() locks a live track to a concrete device; the browser
+    // does not automatically migrate it when the OS default changes mid
+    // session (headset unplugged, Bluetooth device swapped, Windows itself
+    // switching the default), so that has to be detected and handled here.
+    const activeInputId = inputDeviceId || DEFAULT_DEVICE;
+    let shouldUpdateInput = false;
+
+    if (activeInputId !== DEFAULT_DEVICE) {
+      // User explicitly picked a specific mic. If it disappeared, fall back.
+      if (!audioInputDevices.find((d) => d.deviceId === activeInputId)) {
+        shouldUpdateInput = true;
+      }
+    } else {
+      // User is on 'default'. The virtual 'default' deviceId string never
+      // changes, so compare groupId (which identifies the physical hardware
+      // behind it) to detect the OS default itself changing.
+      const oldDefault = inputDevices.find((d) => d.deviceId === DEFAULT_DEVICE);
+      const newDefault = audioInputDevices.find((d) => d.deviceId === DEFAULT_DEVICE);
+      if (oldDefault && newDefault && oldDefault.groupId !== newDefault.groupId) {
+        shouldUpdateInput = true;
+      }
+    }
+
+    if (shouldUpdateInput) {
+      logger.warn({
+        logCode: 'audio_input_live_selector',
+        extraInfo: { fallbackDeviceId: DEFAULT_DEVICE },
+      }, 'Current input device was removed or default changed. Fallback to new default device');
+
+      setTimeout(() => {
+        liveChangeInputDevice(DEFAULT_DEVICE).catch(() => {
+          notify(intl.formatMessage(intlMessages.deviceChangeFailed), true);
+        });
+      }, 1500); // Give the OS time to settle before re-requesting the stream
+    }
+  }, [inputDeviceId, outputDeviceId, inputDevices]);
 
   const updateDevices = useCallback(() => {
     navigator.mediaDevices.enumerateDevices()
@@ -173,7 +191,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
         updateInputDevices(audioInputDevices as InputDeviceInfo[]);
         updateOutputDevices(audioOutputDevices);
 
-        if (inAudio) updateRemovedDevices(audioInputDevices, audioOutputDevices);
+        if (inAudio) updateRemovedDevices(audioInputDevices as InputDeviceInfo[], audioOutputDevices);
       })
       .catch((error) => {
         logger.warn({

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -709,6 +709,11 @@ class AudioManager {
         setUserSelectedListenOnly(true);
       }
 
+      // Was this an explicit user choice, as opposed to the default ('')
+      // being resolved to a concrete deviceId by the browser? Captured
+      // before the extraction below can overwrite this.inputDeviceId.
+      const userChoseInputDevice = this.inputDeviceId !== DEFAULT_INPUT_DEVICE_ID;
+
       this.inputStream = this.bridge ? this.bridge.inputStream : null;
       // Enforce correct output device on audio join
       this.changeOutputDevice(this.outputDeviceId, true);
@@ -728,8 +733,11 @@ class AudioManager {
         }
       }
       // Audio joined successfully - add device IDs to session storage so they
-      // can be re-used on refreshes/other sessions
-      storeAudioInputDeviceId(this.inputDeviceId);
+      // can be re-used on refreshes/other sessions. Only persist a device the
+      // user explicitly picked: storing an auto-resolved deviceId here would
+      // turn "follow the OS default" into a permanent pin on next join,
+      // since a stored id is later requested with deviceId: { exact }.
+      if (userChoseInputDevice) storeAudioInputDeviceId(this.inputDeviceId);
     } catch (error) {
       logger.warn({
         logCode: 'audiomanager_device_enforce_failed',

--- a/bigbluebutton-html5/imports/utils/browserInfo.js
+++ b/bigbluebutton-html5/imports/utils/browserInfo.js
@@ -9,6 +9,7 @@ const isSafari = BOWSER_RESULTS.browser.name === 'Safari';
 const isEdge = BOWSER_RESULTS.browser.name === 'Microsoft Edge';
 const isIe = BOWSER_RESULTS.browser.name === 'Internet Explorer';
 const isFirefox = BOWSER_RESULTS.browser.name === 'Firefox';
+const isBlink = BOWSER_RESULTS.engine.name === 'Blink';
 
 const browserName = BOWSER_RESULTS.browser.name;
 
@@ -47,6 +48,7 @@ const browserInfo = {
   isEdge,
   isIe,
   isFirefox,
+  isBlink,
   browserName,
   versionNumber,
   isValidSafariVersion,


### PR DESCRIPTION
See issue #25400 for full analysis. This PR includes both the exact device constraint for Blink and the auto-recovery logic for OS default changes.