### PR TITLE
feat(plugin-sdk): add senderRole to useLoadedChatMessages

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/chat/loaded-chat-messages/hook-manager.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/chat/loaded-chat-messages/hook-manager.ts
@@ -20,13 +20,14 @@ const LoadedChatMessagesHookContainer = (props: GeneralHookManagerProps) => {
     message: message.message,
     messageId: message.messageId,
     user: message.user,
+    senderRole: message.senderRole,
     messageMetadata: message.messageMetadata,
   }));
 
   const { version } = props;
   const previousVersion = usePreviousValue(version);
 
-  const updateLoadedChatMessagesForPlugin = () => {
+  const updateLoadedChatMessagesForPlugin: () => void = () => {
     window.dispatchEvent(new CustomEvent<
       UpdatedEventDetails<PluginSdk.GraphqlResponseWrapper<LoadedChatMessage[]>>
     >(HookEvents.BBB_CORE_SENT_NEW_DATA, {

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/chat/loaded-chat-messages/utils.ts
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/data-consumption/domain/chat/loaded-chat-messages/utils.ts
@@ -9,6 +9,7 @@ const formatLoadedChatMessagesDataFromGraphql = (
     message: chatMessagesData.message,
     messageId: chatMessagesData.messageId,
     senderUserId: chatMessagesData.user?.userId,
+    senderRole: chatMessagesData.senderRole,
     messageMetadata: chatMessagesData.messageMetadata,
   }) as PluginSdk.LoadedChatMessage),
   loading: !(responseData),


### PR DESCRIPTION
## Add `senderRole` to `useLoadedChatMessages`

Exposes the sender's role as it was at the moment the message was sent. Unlike the role available through `useUsersBasicInfo` / `useLoadedUserList`, this value is **static**: it does not change if the user is promoted/demoted later, and it survives the user leaving the meeting.


If you have suggestions for additional properties that should be included, feel free to leave a comment below.

This could be useful for addressing security concerns related to message authenticity. For example, if a user leaves the session and all we have is their userId (the previous scenario), we have no reliable way to determine whether a message was originally sent by a moderator.

### Changes

- `LoadedChatMessage` gains `senderRole: string | null`:

  ```ts
  export interface LoadedChatMessage {
    createdAt: string;
    message: string;
    messageId: string;
    senderUserId: string;
    // Static throughout the meeting; null for system messages
    senderRole: string | null;
    messageMetadata: string;
  }
  ```

- Fixed the chat example in the README, which referenced `msg.senderName` — a field that does not exist on `LoadedChatMessage`.

### Why nullable

`senderRole` is `null` for system messages (welcome message, moderator-only message, chat-cleared), which have no sender:

- `ChatMessageDAO.insertSystemMsg` inserts with `senderRole = None`
- `bbb_schema.sql` declares `"senderRole" varchar(20)` with no `NOT NULL`

These messages are returned by the same chat page query, so plugins will see them.

### More

Closely related to the PR on the SDK: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/281