### PR TITLE
fix(whiteboard): Frame rename drops characters when typing at normal speed

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -496,8 +496,9 @@ const Whiteboard = React.memo((props) => {
     }
     debouncedUpdateShapes(
       shapes, tlEditorRef, presentationIdRef, pageChanged, assets, bgShape,
+      currentUser?.userId,
     );
-  }, [shapes]);
+  }, [shapes, currentUser?.userId]);
 
   React.useEffect(() => {
     if (removedShapes && removedShapes.length > 0) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -392,17 +392,19 @@ const debouncedUpdateShapes = debounce((
     tlEditorRef.current?.store.mergeRemoteChanges(() => {
       const editingShape = tlEditorRef.current?.getEditingShape();
       const remoteShapesArray = Object.values(shapes).reduce((acc, shape) => {
+        const remoteVersion = Number(shape.meta?.version ?? 0);
+        const localVersion = Number(editingShape?.meta?.version ?? 0);
         const isStaleOwnActiveFrameName = Boolean(currentUserId)
           && editingShape?.id === shape.id
           && editingShape.type === 'frame'
           && shape.type === 'frame'
           && shape.props?.name !== undefined
           && shape.meta?.updatedBy === currentUserId
+          && remoteVersion >= localVersion
           && editingShape.props.name !== shape.props.name;
 
-        // A frame name input is controlled by the local tldraw store. Applying an
-        // older echoed name while it is being edited can replace newer keystrokes.
-        // Preserve only the local name so server metadata is still reconciled.
+        // A frame name input is controlled by the local tldraw store. Preserve
+        // only its name for current or newer self echoes so metadata is reconciled.
         const shapeToMerge = isStaleOwnActiveFrameName
           ? {
             ...shape,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -394,18 +394,26 @@ const debouncedUpdateShapes = debounce((
       const remoteShapesArray = Object.values(shapes).reduce((acc, shape) => {
         const remoteVersion = Number(shape.meta?.version ?? 0);
         const localVersion = Number(editingShape?.meta?.version ?? 0);
-        const isStaleOwnActiveFrameName = Boolean(currentUserId)
+        const echoAuthor = shape.meta?.updatedBy ?? shape.meta?.createdBy;
+        const isOwnActiveFrame = Boolean(currentUserId)
           && editingShape?.id === shape.id
           && editingShape.type === 'frame'
           && shape.type === 'frame'
           && shape.props?.name !== undefined
-          && shape.meta?.updatedBy === currentUserId
-          && remoteVersion >= localVersion
+          && echoAuthor === currentUserId;
+
+        // store.put replaces the whole local record. Ignore older self echoes so
+        // they cannot roll back keystrokes or any other newer local frame fields.
+        if (isOwnActiveFrame && remoteVersion < localVersion) {
+          return acc;
+        }
+
+        const shouldPreserveActiveFrameName = isOwnActiveFrame
           && editingShape.props.name !== shape.props.name;
 
-        // A frame name input is controlled by the local tldraw store. Preserve
-        // only its name for current or newer self echoes so metadata is reconciled.
-        const shapeToMerge = isStaleOwnActiveFrameName
+        // Preserve the locally controlled name for current or newer self echoes
+        // while still reconciling the rest of the server record.
+        const shapeToMerge = shouldPreserveActiveFrameName
           ? {
             ...shape,
             props: {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/service.js
@@ -386,17 +386,39 @@ const sanitizeShape = (shape) => {
 };
 
 const debouncedUpdateShapes = debounce((
-  shapes, tlEditorRef, presentationIdRef, pageChanged, assets, bgShape,
+  shapes, tlEditorRef, presentationIdRef, pageChanged, assets, bgShape, currentUserId,
 ) => {
   if (shapes && Object.keys(shapes).length > 0) {
     tlEditorRef.current?.store.mergeRemoteChanges(() => {
+      const editingShape = tlEditorRef.current?.getEditingShape();
       const remoteShapesArray = Object.values(shapes).reduce((acc, shape) => {
+        const isStaleOwnActiveFrameName = Boolean(currentUserId)
+          && editingShape?.id === shape.id
+          && editingShape.type === 'frame'
+          && shape.type === 'frame'
+          && shape.props?.name !== undefined
+          && shape.meta?.updatedBy === currentUserId
+          && editingShape.props.name !== shape.props.name;
+
+        // A frame name input is controlled by the local tldraw store. Applying an
+        // older echoed name while it is being edited can replace newer keystrokes.
+        // Preserve only the local name so server metadata is still reconciled.
+        const shapeToMerge = isStaleOwnActiveFrameName
+          ? {
+            ...shape,
+            props: {
+              ...shape.props,
+              name: editingShape.props.name,
+            },
+          }
+          : shape;
+
         if (
           (shape.meta?.presentationId === presentationIdRef.current
           || shape?.whiteboardId?.includes(presentationIdRef.current))
           && isValidShapeType(shape)
         ) {
-          acc.push(sanitizeShape(shape));
+          acc.push(sanitizeShape(shapeToMerge));
         }
         return acc;
       }, []);


### PR DESCRIPTION
### What does this PR do?

adjusts shape update to prevent stale self-updates from dropping frame name characters

#### before

[before-reproduction.webm](https://github.com/user-attachments/assets/2f4b0520-ef1e-4ca8-8cc2-0ab2152ffeb0)


#### after

[after-regression-run.webm](https://github.com/user-attachments/assets/1f63a299-1dfb-434b-94c9-7ec18a8378da)


### Closes Issue(s)
Closes #23511

### How to test
1. Go to the whiteboard
2. Create and select a frame
3. Double click to rename
4. Type at normal speed in the rename field
