### PR TITLE
fix(notes): update user activity on shared notes edits

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -649,7 +649,9 @@ class MeetingActor(
       case m: PadCreateReqMsg               => padsApp2x.handle(m, liveMeeting, msgBus)
       case m: PadCreatedEvtMsg              => padsApp2x.handle(m, liveMeeting, msgBus)
       case m: BNSharedNotesCreatedEvtMsg    => padsApp2x.handle(m, liveMeeting, msgBus)
-      case m: BNSharedNotesUpdatedEvtMsg    => padsApp2x.handle(m, liveMeeting, msgBus)
+      case m: BNSharedNotesUpdatedEvtMsg    =>
+        padsApp2x.handle(m, liveMeeting, msgBus)
+        updateUserLastActivity(m.body.intUserId)
       case m: PadCreateSessionReqMsg        => padsApp2x.handle(m, liveMeeting, msgBus)
       case m: PadSessionCreatedEvtMsg       => padsApp2x.handle(m, liveMeeting, msgBus)
       case m: PadSessionDeletedSysMsg       => padsApp2x.handle(m, liveMeeting, msgBus)


### PR DESCRIPTION
### What does this PR do?
Editing the BlockNote shared notes doesn't reset the user's inactivity timer, because the client talks to bbb-shared-notes-server directly over its own websocket connection, and `BNSharedNotesUpdatedEvtMsg` is the only signal that reaches akka-bbb-apps about it. As a result, users who only interact with the notes during a meeting can still be flagged as inactive and disconnected.

Call `updateUserLastActivity` with the editing user's id when handling `BNSharedNotesUpdatedEvtMsg`, mirroring how `PadUpdatedSysMsg` already resets activity for the legacy Etherpad-based notes.


### Closes Issue(s)
Closes -

### Motivation
<!-- What inspired you to submit this pull request? -->


### How to test
1. Ensure that the inactivity settings are correctly configured:
  ```
  userInactivityInpectTimerInMinutes=1
  userInactivityThresholdInMinutes=1
  userActivitySignResponseDelayInMinutes=1
  ```
2. Create and join meeting
3. Interact only with the block notes
4. Before this fix: See inactivity warning being prompted, even when actively interact with the block notes
    With this fix: the inactivity warning is not prompted.