### PR TITLE
docs: install sbt 1.10.7 in the dev setup

### DIFF
--- a/docs/docs/development/dev-guide.md
+++ b/docs/docs/development/dev-guide.md
@@ -165,7 +165,7 @@ source "$HOME/.sdkman/bin/sdkman-init.sh"
 
 sdk install gradle 8.14.3 
 sdk install grails 7.0.0
-sdk install sbt 1.6.2
+sdk install sbt 1.10.7
 sdk install maven 3.5.0
 ```
 


### PR DESCRIPTION
The dev setup instructions still say `sdk install sbt 1.6.2`, but every module's `project/build.properties` pins `sbt.version=1.10.7` (since #24938). A developer following the guide installs a build tool the project no longer uses, and then hits the exact `'21' is not a valid choice for '-release'` error that the troubleshooting section further down this same guide describes.

```diff
- sdk install sbt 1.6.2
+ sdk install sbt 1.10.7
```

Spotted by CodeRabbit while reviewing the 3.0 backport (#25581), where the same line is already fixed.

The identical stale line is also on `v4.1.x-develop` and `v4.0.x-release` (both L168) if you want it carried across. `develop` does not need it — it still pins sbt 1.6.2 in `build.properties`, so it is internally consistent