### PR TITLE
refactor: remove deprecated allowDuplicateExtUserid

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -150,8 +150,6 @@ public class ParamsProcessorUtil {
   	private Integer userInactivityInspectTimerInMinutes = 120;
   	private Integer userInactivityThresholdInMinutes = 30;
     private Integer userActivitySignResponseDelayInMinutes = 5;
-    private Boolean defaultAllowDuplicateExtUserid = true;
-
     private Integer maxUserConcurrentAccesses = 0;
   	private Boolean defaultEndWhenNoModerator = false;
   	private Integer defaultEndWhenNoModeratorDelayInMinutes = 1;
@@ -968,11 +966,6 @@ public class ParamsProcessorUtil {
         String avatarURL = useDefaultAvatar ? defaultAvatarURL : "";
         String botAvatarURL = defaultBotAvatarURL;
         String webcamBackgroundURL = useDefaultWebcamBackground ? defaultWebcamBackgroundURL : "";
-
-        if(defaultAllowDuplicateExtUserid == false) {
-            log.warn("[DEPRECATION] use `maxUserConcurrentAccesses=1` instead of `allowDuplicateExtUserid=false`");
-            maxUserConcurrentAccesses = 1;
-        }
 
         // Create the meeting with all passed in parameters.
         Meeting meeting = new Meeting.Builder(externalMeetingId,
@@ -1874,10 +1867,6 @@ public class ParamsProcessorUtil {
 
     public void setLockSettingsPresenterPolicy(String lockSettingsPresenterPolicy) {
 		this.defaultLockSettingsPresenterPolicy = lockSettingsPresenterPolicy;
-	}
-
-	public void setAllowDuplicateExtUserid(Boolean allow) {
-		this.defaultAllowDuplicateExtUserid = allow;
 	}
 
     public void setMaxUserConcurrentAccesses(Integer maxUserConcurrentAccesses) {

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -180,7 +180,7 @@ BBB_WEB_ETC_CONFIG="/etc/bigbluebutton/bbb-web.properties"
 # Properties that have been retired and should no longer be set by administrators.
 # bbb-conf --check will warn if any of these are found in $BBB_WEB_ETC_CONFIG.
 RETIRED_BBB_WEB_PROPERTIES=(
-    allowDuplicateExtUserid           # Removed in BBB 4.0 (use maxUserConcurrentAccesses=1 instead)
+    allowDuplicateExtUserid           # Removed in BBB 4.0 (use maxUserConcurrentAccesses instead)
     lockSettingsDisableNote           # Renamed in BBB 2.5 (use lockSettingsDisableNotes instead)
     breakoutRoomsEnabled              # Removed in BBB 3.0
     learningDashboardEnabled          # Removed in BBB 3.0

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -180,6 +180,7 @@ BBB_WEB_ETC_CONFIG="/etc/bigbluebutton/bbb-web.properties"
 # Properties that have been retired and should no longer be set by administrators.
 # bbb-conf --check will warn if any of these are found in $BBB_WEB_ETC_CONFIG.
 RETIRED_BBB_WEB_PROPERTIES=(
+    allowDuplicateExtUserid           # Removed in BBB 4.0 (use maxUserConcurrentAccesses=1 instead)
     lockSettingsDisableNote           # Renamed in BBB 2.5 (use lockSettingsDisableNotes instead)
     breakoutRoomsEnabled              # Removed in BBB 3.0
     learningDashboardEnabled          # Removed in BBB 3.0

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -597,9 +597,6 @@ notifyRecordingIsOn=false
 # Allow endpoint with current BigBlueButton version
 allowRevealOfBBBVersion=false
 
-# legacy, please use maxUserConcurrentAccesses instead
-allowDuplicateExtUserid=true
-
 # list of plugins manifests (json array)
 # e.g: [{url: "https://plugin_manifest.json"}]
 pluginManifests=

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -260,7 +260,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="lockSettingsHideViewersCursor" value="${lockSettingsHideViewersCursor}"/>
         <property name="lockSettingsHideViewersAnnotation" value="${lockSettingsHideViewersAnnotation}"/>
         <property name="lockSettingsPresenterPolicy" value="${lockSettingsPresenterPolicy}"/>
-        <property name="allowDuplicateExtUserid" value="${allowDuplicateExtUserid}"/>
         <property name="maxUserConcurrentAccesses" value="${maxUserConcurrentAccesses}"/>
         <property name="endWhenNoModerator" value="${endWhenNoModerator}"/>
         <property name="endWhenNoModeratorDelayInMinutes" value="${endWhenNoModeratorDelayInMinutes}"/>

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1731,7 +1731,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 |---|---|---|---|
 | `defaultMeetingLayout` | Default meeting layout | UNIFIED_LAYOUT, CAMERAS_ONLY, PRESENTATION_ONLY, PARTICIPANTS_AND_CHAT_ONLY, MEDIA_ONLY | UNIFIED_LAYOUT _`overwritable`_ (via `meetingLayout`) |
 | `defaultMaxUsers` | Maximum number of users a meeting can have | Integer (0=disable) | 0 _`overwritable`_ (via `maxParticipants`) |
-| `maxUserConcurrentAccesses` | Maximum number of sessions a single user (extId) can open simultaneously in the same meeting; oldest session is ended when exceeded | Integer (0=disable) | 3 |
+| `maxUserConcurrentAccesses` | Maximum number of sessions a single user (extId) can open simultaneously in the same meeting; oldest session is ended when exceeded. Supersedes the removed `allowDuplicateExtUserid` property (`false` is equivalent to `maxUserConcurrentAccesses=1`). | Integer (0=disable) | 3 |
 | `defaultMeetingDuration` | Default duration of the meeting in minutes | Integer (0=disable) | 0 _`overwritable`_ (via `duration`) |
 | `defaultGuestPolicy` | Default guest policy applied to meetings | ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR | ALWAYS_ACCEPT _`overwritable`_ (via `guestPolicy`) |
 | `authenticatedGuest` | Enable authenticated guest mode | true/false | true |

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1731,7 +1731,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 |---|---|---|---|
 | `defaultMeetingLayout` | Default meeting layout | UNIFIED_LAYOUT, CAMERAS_ONLY, PRESENTATION_ONLY, PARTICIPANTS_AND_CHAT_ONLY, MEDIA_ONLY | UNIFIED_LAYOUT _`overwritable`_ (via `meetingLayout`) |
 | `defaultMaxUsers` | Maximum number of users a meeting can have | Integer (0=disable) | 0 _`overwritable`_ (via `maxParticipants`) |
-| `maxUserConcurrentAccesses` | Maximum number of sessions a single user (extId) can open simultaneously in the same meeting; oldest session is ended when exceeded. Supersedes the removed `allowDuplicateExtUserid` property (`false` is equivalent to `maxUserConcurrentAccesses=1`). | Integer (0=disable) | 3 |
+| `maxUserConcurrentAccesses` | Maximum number of sessions a single user (extId) can open simultaneously in the same meeting; oldest session is ended when exceeded. | Integer (0=disable) | 3 |
 | `defaultMeetingDuration` | Default duration of the meeting in minutes | Integer (0=disable) | 0 _`overwritable`_ (via `duration`) |
 | `defaultGuestPolicy` | Default guest policy applied to meetings | ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR | ALWAYS_ACCEPT _`overwritable`_ (via `guestPolicy`) |
 | `authenticatedGuest` | Enable authenticated guest mode | true/false | true |

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -260,6 +260,7 @@ The deprecated REST endpoint `/api/rest/clientSettings` has been removed. Client
 
 #### Removed
 
+- **Behavior change:** `allowDuplicateExtUserid` is no longer recognized. On upgrade, deployments that set `allowDuplicateExtUserid=false` will silently move from one session per external user to the default of three concurrent sessions unless they set `maxUserConcurrentAccesses=1`. This may weaken anti-account-sharing, exam-integrity, or seat-enforcement controls that relied on the removed property. Previously, `allowDuplicateExtUserid=false` also overrode an explicit `maxUserConcurrentAccesses` value (for example, `5`) with `1`; after this change, the explicit value is preserved.
 - `lockSettingsDisableNote` is no longer recognized; use `lockSettingsDisableNotes` instead. The singular property was renamed in BBB 2.5.
 - `clientLogoutTimerInMinutes` was removed. It was never consumed by the HTML5 client; its last reader, the `/enter` endpoint, was removed before BBB 4.0.
   - If you customized `/usr/share/bbb-web/WEB-INF/classes/spring/resources.xml` in place, also remove the `<property name="clientLogoutTimerInMinutes" .../>` entry - bbb-web will fail to start (`NotWritablePropertyException`) otherwise. The `bbb-conf --check` retired-property warning only scans `/etc/bigbluebutton/bbb-web.properties`, not `resources.xml`.

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -260,7 +260,7 @@ The deprecated REST endpoint `/api/rest/clientSettings` has been removed. Client
 
 #### Removed
 
-- **Behavior change:** `allowDuplicateExtUserid` is no longer recognized. On upgrade, deployments that set `allowDuplicateExtUserid=false` will silently move from one session per external user to the default of three concurrent sessions unless they set `maxUserConcurrentAccesses=1`. This may weaken anti-account-sharing, exam-integrity, or seat-enforcement controls that relied on the removed property. Previously, `allowDuplicateExtUserid=false` also overrode an explicit `maxUserConcurrentAccesses` value (for example, `5`) with `1`; after this change, the explicit value is preserved.
+- `allowDuplicateExtUserid` is no longer recognized. Use `maxUserConcurrentAccesses` instead.
 - `lockSettingsDisableNote` is no longer recognized; use `lockSettingsDisableNotes` instead. The singular property was renamed in BBB 2.5.
 - `clientLogoutTimerInMinutes` was removed. It was never consumed by the HTML5 client; its last reader, the `/enter` endpoint, was removed before BBB 4.0.
   - If you customized `/usr/share/bbb-web/WEB-INF/classes/spring/resources.xml` in place, also remove the `<property name="clientLogoutTimerInMinutes" .../>` entry - bbb-web will fail to start (`NotWritablePropertyException`) otherwise. The `bbb-conf --check` retired-property warning only scans `/etc/bigbluebutton/bbb-web.properties`, not `resources.xml`.


### PR DESCRIPTION
### What does this PR do?

Removes the deprecated `allowDuplicateExtUserid` bbb-web property. It was superseded by
`maxUserConcurrentAccesses` in BBB 2.6 and since then has been nothing but a shim that
translated `allowDuplicateExtUserid=false` into `maxUserConcurrentAccesses=1` and logged a
deprecation warning.

That shim also leaked state: it assigned to the `maxUserConcurrentAccesses` **instance field**
of `ParamsProcessorUtil`, which is a singleton. So the first meeting created with
`allowDuplicateExtUserid=false` pinned the limit to 1 for every meeting created afterwards in
the same process, ignoring the configured value.

Gone: the field, the setter, the shim, the `bigbluebutton.properties` entry and the Spring
wiring. Added: `allowDuplicateExtUserid` to bbb-conf's retired-properties list, so
`bbb-conf --check` points admins at the replacement, plus an upgrade note in the docs.

**Behavior change on upgrade:** a server still setting `allowDuplicateExtUserid=false` goes from
1 concurrent session per external user to the default of 3, unless the admin sets
`maxUserConcurrentAccesses=1`. There is no auto-migration — `bbb-conf --check` and the release
note are the only signals.

### Closes Issue(s)

Closes #25056

### How to test

Requires a bbb-web build and deploy.

1. Leave `allowDuplicateExtUserid=false` in `/etc/bigbluebutton/bbb-web.properties` and restart —
   bbb-web should boot normally (no unresolved Spring placeholder); the key is just ignored.
2. `bbb-conf --check` should flag `allowDuplicateExtUserid` as retired.
3. Set `maxUserConcurrentAccesses=1`, join a meeting, then join again with the same `userID` —
   the first session should be ended. This is the behavior `allowDuplicateExtUserid=false` used
   to force.
4. With the default `maxUserConcurrentAccesses=3`, three sessions sharing a `userID` should
   coexist, whatever `allowDuplicateExtUserid` is set to.

### More

- `docs/docs/data/create.tsx` and `development/api.md` were deliberately left alone: this is a
  server property, not a `/create` parameter, so it never appeared there. That's the one
  difference from the `lockSettingsDisableNote` removal (#25481), which this otherwise mirrors.
- The `bbb-common-web` test suite doesn't compile on `v4.0.x-develop` for unrelated reasons, so
  validation was done on a running 4.0 server.
- [x] Added/updated documentation (`new-features.md` upgrade note, `customize.md`
  `maxUserConcurrentAccesses` row)
