### PR TITLE
fix: BlockNote - the options menu disappears while notes are pinned to the whiteboard

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -545,9 +545,10 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
 
 interface BlockNoteContainerProps {
   isVisible: boolean;
+  isOnMediaArea: boolean;
 }
 
-function BlockNoteContainer({ isVisible }: BlockNoteContainerProps): React.ReactElement {
+function BlockNoteContainer({ isVisible, isOnMediaArea }: BlockNoteContainerProps): React.ReactElement {
   const {
     error, isAuthenticating, hocuspocusProvider, connectionClosed, handleRetry, isSynced,
   } = useHocuspocusProvider();
@@ -585,7 +586,11 @@ function BlockNoteContainer({ isVisible }: BlockNoteContainerProps): React.React
     };
   }, [renderBlockNote, isVisible, markNotesAsRead]);
   return (
-    <Styled.Notes id="bn-notes-scroll-container" isPresenter={currentUser?.presenter ?? false}>
+    <Styled.Notes
+      id="bn-notes-scroll-container"
+      isPresenter={currentUser?.presenter ?? false}
+      isOnMediaArea={isOnMediaArea}
+    >
       {(hasError) && (
         <Styled.WarningNotificationContainer data-test="notesError">
           <Styled.ErrorMessage>{error}</Styled.ErrorMessage>

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/styles.ts
@@ -3,15 +3,15 @@ import { colorDanger, colorGray, colorWhite } from '/imports/ui/stylesheets/styl
 import { lgBorderRadius } from '/imports/ui/stylesheets/styled-components/general';
 import { smallOnly } from '/imports/ui/stylesheets/styled-components/breakpoints';
 
-const Notes = styled.div<{isPresenter: boolean}>`
+const Notes = styled.div<{isPresenter: boolean, isOnMediaArea: boolean}>`
   background-color: ${colorWhite};
   display: flex;
   flex-grow: 1;
   flex-direction: column;
   height: 100%;
   overflow: auto;
-  border-radius: ${({ isPresenter }) => (
-    isPresenter ? `0 0 ${lgBorderRadius} ${lgBorderRadius}` : `${lgBorderRadius}`)};
+  border-radius: ${({ isPresenter, isOnMediaArea }) => (
+    isPresenter || isOnMediaArea ? `0 0 ${lgBorderRadius} ${lgBorderRadius}` : `${lgBorderRadius}`)};
 
   @media ${smallOnly} {
     transform: none !important;

--- a/bigbluebutton-html5/imports/ui/components/notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/component.tsx
@@ -97,6 +97,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
 
   const isHidden = (isOnMediaArea && (sharedNotesOutput.width === 0 || sharedNotesOutput.height === 0))
     || (!isVisible && !ignoreDelayforUnmount);
+  const isEtherpadSharedNotes = sharedNotesEditor === 'etherpad';
 
   // Shared between the kebab menu (opens the modal) and the BlockNote editor
   // (renders the modal and applies the import). See import-context.tsx.
@@ -121,22 +122,29 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     return () => clearTimeout(timeoutRef.current);
   }, [isVisible]);
 
-  const renderHeaderOnMedia = () => {
-    return amIPresenter ? (
-      <Styled.Header
-        title={intl.formatMessage(intlMessages.title)}
-        rightButtonProps={{
-          'aria-label': intl.formatMessage(intlMessages.unpinNotes),
-          'data-test': 'unpinNotes',
-          icon: 'close',
-          label: intl.formatMessage(intlMessages.unpinNotes),
-          onClick: () => {
-            handlePinSharedNotes(false);
-          },
-        }}
-      />
-    ) : null;
-  };
+  const renderHeaderOnMedia = () => (
+    <Styled.Header
+      data-test="pinnedNotesHeader"
+      title={intl.formatMessage(intlMessages.title)}
+      customRightButton={(
+        <NotesDropdown
+          isEtherpadSharedNotes={isEtherpadSharedNotes}
+          handlePinSharedNotes={handlePinSharedNotes}
+          padId={padId}
+          isPinned
+        />
+      )}
+      rightButtonProps={amIPresenter ? {
+        'aria-label': intl.formatMessage(intlMessages.unpinNotes),
+        'data-test': 'unpinNotes',
+        icon: 'close',
+        label: intl.formatMessage(intlMessages.unpinNotes),
+        onClick: () => {
+          handlePinSharedNotes(false);
+        },
+      } : undefined}
+    />
+  );
 
   const {
     height,
@@ -155,8 +163,6 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
     right,
     zIndex,
   };
-
-  const isEtherpadSharedNotes = sharedNotesEditor === 'etherpad';
 
   return (shouldRenderNotes || shouldShowSharedNotesOnPresentationArea) && (
     <SharedNotesImportContext.Provider value={importContextValue}>
@@ -178,6 +184,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
                   isEtherpadSharedNotes={isEtherpadSharedNotes}
                   handlePinSharedNotes={handlePinSharedNotes}
                   padId={padId}
+                  isPinned={false}
                 />
               )}
             />
@@ -196,7 +203,7 @@ const NotesGraphql: React.FC<NotesGraphqlProps> = (props) => {
               amIPresenter={amIPresenter}
               isVisible={isVisible}
             />
-          ) : <BlockNoteContainer isVisible={isVisible} />}
+          ) : <BlockNoteContainer isVisible={isVisible} isOnMediaArea={isOnMediaArea} />}
       </Styled.PanelContent>
     </SharedNotesImportContext.Provider>
   );

