### PR TITLE
feat(plugins): handle sidekickArea.panel open/close commands from the SDK

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/handler.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PluginChatUiCommandsHandler from './chat/handler';
 import PluginSidekickOptionsContainerUiCommandsHandler from './sidekick-options-container/handler';
+import PluginSidekickAreaUiCommandsHandler from './sidekick-area/handler';
 import PluginPresentationAreaUiCommandsHandler from './presentation/handler';
 import PluginUserStatusUiCommandsHandler from './user-status/handler';
 import PluginConferenceUiCommandsHandler from './conference/handler';
@@ -22,6 +23,7 @@ const PluginUiCommandsHandler = () => (
     <PluginCaptionsUiCommandsHandler />
     <PluginNavBarUiCommandsHandler />
     <PluginSidekickOptionsContainerUiCommandsHandler />
+    <PluginSidekickAreaUiCommandsHandler />
     <PluginPresentationAreaUiCommandsHandler />
     <PluginUserStatusUiCommandsHandler />
     <PluginConferenceUiCommandsHandler />

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect } from 'react';
+import {
+  SidekickAreaCorePanelEnum,
+  SidekickAreaPanelEnum,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/panel/enums';
+import {
+  SidekickAreaPanelCommandArguments,
+} from 'bigbluebutton-html-plugin-sdk/dist/cjs/ui-commands/sidekick-area/panel/types';
+import logger from '/imports/startup/client/logger';
+import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
+import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { Input } from '/imports/ui/components/layout/layoutTypes';
+import { useIsMultiFunctionalModeEnabled } from '/imports/ui/services/features';
+
+// A plugin can dispatch the raw event, so the enum alone is not a boundary.
+const ALLOWED_CORE_PANELS: string[] = Object.values(SidekickAreaCorePanelEnum);
+
+// The only core panels kept in registeredApps, whose registration already encodes the
+// user's role and the feature flag.
+const REGISTRY_BACKED_CORE_PANELS: string[] = [
+  PANELS.POLL,
+  PANELS.TIMER,
+  PANELS.BREAKOUT,
+];
+
+const PluginSidekickAreaUiCommandsHandler = () => {
+  const CHAT_CONFIG = window.meetingClientSettings.public.chat;
+  const PUBLIC_GROUP_CHAT_ID = CHAT_CONFIG.public_group_id;
+  const layoutContextDispatch = layoutDispatch();
+  const { registeredApps } = layoutSelectInput((i: Input) => i.sidebarNavigation);
+  const {
+    sidebarContentPanel,
+    isOpen: isSidebarContentOpen,
+  } = layoutSelectInput((i: Input) => i.sidebarContent);
+  const {
+    sidebarContentPanel: sidebarContentPanelAuxiliary,
+    isOpen: isAuxiliaryOpen,
+  } = layoutSelectInput((i: Input) => i.sidebarContentAuxiliary);
+  const isMultiFunctionalModeEnabled = useIsMultiFunctionalModeEnabled();
+
+  const resolvePanel = useCallback((
+    { id }: SidekickAreaPanelCommandArguments,
+  ): string | null => {
+    if (!id) return null;
+
+    if (ALLOWED_CORE_PANELS.includes(id)) {
+      if (REGISTRY_BACKED_CORE_PANELS.includes(id)) {
+        if (registeredApps?.[id]) {
+          return id;
+        }
+        logger.info({
+          logCode: 'plugin_core_panel_unavailable',
+          extraInfo: { panel: id },
+        }, 'Plugin asked for a core panel unavailable to this user. Ignored.');
+        return null;
+      }
+      return id;
+    }
+
+    const genericContentPanel = PANELS.GENERIC_CONTENT_SIDEKICK + id;
+
+    // An unregistered panel would open the sidebar content area empty.
+    if (!registeredApps?.[genericContentPanel]) {
+      logger.warn({
+        logCode: 'plugin_sidekick_panel_unknown_id',
+        extraInfo: { id },
+      }, 'Plugin asked for a sidekick panel that is not registered');
+      return null;
+    }
+    return genericContentPanel;
+  }, [registeredApps]);
+
+  const handlePanelOpen = useCallback((
+    event: CustomEvent<SidekickAreaPanelCommandArguments>,
+  ) => {
+    const request = event.detail;
+
+    if (!request?.id) {
+      logger.info({
+        logCode: 'plugin_sidekick_panel_open_without_target',
+      }, 'Plugin tried to open a sidekick panel without naming one. Ignored.');
+      return;
+    }
+
+    const panel = resolvePanel(request);
+    if (!panel) return;
+
+    // Asking for a panel already on display while the auxiliary sidebar is open would
+    // copy it there, showing the same content twice and dropping what was in it.
+    const isDisplayedInSidebarContent = isSidebarContentOpen && sidebarContentPanel === panel;
+    const isDisplayedInAuxiliary = isMultiFunctionalModeEnabled
+      && isAuxiliaryOpen
+      && sidebarContentPanelAuxiliary === panel;
+    if (isDisplayedInSidebarContent || isDisplayedInAuxiliary) return;
+
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: true,
+    });
+    if (panel === PANELS.CHAT) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: PUBLIC_GROUP_CHAT_ID,
+      });
+    }
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: panel,
+    });
+  }, [
+    resolvePanel,
+    layoutContextDispatch,
+    isSidebarContentOpen,
+    sidebarContentPanel,
+    isMultiFunctionalModeEnabled,
+    isAuxiliaryOpen,
+    sidebarContentPanelAuxiliary,
+  ]);
+
+  const handlePanelClose = useCallback((
+    event: CustomEvent<SidekickAreaPanelCommandArguments>,
+  ) => {
+    const request = event.detail;
+    const namesAPanel = Boolean(request?.id);
+    let panel: string | null = null;
+
+    if (namesAPanel) {
+      panel = resolvePanel(request);
+      if (!panel) return;
+    }
+
+    // The named panel may be in the auxiliary sidebar rather than the primary one.
+    const isInAuxiliaryPanel = isMultiFunctionalModeEnabled
+      && isAuxiliaryOpen
+      && panel !== null
+      && sidebarContentPanelAuxiliary === panel;
+
+    // Only close a panel that is on display, so a plugin does not close one it does
+    // not own. Naming none closes the sidekick area.
+    if (namesAPanel && panel !== sidebarContentPanel && !isInAuxiliaryPanel) return;
+
+    if (panel === PANELS.CHAT) {
+      layoutContextDispatch({
+        type: ACTIONS.SET_ID_CHAT_OPEN,
+        value: undefined,
+      });
+    }
+
+    if (isInAuxiliaryPanel) {
+      // As in usePanelClose: the auxiliary sidebar keeps its panel while closed so the
+      // core can restore it, so only isOpen flips.
+      layoutContextDispatch({
+        type: ACTIONS.SET_SIDEBAR_CONTENT_AUXILIARY_IS_OPEN,
+        value: false,
+      });
+      return;
+    }
+
+    // Closing the primary sidebar closes the auxiliary with it, so this must run before
+    // PANELS.NONE, which would otherwise be routed into the auxiliary.
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_IS_OPEN,
+      value: false,
+    });
+    layoutContextDispatch({
+      type: ACTIONS.SET_SIDEBAR_CONTENT_PANEL,
+      value: PANELS.NONE,
+    });
+  }, [
+    resolvePanel,
+    layoutContextDispatch,
+    sidebarContentPanel,
+    isMultiFunctionalModeEnabled,
+    isAuxiliaryOpen,
+    sidebarContentPanelAuxiliary,
+  ]);
+
+  useEffect(() => {
+    window.addEventListener(
+      SidekickAreaPanelEnum.OPEN,
+      handlePanelOpen as EventListener,
+    );
+    window.addEventListener(
+      SidekickAreaPanelEnum.CLOSE,
+      handlePanelClose as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        SidekickAreaPanelEnum.OPEN,
+        handlePanelOpen as EventListener,
+      );
+      window.removeEventListener(
+        SidekickAreaPanelEnum.CLOSE,
+        handlePanelClose as EventListener,
+      );
+    };
+  }, [handlePanelOpen, handlePanelClose]);
+  return null;
+};
+
+export default PluginSidekickAreaUiCommandsHandler;

