### PR TITLE
fix: explain expired session links on the error screen

### DIFF
--- a/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
+++ b/bigbluebutton-html5/imports/startup/client/intlLoader.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useEffect } from 'react';
 import { IntlProvider } from 'react-intl';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
+import { RETRY_DESCRIPTION } from '/imports/ui/components/error-screen/loader-error';
+import Session from '/imports/ui/services/storage/in-memory';
 import useCurrentLocale from '/imports/ui/core/local-states/useCurrentLocale';
 import logger from './logger';
 
@@ -222,6 +224,14 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
   const [fallbackOnEmptyLocaleString, setFallbackOnEmptyLocaleString] = React.useState(false);
   const skipInitialLocaleFetch = React.useRef(true);
 
+  // Never leave the error screen with a bare headline: we cannot say why the locale never arrived,
+  // but "reload" is still the useful next step.
+  const failLocaleLoad = useCallback(() => {
+    Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
+    setHasError(true);
+    setFetching(false);
+  }, []);
+
   const fetchLocalizedMessages = useCallback((locale: string, init: boolean, signal: AbortSignal) => {
     setFetching(true);
     setHasError(false);
@@ -237,8 +247,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
         // surface the error screen instead of crashing on .map or spinning on a
         // blank screen.
         if (!Array.isArray(resp)) {
-          setHasError(true);
-          setFetching(false);
+          failLocaleLoad();
           return;
         }
         const data = fetchLocaleOptions(
@@ -266,8 +275,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
             const foundLocales = resp.filter((locale): locale is LocaleJson => locale !== false);
             if (foundLocales.length === 0) {
               logger.error({ logCode: 'intl_fetch_locale_none_error', extraInfo: { languageSets } }, 'Could not fetch any locale file');
-              setHasError(true);
-              setFetching(false);
+              failLocaleLoad();
               return;
             }
             const mergedLocale = foundLocales
@@ -285,8 +293,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
               },
               'Error fetching localized messages',
             );
-            setHasError(true);
-            setFetching(false);
+            failLocaleLoad();
           });
       })
       .catch((error) => {
@@ -297,8 +304,7 @@ const IntlLoader: React.FC<IntlLoaderProps> = ({
           },
           'Unable to fetch localized messages',
         );
-        setHasError(true);
-        setFetching(false);
+        failLocaleLoad();
       });
   }, []);
 

--- a/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/component.jsx
@@ -1,165 +1,244 @@
-import React, { PureComponent } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import Session from '/imports/ui/services/storage/in-memory';
 import Styled from './styles';
 import intlHolder from '../../core/singletons/intlHolder';
