### PR TITLE
fix(shared-notes): name the notes download after the meeting (#15778)

### DIFF
--- a/bbb-shared-notes-server/src/common/filename.ts
+++ b/bbb-shared-notes-server/src/common/filename.ts
@@ -1,0 +1,4 @@
+export const sanitizeFilenameSegment = (value: string): string =>
+  value
+    .replace(/\s/g, '_')
+    .replace(/[^a-z0-9_.-]/gi, '_');

--- a/bbb-shared-notes-server/src/express/rest-api.ts
+++ b/bbb-shared-notes-server/src/express/rest-api.ts
@@ -36,9 +36,14 @@ const firstQueryValue = (value: unknown): string | undefined => {
   return typeof value === 'string' ? value : undefined;
 };
 
+// Millisecond precision: two exports of the same notes are told apart even when
+// they happen within the same second, so a download never silently overwrites the
+// previous one. Separator scheme follows the poll-result download filename
+// (bigbluebutton-html5 .../poll-content/component.tsx).
 const formatTimestamp = (date: Date): string => {
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}_${pad(date.getHours())}-${pad(date.getMinutes())}`;
+  const pad = (n: number, width = 2) => String(n).padStart(width, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+    + `_${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}-${pad(date.getMilliseconds(), 3)}`;
 };
 
 // Same sanitization used for breakout notes capture (redis/handler.ts): keep only
@@ -49,18 +54,15 @@ const sanitizeMeetingName = (name: string): string =>
     .replace(/[^a-z0-9_.-]/gi, '_')
     .slice(0, MAX_MEETING_NAME_LENGTH);
 
-// Build the download filename from the meeting identity supplied by the client.
-// Both params are optional: paramless callers (breakout capture, direct API, stale
-// clients) must never make this throw, so every input is defensively coerced.
+// Build the download filename from the meeting name supplied by the client, stamped
+// with the moment of the download. meetingName is optional: paramless callers
+// (breakout capture, direct API, stale clients) must never make this throw, so the
+// input is defensively coerced.
 const getExportFilename = (
   extension: string,
   meetingName?: string,
-  meetingStartTime?: string,
 ): string => {
-  const startTime = Number(meetingStartTime);
-  const startDate = new Date(startTime);
-  const date = Number.isFinite(startTime) && startTime > 0 && !Number.isNaN(startDate.getTime()) ? startDate : new Date();
-  const timestamp = formatTimestamp(date);
+  const timestamp = formatTimestamp(new Date());
 
   const sanitized = typeof meetingName === 'string' ? sanitizeMeetingName(meetingName) : '';
   const hasName = /[a-z0-9]/i.test(sanitized);
@@ -143,12 +145,11 @@ const documentApi: DocumentApi = {
       return sendExportError(response, 400, 'Invalid document name');
     }
 
-    // Meeting identity for the download filename, supplied by the client as query
-    // params (the shared-notes server itself has no access to meeting name/start time).
+    // Meeting name for the download filename, supplied by the client as a query
+    // param (the shared-notes server itself has no access to the meeting name).
     const meetingName = firstQueryValue(request.query.meetingName);
-    const meetingStartTime = firstQueryValue(request.query.meetingStartTime);
     const buildFilename = (extension: string): string =>
-      getExportFilename(extension, meetingName, meetingStartTime);
+      getExportFilename(extension, meetingName);
 
     try {
       switch (format) {

--- a/bbb-shared-notes-server/src/express/rest-api.ts
+++ b/bbb-shared-notes-server/src/express/rest-api.ts
@@ -26,11 +26,48 @@ const sendExportError = (
   );
 };
 
-const getExportFilename = (extension: string): string => {
-  const now = new Date();
+// Meeting names can be long; cap the sanitized segment so the whole filename
+// stays comfortably under the 255-byte filesystem limit (fixed overhead is ~35 chars).
+const MAX_MEETING_NAME_LENGTH = 200;
+
+// Coerce a possibly-array/undefined query value to a plain string (or undefined).
+const firstQueryValue = (value: unknown): string | undefined => {
+  if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : undefined;
+  return typeof value === 'string' ? value : undefined;
+};
+
+const formatTimestamp = (date: Date): string => {
   const pad = (n: number) => String(n).padStart(2, '0');
-  const date = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
-  return `document_${date}.${extension}`;
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}_${pad(date.getHours())}-${pad(date.getMinutes())}`;
+};
+
+// Same sanitization used for breakout notes capture (redis/handler.ts): keep only
+// header-safe, filesystem-safe ASCII so the value is safe to drop into Content-Disposition.
+const sanitizeMeetingName = (name: string): string =>
+  name
+    .replace(/\s/g, '_')
+    .replace(/[^a-z0-9_.-]/gi, '_')
+    .slice(0, MAX_MEETING_NAME_LENGTH);
+
+// Build the download filename from the meeting identity supplied by the client.
+// Both params are optional: paramless callers (breakout capture, direct API, stale
+// clients) must never make this throw, so every input is defensively coerced.
+const getExportFilename = (
+  extension: string,
+  meetingName?: string,
+  meetingStartTime?: string,
+): string => {
+  const startTime = Number(meetingStartTime);
+  const startDate = new Date(startTime);
+  const date = Number.isFinite(startTime) && startTime > 0 && !Number.isNaN(startDate.getTime()) ? startDate : new Date();
+  const timestamp = formatTimestamp(date);
+
+  const sanitized = typeof meetingName === 'string' ? sanitizeMeetingName(meetingName) : '';
+  const hasName = /[a-z0-9]/i.test(sanitized);
+
+  return hasName
+    ? `${sanitized}_${timestamp}_Shared_Notes.${extension}`
+    : `Shared_Notes_${timestamp}.${extension}`;
 };
 
 const documentApi: DocumentApi = {
@@ -106,6 +143,13 @@ const documentApi: DocumentApi = {
       return sendExportError(response, 400, 'Invalid document name');
     }
 
+    // Meeting identity for the download filename, supplied by the client as query
+    // params (the shared-notes server itself has no access to meeting name/start time).
+    const meetingName = firstQueryValue(request.query.meetingName);
+    const meetingStartTime = firstQueryValue(request.query.meetingStartTime);
+    const buildFilename = (extension: string): string =>
+      getExportFilename(extension, meetingName, meetingStartTime);
+
     try {
       switch (format) {
         case 'html': {
@@ -114,7 +158,7 @@ const documentApi: DocumentApi = {
 
           // Set response headers
           response.setHeader('Content-Type', 'text/html; charset=utf-8');
-          response.setHeader('Content-Disposition', `attachment; filename="${getExportFilename('html')}"`);
+          response.setHeader('Content-Disposition', `attachment; filename="${buildFilename('html')}"`);
 
           // Send HTML
           response.send(fullHtml);
@@ -135,7 +179,7 @@ const documentApi: DocumentApi = {
 
           // Set response headers
           response.setHeader('Content-Type', 'application/pdf');
-          response.setHeader('Content-Disposition', `attachment; filename="${getExportFilename('pdf')}"`);
+          response.setHeader('Content-Disposition', `attachment; filename="${buildFilename('pdf')}"`);
           response.setHeader('Content-Length', pdfBuffer.length);
 
           logger.info('PDF generated successfully', { documentName });
@@ -167,7 +211,7 @@ const documentApi: DocumentApi = {
 
           // Set response headers
           response.setHeader('Content-Type', 'text/plain; charset=utf-8');
-          response.setHeader('Content-Disposition', `attachment; filename="${getExportFilename('txt')}"`);
+          response.setHeader('Content-Disposition', `attachment; filename="${buildFilename('txt')}"`);
 
           logger.info('TXT exported successfully', { documentName });
 
@@ -179,7 +223,7 @@ const documentApi: DocumentApi = {
           const jsonContent = await exportDocumentToJson(documentName);
 
           response.setHeader('Content-Type', 'application/json; charset=utf-8');
-          response.setHeader('Content-Disposition', `attachment; filename="${getExportFilename('json')}"`);
+          response.setHeader('Content-Disposition', `attachment; filename="${buildFilename('json')}"`);
 
           logger.info('JSON exported successfully', { documentName });
 
@@ -190,7 +234,7 @@ const documentApi: DocumentApi = {
           const yjsContent = await exportDocumentToYjs(documentName);
 
           response.setHeader('Content-Type', 'text/plain; charset=utf-8');
-          response.setHeader('Content-Disposition', `attachment; filename="${getExportFilename('yjs')}"`);
+          response.setHeader('Content-Disposition', `attachment; filename="${buildFilename('yjs')}"`);
 
           logger.info('YJS exported successfully', { documentName });
 
@@ -201,7 +245,7 @@ const documentApi: DocumentApi = {
           const markdownContent = await exportDocumentToMarkdown(documentName);
 
           response.setHeader('Content-Type', 'text/plain; charset=utf-8');
-          response.setHeader('Content-Disposition', `attachment; filename="${getExportFilename('md')}"`);
+          response.setHeader('Content-Disposition', `attachment; filename="${buildFilename('md')}"`);
 
           logger.info('Markdown exported successfully', { documentName });
 

--- a/bbb-shared-notes-server/src/express/rest-api.ts
+++ b/bbb-shared-notes-server/src/express/rest-api.ts
@@ -8,6 +8,8 @@ import { exportDocumentToMarkdown } from "./handlers/exportDocumentToMarkdown";
 import { exportHtmlToPdf } from "./handlers/exportDocumentToPdf";
 import { exportDocumentToJson } from "./handlers/exportDocumentToJson";
 import { exportDocumentToYjs } from "./handlers/exportDocumentToYjs";
+import { sanitizeFilenameSegment } from "../common/filename";
+import { decodeURLEncodedString } from "./utils";
 
 interface DocumentApi {
   get: RequestHandler;
@@ -30,39 +32,23 @@ const sendExportError = (
 // stays comfortably under the 255-byte filesystem limit (fixed overhead is ~35 chars).
 const MAX_MEETING_NAME_LENGTH = 200;
 
-// Coerce a possibly-array/undefined query value to a plain string (or undefined).
-const firstQueryValue = (value: unknown): string | undefined => {
-  if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : undefined;
-  return typeof value === 'string' ? value : undefined;
-};
-
-// Millisecond precision: two exports of the same notes are told apart even when
-// they happen within the same second, so a download never silently overwrites the
-// previous one. Separator scheme follows the poll-result download filename
-// (bigbluebutton-html5 .../poll-content/component.tsx).
 const formatTimestamp = (date: Date): string => {
-  const pad = (n: number, width = 2) => String(n).padStart(width, '0');
+  const pad = (n: number) => String(n).padStart(2, '0');
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
-    + `_${pad(date.getHours())}-${pad(date.getMinutes())}-${pad(date.getSeconds())}-${pad(date.getMilliseconds(), 3)}`;
+    + `_${pad(date.getHours())}-${pad(date.getMinutes())}`;
 };
 
-// Same sanitization used for breakout notes capture (redis/handler.ts): keep only
-// header-safe, filesystem-safe ASCII so the value is safe to drop into Content-Disposition.
 const sanitizeMeetingName = (name: string): string =>
-  name
-    .replace(/\s/g, '_')
-    .replace(/[^a-z0-9_.-]/gi, '_')
-    .slice(0, MAX_MEETING_NAME_LENGTH);
+  sanitizeFilenameSegment(name).slice(0, MAX_MEETING_NAME_LENGTH);
 
-// Build the download filename from the meeting name supplied by the client, stamped
-// with the moment of the download. meetingName is optional: paramless callers
-// (breakout capture, direct API, stale clients) must never make this throw, so the
-// input is defensively coerced.
 const getExportFilename = (
   extension: string,
   meetingName?: string,
+  meetingCreateTime?: string,
 ): string => {
-  const timestamp = formatTimestamp(new Date());
+  const parsedMeetingCreateTime = Number(meetingCreateTime);
+  const hasMeetingCreateTime = Number.isFinite(parsedMeetingCreateTime) && parsedMeetingCreateTime > 0;
+  const timestamp = formatTimestamp(new Date(hasMeetingCreateTime ? parsedMeetingCreateTime : Date.now()));
 
   const sanitized = typeof meetingName === 'string' ? sanitizeMeetingName(meetingName) : '';
   const hasName = /[a-z0-9]/i.test(sanitized);
@@ -145,11 +131,17 @@ const documentApi: DocumentApi = {
       return sendExportError(response, 400, 'Invalid document name');
     }
 
-    // Meeting name for the download filename, supplied by the client as a query
-    // param (the shared-notes server itself has no access to the meeting name).
-    const meetingName = firstQueryValue(request.query.meetingName);
+    const encodedMeetingName = request.headers['meeting-name'];
+    const meetingName = typeof encodedMeetingName === 'string'
+      ? decodeURLEncodedString(encodedMeetingName) || undefined
+      : undefined;
+    const meetingCreateTime = request.headers['meeting-create-time'];
     const buildFilename = (extension: string): string =>
-      getExportFilename(extension, meetingName);
+      getExportFilename(
+        extension,
+        meetingName,
+        typeof meetingCreateTime === 'string' ? meetingCreateTime : undefined,
+      );
 
     try {
       switch (format) {

--- a/bbb-shared-notes-server/src/redis/handler.ts
+++ b/bbb-shared-notes-server/src/redis/handler.ts
@@ -1,4 +1,5 @@
 import { Logger } from '../common/logger';
+import { sanitizeFilenameSegment } from '../common/filename';
 import { connectionsMap } from '../common/singleton';
 import { sender } from './sender';
 import config from '../config';
@@ -204,8 +205,7 @@ const handleBlockNoteExport = async (header: MessageHeader, body: MessageBody): 
     // Export the document
     const documentName = presId;
     const notesFormat = 'pdf';
-    const underscoredFilename = serverSideFilename.replace(/\s/g, '_');
-    const sanitizedFilename = underscoredFilename.replace(/[^a-z0-9_.-]/gi, '_');
+    const sanitizedFilename = sanitizeFilenameSegment(serverSideFilename);
     const outputFilename = `${sanitizedFilename}.${notesFormat}`;
     const filePath = path.join(temporarySavingDir, outputFilename);
 

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -61,13 +61,12 @@ interface NotesDropdownGraphqlProps extends NotesDropdownContainerGraphqlProps {
   padId: string;
   presentationEnabled: boolean;
   meetingName: string;
-  meetingStartTime: number;
 }
 
 const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
   const {
     amIPresenter, presentations, handlePinSharedNotes, isRTL, padId, presentationEnabled,
-    isEtherpadSharedNotes, isPinned, meetingName, meetingStartTime,
+    isEtherpadSharedNotes, isPinned, meetingName,
   } = props;
   const [converterButtonDisabled, setConverterButtonDisabled] = useState(false);
   const intl = useIntl();
@@ -118,10 +117,9 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
       const { sessionToken } = Auth;
       const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
         || window.location.hostname;
-      // Carry the meeting identity so the server can name the download after the
-      // meeting (name + start time) instead of a generic timestamped filename.
-      const exportMeetingParams = `&meetingName=${encodeURIComponent(meetingName)}`
-        + `&meetingStartTime=${meetingStartTime}`;
+      // Carry the meeting name so the server can name the download after the meeting
+      // instead of using a generic filename. The server stamps the download moment.
+      const exportMeetingParams = `&meetingName=${encodeURIComponent(meetingName)}`;
 
       menuItems.push(
         {
@@ -207,7 +205,6 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
   const amIPresenter = !!currentUserData?.presenter;
   const { data: meetingData } = useMeeting((m) => ({
     name: m.name,
-    createdTime: m.createdTime,
   }));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isRTL = layoutSelect((i: any) => i.isRTL);
@@ -231,7 +228,6 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
       isEtherpadSharedNotes={isEtherpadSharedNotes}
       isPinned={isPinned}
       meetingName={meetingData?.name || ''}
-      meetingStartTime={meetingData?.createdTime || 0}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -3,6 +3,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import Trigger from '/imports/ui/components/common/control-header/right/component';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { uniqueId } from '/imports/utils/string-utils';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import {
@@ -59,12 +60,14 @@ interface NotesDropdownGraphqlProps extends NotesDropdownContainerGraphqlProps {
   isRTL: boolean;
   padId: string;
   presentationEnabled: boolean;
+  meetingName: string;
+  meetingStartTime: number;
 }
 
 const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
   const {
     amIPresenter, presentations, handlePinSharedNotes, isRTL, padId, presentationEnabled,
-    isEtherpadSharedNotes, isPinned,
+    isEtherpadSharedNotes, isPinned, meetingName, meetingStartTime,
   } = props;
   const [converterButtonDisabled, setConverterButtonDisabled] = useState(false);
   const intl = useIntl();
@@ -115,6 +118,10 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
       const { sessionToken } = Auth;
       const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
         || window.location.hostname;
+      // Carry the meeting identity so the server can name the download after the
+      // meeting (name + start time) instead of a generic timestamped filename.
+      const exportMeetingParams = `&meetingName=${encodeURIComponent(meetingName)}`
+        + `&meetingStartTime=${meetingStartTime}`;
 
       menuItems.push(
         {
@@ -123,7 +130,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
           dataTest: 'exportNotesAsPDF',
           label: intl.formatMessage(intlMessages.exportAsPDFLabel),
           onClick: () => {
-            window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}`);
+            window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}${exportMeetingParams}`);
           },
         },
       );
@@ -136,7 +143,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
             dataTest: 'exportNotesAsMarkdown',
             label: intl.formatMessage(intlMessages.exportAsMarkdownLabel),
             onClick: () => {
-              window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/md?sessionToken=${sessionToken}`);
+              window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/md?sessionToken=${sessionToken}${exportMeetingParams}`);
             },
           },
         );
@@ -198,6 +205,10 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
     presenter: user.presenter,
   }));
   const amIPresenter = !!currentUserData?.presenter;
+  const { data: meetingData } = useMeeting((m) => ({
+    name: m.name,
+    createdTime: m.createdTime,
+  }));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isRTL = layoutSelect((i: any) => i.isRTL);
   const isPresentationEnabled = useIsPresentationEnabled();
@@ -219,6 +230,8 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
       padId={padId}
       isEtherpadSharedNotes={isEtherpadSharedNotes}
       isPinned={isPinned}
+      meetingName={meetingData?.name || ''}
+      meetingStartTime={meetingData?.createdTime || 0}
     />
   );
 };

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -3,7 +3,6 @@ import { defineMessages, useIntl } from 'react-intl';
 import BBBMenu from '/imports/ui/components/common/menu/component';
 import Trigger from '/imports/ui/components/common/control-header/right/component';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
-import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import { uniqueId } from '/imports/utils/string-utils';
 import { layoutSelect } from '/imports/ui/components/layout/context';
 import {
@@ -60,13 +59,12 @@ interface NotesDropdownGraphqlProps extends NotesDropdownContainerGraphqlProps {
   isRTL: boolean;
   padId: string;
   presentationEnabled: boolean;
-  meetingName: string;
 }
 
 const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
   const {
     amIPresenter, presentations, handlePinSharedNotes, isRTL, padId, presentationEnabled,
-    isEtherpadSharedNotes, isPinned, meetingName,
+    isEtherpadSharedNotes, isPinned,
   } = props;
   const [converterButtonDisabled, setConverterButtonDisabled] = useState(false);
   const intl = useIntl();
@@ -117,9 +115,6 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
       const { sessionToken } = Auth;
       const hocuspocusServerHostname = window.meetingClientSettings.public.sharedNotes.serverHostname
         || window.location.hostname;
-      // Carry the meeting name so the server can name the download after the meeting
-      // instead of using a generic filename. The server stamps the download moment.
-      const exportMeetingParams = `&meetingName=${encodeURIComponent(meetingName)}`;
 
       menuItems.push(
         {
@@ -128,7 +123,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
           dataTest: 'exportNotesAsPDF',
           label: intl.formatMessage(intlMessages.exportAsPDFLabel),
           onClick: () => {
-            window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}${exportMeetingParams}`);
+            window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/pdf?sessionToken=${sessionToken}`);
           },
         },
       );
@@ -141,7 +136,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
             dataTest: 'exportNotesAsMarkdown',
             label: intl.formatMessage(intlMessages.exportAsMarkdownLabel),
             onClick: () => {
-              window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/md?sessionToken=${sessionToken}${exportMeetingParams}`);
+              window.open(`https://${hocuspocusServerHostname}/hocuspocus/api/documents/${padId}/export/md?sessionToken=${sessionToken}`);
             },
           },
         );
@@ -203,9 +198,6 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
     presenter: user.presenter,
   }));
   const amIPresenter = !!currentUserData?.presenter;
-  const { data: meetingData } = useMeeting((m) => ({
-    name: m.name,
-  }));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isRTL = layoutSelect((i: any) => i.isRTL);
   const isPresentationEnabled = useIsPresentationEnabled();
@@ -227,7 +219,6 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
       padId={padId}
       isEtherpadSharedNotes={isEtherpadSharedNotes}
       isPinned={isPinned}
-      meetingName={meetingData?.name || ''}
     />
   );
 };

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
@@ -67,8 +67,19 @@ export class MarkdownSharedNotes extends MultiUsers {
     );
 
     if (!download?.download) throw new Error('Markdown export download did not start');
