### PR TITLE
[3.0 video preview] Fix: Keep the webcam preview modal open when multiple cameras are available

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -613,11 +613,14 @@ class VideoPreview extends Component {
     if (!cameraAsContent) {
       // Store selected profile, camera ID and virtual background in the storage
       // for future use
+      const keepModalOpen = VideoService.isMultipleCamerasEnabled();
       PreviewService.changeProfile(selectedProfile);
       PreviewService.changeWebcam(webcamDeviceId);
       this.updateVirtualBackgroundInfo();
       this.updateCameraBrightnessInfo();
-      this.cleanupStreamAndVideo();
+      if (!keepModalOpen) {
+        this.cleanupStreamAndVideo();
+      }
       startSharing(webcamDeviceId);
     } else {
       this.cleanupStreamAndVideo();
@@ -639,12 +642,21 @@ class VideoPreview extends Component {
 
     if (this.isCameraAsContentDevice(webcamDeviceId)) {
       stopSharingCameraAsContent();
+      if (resolve) resolve();
     } else {
+      const shouldKeepModalOpen = VideoService.isMultipleCamerasEnabled();
       PreviewService.deleteStream(webcamDeviceId);
       stopSharing(webcamDeviceId);
-      this.cleanupStreamAndVideo();
+      if (shouldKeepModalOpen) {
+        this.getInitialCameraStream(webcamDeviceId).then(() => {
+          if (this._isMounted) {
+            this.displayPreview();
+          }
+        });
+      } else if (resolve) {
+        resolve();
+      }
     }
-    if (resolve) resolve();
   }
 
   handleStopSharingAll() {

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -611,9 +611,9 @@ class VideoPreview extends Component {
     }
 
     if (!cameraAsContent) {
+      const keepModalOpen = VideoService.isMultipleCamerasEnabled();
       // Store selected profile, camera ID and virtual background in the storage
       // for future use
-      const keepModalOpen = VideoService.isMultipleCamerasEnabled();
       PreviewService.changeProfile(selectedProfile);
       PreviewService.changeWebcam(webcamDeviceId);
       this.updateVirtualBackgroundInfo();

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -647,6 +647,7 @@ class VideoPreview extends Component {
       const shouldKeepModalOpen = VideoService.isMultipleCamerasEnabled();
       PreviewService.deleteStream(webcamDeviceId);
       stopSharing(webcamDeviceId);
+      this.cleanupStreamAndVideo();
       if (shouldKeepModalOpen) {
         this.getInitialCameraStream(webcamDeviceId).then(() => {
           if (this._isMounted) {

--- a/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/component.jsx
@@ -611,14 +611,13 @@ class VideoPreview extends Component {
     }
 
     if (!cameraAsContent) {
-      const keepModalOpen = VideoService.isMultipleCamerasEnabled();
       // Store selected profile, camera ID and virtual background in the storage
       // for future use
       PreviewService.changeProfile(selectedProfile);
       PreviewService.changeWebcam(webcamDeviceId);
       this.updateVirtualBackgroundInfo();
       this.updateCameraBrightnessInfo();
-      if (!keepModalOpen) {
+      if (!VideoService.isMultipleCamerasEnabled()) {
         this.cleanupStreamAndVideo();
       }
       startSharing(webcamDeviceId);

--- a/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/video-preview/container.jsx
@@ -46,8 +46,14 @@ const VideoPreviewContainer = (props) => {
   const hideNotifications = hideNotificationToasts
     || getFromUserSettings('bbb_hide_notifications', false);
   const stopSharing = (deviceId) => {
-    callbackToClose();
-    setIsOpen(false);
+    const shouldKeepModalOpen = deviceId
+      && VideoService.isMultipleCamerasEnabled();
+
+    if (!shouldKeepModalOpen) {
+      callbackToClose();
+      setIsOpen(false);
+    }
+
     if (deviceId) {
       const streamId = VideoService.getMyStreamId(deviceId, streams);
       if (streamId) stopVideo(streamId);
@@ -81,8 +87,10 @@ const VideoPreviewContainer = (props) => {
   };
 
   const startSharing = (deviceId) => {
-    callbackToClose();
-    setIsOpen(false);
+    if (!VideoService.isMultipleCamerasEnabled()) {
+      callbackToClose();
+      setIsOpen(false);
+    }
     VideoService.joinVideo(deviceId, isCamLocked);
   };
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
This PR improves the workflow for sharing multiple webcams from the webcam preview modal.

When multiple webcam sharing is available:
- The preview modal remains open after starting an individual webcam share.
- The preview modal remains open after stopping an individual webcam share.
- The current preview stream is preserved after starting webcam sharing, preventing the preview area from becoming empty.
- After stopping an individual webcam, its preview stream is reacquired so that the camera can be previewed and shared again.
- The existing behavior is preserved for single-camera environments, when using the camera as presentation content, and when stopping all shared webcams.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #25545 

### Motivation
<!-- What inspired you to submit this pull request? -->
When a user shares multiple webcams, the webcam preview modal currently closes after each webcam is started or stopped. This requires the user to repeatedly reopen the modal to manage additional cameras.

Keeping the modal open allows users to select, preview, start, and stop multiple webcams consecutively from the same interface.

The previous implementation also cleared the preview stream when starting a webcam. This was not visible because the modal immediately closed, but it resulted in an empty preview area once the modal was kept open. This PR preserves or reacquires the preview stream as appropriate to keep the modal state consistent.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
A desktop browser and at least two available webcam devices are required.

1. Enable multiple webcam sharing.
2. Join a meeting with at least two webcam devices available.
3. Open the webcam preview modal.
4. Select, share, and unshare the multiple webcams.
5. Verify that the modal remains open, the preview is not empty, and the user can use the modal like the real webcam control panel

### More
<!-- Anything else we should know when reviewing? -->
When this PR is applied, the current 'cancel' button on the modal does not make sense and needs to be labelled 'close' because it does not cancel anything. In that sense, this PR is in accordance with the PR #25532.
I am not 100% sure if this problem happens also on 4.0 as I do not have any testing environment. But I would say so, judging from the code.