### PR TITLE
feat(sidebar-navigation): align sizing and notification badge colors with design spec

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
@@ -3,13 +3,16 @@ import {
   borderSize,
   borderSizeSmall,
   navigationSidebarListItemsWidth,
+  navigationSidebarIconSize,
+  navigationSidebarIconSizeSmallHeight,
   navigationSidebarNotificationBadgeSize,
-  navigationSidebarNotificationBadgePosition,
+  navigationSidebarNotificationBadgeFontSize,
+  navigationSidebarNotificationBadgeBottom,
+  navigationSidebarNotificationBadgeRight,
 } from '/imports/ui/stylesheets/styled-components/general';
 import {
-  colorGrayLight,
   colorWhite,
-  colorDanger,
+  notificationBadgeBg,
   colorPrimary,
   listItemBgHover,
   itemFocusBorder,
@@ -35,11 +38,11 @@ export const ListItem = styled.div<ListItemProps>`
   border-radius: 50%;
 
   > i {
-    font-size: 140%;
-    color: ${colorGrayLight};
+    font-size: ${navigationSidebarIconSize};
+    color: ${colorGrayIcons};
 
     @media ${smallHeight} {
-      font-size: 110%;
+      font-size: ${navigationSidebarIconSizeSmallHeight};
     }
   }
 
@@ -77,9 +80,9 @@ export const ListItem = styled.div<ListItemProps>`
       border-radius: 50%;
       width: ${navigationSidebarNotificationBadgeSize};
       height: ${navigationSidebarNotificationBadgeSize};
-      bottom: ${navigationSidebarNotificationBadgePosition};
-      right: ${navigationSidebarNotificationBadgePosition};
-      background-color: ${colorDanger};
+      bottom: ${navigationSidebarNotificationBadgeBottom};
+      right: ${navigationSidebarNotificationBadgeRight};
+      background-color: ${notificationBadgeBg};
       border: ${borderSizeSmall} solid ${colorWhite};
     }
   `}
@@ -91,12 +94,12 @@ export const ListItem = styled.div<ListItemProps>`
       border-radius: 50%;
       width: ${navigationSidebarNotificationBadgeSize};
       height: ${navigationSidebarNotificationBadgeSize};
-      bottom: ${navigationSidebarNotificationBadgePosition};
-      right: ${navigationSidebarNotificationBadgePosition};
-      background-color: ${colorDanger};
+      bottom: ${navigationSidebarNotificationBadgeBottom};
+      right: ${navigationSidebarNotificationBadgeRight};
+      background-color: ${notificationBadgeBg};
       border: ${borderSizeSmall} solid ${colorWhite};
       color: ${colorWhite};
-      font-size: 10px;
+      font-size: ${navigationSidebarNotificationBadgeFontSize};
       font-weight: bold;
       display: flex;
       align-items: center;

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
@@ -1,9 +1,15 @@
 import styled from 'styled-components';
 import {
   borderSize,
+  borderSizeSmall,
   navigationSidebarBorderRadius,
   navigationSidebarListItemsContainerGap,
+  navigationSidebarListItemsContainerGapSmallHeight,
   navigationSidebarListItemsGap,
+  navigationSidebarListItemsGapSmallHeight,
+  navigationSidebarNotificationBadgeSize,
+  navigationSidebarNotificationBadgeBottom,
+  navigationSidebarNotificationBadgeRight,
   navigationSidebarPaddingY,
   navigationSidebarMargin,
 } from '/imports/ui/stylesheets/styled-components/general';
@@ -11,6 +17,7 @@ import {
   colorGrayDark,
   colorWhite,
   colorDanger,
+  notificationBadgeBg,
   colorBackground,
 } from '/imports/ui/stylesheets/styled-components/palette';
 import { ScrollboxVertical } from '/imports/ui/stylesheets/styled-components/scrollable';
@@ -62,12 +69,12 @@ const NavigationToggleButton = styled(Button)`
       content: '';
       position: absolute;
       border-radius: 50%;
-      width: 12px;
-      height: 12px;
-      bottom: ${borderSize};
-      right: 3px;
-      background-color: ${colorDanger};
-      border: ${borderSize} solid ${colorGrayDark};
+      width: ${navigationSidebarNotificationBadgeSize};
+      height: ${navigationSidebarNotificationBadgeSize};
+      bottom: ${navigationSidebarNotificationBadgeBottom};
+      right: ${navigationSidebarNotificationBadgeRight};
+      background-color: ${notificationBadgeBg};
+      border: ${borderSizeSmall} solid ${colorWhite};
     }
   `}
 `;
@@ -86,7 +93,7 @@ const NavigationSidebarListItemsContainer = styled(ScrollboxVertical)<{
   border-radius: ${navigationSidebarBorderRadius};
   gap: ${navigationSidebarListItemsContainerGap};
   @media ${smallHeight} {
-    gap: 1.25rem;
+    gap: ${navigationSidebarListItemsContainerGapSmallHeight};
   }
 
   ${({ isExpanded }) => (isExpanded ? `
