### PR TITLE
fix: restore chat input rounded border

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/chat/chat-graphql/chat-message-form/styles.ts
@@ -192,14 +192,6 @@ const InputWrapper = styled.div`
   gap: 3px;
   cursor: text;
 
-  [dir='ltr'] & {
-    border-radius: 0.75rem 0 0 0.75rem;
-  }
-
-  [dir='rtl'] & {
-    border-radius: 0 0.75rem 0.75rem 0;
-  }
-
   &:focus-within {
     border-color: ${colorPrimary};
     box-shadow: 0 0 0 ${xsPadding} ${colorBorder};


### PR DESCRIPTION
### What does this PR do?

Restores the (right-hand side) border-radius in chat input

#### before

<img width="429" height="95" alt="Screenshot From 2026-08-18 13-28-41" src="https://github.com/user-attachments/assets/73049fdb-33e5-4a22-8c26-9ee3c76dd8c4" />


#### after

<img width="429" height="95" alt="Screenshot From 2026-08-18 13-28-46" src="https://github.com/user-attachments/assets/599a483d-bd7e-4025-8bc2-4ab50a3cc4aa" />


### Motivation

regression from 3.0 -> 4.0 merges