### PR TITLE
Fix: export indentation

### DIFF
--- a/bbb-shared-notes-server/src/express/handlers/exportDocumentToHtml.ts
+++ b/bbb-shared-notes-server/src/express/handlers/exportDocumentToHtml.ts
@@ -1,6 +1,43 @@
 import hocuspocus from "../../hocuspocus";
 import { ServerBlockNoteEditor } from "@blocknote/server-util";
 
+// Indentation for nested non-list blocks (issue #25585).
+// blocksToHTMLLossy() preserves real nesting only for list items; every other nested
+// block (paragraph, heading, quote, code block, table) is flattened into a sibling that
+// records its depth in a data-nesting-level="N" attribute. Indent those blocks by scoping
+// a margin-left rule to the elements that carry the attribute directly. List items keep
+// the attribute on the <li>, which already sits in a padded <ul>/<ol>, so <li> is
+// deliberately excluded here - otherwise nested lists would be indented twice.
+//
+// The step is a fixed pixel value, not the lists' 2em, on purpose: em resolves against each
+// element's own font-size, so a level-2 heading (font-size 1.5em) would indent ~1.5x a
+// paragraph at the same depth and the block types would no longer line up. 32px equals the
+// lists' 2em at the default 16px root, so a paragraph flattened out from under a bullet
+// still lines up with that bullet's content, and every block type shares one indent per level.
+//
+// wkhtmltopdf runs an old WebKit with no attr()/calc() in properties, so the depth cannot be
+// read from the attribute at render time; the rules are enumerated per level up to a cap
+// instead (attribute-value selectors already render there, see the color rules below). A depth
+// beyond the cap is clamped to the maximum indent by a fallback rule placed before the
+// enumerated ones: they share specificity, so the later per-level rule wins within range while
+// deeper levels match only the fallback. The per-level loop stops one short of the cap because
+// the last level would repeat the fallback's value.
+const NESTING_INDENT_STEP_PX = 32;
+const MAX_NESTING_LEVEL = 10;
+const NESTED_BLOCK_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pre', 'table'];
+const NESTING_INDENT_RULES = [
+  `${NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level]`).join(', ')} { margin-left: ${MAX_NESTING_LEVEL * NESTING_INDENT_STEP_PX}px; }`,
+  ...Array.from({ length: MAX_NESTING_LEVEL - 1 }, (_, index) => {
+    const level = index + 1;
+    const selector = NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level="${level}"]`).join(', ');
+    return `${selector} { margin-left: ${level * NESTING_INDENT_STEP_PX}px; }`;
+  }),
+  // Tables default to width: 100%; a margin-left on a full-width table would push its right
+  // edge past the page's right margin. Let indented tables size to their content instead, so
+  // the indentation reads without overflowing.
+  'table[data-nesting-level] { width: auto; }',
+];
+
 async function exportDocumentToHtml(documentName: string): Promise<string> {
   const connection = await hocuspocus.openDirectConnection(documentName);
 
@@ -27,11 +64,13 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
       // Convert blocks to HTML (using type assertion to handle schema differences)
       htmlContent = await editor.blocksToHTMLLossy(blocks as any);
 
-      // Replace empty paragraph tags with paragraphs containing a <br> tag so
-      // empty lines are preserved in the HTML output. Indented empty lines are
-      // flattened to <p data-nesting-level="N"></p>, so keep that attribute
+      // Preserve empty lines in the HTML output. BlockNote exports a blank line as a
+      // paragraph whose only content is U+FFFC (the object replacement character),
+      // i.e. <p>￼</p>, which otherwise renders as a "tofu" box. Replace that
+      // sole FFFC with a <br> so the line stays blank. Indented empty lines are
+      // flattened to <p data-nesting-level="N">￼</p>, so keep the attribute
       // (the stylesheet below indents them). See issues #25122 and #25585.
-      htmlContent = htmlContent.replace(/<p( data-nesting-level="\d+")?><\/p>/g, '<p$1><br></p>');
+      htmlContent = htmlContent.replace(/<p( data-nesting-level="\d+")?>\uFFFC<\/p>/g, '<p$1><br></p>');
 
       // Strip hardcoded inline color styles from BlockNote color spans.
       // The data-style-type / data-value attributes remain, and the CSS below
@@ -49,36 +88,6 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
   } finally {
     await connection.disconnect();
   }
