### PR TITLE
fix(shared-notes): add missing border radius to pinned BlockNote

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -576,7 +576,7 @@ function BlockNoteContainer({ isVisible }: BlockNoteContainerProps): React.React
     };
   }, [renderBlockNote, isVisible, markNotesAsRead]);
   return (
-    <Styled.Notes id="bn-notes-scroll-container">
+    <Styled.Notes id="bn-notes-scroll-container" isPresenter={currentUser?.presenter ?? false}>
       {(hasError) && (
         <Styled.WarningNotificationContainer data-test="notesError">
           <Styled.ErrorMessage>{error}</Styled.ErrorMessage>

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/styles.ts
@@ -1,14 +1,17 @@
 import styled from 'styled-components';
 import { colorDanger, colorGray, colorWhite } from '/imports/ui/stylesheets/styled-components/palette';
+import { lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 
-const Notes = styled.div`
+const Notes = styled.div<{isPresenter: boolean}>`
   background-color: ${colorWhite};
   display: flex;
   flex-grow: 1;
   flex-direction: column;
   height: 100%;
   overflow: auto;
+  border-radius: ${({ isPresenter }) => (
+    isPresenter ? `0 0 ${lgBorderRadius} ${lgBorderRadius}` : `${lgBorderRadius}`)};
 
   @media ${smallOnly} {
     transform: none !important;


### PR DESCRIPTION
### What does this PR do?
When BlockNote is pinned, it has no border radius, which does not match the visual style of the 4.0 UI.

Add border radius to the BlockNote shared notes element when pinned.

Both views(mod and presenter after borders have been fixed):
<img width="1925" height="904" alt="notes_1" src="https://github.com/user-attachments/assets/d22c4bb4-f53e-4ecc-a08e-2eaf058a266e" />
<img width="1925" height="904" alt="notes_2" src="https://github.com/user-attachments/assets/a41935bc-537d-44c7-b8ae-f45496fc3e10" />
