### PR TITLE
chore: update showSessionDetailsOnJoin default value

### DIFF
--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -847,7 +847,7 @@ public:
   layout:
     hidePresentationOnJoin: false
     showParticipantsOnLogin: false
-    showSessionDetailsOnJoin: true
+    showSessionDetailsOnJoin: false
     showScreenshareQuickSwapButton: false
     showLeaveSessionLabel: false
     usersPerUserListPage: 50


### PR DESCRIPTION
### What does this PR do?

updates `showSessionDetailsOnJoin` default value to `false`

### Motivation

https://github.com/bigbluebutton/bigbluebutton/issues/23426#issuecomment-4137441949

### Closes Issue(s)
Closes #23426