-
-  // Indentation for nested non-list blocks (issue #25585).
-  // blocksToHTMLLossy() preserves real nesting only for list items; every other
-  // nested block (paragraph, heading, quote) is flattened into a sibling that
-  // records its depth in a data-nesting-level="N" attribute. Indent those blocks
-  // by scoping a margin-left rule to the elements that carry the attribute
-  // directly. List items keep the attribute on the <li>, which already sits in a
-  // padded <ul>/<ol>, so <li> is deliberately excluded here - otherwise nested
-  // lists would be indented twice.
-  //
-  // The step matches the 2em padding-left of the exported lists, so a paragraph
-  // flattened out from under a bullet lines up with that bullet's content.
-  // wkhtmltopdf runs an old WebKit with no attr()/calc() in properties, so the
-  // depth cannot be read from the attribute at render time; the rules are
-  // enumerated per level up to a cap instead (attribute-value selectors already
-  // render there, see the color rules above). A depth beyond the cap is clamped
-  // to the maximum indent by a fallback rule placed before the enumerated ones:
-  // they share specificity, so the later per-level rule wins within range while
-  // deeper levels match only the fallback.
-  const NESTING_INDENT_STEP_PX = 32;
-  const MAX_NESTING_LEVEL = 10;
-  const NESTED_BLOCK_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote'];
-  const nestingIndentRules = [
-    `${NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level]`).join(', ')} { margin-left: ${MAX_NESTING_LEVEL * NESTING_INDENT_STEP_PX}px; }`,
-    ...Array.from({ length: MAX_NESTING_LEVEL }, (_, index) => {
-      const level = index + 1;
-      const selector = NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level="${level}"]`).join(', ');
-      return `${selector} { margin-left: ${level * NESTING_INDENT_STEP_PX}px; }`;
-    }),
-  ];
 
   // Create HTML document with styling
   const fullHtml = [
@@ -178,9 +187,9 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
       '   Checkbox items have <input> as the first child, so :first-child never matches them. */',
       String.raw`ul > li > p.bn-inline-content:first-child::before { content: "\2022\00A0"; }`,
       'li { margin-bottom: 4px; }',
-      '/* Indent nested non-list blocks (paragraphs, headings, quotes) that',
-      '   blocksToHTMLLossy() flattens into data-nesting-level siblings. */',
-      ...nestingIndentRules,
+      '/* Indent nested non-list blocks (paragraphs, headings, quotes, code blocks,',
+      '   tables) that blocksToHTMLLossy() flattens into data-nesting-level siblings. */',
+      ...NESTING_INDENT_RULES,
       'code {',
       '  background-color: #f6f8fa;',
       '  padding: 0.2em 0.4em;',

--- a/bbb-shared-notes-server/src/express/handlers/exportDocumentToHtml.ts
+++ b/bbb-shared-notes-server/src/express/handlers/exportDocumentToHtml.ts
@@ -27,9 +27,11 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
       // Convert blocks to HTML (using type assertion to handle schema differences)
       htmlContent = await editor.blocksToHTMLLossy(blocks as any);
 
-      // Replace empty paragraph tags with paragraphs containing a <br> tag
-      // This ensures empty lines are preserved in the HTML output
-      htmlContent = htmlContent.replaceAll('<p></p>', '<p><br></p>');
+      // Replace empty paragraph tags with paragraphs containing a <br> tag so
+      // empty lines are preserved in the HTML output. Indented empty lines are
+      // flattened to <p data-nesting-level="N"></p>, so keep that attribute
+      // (the stylesheet below indents them). See issues #25122 and #25585.
+      htmlContent = htmlContent.replace(/<p( data-nesting-level="\d+")?><\/p>/g, '<p$1><br></p>');
 
       // Strip hardcoded inline color styles from BlockNote color spans.
       // The data-style-type / data-value attributes remain, and the CSS below
@@ -47,6 +49,36 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
   } finally {
     await connection.disconnect();
   }
