### PR TITLE
fix(html5): align audio modal microphone and listen-only icons vertically

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-modal/styles.js
@@ -35,18 +35,11 @@ const AudioModalButton = styled(Button)`
     }
   }
 
-  // The bbb-icons unmute (microphone) glyph has a taller ink box than the listen (headphone)
-  // glyph at the same font-size: mic ink is ~61px tall vs the headphone's ~49px at 3.5rem, so
-  // even with their centers aligned the mic overhangs the headphone by ~6px at each end and reads
-  // as a different size inside its circle. scale(0.8) (rounded from 49/61 ~= 0.803) shrinks the mic
-  // to the headphone's ink height about the glyph's geometric center (transform-origin defaults to
-  // center), so the two icons occupy the same vertical band. Uniform scale keeps the mic's natural
-  // proportions - scaleY alone flattens it, and a smaller font-size overshoots and re-anchors the
-  // glyph on the text baseline, dropping its center below the headphone's. Scoped to the unmute
-  // glyph inside AudioModalButton so the icon reused elsewhere (mute toggle, audio test) is
-  // untouched.
+  // The unmute and listen glyphs have matching ink heights, but the unmute glyph sits slightly
+  // higher in its em box. Move only this instance down so both icons occupy the same vertical band.
+  // The em-based offset scales with the desktop and mobile font sizes.
   & span:first-child i.icon-bbb-unmute {
-    transform: scale(0.8);
+    transform: translateY(0.025em);
   }
 
   // When hovering over a button of class audioBtn, change the border colour of first span-child


### PR DESCRIPTION
### What does this PR do?

Reworks #25396 for the 4.0 audio modal to align the updated icons vertically.

<img width="1168" height="400" alt="audio-modal-icons-before-after-red-lines" src="https://github.com/user-attachments/assets/9cfe6b6c-80c7-4e81-85e8-0eb5f48fff16" />


### How to test
1. create a meeting with the custom settings `audioBridge=bbb-webrtc-sfu`
2. open the audio-join modal
3. check if the "microphone" and "listen only" icons have the same size