### PR TITLE
feat(audio): add WorkAdventure/DTLN noise suppression provider

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -15,23 +15,21 @@ import {
 import Auth from '/imports/ui/services/auth';
 import BaseAudioBridge from './base';
 import logger from '/imports/startup/client/logger';
-import browserInfo from '/imports/utils/browserInfo';
 import {
   getAudioConstraints,
   filterSupportedConstraints,
+  destroyWasmProcessor,
   doGUM,
   isWasmProcessingEnabled,
 } from '/imports/api/audio/client/bridge/service';
 import { liveKitRoom, LK_FATAL_ERROR_EVENT } from '/imports/ui/services/livekit';
 import { getLiveKitStats } from '/imports/ui/services/livekit/stats';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
-import { isWasmProcessorSupported } from '/imports/ui/components/audio/audio-processor/service';
 
 const BRIDGE_NAME = 'livekit';
 const SENDRECV_ROLE = 'sendrecv';
 const PUBLISH_OP = 'publish';
 const UNPUBLISH_OP = 'unpublish';
-const IS_CHROME = browserInfo.isChrome;
 const ROOM_CONNECTION_TIMEOUT = 15000;
 const DEFAULT_UNPUBLISH_AFTER_MUTE_MS = 5000;
 
@@ -1525,15 +1523,64 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
       const matchConstraints = filterSupportedConstraints(constraints);
 
-      if (IS_CHROME || isWasmProcessorSupported()) {
-        // @ts-ignore
-        matchConstraints.deviceId = this.inputDeviceId;
-        const stream = await doGUM({ audio: matchConstraints });
-        await this.setInputStream(stream, { deviceId: this.inputDeviceId, force: true });
-      } else {
-        this.inputStream?.getAudioTracks()
-          .forEach((track) => track.applyConstraints(matchConstraints));
+      if (this.inputDeviceId) {
+        // exact, as getAudioConstraints does everywhere else. doGUM will handle
+        // fallbacks if necessary.
+        // @ts-ignore - deviceId is a valid MediaTrackConstraints member
+        matchConstraints.deviceId = { exact: this.inputDeviceId };
       }
+
+      const newStream = await doGUM({ audio: matchConstraints });
+      const newAudioTrack = newStream?.getAudioTracks()[0];
+      const localTrack = this.publicationTrack;
+
+      if (!newStream || !newAudioTrack) {
+        throw new Error('LiveKit: no audio track acquired for constraint update');
+      }
+
+      // Align the new track before it can reach a sender: LiveKit only does so
+      // after handing it over, and setInputStream below may publish it as-is.
+      // Muted if either source says so - shouldBeMuted is BBB's intent and the only
+      // one left when nothing is published, and it leads isMuted while an unmute is
+      // still in flight.
+      newAudioTrack.enabled = !(this.shouldBeMuted || localTrack?.isMuted);
+
+      // replaceTrack needs an active RTCRtpSender; a publication without a attached
+      // track would throw (and that may happen). Treat as unpublished.
+      if (!localTrack?.sender) {
+        // Nothing published, swap the stream only.
+        await this.setInputStream(newStream, { deviceId: this.inputDeviceId, force: true });
+        return;
+      }
+
+      const previousStream = this.originalStream;
+
+      try {
+        await localTrack.replaceTrack(newAudioTrack);
+      } catch (replaceError) {
+        // This is not really recoverable. The previous pub should still be working,
+        // though - so bubble the error up.
+        // newStream never becomes this.originalStream here, so AudioManager's
+        // post-update cleanup will not see it: release the processor as well as
+        // the tracks, or its AudioContext and worklet outlive the failed swap.
+        destroyWasmProcessor(newStream);
+        MediaStreamUtils.stopMediaStreamTracks(newStream);
+        throw replaceError;
+      }
+
+      this.originalStream = newStream;
+      logger.debug({
+        logCode: 'livekit_audio_constraints_replace_track',
+        extraInfo: {
+          bridge: this.bridgeName,
+          role: this.role,
+          inputDeviceId: this.inputDeviceId,
+          constraints: matchConstraints,
+          newStreamData: MediaStreamUtils.getMediaStreamLogData(newStream),
+          previousStreamData: MediaStreamUtils.getMediaStreamLogData(previousStream),
+          wasmProcessingEnabled: isWasmProcessingEnabled(),
+        },
+      }, 'LiveKit: audio constraints applied via replaceTrack');
     } catch (error) {
       logger.error({
         logCode: 'livekit_audio_constraint_error',

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -6,6 +6,7 @@ import {
   adoptWasmProcessor,
   createWasmProcessorStream,
   destroyWasmProcessor,
+  getProviderForcedMicrophoneConstraints,
   isWasmProcessorSupported,
   loadWasmProcessorFiles,
   setWasmProcessorEnabled,
@@ -116,6 +117,17 @@ const filterSupportedConstraints = (audioDeviceConstraints) => {
   }
 };
 
+// Used by doGUM()'s getUserMedia retry ladder: dropping deviceId (the only
+// thing that retry is meant to give up on) must not also silently reset
+// echoCancellation/autoGainControl/noiseSuppression - including a
+// provider's forcedMicrophoneConstraints - back to the browser's own
+// defaults, which are `true` for all three in Firefox/Chrome/Safari alike.
+const withoutDeviceIdConstraint = (audioConstraints) => {
+  if (!audioConstraints || typeof audioConstraints !== 'object') return true;
+  const { deviceId, ...rest } = audioConstraints;
+  return rest;
+};
+
 const getWasmProcessingSettings = () => {
   const setting = window.meetingClientSettings.public.media.audio.audioWasmProcessing;
 
@@ -127,7 +139,7 @@ const getWasmProcessingSettings = () => {
 
 const isWasmProcessingConfigEnabled = () => !!getWasmProcessingSettings().enabled;
 
-const isBBBAWasmSupported = () => isWasmProcessorSupported()
+const isAdvancedProcessingSupported = () => isWasmProcessorSupported()
   && isWasmProcessingConfigEnabled();
 
 // check if any browser-level audio filter constraint (AGC, echo cancellation,
@@ -174,7 +186,7 @@ const getConstraintsForMode = (mode) => {
 const resolveAudioProcessingMode = (mode) => {
   const validMode = AUDIO_PROCESSING_MODES.includes(mode) ? mode : 'standard';
 
-  if (validMode === 'advanced' && !isBBBAWasmSupported()) return 'standard';
+  if (validMode === 'advanced' && !isAdvancedProcessingSupported()) return 'standard';
 
   return validMode;
 };
@@ -234,7 +246,7 @@ const getAudioConstraints = (constraintFields = {}) => {
 const isWasmProcessingEnabled = () => getEffectiveAudioProcessingMode() === 'advanced';
 
 const loadWasmProcessor = async () => {
-  if (isBBBAWasmSupported()) {
+  if (isAdvancedProcessingSupported()) {
     try {
       await loadWasmProcessorFiles();
       return true;
@@ -278,10 +290,22 @@ const doGUM = async (
         autoGainControl: true,
         noiseSuppression: true,
       };
+      // Some providers have a hard requirement on top of the admin's own
+      // configured wasmConstraints (media.audio.audioWasmProcessing.constraints)
+      // - e.g. the WorkAdventure/DTLN provider's docs ask for the browser's
+      // own noiseSuppression to stay off so it doesn't double-process the
+      // signal alongside the model. That can't be expressed as just another
+      // default: settings.yml ships audioWasmProcessing.constraints
+      // non-empty (tuned for BBBA), so a merely-overridable value would
+      // silently lose to it for every deployment that hasn't customized
+      // that block. forcedMicrophoneConstraints is applied last so it always
+      // wins; today only the WA/DTLN provider forces anything.
+      const forcedMicrophoneConstraints = getProviderForcedMicrophoneConstraints();
       // eslint-disable-next-line no-param-reassign
       constraints.audio = filterSupportedConstraints({
         ...defaults,
         ...wasmConstraints,
+        ...forcedMicrophoneConstraints,
       });
 
       if (rawDeviceId) {
@@ -310,6 +334,8 @@ const doGUM = async (
     const retryableErrors = ['NotFoundError', 'OverconstrainedError', 'NotReadableError'];
 
     if (!retryableErrors.includes(error.name)) throw error;
+
+    const fallbackAudioConstraints = withoutDeviceIdConstraint(constraints?.audio);
 
     // If the deviceId was 'exact' and we got OverconstrainedError, relax to
     // 'ideal' before falling back further. This handles systems with dynamic
@@ -341,9 +367,9 @@ const doGUM = async (
             errorName: idealError.name,
             errorMessage: idealError.message,
           },
-        }, 'doGUM: ideal deviceId also failed, falling back to { audio: true }');
+        }, 'doGUM: ideal deviceId also failed, falling back without a specific device');
 
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream = await navigator.mediaDevices.getUserMedia({ audio: fallbackAudioConstraints });
       }
     } else if (retryOnFailure) {
       logger.warn({
@@ -355,7 +381,7 @@ const doGUM = async (
         },
       }, 'Audio getUserMedia returned OverconstrainedError, rollback');
 
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream = await navigator.mediaDevices.getUserMedia({ audio: fallbackAudioConstraints });
     } else {
       throw error;
     }
@@ -463,7 +489,7 @@ export {
   doGUM,
   destroyWasmProcessor,
   stereoUnsupported,
-  isBBBAWasmSupported,
+  isAdvancedProcessingSupported,
   isWasmProcessorSupported,
   isWasmProcessingConfigEnabled,
   isWasmProcessingEnabled,

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -117,8 +117,8 @@ const filterSupportedConstraints = (audioDeviceConstraints) => {
   }
 };
 
-// Used by doGUM()'s getUserMedia retry ladder: dropping deviceId (the only
-// thing that retry is meant to give up on) must not also silently reset
+// First rung of doGUM()'s getUserMedia retry ladder: dropping deviceId (the
+// usual cause) must not also silently reset
 // echoCancellation/autoGainControl/noiseSuppression - including a
 // provider's forcedMicrophoneConstraints - back to the browser's own
 // defaults, which are `true` for all three in Firefox/Chrome/Safari alike.
@@ -126,6 +126,26 @@ const withoutDeviceIdConstraint = (audioConstraints) => {
   if (!audioConstraints || typeof audioConstraints !== 'object') return true;
   const { deviceId, ...rest } = audioConstraints;
   return rest;
+};
+
+// Last rung. media.audio.audioWasmProcessing.constraints and
+// media.audio.microphoneConstraints are free-form admin config and may hold an
+// exact/min/max value that is itself what overconstrained the request;
+// filterSupportedConstraints() only checks that the browser knows the
+// constraint name, not that the device can satisfy it. Keep only what the
+// active provider hard-requires - and only when this call actually has a
+// processor: getActiveProvider() is admin config and knows nothing about the
+// current mode, so forcing e.g. workadventureDtln's noiseSuppression:false
+// onto a plain 'standard'/'original' retry - or onto an 'advanced' call whose
+// provider failed to load - would disable the browser's own suppression with
+// no WASM model there to replace it. haveWasmProcessor, not the mode flag, is
+// what gates the same constraints on the first attempt.
+const forcedConstraintsOnly = (haveWasmProcessor) => {
+  if (!haveWasmProcessor) return true;
+
+  const forced = getProviderForcedMicrophoneConstraints();
+
+  return Object.keys(forced || {}).length > 0 ? { ...forced } : true;
 };
 
 const getWasmProcessingSettings = () => {
@@ -264,6 +284,29 @@ const loadWasmProcessor = async () => {
   return false;
 };
 
+// Retry without the device, then - if the remaining constraints are what the
+// device cannot satisfy - without them either.
+const retryWithoutDevice = async (audioConstraints, haveWasmProcessor) => {
+  try {
+    return await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
+  } catch (error) {
+    if (error.name !== 'OverconstrainedError') throw error;
+
+    logger.warn({
+      logCode: 'audio_dogum_constraint_rollback',
+      extraInfo: {
+        errorName: error.name,
+        errorMessage: error.message,
+        constraint: error.constraint,
+      },
+    }, 'doGUM: retry still overconstrained, dropping configured constraints');
+
+    return navigator.mediaDevices.getUserMedia({
+      audio: forcedConstraintsOnly(haveWasmProcessor),
+    });
+  }
+};
+
 const doGUM = async (
   constraints, {
     adoptProcessorAsPrimary = true,
@@ -294,12 +337,7 @@ const doGUM = async (
       // configured wasmConstraints (media.audio.audioWasmProcessing.constraints)
       // - e.g. the WorkAdventure/DTLN provider's docs ask for the browser's
       // own noiseSuppression to stay off so it doesn't double-process the
-      // signal alongside the model. That can't be expressed as just another
-      // default: settings.yml ships audioWasmProcessing.constraints
-      // non-empty (tuned for BBBA), so a merely-overridable value would
-      // silently lose to it for every deployment that hasn't customized
-      // that block. forcedMicrophoneConstraints is applied last so it always
-      // wins; today only the WA/DTLN provider forces anything.
+      // signal alongside the model. Merge these on top of the configured constraints.
       const forcedMicrophoneConstraints = getProviderForcedMicrophoneConstraints();
       // eslint-disable-next-line no-param-reassign
       constraints.audio = filterSupportedConstraints({
@@ -366,10 +404,12 @@ const doGUM = async (
           extraInfo: {
             errorName: idealError.name,
             errorMessage: idealError.message,
+            constraints,
+            fallbackAudioConstraints,
           },
         }, 'doGUM: ideal deviceId also failed, falling back without a specific device');
 
-        stream = await navigator.mediaDevices.getUserMedia({ audio: fallbackAudioConstraints });
+        stream = await retryWithoutDevice(fallbackAudioConstraints, haveWasmProcessor);
       }
     } else if (retryOnFailure) {
       logger.warn({
@@ -378,10 +418,11 @@ const doGUM = async (
           constraints,
           errorName: error.name,
           errorMessage: error.message,
+          fallbackAudioConstraints,
         },
       }, 'Audio getUserMedia returned OverconstrainedError, rollback');
 
-      stream = await navigator.mediaDevices.getUserMedia({ audio: fallbackAudioConstraints });
+      stream = await retryWithoutDevice(fallbackAudioConstraints, haveWasmProcessor);
     } else {
       throw error;
     }

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -196,9 +196,13 @@ const isAudioFilterEnabled = (constraints) => {
 // ("on top of WASM"), so the all-false result below is only the baseline
 // used before that override
 const getConstraintsForMode = (mode) => {
-  if (mode !== 'standard') return DISABLED_MICROPHONE_CONSTRAINTS;
+  // Always return a new object. Main consumer for this is, at the end,
+  // audio/container via a `useEffect`. If we return the same object, it never
+  // fires and original <-> advanced switches become no-op; shallow comparison
+  // shenanigans :)
+  if (mode !== 'standard') return { ...DISABLED_MICROPHONE_CONSTRAINTS };
 
-  return window.meetingClientSettings.public.media.audio.microphoneConstraints || {};
+  return { ...(window.meetingClientSettings.public.media.audio.microphoneConstraints || {}) };
 };
 
 // Validates a mode and resolves it against actual browser support.

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -697,6 +697,7 @@ export interface LiveKitSettings {
 
 export interface AudioWasmProcessingSettings {
   enabled: boolean
+  provider?: 'bbba' | 'workadventureDtln'
   // See: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints
   constraints?: Record<string, unknown>
 }

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/providers/bbba.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/providers/bbba.js
@@ -1,0 +1,248 @@
+import { isGenericWasmProcessingSupported } from '../wasmCapability';
+
+// files loaded during loadFiles()
+const loadedFiles = {
+  // store first caught error
+  error: null,
+  // BBBA-mapi.wasm
+  wasmBlob: null,
+  // BBBA-mapi.js
+  wasmJS: null,
+  // mapi-proc.js
+  worklet: null,
+};
+
+// create audio worklet or script processor
+// we rely on script processor because worklets must run at 128 block size, which is not possible on low-spec machines
+const createWasmProcessor = (audioContext, stream) => new Promise((resolve, reject) => {
+  const contextSource = audioContext.createMediaStreamSource(stream);
+  const contextDestination = audioContext.createMediaStreamDestination();
+
+  if (!navigator.userAgent.match(/Android/i)) {
+    // Using Audio Worklet
+    const processorBlob = new Blob([loadedFiles.worklet], { type: 'text/javascript' });
+    const processorURL = URL.createObjectURL(processorBlob);
+
+    audioContext.audioWorklet.addModule(processorURL).then(() => {
+      const audioProcessorOptions = {
+        channelCount: 1,
+        numberOfInputs: 1,
+        numberOfOutputs: 1,
+        outputChannelCount: [1],
+      };
+      const processor = new AudioWorkletNode(audioContext, 'mapi-proc', audioProcessorOptions);
+      processor.port.onmessage = (event) => {
+        if (event.data?.type === 'loaded') {
+          processor.port.postMessage({ type: 'param', symbol: 'intensity', value: 100 });
+          processor.port.postMessage({ type: 'param', symbol: 'leveler_target', value: -18 });
+          processor.port.postMessage({ type: 'param', symbol: 'sb_strength', value: 60 });
+          processor.port.postMessage({ type: 'param', symbol: 'mb_strength', value: 60 });
+          processor.port.postMessage({ type: 'param', symbol: 'pre_gain', value: 2 });
+          processor.port.postMessage({ type: 'param', symbol: 'post_gain', value: 0 });
+
+          contextSource.connect(processor);
+          processor.connect(contextDestination);
+          resolve({ stream: contextDestination.stream, processor });
+        } else if (event.data?.type === 'error') {
+          reject(event.data.error);
+        }
+      };
+      processor.port.postMessage({ type: 'init', wasm: loadedFiles.wasmBlob, js: loadedFiles.wasmJS });
+    }).catch(reject);
+    return;
+  }
+
+  // fallback with createScriptProcessor follows here
+
+  // execute JS to expose the emscripten load module function
+  const jsfnBbba = new Function(`${loadedFiles.wasmJS}return mapi_bbba;`);
+  const createModuleBbba = jsfnBbba.call();
+
+  // audio setup
+  const bufferSize = 8192;
+  const numberOfInputs = 1;
+  const numberOfOutputs = 1;
+  const processor = audioContext.createScriptProcessor(bufferSize, numberOfInputs, numberOfOutputs);
+
+  // create the wasm module and instance
+  createModuleBbba({
+    instantiateWasm: (imports, successCallback) => {
+      WebAssembly.instantiate(loadedFiles.wasmBlob, imports)
+        .then((output) => {
+          successCallback(output.instance, output.module);
+        })
+        .catch(reject);
+      return {};
+    },
+    postRun(module) {
+      const handle = module._mapi_create(audioContext.sampleRate, bufferSize);
+
+      const audioData = module._malloc(module.HEAPF32.BYTES_PER_ELEMENT * bufferSize);
+      const audioPtrs = module._malloc(module.HEAPU32.BYTES_PER_ELEMENT);
+      module.HEAPU32[(audioPtrs + (0 << 2)) >> 2] = audioData;
+
+      const maxSymbolLength = 255;
+      const csymbolData = module._malloc(maxSymbolLength);
+      const csymbol = (symbol) => {
+        const len = Math.min(maxSymbolLength, module.lengthBytesUTF8(symbol) + 1);
+        module.stringToUTF8(symbol, csymbolData, len);
+        return csymbolData;
+      };
+
+      let enabled = true;
+      processor.onaudioprocess = (e) => {
+        if (!enabled) {
+          e.outputBuffer.copyToChannel(e.inputBuffer.getChannelData(0), 0);
+          return;
+        }
+
+        let buffer = e.inputBuffer.getChannelData(0);
+
+        for (let i = 0; i < bufferSize; ++i) {
+          module.HEAPF32[(audioData + (i << 2)) >> 2] = buffer[i];
+        }
+
+        module._mapi_process(handle, audioPtrs, audioPtrs, bufferSize);
+
+        buffer = e.outputBuffer.getChannelData(0);
+        for (let i = 0; i < bufferSize; ++i) {
+          buffer[i] = module.HEAPF32[(audioData + (i << 2)) >> 2];
+        }
+      };
+
+      // use same API as worklet for pushing changes
+      processor.port = {
+        postMessage: (data) => {
+          switch (data.type) {
+            case 'enable':
+              enabled = !!data.enable;
+              break;
+            case 'param':
+              module._mapi_set_parameter(handle, csymbol(data.symbol), data.value);
+              break;
+            case 'destroy':
+              break;
+            default:
+              break;
+          }
+        },
+      };
+
+      contextSource.connect(processor);
+      processor.connect(contextDestination);
+      resolve({ stream: contextDestination.stream, processor });
+    },
+  });
+});
+
+// load processor files, trigger Promise resolve when all done
+const loadFiles = () => new Promise((resolve, reject) => {
+  const checkResolved = () => {
+    if (loadedFiles.wasmBlob && loadedFiles.wasmJS && loadedFiles.worklet) {
+      resolve(true);
+      return true;
+    }
+    if (loadedFiles.error) {
+      reject(loadedFiles.error);
+      return true;
+    }
+    return false;
+  };
+  const catchHandler = (error) => {
+    // only reject Promise once
+    if (!loadedFiles.error) {
+      loadedFiles.error = error;
+      reject(loadedFiles.error);
+    }
+  };
+
+  // try again in case of previous error
+  loadedFiles.error = null;
+
+  // return early if already loaded before
+  if (checkResolved()) return;
+
+  // check if SIMD is supported, needed for old Safari versions
+  const supportsSIMD = WebAssembly.validate(
+    // eslint-disable-next-line max-len
+    new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8, 0, 65, 0, 253, 15, 253, 98, 11]),
+  );
+
+  // load wasm files and worklet
+  const pathMatch = window.location.pathname.match('^(.*)/html5client/?$');
+  const serverPathPrefix = pathMatch ? pathMatch[1] : '';
+  const basepath = `${serverPathPrefix}/html5client/wasm/`;
+  const suffix = supportsSIMD ? '' : '-nosimd';
+  fetch(`${basepath}BBBA${suffix}-mapi.wasm`).then((resp) => {
+    resp.arrayBuffer().then((bytes) => {
+      loadedFiles.wasmBlob = bytes;
+      checkResolved();
+    }).catch(catchHandler);
+  }).catch(catchHandler);
+  fetch(`${basepath}BBBA${suffix}-mapi.js`).then((resp) => {
+    resp.text().then((text) => {
+      loadedFiles.wasmJS = text;
+      checkResolved();
+    }).catch(catchHandler);
+  }).catch(catchHandler);
+  fetch(`${basepath}mapi-proc.js`).then((resp) => {
+    resp.text().then((text) => {
+      loadedFiles.worklet = text;
+      checkResolved();
+    }).catch(catchHandler);
+  }).catch(catchHandler);
+});
+
+// create an audio processor on top of a stream, resolving to the contract
+// shape the audio-processor dispatcher expects from every provider
+const createProcessorStream = (stream) => new Promise((resolve, reject) => {
+  // fetch sampleRate from stream - BBBA runs at whatever rate the mic gives it
+  const { sampleRate } = stream.getAudioTracks()[0]?.getSettings() || {};
+
+  const audioContext = new AudioContext({ sampleRate });
+  const closeAndReject = (error) => {
+    audioContext.close?.().catch(() => {});
+    reject(error);
+  };
+
+  const loadAudioWorklet = () => {
+    createWasmProcessor(audioContext, stream).then(({ stream: outputStream, processor }) => {
+      resolve({
+        stream: outputStream,
+        context: audioContext,
+        setEnabled: (enabled) => processor.port.postMessage({ type: 'enable', enable: enabled }),
+        destroy: () => processor.port.postMessage({ type: 'destroy' }),
+        setParameter: (index, value) => processor.port.postMessage({ type: 'param', index, value }),
+      });
+    }).catch(closeAndReject);
+  };
+
+  // Firefox allows to resume right away, while Chrome does not
+  // handle both cases here
+  audioContext.resume().then(loadAudioWorklet).catch((err) => {
+    // Chrome does not allow to load worklet while audio context is suspended
+    // resuming audio context requires user interaction
+    if (audioContext.state === 'suspended') {
+      const resume = () => {
+        audioContext.resume().then(loadAudioWorklet).catch(closeAndReject);
+        document.removeEventListener('click', resume);
+      };
+      document.addEventListener('click', resume);
+    } else {
+      closeAndReject(err);
+    }
+  });
+});
+
+// No forced constraints - BBBA has no requirement that must override an
+// admin's explicit media.audio.audioWasmProcessing.constraints choice.
+const forcedMicrophoneConstraints = {};
+
+const isSupported = () => isGenericWasmProcessingSupported();
+
+export default {
+  isSupported,
+  loadFiles,
+  createProcessorStream,
+  forcedMicrophoneConstraints,
+};

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/providers/workadventureDtln.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/providers/workadventureDtln.js
@@ -1,0 +1,104 @@
+import { isGenericWasmProcessingSupported } from '../wasmCapability';
+
+const SAMPLE_RATE = 16000;
+
+const isSupported = () => isGenericWasmProcessingSupported();
+
+// Resolved once and reused: the package memoizes the LiteRT wasm binary
+// module-globally and the browser caches the worklet module, so a second
+// prefetch would still re-instantiate LiteRT inside a throwaway worklet for
+// nothing. Cleared on failure so a later join retries, as BBBA's loader does.
+let prefetch = null;
+
+const prefetchProcessorAssets = async () => {
+  const { createNoiseSuppressionAudioWorklet } = await import('@workadventure/noise-suppression/audio-worklet');
+
+  // OfflineAudioContext, not a real one: it is never rendered and carries no
+  // autoplay gating, so this is safe to run outside a user gesture.
+  const worklet = await createNoiseSuppressionAudioWorklet(
+    new OfflineAudioContext(1, 1, SAMPLE_RATE),
+  );
+
+  try {
+    await worklet.ready;
+  } finally {
+    worklet.dispose();
+  }
+};
+
+const loadFiles = () => {
+  if (!prefetch) {
+    prefetch = prefetchProcessorAssets().catch((error) => {
+      prefetch = null;
+      throw error;
+    });
+  }
+
+  return prefetch;
+};
+
+// Already resolved by loadFiles() on the join path; chained again here for
+// the callers that create a stream without going through it.
+const createProcessorStream = (stream) => import('@workadventure/noise-suppression/audio-worklet')
+  .then(({ createNoiseSuppressionAudioWorklet }) => new Promise((resolve, reject) => {
+    // DTLN operates at a fixed 16kHz/mono, unlike BBBA which runs at whatever
+    // rate the source stream provides. MediaStreamAudioSourceNode resamples
+    // the incoming track to the context's rate automatically.
+    const context = new AudioContext({ sampleRate: SAMPLE_RATE });
+    let worklet = null;
+
+    const closeAndReject = (error) => {
+      worklet?.dispose();
+      context.close?.().catch(() => {});
+      reject(error);
+    };
+
+    const setUpWorklet = () => {
+      const source = context.createMediaStreamSource(stream);
+      const destination = context.createMediaStreamDestination();
+
+      // threads/numThreads default to false/unset - enabling them needs
+      // COOP/COEP headers this client doesn't set today, so this stays on
+      // the single-threaded default rather than requesting cross-origin
+      // isolation.
+      createNoiseSuppressionAudioWorklet(context).then((createdWorklet) => {
+        worklet = createdWorklet;
+
+        return worklet.ready.then(() => {
+          source.connect(worklet.node);
+          worklet.node.connect(destination);
+
+          resolve({
+            stream: destination.stream,
+            context,
+            // The package exposes no runtime enable/disable toggle -
+            // dispose() is its only lifecycle control - so there's nothing
+            // to wire up here.
+            setEnabled: () => {},
+            destroy: () => worklet.dispose(),
+          });
+        });
+      }).catch(closeAndReject);
+    };
+
+    context.resume().then(setUpWorklet).catch(closeAndReject);
+  }));
+
+// The package's docs ask consumers to disable the browser's own
+// noiseSuppression so it doesn't double-process the signal alongside DTLN.
+// This is forced, not a default an admin's constraints could override:
+// settings.yml ships audioWasmProcessing.constraints non-empty
+// (noiseSuppression: true, tuned for BBBA), so a merely-overridable value
+// would silently lose to that shipped default for any deployment that
+// hasn't customized it - and running the browser's own noiseSuppression
+// alongside DTLN actively degrades the signal DTLN receives.
+const forcedMicrophoneConstraints = {
+  noiseSuppression: false,
+};
+
+export default {
+  isSupported,
+  loadFiles,
+  createProcessorStream,
+  forcedMicrophoneConstraints,
+};

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
@@ -1,7 +1,9 @@
 import bbbaProvider from './providers/bbba';
+import workadventureDtlnProvider from './providers/workadventureDtln';
 
 const PROVIDERS = {
   bbba: bbbaProvider,
+  workadventureDtln: workadventureDtlnProvider,
 };
 const DEFAULT_PROVIDER_ID = 'bbba';
 

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
@@ -1,277 +1,48 @@
-// files loaded during loadWasmProcessorFiles
-const loadedFiles = {
-  // store first caught error
-  error: null,
-  // BBBA-mapi.wasm
-  wasmBlob: null,
-  // BBBA-mapi.js
-  wasmJS: null,
-  // mapi-proc.js
-  worklet: null,
+import bbbaProvider from './providers/bbba';
+
+const PROVIDERS = {
+  bbba: bbbaProvider,
+};
+const DEFAULT_PROVIDER_ID = 'bbba';
+
+const getActiveProviderId = () => {
+  const configured = window.meetingClientSettings.public.media.audio
+    .audioWasmProcessing.provider;
+  return PROVIDERS[configured] ? configured : DEFAULT_PROVIDER_ID;
 };
 
-// The active audio processor for runtime control (setWasmProcessorEnabled/Parameter etc).
-// Updated when a processor is adopted as the primary via doGUM.
-let audioProcessor = null;
+const getActiveProvider = () => PROVIDERS[getActiveProviderId()];
 
-// Registry of all live {processor, audioContext} pairs, idx by output stream ID.
+const getProviderForcedMicrophoneConstraints = () => getActiveProvider()
+  .forcedMicrophoneConstraints;
+
+// The active provider's control handle, for runtime calls
+// (setWasmProcessorEnabled/Parameter). Updated when a processor is adopted
+// as the primary via doGUM (bridge/service.js).
+let activeProviderControl = null;
+
+// Registry of all live {control, context} pairs, idx by output stream ID.
 // Allows explicit cleanup of specific processors without affecting others
 const processorRegistry = new Map();
 
-// check if wasm processor is supported, assigned to undefined if not checked yet
-let wasmProcessorUnsupportedError;
+const isWasmProcessorSupported = () => getActiveProvider().isSupported();
 
-// create audio worklet or script processor
-// we rely on script processor because worklets must run at 128 block size, which is not possible on low-spec machines
-const createWasmProcessor = (audioContext, stream) => {
-  return new Promise((resolve, reject) => {
-    const contextSource = audioContext.createMediaStreamSource(stream);
-    const contextDestination = audioContext.createMediaStreamDestination();
+const loadWasmProcessorFiles = () => getActiveProvider().loadFiles();
 
-    if (! navigator.userAgent.match(/Android/i)) {
-      // Using Audio Worklet
-      const processorBlob = new Blob([loadedFiles.worklet], { type: 'text/javascript' });
-      const processorURL = URL.createObjectURL(processorBlob);
+const createWasmProcessorStream = async (stream) => {
+  const {
+    stream: outputStream, context, setEnabled, destroy, setParameter,
+  } = await getActiveProvider().createProcessorStream(stream);
 
-      audioContext.audioWorklet.addModule(processorURL).then(() => {
-        const audioProcessorOptions = {
-          channelCount: 1,
-          numberOfInputs: 1,
-          numberOfOutputs: 1,
-          outputChannelCount: [1],
-        };
-        const processor = new AudioWorkletNode(audioContext, 'mapi-proc', audioProcessorOptions);
-        processor.port.onmessage = (event) => {
-          if (event.data?.type === 'loaded') {
-            processor.port.postMessage({ type: 'param', symbol: "intensity", value: 100 });
-            processor.port.postMessage({ type: 'param', symbol: "leveler_target", value: -18 });
-            processor.port.postMessage({ type: 'param', symbol: "sb_strength", value: 60 });
-            processor.port.postMessage({ type: 'param', symbol: "mb_strength", value: 60 });
-            processor.port.postMessage({ type: 'param', symbol: "pre_gain", value: 2 });
-            processor.port.postMessage({ type: 'param', symbol: "post_gain", value: 0 });
-
-            contextSource.connect(processor);
-            processor.connect(contextDestination);
-            resolve({ stream: contextDestination.stream, processor });
-          } else if (event.data?.type === 'error') {
-            reject(event.data.error);
-          }
-        };
-        processor.port.postMessage({ type: 'init', wasm: loadedFiles.wasmBlob, js: loadedFiles.wasmJS });
-
-      }).catch(reject);
-      return;
-    }
-
-    // fallback with createScriptProcessor follows here
-
-    // execute JS to expose the emscripten load module function
-    const jsfn_bbba = new Function(loadedFiles.wasmJS + 'return mapi_bbba;');
-    const create_module_bbba = jsfn_bbba.call();
-
-    // audio setup
-    const bufferSize = 8192;
-    const numberOfInputs = 1;
-    const numberOfOutputs = 1;
-    const processor = audioContext.createScriptProcessor(bufferSize, numberOfInputs, numberOfOutputs);
-
-    // create the wasm module and instance
-    create_module_bbba({
-      instantiateWasm: (imports, successCallback) => {
-        WebAssembly.instantiate(loadedFiles.wasmBlob, imports)
-        .then(output => {
-          successCallback(output.instance, output.module);
-        })
-        .catch(reject);
-        return {};
-      },
-      postRun: function(module) {
-        const handle = module._mapi_create(audioContext.sampleRate, bufferSize);
-
-        const audioData = module._malloc(module.HEAPF32.BYTES_PER_ELEMENT * bufferSize);
-        const audioPtrs = module._malloc(module.HEAPU32.BYTES_PER_ELEMENT);
-        module.HEAPU32[audioPtrs + (0 << 2) >> 2] = audioData;
-
-        const maxSymbolLength = 255;
-        const csymbolData = module._malloc(maxSymbolLength);
-        const csymbol = (symbol) => {
-          const len = Math.min(maxSymbolLength, module.lengthBytesUTF8(symbol) + 1);
-          module.stringToUTF8(symbol, csymbolData, len);
-          return csymbolData;
-        }
-
-        let enabled = true;
-        processor.onaudioprocess = function (e) {
-          if (! enabled) {
-            e.outputBuffer.copyToChannel(e.inputBuffer.getChannelData(0), 0);
-            return;
-          }
-
-          let buffer = e.inputBuffer.getChannelData(0);
-
-          for (let i = 0; i < bufferSize; ++i)
-            module.HEAPF32[audioData + (i << 2) >> 2] = buffer[i];
-
-          module._mapi_process(handle, audioPtrs, audioPtrs, bufferSize);
-
-          buffer = e.outputBuffer.getChannelData(0);
-          for (let i = 0; i < bufferSize; ++i)
-            buffer[i] = module.HEAPF32[audioData + (i << 2) >> 2];
-        };
-
-        // use same API as worklet for pushing changes
-        processor.port = {
-          postMessage: (data) => {
-            switch (data.type)
-            {
-              case 'enable':
-                enabled = !!data.enable;
-                break;
-              case 'param':
-                module._mapi_set_parameter(handle, csymbol(data.symbol), data.value);
-                break;
-              case 'destroy':
-                break;
-            }
-          },
-        };
-
-        contextSource.connect(processor);
-        processor.connect(contextDestination);
-        resolve({ stream: contextDestination.stream, processor });
-      },
-    });
+  processorRegistry.set(outputStream.id, {
+    context,
+    control: { setEnabled, destroy, setParameter },
   });
+
+  return outputStream;
 };
 
-// create an audio processor on top of a stream, trigger Promise resolve with a processed stream
-const createWasmProcessorStream = (stream) => new Promise((resolve, reject) => {
-  // fetch sampleRate from stream
-  const { sampleRate } = stream.getAudioTracks()[0]?.getSettings() || {};
-
-  // create audio context first
-  const audioContext = new AudioContext({ sampleRate });
-  const closeAndReject = (error) => {
-    audioContext.close?.().catch(() => {});
-    reject(error);
-  };
-
-  // function to load audio worklet, called once audio context is running
-  const loadAudioWorklet = () => {
-    createWasmProcessor(audioContext, stream).then(({ stream: outputStream, processor }) => {
-      processorRegistry.set(outputStream.id, {
-        processor,
-        context: audioContext,
-      });
-      resolve(outputStream);
-    }).catch(closeAndReject);
-  };
-
-  // Firefox allows to resume right away, while Chrome does not
-  // handle both cases here
-  audioContext.resume().then(loadAudioWorklet).catch((err) => {
-    // Chrome does not allow to load worklet while audio context is suspended
-    // resuming audio context requires user interaction
-    if (audioContext.state === 'suspended') {
-      const resume = () => {
-        audioContext.resume().then(loadAudioWorklet).catch(closeAndReject);
-        document.removeEventListener('click', resume);
-      };
-      document.addEventListener('click', resume);
-    } else {
-      closeAndReject(err);
-    }
-  });
-});
-
-const isWasmProcessorSupported = () => {
-  if (typeof wasmProcessorUnsupportedError !== 'undefined') {
-    return !wasmProcessorUnsupportedError;
-  }
-
-  if (typeof AudioContext === 'undefined') {
-    wasmProcessorUnsupportedError = 'AudioContext unsupported';
-    return false;
-  }
-  if (typeof WebAssembly === 'undefined') {
-    wasmProcessorUnsupportedError = 'WebAssembly unsupported';
-    return false;
-  }
-  // eslint-disable-next-line max-len
-  if (!WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 2, 8, 1, 1, 97, 1, 98, 3, 127, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 5, 1, 1, 97, 3, 1]))) {
-    wasmProcessorUnsupportedError = 'Importable/Exportable mutable globals unsupported';
-    return false;
-  }
-
-  wasmProcessorUnsupportedError = '';
-  return true;
-};
-
-// load processor files, trigger Promise resolve when all done
-const loadWasmProcessorFiles = () => new Promise((resolve, reject) => {
-  // early check
-  if (!isWasmProcessorSupported()) {
-    reject(wasmProcessorUnsupportedError);
-    return;
-  }
-
-  const checkResolved = () => {
-    if (loadedFiles.wasmBlob && loadedFiles.wasmJS && loadedFiles.worklet) {
-      resolve(true);
-      return true;
-    }
-    if (loadedFiles.error) {
-      reject(loadedFiles.error);
-      return true;
-    }
-    return false;
-  };
-  const catchHandler = (error) => {
-    // only reject Promise once
-    if (!loadedFiles.error) {
-      loadedFiles.error = error;
-      reject(loadedFiles.error);
-    }
-  };
-
-  // try again in case of previous error
-  loadedFiles.error = null;
-
-  // return early if already loaded before
-  if (checkResolved()) return;
-
-  // check if SIMD is supported, needed for old Safari versions
-  const supportsSIMD = WebAssembly.validate(
-    // eslint-disable-next-line max-len
-    new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8, 0, 65, 0, 253, 15, 253, 98, 11]),
-  );
-
-  // load wasm files and worklet
-  const pathMatch = window.location.pathname.match('^(.*)/html5client/?$');
-  const serverPathPrefix = pathMatch ? pathMatch[1] : '';
-  const basepath = `${serverPathPrefix}/html5client/wasm/`;
-  const suffix = supportsSIMD ? '' : '-nosimd';
-  fetch(`${basepath}BBBA${suffix}-mapi.wasm`).then((resp) => {
-    resp.arrayBuffer().then((bytes) => {
-      loadedFiles.wasmBlob = bytes;
-      checkResolved();
-    }).catch(catchHandler);
-  }).catch(catchHandler);
-  fetch(`${basepath}BBBA${suffix}-mapi.js`).then((resp) => {
-    resp.text().then((text) => {
-      loadedFiles.wasmJS = text;
-      checkResolved();
-    }).catch(catchHandler);
-  }).catch(catchHandler);
-  fetch(`${basepath}mapi-proc.js`).then((resp) => {
-    resp.text().then((text) => {
-      loadedFiles.worklet = text;
-      checkResolved();
-    }).catch(catchHandler);
-  }).catch(catchHandler);
-});
-
-// Destroy a specific WASM processor by its output stream or stream ID.
+// Destroy a specific processor by its output stream or stream ID.
 const destroyWasmProcessor = (streamOrId) => {
   const streamId = typeof streamOrId === 'string' ? streamOrId : streamOrId?.id;
 
@@ -281,12 +52,11 @@ const destroyWasmProcessor = (streamOrId) => {
 
   if (!entry) return;
 
-  entry.processor?.port?.postMessage({ type: 'destroy' });
+  entry.control?.destroy?.();
   entry.context?.close?.().catch(() => {});
   processorRegistry.delete(streamId);
 
-  // Clear the runtime processor var if it pointed to the destroyed processor
-  if (audioProcessor === entry.processor) audioProcessor = null;
+  if (activeProviderControl === entry.control) activeProviderControl = null;
 };
 
 // Promote a processor (by its output stream) as the primary for runtime control.
@@ -296,26 +66,22 @@ const adoptWasmProcessor = (streamOrId) => {
   const streamId = typeof streamOrId === 'string' ? streamOrId : streamOrId?.id;
   const entry = streamId ? processorRegistry.get(streamId) : null;
 
-  audioProcessor = entry?.processor || null;
+  activeProviderControl = entry?.control || null;
 };
 
-// run-time changes to wasm processor
 const setWasmProcessorEnabled = (enabled) => {
-  if (audioProcessor) {
-    audioProcessor.port.postMessage({ type: 'enable', enable: enabled });
-  }
+  activeProviderControl?.setEnabled?.(enabled);
 };
 
 const setWasmProcessorParameter = (index, value) => {
-  if (audioProcessor) {
-    audioProcessor.port.postMessage({ type: 'param', index, value });
-  }
+  activeProviderControl?.setParameter?.(index, value);
 };
 
 export {
   adoptWasmProcessor,
   createWasmProcessorStream,
   destroyWasmProcessor,
+  getProviderForcedMicrophoneConstraints,
   isWasmProcessorSupported,
   loadWasmProcessorFiles,
   setWasmProcessorEnabled,

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/wasmCapability.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/wasmCapability.js
@@ -1,0 +1,29 @@
+// check if wasm processor is supported, assigned to undefined if not checked yet
+let wasmProcessorUnsupportedError;
+
+const isGenericWasmProcessingSupported = () => {
+  if (typeof wasmProcessorUnsupportedError !== 'undefined') {
+    return !wasmProcessorUnsupportedError;
+  }
+
+  if (typeof AudioContext === 'undefined') {
+    wasmProcessorUnsupportedError = 'AudioContext unsupported';
+    return false;
+  }
+  if (typeof WebAssembly === 'undefined') {
+    wasmProcessorUnsupportedError = 'WebAssembly unsupported';
+    return false;
+  }
+  // eslint-disable-next-line max-len
+  if (!WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 2, 8, 1, 1, 97, 1, 98, 3, 127, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 5, 1, 1, 97, 3, 1]))) {
+    wasmProcessorUnsupportedError = 'Importable/Exportable mutable globals unsupported';
+    return false;
+  }
+
+  wasmProcessorUnsupportedError = '';
+  return true;
+};
+
+export {
+  isGenericWasmProcessingSupported,
+};

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -639,6 +639,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
         allowAudioJoinCancel: true,
         audioWasmProcessing: {
           enabled: false,
+          provider: 'bbba',
           constraints: {
             echoCancellation: true,
             autoGainControl: true,

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -1389,7 +1389,17 @@ class AudioManager {
   }
 
   async updateAudioConstraints(constraints) {
+    const prevInputStream = this.inputStream;
+
     await this.bridge.updateAudioConstraints(constraints);
+    this.inputStream = this.bridge ? this.bridge.inputStream : this.inputStream;
+
+    // Bridges may re-acquire the stream when doing this. Cleanup is in order if
+    // applicable (i.e.: old one is stale, compare via id).
+    if (prevInputStream && (prevInputStream.id !== this.inputStream?.id)) {
+      destroyWasmProcessor(prevInputStream);
+      MediaStreamUtils.stopMediaStreamTracks(prevInputStream);
+    }
   }
 
   /**

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -34,6 +34,7 @@
         "@types/node": "^20.5.7",
         "@types/ramda": "^0.29.2",
         "@types/react": "^18.2.18",
+        "@workadventure/noise-suppression": "0.1.1",
         "autoprefixer": "^10.4.4",
         "babel-runtime": "~6.26.0",
         "bigbluebutton-html-plugin-sdk": "0.1.24",
@@ -3875,6 +3876,63 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
@@ -5242,6 +5300,15 @@
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
       "license": "MIT"
     },
+    "node_modules/@ricky0123/vad-web": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@ricky0123/vad-web/-/vad-web-0.0.30.tgz",
+      "integrity": "sha512-cJyYrh4YeeUBJcbR9Bic/bFDyB9qBkAepvpuWM3vLxnAi7bC3VHzf51UeNdT+OtY4D7MLAgV8iJMc4z41ZnaWg==",
+      "license": "ISC",
+      "dependencies": {
+        "onnxruntime-web": "^1.17.0"
+      }
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.56.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
@@ -6505,6 +6572,16 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@workadventure/noise-suppression": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@workadventure/noise-suppression/-/noise-suppression-0.1.1.tgz",
+      "integrity": "sha512-G2RmkYpLgHy44mFasv+XNQUqQv27r0XqO9lJ2FSr9fnK2QWP97gXPrgRRPtsoqChb5849Cdk0AhbeW1Zc1tKPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ricky0123/vad-web": "^0.0.30",
+        "fft.js": "^4.0.4"
       }
     },
     "node_modules/@wry/caches": {
@@ -10238,6 +10315,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fft.js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fft.js/-/fft.js-4.0.4.tgz",
+      "integrity": "sha512-f9c00hphOgeQTlDyavwTtu6RiK8AIFjD6+jvXkNkpeQ7rirK3uFWVpalkoS4LAwbdX7mfZ8aoBfFVQX1Re/8aw==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -10399,6 +10482,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -10856,6 +10945,12 @@
       "peerDependencies": {
         "graphql": ">=0.11 <=16"
       }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -12893,6 +12988,12 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13551,6 +13652,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz",
+      "integrity": "sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.27.0.tgz",
+      "integrity": "sha512-ogDLsqIozHZwifPuN37OproAo0byX6t43/bP8GzeZWBWD6MOGExswFAx3up4NS/vvWBOg2u2PXomDt3rMmdQSg==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.27.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/open": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
@@ -13966,6 +14087,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
@@ -14616,6 +14743,29 @@
         "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -77,6 +77,7 @@
     "@types/node": "^20.5.7",
     "@types/ramda": "^0.29.2",
     "@types/react": "^18.2.18",
+    "@workadventure/noise-suppression": "0.1.1",
     "autoprefixer": "^10.4.4",
     "babel-runtime": "~6.26.0",
     "bigbluebutton-html-plugin-sdk": "0.1.24",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -905,12 +905,25 @@ public:
       # by closing the audio modal while audio is being negotiated.
       # If false, the audio modal will be locked until the process finishes.
       allowAudioJoinCancel: true
-      # audioWasmProcessing: audio input processing through WASM/BBBA
-      #   enabled: whether BBBA should be exposed to users. If false, browser's
-      #            built-in audio processing will be used instead.
+      # audioWasmProcessing: audio input processing through WASM
+      #   enabled: whether advanced/WASM processing should be exposed to users.
+      #            If false, browser's built-in audio processing will be used instead.
+      #   provider: which WASM backend runs the processing - 'bbba' or
+      #             'workadventureDtln'. Defaults to 'bbba' if unset/unrecognized.
       #   constraints: browser-level audio constraints applied ON TOP of WASM processing.
+      #                Not every value here is guaranteed to reach the browser as-is:
+      #                a provider can force its own value for a given constraint,
+      #                overriding whatever is configured below, when running the
+      #                browser's native filter alongside its WASM processing would
+      #                hurt rather than help. A provider's forced value always wins.
+      #                Each provider declares its overrides (if any) via
+      #                forcedMicrophoneConstraints, in
+      #                imports/ui/components/audio/audio-processor/providers/:
+      #                  - bbba: none. Every constraint below is honored as configured.
+      #                    (providers/bbba.js)
       audioWasmProcessing:
         enabled: false
+        provider: bbba
         constraints:
           echoCancellation: true
           autoGainControl: true

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -911,16 +911,8 @@ public:
       #   provider: which WASM backend runs the processing - 'bbba' or
       #             'workadventureDtln'. Defaults to 'bbba' if unset/unrecognized.
       #   constraints: browser-level audio constraints applied ON TOP of WASM processing.
-      #                Not every value here is guaranteed to reach the browser as-is:
-      #                a provider can force its own value for a given constraint,
-      #                overriding whatever is configured below, when running the
-      #                browser's native filter alongside its WASM processing would
-      #                hurt rather than help. A provider's forced value always wins.
-      #                Each provider declares its overrides (if any) via
-      #                forcedMicrophoneConstraints, in
-      #                imports/ui/components/audio/audio-processor/providers/:
-      #                  - bbba: none. Every constraint below is honored as configured.
-      #                    (providers/bbba.js)
+      #                Providers can force their own value for a given constraint,
+      #                overriding whatever is configured below.
       audioWasmProcessing:
         enabled: false
         provider: bbba

--- a/bigbluebutton-tests/playwright/audio/liveKitProbe.ts
+++ b/bigbluebutton-tests/playwright/audio/liveKitProbe.ts
@@ -86,6 +86,7 @@ export interface LocalMicState {
   allMuted: boolean;
   canPublish: boolean;
   canSubscribe: boolean;
+  trackSids: string[];
 }
 
 export const getLocalMicState = (page: PlaywrightPage): Promise<LocalMicState> =>
@@ -104,8 +105,61 @@ export const getLocalMicState = (page: PlaywrightPage): Promise<LocalMicState> =
       allMuted: pubs.length === 0 || pubs.every((pub) => pub.isMuted),
       canPublish: room.localParticipant.permissions?.canPublish ?? false,
       canSubscribe: room.localParticipant.permissions?.canSubscribe ?? false,
+      trackSids: pubs.map((pub) => pub.trackSid).filter((sid): sid is string => !!sid),
     };
   }, LK_NOT_EXPOSED_ERR_MSG);
+
+export interface MicContinuitySample {
+  atMs: number;
+  trackSids: string[];
+  micPublications: number;
+  allMuted: boolean;
+}
+
+// Samples the local mic publication continuously. The bug this guards against
+// is transient: a republish mutes the new track and a corrective unmute may win
+// the race. Sampling proves the invariant held throughout, not just at the end.
+export const startLocalMicWatch = (page: PlaywrightPage, intervalMs = 100): Promise<void> =>
+  page.evaluate((interval) => {
+    const w = window as TestWindow & {
+      bbbMicWatchSamples?: MicContinuitySample[];
+      bbbMicWatchTimer?: ReturnType<typeof setInterval>;
+    };
+
+    if (w.bbbMicWatchTimer) clearInterval(w.bbbMicWatchTimer);
+
+    w.bbbMicWatchSamples = [];
+
+    w.bbbMicWatchTimer = setInterval(() => {
+      const room = w.liveKitRoom;
+
+      if (!room) return;
+
+      const pubs = Array.from(room.localParticipant.audioTrackPublications.values()).filter(
+        (pub) => pub.source === 'microphone',
+      );
+
+      w.bbbMicWatchSamples?.push({
+        atMs: Date.now(),
+        trackSids: pubs.map((pub) => pub.trackSid).filter((sid): sid is string => !!sid),
+        micPublications: pubs.length,
+        allMuted: pubs.length === 0 || pubs.every((pub) => pub.isMuted),
+      });
+    }, interval);
+  }, intervalMs);
+
+export const stopLocalMicWatch = (page: PlaywrightPage): Promise<MicContinuitySample[]> =>
+  page.evaluate(() => {
+    const w = window as TestWindow & {
+      bbbMicWatchSamples?: MicContinuitySample[];
+      bbbMicWatchTimer?: ReturnType<typeof setInterval>;
+    };
+
+    if (w.bbbMicWatchTimer) clearInterval(w.bbbMicWatchTimer);
+    w.bbbMicWatchTimer = undefined;
+
+    return w.bbbMicWatchSamples ?? [];
+  });
 
 // Identities of LK users publishing an unmuted mic track. LiveKit identity == BBB intId for web users.
 export const getAudioPublisherIdentities = (page: PlaywrightPage): Promise<string[]> =>

--- a/bigbluebutton-tests/playwright/options/audioProcessingMode.ts
+++ b/bigbluebutton-tests/playwright/options/audioProcessingMode.ts
@@ -53,11 +53,14 @@ export type AudioProcessingModeValue = 'advanced' | 'standard' | 'original';
 // 'standard' mode browser-level filters (media.audio.microphoneConstraints)
 // and the 'advanced'/WASM ones (media.audio.audioWasmProcessing.constraints),
 // regardless of what the server under test actually ships.
+export type AudioWasmProvider = 'bbba' | 'workadventureDtln';
+
 export function audioProcessingModeOverrides(
   wasmEnabled: boolean,
   processingMode: AudioProcessingModeValue,
   microphoneConstraints?: ClientSettingsOverrides,
   wasmConstraints?: ClientSettingsOverrides,
+  provider?: AudioWasmProvider,
 ): ClientSettingsOverrides {
   return {
     public: {
@@ -65,6 +68,7 @@ export function audioProcessingModeOverrides(
         audio: {
           audioWasmProcessing: {
             enabled: wasmEnabled,
+            ...(provider ? { provider } : {}),
             ...(wasmConstraints ? { constraints: wasmConstraints } : {}),
           },
           ...(microphoneConstraints ? { microphoneConstraints } : {}),
@@ -111,6 +115,10 @@ export class AudioProcessingMode extends MultiUsers {
 
   wasmProcessorWasLoaded(): boolean {
     return this.wasmRequestUrls.length > 0;
+  }
+
+  getWasmRequestUrls(): string[] {
+    return [...this.wasmRequestUrls];
   }
 
   async openSettings(): Promise<void> {

--- a/bigbluebutton-tests/playwright/options/audioProcessingMode.ts
+++ b/bigbluebutton-tests/playwright/options/audioProcessingMode.ts
@@ -130,6 +130,18 @@ export class AudioProcessingMode extends MultiUsers {
     await this.modPage.waitAndClick(e.audioTab);
   }
 
+  async selectProcessingMode(mode: AudioProcessingModeValue): Promise<void> {
+    const radio = {
+      advanced: e.advancedFilteringRadio,
+      standard: e.standardFilteringRadio,
+      original: e.originalAudioRadio,
+    }[mode];
+
+    await this.openAudioSettings();
+    await this.modPage.waitAndClick(radio);
+    await this.modPage.waitAndClick(e.saveSettingsButton);
+  }
+
   async joinWithMicrophone(): Promise<void> {
     await this.modPage.waitAndClick(e.joinAudio);
     await connectMicrophone(this.modPage);

--- a/bigbluebutton-tests/playwright/options/audioProcessingModeTrack.spec.ts
+++ b/bigbluebutton-tests/playwright/options/audioProcessingModeTrack.spec.ts
@@ -151,4 +151,75 @@ test.describe('Audio processing mode - actual getUserMedia constraints', { tag: 
     expect(lastConstraints).toMatchObject(wasmConstraintsOverride);
     expect(lastConstraints).not.toMatchObject(microphoneConstraintsOverride);
   });
+
+  test('loads the WorkAdventure/DTLN processor for Advanced filtering when configured', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    const audioProcessingMode = new AudioProcessingMode(browser, context);
+    await audioProcessingMode.trackWasmProcessorRequests(page);
+    await audioProcessingMode.initModPage(page, {
+      testInfo,
+      clientSettingsOverrides: audioProcessingModeOverrides(
+        true,
+        'advanced',
+        undefined,
+        undefined,
+        'workadventureDtln',
+      ),
+    });
+
+    await audioProcessingMode.joinWithMicrophone();
+
+    await expect(async () => {
+      expect(audioProcessingMode.wasmProcessorWasLoaded()).toBe(true);
+    }).toPass();
+
+    // Rule out a silent fallback to bbba (which would also flip
+    // wasmProcessorWasLoaded() to true via its own .wasm fetch) - confirm
+    // at least one observed request is NOT one of BBBA's named files.
+    const wasmUrls = audioProcessingMode.getWasmRequestUrls();
+    expect(wasmUrls.some((url) => !url.toLowerCase().includes('bbba'))).toBe(true);
+  });
+
+  test('forces noiseSuppression off for Advanced filtering with the WorkAdventure/DTLN provider, even if audioWasmProcessing.constraints says otherwise', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    await captureGetUserMediaAudioConstraints(page);
+
+    const audioProcessingMode = new AudioProcessingMode(browser, context);
+    await audioProcessingMode.trackWasmProcessorRequests(page);
+    // Deliberately the opposite of what this provider needs - settings.yml
+    // ships audioWasmProcessing.constraints.noiseSuppression: true by
+    // default (tuned for BBBA), so this reproduces that exact shipped
+    // default rather than a contrived override, to prove the forced
+    // constraint - not just a default - is what makes this work.
+    await audioProcessingMode.initModPage(page, {
+      testInfo,
+      clientSettingsOverrides: audioProcessingModeOverrides(
+        true,
+        'advanced',
+        undefined,
+        { echoCancellation: true, autoGainControl: true, noiseSuppression: true },
+        'workadventureDtln',
+      ),
+    });
+
+    await audioProcessingMode.joinWithMicrophone();
+
+    await expect(async () => {
+      expect(audioProcessingMode.wasmProcessorWasLoaded()).toBe(true);
+    }).toPass();
+
+    const captured = await getCapturedAudioConstraints(page);
+    const lastConstraints = captured[captured.length - 1];
+    expect(lastConstraints).toMatchObject({
+      echoCancellation: true,
+      autoGainControl: true,
+      noiseSuppression: false,
+    });
+  });
 });

--- a/bigbluebutton-tests/playwright/options/audioProcessingModeTrack.spec.ts
+++ b/bigbluebutton-tests/playwright/options/audioProcessingModeTrack.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from '@playwright/test';
 
+import { getLocalMicState, startLocalMicWatch, stopLocalMicWatch, type TestWindow } from '../audio/liveKitProbe';
+import { ELEMENT_WAIT_LONGER_TIME } from '../core/constants';
+import { elements as e } from '../core/elements';
+import { isLiveKit } from '../core/livekit';
+import { ClientSettingsOverrides } from '../core/page';
 import { test } from '../core/setup/fixtures';
 import {
   AudioProcessingMode,
@@ -221,5 +226,141 @@ test.describe('Audio processing mode - actual getUserMedia constraints', { tag: 
       autoGainControl: true,
       noiseSuppression: false,
     });
+  });
+});
+
+const hasExactConstraint = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && 'exact' in (value as Record<string, unknown>);
+
+// Overall rationale of this test block: an audio filter change must not
+// disturb the microphone publication - i.e.: no mute/unmute state flap.
+test.describe('Audio processing mode - publication continuity', { tag: ['@ci', '@media'] }, () => {
+  test('keeps the same microphone publication when the processing mode changes', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    test.skip(!isLiveKit, 'publication continuity is specific to the LiveKit audio bridge');
+
+    await captureGetUserMediaAudioConstraints(page);
+    await page.addInitScript(() => {
+      (window as TestWindow).BBB_EXPOSE_LIVEKIT_ROOM = true;
+    });
+
+    const audioProcessingMode = new AudioProcessingMode(browser, context);
+    await audioProcessingMode.initModPage(page, {
+      testInfo,
+      clientSettingsOverrides: audioProcessingModeOverrides(true, 'standard'),
+    });
+
+    await audioProcessingMode.joinWithMicrophone();
+    await audioProcessingMode.modPage.waitAndClick(e.unmuteMicButton);
+    await audioProcessingMode.modPage.hasElement(e.isTalking, 'should be unmuted after clicking unmute');
+
+    const before = await getLocalMicState(page);
+    expect(before.micPublications, 'a mic track should be published while unmuted').toBeGreaterThan(0);
+    expect(before.allMuted, 'the mic track should be unmuted before the mode change').toBeFalsy();
+
+    // Watch microphone state _across the test_; flapping may occur throughout,
+    // so checking start-end is not sufficient.
+    await startLocalMicWatch(page);
+    await audioProcessingMode.selectProcessingMode('original');
+    // Covers the ~5s unpublishOnMute window the spurious mute would arm.
+    // The magic 7s may need to be changed if the unpublishOnMute defaults ever change.
+    // so be aware if flakiness hits this test in the future.
+    await audioProcessingMode.modPage.page.waitForTimeout(7000);
+    const samples = await stopLocalMicWatch(page);
+
+    // Guarantee audio mode actually changed
+    const captured = (await getCapturedAudioConstraints(page)) as CapturedAudioConstraints[];
+    expect(
+      captured.some((c) => c && c.echoCancellation === false && c.noiseSuppression === false),
+      'the Original-audio constraints should have reached getUserMedia',
+    ).toBe(true);
+
+    // Guarantee updateAudioConstraints/mic re-acquisition PINS the deviceId.
+    // Not pinning (ie ideal) has been a source of bugs (of the selected device
+    // state mismatch sort).
+    const reacquired = captured.find((c) => c && c.echoCancellation === false && c.noiseSuppression === false);
+    expect(reacquired?.deviceId, 'the re-acquire must pin the active input device').toBeTruthy();
+    expect(
+      hasExactConstraint(reacquired?.deviceId),
+      'the re-acquire must pin the device with `exact`, not a bare/ideal deviceId',
+    ).toBe(true);
+
+    expect(samples.length, 'the publication should have been sampled during the change').toBeGreaterThan(0);
+    expect(
+      samples.filter((sample) => sample.allMuted),
+      'the user must never be muted by a processing-mode change',
+    ).toEqual([]);
+    expect(
+      samples.filter((sample) => JSON.stringify(sample.trackSids) !== JSON.stringify(before.trackSids)),
+      'the microphone publication must survive a processing-mode change',
+    ).toEqual([]);
+
+    await audioProcessingMode.modPage.hasElement(e.muteMicButton, 'the user must still be unmuted');
+  });
+
+  test('keeps a muted user muted when the processing mode changes, and unmute still works', async ({
+    browser,
+    context,
+    page,
+  }, testInfo) => {
+    test.skip(!isLiveKit, 'publication continuity is specific to the LiveKit audio bridge');
+
+    await page.addInitScript(() => {
+      (window as TestWindow).BBB_EXPOSE_LIVEKIT_ROOM = true;
+    });
+
+    const audioProcessingMode = new AudioProcessingMode(browser, context);
+    await audioProcessingMode.initModPage(page, {
+      testInfo,
+      // unpublishOnMute off on purpose: with it on, a muted user's track is gone
+      // within ~5s and `micPublications > 0` below would match nothing, making the
+      // assertion useless. Keeping the track published is what puts the swap on
+      // the muted-and-published path this guards.
+      clientSettingsOverrides: {
+        ...audioProcessingModeOverrides(true, 'standard'),
+        public: {
+          ...(audioProcessingModeOverrides(true, 'standard').public as ClientSettingsOverrides),
+          media: {
+            ...((audioProcessingModeOverrides(true, 'standard').public as ClientSettingsOverrides)
+              .media as ClientSettingsOverrides),
+            livekit: { audio: { unpublishOnMute: false } },
+          },
+        },
+      },
+    });
+
+    await audioProcessingMode.joinWithMicrophone();
+    await audioProcessingMode.modPage.hasElement(e.unmuteMicButton, 'should join audio muted');
+    // Publish the track, then mute it
+    await audioProcessingMode.modPage.waitAndClick(e.unmuteMicButton);
+    await audioProcessingMode.modPage.hasElement(e.isTalking, 'should be unmuted after clicking unmute');
+    await audioProcessingMode.modPage.waitAndClick(e.muteMicButton);
+    await audioProcessingMode.modPage.hasElement(e.unmuteMicButton, 'should be muted again');
+
+    const beforeMuted = await getLocalMicState(page);
+    expect(beforeMuted.micPublications, 'the mic track must stay published while muted').toBeGreaterThan(0);
+    expect(beforeMuted.allMuted, 'the mic track should be muted before the mode change').toBeTruthy();
+
+    await startLocalMicWatch(page);
+    await audioProcessingMode.selectProcessingMode('original');
+    await audioProcessingMode.modPage.page.waitForTimeout(7000);
+    const samples = await stopLocalMicWatch(page);
+
+    expect(samples.length, 'the publication should have been sampled during the change').toBeGreaterThan(0);
+    expect(
+      samples.filter((sample) => sample.micPublications > 0 && !sample.allMuted),
+      'a muted user must never start sending audio because of a mode change',
+    ).toEqual([]);
+    await audioProcessingMode.modPage.hasElement(e.unmuteMicButton, 'the user must still be muted');
+
+    await audioProcessingMode.modPage.waitAndClick(e.unmuteMicButton);
+    await audioProcessingMode.modPage.hasElement(
+      e.isTalking,
+      'audio must come back after unmuting',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
   });
 });

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1670,7 +1670,7 @@ If you are using LiveKit as audio gateway, use [bbb-livekit-stt](https://github.
 
 #### Advanced Filtering (WASM audio processing)
 
-BigBlueButton 4.0 ships with an optional WASM-based audio processor (internally referred to as "BBBA") that runs on top of the microphone stream. It is exposed to users as the **"Advanced Filtering"** option in the Settings > Audio tab, and offers an alternative to the browser's built-in audio processing ("Standard Filtering"), isolating the speaker's voice and eliminating background noise. Users who want no processing at all — for example when sharing music, where noise suppression and automatic gain control would be undesirable — can select "Original Audio" in the same tab.
+BigBlueButton 4.0 ships with an optional WASM-based audio processor that runs on top of the microphone stream. It is exposed to users as the **"Advanced Filtering"** option in the Settings > Audio tab, and offers an alternative to the browser's built-in audio processing ("Standard Filtering"), isolating the speaker's voice and eliminating background noise. Users who want no processing at all — for example when sharing music, where noise suppression and automatic gain control would be undesirable — can select "Original Audio" in the same tab.
 
 It is **disabled by default**. To make it available to users, set `enabled: true` under `public.media.audio.audioWasmProcessing` in `/etc/bigbluebutton/bbb-html5.yml`:
 
@@ -1678,12 +1678,17 @@ It is **disabled by default**. To make it available to users, set `enabled: true
 public:
   media:
     audio:
-      # audioWasmProcessing: audio input processing through WASM/BBBA
-      #   enabled: whether BBBA should be exposed to users. If false, the
-      #            browser's built-in audio processing is used instead.
+      # audioWasmProcessing: audio input processing through WASM
+      #   enabled: whether advanced/WASM processing should be exposed to users.
+      #            If false, the browser's built-in audio processing is used instead.
+      #   provider: which WASM backend runs the processing - 'bbba' or
+      #             'workadventureDtln'. Defaults to 'bbba' if unset/unrecognized.
       #   constraints: browser-level audio constraints applied ON TOP of WASM processing.
+      #                Providers can force their own value for a given constraint,
+      #                overriding whatever is configured here.
       audioWasmProcessing:
         enabled: true
+        provider: bbba
         constraints:
           echoCancellation: true
           autoGainControl: true

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -286,7 +286,7 @@ These changes apply to the client configuration file (`/etc/bigbluebutton/bbb-ht
 - `public.userList.searchBar.enabled` (default `true`) - enables the user list search field.
 - `public.app.appsGallery.maxPinnedApps` (default `3`) - maximum number of apps a user can pin in the Apps Gallery.
 - `public.sidebarNavigation.appsToLabelAsNew` (default `[]`) - apps to highlight with a "new" label (e.g. `poll`, `breakoutroom`, `timer`, `audio-captions`).
-- `public.media.audio.audioWasmProcessing` - configuration block for the "Advanced Filtering" (WASM/BBBA) audio-processing option; see [Dedicated Audio settings tab](#dedicated-audio-settings-tab).
+- `public.media.audio.audioWasmProcessing` - configuration block for the "Advanced Filtering" (WASM) audio-processing option; `provider` selects the backend (`bbba` default, or `workadventureDtln`) and a provider may override values set in `constraints`; see [Dedicated Audio settings tab](#dedicated-audio-settings-tab).
 - `public.app.defaultSettings.audio.processingMode` (default `standard`) - which of the three audio-processing modes (`advanced`, `standard`, `original`) comes pre-selected for a new user in Settings > Audio. `advanced` falls back to `standard` when WASM processing is unsupported by the browser or disabled server-side.
 - `public.media.audio.microphoneConstraints` - browser-level audio constraints (auto gain control, echo cancellation, noise suppression) applied when the user selects the `standard` audio-processing mode (moved from `public.app.defaultSettings.application.microphoneConstraints`).
 - `public.timer.presets`, `public.timer.quickAddButtons`, `public.timer.maxHours`, `public.timer.serverSyncTimeInterval` - timer presets and behavior.


### PR DESCRIPTION
## What does this PR do?

Adds a second WASM-based noise suppression provider, WorkAdventure/DTLN, as an alternative to BBBA for the "advanced" audio processing mode, and makes the WASM audio-processing backend pluggable per provider so this and future providers don't require branching provider-specific code inline in `audio-processor/service.js`.

- Extracts BBBA's WASM processing into its own provider module (`providers/bbba.js`) behind a small contract (`isSupported`/`loadFiles`/`createProcessorStream`/`forcedMicrophoneConstraints`), and factors the generic browser-capability probe into a shared `wasmCapability.js` helper.
- Adds a `media.audio.audioWasmProcessing.provider` setting (`bbba` or `workadventureDtln`, defaults to `bbba`) so admins can pick the active provider; existing deployments see no behavior change.
- Lets a provider declare `forcedMicrophoneConstraints` that always win over admin config in `settings.yml` — needed because running the browser's native noise suppression alongside a WASM provider's own processing can hurt rather than help. `workadventureDtln` forces `noiseSuppression: false`, per the package's own guidance.
- Fixes `doGUM()`'s getUserMedia retry ladder, which reset to a bare `{ audio: true }` on `OverconstrainedError`/`NotFoundError`/`NotReadableError`, discarding every already-resolved constraint (defaults, admin config, and now `forcedMicrophoneConstraints`). This was harmless for BBBA by coincidence, but would silently defeat a provider's forced `noiseSuppression: false`. The fallback now only gives up on `deviceId`.
- Fixes a no-op switch between the `original` and `advanced` audio processing modes: `getConstraintsForMode` returned the same shared object for both, so the change compared equal under `audio/container`'s shallow comparison and `updateAudioConstraints` never fired. `getConstraintsForMode` now always returns a new object.
- Fixes LiveKit audio constraint updates so they no longer republish the microphone: a constraint change previously went through `doGUM` + `setInputStream(force)`, which unpublishes and republishes the track, briefly dropping the user's unmuted state server-side. Depending on whether a corrective unmute won that race, this could leave the user muted for up to five seconds (until `unpublishOnMute` kicked in). `updateAudioConstraints` now uses `replaceTrack` to swap the track in place — no unpublish/publish cycle — and propagates mute state between the old and new tracks. Also pins the device with `exact` (previously unpinned, letting the browser silently substitute the default microphone) and releases the previous WASM processor after the swap.
- Adds the `workadventureDtln` provider itself, wrapping `@workadventure/noise-suppression`'s `createNoiseSuppressionAudioWorklet`. It runs at a fixed 16kHz/mono (unlike BBBA, which matches the source stream's rate), so it creates its own `AudioContext` instead of reusing a shared one.
- Adds Playwright coverage for the audio processing mode default and for exercising a real (non-mocked) audio track through it.

## How to test

1. Set the following in `settings.yml` (or override via the client's meeting settings), keeping `advanced` as the audio processing mode:

   ```yaml
   public:
     media:
       audio:
         audioWasmProcessing:
           enabled: true
           provider: workadventureDtln
   ```

2. Join a meeting, open the audio modal, and confirm the mic joins successfully with the WASM/advanced path active (no console errors from the worklet/`.wasm` loading).
3. Confirm the browser's native noise suppression is not also applied on top (the provider forces `noiseSuppression: false` regardless of the constraints block in `settings.yml`).
4. Switch provider back to `bbba` (or leave it unset) and confirm BBBA's behavior is unchanged from before this PR.
5. Run the new Playwright spec:

   ```bash
   cd bigbluebutton-tests/playwright
   npx playwright test options/audioProcessingModeTrack.spec.ts
   ```