### PR TITLE
fix(core): count screenshare start/stop as user activity

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -762,11 +762,15 @@ class MeetingActor(
         updateUserLastActivity(m.header.userId)
 
       // Screenshare
-      case m: ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg => screenshareApp2x.handle(m, liveMeeting, msgBus)
-      case m: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg => screenshareApp2x.handle(m, liveMeeting, msgBus)
-      case m: GetScreenshareStatusReqMsg                     => screenshareApp2x.handle(m, liveMeeting, msgBus)
-      case m: GetScreenBroadcastPermissionReqMsg             => handleGetScreenBroadcastPermissionReqMsg(m)
-      case m: GetScreenSubscribePermissionReqMsg             => handleGetScreenSubscribePermissionReqMsg(m)
+      case m: ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg =>
+        screenshareApp2x.handle(m, liveMeeting, msgBus)
+        updateUserLastActivity(m.body.userId)
+      case m: ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg =>
+        screenshareApp2x.handle(m, liveMeeting, msgBus)
+        updateUserLastActivity(m.body.userId)
+      case m: GetScreenshareStatusReqMsg         => screenshareApp2x.handle(m, liveMeeting, msgBus)
+      case m: GetScreenBroadcastPermissionReqMsg => handleGetScreenBroadcastPermissionReqMsg(m)
+      case m: GetScreenSubscribePermissionReqMsg => handleGetScreenSubscribePermissionReqMsg(m)
 
       // AudioCaptions
       case m: UpdateTranscriptPubMsg =>


### PR DESCRIPTION
### What does this PR do?
Renews the user's last activity timestamp when a screenshare broadcast starts and when it stops.

Screenshare was the only media toggle that did not renew activity: camera broadcast already does it on both ends via `UserBroadcastCamStartMsg`/`UserBroadcastCamStopMsg`, while `ScreenshareRtmpBroadcastStartedVoiceConfEvtMsg`/`ScreenshareRtmpBroadcastStoppedVoiceConfEvtMsg` went straight to the handler. As a result, starting or stopping a screen share counted as nothing at all for the user inactivity monitor.

As with camera, only the start/stop events count. An ongoing broadcast does not renew activity continuously — a broadcast left running is a passive signal and deliberately does not keep a user marked as active.

The broadcaster is taken from `body.userId` on both events.

### Closes Issue(s)
Closes None
