### PR TITLE
[3.0] refactor(audio): better BBB<->LiveKit state reconciliation on reconnects, bbb-webrtc-sfu@v2.24.0- #25550

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
@@ -21,6 +21,9 @@ trait LiveKitParticipantLeftEvtMsgHdlr {
     val userId = msg.header.userId
     val isPresenter = Users2x.isPresenter(userId, liveMeeting.users2x)
 
+    // User has been removed from LK - this is an ACK for the reconciler, forget them
+    liveMeeting.voiceUserReconciler.forget(userId)
+
     // Clean up any voice users associated with the user
     for {
       vu <- VoiceUsers.findWIthIntId(liveMeeting.voiceUsers, userId)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UserJoinMeetingReqMsgHdlr.scala
@@ -164,7 +164,7 @@ trait UserJoinMeetingReqMsgHdlr extends HandlerHelpers {
 
   private def generateLivekitToken(regUser: RegisteredUser, liveMeeting: LiveMeeting) = {
     if (isUsingLiveKit(liveMeeting)) {
-      val grant = buildLiveKitTokenGrant(
+      val grant = HandlerHelpers.buildLiveKitTokenGrant(
         room = liveMeeting.props.meetingProp.intId,
         canPublish = true,
         canSubscribe = true,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/MediaActionOutcomeMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/MediaActionOutcomeMsgHdlr.scala
@@ -1,0 +1,30 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.bigbluebutton.common2.msgs.{ EjectUserFromVoiceConfRespMsg, UpdateLiveKitParticipantPermissionsRespMsg }
+import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
+
+/**
+ * Outcomes the SFU reports for actions akka cannot confirm itself. For now,
+ * only the VoiceUserReconciler cares about these.
+ */
+trait MediaActionOutcomeMsgHdlr {
+  val liveMeeting: LiveMeeting
+  val outGW: OutMsgRouter
+
+  def handleUpdateLiveKitParticipantPermissionsRespMsg(msg: UpdateLiveKitParticipantPermissionsRespMsg): Unit = {
+    liveMeeting.voiceUserReconciler.onPermissionsOutcome(
+      liveMeeting,
+      msg.header.userId,
+      msg.body.grant,
+      msg.body.outcome
+    )
+  }
+
+  def handleEjectUserFromVoiceConfRespMsg(msg: EjectUserFromVoiceConfRespMsg): Unit = {
+    liveMeeting.voiceUserReconciler.onEjectOutcome(
+      liveMeeting,
+      msg.body.voiceUserId,
+      msg.body.outcome
+    )
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserJoinedVoiceConfEvtMsgHdlr.scala
@@ -185,7 +185,22 @@ trait UserJoinedVoiceConfEvtMsgHdlr extends SystemConfiguration with HandlerHelp
           letUserEnter(state)
         }
       } else {
-        // Regular users reach this point after being allowed to join
+        if (liveMeeting.voiceUserReconciler.isOrphanedVoiceJoin(liveMeeting, msg.body.intId)) {
+          // LiveKit/media usually reconns faster than the graphql side, so this is also how a
+          // returning user's voice session arrives. Admit it either way and let the media grants
+          // decide: a later user re-join will restore permissions, while an orphan will have none
+          // by default.
+          liveMeeting.voiceUserReconciler.fenceVoiceJoin(
+            liveMeeting,
+            outGW,
+            msg.body.intId,
+            msg.body.voiceUserId
+          )
+        } else {
+          // Guarantee that a returning voice user has the same permissions as before they left if
+          // they aren't orphaned.
+          liveMeeting.voiceUserReconciler.restorePermissions(liveMeeting, outGW, msg.body.intId)
+        }
         letUserEnter(state)
       }
     }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/UserLeftVoiceConfEvtMsgHdlr.scala
@@ -48,6 +48,9 @@ trait UserLeftVoiceConfEvtMsgHdlr {
     for {
       user <- VoiceUsers.findWithVoiceUserId(liveMeeting.voiceUsers, msg.body.voiceUserId)
     } yield {
+      // Bridge-agnostic ACK that the audio session is gone for the VU reconciler
+      liveMeeting.voiceUserReconciler.forget(user.intId)
+
       liveMeeting.audioFloorManager.handleUserLeftVoice(
         user.intId,
         System.currentTimeMillis(),

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp.scala
@@ -250,7 +250,19 @@ object VoiceApp extends SystemConfiguration {
               }
             }
           case None =>
-            if (!cvu.intId.startsWith(IntIdPrefixType.DIAL_IN)) {
+            if (cvu.intId.startsWith(IntIdPrefixType.DIAL_IN)) {
+              // Dial-in users get their user record from the voice join itself.
+            } else {
+              // Same rule as in UserJoinedVoiceConfEvtMsgHdlr: the VU is created
+              // either way. If orphaned, with downgraded media permissions.
+              if (liveMeeting.voiceUserReconciler.isOrphanedVoiceJoin(liveMeeting, cvu.intId)) {
+                liveMeeting.voiceUserReconciler.fenceVoiceJoin(
+                  liveMeeting,
+                  outGW,
+                  cvu.intId,
+                  cvu.voiceUserId
+                )
+              }
               handleUserJoinedVoiceConfEvtMsg(
                 liveMeeting,
                 outGW,

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceApp2x.scala
@@ -24,6 +24,7 @@ trait VoiceApp2x extends UserJoinedVoiceConfEvtMsgHdlr
   with ChannelHoldChangedVoiceConfEvtMsgHdlr
   with ListenOnlyModeToggledInSfuEvtMsgHdlr
   with DeafenUserCmdMsgHdlr
+  with MediaActionOutcomeMsgHdlr
   with SetUserListenOnlyInputCmdMsgHdlr {
   this: MeetingActor =>
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceUserReconciler.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/voice/VoiceUserReconciler.scala
@@ -1,0 +1,351 @@
+package org.bigbluebutton.core.apps.voice
+
+import org.apache.pekko.actor.ActorContext
+import org.bigbluebutton.SystemConfiguration
+import org.bigbluebutton.common2.msgs.{ LiveKitGrant, MediaActionOutcome }
+import org.bigbluebutton.core.models.{ IntIdPrefixType, Users2x, VoiceUserState, VoiceUsers }
+import org.bigbluebutton.core.running.{ HandlerHelpers, LiveMeeting, OutMsgRouter }
+import org.bigbluebutton.core2.message.senders.MsgBuilder
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+case class OrphanedVoiceUser(
+    firstSeenOn:  Long,
+    ejectKey:     String,
+    confirmed:    Boolean = false,
+    failures:     Int     = 0,
+    awaitingAck:  Boolean = false,
+    abandoned:    Boolean = false,
+    lastActionOn: Long    = 0L
+)
+
+case class PendingRestore(
+    firstSentOn:  Long,
+    lastActionOn: Long,
+    attempts:     Int  = 1
+)
+
+object VoiceUserReconciler {
+  val MaxEnforcementFailures = 6
+
+  val MaxRestoreAttempts = 6
+
+  val MinActionIntervalMs = 5000L
+
+  // Minimal LiveKit grant for transient participants that are orphaned from Users2x
+  def downgradedGrant(room: String): LiveKitGrant =
+    HandlerHelpers.buildLiveKitTokenGrant(room = room, canPublish = false, canSubscribe = false)
+
+  // Default token grants for a user that has been re-admitted to the meeting.
+  def defaultUserGrant(room: String): LiveKitGrant =
+    HandlerHelpers.buildLiveKitTokenGrant(room = room, canPublish = true, canSubscribe = true)
+}
+
+/**
+ * This is a VoiceUsers <-> Users2x state reconciling watchdog with two
+ * basic roles:
+ *  - Downgrading voice users LK grants that are orphaned from Users2x OR
+ *    ejecting them from the voice bridge if it is not LK-based (mediasoup/FS)
+ *  - Restoring LK grants for a user that has been re-admitted to the meeting
+ *
+ * For LK, state enforcement is a permission downgrade/upgrade rather than an eject:
+ * a gentler approach to transient reconnects which still guarantees enforcement.
+ * For FreeSWITCH-based bridges, we use ejections as we always have.
+ *
+ * bbb-webrtc-sfu is the other acting party here - it executes both ejections
+ * and permission up/downgrades, and it reports the outcome of each.
+ *
+ * Dial-in users are exempt from this reconciliation - they follow a separate
+ * admission path (call gateways with pins).
+ */
+class VoiceUserReconciler(meetingId: String) extends SystemConfiguration {
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val trackedOrphans = mutable.Map[String, OrphanedVoiceUser]()
+
+  // Permission restore reqs are re-sent until acked by webrtc-sfu.
+  private val pendingRestores = mutable.Map[String, PendingRestore]()
+
+  private def enabled(liveMeeting: LiveMeeting): Boolean =
+    ejectRogueVoiceUsers && !liveMeeting.props.meetingProp.isBreakout
+
+  private def isReconcilable(intId: String): Boolean =
+    !intId.startsWith(IntIdPrefixType.DIAL_IN)
+
+  private def hasMeetingUser(liveMeeting: LiveMeeting, intId: String): Boolean =
+    Users2x.findWithIntId(liveMeeting.users2x, intId).isDefined
+
+  // A VoiceUser with no Users2x is considered orphan - except dial-in.
+  def isOrphanedVoiceJoin(liveMeeting: LiveMeeting, intId: String): Boolean =
+    enabled(liveMeeting) && isReconcilable(intId) && !hasMeetingUser(liveMeeting, intId)
+
+  // intId is the LiveKit identity and the only persistent ID for it; voiceUserId is a
+  // per-session sid whose alias the SFU drops on leave.
+  private def ejectKey(liveMeeting: LiveMeeting, intId: String, voiceUserId: String): String =
+    if (HandlerHelpers.isUsingLiveKitAudio(liveMeeting)) intId else voiceUserId
+
+  /**
+   * "Fences" a voice session that has no meeting user. The voice user is still created:
+   * it keeps the session visible in BBB's own state, and it gives a later
+   * re-admission something to restore. The permission downgrade is what makes it inert.
+   */
+  def fenceVoiceJoin(
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter,
+      intId:       String,
+      voiceUserId: String
+  )(implicit context: ActorContext): Unit = {
+    if (!enabled(liveMeeting) || !isReconcilable(intId)) return
+
+    log.warn(
+      s"Admitting a voice user with no meeting user under downgraded grants. " +
+        s"meetingId=$meetingId userId=$intId voiceUserId=$voiceUserId"
+    )
+    track(liveMeeting, outGW, intId, ejectKey(liveMeeting, intId, voiceUserId))
+    enforce(liveMeeting, outGW, intId)
+  }
+
+  /**
+   * "Fences" a user the akka lifecycle just dropped from User2x, while their
+   * media session outlived them. Grants are pulled until reconciliation happens.
+   */
+  def fenceRemovedUser(
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter,
+      intId:       String
+  )(implicit context: ActorContext): Unit = {
+    if (!enabled(liveMeeting) || !isReconcilable(intId)) return
+
+    VoiceUsers.findWithIntId(liveMeeting.voiceUsers, intId) foreach { vu =>
+      log.warn(
+        s"Downgrading LiveKit grants for a user removed from the meeting. " +
+          s"meetingId=$meetingId userId=$intId"
+      )
+      track(liveMeeting, outGW, intId, ejectKey(liveMeeting, intId, vu.voiceUserId))
+      enforce(liveMeeting, outGW, intId)
+    }
+  }
+
+  def forget(intId: String): Unit = {
+    trackedOrphans.remove(intId)
+    pendingRestores.remove(intId)
+  }
+
+  def restorePermissions(liveMeeting: LiveMeeting, outGW: OutMsgRouter, intId: String): Unit = {
+    forget(intId)
+
+    if (!enabled(liveMeeting) || !isReconcilable(intId)) return
+    if (!HandlerHelpers.isUsingLiveKitAudio(liveMeeting)) return
+
+    val now = System.currentTimeMillis()
+    pendingRestores.put(intId, PendingRestore(firstSentOn = now, lastActionOn = now))
+    sendRestore(intId, outGW)
+  }
+
+  private def sendRestore(intId: String, outGW: OutMsgRouter): Unit =
+    outGW.send(MsgBuilder.buildUpdateLiveKitParticipantPermissionsSysMsg(
+      meetingId,
+      intId,
+      VoiceUserReconciler.defaultUserGrant(meetingId)
+    ))
+
+  /**
+   * Records an orphan and gives up anything it should no longer hold. A new session
+   * restarts the enforcement state but never firstSeenOn, which stays the moment the
+   * user first went missing.
+   */
+  private def track(
+      liveMeeting: LiveMeeting,
+      outGW:       OutMsgRouter,
+      intId:       String,
+      key:         String
+  )(implicit context: ActorContext): Unit = {
+    val known = trackedOrphans.contains(intId)
+
+    trackedOrphans.updateWith(intId) {
+      case Some(tracking) =>
+        Some(tracking.copy(
+          ejectKey = key,
+          confirmed = false,
+          failures = 0,
+          awaitingAck = false,
+          abandoned = false,
+          lastActionOn = 0L
+        ))
+      case None =>
+        Some(OrphanedVoiceUser(firstSeenOn = System.currentTimeMillis(), ejectKey = key))
+    }
+
+    // A fenced user cannot publish audio anymore, so release its floor here.
+    // The floor manager only does so on a real voice departure.
+    if (!known) liveMeeting.audioFloorManager.handleUserLeftVoice(intId, liveMeeting = liveMeeting, outGW = outGW)
+  }
+
+  /**
+   * Outcome of a LK permission update. The grant itself diffs the update direction:
+   * - Restore permission asks for canPublish=true
+   * - Enforce downgrade asks for canPublish=false
+   */
+  def onPermissionsOutcome(
+      liveMeeting: LiveMeeting,
+      intId:       String,
+      grant:       LiveKitGrant,
+      outcome:     String
+  ): Unit = {
+    if (!acceptsOutcomes(liveMeeting, intId)) return
+
+    if (grant.canPublish) onRestoreOutcome(intId, outcome)
+    else onEnforcementOutcome(intId, outcome, "Downgrading LiveKit grants")
+  }
+
+  private def acceptsOutcomes(liveMeeting: LiveMeeting, intId: String): Boolean =
+    enabled(liveMeeting) && isReconcilable(intId) && HandlerHelpers.isUsingLiveKitAudio(liveMeeting)
+
+  private def onRestoreOutcome(intId: String, outcome: String): Unit = outcome match {
+    // Absent is as good as restored, i.e.: there is no session left carrying a downgrade
+    // and it'll likely pick up a fresh token on rejoin (with default grants).
+    case MediaActionOutcome.APPLIED | MediaActionOutcome.PARTICIPANT_ABSENT =>
+      pendingRestores.remove(intId)
+    case _ =>
+      log.warn(
+        s"Restoring LiveKit grants did not land; will retry. meetingId=$meetingId " +
+          s"userId=$intId outcome=$outcome"
+      )
+  }
+
+  /**
+   * Outcome of an eject. Only the LiveKit bridge reports one.
+   * FreeSWITCH signals a departure through the voice-conf leave handler.
+   */
+  def onEjectOutcome(liveMeeting: LiveMeeting, intId: String, outcome: String): Unit = {
+    if (!acceptsOutcomes(liveMeeting, intId)) return
+
+    onEnforcementOutcome(intId, outcome, "Ejecting a voice user with no meeting user")
+  }
+
+  private def onEnforcementOutcome(intId: String, outcome: String, action: String): Unit =
+    outcome match {
+      case MediaActionOutcome.APPLIED =>
+        trackedOrphans.get(intId) foreach { t =>
+          trackedOrphans.put(intId, t.copy(confirmed = true, awaitingAck = false, failures = 0))
+        }
+      case MediaActionOutcome.PARTICIPANT_ABSENT =>
+        trackedOrphans.remove(intId)
+      case _ =>
+        trackedOrphans.get(intId) foreach { t =>
+          trackedOrphans.put(intId, t.copy(awaitingAck = false, failures = t.failures + 1))
+        }
+        log.warn(
+          s"$action did not land; will retry. meetingId=$meetingId userId=$intId outcome=$outcome"
+        )
+    }
+
+  /**
+   * Applies grant enforcement once, and charges the previous attempt if it was never
+   * acked. Gives up at MaxEnforcementFailures rather than retrying forever. Log
+   * it for auditing purposes as exhaustion should never happen.
+   */
+  private def enforce(liveMeeting: LiveMeeting, outGW: OutMsgRouter, intId: String): Unit = {
+    val now = System.currentTimeMillis()
+
+    trackedOrphans.get(intId) foreach { tracking =>
+      if (now - tracking.lastActionOn >= VoiceUserReconciler.MinActionIntervalMs) {
+        val failures = if (tracking.awaitingAck) tracking.failures + 1 else tracking.failures
+
+        if (failures >= VoiceUserReconciler.MaxEnforcementFailures) {
+          log.error(
+            s"Abandoning enforcement against a voice user with no meeting user; it may still " +
+              s"be publishing. meetingId=$meetingId userId=$intId failures=$failures"
+          )
+          trackedOrphans.put(intId, tracking.copy(
+            failures = failures,
+            awaitingAck = false,
+            abandoned = true
+          ))
+        } else {
+          if (HandlerHelpers.isUsingLiveKitAudio(liveMeeting)) {
+            log.warn(
+              s"Downgrading LiveKit grants for a voice user with no meeting user. " +
+                s"meetingId=$meetingId userId=$intId failures=$failures"
+            )
+            outGW.send(MsgBuilder.buildUpdateLiveKitParticipantPermissionsSysMsg(
+              meetingId,
+              intId,
+              VoiceUserReconciler.downgradedGrant(meetingId)
+            ))
+          } else {
+            outGW.send(MsgBuilder.buildEjectUserFromVoiceConfSysMsg(
+              meetingId,
+              liveMeeting.props.voiceProp.voiceConf,
+              tracking.ejectKey
+            ))
+          }
+
+          trackedOrphans.put(intId, tracking.copy(
+            failures = failures,
+            awaitingAck = true,
+            lastActionOn = now
+          ))
+        }
+      }
+    }
+  }
+
+  private def retryRestores(outGW: OutMsgRouter, now: Long): Unit = {
+    pendingRestores.keys.toVector.foreach { intId =>
+      pendingRestores.get(intId) foreach { pending =>
+        if (pending.attempts >= VoiceUserReconciler.MaxRestoreAttempts) {
+          log.error(
+            s"Giving up on restoring LiveKit grants; the user may be left unable to publish. " +
+              s"meetingId=$meetingId userId=$intId attempts=${pending.attempts}"
+          )
+          pendingRestores.remove(intId)
+        } else if (now - pending.lastActionOn >= VoiceUserReconciler.MinActionIntervalMs) {
+          sendRestore(intId, outGW)
+          pendingRestores.put(intId, pending.copy(
+            lastActionOn = now,
+            attempts = pending.attempts + 1
+          ))
+        }
+      }
+    }
+  }
+
+  /**
+   * Main VoiceUsers <-> Users2x reconciliation routine.
+   * Used by akka-apps' audit in MeetingActor for periodic reconciliation.
+   */
+  def reconcile(liveMeeting: LiveMeeting, outGW: OutMsgRouter)(implicit context: ActorContext): Unit = {
+    if (!enabled(liveMeeting)) return
+
+    val now = System.currentTimeMillis()
+    retryRestores(outGW, now)
+
+    val meetingUserIds = Users2x.findAll(liveMeeting.users2x).map(_.intId).toSet
+    val observedOrphans: Map[String, VoiceUserState] = VoiceUsers.findAll(liveMeeting.voiceUsers)
+      .filter(vu => isReconcilable(vu.intId) && !meetingUserIds.contains(vu.intId))
+      .map(vu => vu.intId -> vu)
+      .toMap
+
+    observedOrphans.foreach {
+      case (intId, vu) =>
+        trackedOrphans.get(intId) match {
+          case None =>
+            track(liveMeeting, outGW, intId, ejectKey(liveMeeting, intId, vu.voiceUserId))
+          // Publishing again after a confirmed downgrade means something restored the
+          // grants behind us, so the confirmation no longer holds.
+          case Some(tracking) if tracking.confirmed && !vu.muted =>
+            trackedOrphans.put(intId, tracking.copy(confirmed = false, failures = 0))
+          case _ =>
+        }
+    }
+
+    trackedOrphans.keys.toVector.foreach { intId =>
+      val tracking = trackedOrphans.get(intId)
+      // Abandoned entries are kept, not dropped: dropping one only means the next
+      // scan re-tracks it with a fresh budget and the give-up never takes.
+      if (!tracking.exists(t => t.confirmed || t.abandoned)) enforce(liveMeeting, outGW, intId)
+    }
+  }
+}

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/pubsub/senders/ReceivedJsonMsgHandlerActor.scala
@@ -243,6 +243,10 @@ class ReceivedJsonMsgHandlerActor(
         routeGenericMsg[GenerateLiveKitTokenRespMsg](envelope, jsonNode)
       case LiveKitParticipantLeftEvtMsg.NAME =>
         routeGenericMsg[LiveKitParticipantLeftEvtMsg](envelope, jsonNode)
+      case UpdateLiveKitParticipantPermissionsRespMsg.NAME =>
+        routeGenericMsg[UpdateLiveKitParticipantPermissionsRespMsg](envelope, jsonNode)
+      case EjectUserFromVoiceConfRespMsg.NAME =>
+        routeGenericMsg[EjectUserFromVoiceConfRespMsg](envelope, jsonNode)
 
       // Breakout rooms
       case BreakoutRoomsListMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/HandlerHelpers.scala
@@ -117,6 +117,10 @@ trait HandlerHelpers extends SystemConfiguration {
           case None =>
             Users2x.add(liveMeeting.users2x, newUser)
 
+            // Guarantee that an eventual orphaned VoiceUser has its permissions
+            // restored. No-ops if not applicable.
+            liveMeeting.voiceUserReconciler.restorePermissions(liveMeeting, outGW, newUser.intId)
+
             val event = UserJoinedMeetingEvtMsgBuilder.build(liveMeeting.props.meetingProp.intId, newUser)
             outGW.send(event)
 
@@ -406,9 +410,22 @@ trait HandlerHelpers extends SystemConfiguration {
     liveMeeting.props.meetingProp.screenShareBridge == "livekit"
   }
 
-  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean = {
-    liveMeeting.props.meetingProp.audioBridge == "livekit"
+  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean =
+    HandlerHelpers.isUsingLiveKitAudio(liveMeeting)
+
+  def buildLiveKitParticipantMetadata(
+    liveMeeting: LiveMeeting,
+  ): LiveKitParticipantMetadata = {
+    LiveKitParticipantMetadata(
+      meetingId = liveMeeting.props.meetingProp.intId,
+      voiceConf = liveMeeting.props.voiceProp.voiceConf
+    )
   }
+}
+
+object HandlerHelpers {
+  def isUsingLiveKitAudio(liveMeeting: LiveMeeting): Boolean =
+    liveMeeting.props.meetingProp.audioBridge == "livekit"
 
   def buildLiveKitTokenGrant(
     room: String,
@@ -443,15 +460,6 @@ trait HandlerHelpers extends SystemConfiguration {
       roomJoin = roomJoin,
       roomList = roomList,
       roomRecord = roomRecord,
-    )
-  }
-
-  def buildLiveKitParticipantMetadata(
-    liveMeeting: LiveMeeting,
-  ): LiveKitParticipantMetadata = {
-    LiveKitParticipantMetadata(
-      meetingId = liveMeeting.props.meetingProp.intId,
-      voiceConf = liveMeeting.props.voiceProp.voiceConf
     )
   }
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/LiveMeeting.scala
@@ -2,7 +2,7 @@ package org.bigbluebutton.core.running
 
 import org.bigbluebutton.common2.domain.DefaultProps
 import org.bigbluebutton.core.apps._
-import org.bigbluebutton.core.apps.voice.AudioFloorManager
+import org.bigbluebutton.core.apps.voice.{ AudioFloorManager, VoiceUserReconciler }
 import org.bigbluebutton.core.models._
 import org.bigbluebutton.core2.MeetingStatus2x
 
@@ -30,4 +30,5 @@ class LiveMeeting(
     val plugins:             PluginModel,
 ) {
   val audioFloorManager = new AudioFloorManager(props.meetingProp.intId)
+  val voiceUserReconciler = new VoiceUserReconciler(props.meetingProp.intId)
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -513,6 +513,9 @@ class MeetingActor(
       case m: SetUserEchoTestRunningReqMsg => usersApp.handleSetUserEchoTestRunningReqMsg(m)
       case m: GenerateLiveKitTokenRespMsg  => handleGenerateLiveKitTokenRespMsg(m)
       case m: LiveKitParticipantLeftEvtMsg => handleLiveKitParticipantLeftEvtMsg(m)
+      case m: UpdateLiveKitParticipantPermissionsRespMsg =>
+        handleUpdateLiveKitParticipantPermissionsRespMsg(m)
+      case m: EjectUserFromVoiceConfRespMsg => handleEjectUserFromVoiceConfRespMsg(m)
 
       // Client requested to eject user
       case m: EjectUserFromMeetingCmdMsg =>
@@ -991,6 +994,9 @@ class MeetingActor(
   def handleMonitorNumberOfUsers(msg: MonitorNumberOfUsersInternalMsg) {
     state = removeUsersWithExpiredUserLeftFlag(liveMeeting, state)
 
+    // Reconcile VoiceUsers <-> Users2x
+    liveMeeting.voiceUserReconciler.reconcile(liveMeeting, outGW)
+
     if (!liveMeeting.props.meetingProp.isBreakout) {
       // Track expiry only for non-breakout rooms. The breakout room lifecycle is
       // driven by the parent meeting.
@@ -1138,6 +1144,10 @@ class MeetingActor(
         ru <- RegisteredUsers.findWithUserId(leftUser.intId, liveMeeting.registeredUsers)
       } yield {
         log.info("Removing user from meeting. meetingId=" + props.meetingProp.intId + " userId=" + u.intId + " user=" + u)
+
+        // Their media session might outlive them (for good reason - e.g.: smoother reconns).
+        // Fence them until restored or ejected.
+        liveMeeting.voiceUserReconciler.fenceRemovedUser(liveMeeting, outGW, u.intId)
 
         val updatedRegUser = RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, ru, joined = false)
         UserDAO.update(updatedRegUser)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/FromAkkaAppsMsgSenderActor.scala
@@ -54,6 +54,8 @@ class FromAkkaAppsMsgSenderActor(msgSender: MessageSender)
         msgSender.send(toVoiceConfRedisChannel, json)
 
       // Sent to SFU
+      case UpdateLiveKitParticipantPermissionsSysMsg.NAME =>
+        msgSender.send(toSfuRedisChannel, json)
       case EjectUserFromSfuSysMsg.NAME =>
         msgSender.send(toSfuRedisChannel, json)
       case CamBroadcastStopSysMsg.NAME =>

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core2/message/senders/MsgBuilder.scala
@@ -293,6 +293,20 @@ object MsgBuilder {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildUpdateLiveKitParticipantPermissionsSysMsg(
+      meetingId: String,
+      userId:    String,
+      grant:     LiveKitGrant
+  ): BbbCommonEnvCoreMsg = {
+    val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
+    val envelope = BbbCoreEnvelope(UpdateLiveKitParticipantPermissionsSysMsg.NAME, routing)
+    val body = UpdateLiveKitParticipantPermissionsSysMsgBody(userId, grant)
+    val header = BbbCoreHeaderWithMeetingId(UpdateLiveKitParticipantPermissionsSysMsg.NAME, meetingId)
+    val event = UpdateLiveKitParticipantPermissionsSysMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
   def buildMeetingMutedEvtMsg(meetingId: String, userId: String, muted: Boolean, mutedBy: String): BbbCommonEnvCoreMsg = {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, meetingId, userId)
     val envelope = BbbCoreEnvelope(MeetingMutedEvtMsg.NAME, routing)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LiveKitMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/LiveKitMsgs.scala
@@ -105,3 +105,57 @@ case class LiveKitParticipantLeftEvtMsg(
 case class LiveKitParticipantLeftEvtMsgBody(
     userId: String,
 )
+
+/**
+ * Re-applies a participant's LiveKit permissions on their live session, keyed by
+ * BBB intId (the LiveKit identity for web users). LiveKit writes the change into
+ * the participant's claim grants and refreshes the client's token, so it survives
+ * an ordinary SDK reconnect. Idempotent.
+ */
+object UpdateLiveKitParticipantPermissionsSysMsg { val NAME = "UpdateLiveKitParticipantPermissionsSysMsg" }
+case class UpdateLiveKitParticipantPermissionsSysMsg(
+    header: BbbCoreHeaderWithMeetingId,
+    body:   UpdateLiveKitParticipantPermissionsSysMsgBody
+) extends BbbCoreMsg
+case class UpdateLiveKitParticipantPermissionsSysMsgBody(
+    userId: String,
+    grant:  LiveKitGrant,
+)
+
+/**
+ * Outcome of a media-stack action that akka-apps requested to bbb-webrtc-sfu
+ */
+object MediaActionOutcome {
+  val APPLIED = "applied"
+  val ROOM_ABSENT = "roomAbsent"
+  val PARTICIPANT_ABSENT = "participantAbsent"
+  val FAILED = "failed"
+}
+
+/**
+ * Acknowledges an UpdateLiveKitParticipantPermissionsSysMsg
+ */
+object UpdateLiveKitParticipantPermissionsRespMsg { val NAME = "UpdateLiveKitParticipantPermissionsRespMsg" }
+case class UpdateLiveKitParticipantPermissionsRespMsg(
+    header: BbbClientMsgHeader,
+    body:   UpdateLiveKitParticipantPermissionsRespMsgBody
+) extends StandardMsg
+case class UpdateLiveKitParticipantPermissionsRespMsgBody(
+    grant:   LiveKitGrant,
+    outcome: String,
+)
+
+/**
+ * Acknowledges an EjectUserFromVoiceConfSysMsg. Only the LiveKit bridge sends it;
+ * the FreeSWITCH path reports a leave event instead (as always).
+ */
+object EjectUserFromVoiceConfRespMsg { val NAME = "EjectUserFromVoiceConfRespMsg" }
+case class EjectUserFromVoiceConfRespMsg(
+    header: BbbClientMsgHeader,
+    body:   EjectUserFromVoiceConfRespMsgBody
+) extends StandardMsg
+case class EjectUserFromVoiceConfRespMsgBody(
+    voiceConf:   String,
+    voiceUserId: String,
+    outcome:     String,
+)

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.22.2 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.24.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu


### PR DESCRIPTION
### What does this PR do?
                                                                                                                                                                                                                                                                                          
Backport of https://github.com/bigbluebutton/bigbluebutton/pull/25550 into 3.0.

- [refactor(audio): better BBB<->LiveKit state reconciliation on reconnects](https://github.com/bigbluebutton/bigbluebutton/commit/b70f2a185b8cbcce58e0cd24575f7da59c686f33)
  - Especially under reconnects, BBB <-> LiveKit state can drift apart.
This is both due to them being two separate systems, but also due to
the fact that akka-apps itself makes VoiceUsers (which is the basic
media participant unit in BBB) just _very loosely coupled_ to the
Users2x model of users. This may cause a few issues, such as a client
being marked as out of audio after a reconnect with no way to recover
it - even though it got back its media session.
  - Introduce a voice user reconciler that centralizes VoiceUsers <->
Users2x state reconciliation and makes it easier to reason about the
state of a voice user in BBB and propagate it to LiveKit.
  - More details in the commit log
- [build(bbb-webrtc-sfu): v2.24.0 (up from v2.23.0)](https://github.com/bigbluebutton/bigbluebutton/commit/b8c6e31c546cd972e997dfcd2c7672cc0eb2ea94)  
  - feat(livekit): handle participant permission updates from akka
  - feat(livekit): ack participant permission and voice eject outcomes

### Closes Issue(s)                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                             
None                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                             
### How to test

See #25550 automated tests.