### PR TITLE
fix: underline styles do not work in shared notes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-content/styles.ts
@@ -103,10 +103,6 @@ export const SidebarContentPanel = styled.div<SidebarContentPanelProps>`
       text-decoration: underline;
     }
   }
-  u {
-    text-decoration-line: none;
-  }
-
   ${({ isChrome }) => isChrome && `
     transform: translateZ(0);
   `}


### PR DESCRIPTION
### What does this PR do?

Removes `text-decoration-line: none;` styles being applied to shared notes. 

It should be only applied to the chat (and its already in https://github.com/bigbluebutton/bigbluebutton/blob/v4.0.x-develop/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/styles.ts#L61)

#### before

<img width="476" height="181" alt="Screenshot From 2026-07-27 10-17-53" src="https://github.com/user-attachments/assets/8c6004db-0a42-459b-92af-665893034ed1" />

#### after

<img width="476" height="181" alt="Screenshot From 2026-07-27 10-17-07" src="https://github.com/user-attachments/assets/5796d66b-b773-468c-8d55-0395ebc7ebd7" />


### How to test
1. start a meeting with shared notes enabled
2. open shared notes panel
3. write something, select the text and press the "**U**" button to apply underline styles to it