### PR TITLE
fix(lad): incorrect row data and crashes from browser auto-translation

### DIFF
--- a/bbb-learning-dashboard/package.json
+++ b/bbb-learning-dashboard/package.json
@@ -26,6 +26,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "lint": "eslint src --ext .js,.jsx",
+    "lint:fix": "eslint src --ext .js,.jsx --fix",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/bbb-learning-dashboard/public/index.html
+++ b/bbb-learning-dashboard/public/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="utf-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -8,7 +8,7 @@ import TabsUnstyled from '@mui/base/TabsUnstyled';
 import { Stack } from '@mui/material';
 import './App.css';
 import {
-  FormattedMessage, FormattedDate, injectIntl, FormattedTime,
+  FormattedMessage, injectIntl,
 } from 'react-intl';
 import CardBody from './components/Card';
 import UsersTable from './components/UsersTable';
@@ -462,14 +462,13 @@ class App extends React.Component {
           </h1>
           <div className="mt-3 col-text-right py-1 text-gray-500 inline-block">
             <p className="font-bold">
-              <div className="inline" data-test="meetingDateDashboard">
-                <FormattedDate
-                  value={activitiesJson.createdOn}
-                  year="numeric"
-                  month="short"
-                  day="numeric"
-                />
-              </div>
+              <span className="inline" data-test="meetingDateDashboard">
+                {intl.formatDate(activitiesJson.createdOn, {
+                  year: 'numeric',
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </span>
               &nbsp;&nbsp;
               {
                 activitiesJson.endedOn > 0
@@ -493,7 +492,7 @@ class App extends React.Component {
             <p data-test="meetingDurationTimeDashboard">
               <FormattedMessage id="app.learningDashboard.indicators.duration" defaultMessage="Duration" />
               :&nbsp;
-              {tsToHHmmss(this.totalOfActivity())}
+              <span>{tsToHHmmss(this.totalOfActivity())}</span>
             </p>
           </div>
         </div>
@@ -629,7 +628,7 @@ class App extends React.Component {
                 </CardContent>
               </Card>
             </TabUnstyled>
-            {pluginUserDataColumnTitleList.length && (
+            {pluginUserDataColumnTitleList.length > 0 && (
               <TabUnstyled className="rounded focus:outline-none focus:ring focus:ring-red-500 ring-offset-2" data-test="pluginsPanelDashboard">
                 <Card>
                   <CardContent classes={{ root: '!p-0' }}>
@@ -780,16 +779,15 @@ class App extends React.Component {
                       defaultMessage="Last updated at"
                     />
                     &nbsp;
-                    <FormattedTime
-                      value={lastUpdated}
-                    />
+                    <span>{intl.formatTime(lastUpdated)}</span>
                     &nbsp;
-                    <FormattedDate
-                      value={lastUpdated}
-                      year="numeric"
-                      month="long"
-                      day="numeric"
-                    />
+                    <span>
+                      {intl.formatDate(lastUpdated, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })}
+                    </span>
                   </>
                 )
               }

--- a/bbb-learning-dashboard/src/App.js
+++ b/bbb-learning-dashboard/src/App.js
@@ -50,10 +50,12 @@ class App extends React.Component {
       sessionToken: '',
       lastUpdated: null,
       modalOpen: false,
+      sessionDataDownloaded: false,
     };
 
     this.handleCloseModal = this.handleCloseModal.bind(this);
     this.handleOpenModal = this.handleOpenModal.bind(this);
+    this.downloadButtonRef = React.createRef();
   }
 
   componentDidMount() {
@@ -74,9 +76,7 @@ class App extends React.Component {
     this.setState({ modalOpen: false });
   }
 
-  handleSaveSessionData(e) {
-    const { target: downloadButton } = e;
-    const downloadButtonLabel = downloadButton.querySelector('span') || downloadButton;
+  handleSaveSessionData() {
     const { intl } = this.props;
     const { activitiesJson } = this.state;
     const {
@@ -89,21 +89,22 @@ class App extends React.Component {
     const data = makeUserCSVData(users, polls, intl);
     const filename = `LearningDashboard_${meetingName}_${new Date(createdOn).toISOString().substr(0, 10)}.csv`.replace(/ /g, '-');
 
-    downloadButton.setAttribute('disabled', 'true');
-    downloadButton.style.cursor = 'not-allowed';
     link.setAttribute('href', `data:text/csv;charset=UTF-8,${encodeURIComponent(data)}`);
     link.setAttribute('download', filename);
     link.style.display = 'none';
     document.body.appendChild(link);
     link.click();
-    downloadButtonLabel.innerHTML = intl.formatMessage({ id: 'app.learningDashboard.sessionDataDownloadedLabel', defaultMessage: 'Downloaded!' });
-    setTimeout(() => {
-      downloadButtonLabel.innerHTML = intl.formatMessage({ id: 'app.learningDashboard.downloadSessionDataLabel', defaultMessage: 'Download Session Data' });
-      downloadButton.removeAttribute('disabled');
-      downloadButton.style.cursor = 'pointer';
-      downloadButton.focus();
-    }, 3000);
     document.body.removeChild(link);
+
+    // Label and disabled state go through React: writing innerHTML on a button React
+    // renders detaches the text node React tracks, and every later update is lost.
+    this.setState({ sessionDataDownloaded: true });
+
+    setTimeout(() => {
+      this.setState({ sessionDataDownloaded: false });
+
+      if (this.downloadButtonRef.current) this.downloadButtonRef.current.focus();
+    }, 3000);
   }
 
   setDashboardParams(callback) {
@@ -379,7 +380,7 @@ class App extends React.Component {
   render() {
     const {
       activitiesJson, tab, loading, lastUpdated, ldAccessTokenCopied, sessionToken,
-      modalOpen,
+      modalOpen, sessionDataDownloaded,
     } = this.state;
 
     const presentationBase = process.env.REACT_APP_STANDALONE_MODE === 'true'
@@ -800,6 +801,9 @@ class App extends React.Component {
                 <button
                   data-test="downloadSessionDataDashboard"
                   type="button"
+                  ref={this.downloadButtonRef}
+                  disabled={sessionDataDownloaded}
+                  style={{ cursor: sessionDataDownloaded ? 'not-allowed' : 'pointer' }}
                   className="flex border-2 text-gray-700 border-gray-200 rounded-md px-4 py-2 bg-white focus:outline-none focus:ring ring-offset-2 focus:ring-gray-500 focus:ring-opacity-50"
                   onClick={this.handleSaveSessionData.bind(this)}
                 >
@@ -808,10 +812,9 @@ class App extends React.Component {
                   </svg>
                   &nbsp;
                   <span>
-                    <FormattedMessage
-                      id="app.learningDashboard.downloadSessionDataLabel"
-                      defaultMessage="Download Session Data"
-                    />
+                    {sessionDataDownloaded
+                      ? intl.formatMessage({ id: 'app.learningDashboard.sessionDataDownloadedLabel', defaultMessage: 'Downloaded!' })
+                      : intl.formatMessage({ id: 'app.learningDashboard.downloadSessionDataLabel', defaultMessage: 'Download Session Data' })}
                   </span>
                 </button>
               )

--- a/bbb-learning-dashboard/src/components/ErrorBoundary.jsx
+++ b/bbb-learning-dashboard/src/components/ErrorBoundary.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import ErrorMessage from './ErrorMessage';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('Learning Dashboard render failed', error, errorInfo);
+  }
+
+  render() {
+    const { hasError } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return (
+        <ErrorMessage
+          message={(
+            <FormattedMessage
+              id="app.learningDashboard.errors.genericError"
+              defaultMessage="Something went wrong. Please reload the page."
+            />
+          )}
+        />
+      );
+    }
+
+    return children;
+  }
+}
+
+ErrorBoundary.defaultProps = {
+  children: null,
+};
+
+export default ErrorBoundary;

--- a/bbb-learning-dashboard/src/components/PluginsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PluginsTable.jsx
@@ -109,8 +109,8 @@ const PluginsTable = (props) => {
   });
   const gridRows = useMemo(() => Object.values(allUserPluginInformation).filter(
     (u) => !(Object.keys(u?.pluginUserData)?.length === 0),
-  ).map((u, i) => ({
-    id: i + 1,
+  ).map((u) => ({
+    id: u.userKey,
     User: u,
     // This is going to be of the form:
     // [learningAnalyticsDashboardColumnTitle]: learningAnalyticsDashboardValue, for each entry

--- a/bbb-learning-dashboard/src/components/PollsTable.jsx
+++ b/bbb-learning-dashboard/src/components/PollsTable.jsx
@@ -376,14 +376,14 @@ const PollsTable = (props) => {
     return v;
   });
 
-  Object.values(allUsers).map((u, i) => {
+  Object.values(allUsers).map((u) => {
     if (u?.isModerator && Object.keys(u?.answers)?.length === 0) return u;
-    gridRows.push({ id: i + 1, User: u, ...{ ...initPollData, ...u?.answers } });
+    gridRows.push({ id: u.userKey, User: u, ...{ ...initPollData, ...u?.answers } });
     return u;
   });
 
   if (hasAnonymousPoll) {
-    anonGridRow.push({ id: 1, User: { name: 'Anonymous' }, ...{ ...initPollData, ...anonymousPollData } });
+    anonGridRow.push({ id: 'anonymous', User: { name: 'Anonymous' }, ...{ ...initPollData, ...anonymousPollData } });
   }
 
   const commonGridProps = {

--- a/bbb-learning-dashboard/src/components/QuizzesTable.jsx
+++ b/bbb-learning-dashboard/src/components/QuizzesTable.jsx
@@ -382,18 +382,26 @@ const QuizzesTable = (props) => {
           {['success', 'error', 'unknown', 'locked'].includes(type) && (
             <>
               {symbols[type]}
-              &nbsp;
-              {responses}
+              <span>&nbsp;</span>
+              <span>{responses}</span>
             </>
           )}
-          {type === 'default' && intl.formatMessage({
-            id: 'app.learningDashboard.quizzes.noResponse',
-            defaultMessage: 'No response',
-          })}
-          {type === 'waiting' && intl.formatMessage({
-            id: 'app.learningDashboard.quizzes.waitingResponse',
-            defaultMessage: 'Waiting user response',
-          })}
+          {type === 'default' && (
+            <span>
+              {intl.formatMessage({
+                id: 'app.learningDashboard.quizzes.noResponse',
+                defaultMessage: 'No response',
+              })}
+            </span>
+          )}
+          {type === 'waiting' && (
+            <span>
+              {intl.formatMessage({
+                id: 'app.learningDashboard.quizzes.waitingResponse',
+                defaultMessage: 'Waiting user response',
+              })}
+            </span>
+          )}
         </Box>
         {showPopper && (
           <Popper
@@ -487,7 +495,7 @@ const QuizzesTable = (props) => {
     return v;
   });
 
-  Object.values(allUsers).forEach((u, i) => {
+  Object.values(allUsers).forEach((u) => {
     if (u?.isModerator && Object.keys(u?.answers)?.length === 0) return;
 
     const result = Object
@@ -505,7 +513,7 @@ const QuizzesTable = (props) => {
       });
 
     gridRows.push({
-      id: i + 1,
+      id: u.userKey,
       user: u,
       ...{
         ...initQuizData,

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -121,8 +121,16 @@ class StatusTable extends React.Component {
     const usersPeriods = {};
     Object.values(allUsers || {}).forEach((user) => {
       usersPeriods[user.userKey] = [];
-      Object.values(user.intIds || {}).forEach((intId, index, intIdsArray) => {
-        intId.sessions.forEach((session, sessionIndex, sessionArray) => {
+      // The session merge below consumes entries as it walks them. Copy the session arrays first:
+      // they belong to the polled payload held in App's state, and splicing them there
+      // deletes sessions for every other consumer until the next poll replaces it.
+      const intIdsArray = Object.values(user.intIds || {})
+        .map((intId) => ({ ...intId, sessions: [...(intId.sessions || [])] }));
+
+      for (let index = 0; index < intIdsArray.length; index += 1) {
+        const sessionArray = intIdsArray[index].sessions;
+        for (let sessionIndex = 0; sessionIndex < sessionArray.length; sessionIndex += 1) {
+          const session = sessionArray[sessionIndex];
           let { leftOn } = session;
           const nextSession = sessionArray[sessionIndex + 1];
           if (nextSession && Math.abs(leftOn - nextSession.registeredOn) <= 30000) {
@@ -140,8 +148,8 @@ class StatusTable extends React.Component {
             registeredOn: session.registeredOn,
             leftOn,
           });
-        });
-      });
+        }
+      }
     });
 
     const usersRegisteredTimes = Object

--- a/bbb-learning-dashboard/src/components/StatusTable.jsx
+++ b/bbb-learning-dashboard/src/components/StatusTable.jsx
@@ -242,6 +242,7 @@ class StatusTable extends React.Component {
                   : `${URLPrefix}/${presentationId}/thumbnail/${pageNum}${tokenParams}`;
                 return (
                   <td
+                    key={start}
                     style={{
                       [padding]: `${(end - start) / 1000}px`,
                     }}
@@ -289,7 +290,7 @@ class StatusTable extends React.Component {
                 return 0;
               })
               .map((user) => (
-                <tr className="text-gray-700 bg-inherit">
+                <tr className="text-gray-700 bg-inherit" key={user.userKey}>
                   <th
                     className={`z-30 px-4 py-3 bg-inherit sticky ${isRTL ? 'right-0' : 'left-0'}`}
                     scope="row"
@@ -313,7 +314,7 @@ class StatusTable extends React.Component {
                     const boundaryRight = period.end;
                     const interval = period.end - period.start;
                     return (
-                      <td className="relative px-3.5 2xl:px-4 py-3 text-sm col-text-left">
+                      <td className="relative px-3.5 2xl:px-4 py-3 text-sm col-text-left" key={period.start}>
                         { usersPeriods[user.userKey].length > 0 ? (
                           usersPeriods[user.userKey].map((userPeriod) => {
                             const { registeredOn, leftOn } = userPeriod;
@@ -323,7 +324,7 @@ class StatusTable extends React.Component {
                               leftOn >= boundaryLeft && leftOn <= boundaryRight
                                 ? leftOn : boundaryRight);
                             return (
-                              <>
+                              <React.Fragment key={`${registeredOn}-${leftOn}`}>
                                 { (registeredOn >= boundaryLeft && registeredOn <= boundaryRight)
                                   || (leftOn >= boundaryLeft && leftOn <= boundaryRight)
                                   || (boundaryLeft > registeredOn && boundaryRight < leftOn)
@@ -337,6 +338,7 @@ class StatusTable extends React.Component {
                                   const redress = '(0.875rem / 2 + 0.25rem + 2px)';
                                   return (
                                     <div
+                                      key={`${reaction.sentOn}-${reaction.name}`}
                                       className="flex absolute p-1 border-white border-2 rounded-full text-sm z-20 bg-purple-500 text-purple-200 timeline-reaction select-none"
                                       role="generic"
                                       style={{
@@ -348,7 +350,7 @@ class StatusTable extends React.Component {
                                     </div>
                                   );
                                 }) }
-                              </>
+                              </React.Fragment>
                             );
                           })
                         ) : null }

--- a/bbb-learning-dashboard/src/components/UserDetails/component.jsx
+++ b/bbb-learning-dashboard/src/components/UserDetails/component.jsx
@@ -1,13 +1,17 @@
 import React, { useContext, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import {
-  FormattedMessage, FormattedNumber, FormattedTime, injectIntl,
-} from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { UserDetailsContext } from './context';
 import UserAvatar from '../UserAvatar';
 import { getSumOfTime, tsToHHmmss, getActivityScore } from '../../services/UserService';
 import { usePreviousValue } from '../../utils/hooks';
 import { toCamelCase } from '../../utils/string';
+
+const SCORE_FORMAT = { minimumFractionDigits: 0, maximumFractionDigits: 1 };
+const NOT_AVAILABLE_MESSAGE = {
+  id: 'app.learningDashboard.usersTable.notAvailable',
+  defaultMessage: 'N/A',
+};
 
 const UserDatailsComponent = (props) => {
   const {
@@ -198,7 +202,7 @@ const UserDatailsComponent = (props) => {
     'Poll Votes': pollsAverage,
   };
 
-  function renderPollItem(poll, answers) {
+  function renderPollItem(poll, answers, itemKey) {
     const { anonymous: isAnonymous, question, pollId } = poll;
     const answersSorted = Object
       .entries(pollVotesCount[pollId])
@@ -217,7 +221,7 @@ const UserDatailsComponent = (props) => {
     );
 
     return (
-      <tr className="p-6 flex flex-row justify-between items-center">
+      <tr className="p-6 flex flex-row justify-between items-center" key={itemKey}>
         <td className="min-w-[40%] text-ellipsis">{question}</td>
         { isAnonymous ? (
           <td
@@ -246,7 +250,7 @@ const UserDatailsComponent = (props) => {
             </span>
           </td>
         ) : (
-          <td className="min-w-[20%] grow text-center mx-3">{answers.map((answer) => <p title={answer} className="overflow-hidden text-ellipsis">{answer}</p>)}</td>
+          <td className="min-w-[20%] grow text-center mx-3">{answers.map((answer) => <p title={answer} className="overflow-hidden text-ellipsis" key={answer}>{answer}</p>)}</td>
         ) }
         <td
           className="min-w-[40%] text-ellipsis text-center overflow-hidden"
@@ -265,7 +269,7 @@ const UserDatailsComponent = (props) => {
     );
   }
 
-  function renderQuizItem(quiz, data) {
+  function renderQuizItem(quiz, data, itemKey) {
     const { isCorrect, response } = data;
     const { anonymous: isAnonymous, question } = quiz;
     let variant;
@@ -290,7 +294,7 @@ const UserDatailsComponent = (props) => {
     };
 
     return (
-      <tr>
+      <tr key={itemKey}>
         <td className="min-w-[40%] text-ellipsis p-6 py-2">{question}</td>
         { isAnonymous ? (
           <td
@@ -321,9 +325,9 @@ const UserDatailsComponent = (props) => {
         ) : (
           <td className="min-w-[20%] grow text-center mx-3 p-6 py-2">
             <span className={`overflow-hidden text-ellipsis w-full ${variants[variant]}`}>
-              {variant === 'success' && <>&#9989;&nbsp;</>}
-              {variant === 'error' && <>&#10060;&nbsp;</>}
-              {label}
+              {variant === 'success' && <span>&#9989;&nbsp;</span>}
+              {variant === 'error' && <span>&#10060;&nbsp;</span>}
+              <span>{label}</span>
             </span>
           </td>
         ) }
@@ -335,7 +339,7 @@ const UserDatailsComponent = (props) => {
     category, average, activityPoints, totalOfActivity,
   ) {
     return (
-      <tr className="p-6 flex flex-row justify-between items-end">
+      <tr className="p-6 flex flex-row justify-between items-end" key={category}>
         <td className="min-w-[20%] text-ellipsis overflow-hidden">
           <FormattedMessage
             id={`app.learningDashboard.userDetails.${toCamelCase(category)}`}
@@ -346,8 +350,8 @@ const UserDatailsComponent = (props) => {
           <div className="mb-2">
             { (function getAverage() {
               if (average >= 0 && category === 'Talk Time') return tsToHHmmss(average);
-              if (average >= 0 && category !== 'Talk Time') return <FormattedNumber value={average} minimumFractionDigits="0" maximumFractionDigits="1" />;
-              return <FormattedMessage id="app.learningDashboard.usersTable.notAvailable" defaultMessage="N/A" />;
+              if (average >= 0 && category !== 'Talk Time') return intl.formatNumber(average, SCORE_FORMAT);
+              return intl.formatMessage(NOT_AVAILABLE_MESSAGE);
             }()) }
           </div>
           <div className="rounded-2xl bg-gray-200 before:bg-gray-500 h-4 relative before:absolute before:top-[-50%] before:bottom-[-50%] before:w-[2px] before:left-[calc(50%-1px)] before:z-10">
@@ -365,8 +369,8 @@ const UserDatailsComponent = (props) => {
         </td>
         <td className="min-w-[20%] text-sm text-ellipsis overflow-hidden text-right rtl:text-left">
           { activityPoints >= 0
-            ? <FormattedNumber value={activityPoints} minimumFractionDigits="0" maximumFractionDigits="1" />
-            : <FormattedMessage id="app.learningDashboard.usersTable.notAvailable" defaultMessage="N/A" /> }
+            ? intl.formatNumber(activityPoints, SCORE_FORMAT)
+            : intl.formatMessage(NOT_AVAILABLE_MESSAGE) }
         </td>
       </tr>
     );
@@ -456,7 +460,7 @@ const UserDatailsComponent = (props) => {
               <div aria-label={`${intl.formatMessage({ id: 'app.learningDashboard.userDetails.startTime', defaultMessage: 'Joined' })} ${new Date(createdOn).toISOString().substring(11, 19)}`}>
                 <div aria-hidden="true"><FormattedMessage id="app.learningDashboard.userDetails.startTime" defaultMessage="Start Time" /></div>
                 <div aria-hidden="true">
-                  <FormattedTime value={createdOn} />
+                  {intl.formatTime(createdOn)}
                 </div>
               </div>
               <div className="ltr:text-right rtl:text-left">
@@ -467,7 +471,7 @@ const UserDatailsComponent = (props) => {
                       <FormattedMessage id="app.learningDashboard.indicators.meetingStatusActive" defaultMessage="Active" />
                     </span>
                   ) : (
-                    <FormattedTime value={endedOn} />
+                    intl.formatTime(endedOn)
                   ) }
                 </div>
               </div>
@@ -482,7 +486,7 @@ const UserDatailsComponent = (props) => {
             </div>
             <div aria-label={`${intl.formatMessage({ id: 'app.learningDashboard.userDetails.joined', defaultMessage: 'Joined' })} ${new Date(joinTime).toISOString().substring(11, 19)}`}>
               <div aria-hidden="true" className="font-medium">
-                <FormattedTime value={joinTime} />
+                {intl.formatTime(joinTime)}
               </div>
               <div aria-hidden="true"><FormattedMessage id="app.learningDashboard.userDetails.joined" defaultMessage="Joined" /></div>
             </div>
@@ -493,7 +497,7 @@ const UserDatailsComponent = (props) => {
                     <FormattedMessage id="app.learningDashboard.indicators.userStatusOnline" defaultMessage="Online" />
                   </span>
                 ) : (
-                  <FormattedTime value={leftTime} />
+                  intl.formatTime(leftTime)
                 ) }
               </div>
               <div className="px-2"><FormattedMessage id="app.learningDashboard.usersTable.left" defaultMessage="Left" /></div>
@@ -514,7 +518,7 @@ const UserDatailsComponent = (props) => {
                   <FormattedMessage id="app.learningDashboard.indicators.activityScore" defaultMessage="Activity Score" />
                   :&nbsp;
                   <span className="font-bold">
-                    <FormattedNumber value={getActivityScore(user, users, totalPolls)} minimumFractionDigits="0" maximumFractionDigits="1" />
+                    {intl.formatNumber(getActivityScore(user, users, totalPolls), SCORE_FORMAT)}
                   </span>
                 </h3>
               </div>
@@ -570,10 +574,11 @@ const UserDatailsComponent = (props) => {
                   <th aria-label="Response" className="grow text-center font-normal"><FormattedMessage id="app.learningDashboard.userDetails.response" defaultMessage="Response" /></th>
                   <th aria-label="Most Common Answer" className="min-w-[40%] text-ellipsis text-center font-normal"><FormattedMessage id="app.learningDashboard.userDetails.mostCommonAnswer" defaultMessage="Most Common Answer" /></th>
                 </tr>
-                { Object.values(polls || {})
-                  .map((poll) => renderPollItem(
+                { Object.entries(polls || {})
+                  .map(([pollKey, poll]) => renderPollItem(
                     poll,
                     getUserPollAnswer(poll),
+                    pollKey,
                   )) }
               </table>
             </div>
@@ -591,10 +596,11 @@ const UserDatailsComponent = (props) => {
                   <th aria-label="Quiz" className="min-w-[40%] text-ellipsis font-normal text-left p-6 py-2"><FormattedMessage id="app.learningDashboard.userDetails.quiz" defaultMessage="Quiz" /></th>
                   <th aria-label="Response" className="grow text-center font-normal p-6 py-2"><FormattedMessage id="app.learningDashboard.userDetails.response" defaultMessage="Response" /></th>
                 </tr>
-                { Object.values(quizzes || {})
-                  .map((quiz) => renderQuizItem(
+                { Object.entries(quizzes || {})
+                  .map(([quizKey, quiz]) => renderQuizItem(
                     quiz,
                     getUserQuizAnswer(quiz),
+                    quizKey,
                   )) }
               </table>
             </div>

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import {
-  FormattedMessage, FormattedDate, FormattedNumber, injectIntl,
-} from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { getUserReactionsSummary } from '../services/ReactionService';
 import { getActivityScore, getSumOfTime, tsToHHmmss } from '../services/UserService';
 import UserAvatar from './UserAvatar';
 import { UserDetailsContext } from './UserDetails/context';
+
+const SESSION_DATE_FORMAT = {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+};
 
 function renderArrow(order = 'asc') {
   return (
@@ -182,7 +188,7 @@ class UsersTable extends React.Component {
 
   render() {
     const {
-      allUsers, tab,
+      allUsers, tab, intl,
     } = this.props;
 
     const {
@@ -306,7 +312,7 @@ class UsersTable extends React.Component {
               .map((user) => {
                 const opacity = user.leftOn > 0 ? 'opacity-75' : '';
                 return (
-                  <tr key={user} className="text-gray-700">
+                  <tr key={user.userKey} className="text-gray-700">
                     <td className={`flex items-center px-4 py-3 col-text-left text-sm ${opacity}`} data-test="userLabelDashboard">
                       <div className="inline-block relative w-8 h-8 rounded-full">
                         <UserAvatar user={user} />
@@ -339,14 +345,9 @@ class UsersTable extends React.Component {
                                     d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"
                                   />
                                 </svg>
-                                <FormattedDate
-                                  value={session.registeredOn}
-                                  month="short"
-                                  day="numeric"
-                                  hour="2-digit"
-                                  minute="2-digit"
-                                  second="2-digit"
-                                />
+                                <span>
+                                  {intl.formatDate(session.registeredOn, SESSION_DATE_FORMAT)}
+                                </span>
                               </p>
                               { session.leftOn > 0
                                 ? (
@@ -366,14 +367,9 @@ class UsersTable extends React.Component {
                                       />
                                     </svg>
 
-                                    <FormattedDate
-                                      value={session.leftOn}
-                                      month="short"
-                                      day="numeric"
-                                      hour="2-digit"
-                                      minute="2-digit"
-                                      second="2-digit"
-                                    />
+                                    <span>
+                                      {intl.formatDate(session.leftOn, SESSION_DATE_FORMAT)}
+                                    </span>
                                   </p>
                                 )
                                 : null }
@@ -403,10 +399,12 @@ class UsersTable extends React.Component {
                         />
                       </svg>
                       &nbsp;
-                      { tsToHHmmss(Object.values(user.intIds).reduce((prev, intId) => (
-                        prev + intId.sessions.reduce((prev2, session) => ((session.leftOn > 0
-                          ? prev2 + session.leftOn
-                          : prev2 + (new Date()).getTime()) - session.registeredOn), 0)), 0)) }
+                      <span>
+                        { tsToHHmmss(Object.values(user.intIds).reduce((prev, intId) => (
+                          prev + intId.sessions.reduce((prev2, session) => ((session.leftOn > 0
+                            ? prev2 + session.leftOn
+                            : prev2 + (new Date()).getTime()) - session.registeredOn), 0)), 0)) }
+                      </span>
                       <br />
                       {
                         ((function getPercentage() {
@@ -452,7 +450,7 @@ class UsersTable extends React.Component {
                               />
                             </svg>
                             &nbsp;
-                            { tsToHHmmss(user.talk.totalTime) }
+                            <span>{ tsToHHmmss(user.talk.totalTime) }</span>
                           </span>
                         ) : null }
                     </td>
@@ -475,7 +473,7 @@ class UsersTable extends React.Component {
                               />
                             </svg>
                             &nbsp;
-                            { tsToHHmmss(getSumOfTime(user.webcams)) }
+                            <span>{ tsToHHmmss(getSumOfTime(user.webcams)) }</span>
                           </span>
                         ) : null }
                     </td>
@@ -498,17 +496,17 @@ class UsersTable extends React.Component {
                               />
                             </svg>
                             &nbsp;
-                            {user.totalOfMessages}
+                            <span>{user.totalOfMessages}</span>
                           </span>
                         ) : null }
                     </td>
                     <td className={`px-4 py-3 text-sm col-text-left ${opacity}`} data-test="userTotalReactionsDashboard">
                       {
                         Object.keys(usersReactionsSummary[user.userKey] || {}).map((reaction) => (
-                          <div className="text-xs whitespace-nowrap">
-                            {reaction}
+                          <div className="text-xs whitespace-nowrap" key={reaction}>
+                            <span>{reaction}</span>
                             &nbsp;
-                            { usersReactionsSummary[user.userKey][reaction] }
+                            <span>{ usersReactionsSummary[user.userKey][reaction] }</span>
                             &nbsp;
                           </div>
                         ))
@@ -520,7 +518,7 @@ class UsersTable extends React.Component {
                           <span>
                             ✋
                             &nbsp;
-                            {user.raiseHand.length}
+                            <span>{user.raiseHand.length}</span>
                           </span>
                         ) : null }
                     </td>
@@ -542,7 +540,7 @@ class UsersTable extends React.Component {
                     </td>
                     {
                       !user.isModerator ? (
-                        <td className={`px-4 py-3 text-sm text-center items ${opacity}`} data-test="userActivityScoreDashboard">
+                        <td key="activity-score" className={`px-4 py-3 text-sm text-center items ${opacity}`} data-test="userActivityScoreDashboard">
                           <svg viewBox="0 0 82 12" width="82" height="12" className="flex-none m-auto inline">
                             <rect width="12" height="12" fill={usersActivityScore[user.userKey] > 0 ? '#4BA381' : '#e4e4e7'} />
                             <rect width="12" height="12" x="14" fill={usersActivityScore[user.userKey] > 2 ? '#338866' : '#e4e4e7'} />
@@ -551,13 +549,16 @@ class UsersTable extends React.Component {
                             <rect width="12" height="12" x="56" fill={usersActivityScore[user.userKey] > 8 ? '#023B34' : '#e4e4e7'} />
                             <rect width="12" height="12" x="70" fill={usersActivityScore[user.userKey] === 10 ? '#02362B' : '#e4e4e7'} />
                           </svg>
-                          &nbsp;
+                          <span>&nbsp;</span>
                           <span className="text-xs bg-gray-200 rounded-full px-2">
-                            <FormattedNumber value={usersActivityScore[user.userKey]} minimumFractionDigits="0" maximumFractionDigits="1" />
+                            {intl.formatNumber(usersActivityScore[user.userKey], {
+                              minimumFractionDigits: 0,
+                              maximumFractionDigits: 1,
+                            })}
                           </span>
                         </td>
                       ) : (
-                        <td className="px-4 py-3 text-sm text-center">
+                        <td key="activity-score-na" className="px-4 py-3 text-sm text-center">
                           <FormattedMessage id="app.learningDashboard.usersTable.notAvailable" defaultMessage="N/A" />
                         </td>
                       )
@@ -568,12 +569,18 @@ class UsersTable extends React.Component {
                           .sessions.slice(-1)[0].leftOn > 0
                           ? (
                             <span className="px-2 py-1 font-semibold leading-tight text-red-700 bg-red-100 rounded-full">
-                              <FormattedMessage id="app.learningDashboard.usersTable.userStatusOffline" defaultMessage="Offline" />
+                              {intl.formatMessage({
+                                id: 'app.learningDashboard.usersTable.userStatusOffline',
+                                defaultMessage: 'Offline',
+                              })}
                             </span>
                           )
                           : (
                             <span className="px-2 py-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full">
-                              <FormattedMessage id="app.learningDashboard.usersTable.userStatusOnline" defaultMessage="Online" />
+                              {intl.formatMessage({
+                                id: 'app.learningDashboard.usersTable.userStatusOnline',
+                                defaultMessage: 'Online',
+                              })}
                             </span>
                           )
                       }

--- a/bbb-learning-dashboard/src/components/UsersTable.jsx
+++ b/bbb-learning-dashboard/src/components/UsersTable.jsx
@@ -327,9 +327,10 @@ class UsersTable extends React.Component {
                         >
                           {user.name}
                         </button>
-                        { Object.values(user.intIds || {}).map((intId, index) => intId.sessions
+                        { Object.entries(user.intIds || {}).map(([intIdKey, intId], index) => intId
+                          .sessions
                           .map((session, sessionIndex) => (
-                            <>
+                            <React.Fragment key={`${intIdKey}-${session.registeredOn}`}>
                               <p className="text-xs text-gray-700 dark:text-gray-400">
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
@@ -379,7 +380,7 @@ class UsersTable extends React.Component {
                                 : (
                                   <hr className="my-1" />
                                 ) }
-                            </>
+                            </React.Fragment>
                           ))) }
                       </div>
                     </td>

--- a/bbb-learning-dashboard/src/index.js
+++ b/bbb-learning-dashboard/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import { IntlProvider } from 'react-intl';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 import { UserDetailsProvider } from './components/UserDetails/context';
 
 const RTL_LANGUAGES = ['ar', 'dv', 'fa', 'he'];
@@ -47,7 +48,7 @@ class Dashboard extends React.Component {
     };
 
     this.setMessages();
-    this.setRtl();
+    this.setLocaleAttributes();
   }
 
   setMessages() {
@@ -76,8 +77,14 @@ class Dashboard extends React.Component {
       }).catch(() => {});
   }
 
-  setRtl() {
+  setLocaleAttributes() {
     const { intlLocale } = this.state;
+
+    // index.html ships lang="en"; leaving it there while rendering another locale
+    // makes browsers offer to auto-translate the page. Update it.
+    if (isValidLocale(intlLocale)) {
+      document.body.parentNode.setAttribute('lang', intlLocale);
+    }
 
     if (RTL_LANGUAGES.includes(intlLocale.substring(0, 2))) {
       document.body.parentNode.setAttribute('dir', 'rtl');
@@ -94,7 +101,9 @@ class Dashboard extends React.Component {
     return (
       <UserDetailsProvider>
         <IntlProvider defaultLocale="en" locale={locale} messages={intlMessages}>
-          <App />
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
         </IntlProvider>
       </UserDetailsProvider>
     );

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1771,6 +1771,7 @@
     "app.learningDashboard.statusTimelineTable.setAt": "Set at",
     "app.learningDashboard.errors.invalidToken": "Invalid session token",
     "app.learningDashboard.errors.dataUnavailable": "Data is no longer available",
+    "app.learningDashboard.errors.genericError": "Something went wrong. Please reload the page.",
     "app.learningDashboard.closeHelpModal": "Close dashboard help modal",
     "app.learningDashboard.helpButtonLabel": "Help",
     "app.learningDashboard.help.title": "Learning Dashboard Help",


### PR DESCRIPTION
### What does this PR do?

Fixes Learning Dashboard showing one participant's join/leave times,
online time or talk time under another participant's name, and related
crashes and stalled row updates. This stems from actual production issue reports.

Two underlying causes:
- The LAD HTML page declares lang="en" while possibly rendering another
  (e.g.: PT-BR) and carries no auto-translate handling. When browsers
  translate it, text-only nodes are "re-parented" by the browser and
  React later writes land on the detached nodes. i.e.: user row data is
  swapped, LAD may crash when operating orphaned nodes. This is the same
  problem that was fixed previously in the bbb-html5 client.
- LAD rows are keyed `key={user}`, an object, so every row shares the
  key "[object Object]" and React index-matches the list: when a join
  or leave reorders the alphabetically sorted table, a \<tr\> is
  reused for a different participant. This may cause either incorrect
  info to be displayed, or crash the app.

#### In detail

- [fix(lad): stop the timeline from mutating polled payload](https://github.com/bigbluebutton/bigbluebutton/commit/8e1742e4b2745d982f01b91abd8201d916fda55e)
  - `StatusTable` merges sessions less than 30s apart by splicing the array it
  is walking, and that array belongs to `App`'s `activitiesJson`. Rendering the
  timeline permanently drops sessions from the payload every other view reads,
  until the next poll replaces it. Separate bug from the rest of the PR, found
  during the investigation.
- [fix(lad): crashes and inconsistent row data due to auto-translate and re-ordering](https://github.com/bigbluebutton/bigbluebutton/commit/5916ef4b7e16d6564c221610e81dfa42efa7a782) 
  - key rows by `userKey`, block translation the way the html5
  client does while declaring the locale actually rendered, render every
  changing value as the sole string child of its own element so React rebuilds
  it correctly, and wrap the dashboard in an error boundary to handle crashes.
- [refactor(lad): render the download button's label from React state](https://github.com/bigbluebutton/bigbluebutton/commit/a87a7124875e0dd7f91515758a389e012c979754)
  - `handleSaveSessionData` wrote `innerHTML` on a button React renders,
  detaching the node React tracks. Nothing misbehaves today, since the same 
  handler rewrites thelabel on the way back, but any later React-driven updateto that button
would be lost.
- [chore(lad): add an eslint script](https://github.com/bigbluebutton/bigbluebutton/commit/d4051a154880144fc266871cf1e86bb0a8583a1f)
  - The package carries an eslint config but no script to run it.

### Closes Issue(s)

None

### How to test

**Reproduce the bug (on a build without this PR), the re-verify with the fixes**

1. Set Chrome to always translate Portuguese; or use any UI language other than
   the dashboard's locale, so the `lang="en"` / other-lang body mismatch triggers
   translation; or open the LAD and use the browser's translation feature on it
2. Verify the page is being auto-translated by the browser once opened
3. Join and leave with names spread across the alphabet so
   the sorted table reorders.
4. After ~5 LAD probes, compare each row's printed online time against the sum of
   the sessions printed on the same row, and the online-time progress-bar
   percentage against the number beside it. Any data mismatch or crash is the bug.