### PR TITLE
refactor: remove deprecated copyright create parameter

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -31,7 +31,6 @@ public class ApiParams {
     public static final String BANNER_COLOR = "bannerColor";
     public static final String BANNER_TEXT = "bannerText";
     public static final String CHECKSUM = "checksum";
-    public static final String COPYRIGHT = "copyright";
     public static final String DIAL_NUMBER = "dialNumber";
     public static final String DURATION = "duration";
     public static final String FREE_JOIN = "freeJoin";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -1093,9 +1093,6 @@ public class ParamsProcessorUtil {
             meeting.setCustomDarkLogoURL(this.getDefaultLogoURL());
         }
 
-		if (!StringUtils.isEmpty(params.get(ApiParams.COPYRIGHT))) {
-			meeting.setCustomCopyright(params.get(ApiParams.COPYRIGHT));
-		}
 		Boolean muteOnStart = defaultMuteOnStart;
 		if (!StringUtils.isEmpty(params.get(ApiParams.MUTE_ON_START))) {
         	muteOnStart = Boolean.parseBoolean(params.get(ApiParams.MUTE_ON_START));

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -109,7 +109,6 @@ public class Meeting {
 	private ArrayList<Group> groups = new ArrayList<Group>();
 	private String customLogoURL = "";
 	private String customDarkLogoURL = "";
-	private String customCopyright = "";
 	private Boolean muteOnStart = false;
 	private String cameraBridge = "livekit";
 	private String screenShareBridge = "livekit";
@@ -772,14 +771,6 @@ public class Meeting {
 
 	public void setCustomDarkLogoURL(String url) {
 		customDarkLogoURL = url;
-	}
-
-	public void setCustomCopyright(String copyright) {
-    	customCopyright = copyright;
-	}
-
-	public String getCustomCopyright() {
-    	return customCopyright;
 	}
 
 	public void setMuteOnStart(Boolean mute) {

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -134,6 +134,7 @@ Updated in 4.0:
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`).
   - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel) and `pinChatMessage`.
   - **Removed parameter:** `lockSettingsDisableNote` (singular); use `lockSettingsDisableNotes` (plural) instead.
+  - **Removed parameter:** `copyright` (it had no effect; the value was stored but never propagated to the client). To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` (requires `allowOverrideClientSettingsOnCreateCall=true`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**


### PR DESCRIPTION
### What does this PR do?

Removes the deprecated `copyright` create parameter. The value was parsed and stored on the bbb-web `Meeting` object (`customCopyright`) but never propagated to akka-apps or the client, so passing it had no observable effect. Its last server-side reader went away with the `/enter` endpoint (2024) and the original Flash consumer was removed back in 2020 — the field has been write-only ever since.

Nothing is lost by removing it: the client still renders a copyright string from client settings (`app.copyright`), and that value can be overridden per meeting via the existing `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` mechanism.

### Closes Issue(s)

Closes bigbluebutton#25431

### How to test

This is a dead-parameter removal, so the focus is confirming no regression:
- Create a meeting passing `copyright=...` → the request still succeeds (unknown params are silently ignored, so existing callers don't break).
- To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` (requires `allowOverrideClientSettingsOnCreateCall=true`) and confirm it renders in the client.

### More

- [x] Added/updated documentation — noted the removal in the 4.0 API changelog (`docs/docs/development/api.md`), pointing to the client-settings override as the supported replacement.