### PR TITLE
Fix(html5): viewer minimize clobbered

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/layout/context.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/context.jsx
@@ -2,10 +2,10 @@ import React, { useEffect, useReducer, useRef } from 'react';
 import { createContext, useContextSelector } from 'use-context-selector';
 import PropTypes from 'prop-types';
 import { clone } from 'ramda';
-import { getDeviceType, presentationContentHasChanges } from './utils';
+import { getDeviceType, presentationContentHasChanges, LAYOUTS_SYNC } from './utils';
 import {
   ACTIONS, PRESENTATION_AREA, PANELS,
-  CAMERADOCK_POSITION,
+  CAMERADOCK_POSITION, LAYOUT_ELEMENTS, SYNC,
 } from '/imports/ui/components/layout/enums';
 import DEFAULT_VALUES from '/imports/ui/components/layout/defaultValues';
 import { INITIAL_INPUT_STATE, INITIAL_OUTPUT_STATE } from './initState';
@@ -21,6 +21,9 @@ import {
   removePluginUnpinnedApp,
 } from '/imports/ui/components/apps-gallery/service';
 import useMeeting from '/imports/ui/core/hooks/useMeeting';
+import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
+import useSettings from '/imports/ui/services/settings/hooks/useSettings';
+import { SETTINGS } from '/imports/ui/services/settings/enums';
 
 // variable to debug in console log
 const debug = false;
@@ -1766,6 +1769,7 @@ const updatePresentationAreaContent = (
   previousPresentationAreaContentActions,
   layoutContextDispatch,
   isPresentationEnabled,
+  followerPresentationOpen,
 ) => {
   const { layoutType } = layoutContextState;
   const { sidebarContent, sidebarContentAuxiliary, sharedNotes } = layoutContextState.input;
@@ -1885,7 +1889,17 @@ const updatePresentationAreaContent = (
           type: ACTIONS.SET_NOTES_IS_PINNED,
           value: !lastPresentationContentInPile.value.open,
         });
-        shouldOpenPresentation = Session.getItem('presentationLastState');
+        // The pop back to the whiteboard is a shared transition, driven by
+        // meeting state on every client at once. Followers of a synchronized
+        // layout restore to the meeting presentation state (mirroring
+        // replicatePresentationState) so they land on the same view as the
+        // presenter, instead of on their own local memory.
+        if (typeof followerPresentationOpen === 'boolean') {
+          shouldOpenPresentation = followerPresentationOpen;
+          Session.setItem('presentationLastState', followerPresentationOpen);
+        } else {
+          shouldOpenPresentation = Session.getItem('presentationLastState');
+        }
         break;
       }
       default:
