### PR TITLE
fix(sidebar-navigation): stop ghost scrollbar in the navigation rail

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -203,6 +203,7 @@ const SidebarNavigation = ({
         )}
         <Styled.NavigationSidebarListItemsContainer
           ref={scrollRef}
+          data-test="sidebarNavigationScrollbox"
           isMobile={isMobile}
           noVirtualScrollboxBackground={noVirtualScrollboxBackground}
           isExpanded={isExpanded}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/component.tsx
@@ -2,9 +2,11 @@
 import React, { useCallback, memo } from 'react';
 import KEYS from '/imports/utils/keys';
 import resolveIcon from '/imports/ui/components/plugins/plugin-icon/utils';
-import { layoutDispatch, layoutSelectInput } from '/imports/ui/components/layout/context';
-import { Input } from '/imports/ui/components/layout/layoutTypes';
-import { ACTIONS, PANELS } from '/imports/ui/components/layout/enums';
+import { layoutDispatch, layoutSelect, layoutSelectInput } from '/imports/ui/components/layout/context';
+import { Input, Layout } from '/imports/ui/components/layout/layoutTypes';
+import {
+  ACTIONS, DEVICE_TYPE, PANELS,
+} from '/imports/ui/components/layout/enums';
 import TooltipContainer from '/imports/ui/components/common/tooltip/container';
 import { SidebarNavigationButtonProps } from './types';
 import Styled from './styles';
