### PR TITLE
build: Make bbb-etherpad and bbb-pads optional

### DIFF
--- a/.github/actions/install-bbb/action.yml
+++ b/.github/actions/install-bbb/action.yml
@@ -161,6 +161,9 @@ runs:
 
         ./bbb-install.sh -v noble-40-dev -s bbb-ci.test -r packages.bigbluebutton.org -j -d /certs/
 
+        # Etherpad is opt-in since 4.0; install explicitly for the Etherpad e2e tests
+        apt-get install -y bbb-etherpad bbb-pads
+
         bbb-conf --salt bbbci
         sed -i "s/\"minify\": true,/\"minify\": false,/" /usr/share/etherpad-lite/settings.json
         sed -i "s/\"loglevel\": \"INFO\"/\"loglevel\": \"DEBUG\"/" /usr/share/etherpad-lite/settings.json

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -266,9 +266,9 @@ jobs:
           sudo apt-get install -y -qq equivs
 
           DEBS_DIR="all-artifacts"
-          PKGS="bbb-apps-akka bbb-config bbb-etherpad bbb-export-annotations
+          PKGS="bbb-apps-akka bbb-config bbb-export-annotations
                 bbb-freeswitch-core bbb-freeswitch-sounds bbb-fsesl-akka bbb-html5
-                bbb-learning-dashboard bbb-libreoffice-docker bbb-livekit bbb-mkclean bbb-pads
+                bbb-learning-dashboard bbb-libreoffice-docker bbb-livekit bbb-mkclean
                 bbb-shared-notes-server bbb-playback bbb-playback-presentation
                 bbb-record-core bbb-web bbb-webrtc-sfu bbb-webrtc-recorder"
 

--- a/build/packages-template/bigbluebutton/build.sh
+++ b/build/packages-template/bigbluebutton/build.sh
@@ -15,7 +15,6 @@ fi
 
 PKGS="bbb-apps-akka
 bbb-config
-bbb-etherpad
 bbb-export-annotations
 bbb-freeswitch-core
 bbb-freeswitch-sounds
@@ -25,7 +24,6 @@ bbb-learning-dashboard
 bbb-libreoffice-docker
 bbb-livekit
 bbb-mkclean
-bbb-pads
 bbb-shared-notes-server
 bbb-playback
 bbb-playback-presentation


### PR DESCRIPTION
Drop them as requirements for bigbluebutton metapackage Include them explicitly for CI tests until we are ready to fully remove Etherpad

<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Make bbb-etherpad and bbb-pads optional packages on clean BBB 4.0.x installation. Keep them for the CI tests.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Follow-up from https://github.com/bigbluebutton/bigbluebutton/pull/25124 as bbb-pads and bbb-etherpad were still present in clean installations of BBB 4.0.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

Clean installation of BBB 4.0.x should not contain `bbb-etherpad` nor `bbb-pads` listed in `dpkg -l | grep bbb-`.
`apt-cache depends bigbluebutton` should list neither `bbb-etherpad` nor `bbb-pads`.