### PR TITLE
fix: presentation download system message in chat export

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/queries.ts
@@ -12,6 +12,7 @@ export const GET_CHAT_MESSAGE_HISTORY = gql`
 query getChatMessageHistory {
   chat_message_public(order_by: {createdAt: asc}) {
     message
+    messageAsHtml
     messageId
     messageType
     messageMetadata

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -104,6 +104,8 @@ export const generateExportedMessages = (
       case ChatMessageType.API:
       case ChatMessageType.BREAKOUT_ROOM:
       case ChatMessageType.PLUGIN:
+        messageText = htmlDecode(message.messageAsHtml || message.message || '');
+        break;
       case ChatMessageType.TEXT:
       default:
         messageText = htmlDecode(message.message || '');

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -3,7 +3,9 @@ import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { IntlShape, defineMessages } from 'react-intl';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
 import PollService from '/imports/ui/components/poll/service';
-import { parsePresentationMetadata } from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
+import {
+  parsePresentationMetadata,
+} from '/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service';
 
 const intlMessages = defineMessages({
   chatClear: {
@@ -70,35 +72,52 @@ export const generateExportedMessages = (
       case ChatMessageType.POLL: {
         userName = `${intl.formatMessage(intlMessages.pollResult)}:\n`;
 
-        const metadata = JSON.parse(message.messageMetadata);
-        const pollText = htmlDecode(PollService.getPollResultString(metadata, intl).split('<br/>').join('\n'));
-        // remove last \n to avoid empty line
-        messageText = pollText.slice(0, -1);
+        try {
+          const metadata = JSON.parse(message.messageMetadata);
+          const pollText = htmlDecode(PollService.getPollResultString(metadata, intl).split('<br/>').join('\n'));
+          // remove last \n to avoid empty line
+          messageText = pollText.slice(0, -1);
+        } catch {
+          messageText = htmlDecode(message.message || message.messageAsHtml || '');
+        }
         break;
       }
       case ChatMessageType.USER_IS_PRESENTER_MSG: {
-        const { assignedBy } = JSON.parse(message.messageMetadata);
+        try {
+          const { assignedBy } = JSON.parse(message.messageMetadata);
 
-        messageText = (assignedBy)
-          ? `${intl.formatMessage(intlMessages.userIsPresenterSetBy, {
-            presenterName: message.senderName,
-            assignedByName: assignedBy,
-          })}`
-          : `${intl.formatMessage(intlMessages.userIsPresenter, { presenterName: message.senderName })}`;
+          messageText = (assignedBy)
+            ? `${intl.formatMessage(intlMessages.userIsPresenterSetBy, {
+              presenterName: message.senderName,
+              assignedByName: assignedBy,
+            })}`
+            : `${intl.formatMessage(intlMessages.userIsPresenter, { presenterName: message.senderName })}`;
+        } catch {
+          messageText = intl.formatMessage(intlMessages.userIsPresenter, { presenterName: message.senderName });
+        }
         break;
       }
       case ChatMessageType.USER_AWAY_STATUS_MSG: {
-        const { away } = JSON.parse(message.messageMetadata);
+        try {
+          const { away } = JSON.parse(message.messageMetadata);
 
-        messageText = (away)
-          ? `${message.senderName} ${intl.formatMessage(intlMessages.userAway)}`
-          : `${message.senderName} ${intl.formatMessage(intlMessages.userNotAway)}`;
+          messageText = (away)
+            ? `${message.senderName} ${intl.formatMessage(intlMessages.userAway)}`
+            : `${message.senderName} ${intl.formatMessage(intlMessages.userNotAway)}`;
+        } catch {
+          messageText = htmlDecode(message.message || message.messageAsHtml || '');
+        }
         break;
       }
       case ChatMessageType.PRESENTATION: {
-        const { filename } = parsePresentationMetadata(message.messageMetadata);
         const presentationAvailable = intl.formatMessage(intlMessages.presentationAvailableForDownload);
-        messageText = `${presentationAvailable}: ${filename}`;
+
+        try {
+          const { filename } = parsePresentationMetadata(message.messageMetadata);
+          messageText = `${presentationAvailable}: ${filename}`;
+        } catch {
+          messageText = presentationAvailable;
+        }
         break;
       }
       case ChatMessageType.API:

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -104,7 +104,7 @@ export const generateExportedMessages = (
       case ChatMessageType.API:
       case ChatMessageType.BREAKOUT_ROOM:
       case ChatMessageType.PLUGIN:
-        messageText = htmlDecode(message.messageAsHtml || message.message || '');
+        messageText = htmlDecode(message.message || message.messageAsHtml || '');
         break;
       case ChatMessageType.TEXT:
       default:

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -3,7 +3,7 @@ import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { IntlShape, defineMessages } from 'react-intl';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
 import PollService from '/imports/ui/components/poll/service';
-import getPresentationDownloadData from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
+import { parsePresentationMetadata } from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
 
 const intlMessages = defineMessages({
   chatClear: {
@@ -37,7 +37,7 @@ const intlMessages = defineMessages({
   presentationAvailableForDownload: {
     id: 'app.presentationUploader.export.availableForDownload',
     defaultMessage: 'Presentation available for download',
-    description: 'used in exported chat before a presentation download filename and URL',
+    description: 'used in exported chat before a presentation filename',
   },
 });
 
@@ -96,9 +96,9 @@ export const generateExportedMessages = (
         break;
       }
       case ChatMessageType.PRESENTATION: {
-        const { absoluteDownloadUrl, filename } = getPresentationDownloadData(message.messageMetadata);
+        const { filename } = parsePresentationMetadata(message.messageMetadata);
         const presentationAvailable = intl.formatMessage(intlMessages.presentationAvailableForDownload);
-        messageText = `${presentationAvailable}: ${filename} - ${absoluteDownloadUrl}`;
+        messageText = `${presentationAvailable}: ${filename}`;
         break;
       }
       case ChatMessageType.API:

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-header/chat-actions/services.ts
@@ -3,6 +3,7 @@ import { stripTags, unescapeHtml } from '/imports/utils/string-utils';
 import { IntlShape, defineMessages } from 'react-intl';
 import { ChatMessageType } from '/imports/ui/core/enums/chat';
 import PollService from '/imports/ui/components/poll/service';
+import getPresentationDownloadData from '../../chat-message-list/page/chat-message/message-content/presentation-content/service';
 
 const intlMessages = defineMessages({
   chatClear: {
@@ -33,6 +34,11 @@ const intlMessages = defineMessages({
     id: 'app.chat.isPresenterSetBy',
     description: 'message when user is set presenter by someone else',
   },
+  presentationAvailableForDownload: {
+    id: 'app.presentationUploader.export.availableForDownload',
+    defaultMessage: 'Presentation available for download',
+    description: 'used in exported chat before a presentation download filename and URL',
+  },
 });
 
 export const htmlDecode = (input: string) => {
@@ -51,6 +57,11 @@ export const generateExportedMessages = (
     const hourMin = `[${hour}:${min}]`;
     let userName = message.user ? `[${message.user.name} : ${message.user.role}]: ` : '';
     let messageText = '';
+
+    if (message.deletedBy) {
+      messageText = intl.formatMessage(intlMessages.deleteMessage, { userName: message.deletedBy.name });
+      return `${acc}${hourMin} ${userName}${messageText}\n`;
+    }
 
     switch (message.messageType) {
       case ChatMessageType.CHAT_CLEAR:
@@ -84,11 +95,18 @@ export const generateExportedMessages = (
           : `${message.senderName} ${intl.formatMessage(intlMessages.userNotAway)}`;
         break;
       }
+      case ChatMessageType.PRESENTATION: {
+        const { absoluteDownloadUrl, filename } = getPresentationDownloadData(message.messageMetadata);
+        const presentationAvailable = intl.formatMessage(intlMessages.presentationAvailableForDownload);
+        messageText = `${presentationAvailable}: ${filename} - ${absoluteDownloadUrl}`;
+        break;
+      }
+      case ChatMessageType.API:
+      case ChatMessageType.BREAKOUT_ROOM:
+      case ChatMessageType.PLUGIN:
       case ChatMessageType.TEXT:
       default:
-        messageText = message.message
-          ? htmlDecode(message.message)
-          : intl.formatMessage(intlMessages.deleteMessage, { userName: message.deletedBy?.name });
+        messageText = htmlDecode(message.message || '');
         break;
     }
     return `${acc}${hourMin} ${userName}${messageText}\n`;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/component.tsx
@@ -1,28 +1,11 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-import Auth from '/imports/ui/services/auth';
 import Styled from './styles';
+import getPresentationDownloadData from './service';
 
 interface ChatMessagePresentationContentProps {
   metadata: string;
 }
-interface Metadata {
-  fileURI: string;
-  filename: string;
-}
-
-function assertAsMetadata(metadata: unknown): asserts metadata is Metadata {
-  if (typeof metadata !== 'object' || metadata === null) {
-    throw new Error('metadata is not an object');
-  }
-  if (typeof (metadata as Metadata).fileURI !== 'string') {
-    throw new Error('metadata.fileURI is not a string');
-  }
-  if (typeof (metadata as Metadata).filename !== 'string') {
-    throw new Error('metadata.fileName is not a string');
-  }
-}
-
 const intlMessages = defineMessages({
   download: {
     id: 'app.presentation.downloadLabel',
@@ -38,26 +21,19 @@ const ChatMessagePresentationContent: React.FC<ChatMessagePresentationContentPro
   metadata: string,
 }) => {
   const intl = useIntl();
-  const presentationData = JSON.parse(string) as unknown;
-  assertAsMetadata(presentationData);
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore - temporary, while meteor exists in the project
-  const APP_CONFIG = window.meetingClientSettings.public.app;
-
-  const downloadUrl = Auth.authenticateURL(`${APP_CONFIG.bbbWebBase}/${presentationData.fileURI}`);
+  const { downloadUrl, filename } = getPresentationDownloadData(string);
   const parseFilename = (filename = '') => {
     const substrings = filename.split('.');
     substrings.pop();
     const filenameWithoutExtension = substrings.join('');
     return filenameWithoutExtension;
   };
-  const parsedFileName = parseFilename(presentationData.filename);
+  const parsedFileName = parseFilename(filename);
 
   return (
     <Styled.ChatDowloadContainer data-test="downloadPresentationContainer">
       <span>
-        {presentationData.filename}
+        {filename}
         &nbsp;
         (
         {intl.formatMessage(intlMessages.withWhiteboardAnnotations)}

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
@@ -1,0 +1,37 @@
+import Auth from '/imports/ui/services/auth';
+
+interface PresentationMetadata {
+  fileURI: string;
+  filename: string;
+}
+
+function assertAsPresentationMetadata(metadata: unknown): asserts metadata is PresentationMetadata {
+  if (typeof metadata !== 'object' || metadata === null) {
+    throw new Error('metadata is not an object');
+  }
+  if (typeof (metadata as PresentationMetadata).fileURI !== 'string') {
+    throw new Error('metadata.fileURI is not a string');
+  }
+  if (typeof (metadata as PresentationMetadata).filename !== 'string') {
+    throw new Error('metadata.filename is not a string');
+  }
+}
+
+const getPresentationDownloadData = (metadata: string) => {
+  const presentationData = JSON.parse(metadata) as unknown;
+  assertAsPresentationMetadata(presentationData);
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const APP_CONFIG = window.meetingClientSettings.public.app;
+  const downloadUrl = Auth.authenticateURL(`${APP_CONFIG.bbbWebBase}/${presentationData.fileURI}`);
+  const absoluteDownloadUrl = new URL(downloadUrl, window.location.origin).toString();
+
+  return {
+    absoluteDownloadUrl,
+    downloadUrl,
+    filename: presentationData.filename,
+  };
+};
+
+export default getPresentationDownloadData;

--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-list/page/chat-message/message-content/presentation-content/service.ts
@@ -17,18 +17,22 @@ function assertAsPresentationMetadata(metadata: unknown): asserts metadata is Pr
   }
 }
 
-const getPresentationDownloadData = (metadata: string) => {
+export const parsePresentationMetadata = (metadata: string) => {
   const presentationData = JSON.parse(metadata) as unknown;
   assertAsPresentationMetadata(presentationData);
+
+  return presentationData;
+};
+
+const getPresentationDownloadData = (metadata: string) => {
+  const presentationData = parsePresentationMetadata(metadata);
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const APP_CONFIG = window.meetingClientSettings.public.app;
   const downloadUrl = Auth.authenticateURL(`${APP_CONFIG.bbbWebBase}/${presentationData.fileURI}`);
-  const absoluteDownloadUrl = new URL(downloadUrl, window.location.origin).toString();
 
   return {
-    absoluteDownloadUrl,
     downloadUrl,
     filename: presentationData.filename,
   };

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -348,6 +348,7 @@
     "app.presentationUploader.exportCurrentStatePresentation": "Send out a download link for the presentation including whiteboard annotations",
     "app.presentationUploader.enableOriginalPresentationDownload": "Enable download of the presentation ({fileExtension})",
     "app.presentationUploader.disableOriginalPresentationDownload": "Disable download of the original presentation ({fileExtension})",
+    "app.presentationUploader.export.availableForDownload": "Presentation available for download",
     "app.presentationUploader.export.withWhiteboardAnnotations": "with whiteboard annotations",
     "app.presentationUploader.dropdownExportOptions": "Export options",
     "app.presentationUploader.dropdownExportOptionsUncomplete": "Disabled until upload is complete",

--- a/bigbluebutton-tests/playwright/chat/exportSystemMessages.spec.ts
+++ b/bigbluebutton-tests/playwright/chat/exportSystemMessages.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test';
+
+import { elements as e } from '../core/elements';
+import { test } from '../core/setup/fixtures';
+import { MultiUsers } from '../user/multiusers';
+import { openPublicChat } from './util';
+
+test.describe('Export system messages', { tag: '@ci' }, () => {
+  test('presentation download message exports as text (no token/URL)', async ({ browser, context, page }, testInfo) => {
+    test.setTimeout(120_000);
+    const mu = new MultiUsers(browser, context);
+    await mu.initModPage(page, { testInfo });
+    await mu.initUserPage(context, { testInfo });
+    await openPublicChat(mu.modPage);
+
+    // generate a PRESENTATION system message (send current state with annotations)
+    await mu.modPage.waitForSelector(e.whiteboard);
+    await mu.modPage.waitAndClick(e.actions);
+    await mu.modPage.waitAndClick(e.managePresentations);
+    await mu.modPage.waitAndClick(e.presentationOptionsDownloadBtn);
+    await mu.modPage.waitAndClick(e.sendPresentationInCurrentStateBtn);
+    await mu.userPage.hasElement(e.downloadPresentation, 'download link should appear in chat', 90_000);
+
+    await mu.modPage.waitAndClick(e.chatOptions);
+    const { content } = await mu.modPage.handleDownload(mu.modPage.page.locator(e.chatSave));
+    expect(content).toContain('Presentation available for download');
+    expect(content).not.toContain('sessionToken');
+  });
+
+  test('deleted message exports with the deleted-by placeholder', async ({ browser, context, page }, testInfo) => {
+    const mu = new MultiUsers(browser, context);
+    await mu.initModPage(page, { testInfo });
+    await openPublicChat(mu.modPage);
+
+    await mu.modPage.fill(e.chatBox, 'to be deleted');
+    await mu.modPage.waitAndClick(e.sendButton);
+    const last = mu.modPage.page.locator(e.chatMessageItem).last();
+    await last.hover();
+    await mu.modPage.waitAndClick(e.deleteMessageButton);
+    await mu.modPage.waitAndClick(e.confirmDeleteChatMessageButton);
+
+    await mu.modPage.waitAndClick(e.chatOptions);
+    const { content } = await mu.modPage.handleDownload(mu.modPage.page.locator(e.chatSave));
+    expect(content).toContain('This message has been deleted by');
+    expect(content).not.toContain('to be deleted');
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Backports #25404 to v3.0.x-develop:

_Updates chat export to correctly handle deleted messages and exported slides messages._

### How to test

1. Join a meeting as presenter.
2. On the presentation upload modal, open the export dropdown (three-dots menu) and click **Send out a download link for the presentation including whiteboard annotations**.
3. Wait for the annotated PDF to be generated. A "Presentation available for download" card appears in Public Chat with the filename and a download button.
4. In the chat header, click **⋮ → Save**.
5. Open the downloaded `.txt` file.
6. Check the line for the download-link message.
