### PR TITLE
fix: BlockNote difficult to use for math

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -17,6 +17,7 @@ import {
   ComponentsContext,
   FormattingToolbar,
   NestBlockButton,
+  SuggestionMenuController,
   UnnestBlockButton,
   useComponentsContext,
   useCreateBlockNote,
@@ -24,7 +25,7 @@ import {
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Menu as MantineMenu } from '@mantine/core';
 
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Plugin, PluginKey, Transaction } from '@tiptap/pm/state';
 import { Extension } from '@tiptap/core';
 import { defineMessages, useIntl } from 'react-intl';
 import Styled from './styles';
@@ -84,6 +85,17 @@ const escapeBlurExtension = Extension.create({
     };
   },
 });
+
+const shouldOpenSlashMenu = (transaction: Transaction) => {
+  const { $from } = transaction.selection;
+  if ($from.parent.type.isInGroup('tableContent')) return false;
+
+  const previousCharacter = $from.parent.textBetween(
+    Math.max(0, $from.parentOffset - 1),
+    $from.parentOffset,
+  );
+  return previousCharacter === '' || /\s/.test(previousCharacter);
+};
 
 // TODO: remove this workaround once y-prosemirror's cursor decoration can set `marks: []`
 // (the upstream-correct fix is `marks: []` on the cursor `Decoration.widget` in
@@ -480,6 +492,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
         editor={editor}
         theme="light"
         formattingToolbar={!STATIC_FORMATTING_TOOLBAR_ENABLED}
+        slashMenu={false}
         renderEditor={false}
       >
         {STATIC_FORMATTING_TOOLBAR_ENABLED && editable && (
@@ -507,7 +520,12 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             </div>
           </ToolbarWithAccessibleMenus>
         )}
-        <BlockNoteViewEditor />
+        <BlockNoteViewEditor>
+          <SuggestionMenuController
+            triggerCharacter="/"
+            shouldOpen={shouldOpenSlashMenu}
+          />
+        </BlockNoteViewEditor>
       </BlockNoteView>
       {isImportModalOpen && editable && (
         <MarkdownImportModal

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.spec.ts
@@ -17,6 +17,13 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
     await sharedNotes.typeInSharedNotes();
   });
 
+  test('Type fractions without opening the slash menu', async ({ browser, context }, testInfo) => {
+    linkIssue(25577);
+    const sharedNotes = new BlockNoteSharedNotes(browser, context);
+    await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });
+    await sharedNotes.typeFractionsWithoutOpeningSlashMenu();
+  });
+
   test('Format text in shared notes', async ({ browser, context }, testInfo) => {
     const sharedNotes = new BlockNoteSharedNotes(browser, context);
     await initializePages(sharedNotes, browser, { isMultiUser: true, createParameter: CREATE_PARAMETER, testInfo });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/sharednotes.ts
@@ -55,6 +55,39 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
   }
 
+  async typeFractionsWithoutOpeningSlashMenu() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.messagesSidebarButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startSharedNotesBlockNote(this.modPage);
+    const editorLocator = getBlockNoteEditorLocator(this.modPage);
+    const equation = '1/4 + 1/4 = 1/2';
+    await editorLocator.click();
+    await editorLocator.pressSequentially(equation);
+
+    await expect(
+      this.modPage.page.locator(e.blockNoteSlashMenuItem),
+      'a slash inside a fraction should not open the slash menu',
+    ).toHaveCount(0);
+
+    await editorLocator.press('Enter');
+    await expect(editorLocator, 'pressing Enter should keep the complete equation').toContainText(equation);
+
+    await editorLocator.pressSequentially('/');
+    await expect(
+      this.modPage.page.locator(e.blockNoteSlashMenuItem).first(),
+      'a slash at the start of a block should open the slash menu',
+    ).toBeVisible({ timeout: ELEMENT_WAIT_TIME });
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
+    await this.modPage.wasRemoved(e.hideNotesLabel, 'should not display the hide notes label');
+  }
+
   async formatTextInSharedNotes() {
     const { sharedNotesEnabled } = this.modPage.settings || {};
 


### PR DESCRIPTION
### What does this PR do?

changes blocknote slash menu behavior so it only opens if `/` is pressed at the start of a line or the previous character is a space

https://github.com/user-attachments/assets/ac48b785-5247-4d3b-bf06-adc9dc959fbf


### Closes Issue(s)
Closes #25577

### How to test
In shared notes, type 1/4+1/4=1/2 then press Enter.