### PR TITLE
fix(client): Fix BlockNote link editing focus

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -357,12 +357,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   }, [editable]);
 
   // Keep editor focus when clicking SideMenu/DragHandleMenu items.
-  // Skip draggable="true" elements — preventDefault on mousedown prevents drag.
+  // Skip native editable controls and BlockNote form popovers so their focus is preserved.
+  // Also skip draggable="true" elements — preventDefault on mousedown prevents drag.
   React.useEffect(() => {
     const { portalElement } = editor;
     if (!portalElement) return undefined;
     const mousedownHandler = (e: MouseEvent) => {
-      if ((e.target as HTMLElement).closest('[draggable="true"]')) return;
+      const target = e.target as HTMLElement;
+      const nativeEditableSelector = '[draggable="true"], input, textarea, select, [contenteditable="true"], .bn-form-popover';
+      if (target.closest(nativeEditableSelector)) return;
       e.preventDefault();
       editor.focus();
     };

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -417,6 +417,11 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           .bn-mantine .bn-suggestion-menu {
             min-width: 300px;
           }
+          /* BlockNote fixes link form inputs at 300px, which overflows the
+             Shared Notes panel and scrolls the panel when an input is focused. */
+          .bn-mantine .bn-form-popover .mantine-TextInput-root {
+            width: 100%;
+          }
           /* Toolbar and editor are siblings inside .bn-container. DOM order matches
              visual order (toolbar first, editor second), so tab order is correct. */
           .bn-container {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -266,6 +266,17 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
       renderCursor: renderCollaborationCursor,
     },
     schema,
+    links: {
+      onClick: (event) => {
+        if (event.ctrlKey || event.metaKey) {
+          const anchor = (event.target as HTMLElement | null)?.closest<HTMLAnchorElement>(
+            'a[data-inline-content-type="link"]',
+          );
+          if (anchor?.href) window.open(anchor.href, '_blank', 'noopener,noreferrer');
+        }
+        return true;
+      },
+    },
     dictionary: {
       ...BlockNoteLocales[blockNoteLocale as keyof typeof BlockNoteLocales],
       placeholders: {

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -315,6 +315,8 @@ export const elements = {
   blockNoteEditable: '#bn-notes-scroll-container .bn-editor[contenteditable="true"]',
   blockNoteReadOnly: '#bn-notes-scroll-container .bn-editor[contenteditable="false"]',
   blockNoteToolbar: 'div[data-test="blockNoteToolbar"]',
+  blockNoteLinkToolbar: '.bn-link-toolbar',
+  blockNoteLinkForm: '.bn-form-popover',
   blockNoteUnderlineButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Underline"]',
   blockNoteAlignTextLeftButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Align text left"]',
   blockNoteSlashMenuItem: '.bn-suggestion-menu .bn-suggestion-menu-item',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -23,4 +23,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link URL and text can be edited', async () => {
     await blockNoteSharedNotes.linkUrlAndTextCanBeEdited();
   });
+
+  test('Link editor must not overflow the notes panel', async () => {
+    await blockNoteSharedNotes.linkEditorMustNotOverflowNotesPanel();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -19,4 +19,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test("Collaboration cursor must not embed a user's name in a link", async () => {
     await blockNoteSharedNotes.collaborationCursorMustNotEmbedInLink();
   });
+
+  test('Link URL and text can be edited', async () => {
+    await blockNoteSharedNotes.linkUrlAndTextCanBeEdited();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -27,4 +27,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test('Link editor must not overflow the notes panel', async () => {
     await blockNoteSharedNotes.linkEditorMustNotOverflowNotesPanel();
   });
+
+  test('Links open only on ctrl/cmd+click', async () => {
+    await blockNoteSharedNotes.linksOpenOnlyOnCtrlOrCmdClick();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,7 +6,7 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
-  hoverBlockNoteLink,
+  openBlockNoteLinkEditor,
   readLinkAndCursorState,
   startBlockNoteSharedNotes,
   WORD_JOINER,
@@ -33,11 +33,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
       timeout: ELEMENT_WAIT_LONGER_TIME,
     });
-    await hoverBlockNoteLink(this.modPage);
-    await this.modPage.page
-      .locator(e.blockNoteLinkToolbar)
-      .getByRole('button', { name: /edit link/i })
-      .click();
+    await openBlockNoteLinkEditor(this.modPage);
 
     const form = this.modPage.page.locator(e.blockNoteLinkForm);
     const urlInput = form.locator('input[name="url"]');
@@ -61,6 +57,45 @@ export class BlockNoteSharedNotes extends MultiUsers {
     );
   }
 
+  async linkEditorMustNotOverflowNotesPanel() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    const notesPanel = this.modPage.page.locator(e.sharedNotesBackground);
+    const panelX = (await notesPanel.boundingBox())?.x;
+    expect(panelX, 'shared notes panel should be visible').toBeDefined();
+
+    await openBlockNoteLinkEditor(this.modPage);
+    const form = this.modPage.page.locator(e.blockNoteLinkForm);
+    const urlInput = form.locator('input[name="url"]');
+    const textInput = form.locator('input[name="title"]');
+
+    expect((await notesPanel.boundingBox())?.x, 'opening the link editor must not move the notes panel').toBe(panelX);
+    await urlInput.click();
+    expect((await notesPanel.boundingBox())?.x, 'focusing the URL input must not move the notes panel').toBe(panelX);
+    await textInput.click();
+    expect((await notesPanel.boundingBox())?.x, 'focusing the text input must not move the notes panel').toBe(panelX);
+
+    const { scrollWidth, clientWidth } = await form.evaluate((element) => ({
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    }));
+    expect(scrollWidth, 'link editor content must fit within the popover').toBeLessThanOrEqual(clientWidth);
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.
@@ -68,7 +103,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
     const { sharedNotesEnabled } = this.modPage.settings || {};
     if (!sharedNotesEnabled) {
       await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
-      await this.modPage.wasRemoved(e.sharedNotes, 'should not display the shared notes button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
       return;
     }
 

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -6,6 +6,7 @@ import { MultiUsers } from '../../user/multiusers';
 import {
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
+  hoverBlockNoteLink,
   readLinkAndCursorState,
   startBlockNoteSharedNotes,
   WORD_JOINER,
@@ -15,6 +16,51 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async linkUrlAndTextCanBeEdited() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    await hoverBlockNoteLink(this.modPage);
+    await this.modPage.page
+      .locator(e.blockNoteLinkToolbar)
+      .getByRole('button', { name: /edit link/i })
+      .click();
+
+    const form = this.modPage.page.locator(e.blockNoteLinkForm);
+    const urlInput = form.locator('input[name="url"]');
+    const textInput = form.locator('input[name="title"]');
+    const editedUrl = `${LINK_URL}/bigbluebutton`;
+    const editedText = 'BigBlueButton repository';
+
+    await expect(urlInput, 'URL input should receive initial focus').toBeFocused();
+    await urlInput.click();
+    await expect(urlInput, 'URL input should retain focus when clicked').toBeFocused();
+    await urlInput.fill(editedUrl);
+    await textInput.click();
+    await expect(textInput, 'text input should retain focus when clicked').toBeFocused();
+    await textInput.fill(editedText);
+    await textInput.press('Enter');
+
+    await expect(link, 'should update the link text').toHaveText(editedText);
+    await expect(link, 'should update the link URL').toHaveAttribute('href', editedUrl);
+    await expect(editor, 'edited values should not be inserted as document text').not.toContainText(
+      `${LINK_URL} /bigbluebutton`,
+    );
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -35,6 +35,7 @@ export class BlockNoteSharedNotes extends MultiUsers {
       timeout: ELEMENT_WAIT_LONGER_TIME,
     });
     const context = this.modPage.page.context();
+    await context.route(LINK_URL, (route) => route.fulfill({ contentType: 'text/html', body: '' }));
     const plainClickPage = await Promise.all([
       context.waitForEvent('page', { timeout: 3000 }).catch(() => null),
       clickBlockNoteLink(this.modPage),

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -4,6 +4,7 @@ import { ELEMENT_WAIT_LONGER_TIME } from '../../core/constants';
 import { elements as e } from '../../core/elements';
 import { MultiUsers } from '../../user/multiusers';
 import {
+  clickBlockNoteLink,
   getBlockNoteEditorLocator,
   getBlockNoteLinkLocator,
   openBlockNoteLinkEditor,
@@ -16,6 +17,40 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async linksOpenOnlyOnCtrlOrCmdClick() {
+    const { sharedNotesEnabled } = this.modPage.settings || {};
+    if (!sharedNotesEnabled) {
+      await this.modPage.hasElement(e.chatButton, 'should display the public chat button');
+      await this.modPage.wasRemoved(e.sharedNotesSidebarButton, 'should not display the shared notes button');
+      return;
+    }
+
+    await startBlockNoteSharedNotes(this.modPage);
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type(`${LINK_URL} `);
+
+    const link = getBlockNoteLinkLocator(this.modPage);
+    await expect(link, 'should create a link from the typed URL').toHaveCount(1, {
+      timeout: ELEMENT_WAIT_LONGER_TIME,
+    });
+    const context = this.modPage.page.context();
+    const plainClickPage = await Promise.all([
+      context.waitForEvent('page', { timeout: 3000 }).catch(() => null),
+      clickBlockNoteLink(this.modPage),
+    ]).then(([page]) => page);
+    expect(plainClickPage, 'a plain click must not open the link').toBeNull();
+    const caretInsideLink = await link.evaluate((anchor) => {
+      const selection = window.getSelection();
+      return !!selection?.anchorNode && anchor.contains(selection.anchorNode);
+    });
+    expect(caretInsideLink, 'a plain click should leave the caret inside the link').toBe(true);
+    await this.modPage.page.keyboard.press('Escape');
+    const [newPage] = await Promise.all([context.waitForEvent('page'), clickBlockNoteLink(this.modPage, true)]);
+    await expect.poll(() => newPage.url()).toBe(LINK_URL);
+    await newPage.close();
+  }
+
   async linkUrlAndTextCanBeEdited() {
     const { sharedNotesEnabled } = this.modPage.settings || {};
     if (!sharedNotesEnabled) {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,6 +81,22 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
+export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
+  const link = getBlockNoteLinkLocator(testPage);
+  const rect = await link.evaluate((element) => {
+    const clientRect = element.getClientRects()[0];
+    return {
+      x: clientRect.x,
+      y: clientRect.y,
+      width: clientRect.width,
+      height: clientRect.height,
+    };
+  });
+  await testPage.page.mouse.move(rect.x + 5, rect.y + rect.height / 2);
+  await testPage.page.mouse.move(rect.x + rect.width / 2, rect.y + rect.height / 2, { steps: 5 });
+  await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
 // Collects every uncaught exception raised by the client from now on. The array is
 // filled asynchronously, so it must be read *after* the interaction under test.
 export function collectPageErrors(testPage: Page): string[] {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -97,6 +97,15 @@ export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
   await testPage.page.locator(e.blockNoteLinkToolbar).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
 }
 
+export async function openBlockNoteLinkEditor(testPage: Page): Promise<void> {
+  await hoverBlockNoteLink(testPage);
+  await testPage.page
+    .locator(e.blockNoteLinkToolbar)
+    .getByRole('button', { name: /edit link/i })
+    .click();
+  await testPage.page.locator(e.blockNoteLinkForm).waitFor({ timeout: ELEMENT_WAIT_LONGER_TIME });
+}
+
 // Collects every uncaught exception raised by the client from now on. The array is
 // filled asynchronously, so it must be read *after* the interaction under test.
 export function collectPageErrors(testPage: Page): string[] {

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/util.ts
@@ -81,6 +81,25 @@ export function getBlockNoteLinkLocator(testPage: Page) {
   return testPage.page.locator(`${e.blockNoteEditor} a`);
 }
 
+export async function clickBlockNoteLink(testPage: Page, withModifier = false): Promise<void> {
+  const link = getBlockNoteLinkLocator(testPage);
+  const { rect, bounds } = await link.evaluate((element) => {
+    const firstRect = element.getClientRects()[0];
+    const boundingRect = element.getBoundingClientRect();
+    return {
+      rect: { x: firstRect.x, y: firstRect.y, width: firstRect.width, height: firstRect.height },
+      bounds: { x: boundingRect.x, y: boundingRect.y },
+    };
+  });
+  await link.click({
+    modifiers: withModifier ? [process.platform === 'darwin' ? 'Meta' : 'Control'] : [],
+    position: {
+      x: rect.x - bounds.x + rect.width / 2,
+      y: rect.y - bounds.y + rect.height / 2,
+    },
+  });
+}
+
 export async function hoverBlockNoteLink(testPage: Page): Promise<void> {
   const link = getBlockNoteLinkLocator(testPage);
   const rect = await link.evaluate((element) => {


### PR DESCRIPTION
## Summary

Two fixes to the link editor in the Shared Notes (issue 25226).

**Editing a link didn't work.** Clicking the URL or the text field of the link
popover closed it, and whatever you typed next went into the note itself instead
of into the link. The notes panel keeps the editor focused when you click things
like the side menu or the drag handle, and that behavior was also grabbing focus
away from the popover fields. It now leaves form fields alone, while the side
menu and drag handle keep working as before.

**Opening the link editor pushed the panel sideways.** The popover's fields have
a fixed width that is wider than the Shared Notes panel, so the browser scrolled
the panel to fit them whenever a field was focused. The fields now fit the space
the popover actually has.

Clicking a link always navigated away. Any click on a link opened it in a new
tab, so there was no way to click into a link to edit it. A plain click now places
the caret inside the link, and ctrl/cmd+click opens it in a new tab — the usual
convention in editors.

## Closes

Closes #25226 

## Tests

Three new Playwright tests, sharing a helper that opens the link editor:

- Editing a link end to end — the URL and text fields keep focus when clicked,
  the link's text and destination are updated, and nothing typed leaks into the
  note body.
- The link editor stays put — the panel doesn't move when the editor opens or
  when either field is focused, and the popover no longer overflows.
- Links open only on ctrl/cmd+click — a plain click doesn't open a tab and leaves the caret inside the link; ctrl/cmd+click opens the URL in a new tab. The request is stubbed so the test never hits the network.

Along the way, an existing test referenced a shared notes selector that no longer
exists; it now points at the current one.

## Evidence

### Editing a link

Before:

[Before video (MP4)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/c11f4aa1-7e75-4169-9d21-869baf852e7f/before.mp4)

![Before: typed text lands in the note](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/2c49f1dd-58f0-4f86-9144-18b5a446929d/05-after-typing-in-url-field.png)

After:

[After video (MP4)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/47574a7d-112b-4319-aef2-ac0dcaba0743/after.mp4)

![After: link edited end-to-end](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-19/1b24528b-f236-4cdb-abd8-27257d063135/05-after-typing-in-url-field.png)

### Panel shifting

Before:

[![Before: link editor shifts the Shared Notes panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/a4171d66-d76e-4225-b1f3-21ba4a703a96/before.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/d1ea8cc5-87ac-4d6f-b426-3693d2533c7b/before.mp4)

After:

[![After: link editor remains inside the Shared Notes panel](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/d60d684a-320a-4a4a-9e6b-3ab7ed5b427f/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/090f4afb-8f8b-479d-bf04-b307e98496ae/after.mp4)