--- a/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notes/notes-dropdown/component.tsx
@@ -50,6 +50,7 @@ interface NotesDropdownContainerGraphqlProps {
   handlePinSharedNotes: (pinned: boolean) => void;
   padId: string;
   isEtherpadSharedNotes: boolean;
+  isPinned: boolean;
 }
 
 interface NotesDropdownGraphqlProps extends NotesDropdownContainerGraphqlProps {
@@ -62,7 +63,8 @@ interface NotesDropdownGraphqlProps extends NotesDropdownContainerGraphqlProps {
 
 const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
   const {
-    amIPresenter, presentations, handlePinSharedNotes, isRTL, padId, presentationEnabled, isEtherpadSharedNotes,
+    amIPresenter, presentations, handlePinSharedNotes, isRTL, padId, presentationEnabled,
+    isEtherpadSharedNotes, isPinned,
   } = props;
   const [converterButtonDisabled, setConverterButtonDisabled] = useState(false);
   const intl = useIntl();
@@ -141,7 +143,7 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
       }
     }
 
-    if (amIPresenter && NOTES_ARE_PINNABLE()) {
+    if (amIPresenter && !isPinned && NOTES_ARE_PINNABLE()) {
       menuItems.push(
         {
           key: uniqueId('notes-option-'),
@@ -189,7 +191,9 @@ const NotesDropdownGraphql: React.FC<NotesDropdownGraphqlProps> = (props) => {
 };
 
 const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps> = (props) => {
-  const { handlePinSharedNotes, padId, isEtherpadSharedNotes } = props;
+  const {
+    handlePinSharedNotes, padId, isEtherpadSharedNotes, isPinned,
+  } = props;
   const { data: currentUserData } = useCurrentUser((user) => ({
     presenter: user.presenter,
   }));
@@ -214,6 +218,7 @@ const NotesDropdownContainerGraphql: React.FC<NotesDropdownContainerGraphqlProps
       presentationEnabled={isPresentationEnabled}
       padId={padId}
       isEtherpadSharedNotes={isEtherpadSharedNotes}
+      isPinned={isPinned}
     />
   );
 };

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -305,6 +305,7 @@ export const elements = {
   exportPlainButton: 'a[id="exportplaina"] span',
   pinNotes: 'li[data-test="pinNotes"]',
   unpinNotes: 'button[data-test="unpinNotes"]',
+  pinnedNotesHeader: 'header[data-test="pinnedNotesHeader"]',
   exportetherpad: 'span[id="exportetherpad"]',
   exporthtml: 'span[id="exporthtml"]',
 

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -65,6 +65,14 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
     await sharedNotes.pinAndUnpinNotesOntoWhiteboard();
   });
 
+  test('Pinned header exposes permitted notes actions', async ({ browser, context, browserName }, testInfo) => {
+    linkIssue(25584);
+    test.skip(browserName === 'firefox', 'Webcams does not work properly, due to heavy firefox for testing');
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.pinnedHeaderActions();
+  });
+
   test('Unread indicator notifies users of new notes content', async ({ browser, context }, testInfo) => {
     const sharedNotes = new BlockNoteSharedNotes(browser, context);
     await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -4,6 +4,7 @@ import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TI
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 import {
+  enableMarkdownNotesOptions,
   getBlockNoteEditorLocator,
   getBlockNoteReadOnlyLocator,
   hasNoUnreadNotesIndicator,
@@ -364,6 +365,8 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await startSharedNotesBlockNote(this.modPage);
     await this.modPage.waitAndClick(e.notesOptions);
     await this.modPage.waitAndClick(e.pinNotes);
+    await this.modPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
     await this.modPage.hasElement(
       e.unpinNotes,
       'should display the unpin notes button for the moderator after pinning the notes again',
@@ -373,9 +376,113 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.waitAndClick(e.moreOptionsUserItemButton);
     await this.modPage.waitAndClick(e.makePresenter);
     await this.userPage.closeAllToastNotifications();
+    await this.userPage.closeAllToastNotifications();
     await this.userPage.waitAndClick(e.unpinNotes);
     await this.userPage.hasElement(e.whiteboard, 'should restore the presentation for the attendee (previous state)');
     await this.modPage.hasElement(e.whiteboard, 'should restore the presentation for the moderator (previous state)');
+  }
+
+  async pinnedHeaderActions() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.messagesSidebarButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await enableMarkdownNotesOptions(this.modPage);
+    await enableMarkdownNotesOptions(this.userPage);
+    await startSharedNotesBlockNote(this.modPage);
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.waitAndClick(e.pinNotes);
+
+    const assertPinnedHeaderControlsFit = async (width: number, height: number) => {
+      await this.modPage.setHeightWidthViewPortSize({ width, height });
+      const header = this.modPage.page.locator(e.pinnedNotesHeader);
+      const options = this.modPage.page.locator(e.notesOptions);
+      const unpin = this.modPage.page.locator(e.unpinNotes);
+      await expect(header, `should display the pinned header at ${width}x${height}`).toBeVisible();
+      await expect(options, `should display notes options at ${width}x${height}`).toBeVisible();
+      await expect(unpin, `should display unpin at ${width}x${height}`).toBeVisible();
+
+      const [headerBox, optionsBox, unpinBox] = await Promise.all([
+        header.boundingBox(),
+        options.boundingBox(),
+        unpin.boundingBox(),
+      ]);
+      expect(headerBox, 'the pinned header should have layout dimensions').not.toBeNull();
+      expect(optionsBox, 'the notes options control should have layout dimensions').not.toBeNull();
+      expect(unpinBox, 'the unpin control should have layout dimensions').not.toBeNull();
+      if (!headerBox || !optionsBox || !unpinBox) return;
+      expect(optionsBox.x, 'notes options should stay inside the pinned header').toBeGreaterThanOrEqual(headerBox.x);
+      expect(unpinBox.x + unpinBox.width, 'unpin should stay inside the pinned header').toBeLessThanOrEqual(
+        headerBox.x + headerBox.width + 1,
+      );
+      expect(optionsBox.x + optionsBox.width, 'the pinned header controls should not overlap').toBeLessThanOrEqual(
+        unpinBox.x,
+      );
+    };
+
+    await assertPinnedHeaderControlsFit(390, 844);
+    await assertPinnedHeaderControlsFit(1366, 768);
+
+    const modOptions = this.modPage.page.locator(e.notesOptions);
+    await modOptions.focus();
+    await modOptions.press('Enter');
+    await expect(this.modPage.page.locator(e.importNotesFromMarkdown)).toBeVisible();
+    await expect(this.modPage.page.locator(e.sendNotesToWhiteboard)).toBeVisible();
+    await expect(this.modPage.page.locator(e.exportNotesAsPDF)).toBeVisible();
+    await expect(this.modPage.page.locator(e.exportNotesAsMarkdown)).toBeVisible();
+    await expect(this.modPage.page.locator(e.pinNotes), 'should not offer to pin notes that are pinned').toHaveCount(0);
+    await this.modPage.page.keyboard.press('Escape');
+    await expect(this.modPage.page.locator(e.exportNotesAsPDF)).toBeHidden();
+    await expect(modOptions, 'keyboard focus should return to the notes options control').toBeFocused();
+
+    await expect(this.userPage.page.locator(e.pinnedNotesHeader)).toBeVisible();
+    await expect(this.userPage.page.locator(e.unpinNotes), 'a viewer should not be able to unpin notes').toHaveCount(0);
+    const userOptions = this.userPage.page.locator(e.notesOptions);
+    await userOptions.focus();
+    await userOptions.press('Enter');
+    await expect(this.userPage.page.locator(e.exportNotesAsPDF)).toBeVisible();
+    await expect(this.userPage.page.locator(e.exportNotesAsMarkdown)).toBeVisible();
+    await expect(
+      this.userPage.page.locator(e.importNotesFromMarkdown),
+      'a viewer should not be able to import notes',
+    ).toHaveCount(0);
+    await expect(
+      this.userPage.page.locator(e.sendNotesToWhiteboard),
+      'a viewer should not be able to convert notes',
+    ).toHaveCount(0);
+    await expect(this.userPage.page.locator(e.pinNotes)).toHaveCount(0);
+    await this.userPage.page.keyboard.press('Escape');
+
+    await this.modPage.waitAndClick(e.usersListSidebarButton);
+    await this.modPage.waitAndClick(e.moreOptionsUserItemButton);
+    await this.modPage.waitAndClick(e.makePresenter);
+    await expect(
+      this.userPage.page.locator(e.unpinNotes),
+      'the new presenter should be able to unpin notes',
+    ).toBeVisible();
+    await expect(
+      this.modPage.page.locator(e.unpinNotes),
+      'a moderator who is not the presenter should not be able to unpin notes',
+    ).toHaveCount(0);
+
+    await userOptions.focus();
+    await userOptions.press('Enter');
+    await expect(this.userPage.page.locator(e.importNotesFromMarkdown)).toBeVisible();
+    await expect(this.userPage.page.locator(e.sendNotesToWhiteboard)).toBeVisible();
+    await this.userPage.page.keyboard.press('Escape');
+
+    await this.userPage.closeAllToastNotifications();
+    const userUnpin = this.userPage.page.locator(e.unpinNotes);
+    await userUnpin.focus();
+    await userUnpin.press('Enter');
+    await expect(this.userPage.page.locator(e.pinnedNotesHeader)).toHaveCount(0);
+    await expect(this.modPage.page.locator(e.pinnedNotesHeader)).toHaveCount(0);
+    await this.userPage.hasElement(e.whiteboard, 'should restore the presentation for the presenter');
+    await this.modPage.hasElement(e.whiteboard, 'should restore the presentation for the moderator');
   }
 
   async formatBlockNoteMessage() {
@@ -432,7 +539,10 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.page.keyboard.type('Hello attendees');
 
     // viewer (notes panel closed) must see the unread indicator
-    await this.userPage.hasNotificationIcon(e.sharedNotesSidebarButton, 'should display the unread indicator for the viewer');
+    await this.userPage.hasNotificationIcon(
+      e.sharedNotesSidebarButton,
+      'should display the unread indicator for the viewer',
+    );
 
     // opening the notes clears the indicator
     await startSharedNotesBlockNote(this.userPage);
@@ -447,6 +557,9 @@ export class BlockNoteSharedNotes extends MultiUsers {
     const modNotesEditor = getBlockNoteEditorLocator(this.modPage);
     await modNotesEditor.click();
     await this.modPage.page.keyboard.type('New content');
-    await this.userPage.hasNotificationIcon(e.sharedNotesSidebarButton, 'should display the unread indicator again after new edits');
+    await this.userPage.hasNotificationIcon(
+      e.sharedNotesSidebarButton,
+      'should display the unread indicator again after new edits',
+    );
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds the shared notes dropdown when notes are pinned to the whiteboard area:

<img width="290" height="265" alt="Screenshot From 2026-08-17 13-50-05" src="https://github.com/user-attachments/assets/036a50a1-b901-4183-8f7d-ee4ab5207986" />


### Closes Issue(s)
Closes #25584

### How to test
1. Join a meeting as moderator/presenter, open **Shared notes**.
2. Open the notes options menu — the export/import/convert entries are there.
3. Options → **Pin notes**.
4. Look at the pinned notes header in the presentation area.