--- a/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
+++ b/bigbluebutton-html5/imports/ui/components/plugins-engine/ui-commands/sidekick-area/handler.tsx
@@ -10,7 +10,11 @@ import logger from '/imports/startup/client/logger';
 import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
 import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
 import { Input } from '/imports/ui/components/layout/layoutTypes';
-import { useIsMultiFunctionalModeEnabled } from '/imports/ui/services/features';
+import {
+  useIsChatEnabled,
+  useIsMultiFunctionalModeEnabled,
+  useIsSharedNotesEnabled,
+} from '/imports/ui/services/features';
 
 // A plugin can dispatch the raw event, so the enum alone is not a boundary.
 const ALLOWED_CORE_PANELS: string[] = Object.values(SidekickAreaCorePanelEnum);
@@ -36,7 +40,21 @@ const PluginSidekickAreaUiCommandsHandler = () => {
     sidebarContentPanel: sidebarContentPanelAuxiliary,
     isOpen: isAuxiliaryOpen,
   } = layoutSelectInput((i: Input) => i.sidebarContentAuxiliary);
+  const isSharedNotesPinned = layoutSelectInput((i: Input) => i.sharedNotes?.isPinned ?? false);
   const isMultiFunctionalModeEnabled = useIsMultiFunctionalModeEnabled();