-    const extension = download.download.suggestedFilename().split('.').pop();
-    expect(extension, 'the exported file should have a .md extension').toBe('md');
+    const filename = download.download.suggestedFilename();
+
+    // Issue #15778: the download must identify the meeting instead of using a generic
+    // "document_<download-time>" name. Expected shape:
+    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm meeting start>_Shared_Notes.md
+    // The harness names the meeting after its id (already header/filesystem-safe ASCII),
+    // so the sanitized name segment equals the meeting id.
+    const filenamePattern = new RegExp(
+      `^${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_Shared_Notes\\.md$`,
+    );
+    expect(filename, 'the exported filename should identify the meeting and be tagged as shared notes').toMatch(
+      filenamePattern,
+    );
     expect(download.content, 'the exported markdown should contain the typed note').toContain(noteText);
   }
 

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
@@ -70,12 +70,13 @@ export class MarkdownSharedNotes extends MultiUsers {
     const filename = download.download.suggestedFilename();
 
     // Issue #15778: the download must identify the meeting instead of using a generic
-    // "document_<download-time>" name. Expected shape:
-    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm meeting start>_Shared_Notes.md
+    // "document_<timestamp>" name. Expected shape:
+    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm-ss-SSS download moment>_Shared_Notes.md
+    // The millisecond segment is what keeps two downloads of the same notes apart.
     // The harness names the meeting after its id (already header/filesystem-safe ASCII),
     // so the sanitized name segment equals the meeting id.
     const filenamePattern = new RegExp(
-      `^${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_Shared_Notes\\.md$`,
+      `^${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}_Shared_Notes\\.md$`,
     );
     expect(filename, 'the exported filename should identify the meeting and be tagged as shared notes').toMatch(
       filenamePattern,

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts
@@ -4,7 +4,12 @@ import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { createMeetingWithModules } from '../../core/helpers';
 import { MultiUsers } from '../../user/multiusers';
-import { enableMarkdownNotesOptions, getBlockNoteEditorLocator, startBlockNoteSharedNotes } from './util';
+import {
+  enableMarkdownNotesOptions,
+  expectedSharedNotesFilename,
+  getBlockNoteEditorLocator,
+  startBlockNoteSharedNotes,
+} from './util';
 
 // Markdown seeded through the sharedNotesInitialContentMarkdown create parameter.
 // Kept in sync with the value passed in markdown.spec.ts.
@@ -60,6 +65,9 @@ export class MarkdownSharedNotes extends MultiUsers {
     await expect(editor, 'the typed note should be visible in the editor').toContainText(noteText);
 
     await this.modPage.waitAndClick(e.notesOptions);
+    const exportRequestPromise = this.modPage.page.context().waitForEvent('request', {
+      predicate: (request) => request.url().includes('/export/md'),
+    });
     const download = await this.modPage.handleDownload(
       this.modPage.page.locator(e.exportNotesAsMarkdown),
       undefined,
@@ -68,18 +76,17 @@ export class MarkdownSharedNotes extends MultiUsers {
 
     if (!download?.download) throw new Error('Markdown export download did not start');
     const filename = download.download.suggestedFilename();
+    const exportRequest = await exportRequestPromise;
+    expect(
+      new URL(exportRequest.url()).searchParams.has('meetingName'),
+      'meeting data should not be exposed in the export URL',
+    ).toBeFalsy();
 
-    // Issue #15778: the download must identify the meeting instead of using a generic
-    // "document_<timestamp>" name. Expected shape:
-    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm-ss-SSS download moment>_Shared_Notes.md
-    // The millisecond segment is what keeps two downloads of the same notes apart.
-    // The harness names the meeting after its id (already header/filesystem-safe ASCII),
-    // so the sanitized name segment equals the meeting id.
-    const filenamePattern = new RegExp(
-      `^${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}_Shared_Notes\\.md$`,
-    );
-    expect(filename, 'the exported filename should identify the meeting and be tagged as shared notes').toMatch(
-      filenamePattern,
+    // The filename uses the server-local rendering of createTime. Tests must run
+    // in the same timezone as the BBB server for this deterministic comparison.
+    const expectedFilename = await expectedSharedNotesFilename(this.modPage.meetingId, 'md');
+    expect(filename, 'the exported filename should identify the meeting and use its create time').toBe(
+      expectedFilename,
     );
     expect(download.content, 'the exported markdown should contain the typed note').toContain(noteText);
   }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -199,6 +199,17 @@ export class BlockNoteSharedNotes extends MultiUsers {
       'empty shared notes PDF export should return a PDF document',
     ).toContain('application/pdf');
 
+    // Issue #15778: the Content-Disposition filename must identify the meeting
+    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm meeting start>_Shared_Notes.<ext>
+    // The harness names the meeting after its id (already header-safe ASCII), so the
+    // sanitized name segment equals the meeting id.
+    const filenamePattern = (ext: string) =>
+      new RegExp(`filename="${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_Shared_Notes\\.${ext}"`);
+    expect(
+      pdfResponse.headers()['content-disposition'] || '',
+      'the empty PDF export filename should identify the meeting and be tagged as shared notes',
+    ).toMatch(filenamePattern('pdf'));
+
     // Issue #25122 is general ("empty page should not be an error"), so every
     // export format must treat an empty document as a valid empty file. Reuse
     // the authenticated export URL and assert via API requests, which are
@@ -224,6 +235,10 @@ export class BlockNoteSharedNotes extends MultiUsers {
         response.headers()['content-type'] || '',
         `empty shared notes ${format} export should return ${contentType}`,
       ).toContain(contentType);
+      expect(
+        response.headers()['content-disposition'] || '',
+        `empty shared notes ${format} export filename should identify the meeting`,
+      ).toMatch(filenamePattern(format));
       // eslint-disable-next-line no-await-in-loop
       if (body) body(await response.text());
     }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -200,11 +200,14 @@ export class BlockNoteSharedNotes extends MultiUsers {
     ).toContain('application/pdf');
 
     // Issue #15778: the Content-Disposition filename must identify the meeting
-    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm meeting start>_Shared_Notes.<ext>
+    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm-ss-SSS download moment>_Shared_Notes.<ext>
+    // The millisecond segment is what keeps two downloads of the same notes apart.
     // The harness names the meeting after its id (already header-safe ASCII), so the
     // sanitized name segment equals the meeting id.
     const filenamePattern = (ext: string) =>
-      new RegExp(`filename="${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}_Shared_Notes\\.${ext}"`);
+      new RegExp(
+        `filename="${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}_Shared_Notes\\.${ext}"`,
+      );
     expect(
       pdfResponse.headers()['content-disposition'] || '',
       'the empty PDF export filename should identify the meeting and be tagged as shared notes',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -5,6 +5,7 @@ import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 import {
   enableMarkdownNotesOptions,
+  expectedSharedNotesFilename,
   getBlockNoteEditorLocator,
   getBlockNoteReadOnlyLocator,
   hasNoUnreadNotesIndicator,
@@ -199,19 +200,14 @@ export class BlockNoteSharedNotes extends MultiUsers {
       'empty shared notes PDF export should return a PDF document',
     ).toContain('application/pdf');
 
-    // Issue #15778: the Content-Disposition filename must identify the meeting
-    //   <sanitized meeting name>_<YYYY-MM-DD_HH-mm-ss-SSS download moment>_Shared_Notes.<ext>
-    // The millisecond segment is what keeps two downloads of the same notes apart.
-    // The harness names the meeting after its id (already header-safe ASCII), so the
-    // sanitized name segment equals the meeting id.
-    const filenamePattern = (ext: string) =>
-      new RegExp(
-        `filename="${this.modPage.meetingId}_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}_Shared_Notes\\.${ext}"`,
-      );
+    // The filename uses the server-local rendering of createTime. Tests must run
+    // in the same timezone as the BBB server for this deterministic comparison.
+    const expectedContentDisposition = async (ext: string) =>
+      `attachment; filename="${await expectedSharedNotesFilename(this.modPage.meetingId, ext)}"`;
     expect(
       pdfResponse.headers()['content-disposition'] || '',
-      'the empty PDF export filename should identify the meeting and be tagged as shared notes',
-    ).toMatch(filenamePattern('pdf'));
+      'the empty PDF export filename should identify the meeting and use its create time',
+    ).toBe(await expectedContentDisposition('pdf'));
 
     // Issue #25122 is general ("empty page should not be an error"), so every
     // export format must treat an empty document as a valid empty file. Reuse
@@ -241,7 +237,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
       expect(
         response.headers()['content-disposition'] || '',
         `empty shared notes ${format} export filename should identify the meeting`,
-      ).toMatch(filenamePattern(format));
+      ).toBe(await expectedContentDisposition(format));
       // eslint-disable-next-line no-await-in-loop
       if (body) body(await response.text());
     }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -2,7 +2,28 @@ import { expect, Locator } from '@playwright/test';
 
 import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
+import { apiCall } from '../../core/helpers';
 import { Page } from '../../core/page';
+
+interface GetMeetingInfoResponse {
+  response: {
+    createTime: string[];
+  };
+}
+
+function formatMeetingCreateTime(createTime: string): string {
+  const date = new Date(Number(createTime));
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `_${pad(date.getHours())}-${pad(date.getMinutes())}`
+  );
+}
+
+export async function expectedSharedNotesFilename(meetingId: string, extension: string): Promise<string> {
+  const { data } = await apiCall<GetMeetingInfoResponse>('getMeetingInfo', { meetingID: meetingId });
+  return `${meetingId}_${formatMeetingCreateTime(data.response.createTime[0])}_Shared_Notes.${extension}`;
+}
 
 export async function startSharedNotesBlockNote(testPage: Page) {
   await testPage.waitAndClick(e.sharedNotesSidebarButton);

--- a/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
+++ b/bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy
@@ -45,10 +45,15 @@ class ConnectionController {
       response.contentType = 'plain/text'
 
       if (userSession != null && !isSessionTokenInvalid) {
+        Meeting meeting = meetingService.getMeeting(userSession.meetingID)
         response.addHeader("User-Id", userSession.internalUserId)
         response.addHeader("Meeting-Id", userSession.meetingID)
         response.addHeader("Voice-Bridge", userSession.voicebridge )
         response.addHeader("User-Name", URLEncoder.encode(userSession.fullname, StandardCharsets.UTF_8.name()))
+        if (meeting) {
+          response.addHeader("Meeting-Name", URLEncoder.encode(meeting.getName(), StandardCharsets.UTF_8.name()))
+          response.addHeader("Meeting-Create-Time", meeting.getCreateTime().toString())
+        }
         response.setStatus(200)
         response.outputStream << 'authorized'
       } else {

--- a/build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx
+++ b/build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx
@@ -56,6 +56,8 @@ location /hocuspocus/api/ {
   auth_request_set $auth_status $upstream_status;
   auth_request_set $meeting_id $sent_http_meeting_id;
   auth_request_set $user_id $sent_http_user_id;
+  auth_request_set $meeting_name $sent_http_meeting_name;
+  auth_request_set $meeting_create_time $sent_http_meeting_create_time;
 
   gzip_static on;
   proxy_pass http://localhost:8787/api/;
@@ -65,6 +67,8 @@ location /hocuspocus/api/ {
   proxy_set_header Host $host;
   proxy_set_header Meeting-Id $meeting_id;
   proxy_set_header User-id $user_id;
+  proxy_set_header Meeting-Name $meeting_name;
+  proxy_set_header Meeting-Create-Time $meeting_create_time;
 }
 
 location /hocuspocus/sample {


### PR DESCRIPTION
## Summary

Shared notes exports currently use generic filenames that do not identify the meeting. This makes files from different meetings difficult to distinguish.

The exported filename now follows this format for all six supported formats:

`<sanitized meeting name>_<meeting create time>_Shared_Notes.<ext>`

**Solution:** `ConnectionController.checkAuthorization` adds the URL-encoded meeting name and the meeting `createTime` to its authorization response headers. The `/hocuspocus/api/` nginx block forwards those values to `bbb-shared-notes-server`, which decodes and sanitizes the name and renders the create time as `YYYY-MM-DD_HH-mm`. No meeting data travels in the export URL. Direct internal callers without these headers retain the `Shared_Notes_<timestamp>.<ext>` fallback.

Closes bigbluebutton/bigbluebutton#15778

## Root Cause

The BlockNote export handler only had access to the current server time. Before this fix, the authorization response used by the export endpoint exposed the user ID and meeting ID, but not the meeting name or create time, so the server could not build a meeting-specific filename.

## Implementation

**Direction chosen:** following reviewer feedback, the server-side authorization path now supplies the meeting data needed by the export endpoint:

1. `ConnectionController.checkAuthorization` looks up the meeting and emits `Meeting-Name` with `URLEncoder.encode` and `Meeting-Create-Time` from `Meeting.getCreateTime()`.
2. The `/hocuspocus/api/` nginx block lifts and forwards both authorization response headers.
3. `rest-api.ts` reads the headers, decodes the meeting name, sanitizes it, and applies the meeting create time to every export format.
4. The client export URLs now contain only the session token.

Alternatives considered and rejected:

- Client query parameters: rejected because meeting metadata should not be exposed in the export URL, and the server authorization path can provide it directly.
- In-memory meeting data populated by `handleMeetingCreated`: rejected because it is fragile across process restarts and missing events.
- Full client-side download using `fetch`, a blob, and an anchor: rejected because it changes the current `window.open` behavior and introduces cross-origin requirements when the shared-notes host differs from the client host.

Files changed:

- **`bigbluebutton-web/grails-app/controllers/org/bigbluebutton/web/controllers/ConnectionController.groovy`** - adds the meeting name and create time to successful authorization responses.
- **`build/packages-template/bbb-shared-notes-server/bbb-shared-notes-server.nginx`** - forwards the new authorization headers to the export endpoint.
- **`bbb-shared-notes-server/src/common/filename.ts`** - centralizes the filename segment sanitization shared by user downloads and breakout notes capture.
- **`bbb-shared-notes-server/src/express/rest-api.ts`** - builds filenames from the forwarded headers, using `YYYY-MM-DD_HH-mm` for the meeting create time and preserving the paramless fallback.
- **`bbb-shared-notes-server/src/redis/handler.ts`** - reuses the shared sanitization helper without changing breakout capture behavior.
- **`bigbluebutton-tests/playwright/sharednotes/blocknote/markdown.ts`** - asserts the exact filename derived from `getMeetingInfo.createTime` and verifies that the export URL contains no meeting metadata.
- **`bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts`** - applies the same deterministic create-time assertion to PDF and the five other export formats.
- **`bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts`** - provides the shared deterministic filename expectation.

## Test Coverage

- Markdown export compares the browser-proposed filename with the exact meeting `createTime` returned by `getMeetingInfo`.
- Empty PDF export and the HTML, TXT, Markdown, JSON, and Yjs variants compare `Content-Disposition` with the same deterministic value.
- The Markdown test verifies that meeting metadata is absent from the export URL.
- Direct paramless requests cover the fallback used by internal callers, including breakout notes capture.

## Validation

- BBB 4.0 from-source: Markdown export passed with an exact create-time filename.
- BBB 4.0 from-source: empty PDF plus HTML, TXT, Markdown, JSON, and Yjs exports passed with exact create-time filenames.
- Direct paramless calls returned HTTP 200 for all six formats with `Shared_Notes_YYYY-MM-DD_HH-mm.<ext>`.
- `bbb-shared-notes-server` targeted lint and typecheck passed.
- The touched HTML5 component and end-to-end test files passed lint. The HTML5 staged TypeScript check passed during commit.
- The full breakout notes capture flow (breakout creation/end and presentation upload) was not exercised; its fallback path is covered by the direct paramless calls above.

## Evidence

Animated preview below - click the GIF to open the MP4 in higher quality:

[![Shared notes export with a meeting-specific filename, filename shown at 00:00:09](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-31/be27c292-6abd-4466-a36b-d9a0fcea50d6/weekly_export_after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-31/fe54f1b3-22f7-4a3e-8536-880faaae80b3/weekly_export_after.mp4)

## Risks and Notes

- Meeting names are URL-encoded by BBB Web and restricted by the shared-notes server to `[a-z0-9_.-]` before entering `Content-Disposition`.
- The timestamp is the meeting `createTime`, rendered in the server's local timezone as `YYYY-MM-DD_HH-mm`.
- Repeated exports intentionally have the same filename. Browsers append a numeric suffix when a file with that name already exists.
- The convert-to-presentation filename, breakout server-side filename, and legacy Etherpad behavior remain unchanged.

Co-authored-by: Tainan Felipe <tainanfelipe214@gmail.com>
