### PR TITLE
[3.0 whiteboard] fix: prevent pinch zoom outside allowed range

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -222,6 +222,7 @@ const Whiteboard = React.memo((props) => {
   const shapeBatchRef = useRef({});
   const isMountedRef = useRef(false);
   const isWheelZoomRef = useRef(false);
+  const isTouchZoomRef = useRef(false);
   const pageJustChangedRef = useRef(false);
   const isPresenterRef = useRef(isPresenter);
   const viewerCanPanRef = useRef(viewerCanPan);
@@ -1692,6 +1693,7 @@ const Whiteboard = React.memo((props) => {
         if (
           zoomed
           && isPresenterRef.current
+          && isTouchZoomRef.current
           && currentPage
           && Number.isFinite(currentPage.scaledWidth)
           && currentPage.scaledWidth > 0
@@ -2019,7 +2021,7 @@ const Whiteboard = React.memo((props) => {
 
   useMouseEvents(
     {
-      whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoomRef, isPresenterRef,
+      whiteboardRef, tlEditorRef, isWheelZoomRef, isTouchZoomRef, initialZoomRef, isPresenterRef,
     },
     {
       hasWBAccess: hasWBAccessRef.current,

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1676,7 +1676,6 @@ const Whiteboard = React.memo((props) => {
         let viewportWidth;
         let viewportHeight;
 
-        // Prevent pinch zoom outside allowed range
         if (isPresenterRef.current) {
           const viewportPageBounds = editor?.getViewportPageBounds();
           viewportWidth = viewportPageBounds?.w;
@@ -1689,6 +1688,7 @@ const Whiteboard = React.memo((props) => {
         const zoomed = next?.id?.includes('camera') && prev.z !== next.z;
         const currentPage = currentPresentationPageRef.current;
 
+        // Prevent pinch zoom outside allowed range
         if (
           zoomed
           && isPresenterRef.current

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1693,7 +1693,6 @@ const Whiteboard = React.memo((props) => {
           zoomed
           && isPresenterRef.current
           && currentPage
-          && !currentPage.infiniteWhiteboard
           && Number.isFinite(currentPage.scaledWidth)
           && currentPage.scaledWidth > 0
           && Number.isFinite(currentPage.scaledHeight)
@@ -1701,28 +1700,32 @@ const Whiteboard = React.memo((props) => {
         ) {
           const { widthGap } = getContainerDimensions();
 
-          let minimumZoom = calculateZoomValueRef.current(
+          let baseZoom = calculateZoomValueRef.current(
             currentPage.scaledWidth,
             currentPage.scaledHeight,
           );
 
           if (widthGap > 0) {
-            minimumZoom = calculateZoomWithGapValueRef.current(
+            baseZoom = calculateZoomWithGapValueRef.current(
               currentPage.scaledWidth,
               currentPage.scaledHeight,
               widthGap,
             );
           }
 
-          if (Number.isFinite(minimumZoom) && minimumZoom > 0) {
-            const maximumZoom = minimumZoom * 4;
+          if (Number.isFinite(baseZoom) && baseZoom > 0) {
+            const minimumZoom = currentPage.infiniteWhiteboard
+              ? baseZoom * 0.25
+              : baseZoom;
+
+            const maximumZoom = baseZoom * 4;
 
             if (next.z < minimumZoom || next.z > maximumZoom) {
               return prev;
             }
           }
         }
-
+        
         const presentationWidthLocal = currentPresentationPageRef.current?.scaledWidth || 0;
         const presentationHeightLocal = currentPresentationPageRef.current?.scaledHeight || 0;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1676,6 +1676,7 @@ const Whiteboard = React.memo((props) => {
         let viewportWidth;
         let viewportHeight;
 
+        // Prevent pinch zoom outside allowed range
         if (isPresenterRef.current) {
           const viewportPageBounds = editor?.getViewportPageBounds();
           viewportWidth = viewportPageBounds?.w;
@@ -1683,6 +1684,43 @@ const Whiteboard = React.memo((props) => {
         } else {
           viewportWidth = currentPresentationPageRef.current?.scaledViewBoxWidth;
           viewportHeight = currentPresentationPageRef.current?.scaledViewBoxHeight;
+        }
+
+        const zoomed = next?.id?.includes('camera') && prev.z !== next.z;
+        const currentPage = currentPresentationPageRef.current;
+
+        if (
+          zoomed
+          && isPresenterRef.current
+          && currentPage
+          && !currentPage.infiniteWhiteboard
+          && Number.isFinite(currentPage.scaledWidth)
+          && currentPage.scaledWidth > 0
+          && Number.isFinite(currentPage.scaledHeight)
+          && currentPage.scaledHeight > 0
+        ) {
+          const { widthGap } = getContainerDimensions();
+
+          let minimumZoom = calculateZoomValueRef.current(
+            currentPage.scaledWidth,
+            currentPage.scaledHeight,
+          );
+
+          if (widthGap > 0) {
+            minimumZoom = calculateZoomWithGapValueRef.current(
+              currentPage.scaledWidth,
+              currentPage.scaledHeight,
+              widthGap,
+            );
+          }
+
+          if (Number.isFinite(minimumZoom) && minimumZoom > 0) {
+            const maximumZoom = minimumZoom * 4;
+
+            if (next.z < minimumZoom || next.z > maximumZoom) {
+              return prev;
+            }
+          }
         }
 
         const presentationWidthLocal = currentPresentationPageRef.current?.scaledWidth || 0;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1725,7 +1725,7 @@ const Whiteboard = React.memo((props) => {
             }
           }
         }
-        
+
         const presentationWidthLocal = currentPresentationPageRef.current?.scaledWidth || 0;
         const presentationHeightLocal = currentPresentationPageRef.current?.scaledHeight || 0;
 

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -87,12 +87,20 @@ const useMouseEvents = ({
   const initialPinchDistanceRef = React.useRef(0);
   const isPinchingRef = React.useRef(false);
   const mouseLeaveTimeoutRef = React.useRef();
+  const touchZoomResetTimeoutRef = React.useRef();
   const PINCH_THRESHOLD = 10;
 
   const getDistanceBetweenTouches = (touch1, touch2) => {
     const dx = touch2.clientX - touch1.clientX;
     const dy = touch2.clientY - touch1.clientY;
     return Math.sqrt(dx * dx + dy * dy);
+  };
+
+  const resetTouchZoomAfterCameraSettles = () => {
+    clearTimeout(touchZoomResetTimeoutRef.current);
+    touchZoomResetTimeoutRef.current = setTimeout(() => {
+      isTouchZoomRef.current = false;
+    }, 175);
   };
 
   const handleMouseUp = () => {
@@ -268,8 +276,11 @@ const useMouseEvents = ({
   };
 
   const handleTouchStart = (event) => {
-    isTouchZoomRef.current = isPresenterRef.current && event.touches.length === 2;
     if (event.touches.length === 2) {
+      clearTimeout(touchZoomResetTimeoutRef.current);
+      if (isPresenterRef.current) {
+        isTouchZoomRef.current = true;
+      }
       if (!isPresenterRef.current) {
         event.preventDefault();
         event.stopPropagation();
@@ -339,7 +350,7 @@ const useMouseEvents = ({
 
   const handleTouchEnd = (event) => {
     if (event.touches.length < 2) {
-      isTouchZoomRef.current = false;
+      resetTouchZoomAfterCameraSettles();
     }
 
     if (event.touches.length === 0) {
@@ -358,6 +369,13 @@ const useMouseEvents = ({
       isPinchingRef.current = false;
       initialPinchDistanceRef.current = 0;
     }
+  };
+
+  const handleTouchCancel = () => {
+    fingerCountRef.current = 0;
+    isPinchingRef.current = false;
+    initialPinchDistanceRef.current = 0;
+    resetTouchZoomAfterCameraSettles();
   };
 
   React.useEffect(() => {
@@ -390,6 +408,7 @@ const useMouseEvents = ({
       presentationWrapper.addEventListener('pointerdown', handlePointerDown, { capture: true });
       presentationWrapper.addEventListener('touchstart', handleTouchStart, { passive: false, capture: true });
       presentationWrapper.addEventListener('touchend', handleTouchEnd, { passive: false, capture: true });
+      presentationWrapper.addEventListener('touchcancel', handleTouchCancel, { passive: false, capture: true });
       presentationWrapper.addEventListener('touchmove', handleTouchMove, { passive: false });
     }
 
@@ -403,6 +422,7 @@ const useMouseEvents = ({
         presentationWrapper.removeEventListener('pointerdown', handlePointerDown, { capture: true });
         presentationWrapper.removeEventListener('touchstart', handleTouchStart, { capture: true });
         presentationWrapper.removeEventListener('touchend', handleTouchEnd, { capture: true });
+        presentationWrapper.removeEventListener('touchcancel', handleTouchCancel, { capture: true });
         presentationWrapper.removeEventListener('touchmove', handleTouchMove);
       }
       window.removeEventListener('mousedown', handleMouseDownWindow);

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -68,7 +68,7 @@ const getTldrawOpenMenu = () => {
 };
 
 const useMouseEvents = ({
-  whiteboardRef, tlEditorRef, isWheelZoomRef, initialZoomRef, isPresenterRef,
+  whiteboardRef, tlEditorRef, isWheelZoomRef, isTouchZoomRef, initialZoomRef, isPresenterRef,
 }, {
   hasWBAccess,
   whiteboardToolbarAutoHide,
@@ -268,6 +268,7 @@ const useMouseEvents = ({
   };
 
   const handleTouchStart = (event) => {
+    isTouchZoomRef.current = isPresenterRef.current && event.touches.length === 2;
     if (event.touches.length === 2) {
       if (!isPresenterRef.current) {
         event.preventDefault();
@@ -337,6 +338,10 @@ const useMouseEvents = ({
   });
 
   const handleTouchEnd = (event) => {
+    if (event.touches.length < 2) {
+      isTouchZoomRef.current = false;
+    }
+
     if (event.touches.length === 0) {
       const count = fingerCountRef.current;
 


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
This PR prevents the presenter camera from moving outside the allowed zoom range on non-infinite whiteboards.
It extends the approach introduced in #25659, which prevented pinch zoom from temporarily going below the minimum zoom level. In addition to the lower bound, this PR also enforces the 400% upper bound.
Instead of modifying only the camera z value after an out-of-range camera update has been calculated, the entire camera update is rejected when the requested zoom is outside the allowed range. This keeps the camera x, y, and z values consistent and avoids unexpected camera movement.


### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #25517, #25663

### Motivation
On mobile devices, tldraw's native pinch gesture can temporarily move the camera outside BigBlueButton's intended zoom range.
Below 100%, this can cause the presenter view to flicker between an invalid zoom level and 100%. Above 400%, the native camera can temporarily zoom far beyond the BBB limit while BBB's zoom state remains capped at 400%.
The latter can also cause presenter/viewer desynchronization because the actual tldraw camera zoom and BBB's zoom-value no longer match.
This PR is a further development of #25659 ; rather than handling only the minimum zoom boundary, it prevents camera updates outside both the minimum and maximum zoom limits before they are applied.


### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Join a meeting as presenter using a touch device.
2. Use a presentation with Infinite Whiteboard disabled.
3. Pinch to zoom out repeatedly near 100%.
4. Check if the zoom stops at 100% and the presentation does not flicker.
5. Pinch to zoom in repeatedly near 400%.
6. Check if the zoom stops at 400% and the viewer's screen follows the update correctly.
7. While zoomed in, use one-finger or two-fingers panning and pinch-and-pan gestures.
8. Panning should continue to work normally.
9. Turn on the infinite whiteboard and check if the pinch-zoom go below 100% but not beyond 400%.

### More
To fix the problem of shifted zoom center (#25661), we need to merge https://github.com/bigbluebutton/tldraw/pull/57 in addition to this PR.

I closed #25659.

(Added on 13 Sep) Note that the 175ms delay in `resetTouchZoomAfterCameraSettles` delays resetting `isTouchZoomRef` so that any camera update still pending after touchend, due to the existing touch-move throttle or camera transition, is recognized and published as part of the same touch gesture. The 175 ms value matches the timing already used for these operations in the current code, for example, https://github.com/bigbluebutton/bigbluebutton/blob/4c3a477fe3e34a7da6854c491be2c8d02e83c083/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js#L287