+import fetchStandaloneLocale from './standalone-locale';
 
 const intlMessages = defineMessages({
   503: {
     id: 'app.error.503',
+    description: 'error screen headline: the connection dropped',
   },
   500: {
     id: 'app.error.500',
-    defaultMessage: 'Oops, something went wrong',
+    description: 'error screen headline: unexpected failure',
   },
   410: {
     id: 'app.error.410',
+    description: 'error screen headline: the session no longer exists',
   },
   409: {
     id: 'app.error.409',
+    description: 'error screen headline: conflicting request',
   },
   408: {
     id: 'app.error.408',
+    description: 'error screen headline: authentication failed',
   },
   404: {
     id: 'app.error.404',
-    defaultMessage: 'Not found',
+    description: 'error screen headline: not found',
   },
   403: {
     id: 'app.error.403',
+    description: 'error screen headline: the user was removed',
   },
   401: {
     id: 'app.error.401',
+    description: 'error screen headline: not authorized',
   },
   400: {
     id: 'app.error.400',
+    description: 'error screen headline: malformed request',
   },
   meeting_ended: {
-    id: 'app.meeting.endedMessage',
+    id: 'app.error.sessionEnded',
+    description: 'error screen text: the link points to a session that has ended',
   },
   user_logged_out_reason: {
     id: 'app.error.userLoggedOut',
+    description: 'error screen text: the session token was invalidated by a log out',
   },
   validate_token_failed_eject_reason: {
     id: 'app.error.ejectedUser',
+    description: 'error screen text: the session token was invalidated by an ejection',
   },
   banned_user_rejoining_reason: {
     id: 'app.error.userBanned',
+    description: 'error screen text: the user was banned from the session',
   },
   joined_another_window_reason: {
     id: 'app.error.joinedAnotherWindow',
+    description: 'error screen text: the session is open in another browser window',
   },
   user_inactivity_eject_reason: {
     id: 'app.meeting.logout.userInactivityEjectReason',
+    description: 'error screen text: ejected for inactivity',
   },
   user_requested_eject_reason: {
     id: 'app.meeting.logout.ejectedFromMeeting',
+    description: 'error screen text: ejected by a moderator',
   },
   max_participants_reason: {
     id: 'app.meeting.logout.maxParticipantsReached',
+    description: 'error screen text: the session is full',
   },
   guest_deny: {
     id: 'app.guest.guestDeny',
+    description: 'error screen text: the guest was denied entry',
   },
   duplicate_user_in_meeting_eject_reason: {
     id: 'app.meeting.logout.duplicateUserEjectReason',
+    description: 'error screen text: ejected as a duplicate user',
   },
   not_enough_permission_eject_reason: {
     id: 'app.meeting.logout.permissionEjectReason',
+    description: 'error screen text: ejected for a permission violation',
   },
   able_to_rejoin_user_disconnected_reason: {
     id: 'app.error.disconnected.rejoin',
+    description: 'error screen text: the page can be reloaded to try again',
   },
   user_not_found: {
     id: 'app.error.userNotFound',
+    description: 'error screen text: the user was not found',
   },
   request_timeout: {
     id: 'app.error.requestTimeout',
+    description: 'error screen text: the request timed out',
   },
   meeting_not_found: {
     id: 'app.error.meetingNotFound',
+    description: 'error screen text: the meeting was not found',
   },
   session_token_replaced: {
     id: 'app.error.sessionTokenReplaced',
+    description: 'error screen text: a newer session token replaced this one',
   },
   internal_error: {
     id: 'app.error.serverInternalError',
+    description: 'error screen text: server side error',
   },
   param_missing: {
     id: 'app.error.paramMissing',
+    description: 'error screen text: a required parameter is missing from the link',
   },
   too_many_connections: {
     id: 'app.error.tooManyConnections',
+    description: 'error screen text: too many connections',
   },
   server_closed: {
     id: 'app.error.serverClosed',
+    description: 'error screen text: the server closed the connection',
   },
 });
 
 const propTypes = {
-  error: PropTypes.object,
+  children: PropTypes.node,
+  code: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  error: PropTypes.shape({ message: PropTypes.string }),
+  callback: PropTypes.func,
+  endedReason: PropTypes.string,
+  // Only present for the injectIntl default export.
+  intl: PropTypes.shape({ formatMessage: PropTypes.func.isRequired }),
 };
 
-const defaultProps = {
-  callback: () => {},
-  endedReason: null,
-  error: {},
-};
+const GENERIC_CODE = '500';
+// Bounds the wait for the locale files so the screen always resolves to something.
+const LOCALE_FETCH_TIMEOUT = 10000;
+// The locale files are this screen's only source of strings, so when even those are out of reach -
+// the very failure intlLoader reports - one hardcoded sentence is what is left.
+const UNTRANSLATED_MESSAGE = 'Something went wrong';
 
