### PR TITLE
fix(user-list): prevent search input from being squeezed by growing participant list

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-search/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-search/styles.ts
@@ -26,6 +26,7 @@ const SearchContainer = styled.div`
   padding: ${smPaddingY} ${smPaddingX};
   width: auto;
   height: 40px;
+  flex-shrink: 0;
   overflow: hidden;
   box-shadow: none;
   cursor: text;


### PR DESCRIPTION
### What does this PR do?
The search bar had no flex-shrink, so as more users rendered in the scrollable list, flexbox proportionally shrank the search box toward 0px along with it. Pin it to its 40px height.

### Closes Issue(s)
Closes #25500