### PR TITLE
feat(layout): arrange cameras and presentation side by side on phones in landscape

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/dropdown/content/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/dropdown/content/styles.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
+import { smallOnly, hasPhoneDimentions } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import {
   borderSize,
   borderRadius,
@@ -41,7 +41,9 @@ const Content = styled.div`
     display: block;
   }
 
-  @media ${smallOnly} {
+  // Short viewports too, not only narrow ones: both callers sit in the slide controls
+  // bar, which scrolls there and would clip content left in flow.
+  @media ${smallOnly}, ${hasPhoneDimentions} {
     z-index: 1015;
     border-radius: 0;
     background-color: #fff;

--- a/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
+++ b/bigbluebutton-html5/imports/ui/components/layout/defaultValues.js
@@ -18,6 +18,7 @@ const DEFAULT_VALUES = {
   cameraDockTabOrder: 4,
   cameraDockMinHeight: 120,
   cameraDockMinWidth: 120,
+  phoneLandscapeCameraWidthPercentage: 0.25,
   camerasMargin: 10,
   captionsMargin: 10,
 

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
@@ -13,6 +13,7 @@ import Storage from '/imports/ui/services/storage/session';
 import { defaultsDeep } from '/imports/utils/array-utils';
 import Session from '/imports/ui/services/storage/in-memory';
 import getFromUserSettings from '/imports/ui/services/users-settings';
+import deviceInfo from '/imports/utils/deviceInfo';
 
 const windowWidth = () => window.document.documentElement.clientWidth;
 const windowHeight = () => window.document.documentElement.clientHeight;
@@ -280,16 +281,30 @@ const UnifiedLayout = (props) => {
     throttledCalculatesLayout();
   };
 
-  const calculatesSidebarContentHeight = (cameraDockHeight) => {
-    const { isOpen, slidesLength } = presentationInput;
+  const isMediaContentOff = () => {
+    const { slidesLength } = presentationInput;
     const { hasExternalVideo } = externalVideoInput;
     const { genericContentId } = genericMainContentInput;
     const { hasScreenShare } = screenShareInput;
     const { isPinned: isSharedNotesPinned } = sharedNotesInput;
 
     const hasPresentation = isPresentationEnabled && slidesLength !== 0;
-    const isGeneralMediaOff = !hasPresentation && !hasExternalVideo
+
+    return !hasPresentation && !hasExternalVideo
       && !hasScreenShare && !isSharedNotesPinned && !genericContentId;
+  };
+
+  const isSideBySideCamerasEnforced = () => deviceInfo.isPhoneLandscape()
+    && cameraDockInput.numCameras > 0
+    && presentationInput.isOpen
+    && !isMediaContentOff();
+
+  const getCameraDockPosition = () => (isSideBySideCamerasEnforced()
+    ? CAMERADOCK_POSITION.CONTENT_RIGHT
+    : cameraDockInput.position);
+
+  const calculatesSidebarContentHeight = (cameraDockHeight) => {
+    const { isOpen } = presentationInput;
     const {
       sidebarContentMinHeight,
     } = DEFAULT_VALUES;
@@ -300,9 +315,9 @@ const UnifiedLayout = (props) => {
         sidebarContentHeight = windowHeight() - DEFAULT_VALUES.navBarHeight;
       } else if (
         cameraDockInput.numCameras > 0
-        && cameraDockInput.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM
+        && getCameraDockPosition() === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM
         && isOpen
-        && !isGeneralMediaOff
+        && !isMediaContentOff()
       ) {
         sidebarContentHeight = windowHeight() - cameraDockHeight;
       } else {
@@ -332,6 +347,7 @@ const UnifiedLayout = (props) => {
       camerasMargin,
       cameraDockMinHeight,
       cameraDockMinWidth,
+      phoneLandscapeCameraWidthPercentage,
       presentationToolbarMinWidth,
       sidebarContentMinHeight,
     } = DEFAULT_VALUES;
@@ -349,16 +365,18 @@ const UnifiedLayout = (props) => {
     if (cameraDockInput.isDragging) cameraDockBounds.zIndex = 99;
     else cameraDockBounds.zIndex = 1;
 
-    const isCameraTop = cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_TOP;
-    const isCameraBottom = cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_BOTTOM;
-    const isCameraLeft = cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_LEFT;
-    const isCameraRight = cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_RIGHT;
-    const isCameraSidebar = cameraDockInput.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM;
+    const cameraPosition = getCameraDockPosition();
+    const isEnforcedSideBySide = isSideBySideCamerasEnforced();
+
+    const isCameraTop = cameraPosition === CAMERADOCK_POSITION.CONTENT_TOP;
+    const isCameraBottom = cameraPosition === CAMERADOCK_POSITION.CONTENT_BOTTOM;
+    const isCameraLeft = cameraPosition === CAMERADOCK_POSITION.CONTENT_LEFT;
+    const isCameraRight = cameraPosition === CAMERADOCK_POSITION.CONTENT_RIGHT;
+    const isCameraSidebar = cameraPosition === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM;
 
     const stoppedResizing = prevIsResizing && !isResizing;
     if (stoppedResizing) {
-      const isCameraTopOrBottom = cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_TOP
-        || cameraDockInput.position === CAMERADOCK_POSITION.CONTENT_BOTTOM;
+      const isCameraTopOrBottom = isCameraTop || isCameraBottom;
       const sidebarContentMarginToMedia = windowWidth()
         * SIDEBAR_CONTENT_MARGIN_TO_MEDIA_PERCENTAGE_WIDTH;
 
@@ -406,7 +424,15 @@ const UnifiedLayout = (props) => {
     }
 
     if (isCameraLeft || isCameraRight) {
-      if (lastWidth === 0 && !isResizing) {
+      if (isEnforcedSideBySide) {
+        cameraDockWidth = min(
+          max(
+            mediaAreaBounds.width * phoneLandscapeCameraWidthPercentage,
+            cameraDockMinWidth,
+          ),
+          mediaAreaBounds.width - cameraDockMinWidth,
+        );
+      } else if (lastWidth === 0 && !isResizing) {
         cameraDockWidth = min(
           max(mediaAreaBounds.width * 0.2, cameraDockMinWidth),
           mediaAreaBounds.width - cameraDockMinWidth,
@@ -420,16 +446,22 @@ const UnifiedLayout = (props) => {
       }
 
       cameraDockBounds.top = navBarHeight + bannerAreaHeight();
-      cameraDockBounds.minWidth = cameraDockMinWidth;
+      cameraDockBounds.minWidth = isEnforcedSideBySide ? cameraDockWidth : cameraDockMinWidth;
       cameraDockBounds.width = cameraDockWidth;
-      cameraDockBounds.maxWidth = mediaAreaBounds.width * 0.8;
-      cameraDockBounds.presenterMaxWidth = mediaAreaBounds.width
-        - presentationToolbarMinWidth - camerasMargin;
+      cameraDockBounds.maxWidth = isEnforcedSideBySide
+        ? cameraDockWidth
+        : mediaAreaBounds.width * 0.8;
+      cameraDockBounds.presenterMaxWidth = isEnforcedSideBySide
+        ? cameraDockWidth
+        : mediaAreaBounds.width - presentationToolbarMinWidth - camerasMargin;
       cameraDockBounds.minHeight = cameraDockMinHeight;
       cameraDockBounds.height = mediaAreaBounds.height;
       cameraDockBounds.maxHeight = mediaAreaBounds.height;
-      // button size in vertical position
-      cameraDockBounds.height -= 20;
+
+      if (!isEnforcedSideBySide) {
+        // button size in vertical position
+        cameraDockBounds.height -= 20;
+      }
 
       if (isCameraRight) {
         const sizeValue = mediaAreaBounds.left + mediaAreaBounds.width - cameraDockWidth;
@@ -526,7 +558,7 @@ const UnifiedLayout = (props) => {
     const sidebarSize = sidebarNavWidth + sidebarContentWidth;
 
     if (cameraDockInput.numCameras > 0 && !cameraDockInput.isDragging) {
-      switch (cameraDockInput.position) {
+      switch (getCameraDockPosition()) {
         case CAMERADOCK_POSITION.CONTENT_TOP: {
           mediaBounds.width = mediaAreaWidth;
           mediaBounds.height = mediaAreaHeight - cameraDockBounds.height - camerasMargin;
@@ -598,7 +630,8 @@ const UnifiedLayout = (props) => {
       calculatesMediaAreaBounds,
       isTablet,
     } = props;
-    const { position: cameraPosition } = cameraDockInput;
+    const cameraPosition = getCameraDockPosition();
+    const isCameraDockLocked = isSideBySideCamerasEnforced();
     const { camerasMargin, captionsMargin } = DEFAULT_VALUES;
 
     const sidebarNavWidth = calculatesSidebarNavWidth();
@@ -775,12 +808,13 @@ const UnifiedLayout = (props) => {
     });
 
     const isMediaOpen = mediaBounds?.width > 0 && mediaBounds?.height > 0;
+    const canResizeCameraDock = isMediaOpen && !isCameraDockLocked;
 
     layoutContextDispatch({
       type: ACTIONS.SET_CAMERA_DOCK_OUTPUT,
       value: {
         display: cameraDockInput.numCameras > 0 || !presentationInput.isOpen,
-        position: cameraDockInput.position,
+        position: cameraPosition,
         minWidth: cameraDockBounds.minWidth,
         width: cameraDockBounds.width,
         maxWidth: cameraDockBounds.maxWidth,
@@ -792,20 +826,21 @@ const UnifiedLayout = (props) => {
         left: cameraDockBounds.left,
         right: cameraDockBounds.right,
         tabOrder: 4,
-        isDraggable: !isMobile && !isTablet && isMediaOpen,
+        isDraggable: !isMobile && !isTablet && !isCameraDockLocked && isMediaOpen,
         resizableEdge: {
           top:
-          isMediaOpen
+          canResizeCameraDock
             && (input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_BOTTOM
             || (input.cameraDock.position === CAMERADOCK_POSITION.SIDEBAR_CONTENT_BOTTOM
             && input.sidebarContent.isOpen)),
           right:
-            isMediaOpen
+            canResizeCameraDock
             && ((!isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_LEFT)
             || (isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_RIGHT)),
-          bottom: isMediaOpen && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_TOP,
+          bottom: canResizeCameraDock
+            && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_TOP,
           left:
-          isMediaOpen
+          canResizeCameraDock
             && ((!isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_RIGHT)
             || (isRTL && input.cameraDock.position === CAMERADOCK_POSITION.CONTENT_LEFT)),
         },

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
@@ -426,12 +426,13 @@ const UnifiedLayout = (props) => {
 
     if (isCameraLeft || isCameraRight) {
       if (isEnforcedSideBySide) {
+        // max() on the upper bound too: it inverts below twice cameraDockMinWidth.
         cameraDockWidth = min(
           max(
             mediaAreaBounds.width * phoneLandscapeCameraWidthPercentage,
             cameraDockMinWidth,
           ),
-          mediaAreaBounds.width - cameraDockMinWidth,
+          max(mediaAreaBounds.width - cameraDockMinWidth, cameraDockMinWidth),
         );
       } else if (lastWidth === 0 && !isResizing) {
         cameraDockWidth = min(
@@ -458,11 +459,8 @@ const UnifiedLayout = (props) => {
       cameraDockBounds.minHeight = cameraDockMinHeight;
       cameraDockBounds.height = mediaAreaBounds.height;
       cameraDockBounds.maxHeight = mediaAreaBounds.height;
-
-      if (!isEnforcedSideBySide) {
-        // button size in vertical position
-        cameraDockBounds.height -= 20;
-      }
+      // button size in vertical position
+      cameraDockBounds.height -= 20;
 
       if (isCameraRight) {
         const sizeValue = mediaAreaBounds.left + mediaAreaBounds.width - cameraDockWidth;
@@ -570,7 +568,8 @@ const UnifiedLayout = (props) => {
           break;
         }
         case CAMERADOCK_POSITION.CONTENT_RIGHT: {
-          mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - camerasMargin * 2;
+          // Clamped: a negative width reads as open to the `width === 0` guards.
+          mediaBounds.width = max(mediaAreaWidth - cameraDockBounds.width - camerasMargin * 2, 0);
           mediaBounds.height = mediaAreaHeight;
           mediaBounds.top = navBarHeight + bannerAreaHeight();
           mediaBounds.left = !isRTL ? sidebarSize : null;
@@ -586,7 +585,7 @@ const UnifiedLayout = (props) => {
           break;
         }
         case CAMERADOCK_POSITION.CONTENT_LEFT: {
-          mediaBounds.width = mediaAreaWidth - cameraDockBounds.width - camerasMargin * 2;
+          mediaBounds.width = max(mediaAreaWidth - cameraDockBounds.width - camerasMargin * 2, 0);
           mediaBounds.height = mediaAreaHeight;
           mediaBounds.top = navBarHeight + bannerAreaHeight();
           const sizeValue = sidebarNavWidth + sidebarContentWidth

--- a/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/layout-manager/unifiedLayout.jsx
@@ -299,6 +299,7 @@ const UnifiedLayout = (props) => {
     && presentationInput.isOpen
     && !isMediaContentOff();
 
+  // CONTENT_RIGHT mirrors under RTL, as every other camera position does.
   const getCameraDockPosition = () => (isSideBySideCamerasEnforced()
     ? CAMERADOCK_POSITION.CONTENT_RIGHT
     : cameraDockInput.position);

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -114,6 +114,8 @@ const LayoutObserver: React.FC = () => {
   const meetingLayout = currentLayoutType && LAYOUT_TYPE[currentLayoutType as keyof typeof LAYOUT_TYPE];
   const isSharingVideo = currentMeeting?.componentsFlags?.hasExternalVideo;
 
+  // Not compared to `deviceType`: the resize listener captures it on mount, and the
+  // reducer already bails out when the value has not changed.
   const setDeviceType = () => {
     layoutContextDispatch({
       type: ACTIONS.SET_DEVICE_TYPE,
@@ -207,6 +209,7 @@ const LayoutObserver: React.FC = () => {
     handleWindowResize();
     window.addEventListener('resize', handleWindowResize, false);
     orientationQuery.addEventListener('change', handleOrientationChange);
+    // Deprecated, kept as a fallback for engines that do not fire the media query.
     window.addEventListener('orientationchange', handleOrientationChange, false);
 
     return () => {

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -28,6 +28,8 @@ import {
 } from '/imports/ui/components/whiteboard/queries';
 
 const MOBILE_MEDIA = 'only screen and (max-width: 40em)';
+const ORIENTATION_MEDIA = '(orientation: portrait)';
+const ORIENTATION_SETTLE_DELAY = 250;
 
 const LayoutObserver: React.FC = () => {
   const layoutType = useRef<string | null>(null);
@@ -113,13 +115,20 @@ const LayoutObserver: React.FC = () => {
   const isSharingVideo = currentMeeting?.componentsFlags?.hasExternalVideo;
 
   const setDeviceType = () => {
-    const newDeviceType = getDeviceType();
-    if (newDeviceType !== deviceType) {
-      layoutContextDispatch({
-        type: ACTIONS.SET_DEVICE_TYPE,
-        value: newDeviceType,
-      });
-    }
+    layoutContextDispatch({
+      type: ACTIONS.SET_DEVICE_TYPE,
+      value: getDeviceType(),
+    });
+  };
+
+  const setBrowserSize = () => {
+    layoutContextDispatch({
+      type: ACTIONS.SET_BROWSER_SIZE,
+      value: {
+        width: window.document.documentElement.clientWidth,
+        height: window.document.documentElement.clientHeight,
+      },
+    });
   };
 
   const throttledDeviceType = throttle(
@@ -181,13 +190,30 @@ const LayoutObserver: React.FC = () => {
         return shouldEnableResize;
       });
       throttledDeviceType();
+      setBrowserSize();
     });
+
+    let orientationSettleTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const handleOrientationChange = () => {
+      handleWindowResize();
+      window.requestAnimationFrame(handleWindowResize);
+      clearTimeout(orientationSettleTimeout);
+      orientationSettleTimeout = setTimeout(handleWindowResize, ORIENTATION_SETTLE_DELAY);
+    };
+
+    const orientationQuery = window.matchMedia(ORIENTATION_MEDIA);
 
     handleWindowResize();
     window.addEventListener('resize', handleWindowResize, false);
+    orientationQuery.addEventListener('change', handleOrientationChange);
+    window.addEventListener('orientationchange', handleOrientationChange, false);
 
     return () => {
+      clearTimeout(orientationSettleTimeout);
       window.removeEventListener('resize', handleWindowResize, false);
+      orientationQuery.removeEventListener('change', handleOrientationChange);
+      window.removeEventListener('orientationchange', handleOrientationChange, false);
     };
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/observer.tsx
@@ -123,6 +123,8 @@ const LayoutObserver: React.FC = () => {
     });
   };
 
+  // Duplicates each layout manager's own `resize` dispatch, for the sake of the
+  // orientation resamples, which no `resize` event follows.
   const setBrowserSize = () => {
     layoutContextDispatch({
       type: ACTIONS.SET_BROWSER_SIZE,
@@ -205,18 +207,24 @@ const LayoutObserver: React.FC = () => {
     };
 
     const orientationQuery = window.matchMedia(ORIENTATION_MEDIA);
+    // Unsupported on the very engines the deprecated event below covers, and a throw
+    // here would take that fallback and the cleanup down with it.
+    const supportsQueryListener = typeof orientationQuery.addEventListener === 'function';
 
     handleWindowResize();
     window.addEventListener('resize', handleWindowResize, false);
-    orientationQuery.addEventListener('change', handleOrientationChange);
-    // Deprecated, kept as a fallback for engines that do not fire the media query.
     window.addEventListener('orientationchange', handleOrientationChange, false);
+    if (supportsQueryListener) {
+      orientationQuery.addEventListener('change', handleOrientationChange);
+    }
 
     return () => {
       clearTimeout(orientationSettleTimeout);
       window.removeEventListener('resize', handleWindowResize, false);
-      orientationQuery.removeEventListener('change', handleOrientationChange);
       window.removeEventListener('orientationchange', handleOrientationChange, false);
+      if (supportsQueryListener) {
+        orientationQuery.removeEventListener('change', handleOrientationChange);
+      }
     };
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -34,8 +34,8 @@ const useMeetingLayoutUpdater = (
 ) => {
   const [setMeetingLayoutProps] = useMutation(SET_LAYOUT_PROPS);
 
-  const { focusedId, position } = cameraDockOutput;
-  const { isResizing } = cameraDockInput;
+  const { focusedId } = cameraDockOutput;
+  const { isResizing, position } = cameraDockInput;
   const { isOpen: presentationIsOpen } = presentationInput;
   const { selectedLayout } = layoutSettings;
 

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -35,6 +35,7 @@ const useMeetingLayoutUpdater = (
   const [setMeetingLayoutProps] = useMutation(SET_LAYOUT_PROPS);
 
   const { focusedId } = cameraDockOutput;
+  // Position from the input: the output may hold a device-enforced one, which is local.
   const { isResizing, position } = cameraDockInput;
   const { isOpen: presentationIsOpen } = presentationInput;
   const { selectedLayout } = layoutSettings;

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/hooks.ts
@@ -27,16 +27,16 @@ const usePushLayoutUpdater = (pushLayout: boolean) => {
 };
 
 const useMeetingLayoutUpdater = (
-  cameraDockOutput: Output['cameraDock'],
+  // Never the raw output: see getPropagatedCameraDock.
+  propagatedCameraDock: Output['cameraDock'],
   cameraDockInput: Input['cameraDock'],
   presentationInput: Input['presentation'],
   layoutSettings: { pushLayout: boolean, selectedLayout: boolean },
 ) => {
   const [setMeetingLayoutProps] = useMutation(SET_LAYOUT_PROPS);
 
-  const { focusedId } = cameraDockOutput;
-  // Position from the input: the output may hold a device-enforced one, which is local.
-  const { isResizing, position } = cameraDockInput;
+  const { focusedId, position } = propagatedCameraDock;
+  const { isResizing } = cameraDockInput;
   const { isOpen: presentationIsOpen } = presentationInput;
   const { selectedLayout } = layoutSettings;
 
@@ -49,7 +49,7 @@ const useMeetingLayoutUpdater = (
         isResizing,
         cameraPosition: position || 'contentTop',
         focusedCamera: focusedId || 'none',
-        presentationVideoRate: calculatePresentationVideoRate(cameraDockOutput),
+        presentationVideoRate: calculatePresentationVideoRate(propagatedCameraDock),
       },
     });
   };

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -33,6 +33,7 @@ import { useMeetingLayoutUpdater, usePushLayoutUpdater, useLayoutUpdater } from 
 import { setEnforcedLayout } from '/imports/ui/components/plugins-engine/ui-commands/layout/handler';
 import { useIsChatEnabled } from '/imports/ui/services/features';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
+import deviceInfo from '/imports/utils/deviceInfo';
 
 const equalDouble = (n1, n2) => {
   const precision = 0.01;
@@ -315,7 +316,9 @@ const PushLayoutEngine = (props) => {
         replicateFocusedCamera();
       }
 
-      if (syncCameraDockSizeAndPosition) {
+      // A phone in landscape arranges the dock on its own terms, so it must not
+      // follow the presenter's camera dock position and size.
+      if (syncCameraDockSizeAndPosition && !deviceInfo.isPhoneLandscape()) {
         if (layoutReplicateElements.includes(LAYOUT_ELEMENTS.CAMERA_DOCK_POSITION)) {
           replicateCameraDockPosition();
         }

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -28,12 +28,11 @@ import {
   layoutSelectInput,
   layoutSelectOutput,
 } from '../context';
-import { calculatePresentationVideoRate } from './service';
+import { calculatePresentationVideoRate, getPropagatedCameraDock } from './service';
 import { useMeetingLayoutUpdater, usePushLayoutUpdater, useLayoutUpdater } from './hooks';
 import { setEnforcedLayout } from '/imports/ui/components/plugins-engine/ui-commands/layout/handler';
 import { useIsChatEnabled } from '/imports/ui/services/features';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
-import deviceInfo from '/imports/utils/deviceInfo';
 
 const equalDouble = (n1, n2) => {
   const precision = 0.01;
@@ -316,9 +315,9 @@ const PushLayoutEngine = (props) => {
         replicateFocusedCamera();
       }
 
-      // A phone in landscape arranges the dock on its own terms, so it must not
-      // follow the presenter's camera dock position and size.
-      if (syncCameraDockSizeAndPosition && !deviceInfo.isPhoneLandscape()) {
+      // Not guarded on the enforcing device: the layout manager overrides the position
+      // it renders, and a guard here would drop the push for good, nothing replays it.
+      if (syncCameraDockSizeAndPosition) {
         if (layoutReplicateElements.includes(LAYOUT_ELEMENTS.CAMERA_DOCK_POSITION)) {
           replicateCameraDockPosition();
         }
@@ -397,7 +396,7 @@ const PushLayoutEngineContainer = (props) => {
   const {
     width: cameraWidth,
     height: cameraHeight,
-    position: cameraPosition,
+    position: cameraDockPosition,
     focusedId: focusedCamera,
   } = cameraDockOutput;
 
@@ -418,7 +417,8 @@ const PushLayoutEngineContainer = (props) => {
     isResizing: cameraIsResizing,
   } = cameraDockInput;
 
-  const horizontalPosition = cameraPosition === 'contentLeft' || cameraPosition === 'contentRight';
+  const horizontalPosition = cameraDockPosition === 'contentLeft'
+    || cameraDockPosition === 'contentRight';
 
   const currentPluginLayoutRaw = useReactiveVar(setEnforcedLayout);
 
@@ -464,12 +464,14 @@ const PushLayoutEngineContainer = (props) => {
     });
   }, [enforcedLayoutLoading]);
 
-  const presentationVideoRate = calculatePresentationVideoRate(cameraDockOutput);
+  // Same source for the payload and for the change detection that fires it.
+  const propagatedCameraDock = getPropagatedCameraDock(cameraDockOutput, cameraDockInput);
+  const presentationVideoRate = calculatePresentationVideoRate(propagatedCameraDock);
 
   const setLocalSettings = useUserChangedLocalSettings();
   const setPushLayout = usePushLayoutUpdater(pushLayout);
   const setMeetingLayout = useMeetingLayoutUpdater(
-    cameraDockOutput,
+    propagatedCameraDock,
     cameraDockInput,
     presentationInput,
     layoutSettings,
@@ -504,9 +506,10 @@ const PushLayoutEngineContainer = (props) => {
         setLocalSettings,
         pushLayoutMeeting,
         cameraIsResizing,
-        cameraPosition,
         focusedCamera,
         isMeetingLayoutResizing,
+        // What is being propagated, not what the device renders.
+        cameraPosition: propagatedCameraDock.position,
         isModerator,
         isPresenter,
         isChatEnabled,

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/service.ts
@@ -1,4 +1,25 @@
-import { Output } from '../layoutTypes';
+import { Input, Output } from '../layoutTypes';
+import deviceInfo from '/imports/utils/deviceInfo';
+
+// A device-enforced position is local to the output, so what a presenter propagates
+// comes off the input, geometry included - or the rate and the position disagree.
+const getPropagatedCameraDock = (
+  cameraDockOutput: Output['cameraDock'],
+  cameraDockInput: Input['cameraDock'],
+) => {
+  const isPositionEnforced = deviceInfo.isPhoneLandscape()
+    && !!cameraDockOutput.position
+    && cameraDockOutput.position !== cameraDockInput.position;
+
+  if (!isPositionEnforced) return cameraDockOutput;
+
+  return {
+    ...cameraDockOutput,
+    position: cameraDockInput.position,
+    width: cameraDockInput.width,
+    height: cameraDockInput.height,
+  };
+};
 
 const calculatePresentationVideoRate = (cameraDockOutput: Output['cameraDock']) => {
   const {
@@ -18,8 +39,10 @@ const calculatePresentationVideoRate = (cameraDockOutput: Output['cameraDock']) 
 
 export {
   calculatePresentationVideoRate,
+  getPropagatedCameraDock,
 };
 
 export default {
   calculatePresentationVideoRate,
+  getPropagatedCameraDock,
 };

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -718,8 +718,6 @@ class Presentation extends PureComponent {
 
     const toolbarHeight = getToolbarHeight();
 
-    const toolbarWidth = Math.min(svgWidth, presentationBounds.width);
-
     const slideContent = currentSlide?.content
       ? `${intl.formatMessage(intlMessages.slideContentStart)}
     ${currentSlide.content}
@@ -736,6 +734,8 @@ class Presentation extends PureComponent {
       || presentationBounds.width === 0
       || presentationBounds.height === 0;
     if (!presentationIsOpen || presentationIsHidden) return null;
+
+    const toolbarWidth = Math.min(svgWidth || presentationBounds.width, presentationBounds.width);
 
     return (
       <>

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -556,7 +556,7 @@ class Presentation extends PureComponent {
     zoomSlide(w, h, x, y);
   }
 
-  renderPresentationToolbar(toolbarWidth = 0) {
+  renderPresentationToolbar() {
     const {
       currentSlide,
       fullscreenElementId,
@@ -585,7 +585,6 @@ class Presentation extends PureComponent {
           zoom,
           currentSlide,
           slidePosition,
-          toolbarWidth,
           fullscreenElementId,
           layoutContextDispatch,
           presentationIsOpen,
@@ -856,7 +855,7 @@ class Presentation extends PureComponent {
                     width: toolbarWidth,
                   }}
                 >
-                  {this.renderPresentationToolbar(toolbarWidth)}
+                  {this.renderPresentationToolbar()}
                 </Styled.PresentationToolbar>
               )}
             </Styled.SvgContainer>

--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -12,7 +12,6 @@ import Styled from './styles';
 import FullscreenService from '/imports/ui/components/common/fullscreen-button/service';
 import PollingContainer from '/imports/ui/components/polling/container';
 import { ACTIONS } from '../layout/enums';
-import DEFAULT_VALUES from '../layout/defaultValues';
 import browserInfo from '/imports/utils/browserInfo';
 import { addAlert } from '../screenreader-alert/service';
 import { debounce } from '/imports/utils/debounce';
@@ -557,10 +556,9 @@ class Presentation extends PureComponent {
     zoomSlide(w, h, x, y);
   }
 
-  renderPresentationToolbar(svgWidth = 0) {
+  renderPresentationToolbar(toolbarWidth = 0) {
     const {
       currentSlide,
-      isMobile,
       fullscreenElementId,
       fullscreenContext,
       layoutContextDispatch,
@@ -580,12 +578,6 @@ class Presentation extends PureComponent {
 
     if (!currentSlide) return null;
 
-    const { presentationToolbarMinWidth } = DEFAULT_VALUES;
-
-    const toolbarWidth = (this.refWhiteboardArea && svgWidth > presentationToolbarMinWidth)
-      || isMobile
-      ? svgWidth
-      : presentationToolbarMinWidth;
     return (
       <PresentationToolbarContainer
         {...{
@@ -676,7 +668,6 @@ class Presentation extends PureComponent {
       isRTL = false,
       presentationBounds,
       fullscreenContext,
-      isMobile,
       currentPresentationId,
       intl,
       fullscreenElementId,
@@ -727,17 +718,7 @@ class Presentation extends PureComponent {
 
     const toolbarHeight = getToolbarHeight();
 
-    const { presentationToolbarMinWidth } = DEFAULT_VALUES;
-
-    const isLargePresentation = svgWidth > presentationToolbarMinWidth;
-
-    const containerWidth = isLargePresentation
-      ? svgWidth
-      : presentationToolbarMinWidth;
-
-    const mobileAwareContainerWidth = isMobile
-      ? presentationBounds.width
-      : containerWidth;
+    const toolbarWidth = Math.min(svgWidth, presentationBounds.width);
 
     const slideContent = currentSlide?.content
       ? `${intl.formatMessage(intlMessages.slideContentStart)}
@@ -872,10 +853,10 @@ class Presentation extends PureComponent {
                     this.refPresentationToolbar = ref;
                   }}
                   style={{
-                    width: mobileAwareContainerWidth,
+                    width: toolbarWidth,
                   }}
                 >
-                  {this.renderPresentationToolbar(svgWidth)}
+                  {this.renderPresentationToolbar(toolbarWidth)}
                 </Styled.PresentationToolbar>
               )}
             </Styled.SvgContainer>
@@ -931,7 +912,6 @@ Presentation.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func.isRequired,
   }).isRequired,
-  isMobile: PropTypes.bool.isRequired,
   fullscreenContext: PropTypes.bool.isRequired,
   presentationAreaSize: PropTypes.shape({
     presentationAreaWidth: PropTypes.number.isRequired,

--- a/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/container.jsx
@@ -279,7 +279,6 @@ const PresentationContainer = ({
           presentationBounds: presentation,
           fullscreenContext,
           fullscreenElementId,
-          isMobile: deviceType === DEVICE_TYPE.MOBILE,
           isTabledLandscape: deviceType === DEVICE_TYPE.TABLET_LANDSCAPE,
           isIphone,
           currentSlide,

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -12,7 +12,6 @@ import {
 import {
   PresentationToolbarItemType,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/presentation-toolbar-item/enums';
-import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import Styled from './styles';
 import ZoomTool from './zoom-tool/component';
 import SmartMediaShareContainer from './smart-video-share/container';
@@ -351,12 +350,7 @@ class PresentationToolbar extends PureComponent {
       maxNumberOfActiveUsers,
       numberOfJoinedUsers,
       isMobile,
-      toolbarWidth,
     } = this.props;
-
-    // Drops the widest optional control when the presentation is too narrow to
-    // hold the whole set of controls.
-    const hasRoomForZoomTool = toolbarWidth >= DEFAULT_VALUES.presentationToolbarMinWidth;
 
     const startOfSlides = !(currentSlideNum > 1);
     const endOfSlides = !(currentSlideNum < numberOfSlides);
@@ -516,7 +510,7 @@ class PresentationToolbar extends PureComponent {
           ) : (
             <Styled.MUTPlaceholder />
           )}
-          {!isMobile && hasRoomForZoomTool ? (
+          {!isMobile ? (
             <TooltipContainer>
               <ZoomTool
                 slidePosition={slidePosition}
@@ -597,7 +591,6 @@ PresentationToolbar.propTypes = {
   maxNumberOfActiveUsers: PropTypes.number.isRequired,
   numberOfJoinedUsers: PropTypes.number.isRequired,
   isMobile: PropTypes.bool.isRequired,
-  toolbarWidth: PropTypes.number.isRequired,
 };
 
 PresentationToolbar.defaultProps = {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/component.jsx
@@ -12,6 +12,7 @@ import {
 import {
   PresentationToolbarItemType,
 } from 'bigbluebutton-html-plugin-sdk/dist/cjs/extensible-areas/presentation-toolbar-item/enums';
+import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import Styled from './styles';
 import ZoomTool from './zoom-tool/component';
 import SmartMediaShareContainer from './smart-video-share/container';
@@ -350,7 +351,12 @@ class PresentationToolbar extends PureComponent {
       maxNumberOfActiveUsers,
       numberOfJoinedUsers,
       isMobile,
+      toolbarWidth,
     } = this.props;
+
+    // Drops the widest optional control when the presentation is too narrow to
+    // hold the whole set of controls.
+    const hasRoomForZoomTool = toolbarWidth >= DEFAULT_VALUES.presentationToolbarMinWidth;
 
     const startOfSlides = !(currentSlideNum > 1);
     const endOfSlides = !(currentSlideNum < numberOfSlides);
@@ -387,7 +393,6 @@ class PresentationToolbar extends PureComponent {
     return (
       <Styled.PresentationToolbarWrapper
         id="presentationToolbarWrapper"
-        isMobile={isMobile}
       >
         {this.renderAriaDescs()}
         <Styled.QuickPollButtonWrapper>
@@ -511,7 +516,7 @@ class PresentationToolbar extends PureComponent {
           ) : (
             <Styled.MUTPlaceholder />
           )}
-          {!isMobile ? (
+          {!isMobile && hasRoomForZoomTool ? (
             <TooltipContainer>
               <ZoomTool
                 slidePosition={slidePosition}
@@ -592,6 +597,7 @@ PresentationToolbar.propTypes = {
   maxNumberOfActiveUsers: PropTypes.number.isRequired,
   numberOfJoinedUsers: PropTypes.number.isRequired,
   isMobile: PropTypes.bool.isRequired,
+  toolbarWidth: PropTypes.number.isRequired,
 };
 
 PresentationToolbar.defaultProps = {

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -28,16 +28,14 @@ const PresentationToolbarWrapper = styled.div`
   background-color: ${colorOffWhite};
   border-top: 1px solid ${colorBlueLightest};
   border-radius: 0 0 ${lgBorderRadius} ${lgBorderRadius};
-  min-width: fit-content;
   width: 100%;
   bottom: 0px;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   padding: 2px;
-  ${({ isMobile }) => (isMobile
-    ? 'overflow: auto;'
-    : 'min-width: fit-content;'
-  )};
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
 
   select {
     &:-moz-focusring {
@@ -94,6 +92,12 @@ const PresentationToolbarWrapper = styled.div`
   &::-webkit-scrollbar-track:hover { background: rgba(0,0,0,.25); }
   &::-webkit-scrollbar-track:active { background: rgba(0,0,0,.25); }
   &::-webkit-scrollbar-corner { background: 0 0; }
+
+  // overrides the scrollbar styling above: the horizontal bar would overlap the
+  // controls and shorten the slide, since the toolbar height is measured
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const QuickPollButton = styled(QuickPollDropdownContainer)`
@@ -144,7 +148,7 @@ const PrevSlideButton = styled(Button)`
 const NextSlideButton = styled(Button)`
   i {
     font-size: 1rem;
-    
+
     [dir="rtl"] & {
       -webkit-transform: scale(-1, 1);
       -moz-transform: scale(-1, 1);

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import QuickPollDropdownContainer from '/imports/ui/components/actions-bar/quick-poll-dropdown/container';
+import { smallOnly, hasPhoneDimentions } from '/imports/ui/stylesheets/styled-components/breakpoints';
 import {
   colorPrimary,
   colorOffWhite,
@@ -33,12 +34,18 @@ const PresentationToolbarWrapper = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   padding: 2px;
-  min-width: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
+  min-width: fit-content;
 
-  &::-webkit-scrollbar {
-    display: none;
+  // Only where dropdown/content becomes a full-screen overlay - keep both in sync, or
+  // this ~40px box clips a dropdown left in flow above it.
+  @media ${smallOnly}, ${hasPhoneDimentions} {
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   select {
@@ -71,7 +78,6 @@ const PresentationToolbarWrapper = styled.div`
     justify-content: center;
     align-items: center;
   }
-
 `;
 
 const QuickPollButton = styled(QuickPollDropdownContainer)`

--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/styles.js
@@ -37,6 +37,10 @@ const PresentationToolbarWrapper = styled.div`
   overflow-x: auto;
   scrollbar-width: none;
 
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   select {
     &:-moz-focusring {
       outline: none;
@@ -68,36 +72,6 @@ const PresentationToolbarWrapper = styled.div`
     align-items: center;
   }
 
-  // Fancy scroll
-  &::-webkit-scrollbar {
-    width: 5px;
-    height: 5px;
-  }
-  &::-webkit-scrollbar-button {
-    width: 0;
-    height: 0;
-  }
-  &::-webkit-scrollbar-thumb {
-    background: rgba(0,0,0,.25);
-    border: none;
-    border-radius: 50px;
-  }
-  &::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,.5); }
-  &::-webkit-scrollbar-thumb:active { background: rgba(0,0,0,.25); }
-  &::-webkit-scrollbar-track {
-    background: rgba(0,0,0,.25);
-    border: none;
-    border-radius: 50px;
-  }
-  &::-webkit-scrollbar-track:hover { background: rgba(0,0,0,.25); }
-  &::-webkit-scrollbar-track:active { background: rgba(0,0,0,.25); }
-  &::-webkit-scrollbar-corner { background: 0 0; }
-
-  // overrides the scrollbar styling above: the horizontal bar would overlap the
-  // controls and shorten the slide, since the toolbar height is measured
-  &::-webkit-scrollbar {
-    display: none;
-  }
 `;
 
 const QuickPollButton = styled(QuickPollDropdownContainer)`
@@ -148,7 +122,7 @@ const PrevSlideButton = styled(Button)`
 const NextSlideButton = styled(Button)`
   i {
     font-size: 1rem;
-
+    
     [dir="rtl"] & {
       -webkit-transform: scale(-1, 1);
       -moz-transform: scale(-1, 1);

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -107,6 +107,9 @@ const SidebarNavigation = ({
         // restore sidebar expanded state if device is not mobile anymore
         setIsExpanded(true);
       }
+      if (!enableScrollBar) {
+        setEnableScrollBar(true);
+      }
       return;
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -688,8 +688,10 @@ const reserveAudioOnlyTiles = ({
   const uniqueAudioOnly = (showAudioOnlyOnFirstPage && audioOnlyUsers.length > 0)
     ? audioOnlyUsers.filter((audioUser) => !excludeStreams.find((s) => s.userId === audioUser.userId))
     : [];
+  const cameraSlotFloor = reservedCount === 0 && others.length > 0 ? 1 : 0;
+  const audioOnlySlots = Math.max(0, Math.min(availableSlots - cameraSlotFloor, maxAudioOnlyUsers));
   const audioOnlySlotsUsedOnPage1 = uniqueAudioOnly.length > 0
-    ? Math.min(uniqueAudioOnly.length, Math.min(availableSlots, maxAudioOnlyUsers))
+    ? Math.min(uniqueAudioOnly.length, audioOnlySlots)
     : 0;
 
   let totalNumberOfOtherStreams: number;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -688,6 +688,8 @@ const reserveAudioOnlyTiles = ({
   const uniqueAudioOnly = (showAudioOnlyOnFirstPage && audioOnlyUsers.length > 0)
     ? audioOnlyUsers.filter((audioUser) => !excludeStreams.find((s) => s.userId === audioUser.userId))
     : [];
+  // Caps maxAudioOnlyUsers below its configured value on a small page: the two slots
+  // of a mobile page hold one audio-only tile, not two.
   const cameraSlotFloor = reservedCount === 0 && others.length > 0 ? 1 : 0;
   const audioOnlySlots = Math.max(0, Math.min(availableSlots - cameraSlotFloor, maxAudioOnlyUsers));
   const audioOnlySlotsUsedOnPage1 = uniqueAudioOnly.length > 0

--- a/bigbluebutton-html5/imports/utils/deviceInfo.js
+++ b/bigbluebutton-html5/imports/utils/deviceInfo.js
@@ -16,6 +16,9 @@ export const isIphone = !!(userAgent.match(/iPhone/i));
 
 export const isPortrait = () => window.innerHeight > window.innerWidth;
 
+// Tablets are deliberately left out: they keep the regular layout behavior.
+export const isPhoneLandscape = () => isPhone && !isPortrait();
+
 const deviceInfo = {
   isTablet,
   isPhone,
@@ -24,6 +27,7 @@ const deviceInfo = {
   osName,
   osVersion,
   isPortrait,
+  isPhoneLandscape,
   isIos,
   isMacos,
   isIphone,

--- a/bigbluebutton-html5/imports/utils/deviceInfo.js
+++ b/bigbluebutton-html5/imports/utils/deviceInfo.js
@@ -14,7 +14,10 @@ export const isIos = osName === 'iOS' || (isTablet && osName === 'macOS');
 export const isMacos = osName === 'macOS';
 export const isIphone = !!(userAgent.match(/iPhone/i));
 
-export const isPortrait = () => window.innerHeight > window.innerWidth;
+// documentElement, the metric the layout managers measure and the resize dispatch
+// carries. window.inner* diverges from it on mobile.
+export const isPortrait = () => window.document.documentElement.clientHeight
+  > window.document.documentElement.clientWidth;
 
 // Tablets are deliberately left out: they keep the regular layout behavior.
 export const isPhoneLandscape = () => isPhone && !isPortrait();


### PR DESCRIPTION
### What does this PR do?
Reworks how the unified layout behaves on a phone held in landscape (`deviceInfo.isPhone` + landscape orientation — tablets are deliberately excluded, they keep the regular behavior).

- **Cameras right, presentation left.** When both the content and the cameras are visible, the arrangement is imposed by the device instead of being freely placed: the camera dock is docked to the right with a fixed share of the media area (`phoneLandscapeCameraWidthPercentage`), and is neither draggable nor resizable. This is computed as an effective position in the layout manager, so the user's/meeting's stored camera position is left untouched and comes back when the phone returns to portrait. As with every other camera position, `contentRight` mirrors under RTL.
- **No longer follows the presenter's camera placement.** Since the arrangement is local to the device, camera dock position/size are not replicated on such a client. Conversely, the position a presenter propagates now comes from the layout *input* rather than the (possibly device-enforced) output, so a phone in landscape never pushes `contentRight` to the whole meeting.
- **Sidebar navigation scroll after rotating collapsed.** The flag that suppresses the scrollbar during the mobile expand animation was never restored when the device stopped being mobile, so a sidebar collapsed in portrait was left unscrollable in landscape (while one left open kept its scroll).

### Closes Issue(s)

Closes None

### More

- **Pairs with #25340 (mobile layout overhaul).** That PR owns the mobile polish; this one only changes layout geometry and the slide controls sizing. Cosmetic leftovers visible while testing this branch on its own — most notably the camera dock's vertical page arrows overlapping the surrounding controls — are resolved there, since it stops rendering those buttons on mobile and moves pagination into a bar inside the dock. The enforced arrangement here **assumes** that: it no longer reserves the 20px those arrows used to occupy, so until #25340 lands the arrows still render and overlap. The two are meant to go in together.
- The toolbar sizing change is a no-op whenever the slide is wider than `presentationToolbarMinWidth` (430px), which is the case at the default desktop viewports: behavior only changes where the toolbar previously overflowed its area. The width is computed after the `presentationBounds` guard and falls back to the presentation area width while the slide has no measured size.
- Hiding the toolbar scrollbar left the pre-existing "Fancy scroll" rules unable to paint on any engine, so they are removed in the second commit.
- `deviceInfo.isMobile` includes tablets, so a new `isPhoneLandscape()` helper was added rather than reusing it.

#### Moderator
<img width="875" height="458" alt="Screenshot from 2026-08-04 10-20-54" src="https://github.com/user-attachments/assets/2f03273c-1c2f-4f80-a4b9-5ee204a987fe" />

#### Participant
<img width="875" height="458" alt="Screenshot from 2026-08-04 10-18-29" src="https://github.com/user-attachments/assets/0b55996e-c0c6-43f7-89b0-f6f14ce13e9a" />

