### PR TITLE
fix(shared-notes): indent nested non-list blocks in HTML/PDF export

### DIFF
--- a/bbb-shared-notes-server/src/express/handlers/exportDocumentToHtml.ts
+++ b/bbb-shared-notes-server/src/express/handlers/exportDocumentToHtml.ts
@@ -27,9 +27,11 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
       // Convert blocks to HTML (using type assertion to handle schema differences)
       htmlContent = await editor.blocksToHTMLLossy(blocks as any);
 
-      // Replace empty paragraph tags with paragraphs containing a <br> tag
-      // This ensures empty lines are preserved in the HTML output
-      htmlContent = htmlContent.replaceAll('<p></p>', '<p><br></p>');
+      // Replace empty paragraph tags with paragraphs containing a <br> tag so
+      // empty lines are preserved in the HTML output. Indented empty lines are
+      // flattened to <p data-nesting-level="N"></p>, so keep that attribute
+      // (the stylesheet below indents them). See issues #25122 and #25585.
+      htmlContent = htmlContent.replace(/<p( data-nesting-level="\d+")?><\/p>/g, '<p$1><br></p>');
 
       // Strip hardcoded inline color styles from BlockNote color spans.
       // The data-style-type / data-value attributes remain, and the CSS below
@@ -47,6 +49,36 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
   } finally {
     await connection.disconnect();
   }