+
+  // Indentation for nested non-list blocks (issue #25585).
+  // blocksToHTMLLossy() preserves real nesting only for list items; every other
+  // nested block (paragraph, heading, quote) is flattened into a sibling that
+  // records its depth in a data-nesting-level="N" attribute. Indent those blocks
+  // by scoping a margin-left rule to the elements that carry the attribute
+  // directly. List items keep the attribute on the <li>, which already sits in a
+  // padded <ul>/<ol>, so <li> is deliberately excluded here - otherwise nested
+  // lists would be indented twice.
+  //
+  // The step matches the 2em padding-left of the exported lists, so a paragraph
+  // flattened out from under a bullet lines up with that bullet's content.
+  // wkhtmltopdf runs an old WebKit with no attr()/calc() in properties, so the
+  // depth cannot be read from the attribute at render time; the rules are
+  // enumerated per level up to a cap instead (attribute-value selectors already
+  // render there, see the color rules above). A depth beyond the cap is clamped
+  // to the maximum indent by a fallback rule placed before the enumerated ones:
+  // they share specificity, so the later per-level rule wins within range while
+  // deeper levels match only the fallback.
+  const NESTING_INDENT_STEP_PX = 32;
+  const MAX_NESTING_LEVEL = 10;
+  const NESTED_BLOCK_TAGS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote'];
+  const nestingIndentRules = [
+    `${NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level]`).join(', ')} { margin-left: ${MAX_NESTING_LEVEL * NESTING_INDENT_STEP_PX}px; }`,
+    ...Array.from({ length: MAX_NESTING_LEVEL }, (_, index) => {
+      const level = index + 1;
+      const selector = NESTED_BLOCK_TAGS.map((tag) => `${tag}[data-nesting-level="${level}"]`).join(', ');
+      return `${selector} { margin-left: ${level * NESTING_INDENT_STEP_PX}px; }`;
+    }),
+  ];
 
   // Create HTML document with styling
   const fullHtml = [
@@ -146,6 +178,9 @@ async function exportDocumentToHtml(documentName: string): Promise<string> {
       '   Checkbox items have <input> as the first child, so :first-child never matches them. */',
       String.raw`ul > li > p.bn-inline-content:first-child::before { content: "\2022\00A0"; }`,
       'li { margin-bottom: 4px; }',
+      '/* Indent nested non-list blocks (paragraphs, headings, quotes) that',
+      '   blocksToHTMLLossy() flattens into data-nesting-level siblings. */',
+      ...nestingIndentRules,
       'code {',
       '  background-color: #f6f8fa;',
       '  padding: 0.2em 0.4em;',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.spec.ts
@@ -1,0 +1,19 @@
+import { linkIssue } from '../../core/helpers';
+import { test } from '../../core/setup/fixtures';
+import { ExportIndentationSharedNotes } from './export-indentation';
+
+// Regression suite for BBB #25585: PDF/HTML export dropped the indentation of nested
+// non-list blocks (paragraphs, headings, quotes). The meeting is created per-test with
+// a seeded nested document (POST modules payload), so nothing is created in beforeEach.
+test.describe.parallel('Shared Notes - BlockNote export indentation', { tag: '@ci' }, () => {
+  let exportIndentation: ExportIndentationSharedNotes;
+
+  test.beforeEach(async ({ browser, context }) => {
+    linkIssue(25585);
+    exportIndentation = new ExportIndentationSharedNotes(browser, context);
+  });
+
+  test('Nested non-list blocks keep their indentation in the HTML/PDF export', async () => {
+    await exportIndentation.nestedBlocksKeepIndentationInExport();
+  });
+});

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.ts
@@ -12,6 +12,19 @@ const L2 = 'IndentLevelTwo';
 const BULLET_PARENT = 'BulletParent';
 const BULLET_CHILD = 'BulletChild';
 const PARA_UNDER_BULLET = 'ParagraphUnderBullet';
+const HEADING_PARENT = 'HeadingParent';
+const NESTED_HEADING = 'NestedHeading';
+const QUOTE_PARENT = 'QuoteParent';
+const NESTED_QUOTE = 'NestedQuote';
+const CODE_PARENT = 'CodeParent';
+const NESTED_CODE = 'nestedCodeLine';
+const OL_PARENT = 'OrderedParent';
+const OL_CHILD = 'OrderedChild';
+// Deep paragraph chain to exercise the depth cap (indent stops growing beyond
+// MAX_NESTING_LEVEL). L9/L10 straddle the cap; L11 must clamp to L10's indent.
+const CLAMP_L9 = 'ClampLevelNine';
+const CLAMP_L10 = 'ClampLevelTen';
+const CLAMP_L11 = 'ClampLevelEleven';
 
 // Horizontal slack for boundingBox comparisons (sub-pixel rounding / font metrics).
 const X_EPSILON = 4;
@@ -24,28 +37,53 @@ interface SeedBlock {
   children: SeedBlock[];
 }
 
+// Deterministic, unique block ids so the seed payload is stable across runs.
+function uuid(n: number): string {
+  return `00000000-0000-0000-0000-${n.toString().padStart(12, '0')}`;
+}
+
 // Builds a BlockNote block in the shape documented for sharedNotesInitialContentJson
-// (see docs/development/api.md and the markdown spec's jsonModule helper).
+// (see docs/development/api.md and the markdown spec's jsonModule helper). Props are
+// filled per type so each block validates against the default BlockNote schema.
 function block(id: string, type: string, text: string, children: SeedBlock[] = []): SeedBlock {
-  const props: Record<string, unknown> = { textAlignment: 'left', backgroundColor: 'default', textColor: 'default' };
+  let props: Record<string, unknown> = { textAlignment: 'left', backgroundColor: 'default', textColor: 'default' };
   if (type === 'heading') props.level = 2;
+  if (type === 'codeBlock') props = { language: 'javascript' };
   return { id, type, props, content: [{ type: 'text', text, styles: {} }], children };
 }
 
-// A document that exercises the bug: paragraphs nested by Tab (levels 0/1/2) and a
-// paragraph flattened out from under a bullet, plus a real nested bullet to guard
-// against list double-indentation.
+// A single paragraph nested `depth` levels deep (levels 9/10/11 carry marker texts) so the
+// depth cap can be measured: the exported blocks step right until the cap, then stop.
+function deepParagraphChain(): SeedBlock {
+  const label = (level: number): string => {
+    if (level === 9) return CLAMP_L9;
+    if (level === 10) return CLAMP_L10;
+    if (level === 11) return CLAMP_L11;
+    return `ClampFiller${level}`;
+  };
+  let node = block(uuid(111), 'paragraph', label(11));
+  for (let level = 10; level >= 0; level--) {
+    node = block(uuid(100 + level), 'paragraph', label(level), [node]);
+  }
+  return node;
+}
+
+// A document that exercises the bug across every block type blocksToHTMLLossy() flattens
+// into data-nesting-level siblings: paragraphs nested by Tab, a paragraph flattened out from
+// under a bullet, a real nested bullet (list double-indent guard), a nested heading, quote
+// and code block, an ordered list, and a chain deeper than the indent cap.
 function seedModule(): string {
   const blocks: SeedBlock[] = [
-    block('00000000-0000-0000-0000-000000000001', 'paragraph', L0, [
-      block('00000000-0000-0000-0000-000000000002', 'paragraph', L1, [
-        block('00000000-0000-0000-0000-000000000003', 'paragraph', L2),
-      ]),
+    block(uuid(1), 'paragraph', L0, [block(uuid(2), 'paragraph', L1, [block(uuid(3), 'paragraph', L2)])]),
+    block(uuid(4), 'bulletListItem', BULLET_PARENT, [
+      block(uuid(5), 'bulletListItem', BULLET_CHILD),
+      block(uuid(6), 'paragraph', PARA_UNDER_BULLET),
     ]),
-    block('00000000-0000-0000-0000-000000000004', 'bulletListItem', BULLET_PARENT, [
-      block('00000000-0000-0000-0000-000000000005', 'bulletListItem', BULLET_CHILD),
-      block('00000000-0000-0000-0000-000000000006', 'paragraph', PARA_UNDER_BULLET),
-    ]),
+    block(uuid(7), 'paragraph', HEADING_PARENT, [block(uuid(8), 'heading', NESTED_HEADING)]),
+    block(uuid(9), 'paragraph', QUOTE_PARENT, [block(uuid(10), 'quote', NESTED_QUOTE)]),
+    block(uuid(11), 'paragraph', CODE_PARENT, [block(uuid(12), 'codeBlock', NESTED_CODE)]),
+    block(uuid(13), 'numberedListItem', OL_PARENT, [block(uuid(14), 'numberedListItem', OL_CHILD)]),
+    deepParagraphChain(),
   ];
   const json = JSON.stringify(blocks);
   return `<modules><module name="sharedNotesInitialContentJson"><![CDATA[${json}]]></module></modules>`;
@@ -101,9 +139,10 @@ export class ExportIndentationSharedNotes extends MultiUsers {
     const probe = await context.newPage();
     try {
       await probe.setContent(html);
-      const leftEdge = async (tag: string, text: string): Promise<number> => {
-        const box = await probe.locator(`${tag}:text-is("${text}")`).first().boundingBox();
-        expect(box, `"${text}" should be present in the exported HTML`).not.toBeNull();
+      // Left edge of the first element matching the CSS selector that also contains `text`.
+      const leftEdge = async (selector: string, text: string): Promise<number> => {
+        const box = await probe.locator(selector, { hasText: text }).first().boundingBox();
+        expect(box, `"${text}" should be present in the exported HTML (${selector})`).not.toBeNull();
         return box!.x;
       };
 
@@ -140,6 +179,50 @@ export class ExportIndentationSharedNotes extends MultiUsers {
         oneListLevel,
         'a nested bullet should be indented by a single list level (no double-indentation)',
       ).toBeLessThan(60);
+
+      // A nested heading and blockquote are flattened into data-nesting-level siblings too;
+      // both must indent past their (level-0) parent instead of rendering flush left.
+      const xHeadingParent = await leftEdge('p', HEADING_PARENT);
+      const xNestedHeading = await leftEdge('h2', NESTED_HEADING);
+      expect(xNestedHeading, 'a nested heading should be indented past its parent').toBeGreaterThan(
+        xHeadingParent + X_EPSILON,
+      );
+
+      const xQuoteParent = await leftEdge('p', QUOTE_PARENT);
+      const xNestedQuote = await leftEdge('blockquote', NESTED_QUOTE);
+      expect(xNestedQuote, 'a nested blockquote should be indented past its parent').toBeGreaterThan(
+        xQuoteParent + X_EPSILON,
+      );
+
+      // A nested code block is flattened into <pre data-nesting-level>; it must indent too
+      // (this is exactly the case that regressed because <pre> was missing from the rules).
+      const xCodeParent = await leftEdge('p', CODE_PARENT);
+      const xNestedCode = await leftEdge('pre', NESTED_CODE);
+      expect(xNestedCode, 'a nested code block should be indented past its parent').toBeGreaterThan(
+        xCodeParent + X_EPSILON,
+      );
+
+      // An ordered list mirrors the bullet guard: the nested item steps right by exactly one
+      // list level, not two (the margin rule must not leak onto <li>).
+      const xOrderedParent = await leftEdge('p', OL_PARENT);
+      const xOrderedChild = await leftEdge('p', OL_CHILD);
+      const oneOrderedLevel = xOrderedChild - xOrderedParent;
+      expect(oneOrderedLevel, 'a nested ordered item should be indented past its parent').toBeGreaterThan(X_EPSILON);
+      expect(
+        oneOrderedLevel,
+        'a nested ordered item should be indented by a single list level (no double-indentation)',
+      ).toBeLessThan(60);
+
+      // The depth cap: indentation grows up to MAX_NESTING_LEVEL (level 10) and then stops.
+      // Level 10 must sit further right than level 9, and level 11 must clamp to level 10.
+      const xClampL9 = await leftEdge('p', CLAMP_L9);
+      const xClampL10 = await leftEdge('p', CLAMP_L10);
+      const xClampL11 = await leftEdge('p', CLAMP_L11);
+      expect(xClampL10, 'indentation should still grow up to the cap').toBeGreaterThan(xClampL9 + X_EPSILON);
+      expect(
+        Math.abs(xClampL11 - xClampL10),
+        'a depth beyond the cap should clamp to the maximum indent, not keep growing',
+      ).toBeLessThanOrEqual(X_EPSILON);
     } finally {
       await context.close();
     }

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/export-indentation.ts
@@ -1,0 +1,147 @@
+import { expect } from '@playwright/test';
+
+import { elements as e } from '../../core/elements';
+import { createMeetingWithModules } from '../../core/helpers';
+import { MultiUsers } from '../../user/multiusers';
+import { startBlockNoteSharedNotes } from './util';
+
+// Distinct texts so each block can be located by an exact text match.
+const L0 = 'IndentLevelZero';
+const L1 = 'IndentLevelOne';
+const L2 = 'IndentLevelTwo';
+const BULLET_PARENT = 'BulletParent';
+const BULLET_CHILD = 'BulletChild';
+const PARA_UNDER_BULLET = 'ParagraphUnderBullet';
+
+// Horizontal slack for boundingBox comparisons (sub-pixel rounding / font metrics).
+const X_EPSILON = 4;
+
+interface SeedBlock {
+  id: string;
+  type: string;
+  props: Record<string, unknown>;
+  content: { type: 'text'; text: string; styles: Record<string, unknown> }[];
+  children: SeedBlock[];
+}
+
+// Builds a BlockNote block in the shape documented for sharedNotesInitialContentJson
+// (see docs/development/api.md and the markdown spec's jsonModule helper).
+function block(id: string, type: string, text: string, children: SeedBlock[] = []): SeedBlock {
+  const props: Record<string, unknown> = { textAlignment: 'left', backgroundColor: 'default', textColor: 'default' };
+  if (type === 'heading') props.level = 2;
+  return { id, type, props, content: [{ type: 'text', text, styles: {} }], children };
+}
+
+// A document that exercises the bug: paragraphs nested by Tab (levels 0/1/2) and a
+// paragraph flattened out from under a bullet, plus a real nested bullet to guard
+// against list double-indentation.
+function seedModule(): string {
+  const blocks: SeedBlock[] = [
+    block('00000000-0000-0000-0000-000000000001', 'paragraph', L0, [
+      block('00000000-0000-0000-0000-000000000002', 'paragraph', L1, [
+        block('00000000-0000-0000-0000-000000000003', 'paragraph', L2),
+      ]),
+    ]),
+    block('00000000-0000-0000-0000-000000000004', 'bulletListItem', BULLET_PARENT, [
+      block('00000000-0000-0000-0000-000000000005', 'bulletListItem', BULLET_CHILD),
+      block('00000000-0000-0000-0000-000000000006', 'paragraph', PARA_UNDER_BULLET),
+    ]),
+  ];
+  const json = JSON.stringify(blocks);
+  return `<modules><module name="sharedNotesInitialContentJson"><![CDATA[${json}]]></module></modules>`;
+}
+
+export class ExportIndentationSharedNotes extends MultiUsers {
+  // Creates a meeting seeded with the nested document, then joins as moderator.
+  private async createAndJoinSeeded() {
+    const meetingId = await createMeetingWithModules(seedModule(), 'sharedNotesEditor=blocknote');
+    const context = await this.browser.newContext();
+    const page = await context.newPage();
+    await this.initModPage(page, { meetingId });
+  }
+
+  // Reproduces the product's "Export as PDF" action to obtain the export URL, then
+  // fetches the sibling HTML export (same handler, same generated HTML) so the layout
+  // can be measured in a real browser. Returns the exported HTML document.
+  private async fetchExportedHtml(): Promise<string> {
+    // The menu item calls window.open(...export/pdf...); stub it to capture the URL
+    // instead of spawning a popup/download.
+    await this.modPage.page.evaluate(() => {
+      (window as unknown as { bbbExportUrls: string[] }).bbbExportUrls = [];
+      window.open = ((url?: string | URL) => {
+        (window as unknown as { bbbExportUrls: string[] }).bbbExportUrls.push(String(url));
+        return null;
+      }) as typeof window.open;
+    });
+
+    await this.modPage.waitAndClick(e.notesOptions);
+    await this.modPage.page.locator(e.exportNotesAsPDF).click();
+
+    const pdfUrl = await this.modPage.page.evaluate(
+      () => (window as unknown as { bbbExportUrls: string[] }).bbbExportUrls[0],
+    );
+    expect(pdfUrl, 'clicking Export as PDF should open the export URL').toContain('/export/pdf');
+
+    // The PDF is rendered from this same HTML; measuring the HTML export is the
+    // faithful, headless way to assert the indentation the PDF will carry.
+    const htmlUrl = pdfUrl.replace('/export/pdf', '/export/html');
+    const response = await this.modPage.page.request.get(htmlUrl);
+    expect(response.ok(), `the HTML export should be served (GET ${htmlUrl})`).toBeTruthy();
+    return response.text();
+  }
+
+  async nestedBlocksKeepIndentationInExport() {
+    await this.createAndJoinSeeded();
+    await startBlockNoteSharedNotes(this.modPage);
+
+    const html = await this.fetchExportedHtml();
+
+    // Render the exported HTML in an isolated page and read each block's left edge.
+    const context = await this.browser.newContext();
+    const probe = await context.newPage();
+    try {
+      await probe.setContent(html);
+      const leftEdge = async (tag: string, text: string): Promise<number> => {
+        const box = await probe.locator(`${tag}:text-is("${text}")`).first().boundingBox();
+        expect(box, `"${text}" should be present in the exported HTML`).not.toBeNull();
+        return box!.x;
+      };
+
+      const xL0 = await leftEdge('p', L0);
+      const xL1 = await leftEdge('p', L1);
+      const xL2 = await leftEdge('p', L2);
+      const xBulletParent = await leftEdge('p', BULLET_PARENT);
+      const xBulletChild = await leftEdge('p', BULLET_CHILD);
+      const xParaUnderBullet = await leftEdge('p', PARA_UNDER_BULLET);
+
+      // The bug: nested paragraphs collapse to the same left margin. Fixed: each Tab
+      // level steps further right.
+      expect(xL1, 'a once-nested paragraph should be indented past its parent').toBeGreaterThan(xL0 + X_EPSILON);
+      expect(xL2, 'a twice-nested paragraph should be indented past the first level').toBeGreaterThan(xL1 + X_EPSILON);
+
+      // The issue's "further left than its own bullet": a paragraph flattened out from
+      // under a bullet used to sit at the page margin. It must now be indented at least
+      // to the bullet's content column.
+      expect(
+        xParaUnderBullet,
+        'a paragraph nested under a bullet should not render at the page margin',
+      ).toBeGreaterThan(xL0 + X_EPSILON);
+      expect(
+        xParaUnderBullet,
+        'a paragraph under a bullet should align with the bullet content, not fall short of it',
+      ).toBeGreaterThanOrEqual(xBulletParent - X_EPSILON);
+
+      // No regression: a real nested list item stays indented by exactly one list level
+      // (the ~32px list padding), not two. A margin rule that leaked onto <li> would
+      // roughly double this gap (~64px), so anything under 60px proves it did not.
+      const oneListLevel = xBulletChild - xBulletParent;
+      expect(oneListLevel, 'a nested bullet should still be indented past its parent').toBeGreaterThan(X_EPSILON);
+      expect(
+        oneListLevel,
+        'a nested bullet should be indented by a single list level (no double-indentation)',
+      ).toBeLessThan(60);
+    } finally {
+      await context.close();
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Nested blocks in shared notes (paragraphs, headings, quotes, code blocks, tables indented with Tab) lost their indentation when exported to HTML/PDF: everything collapsed to the left margin, and a paragraph under a bullet even rendered to the left of its own bullet.

The export serializer already records each block's depth in a data-nesting-level attribute, but the export stylesheet never used it. This PR adds stepped margin-left rules (32px per level, capped at 10) for those blocks, so the export now mirrors the nesting shown in the editor. Lists are left untouched (the browser already indents them). Also fixes blank lines exporting as a visible replacement-character box.

## Closes Issue(s)

- bigbluebutton/bigbluebutton#25585

## How to test

1. Create a meeting, open shared notes.
2. Type a paragraph, press Tab to indent a second one, Tab again for a third; add a bullet with a paragraph nested under it (and optionally a nested code block).
3. Notes options -> Export -> HTML and PDF.

Before: all nested lines sit flush left. After: nesting steps 32px per level and the paragraph under the bullet aligns with the bullet text. A Playwright spec covering this ships with the PR.

## More

- [ ] Added/updated documentation (not needed: user-facing behavior now matches the editor, no doc change required)