### PR TITLE
Refactor(bbb-web): remove dead logoutTimer configuration

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -41,7 +41,6 @@ public class ApiParams {
     public static final String IS_BREAKOUT = "isBreakout";
     public static final String LOGO = "logo";
     public static final String DARK_LOGO = "darklogo";
-    public static final String LOGOUT_TIMER = "logoutTimer";
     public static final String LOGIN_URL = "loginURL";
     public static final String LOGOUT_URL = "logoutURL";
     public static final String MAX_PARTICIPANTS = "maxParticipants";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -145,7 +145,6 @@ public class ParamsProcessorUtil {
 
     private Long maxPresentationFileUpload = 30000000L; // 30MB
 
-    private Integer clientLogoutTimerInMinutes = 0;
     private Integer defaultMeetingExpireIfNoUserJoinedInMinutes = 5;
     private Integer defaultMeetingExpireWhenLastUserLeftInMinutes = 1;
   	private Integer userInactivityInspectTimerInMinutes = 120;
@@ -602,7 +601,6 @@ public class ParamsProcessorUtil {
         boolean record = processRecordMeeting(params.get(ApiParams.RECORD));
         int maxUsers = processMaxUser(params.get(ApiParams.MAX_PARTICIPANTS));
         int meetingDuration = processMeetingDuration(params.get(ApiParams.DURATION));
-        int logoutTimer = processLogoutTimer(params.get(ApiParams.LOGOUT_TIMER));
 
         // Banner parameters
         String bannerText = params.get(ApiParams.BANNER_TEXT);
@@ -985,7 +983,6 @@ public class ParamsProcessorUtil {
                 .withDuration(meetingDuration)
                 .withLoginUrl(loginUrl)
                 .withLogoutUrl(logoutUrl)
-                .withLogoutTimer(logoutTimer)
                 .withBannerText(bannerText).withBannerColor(bannerColor)
                 .withTelVoice(telVoice)
                 .withDialNumber(dialNumber)
@@ -1354,18 +1351,6 @@ public class ParamsProcessorUtil {
     return mDuration;
   }
 
-	public int processLogoutTimer(String logoutTimer) {
-		int mDuration = clientLogoutTimerInMinutes;
-
-		try {
-			mDuration = Integer.parseInt(logoutTimer);
-		} catch(Exception ex) {
-			mDuration = clientLogoutTimerInMinutes;
-		}
-
-		return mDuration;
-	}
-
     public boolean isTestMeeting(String telVoice) {
         return ((!StringUtils.isEmpty(telVoice)) && (!StringUtils.isEmpty(testVoiceBridge))
                 && (telVoice.equals(testVoiceBridge)));
@@ -1678,10 +1663,6 @@ public class ParamsProcessorUtil {
 
     public void setDefaultMeetingLayout(String meetingLayout) {
 		this.defaultMeetingLayout =  meetingLayout;
-	}
-
-	public void setClientLogoutTimerInMinutes(Integer value) {
-		clientLogoutTimerInMinutes = value;
 	}
 
 	public void setMeetingExpireWhenLastUserLeftInMinutes(Integer value) {

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -61,7 +61,6 @@ public class Meeting {
 	private String welcomeMsgForModerators = "";
 	private String loginUrl;
 	private String logoutUrl;
-	private int logoutTimer = 0;
 	private int maxUsers;
 	private String bannerColor = "#FFFFFF";
 	private String bannerText = "";
@@ -169,7 +168,6 @@ public class Meeting {
         bannerText = builder.bannerText;
         loginUrl = builder.loginUrl;
         logoutUrl = builder.logoutUrl;
-        logoutTimer = builder.logoutTimer;
         defaultAvatarURL = builder.defaultAvatarURL;
         defaultBotAvatarURL = builder.defaultBotAvatarURL;
 				defaultWebcamBackgroundURL = builder.defaultWebcamBackgroundURL;
@@ -655,10 +653,6 @@ public class Meeting {
 		return maxUserConcurrentAccesses;
 	}
 
-	public int getLogoutTimer() {
-		return logoutTimer;
-	}
-
 	public String getBannerColor() {
 		return bannerColor;
 	}
@@ -1075,7 +1069,6 @@ public class Meeting {
 			private String cameraBridge;
 			private String screenShareBridge;
 			private String audioBridge;
-    	private int logoutTimer;
     	private Map<String, String> metadata;
     	private Map<String, String> pluginMetadataParametersMap;
     	private String dialNumber;
@@ -1302,11 +1295,6 @@ public class Meeting {
     	public Builder withLogoutUrl(String l) {
     	  logoutUrl = l;
     	  return this;
-    	}
-
-    	public Builder withLogoutTimer(int l) {
-    		logoutTimer = l;
-    		return this;
     	}
 
     	public Builder withBannerColor(String c) {

--- a/bigbluebutton-config/bin/bbb-conf
+++ b/bigbluebutton-config/bin/bbb-conf
@@ -192,6 +192,7 @@ RETIRED_BBB_WEB_PROPERTIES=(
     textFileCreationExecTimeoutInMs   # Renamed in BBB 3.0.17 (use textFileCreationExecTimeout instead)
     insertDocumentSupportedProtocols  # Renamed in BBB 3.0.23 (use fetchUrlSupportedProtocols instead)
     insertDocumentBlockedHosts        # Renamed in BBB 3.0.23 (use fetchUrlBlockedExternalHosts instead)
+    clientLogoutTimerInMinutes        # Removed in BBB 4.0
 )
 NGINX_IP=$(cat /etc/nginx/sites-available/bigbluebutton | grep -v '#' | sed -n '/server_name/{s/.*server_name[ ]*//;s/;//;p}' | cut -d' ' -f1 | head -n 1)
 

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -269,10 +269,6 @@ maxUserConcurrentAccesses=3
 # Current default is 0 (meeting doesn't end).
 defaultMeetingDuration=0
 
-# Number of minutes to logout client if user
-# isn't responsive
-clientLogoutTimerInMinutes=0
-
 # End meeting if no user joined within
 # a period of time after meeting created.
 meetingExpireIfNoUserJoinedInMinutes=5

--- a/bigbluebutton-web/grails-app/conf/spring/resources.xml
+++ b/bigbluebutton-web/grails-app/conf/spring/resources.xml
@@ -239,7 +239,6 @@ with BigBlueButton; if not, see <http://www.gnu.org/licenses/>.
         <property name="userInactivityThresholdInMinutes" value="${userInactivityThresholdInMinutes}"/>
         <property name="userActivitySignResponseDelayInMinutes" value="${userActivitySignResponseDelayInMinutes}"/>
         <property name="maxPresentationFileUpload" value="${maxFileSizeUpload}"/>
-        <property name="clientLogoutTimerInMinutes" value="${clientLogoutTimerInMinutes}"/>
         <property name="muteOnStart" value="${muteOnStart}"/>
         <property name="cameraBridge" value="${cameraBridge}"/>
         <property name="screenShareBridge" value="${screenShareBridge}"/>

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1710,7 +1710,6 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `defaultGuestPolicy` | Default guest policy applied to meetings | ALWAYS_ACCEPT, ALWAYS_DENY, ASK_MODERATOR | ALWAYS_ACCEPT _`overwritable`_ (via `guestPolicy`) |
 | `authenticatedGuest` | Enable authenticated guest mode | true/false | true |
 | `defaultAllowPromoteGuestToModerator` | Allows moderators to promote guests to moderators when `authenticatedGuest` is enabled | true/false | false _`overwritable`_ (via `allowPromoteGuestToModerator`) |
-| `clientLogoutTimerInMinutes` | Number of minutes to logout client if user isn't responsive | Integer (0=disable) | 0 |
 | `meetingExpireIfNoUserJoinedInMinutes` | End meeting if no user joined within a period of time after meeting created | Integer | 5 _`overwritable`_ |
 | `meetingExpireWhenLastUserLeftInMinutes` | Number of minutes to end meeting when the last user left | Integer (0=disable) | 1 _`overwritable`_ |
 | `endWhenNoModerator` | End meeting when there are no moderators after a certain period of time | true/false | false _`overwritable`_ |

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -135,6 +135,7 @@ Updated in 4.0:
   - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel) and `pinChatMessage`.
   - **Removed parameter:** `lockSettingsDisableNote` (singular); use `lockSettingsDisableNotes` (plural) instead.
   - **Removed parameter:** `copyright` (it had no effect; the value was stored but never propagated to the client). To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` (requires `allowOverrideClientSettingsOnCreateCall=true`).
+  - **Removed parameter:** `logoutTimer` (it had no effect; the value was stored in bbb-web but never propagated to akka-apps or the HTML5 client).
   - **Removed parameter:** `webVoice` (obsolete; it selected a separate voice conference for the old Flash client and had no downstream effect after that client was removed in BBB 2.3, always falling back to `voiceBridge`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -219,6 +219,8 @@ The deprecated REST endpoint `/api/rest/clientSettings` has been removed. Client
 #### Removed
 
 - `lockSettingsDisableNote` is no longer recognized; use `lockSettingsDisableNotes` instead. The singular property was renamed in BBB 2.5.
+- `clientLogoutTimerInMinutes` was removed. It was never consumed by the HTML5 client; its last reader, the `/enter` endpoint, was removed before BBB 4.0.
+  - If you customized `/usr/share/bbb-web/WEB-INF/classes/spring/resources.xml` in place, also remove the `<property name="clientLogoutTimerInMinutes" .../>` entry - bbb-web will fail to start (`NotWritablePropertyException`) otherwise. The `bbb-conf --check` retired-property warning only scans `/etc/bigbluebutton/bbb-web.properties`, not `resources.xml`.
 
 #### Value changed
 


### PR DESCRIPTION
### What does this PR do?

Removes the `logoutTimer` `/create` parameter and its server-side default, `clientLogoutTimerInMinutes`.

bbb-web parsed and stored the value on its `Meeting` object, but never propagated it to akka-apps or the HTML5 client. As a result, both settings had no runtime effect. Idle-user ejection remains handled independently by the akka-apps inactivity monitor.

The change removes the API constant, parser and meeting fields, Spring wiring, default property, and obsolete administration documentation. It also registers `clientLogoutTimerInMinutes` as retired and documents the 4.0 API and upgrade impact.

### Closes Issue(s)

Closes #25430

### How to test

1. Create a meeting with `logoutTimer=5` and confirm the request and join both succeed. Unknown create parameters remain silently ignored.
2. Leave `clientLogoutTimerInMinutes=0` in `/etc/bigbluebutton/bbb-web.properties` and run `bbb-conf --check`. Confirm it reports the property as retired.
3. Confirm `/usr/share/bbb-web/WEB-INF/classes/spring/resources.xml` does not contain a `clientLogoutTimerInMinutes` property.
4. If that Spring property was added manually, remove it during upgrade. Keeping it causes bbb-web to fail with `NotWritablePropertyException`.

### Validation

- BBB 4.0 rebuilt from source successfully.
- bbb-web starts without `NotWritablePropertyException`.
- Meeting creation and join succeed with the removed parameter still supplied.
- `bbb-conf --check` reports the retired server property.
- ShellCheck passes at error severity for `bigbluebutton-config/bin/bbb-conf`.

### More

- [x] Added or updated documentation
