### PR TITLE
fix(akka-apps): isolate failed database batch actions

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -70,7 +70,7 @@ object DatabaseConnection {
         case scala.util.Success(results) =>
           results.zipWithIndex.foreach {
             case (scala.util.Failure(e), index) =>
-              logger.error(s"Error executing batch actions: action ${index + 1}/${batch.size} discarded [${batch(index).getDumpInfo}]: $e")
+              logger.error(s"Error executing batch actions: action ${index + 1}/${batch.size} discarded [${batch(index).getDumpInfo}]", e)
             case _ =>
           }
           val endTime = System.nanoTime()
@@ -81,7 +81,7 @@ object DatabaseConnection {
           isProcessing.set(false)
           if (!queue.isEmpty) tryProcessBatch()
         case scala.util.Failure(e) =>
-          logger.error(s"Error executing batch actions: $e")
+          logger.error("Error executing batch actions", e)
           isProcessing.set(false)
           if (!queue.isEmpty) tryProcessBatch()
       }(dbExecutionContext)

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/DatabaseConnection.scala
@@ -65,9 +65,14 @@ object DatabaseConnection {
 
     if (batch.nonEmpty) {
       val startTime = System.nanoTime()
-      val combinedAction = DBIO.sequence(batch.toList)
+      val combinedAction = DBIO.sequence(batch.toList.map(_.asTry))
       db.run(combinedAction).onComplete {
-        case scala.util.Success(_) =>
+        case scala.util.Success(results) =>
+          results.zipWithIndex.foreach {
+            case (scala.util.Failure(e), index) =>
+              logger.error(s"Error executing batch actions: action ${index + 1}/${batch.size} discarded [${batch(index).getDumpInfo}]: $e")
+            case _ =>
+          }
           val endTime = System.nanoTime()
           val duration = (endTime - startTime) / 1e6 // convert to milliseconds
           if (duration > 2000) {


### PR DESCRIPTION
## Summary

- Isolate each queued database action with Slick `asTry`, so one failed write no longer prevents later actions in the same batch from running.
- Log every discarded action with its batch position, passing the exception separately to preserve the full stack trace, while keeping the existing `Error executing batch actions:` prefix used by monitoring.
- Keep batching, ordering, slow-batch warnings, and queue scheduling unchanged.

## Why

`DBIO.sequence` previously stopped at the first failed action. Because the outer sequence runs in autocommit mode, actions before the failure were already committed while later actions were silently discarded. Replaying the batch is unsafe because it would repeat committed writes. `asTry` isolates the failure in one pass without retrying or resubmitting any action.

Backport of #25630 (3.0) to 4.0, same validated diff.

## Validation

- Red baseline on BBB 4.0 from source: enqueued benign A, an overlong `reactionEmoji`, and benign B in one drain window. Postgres contained A but not B, and the harness captured one generic batch error.
- After the change: the same harness persisted both A and B, dropped only the poison action, and emitted exactly one error identifying `action 2/3`.
- `sbt compile` completed successfully.
- Deployed `bbb-apps-akka` from source and confirmed `/healthz` returned HTTP 200 with `isHealthy: true`.
- Live smoke confirmed meeting creation, browser join, public chat, and reaction writes; both the chat message and reaction were read back from Postgres.
- Not exercised in this validation: audio, webcam, screenshare, mobile clients, and recordings.

## Evidence

Preview below - click the GIF to open the MP4 (higher quality, with controls):

[![BBB 4.0 batch isolation smoke test](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-13/6e106b81-d409-435c-9035-a8aedf0b8d08/batch-isolation-smoke.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-13/ac8e0a44-86af-4eb1-8a37-bbd30b8562d8/batch-isolation-smoke.mp4)

The smoke test shows a meeting created on the fixed build, a user joining via browser, a public chat message delivered, and a reaction set - all writes that flow through the isolated batch.

## Scope

Input-length validation at the API/action layers is tracked separately.
