### PR TITLE
Validate sharedNotesEditor create values

### DIFF
--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -665,13 +665,12 @@ public class ParamsProcessorUtil {
 
         String sharedNotesEditor = defaultSharedNotesEditor;
         if (!StringUtils.isEmpty(params.get(ApiParams.SHARED_NOTES_EDITOR))) {
-            try {
-                sharedNotesEditor = params
-                        .get(ApiParams.SHARED_NOTES_EDITOR);
-            } catch (Exception ex) {
-                log.warn(
-                        "Invalid param [sharedNotesEditor] for meeting=[{}]",
-                        internalMeetingId);
+            String canonicalSharedNotesEditor = SharedNotesEditor.canonicalize(
+                    params.get(ApiParams.SHARED_NOTES_EDITOR));
+            if (canonicalSharedNotesEditor != null) {
+                sharedNotesEditor = canonicalSharedNotesEditor;
+            } else {
+                log.warn("Invalid param [sharedNotesEditor] for meeting=[{}]", internalMeetingId);
             }
         }
 
@@ -2010,7 +2009,14 @@ public class ParamsProcessorUtil {
     }
 
     public void setSharedNotesEditor(String sharedNotesEditor) {
-        this.defaultSharedNotesEditor = sharedNotesEditor;
+        String canonicalSharedNotesEditor = SharedNotesEditor.canonicalize(sharedNotesEditor);
+        if (canonicalSharedNotesEditor == null) {
+            log.error("Invalid default [sharedNotesEditor]=[{}]; using [{}]", sharedNotesEditor,
+                    SharedNotesEditor.BLOCK_NOTE);
+            this.defaultSharedNotesEditor = SharedNotesEditor.BLOCK_NOTE;
+        } else {
+            this.defaultSharedNotesEditor = canonicalSharedNotesEditor;
+        }
     }
 
     /**

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/SharedNotesEditor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/SharedNotesEditor.java
@@ -2,6 +2,8 @@ package org.bigbluebutton.api.domain;
 
 import java.util.Locale;
 
+import org.bigbluebutton.api.util.ParamsUtil;
+
 public final class SharedNotesEditor {
     public static final String ETHERPAD = "etherpad";
     public static final String BLOCK_NOTE = "blockNote";
@@ -12,7 +14,7 @@ public final class SharedNotesEditor {
     public static String canonicalize(String value) {
         if (value == null) return null;
 
-        return switch (value.toLowerCase(Locale.ROOT)) {
+        return switch (ParamsUtil.sanitizeString(value).toLowerCase(Locale.ROOT)) {
             case ETHERPAD -> ETHERPAD;
             case "blocknote" -> BLOCK_NOTE;
             default -> null;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/SharedNotesEditor.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/SharedNotesEditor.java
@@ -1,0 +1,21 @@
+package org.bigbluebutton.api.domain;
+
+import java.util.Locale;
+
+public final class SharedNotesEditor {
+    public static final String ETHERPAD = "etherpad";
+    public static final String BLOCK_NOTE = "blockNote";
+    public static final String VALID_PATTERN = "(?i)^(etherpad|blockNote)?$";
+
+    private SharedNotesEditor() {}
+
+    public static String canonicalize(String value) {
+        if (value == null) return null;
+
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case ETHERPAD -> ETHERPAD;
+            case "blocknote" -> BLOCK_NOTE;
+            default -> null;
+        };
+    }
+}

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/CreateMeeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/model/request/CreateMeeting.java
@@ -2,6 +2,7 @@ package org.bigbluebutton.api.model.request;
 
 import jakarta.ws.rs.core.MediaType;
 import org.bigbluebutton.api.model.constraint.*;
+import org.bigbluebutton.api.domain.SharedNotesEditor;
 import org.bigbluebutton.api.model.shared.Checksum;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +21,7 @@ public class CreateMeeting extends RequestWithChecksum<CreateMeeting.Params> {
         MODERATOR_PW("moderatorPW"),
         IS_BREAKOUT_ROOM("isBreakoutRoom"),
         RECORD("record"),
+        SHARED_NOTES_EDITOR("sharedNotesEditor"),
         PRES_UPLOAD_EXT_URL("presentationUploadExternalUrl");
 
         private final String value;
@@ -54,6 +56,9 @@ public class CreateMeeting extends RequestWithChecksum<CreateMeeting.Params> {
     @IsBooleanConstraint(message = "Record must be a boolean value (true or false)")
     private String recordString;
     private Boolean record;
+
+    @Pattern(regexp = SharedNotesEditor.VALID_PATTERN, key = "invalidSharedNotesEditor", message = "sharedNotesEditor must be either etherpad or blockNote")
+    private String sharedNotesEditor;
 
     @UrlConstraint
     private String presentationUploadExternalUrl;
@@ -126,6 +131,14 @@ public class CreateMeeting extends RequestWithChecksum<CreateMeeting.Params> {
         this.record = record;
     }
 
+    public String getSharedNotesEditor() {
+        return sharedNotesEditor;
+    }
+
+    public void setSharedNotesEditor(String sharedNotesEditor) {
+        this.sharedNotesEditor = sharedNotesEditor;
+    }
+
     public String getPresentationUploadExternalUrl() {
         return presentationUploadExternalUrl;
     }
@@ -143,6 +156,7 @@ public class CreateMeeting extends RequestWithChecksum<CreateMeeting.Params> {
         if(params.containsKey(Params.MODERATOR_PW.getValue())) setModeratorPW(params.get(Params.MODERATOR_PW.getValue())[0]);
         if(params.containsKey(Params.IS_BREAKOUT_ROOM.getValue())) setBreakoutRoomString(params.get(Params.IS_BREAKOUT_ROOM.value)[0]);
         if(params.containsKey(Params.RECORD.getValue())) setRecordString(params.get(Params.RECORD.getValue())[0]);
+        if(params.containsKey(Params.SHARED_NOTES_EDITOR.getValue())) setSharedNotesEditor(params.get(Params.SHARED_NOTES_EDITOR.getValue())[0]);
         if(params.containsKey(Params.PRES_UPLOAD_EXT_URL.getValue())) setPresentationUploadExternalUrl(params.get(Params.PRES_UPLOAD_EXT_URL.getValue())[0]);
     }
 

--- a/bigbluebutton-web/src/test/groovy/org/bigbluebutton/api/domain/SharedNotesEditorSpec.groovy
+++ b/bigbluebutton-web/src/test/groovy/org/bigbluebutton/api/domain/SharedNotesEditorSpec.groovy
@@ -1,0 +1,60 @@
+package org.bigbluebutton.api.domain
+
+import org.bigbluebutton.api.ParamsProcessorUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SharedNotesEditorSpec extends Specification {
+
+  @Unroll
+  def "canonicalizes #input to #expected"() {
+    expect:
+    SharedNotesEditor.canonicalize(input) == expected
+
+    where:
+    input                                || expected
+    "etherpad"                           || "etherpad"
+    "Etherpad"                           || "etherpad"
+    "blockNote"                          || "blockNote"
+    "blocknote"                          || "blockNote"
+    ""                                   || null
+    null                                 || null
+    "pleasebreakme"                      || null
+    "123456789012345678901234567890"     || null
+  }
+
+  def "canonicalizes valid and invalid configured defaults"() {
+    given:
+    def paramsProcessor = new ParamsProcessorUtil()
+    def defaultField = ParamsProcessorUtil.getDeclaredField("defaultSharedNotesEditor")
+    defaultField.accessible = true
+
+    when:
+    paramsProcessor.setSharedNotesEditor("ETHERPAD")
+
+    then:
+    defaultField.get(paramsProcessor) == "etherpad"
+
+    when:
+    paramsProcessor.setSharedNotesEditor("unknown")
+
+    then:
+    defaultField.get(paramsProcessor) == "blockNote"
+  }
+
+  @Unroll
+  def "validates #input as #expected"() {
+    expect:
+    input.matches(SharedNotesEditor.VALID_PATTERN) == expected
+
+    where:
+    input                                || expected
+    "etherpad"                           || true
+    "Etherpad"                           || true
+    "blockNote"                          || true
+    "blocknote"                          || true
+    ""                                   || true
+    "pleasebreakme"                      || false
+    "123456789012345678901234567890"     || false
+  }
+}

--- a/bigbluebutton-web/src/test/groovy/org/bigbluebutton/api/domain/SharedNotesEditorSpec.groovy
+++ b/bigbluebutton-web/src/test/groovy/org/bigbluebutton/api/domain/SharedNotesEditorSpec.groovy
@@ -15,6 +15,8 @@ class SharedNotesEditorSpec extends Specification {
     input                                || expected
     "etherpad"                           || "etherpad"
     "Etherpad"                           || "etherpad"
+    " \tEtherpad\r\n "                 || "etherpad"
+    "Eth\u0000erpad"                    || "etherpad"
     "blockNote"                          || "blockNote"
     "blocknote"                          || "blockNote"
     ""                                   || null
@@ -51,6 +53,7 @@ class SharedNotesEditorSpec extends Specification {
     input                                || expected
     "etherpad"                           || true
     "Etherpad"                           || true
+    " \tEtherpad\r\n "                 || false
     "blockNote"                          || true
     "blocknote"                          || true
     ""                                   || true

--- a/bigbluebutton-web/src/test/groovy/org/bigbluebutton/web/controllers/ApiControllerSpec.groovy
+++ b/bigbluebutton-web/src/test/groovy/org/bigbluebutton/web/controllers/ApiControllerSpec.groovy
@@ -122,6 +122,20 @@ class ApiControllerSpec extends Specification implements ControllerUnitTest<ApiC
     xmlResponseToString() == buildCreateMeetingResponse(controller.meetingService.meetings.getAt(0))
   }
 
+  def "Test create canonicalizes a padded shared notes editor"() {
+    given: "a create request with whitespace and control characters around a known editor"
+    createMeetingWithDefaultParameters()
+    params[ApiParams.SHARED_NOTES_EDITOR] = " \tEtherpad\r\n "
+    setChecksumAndQueryString('create')
+
+    when: "the request runs through validation and meeting creation"
+    controller.create()
+
+    then: "the meeting stores the canonical editor instead of silently using the default"
+    xmlResponseToString() == buildCreateMeetingResponse(controller.meetingService.meetings.getAt(0))
+    controller.meetingService.meetings.getAt(0).sharedNotesEditor == "etherpad"
+  }
+
   def "Test create a meeting with malformed XML body"() {
     when: "necessary meeting parameters are provided with malformed XML"
     createMeetingWithDefaultParameters()

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1783,7 +1783,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `breakoutRoomsMultiUserWhiteboardDefaultOn` | Enable multi-user whiteboard by default in breakout rooms | true/false | true |
 | `learningDashboardCleanupDelayInMinutes` | Minutes the Learning Dashboard remains available after the meeting ends | Integer (0=keep permanently) | 2 _`overwritable`_ |
 | `disabledFeatures` | Comma-separated list of features to disable (see [`/create` docs](/development/api/#create) for the full list of feature names) | csv | _(empty)_ _`overwritable`_ |
-| `sharedNotesEditor` | Type of shared notes editor to use | etherpad, blockNote | blockNote _`overwritable`_ |
+| `sharedNotesEditor` | Type of shared notes editor to use. Values are case-insensitive; invalid configured defaults fall back to `blockNote`. | etherpad, blockNote | blockNote _`overwritable`_ |
 | `maxSharedNotesInitialContentUrlPayloadSize` | Maximum size (in KiB) of the response fetched when seeding shared-notes initial content from `sharedNotesInitialContentJsonUrl` / `sharedNotesInitialContentMarkdownUrl` | Integer (KiB) | 1024 |
 | `allowOverrideClientSettingsOnCreateCall` | Allow `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` to be passed on `/create` | true/false | false |
 | `clientSettingsOverrideStrictValidation` | When true, reject the `/create` call (`bbb-web`) and refuse `bbb-apps-akka` boot if a client settings override has unknown or malformed keys. Intended for test/staging (see [Validating client settings overrides](#validating-client-settings-overrides)) | true/false | false |

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1783,7 +1783,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `breakoutRoomsMultiUserWhiteboardDefaultOn` | Enable multi-user whiteboard by default in breakout rooms | true/false | true |
 | `learningDashboardCleanupDelayInMinutes` | Minutes the Learning Dashboard remains available after the meeting ends | Integer (0=keep permanently) | 2 _`overwritable`_ |
 | `disabledFeatures` | Comma-separated list of features to disable (see [`/create` docs](/development/api/#create) for the full list of feature names) | csv | _(empty)_ _`overwritable`_ |
-| `sharedNotesEditor` | Type of shared notes editor to use. Values are case-insensitive; invalid configured defaults fall back to `blockNote`. | etherpad, blockNote | blockNote _`overwritable`_ |
+| `sharedNotesEditor` | Type of shared notes editor to use. Control characters and surrounding whitespace are stripped, values are case-insensitive, and invalid configured defaults fall back to `blockNote`. | etherpad, blockNote | blockNote _`overwritable`_ |
 | `maxSharedNotesInitialContentUrlPayloadSize` | Maximum size (in KiB) of the response fetched when seeding shared-notes initial content from `sharedNotesInitialContentJsonUrl` / `sharedNotesInitialContentMarkdownUrl` | Integer (KiB) | 1024 |
 | `allowOverrideClientSettingsOnCreateCall` | Allow `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` to be passed on `/create` | true/false | false |
 | `clientSettingsOverrideStrictValidation` | When true, reject the `/create` call (`bbb-web`) and refuse `bbb-apps-akka` boot if a client settings override has unknown or malformed keys. Intended for test/staging (see [Validating client settings overrides](#validating-client-settings-overrides)) | true/false | false |

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -452,7 +452,7 @@ const createEndpointTableData = [
     "required": false,
     "type": "String",
     "default": "blockNote",
-    "description": (<>Editor to be rendered in the shared-notes area: `blockNote` or `etherpad`</>)
+    "description": (<>Editor to be rendered in the shared-notes area: <code>blockNote</code> or <code>etherpad</code>. Values are case-insensitive and stored using the canonical spelling. Unknown values cause the create request to fail.</>)
   },
   {
     "name": "sharedNotesInitialContentJsonUrl",

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -452,7 +452,7 @@ const createEndpointTableData = [
     "required": false,
     "type": "String",
     "default": "blockNote",
-    "description": (<>Editor to be rendered in the shared-notes area: <code>blockNote</code> or <code>etherpad</code>. Values are case-insensitive and stored using the canonical spelling. Unknown values cause the create request to fail.</>)
+    "description": (<>Editor to be rendered in the shared-notes area: <code>blockNote</code> or <code>etherpad</code>. Values are stripped of control characters and surrounding whitespace, matched case-insensitively, and stored using the canonical spelling. Unknown values cause the create request to fail.</>)
   },
   {
     "name": "sharedNotesInitialContentJsonUrl",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -140,7 +140,7 @@ Updated in 4.0:
   - **Removed parameter:** `copyright` (it had no effect; the value was stored but never propagated to the client). To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` (requires `allowOverrideClientSettingsOnCreateCall=true`).
   - **Removed parameter:** `webVoice` (obsolete; it selected a separate voice conference for the old Flash client and had no downstream effect after that client was removed in BBB 2.3, always falling back to `voiceBridge`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
-  - **Changed:** Parameter `sharedNotesEditor` now accepts `etherpad` or `blockNote` case-insensitively, canonicalizes known values, and rejects unknown values.
+  - **Changed:** Parameter `sharedNotesEditor` now strips control characters and surrounding whitespace, accepts `etherpad` or `blockNote` case-insensitively, canonicalizes known values, and rejects unknown values.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**
   - **Changed:** Parameter `enforceLayout` accepted values are now `UNIFIED_LAYOUT`, `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY` (the deprecated `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS` are no longer accepted).

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -140,6 +140,7 @@ Updated in 4.0:
   - **Removed parameter:** `copyright` (it had no effect; the value was stored but never propagated to the client). To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` (requires `allowOverrideClientSettingsOnCreateCall=true`).
   - **Removed parameter:** `webVoice` (obsolete; it selected a separate voice conference for the old Flash client and had no downstream effect after that client was removed in BBB 2.3, always falling back to `voiceBridge`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
+  - **Changed:** Parameter `sharedNotesEditor` now accepts `etherpad` or `blockNote` case-insensitively, canonicalizes known values, and rejects unknown values.
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**
   - **Changed:** Parameter `enforceLayout` accepted values are now `UNIFIED_LAYOUT`, `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY` (the deprecated `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS` are no longer accepted).


### PR DESCRIPTION
## Summary

- Validate `sharedNotesEditor` before creating a meeting, accepting only `etherpad` and `blockNote` case-insensitively.
- Strip control characters and surrounding whitespace before canonicalizing known values, so validation, meeting creation, and internal callers use the same normalized input.
- Fall back to `blockNote` when an invalid server default or internal value is supplied.
- Document the accepted values and normalization behavior.

## Testing

- Added a controller-path regression test that sends whitespace and control characters through create validation and meeting creation, then verifies the stored editor is `etherpad`.
- On a BBB 4.0 from-source environment, confirmed through HTTP `/create` and PostgreSQL readback that a padded `Etherpad` value returns `SUCCESS` and is stored as `etherpad`.
- Confirmed that `blocknote` is stored as `blockNote`, while unknown values return `FAILED` with `invalidSharedNotesEditor` and do not create a meeting.
- Confirmed that an omitted parameter retains the configured `blockNote` default.
- Compiled the updated Groovy test sources and completed the from-source redeploy successfully.

No client UI or media behavior is changed by this patch.

Closes #25640