-class ErrorScreen extends PureComponent {
-  componentDidMount() {
-    const { callback, endedReason } = this.props;
+const ErrorScreen = ({
+  children,
+  code = GENERIC_CODE,
+  error,
+  callback = () => {},
+  endedReason,
+  // Set by the injectIntl default export. intlHolder only fills in once IntlAdapter mounts deep in
+  // the app, so it is the fallback here, not the source of truth.
+  intl: injectedIntl,
+}) => {
+  const intl = injectedIntl || intlHolder.getIntl();
+  const [standaloneMessages, setStandaloneMessages] = useState(null);
+
+  useEffect(() => {
     // stop audio
     callback(endedReason, () => {});
+  }, []);
+
+  useEffect(() => {
+    if (intl) return undefined;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), LOCALE_FETCH_TIMEOUT);
+
+    fetchStandaloneLocale(controller.signal)
+      .then(setStandaloneMessages)
+      .finally(() => clearTimeout(timeout));
+
+    return () => {
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [intl]);
+
+  const translate = (descriptor) => (
+    intl ? intl.formatMessage(descriptor) : standaloneMessages[descriptor.id]
+  );
+
+  // Own-property only: the stored reason is looked up here, so 'constructor' & co must not match.
+  const hasMessage = (key) => Object.prototype.hasOwnProperty.call(intlMessages, key);
+  const messageFor = (key) => (hasMessage(key) ? translate(intlMessages[key]) : null);
+
+  // Nothing is said until we know which language to say it in: flashing the wrong message before
+  // the right one is worse than a beat of nothing on a screen that is already terminal.
+  const ready = Boolean(intl || standaloneMessages);
+
+  const message = ready
+    ? (messageFor(code) || messageFor(GENERIC_CODE) || UNTRANSLATED_MESSAGE)
+    : null;
+
+  // What the failing code chose to surface; `error.message` is the raw throw, a last resort.
+  const reason = Session.getItem('errorMessageDescription') || error?.message;
+  // A known reason resolves through the catalog or not at all - the key is an internal name and
+  // must never reach the user. Anything else is already human-readable (the error boundary
+  // forwards an error's `cause` verbatim), as long as it is a string: a non-string child throws.
+  let description = null;
+
+  if (ready && typeof reason === 'string') {
+    description = hasMessage(reason) ? messageFor(reason) : reason;
   }
 
-  render() {
-    const {
-      children,
-      error,
-    } = this.props;
-    const formatedMessage = 'Oops, something went wrong';
-    let errorMessageDescription = Session.getItem('errorMessageDescription');
-    const intl = intlHolder.getIntl();
+  // The region is painted from mount and filled once `ready`: an alert inserted together with its
+  // text is not reliably announced, whereas a change inside a region already present is.
+  return (
+    <Styled.Background role="alert">
+      {ready && (
+        <>
+          <Styled.Message data-test="errorScreenMessage">
+            {message}
+          </Styled.Message>
+          {
+            !description
+            || message === description
+            || (
+              <Styled.SessionMessage data-test="errorScreenDescription">
+                {description}
+              </Styled.SessionMessage>
+            )
+          }
+          <Styled.Separator />
+          <Styled.CodeError data-test="errorScreenCode">
+            {code}
+          </Styled.CodeError>
+          <div>
+            {children}
+          </div>
+        </>
+      )}
+    </Styled.Background>
+  );
+};
 
-    if (error) {
-      errorMessageDescription = error.message;
-    }
-
-    if (intl) {
-      errorMessageDescription = Session.getItem('errorMessageDescription');
-
-      if (errorMessageDescription in intlMessages) {
-        errorMessageDescription = intl.formatMessage(intlMessages[errorMessageDescription]);
-      }
-    }
-
-    return (
-      <Styled.Background>
-        <Styled.Message data-test="errorScreenMessage">
-          {formatedMessage}
-        </Styled.Message>
-        {
-          !errorMessageDescription
-          || formatedMessage === errorMessageDescription
-          || (
-            <Styled.SessionMessage>
-              {errorMessageDescription}
-            </Styled.SessionMessage>
-          )
-        }
-        <div>
-          {children}
-        </div>
-      </Styled.Background>
-    );
-  }
-}
+ErrorScreen.propTypes = propTypes;
 
 export default injectIntl(ErrorScreen);
 
 export { ErrorScreen };
-
-ErrorScreen.propTypes = propTypes;
-ErrorScreen.defaultProps = defaultProps;

--- a/bigbluebutton-html5/imports/ui/components/error-screen/loader-error.ts
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/loader-error.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared failure classification for SettingsLoader and CustomUsersSettings, which run before the
+ * client can show any real UI. Both fetch through nginx's `auth_request`, which answers 401 once
+ * bbb-web no longer knows the session token - what every stale invite link does - so that gets its
+ * own error code instead of the generic "something went wrong". It used to be told apart only by
+ * accident, by `resp.json()` choking on nginx's HTML 401 page.
+ */
+
+interface LoaderError extends Error {
+  httpStatus?: number;
+  sessionEnded?: boolean;
+}
+
+// nginx answers 401 for an unknown/expired session token; see ConnectionController#checkGraphqlAuthorization.
+const SESSION_EXPIRED_STATUS = 401;
+
+export const ERROR_CODE_GENERIC = '500';
+export const ERROR_CODE_SESSION_ENDED = '410';
+
+// Description keys the error screen maps to localized, actionable messages. Every failure gets one:
+// a bare headline with nothing under it is what made the old screen useless.
+export const SESSION_ENDED_DESCRIPTION = 'meeting_ended';
+// For failures we cannot name, the one thing that helps is still true - reload and try again.
+export const RETRY_DESCRIPTION = 'able_to_rejoin_user_disconnected_reason';
+export const MISSING_TOKEN_DESCRIPTION = 'param_missing';
+
+/** Turns a non-2xx response into a throw `isSessionExpired` can recognize at the catch site. */
+export const rejectOnHttpError = (response: Response): Response => {
+  if (!response.ok) {
+    const error: LoaderError = new Error(`Request failed with status ${response.status}`);
+    error.httpStatus = response.status;
+    throw error;
+  }
+
+  return response;
+};
+
+/**
+ * Same verdict without an HTTP status: bbb-web keeps answering for a removed user's token, so an
+ * ended meeting can pass the auth check and still come back with no meeting at all.
+ */
+export const sessionEndedError = (message: string): Error => {
+  const error: LoaderError = new Error(message);
+  error.sessionEnded = true;
+
+  return error;
+};
+
+export const isSessionExpired = (error: unknown): boolean => {
+  const loaderError = error as LoaderError | null;
+
+  return loaderError?.sessionEnded === true || loaderError?.httpStatus === SESSION_EXPIRED_STATUS;
+};

--- a/bigbluebutton-html5/imports/ui/components/error-screen/standalone-locale.ts
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/standalone-locale.ts
@@ -1,0 +1,64 @@
+/**
+ * Locale lookup for the error screen when it renders outside an IntlProvider. IntlLoader needs the
+ * client settings SettingsLoader fetches, so the failure users hit most - an expired link, where
+ * that fetch is what fails - has no intl at all. The locale files are static and public, so fetch
+ * them straight from there.
+ *
+ * Deliberately simpler than intlLoader: no retries, no locale index, no user override. It does
+ * mirror one thing - English underneath the requested language - because translations lag the
+ * catalog and a missing key must not leave the screen with nothing to say.
+ */
+
+export type LocaleMessages = Record<string, string>;
+
+const BASE_LOCALE = 'en';
+
+/** Locale files are `xx.json` or `xx_YY.json`; most specific first. */
+export const localeCandidates = (language: string): string[] => {
+  const [lang, region] = language.replace(/-/g, '_').split('_');
+
+  if (!lang || lang.toLowerCase() === BASE_LOCALE) return [];
+
+  return region ? [`${lang}_${region.toUpperCase()}`, lang] : [lang];
+};
+
+const fetchLocale = async (locale: string, signal?: AbortSignal): Promise<LocaleMessages | null> => {
+  try {
+    const response = await fetch(`locales/${locale}.json`, { signal });
+
+    return response.ok ? await response.json() : null;
+  } catch {
+    // Missing, malformed, aborted, offline - all mean "no messages", which the caller handles.
+    return null;
+  }
+};
+
+const fetchFirstAvailable = async (
+  locales: string[],
+  signal?: AbortSignal,
+): Promise<LocaleMessages | null> => {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const locale of locales) {
+    if (signal?.aborted) break;
+
+    // Sequential on purpose: the fallback is only worth requesting if the specific file is missing.
+    // eslint-disable-next-line no-await-in-loop
+    const messages = await fetchLocale(locale, signal);
+
+    if (messages) return messages;
+  }
+
+  return null;
+};
+
+const fetchStandaloneLocale = async (signal?: AbortSignal): Promise<LocaleMessages> => {
+  const language = (navigator.languages && navigator.languages[0]) || navigator.language || 'en';
+  const [base, localized] = await Promise.all([
+    fetchLocale(BASE_LOCALE, signal),
+    fetchFirstAvailable(localeCandidates(language), signal),
+  ]);
+
+  return { ...base, ...localized };
+};
+
+export default fetchStandaloneLocale;

