### PR TITLE
feat(learning-dashboard): enable dashboard access in breakout rooms

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/LearningDashboardService.java
@@ -27,6 +27,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
+import java.util.List;
 
 public class LearningDashboardService {
     private static Logger log = LoggerFactory.getLogger(LearningDashboardService.class);
@@ -68,7 +69,10 @@ public class LearningDashboardService {
         }
     }
 
-    public void removeJsonDataFile(String meetingId, int cleanUpDelayMinutes) {
+    // meetingIds is the meeting whose Learning Dashboard is being cleaned up, plus (for a parent
+    // meeting) the internal IDs of any breakout rooms it had: they share the parent's cleanup delay
+    // and are batched into this single scheduled task instead of one Timer thread per room.
+    public void removeJsonDataFiles(List<String> meetingIds, int cleanUpDelayMinutes) {
 
         Calendar cleanUpDelayCalendar = Calendar.getInstance();
         cleanUpDelayCalendar.add(Calendar.MINUTE, cleanUpDelayMinutes);
@@ -78,9 +82,11 @@ public class LearningDashboardService {
                 new java.util.TimerTask() {
                     @Override
                     public void run() {
-                        File ldMeetingFilesDir = new File(learningDashboardFilesDir + File.separatorChar + meetingId);
-                        LearningDashboardService.deleteDirectory(ldMeetingFilesDir);
-                        log.info("Learning Dashboard files removed for meeting {}.",meetingId);
+                        for (String meetingId : meetingIds) {
+                            File ldMeetingFilesDir = new File(learningDashboardFilesDir + File.separatorChar + meetingId);
+                            LearningDashboardService.deleteDirectory(ldMeetingFilesDir);
+                            log.info("Learning Dashboard files removed for meeting {}.",meetingId);
+                        }
                     }
                 }, cleanUpDelayCalendar.getTime()
         );
@@ -96,6 +102,9 @@ public class LearningDashboardService {
          * delete files inside a directory before a directory can be deleted.
          **/
         File[] files = directory.listFiles();
+        // listFiles() is null when the directory doesn't exist (e.g. a breakout that never got any
+        // Learning Dashboard activity) — skip it instead of throwing and aborting the rest of the batch.
+        if (files == null) return;
         for (File file : files) {
             if (file.isDirectory()) {
                 deleteDirectory(file);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -615,7 +615,7 @@ public class MeetingService implements MessageListener {
   private void handleCreateMeeting(Meeting m) {
     if (m.isBreakout()) {
       Meeting parent = meetings.get(m.getParentMeetingId());
-      parent.addBreakoutRoom(m.getExternalId());
+      parent.addBreakoutRoom(m.getExternalId(), m.getInternalId());
       if (storeEvents(parent)) {
         storeService.addBreakoutRoom(parent.getInternalId(), m.getInternalId());
       }
@@ -1198,8 +1198,14 @@ public class MeetingService implements MessageListener {
       }
 
       //Remove Learning Dashboard files
-      if(!m.getDisabledFeatures().contains("learningDashboard") && m.getLearningDashboardCleanupDelayInMinutes() > 0) {
-        learningDashboardService.removeJsonDataFile(message.meetingId, m.getLearningDashboardCleanupDelayInMinutes());
+      //Breakout rooms don't get their data cleaned up on their own end: it's scheduled here, when the
+      //parent meeting ends, so moderators can still check a breakout's dashboard while the parent meeting
+      //is ongoing even after that breakout itself has closed.
+      if (!m.isBreakout() && !m.getDisabledFeatures().contains("learningDashboard") && m.getLearningDashboardCleanupDelayInMinutes() > 0) {
+        List<String> meetingIdsToClean = new ArrayList<>();
+        meetingIdsToClean.add(message.meetingId);
+        meetingIdsToClean.addAll(m.getBreakoutRoomsInternalIds());
+        learningDashboardService.removeJsonDataFiles(meetingIdsToClean, m.getLearningDashboardCleanupDelayInMinutes());
       }
 
       processRemoveEndedMeeting(message);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -922,6 +922,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.RECORD, message.record.toString());
       params.put(ApiParams.AUTO_START_RECORDING, message.autoStartRecording.toString());
       params.put(ApiParams.ALLOW_START_STOP_RECORDING, message.allowStartStopRecording.toString());
+      params.put(ApiParams.MEETING_KEEP_EVENTS, parentMeeting.getMeetingKeepEvents().toString());
       params.put(ApiParams.WELCOME, getMeeting(message.parentMeetingId).getWelcomeMessageTemplate());
       params.put(ApiParams.AUDIO_BRIDGE, message.audioBridge);
       params.put(ApiParams.CAMERA_BRIDGE, message.cameraBridge);

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -773,11 +773,6 @@ public class ParamsProcessorUtil {
 
         }
 
-        // Learning Dashboard not allowed for Breakout Rooms
-        if(isBreakout) {
-		listOfDisabledFeatures.add("learningDashboard");
-	}
-
 	//Set Learning Dashboard configs
         String learningDashboardAccessToken = "";
 	int learningDashboardCleanupMins = 0;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -105,7 +105,7 @@ public class Meeting {
 	private final ConcurrentMap<String, RegisteredUser> registeredUsers;
 	private final ConcurrentMap<String, Long> enteredUsers;
 	private final Boolean isBreakout;
-	private final List<String> breakoutRooms = new ArrayList<>();
+	private final List<BreakoutRoomIds> breakoutRooms = new ArrayList<>();
 	private ArrayList<Group> groups = new ArrayList<Group>();
 	private String customLogoURL = "";
 	private String customDarkLogoURL = "";
@@ -224,12 +224,16 @@ public class Meeting {
         enteredUsers = new  ConcurrentHashMap<>();
     }
 
-	public void addBreakoutRoom(String meetingId) {
-		breakoutRooms.add(meetingId);
+	public void addBreakoutRoom(String externalId, String internalId) {
+		breakoutRooms.add(new BreakoutRoomIds(externalId, internalId));
 	}
 
 	public List<String> getBreakoutRooms() {
-		return breakoutRooms;
+		return breakoutRooms.stream().map(BreakoutRoomIds::externalId).collect(Collectors.toList());
+	}
+
+	public List<String> getBreakoutRoomsInternalIds() {
+		return breakoutRooms.stream().map(BreakoutRoomIds::internalId).collect(Collectors.toList());
 	}
 
 	public Map<String, String> getMetadata() {
@@ -1036,6 +1040,12 @@ public class Meeting {
     public void setSharedNotesInitialContentMarkdownFromPayload(String sharedNotesInitialContentMarkdownFromPayload) {
         this.sharedNotesInitialContentMarkdownFromPayload = sharedNotesInitialContentMarkdownFromPayload;
     }
+
+	// Both IDs are captured at breakout-creation time and kept together so they can't drift apart.
+	// The internal ID is needed for Learning Dashboard cleanup: a breakout is dropped from
+	// MeetingService's live registry as soon as it ends, so by the time this parent meeting ends
+	// there's no live Meeting object left to read it back from.
+	public record BreakoutRoomIds(String externalId, String internalId) {}
 
     /***
 	 * Meeting Builder

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/learning-dashboard-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/learning-dashboard-list-item/component.tsx
@@ -21,7 +21,6 @@ const LearningDashboardListItem = () => {
   const isModerator = currentUser?.isModerator || false;
   const { data: meetingInfo } = useMeeting((meeting) => ({
     learningDashboardAccessToken: meeting.learningDashboardAccessToken,
-    isBreakout: meeting?.isBreakout,
   }));
 
   const openLearningDashboardPanel = useCallback(() => {
@@ -30,7 +29,7 @@ const LearningDashboardListItem = () => {
 
   const label = intl.formatMessage(intlMessages.learningDashboardLabel);
 
-  if (!isLearningDashboardEnabled || !isModerator || meetingInfo?.isBreakout) return null;
+  if (!isLearningDashboardEnabled || !isModerator) return null;
 
   return (
     <SidebarNavigationButton


### PR DESCRIPTION
### What does this PR do?
Breakout rooms had Learning Dashboard unconditionally disabled, a leftover from when joining a breakout forced everyone into moderator role.That's no longer true, so treat each breakout as its own meeting for Learning Dashboard purposes, still respecting an inherited disabledFeatures.

Also anchor a breakout's data cleanup to the parent meeting's end instead of the breakout's own end, so its dashboard stays available while the parent meeting is still running.

Breakout room creation already forwarded the parent's `record`, `autoStartRecording`, and `allowStartStopRecording` flags, but not `keepEvents`. Without it, a breakout always fell back to the server-wide default instead of the parent's per-meeting override, so `processRemoveEndedMeeting` never called `recordingService.markAsEnded()` for it — the breakout's `status/ended/*.done` marker was never written, `rap-starter` never enqueued its `EventsWorker`, and its `events.xml` / post_events scripts (which external tools use to find each session's Learning Dashboard data) never ran. Copy `meetingKeepEvents` from the parent into the breakout's create params, same as the recording flags.

### Closes Issue(s)
Closes #25617 