### PR TITLE
refactor(audio): better BBB<->LiveKit state reconciliation on reconnects, bbb-webrtc-sfu@v2.24.0

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
@@ -21,6 +21,9 @@ trait LiveKitParticipantLeftEvtMsgHdlr {
     val userId = msg.header.userId
     val isPresenter = Users2x.isPresenter(userId, liveMeeting.users2x)
 
+    // User has been removed from LK - this is an ACK for the reconciler, forget them
+    liveMeeting.voiceUserReconciler.forget(userId)
+
     // Clean up any voice users associated with the user
     for {
       vu <- VoiceUsers.findWIthIntId(liveMeeting.voiceUsers, userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -164,7 +164,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
 
   private def generateLivekitToken(regUser: RegisteredUser, liveMeeting: LiveMeeting) = {
     if (isUsingLiveKit(liveMeeting)) {
-      val grant = buildLiveKitTokenGrant(
+      val grant = HandlerHelpers.buildLiveKitTokenGrant(
         room = liveMeeting.props.meetingProp.intId,
         canPublish = true,
         canSubscribe = true,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/MediaActionOutcomeMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/MediaActionOutcomeMsgHdlr.scala
@@ -1,0 +1,30 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.bigbluebutton.common2.msgs.{ EjectUserFromVoiceConfRespMsg, UpdateLiveKitParticipantPermissionsRespMsg }
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+
+/**
+ * Outcomes the SFU reports for actions akka cannot confirm itself. For now,
+ * only the VoiceUserReconciler cares about these.
+ */
+trait MediaActionOutcomeMsgHdlr {
+  val liveMeeting: LiveMeeting
+  val outGW: OutMsgRouter
+
+  def handleUpdateLiveKitParticipantPermissionsRespMsg(msg: UpdateLiveKitParticipantPermissionsRespMsg): Unit = {
+    liveMeeting.voiceUserReconciler.onPermissionsOutcome(
+      liveMeeting,
+      msg.header.userId,
+      msg.body.grant,
+      msg.body.outcome
+    )
+  }
+
+  def handleEjectUserFromVoiceConfRespMsg(msg: EjectUserFromVoiceConfRespMsg): Unit = {
+    liveMeeting.voiceUserReconciler.onEjectOutcome(
+      liveMeeting,
+      msg.body.voiceUserId,
+      msg.body.outcome
+    )
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -190,7 +190,22 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
           letUserEnter(state)
         }
       } else {
-        // Regular users reach this point after being allowed to join
+        if (liveMeeting.voiceUserReconciler.isOrphanedVoiceJoin(liveMeeting, msg.body.intId)) {
+          // LiveKit/media usually reconns faster than the graphql side, so this is also how a
+          // returning user's voice session arrives. Admit it either way and let the media grants
+          // decide: a later user re-join will restore permissions, while an orphan will have none
+          // by default.
+          liveMeeting.voiceUserReconciler.fenceVoiceJoin(
+            liveMeeting,
+            outGW,
+            msg.body.intId,
+            msg.body.voiceUserId
+          )
+        } else {
+          // Guarantee that a returning voice user has the same permissions as before they left if
+          // they aren't orphaned.
+          liveMeeting.voiceUserReconciler.restorePermissions(liveMeeting, outGW, msg.body.intId)
+        }
         letUserEnter(state)
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
@@ -48,6 +48,9 @@ trait UserLeftVoiceConfEvtMsgHdlr {
     for {
       user <- VoiceUsers.findWithVoiceUserId(liveMeeting.voiceUsers, msg.body.voiceUserId)
     } yield {
+      // Bridge-agnostic ACK that the audio session is gone for the VU reconciler
+      liveMeeting.voiceUserReconciler.forget(user.intId)
+
       liveMeeting.audioFloorManager.handleUserLeftVoice(
         user.intId,
         System.currentTimeMillis(),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -250,7 +250,19 @@ object VoiceApp extends SystemConfiguration {
               }
             }
           case None =>
-            if (!cvu.intId.startsWith(IntIdPrefixType.DIAL_IN)) {
+            if (cvu.intId.startsWith(IntIdPrefixType.DIAL_IN)) {
+              // Dial-in users get their user record from the voice join itself.
+            } else {
+              // Same rule as in UserJoinedVoiceConfEvtMsgHdlr: the VU is created
+              // either way. If orphaned, with downgraded media permissions.
+              if (liveMeeting.voiceUserReconciler.isOrphanedVoiceJoin(liveMeeting, cvu.intId)) {
+                liveMeeting.voiceUserReconciler.fenceVoiceJoin(
+                  liveMeeting,
+                  outGW,
+                  cvu.intId,
+                  cvu.voiceUserId
+                )
+              }
               val userRole = Users2x.findWithIntId(liveMeeting.users2x, cvu.intId)
                 .map(_.role)
                 .getOrElse(Roles.VIEWER_ROLE)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
@@ -24,6 +24,7 @@ trait VoiceApp2x extends UserJoinedVoiceConfEvtMsgHdlr
   with ChannelHoldChangedVoiceConfEvtMsgHdlr
   with ListenOnlyModeToggledInSfuEvtMsgHdlr
   with DeafenUserCmdMsgHdlr
+  with MediaActionOutcomeMsgHdlr
   with SetUserListenOnlyInputCmdMsgHdlr {
   this: MeetingActor =>
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceUserReconciler.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceUserReconciler.scala
@@ -1,0 +1,351 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.apache.pekko.actor.ActorContext
+import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.common2.msgs.{ LiveKitGrant, MediaActionOutcome }
+import org.bigbluebutton.core.models.{ IntIdPrefixType, Users2x, VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+case class OrphanedVoiceUser(
+    firstSeenOn:  Long,
+    ejectKey:     String,
+    confirmed:    Boolean = false,
+    failures:     Int     = 0,
+    awaitingAck:  Boolean = false,
+    abandoned:    Boolean = false,
+    lastActionOn: Long    = 0L
+)
+
+case class PendingRestore(
+    firstSentOn:  Long,
+    lastActionOn: Long,
+    attempts:     Int  = 1
+)
+
+object VoiceUserReconciler {
+  val MaxEnforcementFailures = 6
+
+  val MaxRestoreAttempts = 6
+
+  val MinActionIntervalMs = 5000L
+
+  // Minimal LiveKit grant for transient participants that are orphaned from Users2x
+  def downgradedGrant(room: String): LiveKitGrant =
+    HandlerHelpers.buildLiveKitTokenGrant(room = room, canPublish = false, canSubscribe = false)
+
+  // Default token grants for a user that has been re-admitted to the meeting.
+  def defaultUserGrant(room: String): LiveKitGrant =
+    HandlerHelpers.buildLiveKitTokenGrant(room = room, canPublish = true, canSubscribe = true)
+}
+
+/**
+ * This is a VoiceUsers <-> Users2x state reconciling watchdog with two
+ * basic roles:
+ *  - Downgrading voice users LK grants that are orphaned from Users2x OR
+ *    ejecting them from the voice bridge if it is not LK-based (mediasoup/FS)
+ *  - Restoring LK grants for a user that has been re-admitted to the meeting
+ *
+ * For LK, state enforcement is a permission downgrade/upgrade rather than an eject:
+ * a gentler approach to transient reconnects which still guarantees enforcement.
+ * For FreeSWITCH-based bridges, we use ejections as we always have.
+ *
+ * bbb-webrtc-sfu is the other acting party here - it executes both ejections
+ * and permission up/downgrades, and it reports the outcome of each.
+ *
+ * Dial-in users are exempt from this reconciliation - they follow a separate
+ * admission path (call gateways with pins).
+ */
+class VoiceUserReconciler(meetingId: String) extends SystemConfiguration {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val trackedOrphans = mutable.Map[String, OrphanedVoiceUser]()
+
+  // Permission restore reqs are re-sent until acked by webrtc-sfu.
+  private val pendingRestores = mutable.Map[String, PendingRestore]()
+
+  private def enabled(liveMeeting: LiveMeeting): Boolean =
+    ejectRogueVoiceUsers && !liveMeeting.props.meetingProp.isBreakout
+
+  private def isReconcilable(intId: String): Boolean =
+    !intId.startsWith(IntIdPrefixType.DIAL_IN)
+
+  private def hasMeetingUser(liveMeeting: LiveMeeting, intId: String): Boolean =
+    Users2x.findWithIntId(liveMeeting.users2x, intId).isDefined
+
+  // A VoiceUser with no Users2x is considered orphan - except dial-in.
+  def isOrphanedVoiceJoin(liveMeeting: LiveMeeting, intId: String): Boolean =
+    enabled(liveMeeting) && isReconcilable(intId) && !hasMeetingUser(liveMeeting, intId)
+
+  // intId is the LiveKit identity and the only persistent ID for it; voiceUserId is a
+  // per-session sid whose alias the SFU drops on leave.
+  private def ejectKey(liveMeeting: LiveMeeting, intId: String, voiceUserId: String): String =
+    if (HandlerHelpers.isUsingLiveKitAudio(liveMeeting)) intId else voiceUserId
+
+  /**
+   * "Fences" a voice session that has no meeting user. The voice user is still created:
+   * it keeps the session visible in BBB's own state, and it gives a later
+   * re-admission something to restore. The permission downgrade is what makes it inert.
+   */
+  def fenceVoiceJoin(
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter,
+      intId:       String,
+      voiceUserId: String
+  )(implicit context: ActorContext): Unit = {
+    if (!enabled(liveMeeting) || !isReconcilable(intId)) return
+
+    log.warn(
+      s"Admitting a voice user with no meeting user under downgraded grants. " +
+        s"meetingId=$meetingId userId=$intId voiceUserId=$voiceUserId"
+    )
+    track(liveMeeting, outGW, intId, ejectKey(liveMeeting, intId, voiceUserId))
+    enforce(liveMeeting, outGW, intId)
+  }
+
+  /**
+   * "Fences" a user the akka lifecycle just dropped from User2x, while their
+   * media session outlived them. Grants are pulled until reconciliation happens.
+   */
+  def fenceRemovedUser(
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter,
+      intId:       String
+  )(implicit context: ActorContext): Unit = {
+    if (!enabled(liveMeeting) || !isReconcilable(intId)) return
+
+    VoiceUsers.findWithIntId(liveMeeting.voiceUsers, intId) foreach { vu =>
+      log.warn(
+        s"Downgrading LiveKit grants for a user removed from the meeting. " +
+          s"meetingId=$meetingId userId=$intId"
+      )
+      track(liveMeeting, outGW, intId, ejectKey(liveMeeting, intId, vu.voiceUserId))
+      enforce(liveMeeting, outGW, intId)
+    }
+  }
+
+  def forget(intId: String): Unit = {
+    trackedOrphans.remove(intId)
+    pendingRestores.remove(intId)
+  }
+
+  def restorePermissions(liveMeeting: LiveMeeting, outGW: OutMsgRouter, intId: String): Unit = {
+    forget(intId)
+
+    if (!enabled(liveMeeting) || !isReconcilable(intId)) return
+    if (!HandlerHelpers.isUsingLiveKitAudio(liveMeeting)) return
+
+    val now = System.currentTimeMillis()
+    pendingRestores.put(intId, PendingRestore(firstSentOn = now, lastActionOn = now))
+    sendRestore(intId, outGW)
+  }
+
+  private def sendRestore(intId: String, outGW: OutMsgRouter): Unit =
+    outGW.send(MsgBuilder.buildUpdateLiveKitParticipantPermissionsSysMsg(
+      meetingId,
+      intId,
+      VoiceUserReconciler.defaultUserGrant(meetingId)
+    ))
+
+  /**
+   * Records an orphan and gives up anything it should no longer hold. A new session
+   * restarts the enforcement state but never firstSeenOn, which stays the moment the
+   * user first went missing.
+   */
+  private def track(
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter,
+      intId:       String,
+      key:         String
+  )(implicit context: ActorContext): Unit = {
+    val known = trackedOrphans.contains(intId)
+
+    trackedOrphans.updateWith(intId) {
+      case Some(tracking) =>
+        Some(tracking.copy(
+          ejectKey = key,
+          confirmed = false,
+          failures = 0,
+          awaitingAck = false,
+          abandoned = false,
+          lastActionOn = 0L
+        ))
+      case None =>
+        Some(OrphanedVoiceUser(firstSeenOn = System.currentTimeMillis(), ejectKey = key))
+    }
+
+    // A fenced user cannot publish audio anymore, so release its floor here.
+    // The floor manager only does so on a real voice departure.
+    if (!known) liveMeeting.audioFloorManager.handleUserLeftVoice(intId, liveMeeting = liveMeeting, outGW = outGW)
+  }
+
+  /**
+   * Outcome of a LK permission update. The grant itself diffs the update direction:
+   * - Restore permission asks for canPublish=true
+   * - Enforce downgrade asks for canPublish=false
+   */
+  def onPermissionsOutcome(
+      liveMeeting: LiveMeeting,
+      intId:       String,
+      grant:       LiveKitGrant,
+      outcome:     String
+  ): Unit = {
+    if (!acceptsOutcomes(liveMeeting, intId)) return
+
+    if (grant.canPublish) onRestoreOutcome(intId, outcome)
+    else onEnforcementOutcome(intId, outcome, "Downgrading LiveKit grants")
+  }
+
+  private def acceptsOutcomes(liveMeeting: LiveMeeting, intId: String): Boolean =
+    enabled(liveMeeting) && isReconcilable(intId) && HandlerHelpers.isUsingLiveKitAudio(liveMeeting)
+
+  private def onRestoreOutcome(intId: String, outcome: String): Unit = outcome match {
+    // Absent is as good as restored, i.e.: there is no session left carrying a downgrade
+    // and it'll likely pick up a fresh token on rejoin (with default grants).
+    case MediaActionOutcome.APPLIED | MediaActionOutcome.PARTICIPANT_ABSENT =>
+      pendingRestores.remove(intId)
+    case _ =>
+      log.warn(
+        s"Restoring LiveKit grants did not land; will retry. meetingId=$meetingId " +
+          s"userId=$intId outcome=$outcome"
+      )
+  }
+
+  /**
+   * Outcome of an eject. Only the LiveKit bridge reports one.
+   * FreeSWITCH signals a departure through the voice-conf leave handler.
+   */
+  def onEjectOutcome(liveMeeting: LiveMeeting, intId: String, outcome: String): Unit = {
+    if (!acceptsOutcomes(liveMeeting, intId)) return
+
+    onEnforcementOutcome(intId, outcome, "Ejecting a voice user with no meeting user")
+  }
+
+  private def onEnforcementOutcome(intId: String, outcome: String, action: String): Unit =
+    outcome match {
+      case MediaActionOutcome.APPLIED =>
+        trackedOrphans.get(intId) foreach { t =>
+          trackedOrphans.put(intId, t.copy(confirmed = true, awaitingAck = false, failures = 0))
+        }
+      case MediaActionOutcome.PARTICIPANT_ABSENT =>
+        trackedOrphans.remove(intId)
+      case _ =>
+        trackedOrphans.get(intId) foreach { t =>
+          trackedOrphans.put(intId, t.copy(awaitingAck = false, failures = t.failures + 1))
+        }
+        log.warn(
+          s"$action did not land; will retry. meetingId=$meetingId userId=$intId outcome=$outcome"
+        )
+    }
+
+  /**
+   * Applies grant enforcement once, and charges the previous attempt if it was never
+   * acked. Gives up at MaxEnforcementFailures rather than retrying forever. Log
+   * it for auditing purposes as exhaustion should never happen.
+   */
+  private def enforce(liveMeeting: LiveMeeting, outGW: OutMsgRouter, intId: String): Unit = {
+    val now = System.currentTimeMillis()
+
+    trackedOrphans.get(intId) foreach { tracking =>
+      if (now - tracking.lastActionOn >= VoiceUserReconciler.MinActionIntervalMs) {
+        val failures = if (tracking.awaitingAck) tracking.failures + 1 else tracking.failures
+
+        if (failures >= VoiceUserReconciler.MaxEnforcementFailures) {
+          log.error(
+            s"Abandoning enforcement against a voice user with no meeting user; it may still " +
+              s"be publishing. meetingId=$meetingId userId=$intId failures=$failures"
+          )
+          trackedOrphans.put(intId, tracking.copy(
+            failures = failures,
+            awaitingAck = false,
+            abandoned = true
+          ))
+        } else {
+          if (HandlerHelpers.isUsingLiveKitAudio(liveMeeting)) {
+            log.warn(
+              s"Downgrading LiveKit grants for a voice user with no meeting user. " +
+                s"meetingId=$meetingId userId=$intId failures=$failures"
+            )
+            outGW.send(MsgBuilder.buildUpdateLiveKitParticipantPermissionsSysMsg(
+              meetingId,
+              intId,
+              VoiceUserReconciler.downgradedGrant(meetingId)
+            ))
+          } else {
+            outGW.send(MsgBuilder.buildEjectUserFromVoiceConfSysMsg(
+              meetingId,
+              liveMeeting.props.voiceProp.voiceConf,
+              tracking.ejectKey
+            ))
+          }
+
+          trackedOrphans.put(intId, tracking.copy(
+            failures = failures,
+            awaitingAck = true,
+            lastActionOn = now
+          ))
+        }
+      }
+    }
+  }
+
+  private def retryRestores(outGW: OutMsgRouter, now: Long): Unit = {
+    pendingRestores.keys.toVector.foreach { intId =>
+      pendingRestores.get(intId) foreach { pending =>
+        if (pending.attempts >= VoiceUserReconciler.MaxRestoreAttempts) {
+          log.error(
+            s"Giving up on restoring LiveKit grants; the user may be left unable to publish. " +
+              s"meetingId=$meetingId userId=$intId attempts=${pending.attempts}"
+          )
+          pendingRestores.remove(intId)
+        } else if (now - pending.lastActionOn >= VoiceUserReconciler.MinActionIntervalMs) {
+          sendRestore(intId, outGW)
+          pendingRestores.put(intId, pending.copy(
+            lastActionOn = now,
+            attempts = pending.attempts + 1
+          ))
+        }
+      }
+    }
+  }
+
+  /**
+   * Main VoiceUsers <-> Users2x reconciliation routine.
+   * Used by akka-apps' audit in MeetingActor for periodic reconciliation.
+   */
+  def reconcile(liveMeeting: LiveMeeting, outGW: OutMsgRouter)(implicit context: ActorContext): Unit = {
+    if (!enabled(liveMeeting)) return
+
+    val now = System.currentTimeMillis()
+    retryRestores(outGW, now)
+
+    val meetingUserIds = Users2x.findAll(liveMeeting.users2x).map(_.intId).toSet
+    val observedOrphans: Map[String, VoiceUserState] = VoiceUsers.findAll(liveMeeting.voiceUsers)
+      .filter(vu => isReconcilable(vu.intId) && !meetingUserIds.contains(vu.intId))
+      .map(vu => vu.intId -> vu)
+      .toMap
+
+    observedOrphans.foreach {
+      case (intId, vu) =>
+        trackedOrphans.get(intId) match {
+          case None =>
+            track(liveMeeting, outGW, intId, ejectKey(liveMeeting, intId, vu.voiceUserId))
+          // Publishing again after a confirmed downgrade means something restored the
+          // grants behind us, so the confirmation no longer holds.
+          case Some(tracking) if tracking.confirmed && !vu.muted =>
+            trackedOrphans.put(intId, tracking.copy(confirmed = false, failures = 0))
+          case _ =>
+        }
+    }
+
+    trackedOrphans.keys.toVector.foreach { intId =>
+      val tracking = trackedOrphans.get(intId)
+      // Abandoned entries are kept, not dropped: dropping one only means the next
+      // scan re-tracks it with a fresh budget and the give-up never takes.
+      if (!tracking.exists(t => t.confirmed || t.abandoned)) enforce(liveMeeting, outGW, intId)
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -246,6 +246,10 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[GenerateLiveKitTokenRespMsg](envelope, jsonNode)
       case LiveKitParticipantLeftEvtMsg.NAME =>
         routeGenericMsg[LiveKitParticipantLeftEvtMsg](envelope, jsonNode)
+      case UpdateLiveKitParticipantPermissionsRespMsg.NAME =>
+        routeGenericMsg[UpdateLiveKitParticipantPermissionsRespMsg](envelope, jsonNode)
+      case EjectUserFromVoiceConfRespMsg.NAME =>
+        routeGenericMsg[EjectUserFromVoiceConfRespMsg](envelope, jsonNode)
 
       // Breakout rooms
       case BreakoutRoomsListMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -117,6 +117,10 @@ trait HandlerHelpers extends SystemConfiguration {
           case None =>
             Users2x.add(liveMeeting.users2x, newUser)
 
+            // Guarantee that an eventual orphaned VoiceUser has its permissions
+            // restored. No-ops if not applicable.
+            liveMeeting.voiceUserReconciler.restorePermissions(liveMeeting, outGW, newUser.intId)
+
             val event = UserJoinedMeetingEvtMsgBuilder.build(liveMeeting.props.meetingProp.intId, newUser)
             outGW.send(event)
 
@@ -425,9 +429,22 @@ trait HandlerHelpers extends SystemConfiguration {
     liveMeeting.props.meetingProp.screenShareBridge == "livekit"
   }
 
-  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean = {
-    liveMeeting.props.meetingProp.audioBridge == "livekit"
+  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean =
+    HandlerHelpers.isUsingLiveKitAudio(liveMeeting)
+
+  def buildLiveKitParticipantMetadata(
+    liveMeeting: LiveMeeting,
+  ): LiveKitParticipantMetadata = {
+    LiveKitParticipantMetadata(
+      meetingId = liveMeeting.props.meetingProp.intId,
+      voiceConf = liveMeeting.props.voiceProp.voiceConf
+    )
   }
+}
+
+object HandlerHelpers {
+  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean =
+    liveMeeting.props.meetingProp.audioBridge == "livekit"
 
   def buildLiveKitTokenGrant(
     room: String,
@@ -462,15 +479,6 @@ trait HandlerHelpers extends SystemConfiguration {
       roomJoin = roomJoin,
       roomList = roomList,
       roomRecord = roomRecord,
-    )
-  }
-
-  def buildLiveKitParticipantMetadata(
-    liveMeeting: LiveMeeting,
-  ): LiveKitParticipantMetadata = {
-    LiveKitParticipantMetadata(
-      meetingId = liveMeeting.props.meetingProp.intId,
-      voiceConf = liveMeeting.props.voiceProp.voiceConf
     )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.running
 
 import org.bigbluebutton.common2.domain.DefaultProps
 import org.bigbluebutton.core.apps._
-import org.bigbluebutton.core.apps.voice.AudioFloorManager
+import org.bigbluebutton.core.apps.voice.{ AudioFloorManager, VoiceUserReconciler }
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
 
@@ -30,4 +30,5 @@ class LiveMeeting(
     val plugins:             PluginModel,
 ) {
   val audioFloorManager = new AudioFloorManager(props.meetingProp.intId)
+  val voiceUserReconciler = new VoiceUserReconciler(props.meetingProp.intId)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -514,6 +514,9 @@ class MeetingActor(
       case m: SetUserEchoTestRunningReqMsg => usersApp.handleSetUserEchoTestRunningReqMsg(m)
       case m: GenerateLiveKitTokenRespMsg  => handleGenerateLiveKitTokenRespMsg(m)
       case m: LiveKitParticipantLeftEvtMsg => handleLiveKitParticipantLeftEvtMsg(m)
+      case m: UpdateLiveKitParticipantPermissionsRespMsg =>
+        handleUpdateLiveKitParticipantPermissionsRespMsg(m)
+      case m: EjectUserFromVoiceConfRespMsg => handleEjectUserFromVoiceConfRespMsg(m)
 
       // Client requested to eject user
       case m: EjectUserFromMeetingCmdMsg =>
@@ -1012,6 +1015,9 @@ class MeetingActor(
   def handleMonitorNumberOfUsers(msg: MonitorNumberOfUsersInternalMsg) {
     state = removeUsersWithExpiredUserLeftFlag(liveMeeting, state)
 
+    // Reconcile VoiceUsers <-> Users2x
+    liveMeeting.voiceUserReconciler.reconcile(liveMeeting, outGW)
+
     if (!liveMeeting.props.meetingProp.isBreakout) {
       // Track expiry only for non-breakout rooms. The breakout room lifecycle is
       // driven by the parent meeting.
@@ -1159,6 +1165,10 @@ class MeetingActor(
         ru <- RegisteredUsers.findWithUserId(leftUser.intId, liveMeeting.registeredUsers)
       } yield {
         log.info("Removing user from meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
+
+        // Their media session might outlive them (for good reason - e.g.: smoother reconns).
+        // Fence them until restored or ejected.
+        liveMeeting.voiceUserReconciler.fenceRemovedUser(liveMeeting, outGW, u.intId)
 
         val updatedRegUser = RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, ru, joined = false)
         UserDAO.update(updatedRegUser)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -54,6 +54,8 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
         msgSender.send(toVoiceConfRedisChannel, json)
 
       // Sent to SFU
+      case UpdateLiveKitParticipantPermissionsSysMsg.NAME =>
+        msgSender.send(toSfuRedisChannel, json)
       case EjectUserFromSfuSysMsg.NAME =>
         msgSender.send(toSfuRedisChannel, json)
       case CamBroadcastStopSysMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -299,6 +299,20 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildUpdateLiveKitParticipantPermissionsSysMsg(
+      meetingId: String,
+      userId:    String,
+      grant:     LiveKitGrant
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(UpdateLiveKitParticipantPermissionsSysMsg.NAME, routing)
+    val body = UpdateLiveKitParticipantPermissionsSysMsgBody(userId, grant)
+    val header = BbbCoreHeaderWithMeetingId(UpdateLiveKitParticipantPermissionsSysMsg.NAME, meetingId)
+    val event = UpdateLiveKitParticipantPermissionsSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
   def buildMeetingMutedEvtMsg(meetingId: String, userId: String, muted: Boolean, mutedBy: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(MeetingMutedEvtMsg.NAME, routing)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LiveKitMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LiveKitMsgs.scala
@@ -105,3 +105,57 @@ case class LiveKitParticipantLeftEvtMsg(
 case class LiveKitParticipantLeftEvtMsgBody(
     userId: String,
 )
+
+/**
+ * Re-applies a participant's LiveKit permissions on their live session, keyed by
+ * BBB intId (the LiveKit identity for web users). LiveKit writes the change into
+ * the participant's claim grants and refreshes the client's token, so it survives
+ * an ordinary SDK reconnect. Idempotent.
+ */
+object UpdateLiveKitParticipantPermissionsSysMsg { val NAME = "UpdateLiveKitParticipantPermissionsSysMsg" }
+case class UpdateLiveKitParticipantPermissionsSysMsg(
+    header: BbbCoreHeaderWithMeetingId,
+    body:   UpdateLiveKitParticipantPermissionsSysMsgBody
+) extends BbbCoreMsg
+case class UpdateLiveKitParticipantPermissionsSysMsgBody(
+    userId: String,
+    grant:  LiveKitGrant,
+)
+
+/**
+ * Outcome of a media-stack action that akka-apps requested to bbb-webrtc-sfu
+ */
+object MediaActionOutcome {
+  val APPLIED = "applied"
+  val ROOM_ABSENT = "roomAbsent"
+  val PARTICIPANT_ABSENT = "participantAbsent"
+  val FAILED = "failed"
+}
+
+/**
+ * Acknowledges an UpdateLiveKitParticipantPermissionsSysMsg
+ */
+object UpdateLiveKitParticipantPermissionsRespMsg { val NAME = "UpdateLiveKitParticipantPermissionsRespMsg" }
+case class UpdateLiveKitParticipantPermissionsRespMsg(
+    header: BbbClientMsgHeader,
+    body:   UpdateLiveKitParticipantPermissionsRespMsgBody
+) extends StandardMsg
+case class UpdateLiveKitParticipantPermissionsRespMsgBody(
+    grant:   LiveKitGrant,
+    outcome: String,
+)
+
+/**
+ * Acknowledges an EjectUserFromVoiceConfSysMsg. Only the LiveKit bridge sends it;
+ * the FreeSWITCH path reports a leave event instead (as always).
+ */
+object EjectUserFromVoiceConfRespMsg { val NAME = "EjectUserFromVoiceConfRespMsg" }
+case class EjectUserFromVoiceConfRespMsg(
+    header: BbbClientMsgHeader,
+    body:   EjectUserFromVoiceConfRespMsgBody
+) extends StandardMsg
+case class EjectUserFromVoiceConfRespMsgBody(
+    voiceConf:   String,
+    voiceUserId: String,
+    outcome:     String,
+)

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.23.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.24.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu

--- a/bigbluebutton-tests/playwright/audio/audioStateSync.spec.ts
+++ b/bigbluebutton-tests/playwright/audio/audioStateSync.spec.ts
@@ -1,0 +1,309 @@
+import { type Browser, expect, type TestInfo, type WebSocketRoute } from '@playwright/test';
+
+import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { isLiveKit } from '../core/livekit';
+import { Page } from '../core/page';
+import { test } from '../core/setup/fixtures';
+import { Audio } from './audio';
+import {
+  APOLLO_CLIENT_SETTINGS_MODULE,
+  expectUserRemoved,
+  getMeetingUserIds,
+  getOwnUserId,
+  getUnsyncedVoiceUsers,
+  isApolloClientExposed,
+} from './floorProbe';
+import {
+  exposeLiveKitRoom,
+  forceRoomReconnect,
+  getAudioPublisherIdentities,
+  getLocalMicState,
+  getRemoteAudioStates,
+  reconnectWithExistingToken,
+  republishMicrophone,
+  suppressRoomDisconnect,
+} from './liveKitProbe';
+import { connectMicrophone, ensureUnmuted } from './util';
+
+const VIEWER_NAME = 'StrandedViewer';
+
+const APOLLO_EXPOSURE_SKIP_REASON =
+  'requires window.__APOLLO_CLIENT__ for the server-state probe ' +
+  '(dev bundle or enableApolloDevTools provisioned via clientSettingsOverride)';
+
+// Passive user removal: natural eject by akka-apps on disconnects. Lands
+// ~20s after the client's GraphQL closes: 10s user-left flag plus a 10s akka-audit tick.
+const PASSIVE_REMOVAL_WAIT_TIME = 45_000;
+
+// VoiceUser <-> Users2x enforcement timer. Fencing usually lands with user
+// removal- so do the above 45s + a blanket 15s which usually is LK's own ejection
+// timer.
+const ENFORCEMENT_WAIT_TIME = 60_000;
+
+// A still-flowing media stream would add hundreds of packets in this.
+const SILENCE_SAMPLE_WINDOW = 3_000;
+
+// Two pages joining a meeting and then audio. Built from element waits so it
+// scales with the CI multiplier, which the fixed budgets above do not.
+const FIXTURE_SETUP_BUDGET = ELEMENT_WAIT_EXTRA_LONG_TIME * 4;
+
+interface AudioStateSyncFixture {
+  audio: Audio;
+  modPage: Page;
+  viewerPage: Page;
+  viewerUserId: string;
+  cutGraphql: () => Promise<void>;
+  restoreGraphql: () => void;
+}
+
+// Moderator (server-state probe) + viewer (unmuted publisher), both exposing
+// window.liveKitRoom. The viewer's GraphQL socket is proxied so it can be cut
+// without touching LiveKit.
+const initAudioStateSyncScenario = async (browser: Browser, testInfo: TestInfo): Promise<AudioStateSyncFixture> => {
+  const context = await browser.newContext();
+  const audio = new Audio(browser, context);
+
+  const modRawPage = await context.newPage();
+  await exposeLiveKitRoom(modRawPage);
+  await audio.initModPage(modRawPage, { testInfo, createModules: APOLLO_CLIENT_SETTINGS_MODULE });
+  const { modPage } = audio;
+  test.skip(!(await isApolloClientExposed(modPage.page, ELEMENT_WAIT_TIME)), APOLLO_EXPOSURE_SKIP_REASON);
+
+  const viewerRawPage = await context.newPage();
+  await exposeLiveKitRoom(viewerRawPage);
+
+  let blockGraphql = false;
+  const liveSockets = new Set<WebSocketRoute>();
+  await viewerRawPage.routeWebSocket('**/graphql', (ws) => {
+    if (blockGraphql) {
+      ws.close();
+      return;
+    }
+    ws.connectToServer();
+    liveSockets.add(ws);
+  });
+
+  const viewerPage = new Page(browser, viewerRawPage, testInfo);
+  await viewerPage.init(false, { fullName: VIEWER_NAME, meetingId: modPage.meetingId, testInfo });
+  audio.userPage = viewerPage;
+
+  await modPage.waitAndClick(e.joinAudio);
+  await connectMicrophone(modPage);
+  await viewerPage.waitAndClick(e.joinAudio);
+  await connectMicrophone(viewerPage);
+  await ensureUnmuted(viewerPage);
+
+  return {
+    audio,
+    modPage,
+    viewerPage,
+    viewerUserId: await getOwnUserId(viewerPage.page),
+    cutGraphql: async () => {
+      blockGraphql = true;
+      await Promise.all([...liveSockets].map((ws) => ws.close()));
+    },
+    // The client retries on its own, so lifting the block is enough for it to
+    // reconnect and re-fire userJoin, which is what triggers the restore.
+    restoreGraphql: () => {
+      blockGraphql = false;
+    },
+  };
+};
+
+// Two conditions to check: nobody publishes audio without a matching BBB user,
+// and any voice row without one is inert. Media is checked first.
+const expectNoUnknownAudioParticipant = async (
+  fixture: AudioStateSyncFixture,
+  removedUserId: string,
+  timeout: number,
+): Promise<void> => {
+  const { modPage } = fixture;
+  await expect(async () => {
+    const publishers = await getAudioPublisherIdentities(modPage.page);
+    expect(publishers, 'should not receive audio from a participant who is not in the meeting').not.toContain(
+      removedUserId,
+    );
+    // A voice row with no meeting user is is fenced by BBB. What must
+    // not survive is a fenced user still talking or holding the floor.
+    const unsynced = await getUnsyncedVoiceUsers(modPage.page);
+    const loud = unsynced.filter((row) => row.talking || row.floor || !row.muted);
+    expect(loud, 'a voice user with no meeting user should be muted and hold no floor').toEqual([]);
+  }).toPass({ timeout });
+
+  // The check above is publication-level and would also pass on a merely muted
+  // offender, and mute is signalled state. Enforcement revokes canPublish, so the
+  // guarantee is "present with nothing published", not eviction.
+  const states = await getRemoteAudioStates(modPage.page);
+  const orphan = states.find((state) => state.identity === removedUserId);
+  const detail = JSON.stringify(states);
+  if (orphan) {
+    expect(orphan.micPublications, `a user who is not in the meeting should publish no audio (${detail})`).toBe(0);
+    expect(orphan.subscribed, `a user who is not in the meeting should have no subscribed audio (${detail})`).toBe(0);
+    expect(orphan.liveTracks, `a user who is not in the meeting should have no live audio track (${detail})`).toBe(0);
+  }
+};
+
+// Proves no media is arriving at the packet level, independent of signalled state.
+const expectNoInboundAudio = async (fixture: AudioStateSyncFixture, removedUserId: string): Promise<void> => {
+  const { modPage } = fixture;
+  const read = async () =>
+    (await getRemoteAudioStates(modPage.page)).find((state) => state.identity === removedUserId)?.packetsReceived ?? 0;
+
+  const before = await read();
+  await modPage.page.waitForTimeout(SILENCE_SAMPLE_WINDOW);
+  const after = await read();
+  // Negative means the participant went away between reads, which is also a pass.
+  expect(after - before, 'should not receive any audio RTP from a user who is not in the meeting').toBeLessThanOrEqual(
+    0,
+  );
+};
+
+const expectAudioIsFlowing = async (fixture: AudioStateSyncFixture): Promise<void> => {
+  const { modPage, viewerPage, viewerUserId } = fixture;
+  await expect(async () => {
+    const local = await getLocalMicState(viewerPage.page);
+    expect(local.roomState, 'the viewer should be connected to the LiveKit room').toBe('connected');
+    expect(local.micPublications, 'the viewer should publish a microphone track').toBeGreaterThan(0);
+    expect(local.allMuted, 'the viewer should be unmuted').toBe(false);
+    const publishers = await getAudioPublisherIdentities(modPage.page);
+    expect(publishers, 'the moderator should receive the viewer audio before the removal').toContain(viewerUserId);
+  }).toPass({ timeout: ELEMENT_WAIT_LONGER_TIME });
+};
+
+// Best effort: the server is meant to keep the tab out, so a failure here is a
+// correct outcome rather than a test error. The assertion that follows decides.
+const attemptToResumePublishing = async (
+  fixture: AudioStateSyncFixture,
+  how: 'simulate-reconnect' | 'rejoin-with-token',
+): Promise<void> => {
+  const { viewerPage } = fixture;
+  try {
+    if (how === 'simulate-reconnect') await forceRoomReconnect(viewerPage.page);
+    else await reconnectWithExistingToken(viewerPage.page);
+    await republishMicrophone(viewerPage.page);
+  } catch {
+    // Swallowed on purpose.
+  }
+};
+
+test.describe('Audio state sync', { tag: ['@ci', '@media'] }, () => {
+  test.beforeEach(() => {
+    test.skip(!isLiveKit, 'audio state sync enforcement is specific to the LiveKit audio bridge');
+  });
+
+  // A viewer whose client stops talking to the server is removed by the user-left
+  // sweep, then their still-open tab reconnects to LiveKit.
+  test('a passively removed user cannot rejoin audio', async ({ browser }, testInfo) => {
+    const fixture = await initAudioStateSyncScenario(browser, testInfo);
+    const { modPage, viewerPage, viewerUserId } = fixture;
+
+    await expectAudioIsFlowing(fixture);
+
+    // The tab never processes its own removal - the premise of the bug.
+    expect(await suppressRoomDisconnect(viewerPage.page), 'should expose the viewer LiveKit room').toBe(true);
+
+    await fixture.cutGraphql();
+    await expectUserRemoved(
+      modPage.page,
+      viewerUserId,
+      'should drop the viewer from the meeting once the user-left flag expires',
+      PASSIVE_REMOVAL_WAIT_TIME,
+    );
+
+    await attemptToResumePublishing(fixture, 'simulate-reconnect');
+    await expectNoUnknownAudioParticipant(fixture, viewerUserId, ENFORCEMENT_WAIT_TIME);
+    await expectNoInboundAudio(fixture, viewerUserId);
+  });
+
+  // The other half of enforcement: a user who comes back has to end up whole -
+  // publishing again, and with the voice record they were fenced under.
+  test('a fenced user regains audio when they are re-admitted', async ({ browser }, testInfo) => {
+    // Longer than the 3min default: this is the only case that waits out a removal
+    // and a re-admission, so it pays both budgets twice - once fencing, once
+    // restoring. Derived so it follows if either budget is retuned.
+    test.setTimeout(
+      FIXTURE_SETUP_BUDGET + ELEMENT_WAIT_LONGER_TIME + (PASSIVE_REMOVAL_WAIT_TIME + ENFORCEMENT_WAIT_TIME) * 2,
+    );
+
+    const fixture = await initAudioStateSyncScenario(browser, testInfo);
+    const { modPage, viewerPage, viewerUserId } = fixture;
+
+    await expectAudioIsFlowing(fixture);
+
+    // Keep the media session up across the outage: this is the population fencing exists for.
+    expect(await suppressRoomDisconnect(viewerPage.page), 'should expose the viewer LiveKit room').toBe(true);
+
+    await fixture.cutGraphql();
+    await expectUserRemoved(
+      modPage.page,
+      viewerUserId,
+      'should drop the viewer from the meeting once the user-left flag expires',
+      PASSIVE_REMOVAL_WAIT_TIME,
+    );
+
+    // canPublish is pushed down by LiveKit, so it says the grant was revoked
+    // rather than that the client stopped publishing.
+    await expect(async () => {
+      const local = await getLocalMicState(viewerPage.page);
+      expect(local.canPublish, 'the fenced viewer should lose publish rights').toBe(false);
+    }).toPass({ timeout: ENFORCEMENT_WAIT_TIME });
+
+    // Fencing keeps the voice record.
+    const fenced = await getUnsyncedVoiceUsers(modPage.page);
+    expect(
+      fenced.map((row) => row.userId),
+      'a fenced session should keep its voice record so it stays visible',
+    ).toContain(viewerUserId);
+    expect(
+      fenced.filter((row) => row.talking || row.floor || !row.muted),
+      'a fenced voice user should be muted and hold no floor',
+    ).toEqual([]);
+
+    fixture.restoreGraphql();
+    await expect(async () => {
+      const userIds = await getMeetingUserIds(modPage.page);
+      expect(userIds, 'the viewer should be re-admitted once GraphQL recovers').toContain(viewerUserId);
+    }).toPass({ timeout: PASSIVE_REMOVAL_WAIT_TIME });
+
+    // The client does not republish on its own, so drive it inside the loop: a
+    // single attempt before it could race the restore.
+    await expect(async () => {
+      const local = await getLocalMicState(viewerPage.page);
+      expect(local.canPublish, 'a re-admitted user should have publish rights restored').toBe(true);
+      await republishMicrophone(viewerPage.page);
+      const publishers = await getAudioPublisherIdentities(modPage.page);
+      expect(publishers, 'the moderator should hear a re-admitted user again').toContain(viewerUserId);
+    }).toPass({ timeout: ENFORCEMENT_WAIT_TIME });
+  });
+
+  // Same invariant under an explicit user eject. LiveKit does kick the participant,
+  // but the client can still try to rejoin with its existing token.
+  test('an ejected user cannot rejoin audio with their existing LiveKit token', async ({ browser }, testInfo) => {
+    const fixture = await initAudioStateSyncScenario(browser, testInfo);
+    const { modPage, viewerPage, viewerUserId } = fixture;
+
+    await expectAudioIsFlowing(fixture);
+
+    expect(await suppressRoomDisconnect(viewerPage.page), 'should expose the viewer LiveKit room').toBe(true);
+
+    await modPage.waitAndClick(e.usersListSidebarButton);
+    // Scoped to the viewer: the user item selector matches every row, including
+    // the moderator's own.
+    const viewerRow = modPage.page.locator(e.userListItem).filter({ hasText: VIEWER_NAME });
+    await viewerRow.locator(e.moreOptionsUserItemButton).click();
+    await modPage.waitAndClick(e.removeUser);
+    await modPage.waitAndClick(e.removeUserConfirmationBtn);
+    await expectUserRemoved(
+      modPage.page,
+      viewerUserId,
+      'should drop the ejected viewer from the meeting',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+
+    // Re-entering is what the client's own connect effect does when it re-fires.
+    await attemptToResumePublishing(fixture, 'rejoin-with-token');
+    await expectNoUnknownAudioParticipant(fixture, viewerUserId, ELEMENT_WAIT_EXTRA_LONG_TIME);
+    await expectNoInboundAudio(fixture, viewerUserId);
+  });
+});

--- a/bigbluebutton-tests/playwright/audio/floorProbe.ts
+++ b/bigbluebutton-tests/playwright/audio/floorProbe.ts
@@ -35,16 +35,19 @@ const queryDocument = (selections: FieldNode[]) => ({
 });
 
 const USER_VOICE_QUERY = queryDocument([
-  field('user_voice', [field('userId'), field('talking'), field('floor'), field('lastFloorTime')]),
+  field('user_voice', [field('userId'), field('talking'), field('floor'), field('lastFloorTime'), field('muted')]),
 ]);
 
 const USER_CURRENT_QUERY = queryDocument([field('user_current', [field('userId')])]);
+
+const USER_QUERY = queryDocument([field('user', [field('userId'), field('name')])]);
 
 export interface UserVoiceRow {
   userId: string;
   talking: boolean;
   floor: boolean;
   lastFloorTime: string;
+  muted: boolean;
 }
 
 type ApolloQueryWindow = Window & {
@@ -99,6 +102,30 @@ export const getOwnUserId = async (page: PlaywrightPage): Promise<string> => {
 export const getFloorHolders = async (page: PlaywrightPage): Promise<string[]> => {
   const rows = await getUserVoiceRows(page);
   return rows.filter((row) => row.floor).map((row) => row.userId);
+};
+
+export const getMeetingUserIds = async (page: PlaywrightPage): Promise<string[]> => {
+  const data = await runQuery(page, USER_QUERY);
+  return (data.user as { userId: string }[]).map((row) => row.userId);
+};
+
+// Voice rows with no matching meeting user - an orphan, in akka's terms.
+export const getUnsyncedVoiceUsers = async (page: PlaywrightPage): Promise<UserVoiceRow[]> => {
+  const [voiceRows, userIds] = await Promise.all([getUserVoiceRows(page), getMeetingUserIds(page)]);
+  const present = new Set(userIds);
+  return voiceRows.filter((row) => !present.has(row.userId));
+};
+
+// Polls until `userId` is gone from the meeting's user list.
+export const expectUserRemoved = async (
+  page: PlaywrightPage,
+  userId: string,
+  message: string,
+  timeout: number,
+): Promise<void> => {
+  await expect(async () => {
+    expect(await getMeetingUserIds(page), message).not.toContain(userId);
+  }).toPass({ timeout });
 };
 
 // Polls until the meeting observed from `page` has exactly one floor holder: `userId`.

--- a/bigbluebutton-tests/playwright/audio/liveKitProbe.ts
+++ b/bigbluebutton-tests/playwright/audio/liveKitProbe.ts
@@ -1,0 +1,211 @@
+import { type Page as PlaywrightPage } from '@playwright/test';
+
+// Passed into page.evaluate rather than closed over: those callbacks are
+// serialized and run in the browser, where this module's scope does not exist.
+const LK_NOT_EXPOSED_ERR_MSG = 'window.liveKitRoom is not exposed';
+
+// Reads the page's own LiveKit Room through window.liveKitRoom, which the client
+// only publishes when BBB_EXPOSE_LIVEKIT_ROOM (same as other specs like muteReinforcement)
+
+export interface TestPublication {
+  source: string;
+  isMuted: boolean;
+  trackSid?: string;
+}
+
+export interface TestRemotePublication extends TestPublication {
+  isSubscribed: boolean;
+  track?: { mediaStreamTrack?: MediaStreamTrack; receiver?: RTCRtpReceiver };
+}
+
+export interface TestRemoteParticipant {
+  identity: string;
+  audioTrackPublications: Map<string, TestRemotePublication>;
+}
+
+export interface TestRoom {
+  state: string;
+  localParticipant: {
+    audioTrackPublications: Map<string, TestPublication>;
+    setMicrophoneEnabled: (enabled: boolean) => Promise<unknown>;
+    permissions?: { canPublish: boolean; canSubscribe: boolean };
+  };
+  remoteParticipants: Map<string, TestRemoteParticipant>;
+  simulateScenario: (scenario: string) => Promise<void>;
+  disconnect: (stopTracks?: boolean) => Promise<void>;
+}
+
+export type TestWindow = Window & {
+  BBB_EXPOSE_LIVEKIT_ROOM?: boolean;
+  liveKitRoom?: TestRoom;
+  BBB_TEST_LK_CREDENTIALS?: { url: string; token: string };
+};
+
+// Sets the opt-in room expose flag, then wraps Room.connect to capture the (url, token) the
+// client connects with. To be used for reconnect tests (see reconnectWithExistingToken).
+export const exposeLiveKitRoom = (page: PlaywrightPage): Promise<void> =>
+  page.addInitScript(() => {
+    const w = window as TestWindow & { bbbLkConnectWrapped?: boolean };
+
+    w.BBB_EXPOSE_LIVEKIT_ROOM = true;
+
+    const wrap = setInterval(() => {
+      const room = w.liveKitRoom as (TestRoom & { connect?: unknown }) | undefined;
+
+      if (!room || w.bbbLkConnectWrapped) return;
+
+      w.bbbLkConnectWrapped = true;
+
+      const original = (room.connect as (url: string, token: string, opts?: unknown) => Promise<void>).bind(room);
+
+      (room as { connect: unknown }).connect = (url: string, token: string, opts?: unknown) => {
+        w.BBB_TEST_LK_CREDENTIALS = { url, token };
+        return original(url, token, opts);
+      };
+
+      clearInterval(wrap);
+    }, 50);
+  });
+
+// Re-enters the LK room with the credentials the client already used.
+export const reconnectWithExistingToken = (page: PlaywrightPage): Promise<void> =>
+  page.evaluate(async (notExposed) => {
+    const w = window as TestWindow;
+    const room = w.liveKitRoom as (TestRoom & { connect: (u: string, t: string) => Promise<void> }) | undefined;
+
+    if (!room) throw new Error(notExposed);
+
+    if (!w.BBB_TEST_LK_CREDENTIALS) throw new Error('no LiveKit credentials were captured');
+
+    await room.connect(w.BBB_TEST_LK_CREDENTIALS.url, w.BBB_TEST_LK_CREDENTIALS.token);
+  }, LK_NOT_EXPOSED_ERR_MSG);
+
+export interface LocalMicState {
+  roomState: string;
+  micPublications: number;
+  allMuted: boolean;
+  canPublish: boolean;
+  canSubscribe: boolean;
+}
+
+export const getLocalMicState = (page: PlaywrightPage): Promise<LocalMicState> =>
+  page.evaluate((notExposed) => {
+    const room = (window as TestWindow).liveKitRoom;
+
+    if (!room) throw new Error(notExposed);
+
+    const pubs = Array.from(room.localParticipant.audioTrackPublications.values()).filter(
+      (pub) => pub.source === 'microphone',
+    );
+
+    return {
+      roomState: room.state,
+      micPublications: pubs.length,
+      allMuted: pubs.length === 0 || pubs.every((pub) => pub.isMuted),
+      canPublish: room.localParticipant.permissions?.canPublish ?? false,
+      canSubscribe: room.localParticipant.permissions?.canSubscribe ?? false,
+    };
+  }, LK_NOT_EXPOSED_ERR_MSG);
+
+// Identities of LK users publishing an unmuted mic track. LiveKit identity == BBB intId for web users.
+export const getAudioPublisherIdentities = (page: PlaywrightPage): Promise<string[]> =>
+  page.evaluate((notExposed) => {
+    const room = (window as TestWindow).liveKitRoom;
+
+    if (!room) throw new Error(notExposed);
+
+    return Array.from(room.remoteParticipants.values())
+      .filter((participant) =>
+        Array.from(participant.audioTrackPublications.values()).some(
+          (pub) => pub.source === 'microphone' && !pub.isMuted,
+        ),
+      )
+      .map((participant) => participant.identity);
+  }, LK_NOT_EXPOSED_ERR_MSG);
+
+export interface RemoteAudioState {
+  identity: string;
+  micPublications: number;
+  unmuted: number;
+  subscribed: number;
+  liveTracks: number;
+  packetsReceived: number;
+}
+
+// What this page could hear from each remote participant. The distinctions matter:
+// remoteParticipants lists everyone whether subscribed or not, audioTrackPublications
+// includes unsubscribed publications, and isMuted is only signalled state. Just
+// packetsReceived proves audio is arriving.
+export const getRemoteAudioStates = (page: PlaywrightPage): Promise<RemoteAudioState[]> =>
+  page.evaluate(async (notExposed) => {
+    const room = (window as TestWindow).liveKitRoom;
+
+    if (!room) throw new Error(notExposed);
+
+    return Promise.all(
+      Array.from(room.remoteParticipants.values()).map(async (participant) => {
+        const mics = Array.from(participant.audioTrackPublications.values()).filter(
+          (pub) => pub.source === 'microphone',
+        );
+
+        let packetsReceived = 0;
+
+        await Promise.all(
+          mics.map(async (pub) => {
+            const receiver = pub.track?.receiver;
+
+            if (!receiver) return;
+
+            const stats = await receiver.getStats();
+
+            stats.forEach((report: { type: string; packetsReceived?: number }) => {
+              if (report.type === 'inbound-rtp') packetsReceived += report.packetsReceived ?? 0;
+            });
+          }),
+        );
+
+        return {
+          identity: participant.identity,
+          micPublications: mics.length,
+          unmuted: mics.filter((pub) => !pub.isMuted).length,
+          subscribed: mics.filter((pub) => pub.isSubscribed).length,
+          liveTracks: mics.filter((pub) => pub.track?.mediaStreamTrack?.readyState === 'live').length,
+          packetsReceived,
+        };
+      }),
+    );
+  }, LK_NOT_EXPOSED_ERR_MSG);
+
+// Suppresses client-side LK teardown, which funnels down to Room.disconnect().
+// Emulates a tab that never acts on its own removal. False if the room is not exposed.
+export const suppressRoomDisconnect = (page: PlaywrightPage): Promise<boolean> =>
+  page.evaluate(() => {
+    const room = (window as TestWindow).liveKitRoom;
+
+    if (!room) return false;
+
+    room.disconnect = async () => {};
+
+    return true;
+  });
+
+// Publishes the mic straight through the LK SDK.
+export const republishMicrophone = (page: PlaywrightPage): Promise<void> =>
+  page.evaluate(async (notExposed) => {
+    const room = (window as TestWindow).liveKitRoom;
+
+    if (!room) throw new Error(notExposed);
+
+    await room.localParticipant.setMicrophoneEnabled(true);
+  }, LK_NOT_EXPOSED_ERR_MSG);
+
+// Drops and re-establishes the LK session, making LiveKit emit a fresh
+// participant_joined. Uses LK's own simulation mechanism for this (see SDK docs).
+export const forceRoomReconnect = (page: PlaywrightPage): Promise<void> =>
+  page.evaluate(async (notExposed) => {
+    const room = (window as TestWindow).liveKitRoom;
+
+    if (!room) throw new Error(notExposed);
+
+    await room.simulateScenario('full-reconnect');
+  }, LK_NOT_EXPOSED_ERR_MSG);


### PR DESCRIPTION
### What does this PR do?                                                                                                                                                                                                                                 

- [refactor(audio): better BBB<->LiveKit state reconciliation on reconnects](https://github.com/bigbluebutton/bigbluebutton/commit/ef1c4b1516df75d7863d2958877614bb353602d0)
  - Especially under reconnects, BBB <-> LiveKit state can drift apart.
This is both due to them being two separate systems, but also due to
the fact that akka-apps itself makes VoiceUsers (which is the basic
media participant unit in BBB) just _very loosely coupled_ to the
Users2x model of users. This may cause a few issues, such as a client
being marked as out of audio after a reconnect with no way to recover
it - even though it got back its media session.
  - Introduce a voice user reconciler that centralizes VoiceUsers <->
Users2x state reconciliation and makes it easier to reason about the
state of a voice user in BBB and propagate it to LiveKit.
  - More details in the commit log
- [build(bbb-webrtc-sfu): v2.24.0 (up from v2.23.0)](https://github.com/bigbluebutton/bigbluebutton/commit/f3ef29260b529417c8066d41f0b66cd1412f8c9c)  
  - feat(livekit): handle participant permission updates from akka
  - feat(livekit): ack participant permission and voice eject outcomes
- [test(audio): cover the VoiceUsers <-> Users2x reconciliation with LK](https://github.com/bigbluebutton/bigbluebutton/commit/f8a0daf4f204116b43fbc59dc270ba136846f97b) 
  - Cover the new VoiceUsers <-> Users2x reconciliation logic in both the
media and BBB planes.

### Closes Issue(s)                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                             
None                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                             
### How to test

See automated tests.