### PR TITLE
fix: Locking private chat in 4.0 also prevents viewers from private chat with moderator

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -158,13 +158,15 @@ export const generateActionsPermissions = (
   const preventSelfChat = !amISubjectUser;
   const moderatorOverride = currentUserIsModerator
     && !amISubjectUser && !isDialInUser && isPrivateChatEnabled;
+  const viewerToModeratorOverride = isSubjectUserModerator
+    && isChatEnabled && isPrivateChatEnabled && !isDialInUser && !isSubjectUserBot;
   const regularUserCondition = (isPrivateChatEnabled
     && isChatEnabled
     && !lockSettings?.disablePrivateChat
     && !isDialInUser)
     || currentUserIsModerator;
   const allowedToChatPrivately = preventSelfChat
-    && (moderatorOverride || regularUserCondition || !userChatIsLocked)
+    && (moderatorOverride || viewerToModeratorOverride || regularUserCondition || !userChatIsLocked)
     && type === 'participant';
 
   const allowedToMuteAudio = hasAuthority

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import { hoverLastMessage } from '../chat/util';
 import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME, USER_LEFT_NOTIFICATION_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
+import { linkIssue } from '../core/helpers';
 import { enableUserJoinPopup, enableUserLeavePopup, saveSettings } from '../notifications/util';
 import { openSettings } from '../options/util';
 import { getNotesLocator } from '../sharednotes/etherpad/util';
@@ -242,6 +243,52 @@ export class LockViewers extends MultiUsers {
       privateChatMessaSentUser2.locator(e.messageToolbar),
       'should not display the chat message toolbar when locked user is hovering the message',
     ).not.toBeVisible();
+  }
+
+  async lockedViewerCanSendPrivateMessageToModerator() {
+    linkIssue(25601);
+
+    // Lock private chat before the attendee starts a chat with the moderator.
+    await openLockViewers(this.modPage);
+    await this.modPage.waitAndClick(e.participantPermissionsTab);
+    await this.modPage.waitAndClickElement(e.lockPrivateChat);
+    await this.modPage.waitAndClick(e.applyLockSettings);
+
+    await this.userPage.waitAndClick(e.usersListSidebarButton);
+    const moderatorRow = this.userPage.page.locator(e.userListItem).filter({ hasText: this.modPage.username }).first();
+    await expect(moderatorRow, 'should display the moderator for the locked attendee').toBeVisible();
+    await moderatorRow.click();
+
+    const startPrivateChatButton = moderatorRow.locator(e.startPrivateChat);
+    await expect(
+      startPrivateChatButton,
+      'should allow the locked attendee to start a private chat with the moderator',
+    ).toBeVisible();
+    await startPrivateChatButton.click();
+
+    await this.userPage.hasElementEnabled(
+      e.chatBox,
+      'should enable the private chat input for the locked attendee when chatting with the moderator',
+    );
+    await this.userPage.hasElementEnabled(
+      e.sendButton,
+      'should enable the private chat send button for the locked attendee when chatting with the moderator',
+    );
+
+    const message = 'Private message from a locked attendee';
+    await this.userPage.fill(e.chatBox, message);
+    await this.userPage.waitAndClick(e.sendButton);
+    await expect(
+      this.userPage.page.locator(e.chatUserMessageText).last(),
+      'should display the private message for the locked attendee',
+    ).toHaveText(message);
+
+    await this.modPage.waitAndClick(e.privateChatButton);
+    await this.modPage.waitAndClick(e.privateChatItem);
+    await expect(
+      this.modPage.page.locator(e.chatUserMessageText).last(),
+      'should deliver the private message from the locked attendee to the moderator',
+    ).toHaveText(message);
   }
 
   async lockEditSharedNotes() {

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -283,6 +283,7 @@ export class LockViewers extends MultiUsers {
       'should display the private message for the locked attendee',
     ).toHaveText(message);
 
+    await this.modPage.waitAndClick(e.messagesSidebarButton);
     await this.modPage.waitAndClick(e.privateChatButton);
     await this.modPage.waitAndClick(e.privateChatItem);
     await expect(

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -37,6 +37,12 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await multiusers.audioOnlyTileVisibleForAttendee();
     });
 
+    test('Locked viewer can send private messages to moderator', async ({ browser, context, page }, testInfo) => {
+      const lockViewers = new LockViewers(browser, context);
+      await lockViewers.initPages(page, testInfo);
+      await lockViewers.lockedViewerCanSendPrivateMessageToModerator();
+    });
+
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, { testInfo });


### PR DESCRIPTION
### What does this PR do?

Fix regression where locked viewers were not able to start a private chat with a moderator on 4.0 and adds a regression test for this case

### Closes Issue(s)
Closes #25601

### How to test
1. Join a 4.0-beta-4 server as both moderator and viewer
2. Lock viewers from using private chat
3. As a viewer, try to chat with the moderator