### PR TITLE
test: click the rectangle tool without opening the "More" geo popup

### DIFF
--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -331,7 +331,8 @@ export class LockViewers extends MultiUsers {
       'should not display the other viewer annotation for the viewer who just joined',
     ).toHaveScreenshot('viewer2-just-joined.png', screenshotOptions);
     // draw a rectangle and check if it is displayed
-    await this.userPage.waitAndClick(e.wbShapesButton);
+    // the rectangle lives directly on the toolbar, so it must be clicked without opening the "More"
+    // geo popup — the opened popup grid overlaps the toolbar and intercepts the click (see drawShape)
     await this.userPage.waitAndClick(e.wbRectangleShape);
     await this.userPage.waitAndClick(e.whiteboard);
     await this.modPage.page.locator(e.chatButton).hover();


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky `Lock viewers › Lock see other viewers annotations` Playwright test.

The test opened tldraw's "More" geo popup before clicking the rectangle tool:

```js
await this.userPage.waitAndClick(e.wbShapesButton);   // opens the "More" popup
await this.userPage.waitAndClick(e.wbRectangleShape); // button[data-testid$=".rectangle"]
```

tldraw promotes the *active* geo shape to the toolbar and lists only the alternatives in the
popup, so `tools.rectangle` lives on the toolbar and there is no `tools.more.rectangle`. The
popup renders on top of the toolbar, so opening it placed its grid over the very button the
test then clicked, and the click was intercepted:

```
- waiting for locator('button[data-testid$=".rectangle"]')
  - element is visible, enabled and stable
  - <div class="tlui-buttons__grid">…</div> from <div data-radix-popper-content-wrapper>
    subtree intercepts pointer events
```

Measured in the DOM at the moment of failure:

| Observation | Value |
|---|---|
| Elements matching `button[data-testid$=".rectangle"]` | exactly 1 |
| That element | `tools.rectangle`, not inside the popover — main toolbar |
| Its center | (1336, 490) |
| Popup bounding box | x 1214–1362, y 341–527 — contains that point |
| `elementFromPoint` at the button's center | `DIV.tlui-buttons__grid` |
| Buttons inside the popup | `tools.more.` ellipse, diamond, triangle, trapezoid, rhombus, hexagon, cloud, star, oval, x-box, check-box, arrow-×4, line, frame — no rectangle |

The fix removes the popup click, applying the rule already documented in `drawShape.ts`:

> shapes inside the "More" geo popup (`data-testid="tools.more.*"`) need the popup opened first;
> shapes that live directly on the toolbar (e.g. rectangle, arrow) must be clicked without it,
> otherwise the opened popup grid overlaps and intercepts the click on the toolbar button

All other call sites already comply — `shapeTools.ts` and `breakout/join.ts` open the popup for
`tools.more.line`, and `shapeOptions.ts` clicks the rectangle directly. `lockViewers.ts` was the
only remaining violation.

### Closes Issue(s)

Closes #

### Motivation

The test failed 4 out of 5 runs, in both the CI and non-CI Playwright configurations. Because it
fails on an intercepted click rather than an assertion, the failure looks like a product
regression in whiteboard annotation locking when it is purely a test/selector problem — expensive
to re-diagnose every time it appears.

The intermittent pass explains why it was never fully deterministic: `waitAndClick` calls
`page.focus()` before `page.click()`, and focusing the toolbar button is a focus-outside event for
the Radix popover, so it sometimes closed in time for the click to land.

### How to test

No special setup; default server settings.

```bash
cd bigbluebutton-tests/playwright
npm run test:ssh <server> -- --project=chromium -g "Lock see other viewers annotations" --repeat-each=5 --retries=0
```

Before / after on the same server, `--retries=0` so nothing is masked:

| Run | Before | After |
|---|---|---|
| 5 repeats, `CI=true` | failed | **5/5 pass** |
| 5 repeats, `CI` unset (2 workers, 0 retries) | 4/5 failed | **5/5 pass** |
| `tsc --noEmit -p .` | — | clean |
| Full `Lock viewers` group, `CI=true` | — | 16 passed, 1 failed |

10/10 passes across both configurations, including the non-CI config where it originally failed
4 of 5.

The one remaining group failure is `Lock Share microphone`, which this PR does not touch: it times
out on `button[data-test="microphoneBtn"]` inside `joinMicrophone()`, an audio path unrelated to
the whiteboard, and it passed in a separate full `@ci` run. Pre-existing and separately flaky.