@@ -120,7 +127,7 @@ const PositionedDiv = styled.div`
   gap: ${navigationSidebarListItemsGap};
 
   @media ${smallHeight} {
-    gap: 0.4rem;
+    gap: ${navigationSidebarListItemsGapSmallHeight};
   }
 `;
 

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -45,11 +45,17 @@ const descriptionMargin = '3.5rem';
 const navbarHeight = '3.9375rem';
 const barsPadding = '0.8rem'; // so user-list and chat title is aligned with the presentation title
 const navigationSidebarLogoPadding = '15%';
-const navigationSidebarListItemsContainerGap = '2.5rem';
-const navigationSidebarListItemsGap = '0.8rem';
-const navigationSidebarListItemsWidth = '70%';
-const navigationSidebarNotificationBadgeSize = '16px';
-const navigationSidebarNotificationBadgePosition = '-3px';
+const navigationSidebarListItemsContainerGap = 'calc(18rem / 14)';
+const navigationSidebarListItemsContainerGapSmallHeight = 'calc(9rem / 14)';
+const navigationSidebarListItemsGap = 'calc(12rem / 14)';
+const navigationSidebarListItemsGapSmallHeight = 'calc(6rem / 14)';
+const navigationSidebarListItemsWidth = '65%';
+const navigationSidebarIconSize = 'calc(18rem / 14)';
+const navigationSidebarIconSizeSmallHeight = '1rem';
+const navigationSidebarNotificationBadgeSize = '14px';
+const navigationSidebarNotificationBadgeFontSize = '7px';
+const navigationSidebarNotificationBadgeBottom = '-3px';
+const navigationSidebarNotificationBadgeRight = '-1px';
 const navigationSidebarBorderRadius = '48px';
 const navigationSidebarPaddingY = '20px';
 const navigationSidebarMargin = `${SIDEBAR_NAVIGATION_MARGIN_PERCENTAGE_WIDTH * 100}vw`;
@@ -156,10 +162,16 @@ export {
   barsPadding,
   navigationSidebarLogoPadding,
   navigationSidebarListItemsContainerGap,
+  navigationSidebarListItemsContainerGapSmallHeight,
   navigationSidebarListItemsGap,
+  navigationSidebarListItemsGapSmallHeight,
   navigationSidebarListItemsWidth,
+  navigationSidebarIconSize,
+  navigationSidebarIconSizeSmallHeight,
   navigationSidebarNotificationBadgeSize,
-  navigationSidebarNotificationBadgePosition,
+  navigationSidebarNotificationBadgeFontSize,
+  navigationSidebarNotificationBadgeBottom,
+  navigationSidebarNotificationBadgeRight,
   navigationSidebarBorderRadius,
   navigationSidebarPaddingY,
   navigationSidebarMargin,

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/palette.js
@@ -43,6 +43,7 @@ const colorOverlay = 'var(--color-overlay, rgba(6, 23, 42, 0.75))';
 const userListBg = `var(--user-list-bg, ${colorOffWhite})`;
 const userListText = `var(--user-list-text, ${colorGray})`;
 const unreadMessagesBg = `var(--unread-messages-bg, ${colorDanger})`;
+const notificationBadgeBg = 'var(--notification-badge-bg, #FF3939)';
 const colorGrayLabel = `var(--color-gray-label, ${colorGray})`;
 const colorText = `var(--color-text, ${colorGray})`;
 const colorLink = `var(--color-link, ${colorPrimary})`;
@@ -208,6 +209,7 @@ export {
   userListBg,
   userListText,
   unreadMessagesBg,
+  notificationBadgeBg,
   colorGrayLabel,
   colorText,
   colorLink,


### PR DESCRIPTION
### What does this PR do?
Aligns the navigation sidebar with the design spec, replacing hardcoded and proportionally-inconsistent values with tokens in `general.js`.

Geometry — the spec is authored for an 80px panel, while the client renders a 60px one (`SIDEBAR_NAVIGATION_PANEL_WIDTH`), so every spec value is scaled by 0.75 to keep the proportions:

| Metric | Before | After |
| --- | --- | --- |
| Button diameter | `70%` → 42px | `65%` → 39px |
| Icon | `140%` → 19.6px | 18px |
| Gap between buttons | `0.8rem` → 11.2px | 12px |
| Gap button ↔ separator | `2.5rem` → 35px | 18px |
| Short screens: icon / gaps | `110%` / `0.4rem` / `1.25rem` | 14px / 6px / 9px |

These are written as `calc(18rem / 14)` rather than plain pixels so they keep responding to the client font size control (Settings → Application), while resolving to the exact spec values at the default 14px root. The `max-height: 40em` overrides were literals inline before and are now tokens.

### Closes Issue(s)
Closes None

### More
<img width="133" height="449" alt="image" src="https://github.com/user-attachments/assets/880d5dc0-7d3d-42c7-8a39-5fe43acac0bd" />
