### PR TITLE
Fix(html5): layout breakpoint round trip

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -123,6 +123,16 @@ const SidebarNavigation = ({
   }, [isExpanded, isMobile, enableScrollBar]);
 
   useEffect(() => {
+    // collapse the sidebar when the device becomes mobile (e.g. the window is
+    // resized across the breakpoint): mounting on mobile already starts collapsed,
+    // but without this the expanded rail carried over from desktop would overlay
+    // the sidebar content and the media area
+    if (isMobile) {
+      setIsExpanded(false);
+    }
+  }, [isMobile]);
+
+  useEffect(() => {
     if (!isMobile) return;
     const panelWasOpened = sidebarContentPanel !== PANELS.NONE;
     if (panelWasOpened) {

--- a/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/sidebar-navigation/component.tsx
@@ -126,7 +126,11 @@ const SidebarNavigation = ({
     // collapse the sidebar when the device becomes mobile (e.g. the window is
     // resized across the breakpoint): mounting on mobile already starts collapsed,
     // but without this the expanded rail carried over from desktop would overlay
-    // the sidebar content and the media area
+    // the sidebar content and the media area.
+    // Deliberately a separate effect depending on isMobile only, so it fires once
+    // per device type change. Folding it into the effect above (which re-runs on
+    // every isExpanded change) would collapse the rail right back each time the
+    // user taps the toggle to expand it on mobile, breaking the toggle.
     if (isMobile) {
       setIsExpanded(false);
     }

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -1,7 +1,7 @@
 import { elements as e } from '../core/elements';
 import { initializePages, linkIssue } from '../core/helpers';
 import { test } from '../core/setup/fixtures';
-import { Layouts } from './layouts';
+import { Layouts, MOBILE_VIEWPORT } from './layouts';
 
 test.describe.parallel('Unified Layout - meeting create param', { tag: '@ci' }, () => {
   test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
@@ -87,6 +87,42 @@ test.describe.parallel('Unified Layout - focused camera replication', { tag: '@c
       await layouts.unifiedLayoutViewerFocusFollowSticksOnCameraChanges();
     },
   );
+});
+
+test.describe.parallel('Device type breakpoint crossing', { tag: '@ci' }, () => {
+  // the audio modal is irrelevant to these layout assertions, and closing it on a
+  // mobile-sized viewport is not reliable (the audio controls sit behind the open panel)
+  const audioModalOff = {
+    joinParameter: 'userdata-bbb_auto_join_audio=false',
+    shouldCloseAudioModal: false,
+  };
+
+  test('Desktop layout is restored after the viewport crosses the mobile breakpoint and back', async ({
+    browser,
+  }, testInfo) => {
+    linkIssue(25590);
+    const context = await browser.newContext({ recordVideo: { dir: 'test-results/' } });
+    const page = await context.newPage();
+    const layouts = new Layouts(browser, context);
+    await layouts.initModPage(page, { testInfo, ...audioModalOff });
+    await layouts.desktopLayoutRestoredAfterMobileBreakpointRoundTrip();
+  });
+
+  test('Mobile layout is restored after the viewport crosses the desktop breakpoint and back', async ({
+    browser,
+  }, testInfo) => {
+    linkIssue(25590);
+    // own context: this leg must MOUNT the client below the breakpoint, since the
+    // regression followed the mount-time device type
+    const mobileContext = await browser.newContext({
+      viewport: MOBILE_VIEWPORT,
+      recordVideo: { dir: 'test-results/' },
+    });
+    const page = await mobileContext.newPage();
+    const layouts = new Layouts(browser, mobileContext);
+    await layouts.initModPage(page, { testInfo, ...audioModalOff });
+    await layouts.mobileLayoutRestoredAfterDesktopBreakpointRoundTrip();
+  });
 });
 
 test.describe.parallel('Layout', { tag: ['@flaky-3.1', '@media'] }, () => {

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -117,6 +117,17 @@ test.describe.parallel('Device type breakpoint crossing', { tag: '@ci' }, () => 
     await layouts.desktopLayoutRestoredAfterMobileBreakpointRoundTrip();
   });
 
+  test('Sidebar navigation toggle still works after the rail auto-collapses on mobile', async ({
+    browser,
+  }, testInfo) => {
+    linkIssue(25590);
+    const context = await browser.newContext({ recordVideo: { dir: 'test-results/' } });
+    const page = await context.newPage();
+    const layouts = new Layouts(browser, context);
+    await layouts.initModPage(page, { testInfo, ...audioModalOff });
+    await layouts.navigationRailToggleStillWorksAfterAutoCollapse();
+  });
+
   test('Mobile layout is restored after the viewport crosses the desktop breakpoint and back', async ({
     browser,
   }, testInfo) => {

--- a/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.spec.ts
@@ -4,7 +4,10 @@ import { test } from '../core/setup/fixtures';
 import { Layouts, MOBILE_VIEWPORT } from './layouts';
 
 test.describe.parallel('Unified Layout - meeting create param', { tag: '@ci' }, () => {
-  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+  test('First minimize of presentation shows participant tiles for moderator', async ({
+    browser,
+    context,
+  }, testInfo) => {
     const layouts = new Layouts(browser, context);
     await initializePages(layouts, browser, {
       isMultiUser: true,
@@ -17,7 +20,10 @@ test.describe.parallel('Unified Layout - meeting create param', { tag: '@ci' }, 
 });
 
 test.describe.parallel('Unified Layout - meeting create param - with audio', { tag: '@ci' }, () => {
-  test('First minimize of presentation shows participant tiles for moderator', async ({ browser, context }, testInfo) => {
+  test('First minimize of presentation shows participant tiles for moderator', async ({
+    browser,
+    context,
+  }, testInfo) => {
     const layouts = new Layouts(browser, context);
     await initializePages(layouts, browser, {
       isMultiUser: false,
@@ -33,7 +39,10 @@ test.describe.parallel('Unified Layout - meeting create param - with audio', { t
 });
 
 test.describe.parallel('Unified Layout - who-is-talking tiles (no webcams)', { tag: '@ci' }, () => {
-  test('Speaking with no webcams keeps avatar tiles hidden while the presentation is visible', async ({ browser, context }, testInfo) => {
+  test('Speaking with no webcams keeps avatar tiles hidden while the presentation is visible', async ({
+    browser,
+    context,
+  }, testInfo) => {
     linkIssue(25235);
     const layouts = new Layouts(browser, context);
     await initializePages(layouts, browser, {

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -9,15 +9,21 @@ import { checkDefaultLocationReset, checkScreenshots } from './util';
 // Comfortably away from the 600px mobile breakpoint on both sides: getDeviceType()
 // reads documentElement.clientWidth, which differs from the viewport width by the
 // scrollbar, so near-threshold values would make the legs ambiguous.
+// Both legs run under Playwright's default desktop user-agent: the layout device
+// type is derived from width alone, so resizing is enough to flip it, but the
+// UA-based deviceInfo.isMobile stays false throughout. Running these specs under
+// mobile device emulation (mobile UA) would exercise a different mount path.
 export const DESKTOP_VIEWPORT = { width: 1366, height: 768 };
 export const MOBILE_VIEWPORT = { width: 500, height: 768 };
 
 // Width of the open sidebar content panel relative to the viewport: ~1 on the
 // mobile layout (panel takes the whole width), a fraction on the desktop layout.
+// NaN when the panel is absent: it fails both the mobile (> 0.95) and the desktop
+// (< 0.6) bounds, so a panel that never renders cannot pass either leg vacuously.
 async function getSidebarContentWidthRatio(page: Page): Promise<number> {
   const box = await page.page.locator(e.sidebarContentMain).boundingBox();
   const viewport = page.page.viewportSize();
-  if (!box || !viewport) return -1;
+  if (!box || !viewport) return NaN;
   return box.width / viewport.width;
 }
 
@@ -28,16 +34,25 @@ async function assertMobileLayoutActive(page: Page) {
   );
   // entering mobile must also collapse the navigation rail; when it stays
   // expanded it overlays the open panel header and the media area
-  await expect(
-    page.page.locator(e.toggleSidebarNavigation),
+  await assertNavigationRailExpanded(
+    page,
+    false,
     'the sidebar navigation rail should be collapsed on the mobile layout',
-  ).toHaveAttribute('aria-expanded', 'false', { timeout: ELEMENT_WAIT_TIME });
+  );
   await expect
     .poll(() => getSidebarContentWidthRatio(page), {
       message: 'the open panel should take the full viewport width on the mobile layout',
       timeout: ELEMENT_WAIT_TIME,
     })
     .toBeGreaterThan(0.95);
+}
+
+async function assertNavigationRailExpanded(page: Page, expanded: boolean, message: string) {
+  await expect(page.page.locator(e.toggleSidebarNavigation), message).toHaveAttribute(
+    'aria-expanded',
+    String(expanded),
+    { timeout: ELEMENT_WAIT_TIME },
+  );
 }
 
 async function assertDesktopLayoutActive(page: Page) {
@@ -607,6 +622,45 @@ export class Layouts extends MultiUsers {
     // stayed stuck in the mobile layout until a page reload (issue 25590)
     await this.modPage.setHeightWidthViewPortSize(DESKTOP_VIEWPORT);
     await assertDesktopLayoutActive(this.modPage);
+
+    await this.attachPageVideos();
+  }
+
+  async navigationRailToggleStillWorksAfterAutoCollapse() {
+    await this.modPage.waitForSelector(e.whiteboard);
+    await assertDesktopLayoutActive(this.modPage);
+
+    // entering mobile auto-collapses the rail (asserted inside)
+    await this.modPage.setHeightWidthViewPortSize(MOBILE_VIEWPORT);
+    await assertMobileLayoutActive(this.modPage);
+
+    // the auto-collapse must not swallow the user's toggle afterwards: the user
+    // can still expand the rail and collapse it again
+    await this.modPage.waitAndClick(e.toggleSidebarNavigation);
+    await assertNavigationRailExpanded(
+      this.modPage,
+      true,
+      'the user should be able to expand the rail after the automatic collapse',
+    );
+    await this.modPage.waitAndClick(e.toggleSidebarNavigation);
+    await assertNavigationRailExpanded(
+      this.modPage,
+      false,
+      'the user should be able to collapse the rail again with the toggle',
+    );
+
+    // a rail the user expanded is collapsed again on the next entry into mobile:
+    // the collapse fires on every device type change, not only on the first one
+    await this.modPage.waitAndClick(e.toggleSidebarNavigation);
+    await assertNavigationRailExpanded(
+      this.modPage,
+      true,
+      'the rail should be expanded by the user before the desktop round trip',
+    );
+    await this.modPage.setHeightWidthViewPortSize(DESKTOP_VIEWPORT);
+    await assertDesktopLayoutActive(this.modPage);
+    await this.modPage.setHeightWidthViewPortSize(MOBILE_VIEWPORT);
+    await assertMobileLayoutActive(this.modPage);
 
     await this.attachPageVideos();
   }

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -326,7 +326,7 @@ export class Layouts extends MultiUsers {
   }
 
   private async attachPageVideos() {
-    const testInfo = this.modPage.testInfo;
+    const { testInfo } = this.modPage;
     if (!testInfo) return;
 
     // Register future video paths without closing anything — Playwright's fixture

--- a/bigbluebutton-tests/playwright/layouts/layouts.ts
+++ b/bigbluebutton-tests/playwright/layouts/layouts.ts
@@ -1,10 +1,57 @@
 import { expect } from '@playwright/test';
 
-import { VIDEO_LOADING_WAIT_TIME } from '../core/constants';
+import { ELEMENT_WAIT_TIME, VIDEO_LOADING_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { Page } from '../core/page';
 import { MultiUsers } from '../user/multiusers';
 import { checkDefaultLocationReset, checkScreenshots } from './util';
+
+// Comfortably away from the 600px mobile breakpoint on both sides: getDeviceType()
+// reads documentElement.clientWidth, which differs from the viewport width by the
+// scrollbar, so near-threshold values would make the legs ambiguous.
+export const DESKTOP_VIEWPORT = { width: 1366, height: 768 };
+export const MOBILE_VIEWPORT = { width: 500, height: 768 };
+
+// Width of the open sidebar content panel relative to the viewport: ~1 on the
+// mobile layout (panel takes the whole width), a fraction on the desktop layout.
+async function getSidebarContentWidthRatio(page: Page): Promise<number> {
+  const box = await page.page.locator(e.sidebarContentMain).boundingBox();
+  const viewport = page.page.viewportSize();
+  if (!box || !viewport) return -1;
+  return box.width / viewport.width;
+}
+
+async function assertMobileLayoutActive(page: Page) {
+  await page.hasElement(
+    e.toggleSidebarNavigation,
+    'the sidebar navigation toggle should be rendered on the mobile layout',
+  );
+  // entering mobile must also collapse the navigation rail; when it stays
+  // expanded it overlays the open panel header and the media area
+  await expect(
+    page.page.locator(e.toggleSidebarNavigation),
+    'the sidebar navigation rail should be collapsed on the mobile layout',
+  ).toHaveAttribute('aria-expanded', 'false', { timeout: ELEMENT_WAIT_TIME });
+  await expect
+    .poll(() => getSidebarContentWidthRatio(page), {
+      message: 'the open panel should take the full viewport width on the mobile layout',
+      timeout: ELEMENT_WAIT_TIME,
+    })
+    .toBeGreaterThan(0.95);
+}
+
+async function assertDesktopLayoutActive(page: Page) {
+  await page.wasRemoved(
+    e.toggleSidebarNavigation,
+    'the sidebar navigation toggle should not be rendered on the desktop layout',
+  );
+  await expect
+    .poll(() => getSidebarContentWidthRatio(page), {
+      message: 'the open panel should take a fraction of the viewport width on the desktop layout',
+      timeout: ELEMENT_WAIT_TIME,
+    })
+    .toBeLessThan(0.6);
+}
 
 export class Layouts extends MultiUsers {
   async focusOnPresentation() {
@@ -544,6 +591,39 @@ export class Layouts extends MultiUsers {
       this.userPage2.username,
       'presenter should still render the meeting focused camera first',
     );
+
+    await this.attachPageVideos();
+  }
+
+  async desktopLayoutRestoredAfterMobileBreakpointRoundTrip() {
+    await this.modPage.waitForSelector(e.whiteboard);
+    await assertDesktopLayoutActive(this.modPage);
+
+    // crossing into the mobile breakpoint must switch to the mobile layout
+    await this.modPage.setHeightWidthViewPortSize(MOBILE_VIEWPORT);
+    await assertMobileLayoutActive(this.modPage);
+
+    // crossing back must restore the desktop layout: with the regression the client
+    // stayed stuck in the mobile layout until a page reload (issue 25590)
+    await this.modPage.setHeightWidthViewPortSize(DESKTOP_VIEWPORT);
+    await assertDesktopLayoutActive(this.modPage);
+
+    await this.attachPageVideos();
+  }
+
+  async mobileLayoutRestoredAfterDesktopBreakpointRoundTrip() {
+    // the context was created with the mobile viewport, so the client mounted mobile
+    await assertMobileLayoutActive(this.modPage);
+
+    // widening past the breakpoint must switch to the desktop layout
+    await this.modPage.setHeightWidthViewPortSize(DESKTOP_VIEWPORT);
+    await assertDesktopLayoutActive(this.modPage);
+
+    // narrowing again must restore the mobile layout: the regression followed the
+    // mount-time device type, so mounted-narrow clients got stuck in the desktop
+    // layout instead (mirror of issue 25590)
+    await this.modPage.setHeightWidthViewPortSize(MOBILE_VIEWPORT);
+    await assertMobileLayoutActive(this.modPage);
 
     await this.attachPageVideos();
   }


### PR DESCRIPTION
### What does this PR do?

Adds the missing e2e regression coverage for the layout breakpoint round trip, plus a small residual fix in the same flow:

1. Two `@ci` Playwright tests (`bigbluebutton-tests/playwright/layouts/`) covering the device type round trip in both directions: desktop-mounted (1366 -> 500 -> 1366) and mobile-mounted (500 -> 1366 -> 500), since the bug followed the mount-time device type.
2. Fixes `sidebar-navigation/component.tsx`: entering the mobile layout by resize kept the navigation rail expanded, overlaying the open panel header (the "MESSAGES" clipped to "GES" in the issue screenshots) and swallowing taps. One `useEffect` keyed on the mobile transition collapses the rail, symmetric to the existing restore-on-desktop effect; the user can still expand it with the toggle.

### Closes Issue(s)

Closes #25590

### Motivation

The stuck-layout root cause was already fixed in passing by #25565 (removed the `newDeviceType !== deviceType` guard), but nothing linked the two and the behavior had no regression coverage - which is why the breakage went unnoticed for months. This PR locks the round trip down with tests and fixes the remaining rail-collapse defect visible in the same flow.

### How to test

- Automated: `cd bigbluebutton-tests/playwright && BBB_URL=... BBB_SECRET=... npx playwright test --project=Chromium --grep "Device type breakpoint crossing"`. Verified red-first (guard restored locally: both tests fail exactly on the return leg) and green on this branch, from-source 4.0 build.
- Manual: join a meeting, keep a panel open (public chat is open by default), resize the window across 600px in both directions - the interface must always match the current width, and entering mobile must collapse the rail. Phone rotation (portrait <-> landscape) is covered by the same dispatcher.

### More

- Tablet breakpoints share the same dispatcher exercised by the tests (the phone rotation check crosses 600 and 900 both ways); `tablet_portrait` has no cheap DOM projection to assert separately.
- Test-suite lint/prettier debt mentioned in the diff is pre-existing and untouched; the additions are lint-clean.