+  const isChatEnabled = useIsChatEnabled();
+  const isSharedNotesEnabled = useIsSharedNotesEnabled();
+
+  const isCorePanelAvailable = useCallback((id: string): boolean => {
+    // No separate isEnabled check needed here: a disabled feature simply never registers.
+    if (REGISTRY_BACKED_CORE_PANELS.includes(id)) {
+      return Boolean(registeredApps?.[id]);
+    }
+    if (id === PANELS.CHAT) return isChatEnabled;
+    // Pinned notes render in the presentation area, so opening the panel would show it empty.
+    if (id === PANELS.SHARED_NOTES) return isSharedNotesEnabled && !isSharedNotesPinned;
+    return true;
+  }, [registeredApps, isChatEnabled, isSharedNotesEnabled, isSharedNotesPinned]);
 
   const resolvePanel = useCallback((
     { id }: SidekickAreaPanelCommandArguments,
@@ -44,10 +62,7 @@ const PluginSidekickAreaUiCommandsHandler = () => {
     if (!id) return null;
 
     if (ALLOWED_CORE_PANELS.includes(id)) {
-      if (REGISTRY_BACKED_CORE_PANELS.includes(id)) {
-        if (registeredApps?.[id]) {
-          return id;
-        }
+      if (!isCorePanelAvailable(id)) {
         logger.info({
           logCode: 'plugin_core_panel_unavailable',
           extraInfo: { panel: id },
@@ -68,7 +83,7 @@ const PluginSidekickAreaUiCommandsHandler = () => {
       return null;
     }
     return genericContentPanel;
-  }, [registeredApps]);
+  }, [registeredApps, isCorePanelAvailable]);
 
   const handlePanelOpen = useCallback((
     event: CustomEvent<SidekickAreaPanelCommandArguments>,

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -36,7 +36,7 @@
         "@types/react": "^18.2.18",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
-        "bigbluebutton-html-plugin-sdk": "0.1.24",
+        "bigbluebutton-html-plugin-sdk": "0.1.26",
         "bowser": "^2.12.0",
         "browser-bunyan": "^1.8.0",
         "classnames": "^2.2.6",
@@ -7239,9 +7239,9 @@
       }
     },
     "node_modules/bigbluebutton-html-plugin-sdk": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.1.24.tgz",
-      "integrity": "sha512-TmFEKfZnE8AvYQSvVeV7ZjEKO9HjfhZa6TghS8Ltn6bQKXlebdWL5efJ7L/qh8f5SvORB/vToRQwx4TunA+wsQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/bigbluebutton-html-plugin-sdk/-/bigbluebutton-html-plugin-sdk-0.1.26.tgz",
+      "integrity": "sha512-EANOpZiIPsm69npnQf20r6ymhjyQAr8p3zjHyyPHwm7avFtDUt/5kkVBzDBq7emHr4WSYCDrVOxphqCywxC+eg==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@apollo/client": "^3.8.7",

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.2.18",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
-    "bigbluebutton-html-plugin-sdk": "0.1.24",
+    "bigbluebutton-html-plugin-sdk": "0.1.26",
     "bowser": "^2.12.0",
     "browser-bunyan": "^1.8.0",
     "classnames": "^2.2.6",

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -622,4 +622,4 @@ pluginManifestCacheRefreshIntervalMinutes=60
 # List the parameters without including the 'userdata-' prefix
 getJoinUrlUserdataBlocklist=bbb_record_permission,bbb_record_video,bbb_fullaudio_bridge,bbb_transparent_listen_only,bbb_multi_user_pen_only,bbb_presenter_tools,bbb_multi_user_tools
 
-html5PluginSdkVersion=0.1.24
+html5PluginSdkVersion=0.1.26


### PR DESCRIPTION
### What does this PR do?
Add a ui-command handler that opens and closes sidekick panels on request from plugins via the SDK's sidekickArea.panel commands. Core panels route through the existing sidebar registry (poll, timer, breakout check registeredApps; others open directly), and generic panels route through the sidekick content registration, so a plugin naming an unregistered panel is ignored instead of opening the sidebar empty.

### Closes Issue(s)

Closes -

### More
Supersedes #25566 
Closely related to: https://github.com/bigbluebutton/bigbluebutton-html-plugin-sdk/pull/286