+
+  // Indentation for nested non-list blocks (issue #25585).
+  // blocksToHTMLLossy() preserves real nesting only for list items; every other
+  // nested block (paragraph, heading, quote) is flattened into a sibling that
+  // records its depth in a data-nesting-level="N" attribute. Indent those blocks
+  // by scoping a margin-left rule to the elements that carry the attribute
+  // directly. List items keep the attribute on the <li>, which already sits in a
+  // padded <ul>/<ol>, so <li> is deliberately excluded here - otherwise nested
+  // lists would be indented twice.
+  //
+  // The step matches the 2em padding-left of the exported lists, so a paragraph
+  // flattened out from under a bullet lines up with that bullet's content.
+  // wkhtmltopdf runs an old WebKit with no attr()/calc() in properties, so the
+  // depth cannot be read from the attribute at render time; the rules are
+  // enumerated per level up to a cap instead (attribute-value selectors already
+  // render there, see the color rules above). A depth beyond the cap is clamped
+  // to the maximum indent by a fallback rule placed before the enumerated ones:
+  // they share specificity, so the later per-level rule wins within range while
+  // deeper levels match only the fallback.
+  const NESTING_INDENT_STEP_PX = 32;
+  const MAX_NESTING_LEVEL = 10;
+  const NESTED_BLOCK_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote'];
+  const nestingIndentRules = [
+    `${NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level]`).join(', ')} { margin-left: ${MAX_NESTING_LEVEL * NESTING_INDENT_STEP_PX}px; }`,
+    ...Array.from({ length: MAX_NESTING_LEVEL }, (_, index) => {
+      const level = index + 1;
+      const selector = NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level="${level}"]`).join(', ');
+      return `${selector} { margin-left: ${level * NESTING_INDENT_STEP_PX}px; }`;
+    }),
+  ];
 
   // Create HTML document with styling
   const fullHtml = [
@@ -146,6 +178,9 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
       '   Checkbox items have <input> as the first child, so :first-child never matches them. */',
       String.raw`ul > li > p.bn-inline-content:first-child::before { content: "\2022\00A0"; }`,
       'li { margin-bottom: 4px; }',
+      '/* Indent nested non-list blocks (paragraphs, headings, quotes) that',
+      '   blocksToHTMLLossy() flattens into data-nesting-level siblings. */',
+      ...nestingIndentRules,
       'code {',
       '  background-color: #f6f8fa;',
       '  padding: 0.2em 0.4em;',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.spec.ts
@@ -1,0 +1,19 @@
+import { linkIssue } from '../../core/helpers';
+import { test } from '../../core/setup/fixtures';
+import { ExportIndentationSharedNotes } from './export-indentation';
+
+// Regression suite for BBB #25585: PDF/HTML export dropped the indentation of nested
+// non-list blocks (paragraphs, headings, quotes). The meeting is created per-test with
+// a seeded nested document (POST modules payload), so nothing is created in beforeEach.
+test.describe.parallel('Shared Notes - BlockNote export indentation', { tag: '@ci' }, () => {
+  let exportIndentation: ExportIndentationSharedNotes;
+
+  test.beforeEach(async ({ browser, context }) => {
+    linkIssue(25585);
+    exportIndentation = new ExportIndentationSharedNotes(browser, context);
+  });
+
+  test('Nested non-list blocks keep their indentation in the HTML/PDF export', async () => {
+    await exportIndentation.nestedBlocksKeepIndentationInExport();
+  });
+});

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.ts
@@ -1,0 +1,147 @@
+import { expect } from '@playwright/test';
+
+import { elements as e } from '../../core/elements';
+import { createMeetingWithModules } from '../../core/helpers';
+import { MultiUsers } from '../../user/multiusers';
+import { startBlockNoteSharedNotes } from './util';
+
+// Distinct texts so each block can be located by an exact text match.
+const L0 = 'IndentLevelZero';
+const L1 = 'IndentLevelOne';
+const L2 = 'IndentLevelTwo';
+const BULLET_PARENT = 'BulletParent';
+const BULLET_CHILD = 'BulletChild';
+const PARA_UNDER_BULLET = 'ParagraphUnderBullet';
+
+// Horizontal slack for boundingBox comparisons (sub-pixel rounding / font metrics).
+const X_EPSILON = 4;
+
+interface SeedBlock {
+  id: string;
+  type: string;
+  props: Record<string, unknown>;
+  content: { type: 'text'; text: string; styles: Record<string, unknown> }[];
+  children: SeedBlock[];
+}
+
+// Builds a BlockNote block in the shape documented for sharedNotesInitialContentJson
+// (see docs/development/api.md and the markdown spec's jsonModule helper).
+function block(id: string, type: string, text: string, children: SeedBlock[] = []): SeedBlock {
+  const props: Record<string, unknown> = { textAlignment: 'left', backgroundColor: 'default', textColor: 'default' };
+  if (type === 'heading') props.level = 2;
+  return { id, type, props, content: [{ type: 'text', text, styles: {} }], children };
+}
+
+// A document that exercises the bug: paragraphs nested by Tab (levels 0/1/2) and a
+// paragraph flattened out from under a bullet, plus a real nested bullet to guard
+// against list double-indentation.
+function seedModule(): string {
+  const blocks: SeedBlock[] = [
+    block('00000000-0000-0000-0000-000000000001', 'paragraph', L0, [
+      block('00000000-0000-0000-0000-000000000002', 'paragraph', L1, [
+        block('00000000-0000-0000-0000-000000000003', 'paragraph', L2),
+      ]),
+    ]),
+    block('00000000-0000-0000-0000-000000000004', 'bulletListItem', BULLET_PARENT, [
+      block('00000000-0000-0000-0000-000000000005', 'bulletListItem', BULLET_CHILD),
+      block('00000000-0000-0000-0000-000000000006', 'paragraph', PARA_UNDER_BULLET),
+    ]),
+  ];
+  const json = JSON.stringify(blocks);
+  return `<modules><module name="sharedNotesInitialContentJson"><![CDATA[${json}]]></module></modules>`;
+}
+
+export class ExportIndentationSharedNotes extends MultiUsers {
+  // Creates a meeting seeded with the nested document, then joins as moderator.
+  private async createAndJoinSeeded() {
+    const meetingId = await createMeetingWithModules(seedModule(), 'sharedNotesEditor=blocknote');
+    const context = await this.browser.newContext();
+    const page = await context.newPage();
+    await this.initModPage(page, { meetingId });
+  }
+
+  // Reproduces the product's "Export as PDF" action to obtain the export URL, then
+  // fetches the sibling HTML export (same handler, same generated HTML) so the layout
+  // can be measured in a real browser. Returns the exported HTML document.
+  private async fetchExportedHtml(): Promise<string> {
+    // The menu item calls window.open(...export/pdf...); stub it to capture the URL
+    // instead of spawning a popup/download.
+    await this.modPage.page.evaluate(() => {
+      (window as unknown as { bbbExportUrls: string[] }).bbbExportUrls = [];
+      window.open = ((url?: string | URL) => {
+        (window as unknown as { bbbExportUrls: string[] }).bbbExportUrls.push(String(url));
+        return null;
+      }) as typeof window.open;
+    });
+
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.page.locator(e.exportNotesAsPDF).click();
+
+    const pdfUrl = await this.modPage.page.evaluate(
+      () => (window as unknown as { bbbExportUrls: string[] }).bbbExportUrls[0],
+    );
+    expect(pdfUrl, 'clicking Export as PDF should open the export URL').toContain('/export/pdf');
+
+    // The PDF is rendered from this same HTML; measuring the HTML export is the
+    // faithful, headless way to assert the indentation the PDF will carry.
+    const htmlUrl = pdfUrl.replace('/export/pdf', '/export/html');
+    const response = await this.modPage.page.request.get(htmlUrl);
+    expect(response.ok(), `the HTML export should be served (GET ${htmlUrl})`).toBeTruthy();
+    return response.text();
+  }
+
+  async nestedBlocksKeepIndentationInExport() {
+    await this.createAndJoinSeeded();
+    await startBlockNoteSharedNotes(this.modPage);
+
+    const html = await this.fetchExportedHtml();
+
+    // Render the exported HTML in an isolated page and read each block's left edge.
+    const context = await this.browser.newContext();
+    const probe = await context.newPage();
+    try {
+      await probe.setContent(html);
+      const leftEdge = async (tag: string, text: string): Promise<number> => {
+        const box = await probe.locator(`${tag}:text-is("${text}")`).first().boundingBox();
+        expect(box, `"${text}" should be present in the exported HTML`).not.toBeNull();
+        return box!.x;
+      };
+
+      const xL0 = await leftEdge('p', L0);
+      const xL1 = await leftEdge('p', L1);
+      const xL2 = await leftEdge('p', L2);
+      const xBulletParent = await leftEdge('p', BULLET_PARENT);
+      const xBulletChild = await leftEdge('p', BULLET_CHILD);
+      const xParaUnderBullet = await leftEdge('p', PARA_UNDER_BULLET);
+
+      // The bug: nested paragraphs collapse to the same left margin. Fixed: each Tab
+      // level steps further right.
+      expect(xL1, 'a once-nested paragraph should be indented past its parent').toBeGreaterThan(xL0 + X_EPSILON);
+      expect(xL2, 'a twice-nested paragraph should be indented past the first level').toBeGreaterThan(xL1 + X_EPSILON);
+
+      // The issue's "further left than its own bullet": a paragraph flattened out from
+      // under a bullet used to sit at the page margin. It must now be indented at least
+      // to the bullet's content column.
+      expect(
+        xParaUnderBullet,
+        'a paragraph nested under a bullet should not render at the page margin',
+      ).toBeGreaterThan(xL0 + X_EPSILON);
+      expect(
+        xParaUnderBullet,
+        'a paragraph under a bullet should align with the bullet content, not fall short of it',
+      ).toBeGreaterThanOrEqual(xBulletParent - X_EPSILON);
+
+      // No regression: a real nested list item stays indented by exactly one list level
+      // (the ~32px list padding), not two. A margin rule that leaked onto <li> would
+      // roughly double this gap (~64px), so anything under 60px proves it did not.
+      const oneListLevel = xBulletChild - xBulletParent;
+      expect(oneListLevel, 'a nested bullet should still be indented past its parent').toBeGreaterThan(X_EPSILON);
+      expect(
+        oneListLevel,
+        'a nested bullet should be indented by a single list level (no double-indentation)',
+      ).toBeLessThan(60);
+    } finally {
+      await context.close();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the lost indentation of nested non-list blocks in the shared notes HTML/PDF export (issue bigbluebutton/bigbluebutton#25585). In the editor, paragraphs, headings, quotes and paragraphs under bullets can be nested with Tab; the in-app view indents them correctly, but the exported HTML (and the PDF generated from it by wkhtmltopdf) renders every nested block flush left, and a paragraph placed under a list item even lands to the LEFT of its own bullet.

Root cause: the export stylesheet in `bbb-shared-notes-server` (`exportDocumentToHtml.ts`) had no rules consuming the `data-nesting-level` attribute that the BlockNote serializer (`blocksToHTMLLossy`) already emits on every block. The attribute carried the information; nothing translated it into margins.

## Implementation

- Generate stepped `margin-left` rules (32px per level, levels 1..10, with a clamp fallback for deeper nesting) scoped to `p[data-nesting-level]`, `h1`..`h6` and `blockquote` selectors, in the same per-attribute-selector style already used by the `[data-style-type]` color rules from bigbluebutton/bigbluebutton#25033. Lists are deliberately NOT touched: the oracle confirms `data-nesting-level` lands on the `<li>` itself (which the browser already indents via list styling), so scoping to `p,h1-h6,blockquote` cannot double-indent lists.
- The 32px step matches the existing indented-empty-line convention (`:32`) in the same stylesheet, which is also generalized to any nesting level for indented empty lines.

A brief walkthrough for reviewers: the serializer already writes `data-nesting-level="N"` on exported blocks; this PR only adds CSS that maps that attribute to a left margin. One file of product code changes; everything else is a new Playwright spec.

## Testing

- New e2e spec `sharednotes/blocknote/export-indentation.spec.ts`: fails on base (`xL1` expected `> 41.78`, received `37.78`), passes on this branch (left edges 37.78 / 69.78 / 101.78 for levels 0/1/2; paragraph-under-bullet moves from 37.78 to 69.78, aligning with its bullet content; nested bullet gap stays exactly 32px, proving no list double-indent).
- Full `sharednotes/blocknote` @ci suite: 30 passed, no regression (including PDF export, empty-notes PDF export, convert-notes-to-presentation).
- Real PDF verified from the live server endpoint (wkhtmltopdf 0.12.6): nested-paragraph text xMin steps from 21.77pt to 40.21pt / 58.65pt; paragraph-under-bullet aligns to the bullet column; bullets unchanged.
- Component typecheck + eslint clean.

### How to test

1. Create a meeting with shared notes (BlockNote enabled), open the notes editor.
2. Add a paragraph, then Tab-indent a second paragraph one level and a third two levels; add a bullet item and a paragraph nested under it.
3. Notes options -> Export -> HTML: before this PR all lines sit flush left; after, nesting steps 32px per level and the paragraph under the bullet aligns with the bullet text. Export PDF shows the same in the generated file.

Animated preview below - click the GIF to open the MP4 (higher quality, with controls):

[![Shared notes export indentation before/after](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/26710f31-62d6-4679-84c9-ad6de6fb2e61/comparison.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/ad63f338-7a9e-47e3-8274-e7750f38163a/before-after.mp4)

Evidence timestamps in the MP4: in-app notes (before) - 00:12; exported HTML flush left (bug) - 00:24; in-app notes (after) - 00:38; exported HTML stepped (fixed) - 00:50.

Exported HTML side by side:

![Exported HTML before/after](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/6cd31757-833b-4e60-a5a5-4f1f0b6703d2/comparison-html.png)

Real PDF export (wkhtmltopdf) side by side:

![Exported PDF before/after](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/c6e97f09-7a24-47c5-8f9f-64410df60e36/comparison-pdf.png)

## Notes

- The Markdown round-trip comment on the issue (indentation preserved through Markdown export) is a separate handler and out of scope for this PR.
- Backport to 3.0 is a clean cherry-pick; offered as follow-up on request.
