### PR TITLE
chore: use bbb- prefixed npm package names

### DIFF
--- a/bbb-graphql-client-test/README.md
+++ b/bbb-graphql-client-test/README.md
@@ -1,4 +1,4 @@
-# bigbluebutton-graphql
+# bbb-graphql-client-test
 
 This is a demonstration client that connects to BigBlueButton graphql API.
 

--- a/bbb-graphql-client-test/package-lock.json
+++ b/bbb-graphql-client-test/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bigbluebutton-graphql",
+  "name": "bbb-graphql-client-test",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "bigbluebutton-graphql",
+      "name": "bbb-graphql-client-test",
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.7.1",

--- a/bbb-graphql-client-test/package.json
+++ b/bbb-graphql-client-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bigbluebutton-graphql",
+  "name": "bbb-graphql-client-test",
   "homepage": "/graphql-test/",
   "version": "0.1.0",
   "private": true,

--- a/bbb-learning-dashboard/package-lock.json
+++ b/bbb-learning-dashboard/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "learning-analytics-dashboard",
+  "name": "bbb-learning-analytics-dashboard",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "learning-analytics-dashboard",
+      "name": "bbb-learning-analytics-dashboard",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.10.5",

--- a/bbb-learning-dashboard/package.json
+++ b/bbb-learning-dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "learning-analytics-dashboard",
+  "name": "bbb-learning-analytics-dashboard",
   "homepage": ".",
   "version": "0.1.0",
   "private": true,

--- a/bigbluebutton-tests/playwright/package-lock.json
+++ b/bigbluebutton-tests/playwright/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "playwright",
+  "name": "bbb-tests-playwright",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "playwright",
+      "name": "bbb-tests-playwright",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/bigbluebutton-tests/playwright/package.json
+++ b/bigbluebutton-tests/playwright/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "playwright",
+  "name": "bbb-tests-playwright",
   "version": "1.0.0",
   "description": "Tests for BigBlueButton using Playwright.",
   "main": "index.js",


### PR DESCRIPTION
Rename three npm project names so they match their directories and are identifiable as BigBlueButton components:

- bigbluebutton-graphql        -> bbb-graphql-client-test
- learning-analytics-dashboard -> bbb-learning-analytics-dashboard
- playwright                   -> bbb-tests-playwright

Only the package identity is touched (package.json and both root name fields in package-lock.json). The /learning-analytics-dashboard URL path served by nginx and referenced by learningDashboardBase is unchanged, as is the upstream playwright dependency.

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Converges different names for the npm same projects.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
I am writing some prompts and the mismatch in name is confusing