--- a/bigbluebutton-html5/imports/ui/components/error-screen/styles.js
+++ b/bigbluebutton-html5/imports/ui/components/error-screen/styles.js
@@ -26,10 +26,12 @@ const Message = styled.h1`
 `;
 
 const SessionMessage = styled.div`
-  margin: 0;
+  /* Constrained so a full sentence wraps into a readable column instead of one edge-to-edge line. */
+  max-width: 40rem;
+  margin: 0 auto 1rem;
+  padding: 0 1rem;
   color: ${colorWhite};
   font-weight: 400;
-  margin-bottom: 1rem;
   font-size: 1.25rem;
 `;
 
@@ -42,9 +44,13 @@ const Separator = styled.div`
   opacity: .75;
 `;
 
-const CodeError = styled.h1`
+/* Not a heading: it carries a bare number, which is meaningless in a heading-navigation pass and
+   would compete with the real headline as a second <h1>. Weight is set explicitly to keep the
+   appearance an h1 gave it for free. */
+const CodeError = styled.div`
   margin: 0;
   font-size: 1.5rem;
+  font-weight: 700;
   color: ${colorWhite};
 `;
 

--- a/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/join-handler/custom-users-settings/component.tsx
@@ -5,6 +5,15 @@ import BBBWeb from '/imports/api/bbb-web-api';
 import Session from '/imports/ui/services/storage/in-memory';
 import Auth from '/imports/ui/services/auth';
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
+import {
+  ERROR_CODE_GENERIC,
+  ERROR_CODE_SESSION_ENDED,
+  MISSING_TOKEN_DESCRIPTION,
+  RETRY_DESCRIPTION,
+  SESSION_ENDED_DESCRIPTION,
+  isSessionExpired,
+  rejectOnHttpError,
+} from '/imports/ui/components/error-screen/loader-error';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 
 const CONNECTION_TIMEOUT = 60000;
@@ -27,6 +36,7 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
   const [fetched, setFetched] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [errorCode, setErrorCode] = useState(ERROR_CODE_GENERIC);
 
   useEffect(() => {
     setLoading(true);
@@ -35,14 +45,17 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
     timeoutRef.current = setTimeout(() => {
       controller.abort();
       setError('Timeout fetching user custom settings');
+      Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
       setLoading(false);
     }, CONNECTION_TIMEOUT);
 
     const sessionToken = Auth.sessionToken as string | null;
 
     if (!sessionToken) {
+      clearTimeout(timeoutRef.current);
       setLoading(false);
       setError('Missing session token');
+      Session.setItem('errorMessageDescription', MISSING_TOKEN_DESCRIPTION);
       return undefined;
     }
 
@@ -57,6 +70,7 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
           },
           signal: controller.signal,
         })
+          .then(rejectOnHttpError)
           .then((resp) => resp.json())
           .then((data: Response) => {
             const filteredData = data.user_metadata.map((uc) => {
@@ -78,16 +92,29 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
             if (timeoutRef.current) {
               clearTimeout(timeoutRef.current);
             }
-          }).catch(() => {
+          })
+          .catch((fetchError) => {
+            // The token can go stale between this fetch and the settings one that preceded it.
+            if (isSessionExpired(fetchError)) {
+              setErrorCode(ERROR_CODE_SESSION_ENDED);
+              setError('Session no longer valid');
+              Session.setItem('errorMessageDescription', SESSION_ENDED_DESCRIPTION);
+              return;
+            }
             setError('Error fetching user custom settings');
-            Session.setItem('errorMessageDescription', 'meeting_ended');
+            Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
           })
           .finally(() => {
+            // Every terminal path clears the timeout: left armed, it would fire a minute later and
+            // rewrite the message the user is already reading.
+            clearTimeout(timeoutRef.current);
             setLoading(false);
           });
       }).catch((error) => {
+        clearTimeout(timeoutRef.current);
         setLoading(false);
         setError('Error fetching GraphQL URL: '.concat(error?.message || ''));
+        Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
       });
 
     return () => {
@@ -101,6 +128,7 @@ const CustomUsersSettings: React.FC<CustomUsersSettingsProps> = ({
       {fetched ? children : null}
       {error ? (
         <ErrorScreen
+          code={errorCode}
           endedReason={error}
         />
       ) : null}

--- a/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/settings-loader/component.tsx
@@ -3,6 +3,16 @@ import { v4 as uuid } from 'uuid';
 import { setMeetingSettings } from '/imports/ui/core/local-states/useMeetingSettings';
 import MeetingClientSettings from '/imports/ui/Types/meetingClientSettings';
 import { ErrorScreen } from '/imports/ui/components/error-screen/component';
+import {
+  ERROR_CODE_GENERIC,
+  ERROR_CODE_SESSION_ENDED,
+  MISSING_TOKEN_DESCRIPTION,
+  RETRY_DESCRIPTION,
+  SESSION_ENDED_DESCRIPTION,
+  isSessionExpired,
+  rejectOnHttpError,
+  sessionEndedError,
+} from '/imports/ui/components/error-screen/loader-error';
 import LoadingScreen from '/imports/ui/components/common/loading-screen/component';
 import Session from '/imports/ui/services/storage/in-memory';
 import Auth from '/imports/ui/services/auth';
@@ -35,6 +45,7 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
   const { children } = props;
   const [settingsFetched, setSettingsFetched] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  const [errorCode, setErrorCode] = React.useState<string>(ERROR_CODE_GENERIC);
   const [loading, setLoading] = React.useState<boolean>(false);
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
 
@@ -45,6 +56,7 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
     timeoutRef.current = setTimeout(() => {
       controller.abort();
       setError('Timeout fetching client settings');
+      Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
       setLoading(false);
     }, connectionTimeout);
 
@@ -54,8 +66,10 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
     const sessionToken = Auth.sessionToken as string | null;
 
     if (!sessionToken) {
+      clearTimeout(timeoutRef.current);
       setLoading(false);
       setError('Missing session token');
+      Session.setItem('errorMessageDescription', MISSING_TOKEN_DESCRIPTION);
       return;
     }
 
@@ -70,27 +84,45 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
           },
           signal: controller.signal,
         })
+          .then(rejectOnHttpError)
           .then((resp) => resp.json())
           .then((data: Response) => {
             clearTimeout(timeoutRef.current);
+            const meeting = data?.meeting?.[0];
+
+            if (!meeting) throw sessionEndedError('No meeting for this session token');
+
             const {
               clientSettings,
               ...staticData
-            } = data?.meeting[0];
+            } = meeting;
             const settings = clientSettings.clientSettingsJson;
             window.meetingClientSettings = JSON.parse(JSON.stringify(settings));
             MeetingStaticDataStore.setMeetingData(staticData);
             setMeetingSettings(settings);
             setLoading(false);
             setSettingsFetched(true);
-          }).catch(() => {
+          })
+          .catch((fetchError) => {
+            // Every terminal path clears the timeout: left armed, it would fire a minute later and
+            // rewrite the message the user is already reading.
+            clearTimeout(timeoutRef.current);
             setLoading(false);
+            // An expired link is not an unexpected error - and no other failure is an expired link.
+            if (isSessionExpired(fetchError)) {
+              setErrorCode(ERROR_CODE_SESSION_ENDED);
+              setError('Session no longer valid');
+              Session.setItem('errorMessageDescription', SESSION_ENDED_DESCRIPTION);
+              return;
+            }
             setError('Error fetching client settings');
-            Session.setItem('errorMessageDescription', 'meeting_ended');
+            Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
           });
       }).catch((error) => {
+        clearTimeout(timeoutRef.current);
         setLoading(false);
         setError('Error fetching GraphQL URL: '.concat(error.message || ''));
+        Session.setItem('errorMessageDescription', RETRY_DESCRIPTION);
       });
   }, []);
 
@@ -99,6 +131,7 @@ const SettingsLoader: React.FC<SettingsLoaderProps> = (props) => {
       {settingsFetched ? children : null}
       {error ? (
         <ErrorScreen
+          code={errorCode}
           endedReason={error}
         />
       ) : null}

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1106,6 +1106,7 @@
     "app.error.408": "Authentication failed",
     "app.error.409": "Conflict",
     "app.error.410": "Session has ended",
+    "app.error.sessionEnded": "This session has ended, or the link used to join it is no longer valid. Ask the organizer for a new link, or schedule a new session.",
     "app.error.500": "Ops, something went wrong",
     "app.error.503": "You have been disconnected",
     "app.error.disconnected.rejoin": "You are able to refresh the page to rejoin.",

--- a/bigbluebutton-tests/playwright/connectionFailure/expiredSession.spec.ts
+++ b/bigbluebutton-tests/playwright/connectionFailure/expiredSession.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test';
+
+import { elements as e } from '../core/elements';
+import { parameters } from '../core/parameters';
+import { test } from '../core/setup/fixtures';
+
+// Every stale invite link ends up here: nginx answers 401, the client never gets its settings (nor
+// an intl), and the screen used to be a bare "Oops, something went wrong" with nothing else on it.
+test.describe('Expired session link', { tag: '@ci' }, () => {
+  test.beforeEach(async ({ page }) => {
+    // No meeting on purpose - a token bbb-web has never heard of fails exactly like an expired one.
+    const clientURL = new URL('../html5client/?sessionToken=expiredsessiontoken0', parameters.server);
+    await page.goto(clientURL.toString());
+  });
+
+  test('Names the ended session instead of a generic failure', async ({ page }) => {
+    // The screen only paints once the settings loaders give up, which is not instant in CI.
+    await expect(page.locator(e.errorScreenMessage)).toBeVisible({ timeout: 60_000 });
+    await expect(page.locator(e.errorScreenCode)).toHaveText('410');
+    // The actionable part: what the user can do next, not just that something broke.
+    await expect(page.locator(e.errorScreenDescription)).not.toBeEmpty();
+  });
+});

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -47,6 +47,8 @@ export const elements = {
   sendFeedbackButton: 'button[data-test="sendFeedbackButton"]',
   feedbackCommentInput: 'textarea#feedbackComment',
   errorScreenMessage: 'h1[data-test="errorScreenMessage"]',
+  errorScreenDescription: 'div[data-test="errorScreenDescription"]',
+  errorScreenCode: 'div[data-test="errorScreenCode"]',
   errorMessageLabel: 'span[id="error-message"]',
   shareCameraAsContent: 'div[data-test="cameraAsContent"]',
   closePopup: 'button[data-test="closePopup"]',


### PR DESCRIPTION
### What does this PR do?
Makes the client say what happened when it cannot load a meeting.

Every failure that stops the client before the UI loads rendered the same hardcoded English sentence, "Oops, something went wrong", with nothing under it — including the most common one, a link whose session has already ended. The sentence never reached i18n, the error code no longer drove the headline, and the description below it was always empty because the default `error` prop overwrote it with `undefined`.

The headline is driven by the error code again; an expired or unknown session token resolves to 410 with a message saying the session ended and to ask the organizer for a new link; every other failure keeps the generic headline but gains a description, so the screen is never a bare sentence.

`SettingsLoader` and `CustomUsersSettings` run above `IntlLoader`, which needs the client settings they fetch, so no intl exists on the screen that reports their failure. It reads the locale files directly — they are static and public — with English underneath, the way `IntlLoader` merges the fallback locale.

### Closes Issue(s)
Closes None

### How to test

Open `https://<server>/html5client/?sessionToken=doesnotexist`.

Expected: headline "Session has ended", a description telling the user to ask the
organizer for a new link, and code 410.

Verified manually against a live server, English and pt-BR browsers:

| Case | Headline | Description | Code |
|---|---|---|---|
| Expired / unknown session token | Session has ended | actionable text | 410 |
| Same, browser set to pt-BR | Esta sessão terminou | actionable text | 410 |
| Locale files unreachable | Something went wrong | — | 410 |
| Locale file missing the new key | Esta sessão terminou | *(empty — never the raw key)* | 410 |
| `meetingStaticData` unreachable | Ops, something went wrong | refresh to rejoin | 500 |
| No `sessionToken` in the URL | Ops, algo deu errado | Parâmetro ausente… | 500 |

Also measured at 1920/1280/375 with no horizontal overflow, and held for 70 s to confirm the load timeout no longer rewrites the message the user is reading.

**Not verified here:** `connectionFailure/expiredSession.spec.ts` is added but was not run — the suite's `global.setup` fails on the dev box used. Please let CI exercise it.

### More
- The error code is rendered as a `div` rather than a second `<h1>`, and the
  screen is an `aria-live` region so the message is announced when it appears.
