### PR TITLE
fix(etherpad): serve shared-notes pads via trailing-slash proxy_pass (#21417)

### DIFF
--- a/build/packages-template/bbb-etherpad/notes.nginx
+++ b/build/packages-template/bbb-etherpad/notes.nginx
@@ -5,11 +5,9 @@ location /pad/p/ {
         return 401;
     }
 
-    rewrite /pad/p/(.*) /p/$1 break;
-    rewrite ^/pad/p$ /pad/p/ permanent;
-    proxy_pass http://127.0.0.1:9001/p;
+    proxy_pass http://127.0.0.1:9001/p/;
     proxy_pass_header Server;
-    proxy_redirect /p /pad/p;
+    proxy_redirect /p/ /pad/p/;
     proxy_set_header Host $host;
     proxy_buffering off;
 


### PR DESCRIPTION
## Problem

Opening **Shared Notes** returns a 404: Etherpad receives a doubled path `/p//pad/p/<id>` and answers `Cannot GET`. Matches #21417.

## Root cause

The `location /pad/p/` block serves pads with:

```nginx
rewrite /pad/p/(.*) /p/$1 break;
proxy_pass http://127.0.0.1:9001/p;
```

Shared-notes pad names always contain a `$` (`g.XXXX$notes`, sent URL-encoded as `%24`). With `rewrite_log on;` the rewrite itself emits a doubled + truncated path:

```
"/pad/p/(.*)" matches "/pad/p/g.9jcYzXiAO8tqXKgh$notes"
rewritten data:        "/p//pad/p/g.9jcYzXiAO8tqXKg"
```

The `$` in the decoded URI corrupts the `$1` capture substitution, so Etherpad receives `/p//pad/p/<id>` → `Cannot GET`. Regular pads (no `$`) are unaffected, which is why only Shared Notes break. Reproduced on BBB 3.0 (jammy, nginx 1.18.0); it appears nginx/PCRE-build dependent, consistent with not every deployment hitting it.

## Fix

Drop the rewrite and use the canonical trailing-slash `proxy_pass`, which replaces the matched location prefix without any rewrite/capture — so the `$` in the pad name is never interpreted:

```nginx
proxy_pass http://127.0.0.1:9001/p/;
proxy_redirect /p/ /pad/p/;
```

`nginx -t` is clean; after reload the Shared Notes editor loads and is writable. Verified on a live BBB 3.0 install.

Refs #21417
