### PR TITLE
[3.0 whiteboard] fix: prevent <100% zoom out by pinching

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1691,10 +1691,26 @@ const Whiteboard = React.memo((props) => {
           zoomed
           && isPresenterRef.current
           && !currentPresentationPageRef.current?.infiniteWhiteboard
-          && initialZoomRef.current
-          && next.z < initialZoomRef.current
         ) {
-          newNext.z = initialZoomRef.current;
+          const currentPage = currentPresentationPageRef.current;
+          const { widthGap } = getContainerDimensions();
+
+          let minimumZoom = calculateZoomValueRef.current(
+            currentPage.scaledWidth,
+            currentPage.scaledHeight,
+          );
+
+          if (widthGap > 0) {
+            minimumZoom = calculateZoomWithGapValueRef.current(
+              currentPage.scaledWidth,
+              currentPage.scaledHeight,
+              widthGap,
+            );
+          }
+
+          if ( minimumZoom > 0 && next.z < minimumZoom) {
+            newNext.z = minimumZoom;
+          }         
         }
 
         const presentationWidthLocal = currentPresentationPageRef.current?.scaledWidth || 0;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1685,6 +1685,18 @@ const Whiteboard = React.memo((props) => {
           viewportHeight = currentPresentationPageRef.current?.scaledViewBoxHeight;
         }
 
+        const zoomed = next?.id?.includes('camera') && prev.z !== next.z;
+
+        if (
+          zoomed
+          && isPresenterRef.current
+          && !currentPresentationPageRef.current?.infiniteWhiteboard
+          && initialZoomRef.current
+          && next.z < initialZoomRef.current
+        ) {
+          newNext.z = initialZoomRef.current;
+        }
+
         const presentationWidthLocal = currentPresentationPageRef.current?.scaledWidth || 0;
         const presentationHeightLocal = currentPresentationPageRef.current?.scaledHeight || 0;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -234,6 +234,7 @@ const Whiteboard = React.memo((props) => {
   const hasWBAccessRef = React.useRef(hasWBAccess);
   const isModeratorRef = React.useRef(isModerator);
   const currentPresentationPageRef = React.useRef(currentPresentationPage);
+  const presentationAreaDimensionsRef = useRef({width: presentationAreaWidth, height: presentationAreaHeight});
   const initialViewBoxWidthRef = React.useRef(null);
   const initialViewBoxHeightRef = React.useRef(null);
   const previousTool = React.useRef(null);
@@ -248,6 +249,11 @@ const Whiteboard = React.memo((props) => {
   const currentUserRef = useRef(currentUser);
 
   currentUserRef.current = currentUser;
+
+  presentationAreaDimensionsRef.current = {
+    width: presentationAreaWidth,
+    height: presentationAreaHeight,
+  };
 
   const [pageZoomMap, setPageZoomMap] = useState(() => {
     try {
@@ -1687,6 +1693,10 @@ const Whiteboard = React.memo((props) => {
 
         const zoomed = next?.id?.includes('camera') && prev.z !== next.z;
         const currentPage = currentPresentationPageRef.current;
+        const {
+          width: currentPresentationAreaWidth,
+          height: currentPresentationAreaHeight,
+        } = presentationAreaDimensionsRef.current;
 
         if (
           zoomed
@@ -1697,6 +1707,10 @@ const Whiteboard = React.memo((props) => {
           && currentPage.scaledWidth > 0
           && Number.isFinite(currentPage.scaledHeight)
           && currentPage.scaledHeight > 0
+          && Number.isFinite(currentPresentationAreaWidth)
+          && currentPresentationAreaWidth > 0
+          && Number.isFinite(currentPresentationAreaHeight)
+          && currentPresentationAreaHeight > 0
         ) {
           const { widthGap } = getContainerDimensions();
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1686,13 +1686,18 @@ const Whiteboard = React.memo((props) => {
         }
 
         const zoomed = next?.id?.includes('camera') && prev.z !== next.z;
+        const currentPage = currentPresentationPageRef.current;
 
         if (
           zoomed
           && isPresenterRef.current
-          && !currentPresentationPageRef.current?.infiniteWhiteboard
+          && currentPage
+          && !currentPage.infiniteWhiteboard
+          && Number.isFinite(currentPage.scaledWidth)
+          && currentPage.scaledWidth > 0
+          && Number.isFinite(currentPage.scaledHeight)
+          && currentPage.scaledHeight > 0
         ) {
-          const currentPage = currentPresentationPageRef.current;
           const { widthGap } = getContainerDimensions();
 
           let minimumZoom = calculateZoomValueRef.current(
@@ -1708,7 +1713,11 @@ const Whiteboard = React.memo((props) => {
             );
           }
 
-          if ( minimumZoom > 0 && next.z < minimumZoom) {
+          if (
+            Number.isFinite(minimumZoom)
+            && minimumZoom > 0
+            && next.z < minimumZoom
+          ) {
             newNext.z = minimumZoom;
           }         
         }


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
Prevent zooming out by a pinch gesture below 100% as long as the infinite whiteboard is disabled.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #25517

### Motivation
On touch devices such as iPad, presenters can zoom out the whiteboard by pinching below 100% even when Infinite Whiteboard is disabled (#25517).
In my investigation. BBB's pinch handler already enforces a 100% minimum zoom, but tldraw can also process the same gesture and update the camera directly. This bypasses BBB's minimum zoom limit. In hook.js BBB properly prevents the pinch event propagation, but only for non-presenters.
This PR enforces the minimum camera zoom in onBeforeChange when Infinite Whiteboard is disabled. This ensures the 100% minimum is respected regardless of whether the camera change comes from BBB's gesture handling or tldraw.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
- As a presenter, zoom-out the presentation by pinching on mobile devides.


### More
<!-- Anything else we should know when reviewing? -->
- As far as I tested, this fixes the problem both on iOS and on Android.
