### PR TITLE
feat(webcam): allow disabling the grid via config/API

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -443,6 +443,7 @@ export interface Pagination {
   pageChangeDebounceTime: number
   desktopPageSizes: DesktopPageSizes
   mobilePageSizes: MobilePageSizes
+  gridEnabled?: boolean
   desktopGridSizes: DesktopGridSizes
   mobileGridSizes: MobileGridSizes
 }

--- a/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/container.tsx
@@ -7,6 +7,7 @@ import {
   useCurrentVideoPageIndex,
   useExitVideo,
   useInfo,
+  useIsGridEnabled,
   useIsPaginationEnabled,
   useIsCamSharingLocked,
   useLockUser,
@@ -23,7 +24,6 @@ import { VideoItem } from './types';
 import { debounce } from '/imports/utils/debounce';
 import useSettings from '/imports/ui/services/settings/hooks/useSettings';
 import { SETTINGS } from '/imports/ui/services/settings/enums';
-import { useStorageKey } from '/imports/ui/services/storage/hooks';
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import {
   useConnectingStream,
@@ -128,7 +128,7 @@ const VideoProviderContainer: React.FC<VideoProviderContainerProps> = (props) =>
   const myPageSize = useMyPageSize();
   const { numberOfPages } = useVideoState();
   const isPaginationEnabled = useIsPaginationEnabled();
-  const isGridEnabled = useStorageKey('isGridEnabled') as boolean;
+  const isGridEnabled = useIsGridEnabled();
 
   useEffect(() => {
     if (isPaginationEnabled) {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -31,6 +31,7 @@ import {
   AudioOnlyUsersResponse,
 } from '/imports/ui/components/video-provider/queries';
 import videoService from '/imports/ui/components/video-provider/service';
+import { useIsWebcamGridEnabled } from '/imports/ui/services/features';
 import { CAMERA_BROADCAST_STOP } from '/imports/ui/components/video-provider/mutations';
 import {
   GridItem,
@@ -541,9 +542,9 @@ export const useGridSize = () => {
 
 export const useIsGridEnabled = () => {
   const isGridLayout = useStorageKey('isGridEnabled');
-  const { gridEnabled = true } = window.meetingClientSettings.public.kurento.pagination;
+  const isWebcamGridEnabled = useIsWebcamGridEnabled();
 
-  return !!isGridLayout && gridEnabled;
+  return !!isGridLayout && isWebcamGridEnabled;
 };
 
 export const useAudioOnlyUsers = (): AudioOnlyStream[] => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -325,7 +325,7 @@ const OVERFLOW_TILE_PREVIEW_LIMIT = 3;
 export const useGridUsers = (visibleStreamCount: number, visibleUserCount: number) => {
   const gridSize = useGridSize();
   const userCount = getCountData();
-  const isGridEnabled = useStorageKey('isGridEnabled');
+  const isGridEnabled = useIsGridEnabled();
   const canOnlySeeModeratorCameras = useCanOnlySeeModeratorCameras();
   const gridItems = useRef<GridItem[]>([]);
   const overflowCount = useRef<number>(0);
@@ -537,6 +537,13 @@ export const useGridSize = () => {
   }
 
   return size;
+};
+
+export const useIsGridEnabled = () => {
+  const isGridLayout = useStorageKey('isGridEnabled');
+  const { gridEnabled = true } = window.meetingClientSettings.public.kurento.pagination;
+
+  return !!isGridLayout && gridEnabled;
 };
 
 export const useAudioOnlyUsers = (): AudioOnlyStream[] => {

--- a/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/service.ts
@@ -191,10 +191,6 @@ class VideoService {
     VideoService.setCurrentVideoPageIndex(previousPage);
   }
 
-  static isGridEnabled() {
-    return Session.getItem('isGridEnabled');
-  }
-
   stopConnectingStream() {
     this.deviceId = null;
     setConnectingStream(null);

--- a/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/webcam/component.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Resizable } from 're-resizable';
 import Draggable, { DraggableEvent } from 'react-draggable';
-import { useVideoStreams } from '/imports/ui/components/video-provider/hooks';
+import { useIsGridEnabled, useVideoStreams } from '/imports/ui/components/video-provider/hooks';
 import {
   layoutSelect,
   layoutSelectInput,
@@ -434,7 +434,7 @@ const WebcamContainer: React.FC = () => {
   const isUnifiedLayout = selectedLayout === LAYOUT_TYPE.UNIFIED_LAYOUT;
   const snapToCameraGrid = isUnifiedLayout;
 
-  const isGridEnabled = isUnifiedLayout && !presentationIsOpen;
+  const isGridEnabled = useIsGridEnabled();
 
   const { streams: videoUsers, gridUsers } = useVideoStreams();
   VideoService.updateActivePeers(videoUsers);

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -421,6 +421,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
           moderator: 2,
           viewer: 2,
         },
+        gridEnabled: true,
         desktopGridSizes: {
           moderator: 48,
           viewer: 48,

--- a/bigbluebutton-html5/imports/ui/services/features/index.js
+++ b/bigbluebutton-html5/imports/ui/services/features/index.js
@@ -165,3 +165,8 @@ export function useIsEmojiPickerEnabled() {
   return useDisabledFeatures().indexOf('chatEmojiPicker') === -1
     && EMOJI_PICKER_ENABLED;
 }
+
+export function useIsWebcamGridEnabled() {
+  const GRID_ENABLED = window.meetingClientSettings.public.kurento.pagination.gridEnabled ?? true;
+  return useDisabledFeatures().indexOf('webcamGrid') === -1 && GRID_ENABLED;
+}

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -572,7 +572,7 @@ public:
         moderator: 2
         viewer: 2
       # gridEnabled: whether the camera-less avatar grid is shown when presentation
-      # is minimized.
+      # is minimized. Can also be disabled per meeting with disabledFeatures=webcamGrid.
       gridEnabled: true
       # grid size for DESKTOP endpoints
       desktopGridSizes:

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -571,6 +571,9 @@ public:
       mobilePageSizes:
         moderator: 2
         viewer: 2
+      # gridEnabled: whether the camera-less avatar grid is shown when presentation
+      # is minimized.
+      gridEnabled: true
       # grid size for DESKTOP endpoints
       desktopGridSizes:
         moderator: 48

--- a/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
+++ b/bigbluebutton-web/grails-app/conf/bigbluebutton.properties
@@ -586,7 +586,8 @@ endWhenNoModeratorDelayInMinutes=1
 # breakoutRooms, importSharedNotesFromBreakoutRooms, importPresentationWithAnnotationsFromBreakoutRooms,
 # presentation, downloadPresentationWithAnnotations, downloadPresentationOriginalFile, downloadPresentationConvertedToPdf,
 # learningDashboard, learningDashboardDownloadSessionData, snapshotOfCurrentSlide,
-# virtualBackgrounds, customVirtualBackgrounds, raiseHand, userReactions, chatEmojiPicker, quizzes
+# virtualBackgrounds, customVirtualBackgrounds, raiseHand, userReactions, chatEmojiPicker, quizzes,
+# webcamGrid
 disabledFeatures=
 
 # Type of shared notes:

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -626,6 +626,9 @@ const createEndpointTableData = [
             <li>
               <code className="language-plaintext highlighter-rouge">multiFunctionalMode</code> - <b>Multi-Functional Mode - multiple sidebars</b>
             </li>
+            <li>
+              <code className="language-plaintext highlighter-rouge">webcamGrid</code> - <b>Enable/Disable the webcam grid, ie. the avatar tiles rendered for camera-less users while the presentation is minimized (added in BigBlueButton 4.0)</b>
+            </li>
           </ul>
         </>
     ),

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -135,7 +135,7 @@ Updated in 4.0:
 
 - **create**
   - **Added parameters:** `requireUserConsentBeforeUnmuting` (only relevant when `allowModsToUnmuteUsers=true`; when `true`, the user is shown a consent dialog before a moderator can unmute them), `lockSettingsPresenterPolicy` (controls the "Request to Present" policy; one of `moderatorOnly`, `requireApproval` (default), `freeForAll`), `notifyRecordingAppend` (appends optional plain text to the recording notification dialog when `notifyRecordingIsOn=true`).
-  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel) and `pinChatMessage`.
+  - **Added options:** Parameter `disabledFeatures` supports new options: `multiFunctionalMode` (the auxiliary/dual sidebar panel), `pinChatMessage` and `webcamGrid`.
   - **Removed parameter:** `lockSettingsDisableNote` (singular); use `lockSettingsDisableNotes` (plural) instead.
   - **Removed parameter:** `copyright` (it had no effect; the value was stored but never propagated to the client). To customize the copyright text per meeting, override `app.copyright` through `clientSettingsOverride` / `clientSettingsOverrideJsonUrl` (requires `allowOverrideClientSettingsOnCreateCall=true`).
   - **Removed parameter:** `webVoice` (obsolete; it selected a separate voice conference for the old Flash client and had no downstream effect after that client was removed in BBB 2.3, always falling back to `voiceBridge`).


### PR DESCRIPTION
### What does this PR do?

- [feat(webcam): allow disabling the grid](https://github.com/mconf/mconf-live/commit/40da80460a335e836df01a1d7000cb15d2dc4a10) 
  - The webcam/avatar grid is always on when presentation is minimized, so
    deployments that want cameras only have no way out of it. The UI for
    that is not drafted yet, hence a config-only approach for now (that
    should be orthogonal to whatever UI toggle comes later).
  - Add public.kurento.pagination.gridEnabled.
  - Also take the opportunity to centralize grid availability checking via
    an unified hook. The checks to do so are sprinkled over the client, and
    one of them deviates from the rest (webcam/component).
- [feat(webcam): add webcamGrid to disabledFeatures](https://github.com/mconf/mconf-live/commit/ed2b86aab28faa01d1cdcf606b6700f5499ebb94) 
  - The grid can only be turned off through client settings, which are
    server-wide or session-wide through a clientSettingsOverride blob
    on create. Some integrations have an easier time dealing with
    disabledFeatures, so expose it there as well (we have precedent for
    other client-only features in disabledFeatures).
  - Read the new feature name alongside the existing client setting, so
    either one turns the grid off.

### Closes Issue(s)

None

### Motivation

Stems from actual requests from heavy users. There are some meeting scenarios where
having avatar tiles taking up space in the main stage simply _does not work_ - hence
having the ability to toggle avatar tiles via API becomes useful.


### How to test

- Either specify disabledFeatures=webcamGrid or public.app.kurento.pagination.gridEnabled: false (settings.yml)
- Join a meeting with three users, no webcam
- Minimize the presentation: no avatar nor overflow tiles should be shown for any users
- Share one camera
- Still no avatar or overflow tiles - only one camera
- Maximize presentation - still no avatar tiles.
