### PR TITLE
fix: MeetingActor analytics discards VoiceUserState.callerName, logs ERROR after user leaves

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UserBroadcastCamStartMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/UserBroadcastCamStartMsgHdlr.scala
@@ -4,7 +4,7 @@ import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.PermissionCheck
 import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers.permissionFailed
 import org.bigbluebutton.core.bus.MessageBus
-import org.bigbluebutton.core.models.{ WebcamStream, Webcams }
+import org.bigbluebutton.core.models.{ Users2x, WebcamStream, Webcams }
 import org.bigbluebutton.core.running.LiveMeeting
 
 trait UserBroadcastCamStartMsgHdlr {
@@ -47,9 +47,18 @@ trait UserBroadcastCamStartMsgHdlr {
     } else {
       val userIsPresenter = !permissionFailed(PermissionCheck.GUEST_LEVEL, PermissionCheck.PRESENTER_LEVEL, liveMeeting.users2x, msg.header.userId)
       val startAsContent = msg.body.contentType == "screenshare" && userIsPresenter
-      val webcam = WebcamStream(msg.body.stream, msg.header.userId, msg.body.contentType, msg.body.hasAudio, showAsContent = startAsContent, Set.empty)
 
       for {
+        user <- Users2x.findWithIntId(liveMeeting.users2x, msg.header.userId)
+        webcam = WebcamStream(
+          streamId = msg.body.stream,
+          userId = msg.header.userId,
+          userName = user.name,
+          contentType = msg.body.contentType,
+          hasAudio = msg.body.hasAudio,
+          showAsContent = startAsContent,
+          subscribers = Set.empty
+        )
         _ <- Webcams.addWebcamStream(liveMeeting.props.meetingProp.intId, liveMeeting.webcams, webcam)
       } yield broadcastEvent(meetingId, msg.header.userId, msg.body.stream, msg.body.contentType, msg.body.hasAudio)
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Webcams.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/models/Webcams.scala
@@ -100,6 +100,7 @@ class Webcams {
 case class WebcamStream(
     streamId:      String,
     userId:        String,
+    userName:      String,
     contentType:   String,
     hasAudio:      Boolean,
     showAsContent: Boolean,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -953,14 +953,14 @@ class MeetingActor(
     val numOfListenOnlyUsers: Int = listenOnlyUsers.length
     val listenOnlyAudio = ListenOnlyAudio(
       numOfListenOnlyUsers,
-      listenOnlyUsers.map(voiceUserState => User(voiceUserState.voiceUserId, resolveUserName(voiceUserState.intId))).toList
+      listenOnlyUsers.map(voiceUserState => User(voiceUserState.voiceUserId, voiceUserState.callerName)).toList
     )
 
     val freeswitchUsers: Vector[VoiceUserState] = findAllFreeswitchCallers(liveMeeting.voiceUsers)
     val numOfFreeswitchUsers: Int = freeswitchUsers.length
     val twoWayAudio = TwoWayAudio(
       numOfFreeswitchUsers,
-      freeswitchUsers.map(voiceUserState => User(voiceUserState.voiceUserId, resolveUserName(voiceUserState.intId))).toList
+      freeswitchUsers.map(voiceUserState => User(voiceUserState.voiceUserId, voiceUserState.callerName)).toList
     )
 
     // TODO: Placeholder values

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -927,18 +927,12 @@ class MeetingActor(
     )
   }
 
-  private def resolveUserName(userId: String): String = {
-    val userName: String = Users2x.findWithIntId(liveMeeting.users2x, userId).map(_.name).getOrElse("")
-    if (userName.isEmpty) log.error(s"Failed to map username for id $userId")
-    userName
-  }
-
   private def getMeetingInfoWebcamDetails(): Webcam = {
     val liveWebcams: Vector[org.bigbluebutton.core.models.WebcamStream] = findAll(liveMeeting.webcams)
     val numOfLiveWebcams: Int = liveWebcams.length
     val broadcasts: List[Broadcast] = liveWebcams.map(webcam => Broadcast(
       webcam.streamId,
-      User(webcam.userId, resolveUserName(webcam.userId)), 0L
+      User(webcam.userId, webcam.userName), 0L
     )).toList
     val subscribers: Set[String] = liveWebcams.flatMap(_.subscribers).toSet
     val webcamStream: msgs.WebcamStream = msgs.WebcamStream(broadcasts, subscribers)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeTestData.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeTestData.scala
@@ -61,7 +61,7 @@ trait FakeTestData {
     val rusers = Users2x.findAll(liveMeeting.users2x)
     val others = rusers.filterNot(u => u.intId == ruser1.id)
     val subscribers = others.map { o => o.intId }
-    val wstream1 = FakeUserGenerator.createFakeWebcamStreamFor(ruser1.id, subscribers.toSet)
+    val wstream1 = FakeUserGenerator.createFakeWebcamStreamFor(ruser1.id, ruser1.name, subscribers.toSet)
     Webcams.addWebcamStream(liveMeeting.props.meetingProp.intId, liveMeeting.webcams, wstream1)
 
     createFakeUser(liveMeeting, ruser1)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/testdata/FakeUserGenerator.scala
@@ -126,9 +126,17 @@ object FakeUserGenerator {
     )
   }
 
-  def createFakeWebcamStreamFor(userId: String, subscribers: Set[String]): WebcamStream = {
+  def createFakeWebcamStreamFor(userId: String, userName: String, subscribers: Set[String]): WebcamStream = {
     val streamId = RandomStringGenerator.randomAlphanumericString(10)
-    WebcamStream(streamId, userId, "camera", hasAudio = false, showAsContent = false, subscribers)
+    WebcamStream(
+      streamId = streamId,
+      userId = userId,
+      userName = userName,
+      contentType = "camera",
+      hasAudio = false,
+      showAsContent = false,
+      subscribers = subscribers
+    )
   }
 
 }

--- a/akka-bbb-apps/src/test/scala/org/bigbluebutton/core2/testdata/TestDataGen.scala
+++ b/akka-bbb-apps/src/test/scala/org/bigbluebutton/core2/testdata/TestDataGen.scala
@@ -78,7 +78,15 @@ object TestDataGen {
 
   def createFakeWebcamStreamFor(userId: String, subscribers: Set[String]): WebcamStream = {
     val streamId = RandomStringGenerator.randomAlphanumericString(10)
-    WebcamStream(streamId, userId, subscribers)
+    WebcamStream(
+      streamId = streamId,
+      userId = userId,
+      userName = userId,
+      contentType = "camera",
+      hasAudio = false,
+      showAsContent = false,
+      subscribers = subscribers
+    )
   }
 
   def createUserFor(liveMeeting: LiveMeeting, regUser: RegisteredUser, presenter: Boolean): UserState = {


### PR DESCRIPTION
### What does this PR do?

Preserve audio and webcam user names in meeting analytics after participants leave

### Closes Issue(s)
Closes #25232
