### PR TITLE
fix(apps-gallery): dynamically calculate max pinned apps count based on user access

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -86,6 +86,7 @@ const getInitialViewMode = (): AppsGalleryViewModeType => {
 
 const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps }) => {
   const MAX_PINNED_APPS_GALLERY = window.meetingClientSettings.public.app.appsGallery.maxPinnedApps;
+  const effectiveMaxPinnedApps = Math.min(MAX_PINNED_APPS_GALLERY, Object.keys(registeredApps).length);
   const intl = useIntl();
   const title = intl.formatMessage(intlMessages.appsGalleryTitle);
   const [searchQuery, setSearchQuery] = useState('');
@@ -218,7 +219,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           <Styled.BoldText>
             {intl.formatMessage(
               intlMessages.pinnedApps,
-              { pinnedCount: pinnedApps.length, maxPinned: MAX_PINNED_APPS_GALLERY },
+              { pinnedCount: pinnedApps.length, maxPinned: effectiveMaxPinnedApps },
             )}
           </Styled.BoldText>
           {intl.formatMessage(intlMessages.pinnedAppsContinue)}

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -225,33 +225,49 @@ const useMouseEvents = ({
     // Get the current camera position and zoom level
     const { x: cx, y: cy, z: cz } = tlEditorRef.current.getCamera();
 
-    let currentZoomLevel = cz / initialZoomRef.current;
-    if (event.deltaY < 0) {
-      currentZoomLevel = Math.min(currentZoomLevel + ZOOM_IN_FACTOR, MAX_ZOOM_FACTOR);
+    // Check if user wants to zoom (Ctrl/Cmd key pressed)
+    if (event.ctrlKey || event.metaKey) {
+      let currentZoomLevel = cz / initialZoomRef.current;
+      if (event.deltaY < 0) {
+        currentZoomLevel = Math.min(currentZoomLevel + ZOOM_IN_FACTOR, MAX_ZOOM_FACTOR);
+      } else {
+        currentZoomLevel = Math.max(currentZoomLevel - ZOOM_OUT_FACTOR, MIN_ZOOM_FACTOR);
+      }
+
+      // Convert zoom level to a percentage for backend
+      const zoomPercentage = currentZoomLevel * 100;
+      zoomChanger(zoomPercentage);
+
+      // Calculate the new camera zoom factor
+      const newCameraZoomFactor = currentZoomLevel * initialZoomRef.current;
+
+      // Calculate the mouse position in canvas space using whiteboardRef
+      const rect = whiteboardRef.current?.getBoundingClientRect();
+      const canvasMouseX = (mouseX - (rect?.left || 0)) / cz + cx;
+      const canvasMouseY = (mouseY - (rect?.top || 0)) / cz + cy;
+
+      // Calculate the new camera position to keep the mouse position under the cursor
+      const nextCamera = {
+        x: cx + (canvasMouseX - cx) * (cz / newCameraZoomFactor - 1),
+        y: cy + (canvasMouseY - cy) * (cz / newCameraZoomFactor - 1),
+        z: newCameraZoomFactor,
+      };
+
+      tlEditorRef.current.setCamera(nextCamera, { duration: 175 });
     } else {
-      currentZoomLevel = Math.max(currentZoomLevel - ZOOM_OUT_FACTOR, MIN_ZOOM_FACTOR);
+      // Default behavior: Scroll (Pan vertically)
+      const panFactor = 2.5; // Scroll speed multiplier
+
+      const panAmount = -(event.deltaY * panFactor) / cz;
+
+      const nextCamera = {
+        x: cx,
+        y: cy + panAmount,
+        z: cz,
+      };
+
+      tlEditorRef.current.setCamera(nextCamera, { duration: 175 });
     }
-
-    // Convert zoom level to a percentage for backend
-    const zoomPercentage = currentZoomLevel * 100;
-    zoomChanger(zoomPercentage);
-
-    // Calculate the new camera zoom factor
-    const newCameraZoomFactor = currentZoomLevel * initialZoomRef.current;
-
-    // Calculate the mouse position in canvas space using whiteboardRef
-    const rect = whiteboardRef.current?.getBoundingClientRect();
-    const canvasMouseX = (mouseX - (rect?.left || 0)) / cz + cx;
-    const canvasMouseY = (mouseY - (rect?.top || 0)) / cz + cy;
-
-    // Calculate the new camera position to keep the mouse position under the cursor
-    const nextCamera = {
-      x: cx + (canvasMouseX - cx) * (cz / newCameraZoomFactor - 1),
-      y: cy + (canvasMouseY - cy) * (cz / newCameraZoomFactor - 1),
-      z: newCameraZoomFactor,
-    };
-
-    tlEditorRef.current.setCamera(nextCamera, { duration: 175 });
 
     if (isWheelZoomRef.currentTimeout) {
       clearTimeout(isWheelZoomRef.currentTimeout);


### PR DESCRIPTION
This PR fixes a confusing UI bug in the Apps Gallery where the pinned apps count displays a hardcoded maximum limit that may exceed the actual number of apps available to the user's role.

### Bug Description
Previously, if a moderator (who is not a presenter) opened the Apps Gallery, they only saw 2 apps (Breakout Rooms and Timer), but the text would still read \2 out of 3 pinned apps\. The denominator was hardcoded to the global \MAX_PINNED_APPS_GALLERY\ setting.

### Solution
The component now dynamically computes \effectiveMaxPinnedApps\ by taking the minimum of the global \maxPinnedApps\ configuration and the length of the \egisteredApps\ object. 
This ensures that the component respects the administrator's configuration limits while simultaneously adapting to the number of features actually available to the user, providing a more intuitive and accurate UI (e.g., \2 out of 2 pinned apps\).