@@ -1915,9 +1929,24 @@ const LayoutContextProvider = (props) => {
 
   const { data: currentMeeting } = useMeeting((m) => ({
     componentsFlags: m.componentsFlags,
+    layout: m.layout,
   }));
 
   const isSharedNotesPinned = currentMeeting?.componentsFlags?.isSharedNotesPinned;
+
+  const { data: currentUser } = useCurrentUser((user) => ({
+    presenter: user.presenter,
+  }));
+  const { selectedLayout } = useSettings(SETTINGS.LAYOUT);
+
+  const meetingLayout = currentMeeting?.layout;
+  const notInitialLayoutValues = !!meetingLayout?.setByUserId
+    && meetingLayout.setByUserId !== 'system';
+  const layoutReplicatesPresentationState = !!LAYOUTS_SYNC[selectedLayout]
+    ?.[SYNC.REPLICATE_ELEMENTS]?.includes(LAYOUT_ELEMENTS.PRESENTATION_STATE);
+  const followerPresentationOpen = (
+    !currentUser?.presenter && notInitialLayoutValues && layoutReplicatesPresentationState
+  ) ? !meetingLayout.presentationMinimized : undefined;
 
   const [layoutContextState, layoutContextDispatch] = useReducer(reducer, initState);
   const isPresentationEnabled = useIsPresentationEnabled();
@@ -1936,6 +1965,7 @@ const LayoutContextProvider = (props) => {
         previousPresentationAreaContentActions,
         layoutContextDispatch,
         isPresentationEnabled,
+        followerPresentationOpen,
       );
     }
   }, [layoutContextState, isPresentationEnabled]);

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -71,7 +71,6 @@ const propTypes = {
   setLocalSettings: PropTypes.func.isRequired,
   hasMeetingLayout: PropTypes.bool,
   meetingLayoutSetByUserId: PropTypes.string,
-  isChatEnabled: PropTypes.bool,
 };
 
 const PushLayoutEngine = (props) => {

--- a/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
+++ b/bigbluebutton-html5/imports/ui/components/layout/push-layout/pushLayoutEngine.jsx
@@ -57,7 +57,6 @@ const propTypes = {
   meetingLayoutFocusedCamera: PropTypes.string,
   meetingLayoutVideoRate: PropTypes.number,
   meetingPresentationIsOpen: PropTypes.bool,
-  meetingLayoutUpdatedAt: PropTypes.number,
   presentationIsOpen: PropTypes.bool,
   presentationContentUpdatedAt: PropTypes.number,
   presentationVideoRate: PropTypes.number,
@@ -101,7 +100,6 @@ const PushLayoutEngine = (props) => {
     isModerator,
     isPresenter,
     layoutContextDispatch,
-    meetingLayoutUpdatedAt,
     presentationContentUpdatedAt,
     presentationIsOpen,
     presentationVideoRate,
@@ -223,8 +221,7 @@ const PushLayoutEngine = (props) => {
     };
 
     const replicatePresentationState = () => {
-      if (meetingPresentationIsOpen !== prevProps.meetingPresentationIsOpen
-        || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
+      if (meetingPresentationIsOpen !== prevProps.meetingPresentationIsOpen) {
         layoutContextDispatch({
           type: ACTIONS.SET_PRESENTATION_IS_OPEN,
           value: meetingPresentationIsOpen,
@@ -234,8 +231,7 @@ const PushLayoutEngine = (props) => {
     };
 
     const replicateFocusedCamera = () => {
-      if (meetingLayoutFocusedCamera !== prevProps.meetingLayoutFocusedCamera
-        || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
+      if (meetingLayoutFocusedCamera !== prevProps.meetingLayoutFocusedCamera) {
         layoutContextDispatch({
           type: ACTIONS.SET_FOCUSED_CAMERA_ID,
           value: meetingLayoutFocusedCamera,
@@ -245,8 +241,7 @@ const PushLayoutEngine = (props) => {
     };
 
     const replicateCameraDockPosition = () => {
-      if (meetingLayoutCameraPosition !== prevProps.meetingLayoutCameraPosition
-        || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
+      if (meetingLayoutCameraPosition !== prevProps.meetingLayoutCameraPosition) {
         layoutContextDispatch({
           type: ACTIONS.SET_CAMERA_DOCK_POSITION,
           value: meetingLayoutCameraPosition || DEFAULT_VALUES.cameraPosition,
@@ -257,7 +252,7 @@ const PushLayoutEngine = (props) => {
 
     const replicateCameraDockSize = () => {
       if (!equalDouble(meetingLayoutVideoRate, prevProps.meetingLayoutVideoRate)
-        || meetingLayoutUpdatedAt !== prevProps.meetingLayoutUpdatedAt) {
+        || isMeetingLayoutResizing !== prevProps.isMeetingLayoutResizing) {
         let w; let h;
         if (horizontalPosition) {
           w = window.innerWidth * meetingLayoutVideoRate;
@@ -435,7 +430,6 @@ const PushLayoutEngineContainer = (props) => {
     layout: m.layout,
   }));
   const meetingLayout = LAYOUT_TYPE[currentMeeting?.layout?.currentLayoutType];
-  const meetingLayoutUpdatedAt = new Date(currentMeeting?.layout?.updatedAt).getTime();
   const {
     propagateLayout: pushLayoutMeeting,
     cameraDockIsResizing: isMeetingLayoutResizing,
@@ -514,7 +508,6 @@ const PushLayoutEngineContainer = (props) => {
         isPresenter,
         isChatEnabled,
         layoutContextDispatch,
-        meetingLayoutUpdatedAt,
         presentationContentUpdatedAt,
         presentationIsOpen,
         presentationVideoRate,

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -46,6 +46,29 @@ test.describe.parallel('Unified Layout - who-is-talking tiles (no webcams)', { t
   });
 });
 
+test.describe.parallel('Unified Layout - viewer minimize persistence', { tag: '@ci' }, () => {
+  test(
+    'Viewer keeps the presentation minimized while webcams come and go',
+    { tag: '@media' },
+    async ({ browser, context }, testInfo) => {
+      linkIssue(25592);
+      const layouts = new Layouts(browser, context);
+      await initializePages(layouts, browser, {
+        isMultiUser: true,
+        createParameter: 'meetingLayout=UNIFIED_LAYOUT',
+        // Rules out the restoreOnUpdate family: the presentation must stay minimized
+        // because nothing about it changed, not because of any userdata, and the bug
+        // under test reopens it even with the restore feature explicitly disabled.
+        joinParameter: 'userdata-bbb_force_restore_presentation_on_new_events=false',
+        testInfo,
+        recordVideo: true,
+      });
+      await layouts.initUserPage2();
+      await layouts.unifiedLayoutViewerMinimizeSticksOnCameraChanges();
+    },
+  );
+});
+
 test.describe.parallel('Layout', { tag: ['@flaky-3.1', '@media'] }, () => {
   let layouts: Layouts;
 

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -69,6 +69,26 @@ test.describe.parallel('Unified Layout - viewer minimize persistence', { tag: '@
   );
 });
 
+test.describe.parallel('Unified Layout - focused camera replication', { tag: '@ci' }, () => {
+  test(
+    'Viewer follows a camera focus and keeps a local unfocus while webcams come and go',
+    { tag: '@media' },
+    async ({ browser, context }, testInfo) => {
+      linkIssue(25592);
+      const layouts = new Layouts(browser, context);
+      await initializePages(layouts, browser, {
+        isMultiUser: true,
+        createParameter: 'meetingLayout=UNIFIED_LAYOUT',
+        testInfo,
+        recordVideo: true,
+      });
+      await layouts.initUserPage2();
+      await layouts.initModPage2();
+      await layouts.unifiedLayoutViewerFocusFollowSticksOnCameraChanges();
+    },
+  );
+});
+
 test.describe.parallel('Layout', { tag: ['@flaky-3.1', '@media'] }, () => {
   let layouts: Layouts;
 

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 
+import { VIDEO_LOADING_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
@@ -278,6 +279,15 @@ export class Layouts extends MultiUsers {
     if (userVideoPath) {
       testInfo.attachments.push({ name: 'Attendee screen recording', contentType: 'video/webm', path: userVideoPath });
     }
+
+    const user2VideoPath = this.userPage2 ? await this.userPage2.page.video()?.path() : undefined;
+    if (user2VideoPath) {
+      testInfo.attachments.push({
+        name: 'Attendee2 screen recording',
+        contentType: 'video/webm',
+        path: user2VideoPath,
+      });
+    }
   }
 
   async unifiedLayoutMinimizeShowsTiles() {
@@ -359,6 +369,81 @@ export class Layouts extends MultiUsers {
     await this.modPage.hasElement(
       e.talkingIndicator,
       'the navbar "who is talking" indicator must remain visible after restore, making the top tiles redundant',
+    );
+
+    await this.attachPageVideos();
+  }
+
+  async unifiedLayoutViewerMinimizeSticksOnCameraChanges() {
+    // Wait for the whiteboard so the presentation is fully loaded and the minimize
+    // button is enabled on every participant.
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage2.waitForSelector(e.whiteboard);
+
+    // The viewer minimizes the presentation. This is a local action: it does not
+    // propagate to the meeting layout record.
+    await this.userPage.waitAndClick(e.minimizePresentation);
+    await this.userPage.wasRemoved(e.presentationContainer, 'presentation should minimize for the viewer');
+    await this.userPage.hasElement(e.restorePresentation, 'restore presentation button should appear for the viewer');
+
+    // A third participant turns their webcam on. This updates the meeting layout
+    // record (cameraDockAspectRatio + updatedAt) without changing the meeting's
+    // presentation state, and must not clobber the viewer's local minimize.
+    await this.userPage2.shareWebcam();
+    // Fixed wait (matches the sibling tests' style): the wrongful reopen fires ~2s
+    // after the layout record updates, so wait past that window before asserting.
+    await this.userPage.page.waitForTimeout(4000);
+    await this.userPage.wasRemoved(
+      e.presentationContainer,
+      'presentation should stay minimized for the viewer after a webcam turns on',
+    );
+    await this.userPage.hasElement(
+      e.restorePresentation,
+      'restore presentation button should remain visible for the viewer after a webcam turns on',
+    );
+
+    // Same assertion for the symmetric trigger: the webcam turning off also
+    // updates the meeting layout record.
+    await this.userPage2.waitAndClick(e.leaveVideo);
+    await this.userPage2.wasRemoved(
+      e.webcamMirroredVideoContainer,
+      'webcam should stop sharing for the third participant',
+    );
+    await this.userPage.page.waitForTimeout(4000);
+    await this.userPage.wasRemoved(
+      e.presentationContainer,
+      'presentation should stay minimized for the viewer after a webcam turns off',
+    );
+    await this.userPage.hasElement(
+      e.restorePresentation,
+      'restore presentation button should remain visible for the viewer after a webcam turns off',
+    );
+
+    // Control (issue's third control): the presenter minimizing is NOT affected by
+    // camera changes - presenters never replicate the meeting layout onto themselves.
+    await this.modPage.waitAndClick(e.minimizePresentation);
+    await this.modPage.wasRemoved(e.presentationContainer, 'presentation should minimize for the presenter');
+    // Non-regression: the presenter's minimize is a genuine value change in the
+    // meeting layout record, so viewers must still follow it.
+    await this.userPage2.wasRemoved(
+      e.presentationContainer,
+      'viewers should follow the presenter minimize (value-change replication)',
+    );
+    // Share the webcam without the shareWebcam() helper: with the presentation
+    // minimized every participant renders as a tile, so the helper's strict-mode
+    // check on the connecting placeholder resolves to more than one element.
+    await this.userPage2.waitAndClick(e.joinVideo);
+    await this.userPage2.hasElement(
+      e.webcamMirroredVideoPreview,
+      'should display the video preview when sharing webcam',
+    );
+    await this.userPage2.waitAndClick(e.startSharingWebcam);
+    await this.userPage2.waitForSelector(e.leaveVideo, VIDEO_LOADING_WAIT_TIME);
+    await this.modPage.page.waitForTimeout(4000);
+    await this.modPage.wasRemoved(
+      e.presentationContainer,
+      'presentation should stay minimized for the presenter after a webcam turns on',
     );
 
     await this.attachPageVideos();

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -288,6 +288,15 @@ export class Layouts extends MultiUsers {
         path: user2VideoPath,
       });
     }
+
+    const mod2VideoPath = this.modPage2 ? await this.modPage2.page.video()?.path() : undefined;
+    if (mod2VideoPath) {
+      testInfo.attachments.push({
+        name: 'Moderator2 screen recording',
+        contentType: 'video/webm',
+        path: mod2VideoPath,
+      });
+    }
   }
 
   async unifiedLayoutMinimizeShowsTiles() {
@@ -444,6 +453,96 @@ export class Layouts extends MultiUsers {
     await this.modPage.wasRemoved(
       e.presentationContainer,
       'presentation should stay minimized for the presenter after a webcam turns on',
+    );
+
+    await this.attachPageVideos();
+  }
+
+  async unifiedLayoutViewerFocusFollowSticksOnCameraChanges() {
+    // Wait for the whiteboard so the presentation is fully loaded on every participant.
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitForSelector(e.whiteboard);
+    await this.userPage2.waitForSelector(e.whiteboard);
+    await this.modPage2.waitForSelector(e.whiteboard);
+
+    // Three webcams: the focus action only exists with more than two streams, and
+    // it must keep existing after the fourth participant toggles their webcam below.
+    await this.modPage.shareWebcam();
+    await this.userPage.shareWebcam();
+    await this.userPage2.shareWebcam();
+
+    // The presenter focuses the second attendee's camera. This is a genuine value
+    // change of the meeting layout record (cameraWithFocus), so the viewer must
+    // still follow it (value-change replication). The focused camera moves to the
+    // first tile; without the focus the viewer's own webcam would be first, which
+    // makes the assertion discriminating.
+    await this.modPage.page.locator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username }).click();
+    await this.modPage.getVisibleLocator(e.focusWebcamBtn).click();
+    await this.userPage.hasText(
+      `:nth-match(${e.dropdownWebcamButton}, 1)`,
+      this.userPage2.username,
+      'viewer should follow the presenter focusing a camera (value-change replication)',
+    );
+
+    // A fourth participant turns their webcam on: webcam churn is the original
+    // trigger of issue 25592 and must not disturb the viewer's followed focus.
+    await this.modPage2.shareWebcam();
+    // Fixed wait (matches the sibling tests' style): the wrongful re-assert fires
+    // ~2s after the layout record updates, so wait past that window before asserting.
+    await this.userPage.page.waitForTimeout(4000);
+    await this.userPage.hasText(
+      `:nth-match(${e.dropdownWebcamButton}, 1)`,
+      this.userPage2.username,
+      'viewer should keep the followed camera focus after a webcam turns on',
+    );
+
+    // The viewer unfocuses locally. This is a local choice that diverges from the
+    // meeting layout record, which stays focused on the second attendee. Probe the
+    // local state through the tile dropdown - the focused camera's tile offers
+    // "unfocus" while focused and "focus" once the local unfocus applied. (The
+    // first-tile text is not a safe probe here: hasText matches by containment and
+    // the viewer's own username is a prefix of the focused user's.)
+    await this.userPage.page.locator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username }).click();
+    await this.userPage.getVisibleLocator(e.unfocusWebcamBtn).click();
+    await this.userPage.page.locator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username }).click();
+    // Every tile keeps its dropdown menu in the DOM, so scope the probe to the
+    // visible (open) menu.
+    await expect(
+      this.userPage.getVisibleLocator(e.focusWebcamBtn),
+      'the focused camera tile should offer focus again after the viewer unfocuses locally',
+    ).toBeVisible();
+    await this.userPage.press('Escape');
+
+    // The presenter minimizes and restores the presentation: two genuine meeting
+    // layout record writes that do not touch the focused camera. Through the
+    // updatedAt clause each write re-asserted the meeting's focused camera onto
+    // the viewer, clobbering the local unfocus (issue 25592 mechanism). The viewer
+    // is expected to follow the presentation state itself - only the focused
+    // camera must keep the local choice.
+    await this.modPage.waitAndClick(e.minimizePresentation);
+    await this.userPage.wasRemoved(
+      e.presentationContainer,
+      'viewer should follow the presenter minimize (value-change replication)',
+    );
+    await this.modPage.waitAndClick(e.restorePresentation);
+    await this.userPage.hasElement(
+      e.presentationContainer,
+      'viewer should follow the presenter restore (value-change replication)',
+    );
+    await this.userPage.page.waitForTimeout(4000);
+    await this.userPage.page.locator(e.dropdownWebcamButton).filter({ hasText: this.userPage2.username }).click();
+    await expect(
+      this.userPage.getVisibleLocator(e.focusWebcamBtn),
+      'viewer local unfocus should persist after unrelated meeting layout writes',
+    ).toBeVisible();
+    await this.userPage.press('Escape');
+
+    // Control: the meeting layout record kept its focused camera - the presenter
+    // still renders the focused camera on the first tile.
+    await this.modPage.hasText(
+      `:nth-match(${e.dropdownWebcamButton}, 1)`,
+      this.userPage2.username,
+      'presenter should still render the meeting focused camera first',
     );
 
     await this.attachPageVideos();


### PR DESCRIPTION
### What does this PR do?

Fixes a 4.0 regression where a viewer who minimized the presentation could not keep it minimized: any write to the meeting layout record - most commonly another participant turning a webcam on/off - silently forced the presentation back open about 2 seconds later for every non-presenter.

Root cause: in `pushLayoutEngine.jsx`, the four `replicate*` functions that mirror the meeting layout onto viewers fired on `ownValueChanged || meetingLayoutUpdatedAt !== prev`, and the server bumps `layout.updatedAt` on every layout write. In the unified layout the presenter continuously propagates camera dock geometry (webcam toggles change `cameraDockAspectRatio`), so that timestamp catch-all re-asserted the presentation-open state (plus focused camera and dock position/size) onto viewers over their local choices.

The fix makes each replicate function fire only on its own value edge, replaces the `updatedAt` clause in `replicateCameraDockSize` with the `isMeetingLayoutResizing` edge it actually protected, and removes the now-dead `meetingLayoutUpdatedAt` plumbing. A separate commit dedups a duplicated `isChatEnabled` propType, and two `@ci` Playwright regression specs are added (viewer minimize persistence; focused-camera follow/unfocus persistence - both driven red against the unfixed code first).

Scope note: a viewer's locally-diverged focused camera and dock position also persist through unrelated writes now, under the same value-edge rule - intended.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/25592

### Motivation

In a busy call where cameras come and go, a viewer effectively could not keep the presentation minimized. The clobbering was silent by design: the "layout updates applied" toast only fires on significant changes, and geometry writes are not significant.

### How to test

1. Create a meeting on a 4.0 server with the default unified layout; join as presenter, viewer, and a third participant.
2. As the viewer, minimize the presentation.
3. Have the third participant turn their webcam on, then off (wait ~4 s after each - the wrongful reopen fired at ~2 s before the fix).
4. Expected: the presentation stays minimized for the viewer; the restore button remains.
5. Control: when the presenter minimizes, viewers follow (genuine value changes still replicate).
6. Automated: `npx playwright test bigbluebutton-tests/playwright/layouts/layouts.spec.ts` - the two new "Unified Layout" describes cover all of the above plus the focused-camera edge.

### More

- Full root-cause analysis, alternatives considered, and evidence videos (before/after) are in the original long description and the review thread.