@@ -29,6 +31,11 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
   ariaDescribedBy,
 }) => {
   const layoutContextDispatch = layoutDispatch();
+  // Same source of truth as the rail scrollbox gutter (deviceType === MOBILE, i.e.
+  // width <= 599px), so the icon width and the gutter switch at the same threshold
+  // and the 600-640px band no longer dips the icons to the mobile size (issue 25564).
+  const deviceType = layoutSelect((i: Layout) => i.deviceType);
+  const isMobile = deviceType === DEVICE_TYPE.MOBILE;
   const sidebarContentAuxiliaryInput = layoutSelectInput((i: Input) => i.sidebarContentAuxiliary);
   const {
     sidebarContentPanel: sidebarContentPanelAuxiliary,
@@ -107,6 +114,7 @@ const SidebarNavigationButton: React.FC<SidebarNavigationButtonProps> = ({
         $hasPrivateNotification={hasPrivateNotification}
         $disabled={isDisabled}
         $locked={isLocked}
+        $isMobile={isMobile}
       >
         {resolveIcon(iconName)}
         {children}

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/styles.ts
@@ -3,6 +3,7 @@ import {
   borderSize,
   borderSizeSmall,
   navigationSidebarListItemsWidth,
+  navigationSidebarListItemsWidthDesktop,
   navigationSidebarIconSize,
   navigationSidebarIconSizeSmallHeight,
   navigationSidebarNotificationBadgeSize,
@@ -33,9 +34,17 @@ export const ListItem = styled.div<ListItemProps>`
   text-decoration: none;
   color: ${colorGrayIcons};
   cursor: pointer;
-  width: ${navigationSidebarListItemsWidth};
+  /* The fixed desktop size is in rem, so it follows the user font-size setting.
+     Cap it at 100% (the scrollbox content box, which is the rail minus the
+     reserved scrollbar gutter) so a larger font scales the icon up but never
+     overflows the content box. */
+  width: min(${navigationSidebarListItemsWidthDesktop}, 100%);
   aspect-ratio: 1 / 1;
   border-radius: 50%;
+
+  ${({ $isMobile }: ListItemProps) => $isMobile && `
+    width: ${navigationSidebarListItemsWidth};
+  `}
 
   > i {
     font-size: ${navigationSidebarIconSize};

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/sidebar-navigation-button/types.ts
@@ -27,4 +27,5 @@ export interface ListItemProps {
   $hasPrivateNotification?: boolean;
   $disabled?: boolean;
   $locked?: boolean;
+  $isMobile?: boolean;
 }

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/styles.ts
@@ -115,6 +115,11 @@ const NavigationSidebarListItemsContainer = styled(ScrollboxVertical)<{
     gap: ${navigationSidebarListItemsContainerGapSmallHeight};
   }
 
+  ${({ isMobile }) => !isMobile && `
+    scrollbar-gutter: stable both-edges;
+    scrollbar-width: thin;
+  `}
+
   ${({ isExpanded }) => (isExpanded ? `
     max-height: 100%;
     opacity: 1;

--- a/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
+++ b/bigbluebutton-html5/imports/ui/stylesheets/styled-components/general.js
@@ -53,6 +53,11 @@ const navigationSidebarListItemsContainerGapSmallHeight = 'calc(9rem / 14)';
 const navigationSidebarListItemsGap = 'calc(12rem / 14)';
 const navigationSidebarListItemsGapSmallHeight = 'calc(6rem / 14)';
 const navigationSidebarListItemsWidth = '65%';
+// Fixed desktop size for the rail icon buttons. On desktop the rail width is
+// constant (60px), so a fixed size decouples the icons from the scrollbar width
+// and stops the classic scrollbar from shrinking the very icons that caused it
+// (issue 25564). Mobile keeps the responsive percentage above.
+const navigationSidebarListItemsWidthDesktop = 'calc(39rem / 14)';
 const navigationSidebarIconSize = 'calc(18rem / 14)';
 const navigationSidebarIconSizeSmallHeight = '1rem';
 const navigationSidebarNotificationBadgeSize = '14px';
@@ -172,6 +177,7 @@ export {
   navigationSidebarListItemsGap,
   navigationSidebarListItemsGapSmallHeight,
   navigationSidebarListItemsWidth,
+  navigationSidebarListItemsWidthDesktop,
   navigationSidebarIconSize,
   navigationSidebarIconSizeSmallHeight,
   navigationSidebarNotificationBadgeSize,

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -52,6 +52,7 @@ export const elements = {
   closePopup: 'button[data-test="closePopup"]',
   restoreWelcomeMessages: 'li[data-test="restoreWelcomeMessages"]',
   navigationSidebarContainer: 'div[data-test="navigationSidebarContainer"]',
+  sidebarNavigationScrollbox: 'div[data-test="sidebarNavigationScrollbox"]',
   appsGallerySidebarButton: 'div[data-test="appsGallerySidebarButton"]',
 
   // Accesskey

--- a/bigbluebutton-tests/playwright/layouts/sidebarNavigation.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/sidebarNavigation.spec.ts
@@ -1,0 +1,61 @@
+import { initializePages, linkIssue } from '../core/helpers';
+import { test } from '../core/setup/fixtures';
+import { SidebarNavigation } from './sidebarNavigation';
+
+test.describe.parallel('Sidebar navigation rail - scrollbar', { tag: '@ci' }, () => {
+  // Spec A: the ghost scrollbar. Needs real (space-consuming) scrollbars, so it
+  // runs on an own browser without --hide-scrollbars (still headless in CI).
+  test('Icon buttons keep their size when the rail enters the ghost-scrollbar band', async ({
+    browser,
+    context,
+  }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    try {
+      await nav.initModPageWithVisibleScrollbars(testInfo);
+      await nav.assertGhostScrollbarAbsent();
+    } finally {
+      await nav.closeVisibleScrollbarsPage();
+    }
+  });
+
+  // Spec C: dynamic viewport resizes, the real-world trigger of the issue.
+  test('Rail stays correct across viewport resizes (bar only on real overflow)', async ({
+    browser,
+    context,
+  }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    try {
+      await nav.initModPageWithVisibleScrollbars(testInfo);
+      await nav.assertResizeInvariant();
+    } finally {
+      await nav.closeVisibleScrollbarsPage();
+    }
+  });
+
+  // Spec B: CI-safe height-budget guard on the default (scrollbars-hidden) browser.
+  test('Sidebar navigation scrolls only when the content really overflows', async ({ browser, context }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    await initializePages(nav, browser, { testInfo });
+    await nav.assertOverflowIsHonest();
+  });
+
+  // Spec D: the icon size follows the user font-size setting but never overflows the
+  // scrollbox content box. Needs real scrollbars, so it runs on the same own browser
+  // as Specs A and C: with the gutter hidden the content box bound is invisible.
+  test('Rail icons follow the user font size and stay within the rail content box', async ({
+    browser,
+    context,
+  }, testInfo) => {
+    linkIssue(25564);
+    const nav = new SidebarNavigation(browser, context);
+    try {
+      await nav.initModPageWithVisibleScrollbars(testInfo);
+      await nav.assertFontSizeScaling();
+    } finally {
+      await nav.closeVisibleScrollbarsPage();
+    }
+  });
+});

--- a/bigbluebutton-tests/playwright/layouts/sidebarNavigation.ts
+++ b/bigbluebutton-tests/playwright/layouts/sidebarNavigation.ts
@@ -1,0 +1,224 @@
+import { Browser, BrowserContext, chromium, expect, TestInfo } from '@playwright/test';
+
+import { elements as e } from '../core/elements';
+import { Page } from '../core/page';
+import { MultiUsers } from '../user/multiusers';
+
+// Viewports used to exercise the navigation rail (icon column) at 1280px wide.
+// REGIME_A is tall enough that every icon fits with no scroll. GHOST_BAND is the
+// height range where, before the fix, the classic 5px scrollbar reserved width
+// with zero real overflow and shrank the icons that caused it (issue 25564).
+// OVERFLOW is genuinely too short, so a real scrollbar is expected there.
+const REGIME_A = { width: 1280, height: 616 };
+const GHOST_BAND = { width: 1280, height: 550 };
+const OVERFLOW = { width: 1280, height: 460 };
+
+interface RailMetrics {
+  offsetWidth: number;
+  clientWidth: number;
+  scrollHeight: number;
+  clientHeight: number;
+  buttonCount: number;
+  buttonWidth: number | null;
+  lastButtonReachable: boolean;
+}
+
+// Reads the geometry of the rail scrollbox and of its circular icon buttons.
+async function measureRail(page: Page): Promise<RailMetrics> {
+  return page.page.evaluate((selector) => {
+    const scrollbox = document.querySelector(selector) as HTMLElement;
+    // The rail icons are the only circular, square-aspect elements inside the scrollbox.
+    const buttons = Array.from(scrollbox.querySelectorAll('div')).filter((el) => {
+      const style = getComputedStyle(el);
+      return style.borderRadius === '50%' && style.aspectRatio === '1 / 1';
+    });
+    const first = buttons[0] as HTMLElement | undefined;
+    const last = buttons[buttons.length - 1] as HTMLElement | undefined;
+    // Scroll to the bottom and check the last icon is inside the viewport (regime C).
+    scrollbox.scrollTop = scrollbox.scrollHeight;
+    let lastButtonReachable = false;
+    if (last) {
+      const boxRect = scrollbox.getBoundingClientRect();
+      const lastRect = last.getBoundingClientRect();
+      lastButtonReachable = lastRect.bottom <= boxRect.bottom + 1 && lastRect.top >= boxRect.top - 1;
+    }
+    scrollbox.scrollTop = 0;
+    return {
+      offsetWidth: scrollbox.offsetWidth,
+      clientWidth: scrollbox.clientWidth,
+      scrollHeight: scrollbox.scrollHeight,
+      clientHeight: scrollbox.clientHeight,
+      buttonCount: buttons.length,
+      buttonWidth: first ? Number(first.getBoundingClientRect().width.toFixed(2)) : null,
+      lastButtonReachable,
+    };
+  }, e.sidebarNavigationScrollbox);
+}
+
+async function measureAt(page: Page, viewport: { width: number; height: number }): Promise<RailMetrics> {
+  await page.setHeightWidthViewPortSize(viewport);
+  // Let the layout engine and the rail ResizeObserver settle after the resize.
+  await page.page.waitForTimeout(600);
+  return measureRail(page);
+}
+
+export class SidebarNavigation extends MultiUsers {
+  private scrollbarBrowser?: Browser;
+
+  private scrollbarContext?: BrowserContext;
+
+  // The ghost scrollbar only forms with classic (space-consuming) scrollbars.
+  // Playwright launches Chromium with --hide-scrollbars by default, which paints
+  // zero-width scrollbars and hides the bug entirely. This moderator page runs on
+  // an own browser with that flag removed, so the rail behaves like a real desktop
+  // Chrome. It still runs headless in CI (no @only-headed needed).
+  async initModPageWithVisibleScrollbars(testInfo?: TestInfo): Promise<void> {
+    this.scrollbarBrowser = await chromium.launch({
+      headless: true,
+      ignoreDefaultArgs: ['--hide-scrollbars'],
+    });
+    this.scrollbarContext = await this.scrollbarBrowser.newContext();
+    const page = await this.scrollbarContext.newPage();
+    this.modPage = new Page(this.scrollbarBrowser, page, testInfo ?? null);
+    await this.modPage.setHeightWidthViewPortSize(REGIME_A);
+    await this.modPage.init(true, { fullName: 'Moderator', testInfo });
+    await this.modPage.hasElement(e.sidebarNavigationScrollbox, 'the sidebar navigation rail should be displayed');
+  }
+
+  async closeVisibleScrollbarsPage(): Promise<void> {
+    await this.scrollbarContext?.close();
+    await this.scrollbarBrowser?.close();
+  }
+
+  // Spec A - the ghost scrollbar itself. With real (space-consuming) scrollbars,
+  // the icon buttons must keep the same size at the ghost-band height as in the
+  // tall regime. Before the fix they shrink (39px -> 35.75px) because the bar
+  // steals width, which is the feedback loop that keeps a zero-overflow bar alive.
+  async assertGhostScrollbarAbsent(): Promise<void> {
+    const tall = await measureAt(this.modPage, REGIME_A);
+    expect(tall.buttonWidth, 'a reference icon size should be measured in the tall regime').not.toBeNull();
+
+    const band = await measureAt(this.modPage, GHOST_BAND);
+    expect(
+      band.buttonWidth,
+      'icon buttons must not shrink when the rail height enters the old ghost-scrollbar band',
+    ).toBe(tall.buttonWidth);
+    // Honest bar: if the content fits, there is no scroll; if it does not, the bar
+    // is backed by real overflow. Either way a zero-overflow reserved bar is gone.
+    if (band.scrollHeight <= band.clientHeight) {
+      expect(band.lastButtonReachable, 'every icon should be visible when the content fits').toBeTruthy();
+    } else {
+      expect(band.lastButtonReachable, 'the last icon should be reachable by scrolling when it overflows').toBeTruthy();
+    }
+  }
+
+  // Spec C - dynamic viewport resizes (the real field trigger). The icon size must
+  // stay constant across the whole critical range, a real scrollbar must appear
+  // only on genuine overflow, and resizing back to the tall regime must leave no
+  // residual scrollbar.
+  async assertResizeInvariant(): Promise<void> {
+    const base = await measureAt(this.modPage, REGIME_A);
+    const reference = base.buttonWidth;
+
+    for (const height of [590, 560, 550, 520, 490, 460]) {
+      // eslint-disable-next-line no-await-in-loop
+      const metrics = await measureAt(this.modPage, { width: 1280, height });
+      expect(metrics.buttonWidth, `icon size must stay constant at 1280x${height}`).toBe(reference);
+    }
+
+    const overflow = await measureAt(this.modPage, OVERFLOW);
+    expect(overflow.scrollHeight, 'the content should really overflow at a very short height').toBeGreaterThan(
+      overflow.clientHeight,
+    );
+    expect(
+      overflow.lastButtonReachable,
+      'the last icon should be reachable by scrolling on real overflow',
+    ).toBeTruthy();
+
+    const backToTall = await measureAt(this.modPage, REGIME_A);
+    expect(
+      backToTall.scrollHeight,
+      'no overflow should remain after resizing back to the tall regime',
+    ).toBeLessThanOrEqual(backToTall.clientHeight);
+    expect(backToTall.buttonWidth, 'icon size must return to the reference size').toBe(reference);
+  }
+
+  // Spec B - CI-safe invariant guard on the default (scrollbars-hidden) browser.
+  // It does not see the ghost bar, but it guards the height budget: the content
+  // fits in the tall regime and a real scroll reaches the last icon when short.
+  async assertOverflowIsHonest(): Promise<void> {
+    const tall = await measureAt(this.modPage, REGIME_A);
+    expect(tall.scrollHeight, 'the rail content should fit without scroll in the tall regime').toBeLessThanOrEqual(
+      tall.clientHeight,
+    );
+
+    const overflow = await measureAt(this.modPage, OVERFLOW);
+    expect(overflow.scrollHeight, 'the rail content should overflow at a very short height').toBeGreaterThan(
+      overflow.clientHeight,
+    );
+    expect(
+      overflow.lastButtonReachable,
+      'the last icon should be reachable by scrolling when it overflows',
+    ).toBeTruthy();
+  }
+
+  // Measures the rail at one user font-size setting. BBB applies the setting to the
+  // html root element (settings/submenus/application, 12-20px), and the layout
+  // observer only rewrites the root font size on a viewport resize, so the value
+  // survives a plain measurement here. Restored before returning.
+  private measureAtFontSize(fontSize: string): Promise<{
+    buttonWidth: number | null;
+    clientWidth: number;
+    scrollWidth: number;
+  }> {
+    return this.modPage.page.evaluate(
+      ([selector, size]) => {
+        const html = document.getElementsByTagName('html')[0];
+        const previousFontSize = html.style.fontSize;
+        html.style.fontSize = size;
+        const scrollbox = document.querySelector(selector) as HTMLElement;
+        const button = Array.from(scrollbox.querySelectorAll('div')).find((el) => {
+          const style = getComputedStyle(el);
+          return style.borderRadius === '50%' && style.aspectRatio === '1 / 1';
+        }) as HTMLElement | undefined;
+        const result = {
+          buttonWidth: button ? Number(button.getBoundingClientRect().width.toFixed(2)) : null,
+          clientWidth: scrollbox.clientWidth,
+          scrollWidth: scrollbox.scrollWidth,
+        };
+        html.style.fontSize = previousFontSize;
+        return result;
+      },
+      [e.sidebarNavigationScrollbox, fontSize],
+    );
+  }
+
+  // Spec D - locks in the font-size coupling and its bound. The desktop icon size is
+  // min(calc(39rem / 14), 100%), so it follows the user font-size setting up to the
+  // scrollbox content box (the rail minus the reserved scrollbar gutter). It must keep
+  // tracking the setting, and at the largest setting it must stay inside that content
+  // box, so the rail never overflows horizontally (issue 25564). This needs real
+  // (space-consuming) scrollbars: with --hide-scrollbars the gutter is zero and the
+  // content box is the whole rail, so the bound being guarded here cannot be observed.
+  async assertFontSizeScaling(): Promise<void> {
+    const base = await measureAt(this.modPage, REGIME_A);
+    const reference = base.buttonWidth;
+    expect(reference, 'a reference icon size should be measured at the default font size').not.toBeNull();
+
+    // Below the cap the icon still tracks the setting, which is the rem coupling.
+    const smallest = await this.measureAtFontSize('12px');
+    expect(
+      smallest.buttonWidth as number,
+      'the icon size should follow the user font size at the smallest setting',
+    ).toBeLessThan(reference as number);
+
+    const largest = await this.measureAtFontSize('20px');
+    expect(
+      largest.buttonWidth as number,
+      'the icon must stay within the scrollbox content box at the largest font size',
+    ).toBeLessThanOrEqual(largest.clientWidth);
+    expect(largest.scrollWidth, 'the rail must not overflow horizontally at the largest font size').toBeLessThanOrEqual(
+      largest.clientWidth,
+    );
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

Fixes a ghost scrollbar in the 4.0 desktop navigation rail (the left icon column): a full-height scrollbar was painted even when every icon fit and nothing could scroll.

Root cause is a layout feedback loop: icon size derives from the rail width (`width: 65%` + `aspect-ratio: 1/1`), and the classic 5px scrollbar consumes width. When the icon stack barely overflowed, the bar appeared, stole 5px, the icons shrank, the content fit again, and the browser kept the now-empty bar over zero overflow.

The fix is CSS-only and scoped to the rail: reserve the scrollbar gutter (`scrollbar-gutter: stable both-edges` + `scrollbar-width: thin`) and give desktop icons a fixed size (`min(calc(39rem / 14), 100%)`) instead of a width-derived percentage, so icon size can no longer feed back from the scrollbar. The shared `ScrollboxVertical` (chat, user list, panels) is untouched, and on tall windows the rail is visually identical to before.

**### Closes Issue(s)**

Closes bigbluebutton/bigbluebutton#25564

**### How to test**

- Join a meeting as moderator on a desktop window around 1280x560 (the ghost band depends on how many icons your rail renders; with 10 icons it is roughly 520-560px tall). Before: grey full-height bar over content that cannot scroll, icons shrunk to 35.75px. After: icons keep 39px; a bar only appears if the content really overflows (and then it scrolls).
- At 1280x720 (the issue's case), 682 and 616: no bar, full-size icons.
- Shrink to 1280x460: real overflow, honest partial bar, last icon scroll-reachable.
- Optional: set the font size to 16/18/20px in the client - icons scale but stay capped inside the rail (no horizontal spill).
- The PR adds 4 Playwright specs (tag `@ci`) covering exactly these: constant icon size across the ghost band, bar-only-on-real-overflow across viewport resizes, overflow budget on CI's default browser, and font-size scaling.

Evidence in the PR description: before/after GIFs and full-client videos with timestamps, plus DOM readouts per capture.

**### More**

- Mobile rail is unchanged (responsive sizing, no gutter); the same mechanism exists there in theory but is out of scope for this issue.
- One visible side effect on tall windows: the two group separator lines are 5px narrower (they size from the content box, which now excludes the reserved gutter). Everything else is pixel-identical.


- Comparison (before 560 / after 560 / after 720 / after 460, 10 icons each):

  ![comparison](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-20/5cff39c0-45c2-4803-8241-c71b8162d644/comparison.png)