### PR TITLE
fix(apps-gallery): dynamically calculate max pinned apps count based on user access

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/apps-gallery/component.tsx
@@ -86,6 +86,7 @@ const getInitialViewMode = (): AppsGalleryViewModeType => {
 
 const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps }) => {
   const MAX_PINNED_APPS_GALLERY = window.meetingClientSettings.public.app.appsGallery.maxPinnedApps;
+  const effectiveMaxPinnedApps = Math.min(MAX_PINNED_APPS_GALLERY, Object.keys(registeredApps).length);
   const intl = useIntl();
   const title = intl.formatMessage(intlMessages.appsGalleryTitle);
   const [searchQuery, setSearchQuery] = useState('');
@@ -218,7 +219,7 @@ const AppsGallery: React.FC<AppsGalleryProps> = ({ registeredApps, pinnedApps })
           <Styled.BoldText>
             {intl.formatMessage(
               intlMessages.pinnedApps,
-              { pinnedCount: pinnedApps.length, maxPinned: MAX_PINNED_APPS_GALLERY },
+              { pinnedCount: pinnedApps.length, maxPinned: effectiveMaxPinnedApps },
             )}
           </Styled.BoldText>
           {intl.formatMessage(intlMessages.pinnedAppsContinue)}


### PR DESCRIPTION
This PR fixes a confusing UI bug in the Apps Gallery where the pinned apps count displays a hardcoded maximum limit that may exceed the actual number of apps available to the user's role.

Fixes #22897 

### Bug Description
Previously, if a moderator (who is not a presenter) opened the Apps Gallery, they only saw 2 apps (Breakout Rooms and Timer), but the text would still read \2 out of 3 pinned apps\. The denominator was hardcoded to the global \MAX_PINNED_APPS_GALLERY\ setting.

### Solution
The component now dynamically computes \effectiveMaxPinnedApps\ by taking the minimum of the global \maxPinnedApps\ configuration and the length of the \egisteredApps\ object. 
This ensures that the component respects the administrator's configuration limits while simultaneously adapting to the number of features actually available to the user, providing a more intuitive and accurate UI (e.g., \2 out of 2 pinned apps\).

**Note: I have already signed the CLA.**