### PR TITLE
build(gql-server): keep Hasura metadata after applying it

### DIFF
--- a/build/packages-template/bbb-graphql-server/after-install.sh
+++ b/build/packages-template/bbb-graphql-server/after-install.sh
@@ -72,7 +72,6 @@ case "$1" in
     cd /usr/share/bbb-graphql-server
     timeout 15s /usr/bin/hasura metadata apply --skip-update-check
     cd ..
-    rm -rf /usr/share/bbb-graphql-server/metadata
   fi
 
   echo "Graphql-server after-install finished"


### PR DESCRIPTION
### What does this PR do?

- [build(gql-server): keep Hasura metadata after applying it](https://github.com/bigbluebutton/bigbluebutton/commit/7c9af88214a14852beaef3e0c6c1e1b6bb4303d6) 
  - after-install deletes /usr/share/bbb-graphql-server/metadata once
hasura metadata apply succeeds, but keeps config.yaml, which points
metadata at it. The installed tree is therefore a Hasura proj. that
can't be used: operators cannot re-apply or override metadata without
first exporting it back from the running instance.
  - The deletion dates from when the tree shipped under /etc/default,
where removing package-shipped files at least argued against them
reading as configuration. It lost that rationale when the tree moved
to /usr/share and was carried along; bbb_schema.sql, which is equally
redundant once loaded, has always been kept.
  - Keeping the files also fixes dpkg's file accounting, since the metadata
paths stay recorded in the package file list and every installed
server reports them as missing under dpkg --verify.

### Closes Issue(s)

None

### Motivation

See commit log