### PR TITLE
Backport: "fix(audio): assorted fixes and improvements to LiveKit's floor manager"

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/SystemConfiguration.scala
@@ -56,11 +56,11 @@ trait SystemConfiguration {
   lazy val muteOnStartThreshold = Try(config.getInt("voiceConf.muteOnStartThreshold")).getOrElse(0)
   lazy val dialInEnforceGuestPolicy = Try(config.getBoolean("voiceConf.dialInEnforceGuestPolicy")).getOrElse(true)
   lazy val dialInEnforceMuteOnStart = Try(config.getBoolean("voiceConf.dialInEnforceMuteOnStart")).getOrElse(false)
-  lazy val floorEnabled = Try(config.getBoolean("voiceConf.floorControl.enabled")).getOrElse(false)
+  lazy val floorEnabled = Try(config.getBoolean("voiceConf.floorControl.enabled")).getOrElse(true)
   lazy val minTalkingDuration = Try(config.getDuration(
     "voiceConf.floorControl.minTalkingDuration",
     java.util.concurrent.TimeUnit.MILLISECONDS
-  )).getOrElse(2000L)
+  )).getOrElse(2500L)
   lazy val floorSwitchCooldown = Try(config.getDuration(
     "voiceConf.floorControl.floorSwitchCooldown",
     java.util.concurrent.TimeUnit.MILLISECONDS

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
@@ -9,7 +9,6 @@ import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers
 import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.db.ScreenshareDAO
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
-import org.bigbluebutton.core.apps.voice.AudioFloorManager
 
 trait LiveKitParticipantLeftEvtMsgHdlr {
   this: BaseMeetingActor =>
@@ -26,7 +25,7 @@ trait LiveKitParticipantLeftEvtMsgHdlr {
     for {
       vu <- VoiceUsers.findWIthIntId(liveMeeting.voiceUsers, userId)
     } yield {
-      AudioFloorManager.handleUserLeftVoice(
+      liveMeeting.audioFloorManager.handleUserLeftVoice(
         vu.intId,
         System.currentTimeMillis(),
         liveMeeting,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -50,10 +50,38 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       return None
     }
 
+    pruneStaleSpeakingState(timestamp, liveMeeting, outGW)
+
     if (talking) {
       handleStartTalking(userId, timestamp, liveMeeting, outGW)
     } else {
       handleStopTalking(userId, liveMeeting, outGW)
+    }
+  }
+
+  // Catch all for missed stop-talking/left-voice events. Cleanup is important
+  // as stale entries might accumulate and delay actual floor grants for that user
+  // unnecessarily.
+  private def pruneStaleSpeakingState(
+      now:         Long,
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter
+  )(implicit context: ActorContext): Unit = {
+    // 5 min - likely to be tweaked based on observation (prlanzarin)
+    val ttl = 5 * 60 * 1000L
+    val stale = state.speakingStartTimes.collect {
+      case (userId, startedAt) if now - startedAt >= ttl => userId
+    }.toSet
+
+    if (stale.nonEmpty) {
+      logFloorEvent("none", "stale_speaking_state_pruned", Map(
+        "users" -> stale.mkString(",")
+      ))
+      state = state.copy(speakingStartTimes = state.speakingStartTimes -- stale)
+      if (pendingFloors.exists(pending => stale.contains(pending.userId))) {
+        pendingFloors.filterInPlace(pending => !stale.contains(pending.userId))
+        dispatchPendingGrants(liveMeeting, outGW)
+      }
     }
   }
 

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -161,9 +161,11 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       outGW:       OutMsgRouter
   ): Option[String] = {
     if (state.currentHolder.contains(userId)) {
+      // A release does not schedule the switch cooldown - only grants do.
+      // Otherwise a floor holder's departure would defer the grant of the next
+      // speaker until after the cooldown unnecessarily.
       state = state.copy(
-        currentHolder = None,
-        lastFloorSwitch = timestamp
+        currentHolder = None
       )
 
       logFloorEvent(userId, "floor_released", Map(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -9,10 +9,9 @@ import scala.collection.mutable
 import org.slf4j.LoggerFactory
 
 case class FloorState(
-    currentHolder:       Option[String]                     = None,
-    lastFloorSwitch:     Long                               = 0L,
-    speakingStartTimes:  Map[String, Long]                  = Map(),
-    talkingStateChanges: Map[String, List[(Boolean, Long)]] = Map()
+    currentHolder:      Option[String]    = None,
+    lastFloorSwitch:    Long              = 0L,
+    speakingStartTimes: Map[String, Long] = Map()
 )
 
 case class PendingFloor(
@@ -44,8 +43,6 @@ object AudioFloorManager extends SystemConfiguration {
     }
 
     stateLock.synchronized {
-      state = cleanupOldState(state, timestamp)
-
       if (talking) {
         handleStartTalking(userId, timestamp, liveMeeting, outGW)
       } else {
@@ -70,17 +67,6 @@ object AudioFloorManager extends SystemConfiguration {
       logData: Map[String, Any]
   ): Unit = {
     log.debug(s"Floor control event=${event} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
-  }
-
-  private def cleanupOldState(state: FloorState, now: Long): FloorState = {
-    val ttl = 5 * 60 * 1000L
-
-    state.copy(
-      talkingStateChanges = state.talkingStateChanges.map {
-        case (userId, changes) =>
-          userId -> changes.filter(_._2 >= (now - ttl))
-      }.filter(_._2.nonEmpty)
-    )
   }
 
   private def scheduleFloorGrant(
@@ -198,8 +184,7 @@ object AudioFloorManager extends SystemConfiguration {
     }
 
     state = state.copy(
-      speakingStartTimes = state.speakingStartTimes - userId,
-      talkingStateChanges = state.talkingStateChanges - userId
+      speakingStartTimes = state.speakingStartTimes - userId
     )
 
     None
@@ -223,8 +208,7 @@ object AudioFloorManager extends SystemConfiguration {
     }
 
     state = state.copy(
-      speakingStartTimes = state.speakingStartTimes - userId,
-      talkingStateChanges = state.talkingStateChanges - userId
+      speakingStartTimes = state.speakingStartTimes - userId
     )
 
     if (state.currentHolder.contains(userId)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -21,7 +21,7 @@ case class PendingFloor(
 )
 
 object AudioFloorManager {
-  // Floor grants are sheculed to the meeting actor so they run on the actor
+  // Floor grants are scheduled to the meeting actor so they run on the actor
   // thread, serialized with the rest of the meeting's message handling.
   case object DispatchFloorGrantsInternalMsg
 }
@@ -95,7 +95,7 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
 
   // Evaluates the floor grant queue: drops stale entries, grants the floor to
   // the head once both its minimum-talking deadline and the grant cooldown
-  // have elapsed, and otherwise re-schedule itself for the earliest instant a i
+  // have elapsed, and otherwise re-schedule itself for the earliest instant a
   // grant can succeed.
   def dispatchPendingGrants(
       liveMeeting: LiveMeeting,
@@ -117,8 +117,8 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
 
       if (now >= readyAt) {
         try {
-          pendingFloors.dequeue()
           grantFloor(head.userId, now, liveMeeting, outGW)
+          pendingFloors.dequeue()
           dispatchPendingGrants(liveMeeting, outGW)
         } catch {
           // Capture so that the queue doesn't stall

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -1,9 +1,8 @@
 package org.bigbluebutton.core.apps.voice
 
-import java.util.concurrent.{ ScheduledFuture, TimeUnit, ScheduledExecutorService, Executors }
+import java.util.concurrent.{ Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
-import org.bigbluebutton.core.models.{ VoiceUsers, VoiceUserState }
-import scala.concurrent.duration._
+import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.SystemConfiguration
 import scala.collection.mutable
 import org.slf4j.LoggerFactory
@@ -20,15 +19,20 @@ case class PendingFloor(
     timer:     ScheduledFuture[_]
 )
 
-object AudioFloorManager extends SystemConfiguration {
-  private val log = LoggerFactory.getLogger(getClass)
-  private val stateLock = new Object()
-  private var state = FloorState()
+object AudioFloorManager {
+  // This timer is shared across all meetings (light load, no need to creat
+  // one per meeting etc)
   private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r => {
     val t = new Thread(r, "audio-floor-manager")
     t.setDaemon(true)
     t
   })
+}
+
+class AudioFloorManager(meetingId: String) extends SystemConfiguration {
+  private val log = LoggerFactory.getLogger(getClass)
+  private val stateLock = new Object()
+  private var state = FloorState()
   private val pendingFloors = mutable.Queue[PendingFloor]()
 
   def handleUserTalking(
@@ -51,22 +55,12 @@ object AudioFloorManager extends SystemConfiguration {
     }
   }
 
-  def getCurrentFloorHolder: Option[String] = stateLock.synchronized {
-    state.currentHolder
-  }
-
-  def clearFloorState(): Unit = stateLock.synchronized {
-    pendingFloors.foreach(_.timer.cancel(false))
-    pendingFloors.clear()
-    state = FloorState()
-  }
-
   private def logFloorEvent(
       userId:  String,
       event:   String,
       logData: Map[String, Any]
   ): Unit = {
-    log.debug(s"Floor control event=${event} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
+    log.debug(s"Floor control event=${event} meetingId=${meetingId} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
   }
 
   private def scheduleFloorGrant(
@@ -75,7 +69,7 @@ object AudioFloorManager extends SystemConfiguration {
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
   ): Unit = {
-    val future = scheduler.schedule(new Runnable {
+    val future = AudioFloorManager.scheduler.schedule(new Runnable {
       override def run(): Unit = {
         stateLock.synchronized {
           if (pendingFloors.nonEmpty && pendingFloors.head.userId == userId) {
@@ -223,9 +217,11 @@ object AudioFloorManager extends SystemConfiguration {
   }
 
   def destroy(): Unit = stateLock.synchronized {
+    logFloorEvent("none", "floor_manager_destroyed", Map(
+      "pending_grants" -> pendingFloors.size
+    ))
     pendingFloors.foreach(_.timer.cancel(false))
     pendingFloors.clear()
-    scheduler.shutdown()
     state = FloorState()
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/AudioFloorManager.scala
@@ -1,10 +1,12 @@
 package org.bigbluebutton.core.apps.voice
 
-import java.util.concurrent.{ Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit }
+import org.apache.pekko.actor.{ ActorContext, Cancellable }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core.models.VoiceUsers
 import org.bigbluebutton.SystemConfiguration
 import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
 import org.slf4j.LoggerFactory
 
 case class FloorState(
@@ -15,25 +17,27 @@ case class FloorState(
 
 case class PendingFloor(
     userId:    String,
-    startTime: Long,
-    timer:     ScheduledFuture[_]
+    startTime: Long
 )
 
 object AudioFloorManager {
-  // This timer is shared across all meetings (light load, no need to creat
-  // one per meeting etc)
-  private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(r => {
-    val t = new Thread(r, "audio-floor-manager")
-    t.setDaemon(true)
-    t
-  })
+  // Floor grants are sheculed to the meeting actor so they run on the actor
+  // thread, serialized with the rest of the meeting's message handling.
+  case object DispatchFloorGrantsInternalMsg
 }
 
+// All state is confined to the meeting actor: the public entry points run in
+// message handlers and the dispatch timer only enqueues
+// DispatchFloorGrantsInternalMsg back to the same actor.
 class AudioFloorManager(meetingId: String) extends SystemConfiguration {
   private val log = LoggerFactory.getLogger(getClass)
-  private val stateLock = new Object()
   private var state = FloorState()
   private val pendingFloors = mutable.Queue[PendingFloor]()
+  // Single grant dispatch timer that evaluates the queue head. Pending grants
+  // carry no timers of their own: any queue or floor-state change re-runs
+  // the dispatch, so a grant blocked by the cooldown (or by queue order) is
+  // retried when possible.
+  private var grantDispatchTask: Option[Cancellable] = None
 
   def handleUserTalking(
       userId:      String,
@@ -41,17 +45,15 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       timestamp:   Long         = System.currentTimeMillis(),
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Option[String] = {
+  )(implicit context: ActorContext): Option[String] = {
     if (!floorEnabled || liveMeeting.props.meetingProp.audioBridge != "livekit") {
       return None
     }
 
-    stateLock.synchronized {
-      if (talking) {
-        handleStartTalking(userId, timestamp, liveMeeting, outGW)
-      } else {
-        handleStopTalking(userId, timestamp)
-      }
+    if (talking) {
+      handleStartTalking(userId, timestamp, liveMeeting, outGW)
+    } else {
+      handleStopTalking(userId, liveMeeting, outGW)
     }
   }
 
@@ -63,24 +65,52 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
     log.debug(s"Floor control event=${event} meetingId=${meetingId} userId=${userId} currentHolder=${state.currentHolder} logData=${logData}")
   }
 
-  private def scheduleFloorGrant(
-      userId:      String,
-      timestamp:   Long,
+  // Evaluates the floor grant queue: drops stale entries, grants the floor to
+  // the head once both its minimum-talking deadline and the grant cooldown
+  // have elapsed, and otherwise re-schedule itself for the earliest instant a i
+  // grant can succeed.
+  def dispatchPendingGrants(
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Unit = {
-    val future = AudioFloorManager.scheduler.schedule(new Runnable {
-      override def run(): Unit = {
-        stateLock.synchronized {
-          if (pendingFloors.nonEmpty && pendingFloors.head.userId == userId) {
-            pendingFloors.dequeue()
-            grantFloor(userId, timestamp + minTalkingDuration, liveMeeting, outGW)
-          }
-        }
-      }
-    }, minTalkingDuration, TimeUnit.MILLISECONDS)
+  )(implicit context: ActorContext): Unit = {
+    grantDispatchTask.foreach(_.cancel())
+    grantDispatchTask = None
 
-    pendingFloors.enqueue(PendingFloor(userId, timestamp, future))
+    while (pendingFloors.headOption.exists(pending => state.currentHolder.contains(pending.userId))) {
+      pendingFloors.dequeue()
+    }
+
+    pendingFloors.headOption.foreach { head =>
+      val now = System.currentTimeMillis()
+      val readyAt = math.max(
+        head.startTime + minTalkingDuration,
+        state.lastFloorSwitch + floorSwitchCooldown
+      )
+
+      if (now >= readyAt) {
+        try {
+          pendingFloors.dequeue()
+          grantFloor(head.userId, now, liveMeeting, outGW)
+          dispatchPendingGrants(liveMeeting, outGW)
+        } catch {
+          // Capture so that the queue doesn't stall
+          case NonFatal(e) =>
+            log.error(s"Floor control grant dispatch failed meetingId=${meetingId}, re-scheduling", e)
+            scheduleGrantDispatch(floorSwitchCooldown)
+        }
+      } else {
+        scheduleGrantDispatch(readyAt - now)
+      }
+    }
+  }
+
+  private def scheduleGrantDispatch(delayMs: Long)(implicit context: ActorContext): Unit = {
+    import context.dispatcher
+    grantDispatchTask = Some(context.system.scheduler.scheduleOnce(
+      delayMs.milliseconds,
+      context.self,
+      AudioFloorManager.DispatchFloorGrantsInternalMsg
+    ))
   }
 
   private def grantFloor(
@@ -160,26 +190,30 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       timestamp:   Long,
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Option[String] = {
+  )(implicit context: ActorContext): Option[String] = {
     if (!state.speakingStartTimes.contains(userId)) {
       state = state.copy(
         speakingStartTimes = state.speakingStartTimes + (userId -> timestamp)
       )
-      scheduleFloorGrant(userId, timestamp, liveMeeting, outGW)
+      pendingFloors.enqueue(PendingFloor(userId, timestamp))
+      dispatchPendingGrants(liveMeeting, outGW)
     }
 
     None
   }
 
-  private def handleStopTalking(userId: String, timestamp: Long): Option[String] = {
-    pendingFloors.find(_.userId == userId).foreach { pending =>
-      pending.timer.cancel(false)
-      pendingFloors.dequeueFirst(_.userId == userId)
-    }
+  private def handleStopTalking(
+      userId:      String,
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter
+  )(implicit context: ActorContext): Option[String] = {
+    pendingFloors.dequeueFirst(_.userId == userId)
 
     state = state.copy(
       speakingStartTimes = state.speakingStartTimes - userId
     )
+
+    dispatchPendingGrants(liveMeeting, outGW)
 
     None
   }
@@ -189,38 +223,35 @@ class AudioFloorManager(meetingId: String) extends SystemConfiguration {
       timestamp:   Long         = System.currentTimeMillis(),
       liveMeeting: LiveMeeting,
       outGW:       OutMsgRouter
-  ): Option[String] = stateLock.synchronized {
+  )(implicit context: ActorContext): Option[String] = {
     logFloorEvent(userId, "user_left", Map(
       "was_floor_holder" -> state.currentHolder.contains(userId),
       "had_pending_floor" -> pendingFloors.exists(_.userId == userId),
       "speaking_duration" -> state.speakingStartTimes.get(userId).map(timestamp - _)
     ))
 
-    pendingFloors.find(_.userId == userId).foreach { pending =>
-      pending.timer.cancel(false)
-      pendingFloors.dequeueFirst(_.userId == userId)
-    }
+    pendingFloors.dequeueFirst(_.userId == userId)
 
     state = state.copy(
       speakingStartTimes = state.speakingStartTimes - userId
     )
 
-    if (state.currentHolder.contains(userId)) {
+    val wasHolder = state.currentHolder.contains(userId)
+    if (wasHolder) {
       releaseFloor(userId, timestamp, liveMeeting, outGW)
+    }
 
-      pendingFloors.headOption.foreach { next =>
-        grantFloor(next.userId, timestamp, liveMeeting, outGW)
-      }
+    dispatchPendingGrants(liveMeeting, outGW)
 
-      Some(userId)
-    } else None
+    if (wasHolder) Some(userId) else None
   }
 
-  def destroy(): Unit = stateLock.synchronized {
+  def destroy(): Unit = {
     logFloorEvent("none", "floor_manager_destroyed", Map(
       "pending_grants" -> pendingFloors.size
     ))
-    pendingFloors.foreach(_.timer.cancel(false))
+    grantDispatchTask.foreach(_.cancel())
+    grantDispatchTask = None
     pendingFloors.clear()
     state = FloorState()
   }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
@@ -48,7 +48,7 @@ trait UserLeftVoiceConfEvtMsgHdlr {
     for {
       user <- VoiceUsers.findWithVoiceUserId(liveMeeting.voiceUsers, msg.body.voiceUserId)
     } yield {
-      AudioFloorManager.handleUserLeftVoice(
+      liveMeeting.audioFloorManager.handleUserLeftVoice(
         user.intId,
         System.currentTimeMillis(),
         liveMeeting,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -931,7 +931,7 @@ object VoiceApp extends SystemConfiguration {
         liveMeeting,
         outGW
       )
-      AudioFloorManager.handleUserTalking(
+      liveMeeting.audioFloorManager.handleUserTalking(
         talkingUser.intId,
         talking,
         System.currentTimeMillis(),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -2,6 +2,7 @@ package org.bigbluebutton.core.running
 
 import org.bigbluebutton.common2.domain.DefaultProps
 import org.bigbluebutton.core.apps._
+import org.bigbluebutton.core.apps.voice.AudioFloorManager
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
 
@@ -27,4 +28,6 @@ class LiveMeeting(
     val guestsWaiting:       GuestsWaiting,
     val clientSettings:      Map[String, Object],
     val plugins:             PluginModel,
-)
+) {
+  val audioFloorManager = new AudioFloorManager(props.meetingProp.intId)
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -285,6 +285,8 @@ class MeetingActor(
       handleMeetingTasksExecutor()
     case CheckPresentationConversions =>
       state = handleCheckPresentationConversions()
+    case AudioFloorManager.DispatchFloorGrantsInternalMsg =>
+      liveMeeting.audioFloorManager.dispatchPendingGrants(liveMeeting, outGW)
     //=============================
 
     // 2x messages

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -267,6 +267,11 @@ class MeetingActor(
     CheckPresentationConversions
   )
 
+  override def postStop(): Unit = {
+    liveMeeting.audioFloorManager.destroy()
+    super.postStop()
+  }
+
   def receive = {
     case SyncVoiceUserStatusInternalMsg =>
       checkVoiceConfUsersStatus()


### PR DESCRIPTION
### What does this PR do?
Backports https://github.com/bigbluebutton/bigbluebutton/pull/25395 from 4.0 (except tests which 3.0 would not support).

#### Summary

Do a sweep on akka-apps' audio floor managed used by the LK audio bridge and fix a
few issues:
  - Remove the possibility of cross-meeting floor collisions
  - Improve floor cooldown handling so that switches are more deterministic and reactive
  - Fixes a couple of edge cases regarding floor starvation (simultaneous speaking, stale floor entries)
  - Add a few E2E tests for floor actions (LK only)
  
#### In detail
 
- [refactor(audio): remove unused talkingStateChanges floor tracking](https://github.com/bigbluebutton/bigbluebutton/commit/38c1ef0eca6d3b01197d5ceca944e940c3828e8f) 
  - AudioFloorManager's FloorState.talkingStateChanges has no actual usage.
Drop the field and the consequently stale cleanupOldState.
- [fix(audio): scope audio floor control state per meeting](https://github.com/bigbluebutton/bigbluebutton/commit/a0fd696b86c236109fe3b254533cd5643702e3d6) 
  - AudioFloorManager is an akka-apps-wide singleton, which may cause
collisions when handling audio floor events.
  - Turn AudioFloorManager into a per-meeting class held by LiveMeeting, so
floor grants, releases, CDs and pending queues are meeting-scoped and
releases always resolve in the holder's own meeting, and tear it down
from a MeetingActor postStop hook, which covers every termination path.
- [fix(audio): retry floor grants blocked by the floor cooldown](https://github.com/bigbluebutton/bigbluebutton/commit/4594baae6e026c9dcd7ac3aab1a9e00f4ad9a2cc) 
  - Replace the per-queued grant timers with a single re-scheduled grant
dispatch that always evaluates the queue head at the earliest instant a
grant can succeed (talking deadline or cooldown expiry, whichever is
later) and re-runs on every queue or floor-state change.
  - This includes the rewrite of the scheduler to use Pekko's scheduleOnce
via an internal DispatchFloorGrantsInternalMsg to the meeting actor,
handled like the other internal meeting timers, so all floor state is
inside the meeting actor lifecycle.
- [fix(audio): do not schedule the floor switch cooldown on release](https://github.com/bigbluebutton/bigbluebutton/commit/ee7b10d6b9a8d3260bafffbf940cdc12732bac7c) 
  - When a floor holder leaves, the release itself starts a cooldown that
defers the grant to the next pending speaker until after the cooldown
elapses. The cooldown exists to space out floor switches only - a release
event always should come after the cooldown already acted.
- [fix(audio): prune stale speaking states in floor manager](https://github.com/bigbluebutton/bigbluebutton/commit/ed5cf98dd7f2a16ed01db4798da42ff8f714dbbc) 
  - speakingStartTimes entries are removed only by explicit stop-talking or
left-voice events. A user whose events are lost (disconnect, ...) leaves an
entry behind until meeting end. Two obvious issues: queue buildup and
floor grant block for the affected user.

  
### Closes Issue(s)

None